### PR TITLE
Drop unused mssql-tools18 to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" > /etc/apt/sources.list.d/microsoft-prod-22.04.list && \
     printf 'Package: *\nPin: origin packages.microsoft.com\nPin: release n=jammy\nPin-Priority: 100\n\nPackage: msodbcsql17\nPin: origin packages.microsoft.com\nPin: release n=jammy\nPin-Priority: 900\n' > /etc/apt/preferences.d/microsoft-odbc && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 mssql-tools18 unixodbc tdsodbc freetds-dev && \
+    ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 unixodbc tdsodbc freetds-dev && \
     ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql17 && \
     # For PPTX to PNG preview generation (slides mode)
     apt-get install -y --no-install-recommends libreoffice-impress poppler-utils && \


### PR DESCRIPTION
mssql-tools18 (sqlcmd/bcp CLI utilities) is not used by application code — confirmed by grepping the entire codebase. Its download fails because Microsoft's CDN redirects to a geofenced URL that causes apt-get exit code 100.

Tested locally on Ubuntu 24.04: clean install of msodbcsql18, msodbcsql17, unixodbc, tdsodbc, freetds-dev succeeds with all three ODBC drivers registered (FreeTDS, Driver 17, Driver 18).

https://claude.ai/code/session_018pjq8Q7vNf7mWGARyJZPNe