### PR TITLE
fix: prevent playwright tests from failing due to onboarding redirect

### DIFF
--- a/frontend/tests/data_sources/list-data-sources.spec.ts
+++ b/frontend/tests/data_sources/list-data-sources.spec.ts
@@ -1,5 +1,5 @@
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can list data sources', async ({ page }) => {
   await page.goto('/data');

--- a/frontend/tests/evals/list-evals.spec.ts
+++ b/frontend/tests/evals/list-evals.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can view evals page', async ({ page }) => {
   await page.goto('/evals');

--- a/frontend/tests/fixtures/auth.ts
+++ b/frontend/tests/fixtures/auth.ts
@@ -1,5 +1,23 @@
 import { test as base, Page } from '@playwright/test';
 
+// Dismiss onboarding if the page was redirected to it
+async function dismissOnboardingIfNeeded(page: Page) {
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForTimeout(3000);
+
+  if (page.url().includes('/onboarding')) {
+    const skipButton = page.getByRole('button', { name: 'Skip onboarding' });
+    if (await skipButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+      await skipButton.click();
+      await page.waitForURL(
+        (url) => !url.pathname.includes('/onboarding'),
+        { timeout: 15000 }
+      );
+    }
+  }
+}
+
 // Extended test with role-specific page fixtures
 export const test = base.extend<{
   adminPage: Page;
@@ -11,6 +29,8 @@ export const test = base.extend<{
       storageState: 'tests/config/admin.json',
     });
     const page = await context.newPage();
+    // Ensure onboarding is dismissed for admin (only admins get redirected)
+    await dismissOnboardingIfNeeded(page);
     await use(page);
     await context.close();
   },

--- a/frontend/tests/fixtures/feature-test.ts
+++ b/frontend/tests/fixtures/feature-test.ts
@@ -1,0 +1,31 @@
+import { test as base, expect } from '@playwright/test';
+
+/**
+ * Extended test fixture for feature tests that ensures onboarding is dismissed
+ * before each test runs. This prevents test failures caused by the onboarding
+ * middleware redirecting to /onboarding.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Navigate to home to check if onboarding redirect is active
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(3000);
+
+    // If redirected to onboarding, dismiss it
+    if (page.url().includes('/onboarding')) {
+      const skipButton = page.getByRole('button', { name: 'Skip onboarding' });
+      if (await skipButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+        await skipButton.click();
+        await page.waitForURL(
+          (url) => !url.pathname.includes('/onboarding'),
+          { timeout: 15000 }
+        );
+      }
+    }
+
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/frontend/tests/home/home-menu.spec.ts
+++ b/frontend/tests/home/home-menu.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('home menu is visible and contains expected links', async ({ page }) => {
   // Navigate to excel home page

--- a/frontend/tests/instructions/list-instructions.spec.ts
+++ b/frontend/tests/instructions/list-instructions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can view instructions page', async ({ page }) => {
   await page.goto('/instructions');

--- a/frontend/tests/members/member-flow.spec.ts
+++ b/frontend/tests/members/member-flow.spec.ts
@@ -28,6 +28,19 @@ test.describe.serial('Member Flow', () => {
     // Navigate to settings/members
     await page.goto('/settings/members');
     await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(3000);
+
+    // If redirected to onboarding, dismiss it first
+    if (page.url().includes('/onboarding')) {
+      const skipButton = page.getByRole('button', { name: 'Skip onboarding' });
+      if (await skipButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+        await skipButton.click();
+        await page.waitForURL((url) => !url.pathname.includes('/onboarding'), { timeout: 15000 });
+      }
+      // Now navigate to the actual target page
+      await page.goto('/settings/members');
+      await page.waitForLoadState('networkidle');
+    }
 
     // Verify we're on the members page (longer timeout for CI)
     await expect(page.getByRole('heading', { name: 'Settings' }))

--- a/frontend/tests/monitoring/view-monitoring.spec.ts
+++ b/frontend/tests/monitoring/view-monitoring.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can view monitoring page', async ({ page }) => {
   await page.goto('/monitoring');

--- a/frontend/tests/queries/list-queries.spec.ts
+++ b/frontend/tests/queries/list-queries.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can view queries page', async ({ page }) => {
   await page.goto('/queries');

--- a/frontend/tests/reports/list-reports.spec.ts
+++ b/frontend/tests/reports/list-reports.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures/feature-test'
 
 test('can list reports', async ({ page }) => {
   await page.goto('/reports');

--- a/frontend/tests/settings/view-settings.spec.ts
+++ b/frontend/tests/settings/view-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/feature-test';
 
 test('can view settings page', async ({ page }) => {
   await page.goto('/settings');


### PR DESCRIPTION
All feature and member tests were failing because the onboarding middleware redirects admin users to /onboarding when onboarding is not completed or dismissed. Fixed by:

- Making onboarding wizard step 4 more robust: navigates directly to /onboarding, properly waits for Skip button, and double-checks dismissal with a retry
- Creating a feature-test fixture that dismisses onboarding before each feature test as a safety net
- Updating all feature tests to use the new fixture
- Adding onboarding redirect handling to the member-flow test
- Updating the auth fixture's adminPage to dismiss onboarding

https://claude.ai/code/session_01EApXBJ65J22AdHq5dppkin