### PR TITLE
Update gridstack addwidget to use makewidget

### DIFF
--- a/frontend/components/DashboardComponent.vue
+++ b/frontend/components/DashboardComponent.vue
@@ -670,12 +670,17 @@
                     const newElement = document.querySelector(`[gs-id="${savedWidget.id}"]`);
 
                     if (newElement && grid.value) {
-                         grid.value.addWidget(newElement as HTMLElement, {
-                             id: savedWidget.id,
-                             x: savedWidget.x, y: savedWidget.y,
-                             w: savedWidget.width, h: savedWidget.height,
-                             autoPosition: false
-                         });
+                         grid.value.makeWidget(newElement as HTMLElement);
+                         // Update position/size after making it a widget
+                         const node = grid.value.engine.nodes.find(n => n.el === newElement);
+                         if (node && (node.x !== savedWidget.x || node.y !== savedWidget.y || node.w !== savedWidget.width || node.h !== savedWidget.height)) {
+                             grid.value.update(newElement as HTMLElement, { 
+                                 x: savedWidget.x, 
+                                 y: savedWidget.y, 
+                                 w: savedWidget.width, 
+                                 h: savedWidget.height 
+                             });
+                         }
                     } else {
                          console.warn(`Could not find new element ${savedWidget.id} in DOM to add to gridstack.`);
                          // Consider fallback: await loadWidgetsIntoGrid(grid.value, allWidgets.value);


### PR DESCRIPTION
Update GridStack API usage from `addWidget()` to `makeWidget()` and `update()` for HTMLElement to ensure compatibility with GridStack v11.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f19789b-36b6-4a73-82d9-c61a084961bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f19789b-36b6-4a73-82d9-c61a084961bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

