### PR TITLE
Add user confirmation flow for artifact creation and editing

### DIFF
--- a/frontend/components/tools/CreateArtifactTool.vue
+++ b/frontend/components/tools/CreateArtifactTool.vue
@@ -236,7 +236,7 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-const emit = defineEmits(['openArtifact', 'toggleSplitScreen'])
+const emit = defineEmits(['openArtifact', 'toggleSplitScreen', 'stopGeneration'])
 const toast = useToast()
 
 const isCollapsed = ref(false)
@@ -321,6 +321,8 @@ async function rejectConfirmation() {
       body: { approved: false },
     })
   } catch {}
+  // Kill the entire streaming session
+  emit('stopGeneration')
 }
 
 // Labels

--- a/frontend/components/tools/EditArtifactTool.vue
+++ b/frontend/components/tools/EditArtifactTool.vue
@@ -190,7 +190,7 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-const emit = defineEmits(['openArtifact', 'toggleSplitScreen'])
+const emit = defineEmits(['openArtifact', 'toggleSplitScreen', 'stopGeneration'])
 const toast = useToast()
 
 const isCollapsed = ref(true)
@@ -258,6 +258,8 @@ async function rejectConfirmation() {
       body: { approved: false },
     })
   } catch {}
+  // Kill the entire streaming session
+  emit('stopGeneration')
 }
 
 const errorMessage = computed(() => props.toolExecution.result_json?.error || '')

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -178,6 +178,7 @@
 													@toggleSplitScreen="toggleSplitScreen"
 													@editQuery="handleEditQuery"
 													@openArtifact="handleOpenArtifact"
+													@stopGeneration="abortStream"
 												/>
 												<!-- Fallback to generic expandable tool display -->
 												<div v-else>


### PR DESCRIPTION
## Summary
This PR implements a user confirmation workflow for artifact creation and editing operations. Before finalizing artifacts, users are now presented with a confirmation dialog showing visualization previews and allowing them to edit the artifact title. The confirmation auto-approves after 5 seconds if the user doesn't respond.

## Key Changes

**Frontend Components:**
- Added confirmation card UI to `CreateArtifactTool.vue` and `EditArtifactTool.vue` with:
  - Visualization badges preview
  - Editable title input field
  - Approve/Cancel action buttons
  - 5-second auto-approval countdown timer
- Display resolved visualizations as badges after confirmation is resolved
- Hide progress stage text while confirmation is pending

**Backend Tool Implementations:**
- Modified `create_artifact.py` and `edit_artifact.py` to:
  - Emit `ToolConfirmationEvent` with visualization details before finalizing
  - Wait for user confirmation with 5-second timeout (auto-approves on timeout)
  - Apply user-provided title edits if supplied
  - Emit `ToolProgressEvent` with resolved visualizations for UI persistence
  - Cancel artifact creation/editing if user rejects confirmation

**New Confirmation System:**
- Created `app/ai/tools/confirmation.py` module with:
  - `wait_for_confirmation()` async function for tools to pause and wait for user response
  - `resolve_confirmation()` function to handle frontend confirmation submissions
  - Global `PENDING_CONFIRMATIONS` registry to track in-flight confirmations

**API Endpoint:**
- Added `POST /api/artifacts/confirm/{confirmation_id}` endpoint to receive user confirmation responses with optional title updates

**Event System:**
- Added `ToolConfirmationEvent` type to event schema
- Updated report page to handle `tool.confirmation` events and store confirmation state on tool execution
- Added handling for `visualizations_resolved` progress stage to persist visualization badges

## Implementation Details
- Confirmation IDs are generated using UUID4 for uniqueness
- Frontend countdown timer is properly cleaned up on component unmount
- Auto-approval timeout is 5 seconds, matching the countdown display
- User can edit the artifact title during confirmation before approval
- Rejected confirmations result in tool execution ending with "User cancelled" error
- Visualization badges display differently during confirmation (amber border) vs. after resolution (gray background)

https://claude.ai/code/session_01T3URRksZWP7fdDWkeCM4M2