### PR TITLE
Add Sandbox Feedback Loop Design documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ backend/logs
 *.pyc
 backend/alembic.ini
 backend/app.db
+
+# Sandbox session state (credentials, tokens, IDs)
+backend/sandbox_state.json

--- a/SANDBOX_FEEDBACK_LOOP.md
+++ b/SANDBOX_FEEDBACK_LOOP.md
@@ -1,284 +1,243 @@
 # Sandbox Feedback Loop Design
 
-Design for enabling Claude to debug, iterate, and validate changes inside a sandbox environment.
+How Claude debugs, iterates, and validates changes in a local dev environment.
 
-## Principles
+## How It Works
 
-1. **Two feedback loops, not one.** Backend and frontend changes have different needs.
-2. **Fixtures are the preferred action path.** Governed, token-managed, encode domain logic.
-3. **curl is the escape hatch.** When no fixture exists, Claude reads route files and Pydantic schemas to construct the call.
-4. **Persistent DB per session.** No per-test wipe. State accumulates like a real dev environment.
-5. **Claude is the judge for visual output.** Playwright is a camera, not a test framework.
-
-## Architecture Overview
+Local dev is already running (`python main.py` + `yarn dev`). The DB is `backend/db/app.db` (persistent SQLite). Claude uses curl to drive the app, pytest for backend validation, Playwright for visual validation, and sqlite3 to inspect state.
 
 ```
-                    SANDBOX SESSION
-                    ===============
-
-One-time setup:
-  pip install -r requirements_versioned.txt
-  cd frontend && yarn install && npx playwright install chromium
-  cd backend && alembic upgrade head
-  python main.py &          # auto-reload on .py changes
-  cd frontend && yarn dev & # HMR on .vue/.ts changes
-  python tests/sandbox_seed.py  # bootstrap user/org/data source
-
-Two feedback loops:
-
-  BACKEND CHANGE (.py)              FRONTEND CHANGE (.vue/.ts)
-  ─────────────────────             ──────────────────────────
-  pytest -s -m e2e --db=sqlite      Playwright screenshot
-  Fixtures handle setup              Claude looks at the image
-  Assertions validate                curl/fixtures drive the API
-  Fast, deterministic                sqlite3 to inspect state
-  No server needed (TestClient)      Servers already hot (HMR)
+Claude edits code
+  → backend auto-reloads (python main.py has reload=True)
+  → frontend HMR picks up .vue/.ts changes (yarn dev)
+  → Claude validates:
+      Backend change?  → pytest
+      Frontend change? → Playwright screenshot → Claude looks at it
+      Either?          → sqlite3 db/app.db to inspect state
+      Not sure?        → curl the API and check the response
 ```
 
 ## Sandbox Setup
 
-### Environment
+### First-Time Setup
 
-No Docker. Bare Python 3.12 + Node 22 in the sandbox.
-
-```bash
-# Install backend deps
-cd backend
-pip install -r requirements_versioned.txt
-
-# Install frontend deps
-cd frontend
-yarn install
-npx playwright install chromium
-
-# Create persistent SQLite DB
-cd backend
-mkdir -p db uploads/files uploads/branding
-alembic upgrade head  # schema in db/sandbox.db
-```
-
-### Servers
-
-Both run with auto-reload. Start once, leave running for the entire session.
+If the sandbox user doesn't exist yet, create it:
 
 ```bash
-# Backend — auto-reloads on .py changes (reload=True in main.py)
-cd backend
-TESTING=true python main.py &
+# 1. Register sandbox user
+curl -X POST http://localhost:8000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "sandbox@bow.dev", "password": "Sandbox123!", "name": "Sandbox Admin"}'
 
-# Frontend — HMR on .vue/.ts changes
-cd frontend
-yarn dev &
+# 2. Login — save the token
+curl -X POST http://localhost:8000/api/auth/jwt/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d 'username=sandbox@bow.dev&password=Sandbox123!'
+# → {"access_token": "eyJ...", "token_type": "bearer"}
 
-# Wait for both to be ready
-timeout 60 bash -c 'until curl -s http://localhost:8000/health > /dev/null 2>&1; do sleep 1; done'
-timeout 60 bash -c 'until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done'
+# 3. Get organization (auto-created on first user)
+curl http://localhost:8000/api/organizations \
+  -H "Authorization: Bearer $TOKEN"
+# → [{"id": "...", "name": "..."}]  — save the org id
+
+# 4. Install demo data source (chinook SQLite)
+curl http://localhost:8000/api/data_sources/demos \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+# → list of demos — find chinook, save its id
+
+curl -X POST http://localhost:8000/api/data_sources/demos/$DEMO_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+# → {"id": "...", "data_source_id": "..."}  — save data source id
 ```
 
-### Seed Script
+### Returning Session
 
-Bootstraps the minimum state needed to use the app. Runs against the live server.
-
-```python
-# backend/tests/sandbox_seed.py
-"""
-One-time sandbox bootstrap. Run after servers are up.
-Creates admin user, organization, and demo data source.
-Saves session state to sandbox_state.json.
-"""
-import requests
-import json
-
-BASE = "http://localhost:8000"
-
-def seed():
-    # 1. Register admin user
-    r = requests.post(f"{BASE}/api/auth/register", json={
-        "email": "admin@sandbox.dev",
-        "password": "Sandbox123!",
-        "name": "Sandbox Admin"
-    })
-    assert r.status_code == 201, f"Register failed: {r.text}"
-
-    # 2. Login
-    r = requests.post(f"{BASE}/api/auth/jwt/login", data={
-        "username": "admin@sandbox.dev",
-        "password": "Sandbox123!"
-    })
-    token = r.json()["access_token"]
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
-
-    # 3. Create organization (auto-created on first user, fetch it)
-    r = requests.get(f"{BASE}/api/organizations", headers=headers)
-    org = r.json()[0]
-    headers["X-Organization-Id"] = str(org["id"])
-
-    # 4. Install demo data source (chinook SQLite)
-    r = requests.get(f"{BASE}/api/demo-data-sources", headers=headers)
-    demos = r.json()
-    chinook = next(d for d in demos if "chinook" in d["name"].lower())
-    r = requests.post(
-        f"{BASE}/api/demo-data-sources/{chinook['id']}/install",
-        headers=headers
-    )
-    ds = r.json()
-
-    # 5. Save state
-    state = {
-        "token": token,
-        "org_id": org["id"],
-        "ds_id": ds["id"],
-        "email": "admin@sandbox.dev",
-        "password": "Sandbox123!",
-        "base_url": BASE
-    }
-    with open("sandbox_state.json", "w") as f:
-        json.dump(state, f, indent=2)
-
-    print(f"Sandbox ready.")
-    print(f"  Token:   {token[:20]}...")
-    print(f"  Org ID:  {org['id']}")
-    print(f"  DS ID:   {ds['id']}")
-    print(f"  State:   sandbox_state.json")
-    return state
-
-if __name__ == "__main__":
-    seed()
-```
-
-### DB Snapshots
-
-The persistent SQLite DB can accumulate garbage over many iterations. Use snapshots to reset to a known good state.
+If the sandbox user already exists, just login:
 
 ```bash
-# After seed, take a snapshot
-cp backend/db/sandbox.db backend/db/sandbox_snapshot.db
-
-# When state gets corrupted, restore
-cp backend/db/sandbox_snapshot.db backend/db/sandbox.db
-# Restart backend to pick up the fresh DB
+curl -X POST http://localhost:8000/api/auth/jwt/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d 'username=sandbox@bow.dev&password=Sandbox123!'
 ```
 
-## Feedback Loop 1: Backend (pytest)
+### Known Credentials
 
-For changes to `backend/app/**` files.
-
-Uses the **existing pytest infrastructure** with no modifications. Fixtures handle setup, assertions handle validation, TestClient runs in-process (no server dependency).
-
-```bash
-# Run relevant e2e tests
-cd backend
-TESTING=true pytest -s -m e2e --db=sqlite -k test_relevant_thing --disable-warnings
-
-# If changes touch backend/app/ai/**, also run AI tests
-TESTING=true pytest -s -m ai --db=sqlite --disable-warnings
-```
-
-### How It Works
-
-- `conftest.py` creates a fresh SQLite DB per test function (isolated from sandbox DB)
-- Fixtures chain: `create_user` -> `login_user` -> `create_organization` -> `create_report` -> etc.
-- TestClient calls endpoints in-process (no HTTP, no server)
-- Each test gets clean state, asserts deterministic outcomes
-- This is the same flow as CI (`e2e-tests.yml`)
-
-### When to Use
-
-- API logic changes
-- Service layer changes
-- Model/migration changes
-- Auth/permission changes
-- Any backend bug fix
-
-## Feedback Loop 2: Frontend (Playwright + Claude's eyes)
-
-For changes to `frontend/**` files or visual validation of artifacts.
-
-Uses the **running servers** (python main.py + yarn dev) with the **seeded persistent DB**.
-
-### Actions: How Claude Drives the App
-
-**Priority 1 — Fixtures (governed, efficient):**
-
-The existing test fixtures in `backend/tests/fixtures/` are the preferred way to perform actions. They encode domain logic, handle auth tokens, and know the exact payload shapes.
-
-For the sandbox, fixtures are called via the real server (not TestClient). The inner functions are the same — they just need a different HTTP client. Example:
-
-```python
-# Fixture pattern (from tests/fixtures/report.py):
-# response = test_client.post("/api/reports", json=payload, headers=headers)
-#
-# In sandbox, same call via requests:
-# response = requests.post("http://localhost:8000/api/reports", json=payload, headers=headers)
-```
-
-Available fixture files (each contains multiple actions):
-
-| Fixture file | Actions |
+| | Value |
 |---|---|
-| `fixtures/user.py` | create_user |
-| `fixtures/auth.py` | login_user, whoami |
-| `fixtures/organization.py` | create_organization, add_member, update_member, remove_member |
-| `fixtures/report.py` | create_report, get_reports, update_report, delete_report, publish, rerun, schedule, fork |
-| `fixtures/completion.py` | create_completion, get_completions, create_completion_stream |
-| `fixtures/data_source.py` | create_data_source, get_data_sources, test_connection, update, delete, get_schema, refresh_schema |
-| `fixtures/instruction.py` | create_instruction, create_global_instruction, get/update/delete, bulk operations |
-| `fixtures/eval.py` | create_test_suite, create_test_case, create_test_run, get results |
-| `fixtures/file.py` | upload_file, upload_csv, upload_excel, get_files |
-| `fixtures/connection.py` | create_connection, get/update/delete, test connectivity, refresh schema |
-| `fixtures/api_key.py` | create_api_key, list, delete |
-| `fixtures/build.py` | get_builds, get_build, get_main_build, get_diff, rollback |
-| `fixtures/organization_settings.py` | get/update settings, upload/delete icon |
-| `fixtures/console_metrics.py` | get_console_metrics, timeseries, table_usage, top_users |
-| `fixtures/git_repository.py` | create/get/update/delete repo, index, sync, push |
+| Email | `sandbox@bow.dev` |
+| Password | `Sandbox123!` |
+| DB path | `backend/db/app.db` |
+| Backend | `http://localhost:8000` |
+| Frontend | `http://localhost:3000` |
 
-**Priority 2 — curl (fallback, self-service):**
+## Auth Pattern
 
-When no fixture exists for an action, Claude reads the source of truth and constructs a curl call:
+All API calls use the same auth headers:
 
-1. **Route file** (`backend/app/routes/*.py`) — Shows endpoint path, HTTP method, auth dependencies, query parameters
-2. **Pydantic schema** (`backend/app/schemas/*.py`) — Shows exact request body shape with field types, defaults, and validation
-
-Route files to reference:
-
-| Route file | Endpoints |
-|---|---|
-| `routes/report.py` | `/api/reports` CRUD |
-| `routes/completion.py` | `/api/completions` (chat/stream) |
-| `routes/artifact.py` | `/api/artifacts` CRUD, export, previews |
-| `routes/data_source.py` | `/api/data-sources` CRUD, schema, metadata |
-| `routes/instruction.py` | `/api/instructions` CRUD, bulk ops |
-| `routes/llm.py` | `/api/llm` provider management |
-| `routes/organization.py` | `/api/organizations` CRUD, members |
-| `routes/auth.py` | `/api/auth` register, login, JWT |
-| `routes/query.py` | `/api/queries` CRUD |
-| `routes/step.py` | `/api/steps` execution steps |
-| `routes/test.py` | `/api/test-suites`, `/api/test-runs` evals |
-
-**Auth pattern** (same for all endpoints):
 ```bash
-curl -X POST http://localhost:8000/api/{endpoint} \
+curl -X {METHOD} http://localhost:8000/api/{endpoint} \
   -H "Authorization: Bearer $TOKEN" \
   -H "X-Organization-Id: $ORG_ID" \
   -H "Content-Type: application/json" \
-  -d '{ ... payload matching Pydantic schema ... }'
+  -d '{ ... }'
 ```
 
-### Visual Validation
+## Popular Commands
 
-For frontend changes and artifact output, Playwright takes screenshots and Claude evaluates visually.
+### Reports
 
 ```bash
-# Take a screenshot of a specific page
-cd frontend
-npx playwright test tests/{relevant_dir}/ --workers=1
+# Create report
+curl -X POST http://localhost:8000/api/reports \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Test Report", "data_sources": ["$DS_ID"]}'
 
-# Or use Playwright directly for a quick screenshot:
-# (Claude can write a small script)
-python -c "
+# List reports
+curl http://localhost:8000/api/reports \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+
+# Get report
+curl http://localhost:8000/api/reports/$REPORT_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+
+# Delete report
+curl -X DELETE http://localhost:8000/api/reports/$REPORT_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+```
+
+### Completions (Chat)
+
+```bash
+# Create completion (triggers AI agent)
+curl -X POST http://localhost:8000/api/completions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"report_id": "$REPORT_ID", "message": "Show revenue by month"}'
+
+# List completions for a report
+curl http://localhost:8000/api/completions?report_id=$REPORT_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+```
+
+### Data Sources
+
+```bash
+# List data sources
+curl http://localhost:8000/api/data-sources \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+
+# Get schema for a data source
+curl http://localhost:8000/api/data-sources/$DS_ID/schema \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+```
+
+### Instructions
+
+```bash
+# Create instruction
+curl -X POST http://localhost:8000/api/instructions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Always use metric units", "scope": "global"}'
+
+# List instructions
+curl http://localhost:8000/api/instructions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+```
+
+### Artifacts
+
+```bash
+# Get artifacts for a report
+curl http://localhost:8000/api/artifacts/report/$REPORT_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+
+# Get latest artifact
+curl http://localhost:8000/api/artifacts/report/$REPORT_ID/latest \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID"
+```
+
+## When curl Isn't Enough
+
+If the endpoint isn't listed above, read the source of truth:
+
+1. **Route file** (`backend/app/routes/*.py`) — endpoint path, method, auth, query params
+2. **Pydantic schema** (`backend/app/schemas/*.py`) — exact request body shape, field types, defaults
+
+Key route files:
+
+| File | What |
+|---|---|
+| `routes/report.py` | Reports CRUD |
+| `routes/completion.py` | Chat completions, streaming |
+| `routes/artifact.py` | Artifacts CRUD, export, previews |
+| `routes/data_source.py` | Data sources CRUD, schema, metadata |
+| `routes/instruction.py` | Instructions CRUD, bulk ops |
+| `routes/llm.py` | LLM provider management |
+| `routes/organization.py` | Organizations, members |
+| `routes/query.py` | Saved queries |
+| `routes/test.py` | Eval suites and runs |
+| `routes/connection.py` | External connections |
+| `routes/step.py` | Execution steps |
+| `routes/build.py` | Build versioning |
+
+## Backend Validation: pytest
+
+For backend code changes. Uses existing test infrastructure — no modifications needed.
+
+```bash
+cd backend
+
+# Run e2e tests
+TESTING=true pytest -s -m e2e --db=sqlite --disable-warnings
+
+# Run specific test
+TESTING=true pytest -s -m e2e --db=sqlite -k test_create_report --disable-warnings
+
+# Run AI tests (when changing backend/app/ai/**)
+TESTING=true pytest -s -m ai --db=sqlite --disable-warnings
+```
+
+Pytest uses its own isolated DB (not `app.db`). Each test gets a fresh DB via fixtures. This matches CI exactly.
+
+## Frontend Validation: Playwright + Claude's Eyes
+
+For frontend/visual changes. Servers must be running.
+
+### Run Existing Playwright Tests
+
+```bash
+cd frontend
+
+# Run all tests
+npx playwright test --workers=2
+
+# Run specific test suite
+npx playwright test tests/reports/ --workers=1
+
+# Run a single test file
+npx playwright test tests/reports/create-report.spec.ts
+```
+
+### Quick Screenshot (Ad-Hoc)
+
+```python
+# Take a screenshot for Claude to evaluate
 from playwright.sync_api import sync_playwright
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
@@ -287,109 +246,43 @@ with sync_playwright() as p:
     page.wait_for_load_state('networkidle')
     page.screenshot(path='/tmp/screenshot.png', full_page=True)
     browser.close()
-"
-# Claude then reads /tmp/screenshot.png to evaluate the result
 ```
 
-### State Inspection
+Claude reads the screenshot to evaluate: Does it look right? Any errors? Data showing?
 
-Claude can query the persistent SQLite DB directly to understand what was persisted:
+### Artifact Visual Validation
+
+For LLM-generated UI (non-deterministic — can't assert, must look):
+
+```
+1. Create a completion that generates an artifact (via curl)
+2. Playwright screenshots the rendered artifact
+3. Claude looks at the screenshot
+4. If wrong → edit code → servers hot-reload → re-trigger → re-screenshot
+```
+
+## State Inspection: sqlite3
 
 ```bash
-sqlite3 backend/db/sandbox.db "SELECT id, title, status FROM reports"
-sqlite3 backend/db/sandbox.db "SELECT id, mode, version FROM artifacts WHERE report_id = '...'"
-sqlite3 backend/db/sandbox.db ".schema artifacts"
+# Check what's in the DB
+sqlite3 backend/db/app.db "SELECT id, title, status FROM reports"
+sqlite3 backend/db/app.db "SELECT id, mode, version FROM artifacts"
+sqlite3 backend/db/app.db ".tables"
+sqlite3 backend/db/app.db ".schema reports"
 ```
 
-### When to Use
+## Decision Matrix
 
-- Vue/TypeScript component changes
-- Artifact generation/rendering changes
-- CSS/layout changes
-- Any visual/UX change
-- Flows involving SSE, WebSocket, or real HTTP middleware
+| Change | Validate with |
+|---|---|
+| Backend API/service/model | `pytest -s -m e2e --db=sqlite` |
+| Backend AI logic | `pytest -s -m ai --db=sqlite` |
+| Frontend component/page | Playwright screenshot → Claude evaluates |
+| Artifact generation | curl → trigger creation → screenshot → Claude evaluates |
+| Not sure what broke | `sqlite3 app.db` to inspect + server logs |
 
-## Artifact-Specific Flow
+## What Stays Unchanged
 
-The artifact creation flow is the primary use case for visual validation. The generated UI is non-deterministic (LLM-generated React/HTML), so traditional assertions can't validate it.
-
-```
-Claude edits artifact generation code (e.g. create_artifact.py, prompts)
-  |
-  v
-Trigger artifact creation:
-  curl -X POST localhost:8000/api/completions \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "X-Organization-Id: $ORG_ID" \
-    -d '{"report_id": "...", "message": "Create a revenue dashboard"}'
-  |
-  v
-Wait for completion, then screenshot:
-  Playwright navigates to localhost:3000/reports/{report_id}
-  Takes screenshot of the rendered artifact
-  |
-  v
-Claude looks at the screenshot:
-  - Does the dashboard show data?
-  - Are charts rendered correctly?
-  - Any JS errors visible?
-  - Does the layout match the intent?
-  |
-  v
-If not right: edit code -> servers hot-reload -> re-trigger -> re-screenshot
-```
-
-This mirrors the existing validation loop in `create_artifact.py` (lines 341-430) where Playwright renders artifacts and the LLM evaluates screenshots, but now applied to the development workflow itself.
-
-## Environment Variables
-
-Sandbox uses a minimal set of env vars. Defined in `.env.sandbox`:
-
-```bash
-# Required
-TESTING=true
-ENVIRONMENT=development
-
-# Database (SQLite, no Postgres needed)
-# Uses default from settings — no override needed
-
-# Encryption (auto-generated if not set, per start.sh)
-# BOW_ENCRYPTION_KEY=
-
-# Optional: LLM for artifact generation / AI tests
-# OPENAI_API_KEY_TEST=sk-...
-```
-
-## Decision Matrix: Which Loop to Use
-
-| Files changed | Feedback loop | Command |
-|---|---|---|
-| `backend/app/**` (not ai/) | pytest e2e | `pytest -s -m e2e --db=sqlite` |
-| `backend/app/ai/**` | pytest e2e + ai | `pytest -s -m e2e -s -m ai --db=sqlite` |
-| `frontend/**` | Playwright | Screenshots + Claude evaluates |
-| `backend/` + `frontend/` | Both | pytest first, then Playwright |
-| Artifact prompts/tools | Artifact flow | Create artifact -> screenshot -> evaluate |
-
-## What NOT to Change
-
-- **Existing pytest fixtures** — Stay as-is for CI/CD. Per-test DB isolation is correct for deterministic testing.
-- **CI/CD workflow** (`e2e-tests.yml`) — Unchanged. The sandbox is a separate, complementary workflow.
-- **Fixture structure** — No dual-use refactoring. Fixtures remain pytest-native. Claude reads them as documentation and translates to curl when needed.
-
-## Summary
-
-```
-CI/CD (existing, unchanged)           SANDBOX (new)
-========================               =======
-
-pytest + fixtures + assertions         Servers + seed + fixtures/curl + Claude's eyes
-Fresh DB per test                      Persistent DB per session
-TestClient (in-process)                Real HTTP (SSE, WS, middleware)
-Deterministic pass/fail                Claude judges visual output
-Runs on push/PR                        Runs during development
-
-Shared source of truth:
-  - Route files (backend/app/routes/*.py)
-  - Pydantic schemas (backend/app/schemas/*.py)
-  - Test fixtures (backend/tests/fixtures/*.py)
-```
+- **Existing pytest fixtures** — for CI/CD, per-test isolation, deterministic
+- **CI/CD workflows** (`e2e-tests.yml`) — sandbox is complementary, not a replacement
+- **`backend/db/app.db`** — persistent, not wiped between iterations

--- a/SANDBOX_FEEDBACK_LOOP.md
+++ b/SANDBOX_FEEDBACK_LOOP.md
@@ -1,0 +1,395 @@
+# Sandbox Feedback Loop Design
+
+Design for enabling Claude to debug, iterate, and validate changes inside a sandbox environment.
+
+## Principles
+
+1. **Two feedback loops, not one.** Backend and frontend changes have different needs.
+2. **Fixtures are the preferred action path.** Governed, token-managed, encode domain logic.
+3. **curl is the escape hatch.** When no fixture exists, Claude reads route files and Pydantic schemas to construct the call.
+4. **Persistent DB per session.** No per-test wipe. State accumulates like a real dev environment.
+5. **Claude is the judge for visual output.** Playwright is a camera, not a test framework.
+
+## Architecture Overview
+
+```
+                    SANDBOX SESSION
+                    ===============
+
+One-time setup:
+  pip install -r requirements_versioned.txt
+  cd frontend && yarn install && npx playwright install chromium
+  cd backend && alembic upgrade head
+  python main.py &          # auto-reload on .py changes
+  cd frontend && yarn dev & # HMR on .vue/.ts changes
+  python tests/sandbox_seed.py  # bootstrap user/org/data source
+
+Two feedback loops:
+
+  BACKEND CHANGE (.py)              FRONTEND CHANGE (.vue/.ts)
+  ─────────────────────             ──────────────────────────
+  pytest -s -m e2e --db=sqlite      Playwright screenshot
+  Fixtures handle setup              Claude looks at the image
+  Assertions validate                curl/fixtures drive the API
+  Fast, deterministic                sqlite3 to inspect state
+  No server needed (TestClient)      Servers already hot (HMR)
+```
+
+## Sandbox Setup
+
+### Environment
+
+No Docker. Bare Python 3.12 + Node 22 in the sandbox.
+
+```bash
+# Install backend deps
+cd backend
+pip install -r requirements_versioned.txt
+
+# Install frontend deps
+cd frontend
+yarn install
+npx playwright install chromium
+
+# Create persistent SQLite DB
+cd backend
+mkdir -p db uploads/files uploads/branding
+alembic upgrade head  # schema in db/sandbox.db
+```
+
+### Servers
+
+Both run with auto-reload. Start once, leave running for the entire session.
+
+```bash
+# Backend — auto-reloads on .py changes (reload=True in main.py)
+cd backend
+TESTING=true python main.py &
+
+# Frontend — HMR on .vue/.ts changes
+cd frontend
+yarn dev &
+
+# Wait for both to be ready
+timeout 60 bash -c 'until curl -s http://localhost:8000/health > /dev/null 2>&1; do sleep 1; done'
+timeout 60 bash -c 'until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done'
+```
+
+### Seed Script
+
+Bootstraps the minimum state needed to use the app. Runs against the live server.
+
+```python
+# backend/tests/sandbox_seed.py
+"""
+One-time sandbox bootstrap. Run after servers are up.
+Creates admin user, organization, and demo data source.
+Saves session state to sandbox_state.json.
+"""
+import requests
+import json
+
+BASE = "http://localhost:8000"
+
+def seed():
+    # 1. Register admin user
+    r = requests.post(f"{BASE}/api/auth/register", json={
+        "email": "admin@sandbox.dev",
+        "password": "Sandbox123!",
+        "name": "Sandbox Admin"
+    })
+    assert r.status_code == 201, f"Register failed: {r.text}"
+
+    # 2. Login
+    r = requests.post(f"{BASE}/api/auth/jwt/login", data={
+        "username": "admin@sandbox.dev",
+        "password": "Sandbox123!"
+    })
+    token = r.json()["access_token"]
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json"
+    }
+
+    # 3. Create organization (auto-created on first user, fetch it)
+    r = requests.get(f"{BASE}/api/organizations", headers=headers)
+    org = r.json()[0]
+    headers["X-Organization-Id"] = str(org["id"])
+
+    # 4. Install demo data source (chinook SQLite)
+    r = requests.get(f"{BASE}/api/demo-data-sources", headers=headers)
+    demos = r.json()
+    chinook = next(d for d in demos if "chinook" in d["name"].lower())
+    r = requests.post(
+        f"{BASE}/api/demo-data-sources/{chinook['id']}/install",
+        headers=headers
+    )
+    ds = r.json()
+
+    # 5. Save state
+    state = {
+        "token": token,
+        "org_id": org["id"],
+        "ds_id": ds["id"],
+        "email": "admin@sandbox.dev",
+        "password": "Sandbox123!",
+        "base_url": BASE
+    }
+    with open("sandbox_state.json", "w") as f:
+        json.dump(state, f, indent=2)
+
+    print(f"Sandbox ready.")
+    print(f"  Token:   {token[:20]}...")
+    print(f"  Org ID:  {org['id']}")
+    print(f"  DS ID:   {ds['id']}")
+    print(f"  State:   sandbox_state.json")
+    return state
+
+if __name__ == "__main__":
+    seed()
+```
+
+### DB Snapshots
+
+The persistent SQLite DB can accumulate garbage over many iterations. Use snapshots to reset to a known good state.
+
+```bash
+# After seed, take a snapshot
+cp backend/db/sandbox.db backend/db/sandbox_snapshot.db
+
+# When state gets corrupted, restore
+cp backend/db/sandbox_snapshot.db backend/db/sandbox.db
+# Restart backend to pick up the fresh DB
+```
+
+## Feedback Loop 1: Backend (pytest)
+
+For changes to `backend/app/**` files.
+
+Uses the **existing pytest infrastructure** with no modifications. Fixtures handle setup, assertions handle validation, TestClient runs in-process (no server dependency).
+
+```bash
+# Run relevant e2e tests
+cd backend
+TESTING=true pytest -s -m e2e --db=sqlite -k test_relevant_thing --disable-warnings
+
+# If changes touch backend/app/ai/**, also run AI tests
+TESTING=true pytest -s -m ai --db=sqlite --disable-warnings
+```
+
+### How It Works
+
+- `conftest.py` creates a fresh SQLite DB per test function (isolated from sandbox DB)
+- Fixtures chain: `create_user` -> `login_user` -> `create_organization` -> `create_report` -> etc.
+- TestClient calls endpoints in-process (no HTTP, no server)
+- Each test gets clean state, asserts deterministic outcomes
+- This is the same flow as CI (`e2e-tests.yml`)
+
+### When to Use
+
+- API logic changes
+- Service layer changes
+- Model/migration changes
+- Auth/permission changes
+- Any backend bug fix
+
+## Feedback Loop 2: Frontend (Playwright + Claude's eyes)
+
+For changes to `frontend/**` files or visual validation of artifacts.
+
+Uses the **running servers** (python main.py + yarn dev) with the **seeded persistent DB**.
+
+### Actions: How Claude Drives the App
+
+**Priority 1 — Fixtures (governed, efficient):**
+
+The existing test fixtures in `backend/tests/fixtures/` are the preferred way to perform actions. They encode domain logic, handle auth tokens, and know the exact payload shapes.
+
+For the sandbox, fixtures are called via the real server (not TestClient). The inner functions are the same — they just need a different HTTP client. Example:
+
+```python
+# Fixture pattern (from tests/fixtures/report.py):
+# response = test_client.post("/api/reports", json=payload, headers=headers)
+#
+# In sandbox, same call via requests:
+# response = requests.post("http://localhost:8000/api/reports", json=payload, headers=headers)
+```
+
+Available fixture files (each contains multiple actions):
+
+| Fixture file | Actions |
+|---|---|
+| `fixtures/user.py` | create_user |
+| `fixtures/auth.py` | login_user, whoami |
+| `fixtures/organization.py` | create_organization, add_member, update_member, remove_member |
+| `fixtures/report.py` | create_report, get_reports, update_report, delete_report, publish, rerun, schedule, fork |
+| `fixtures/completion.py` | create_completion, get_completions, create_completion_stream |
+| `fixtures/data_source.py` | create_data_source, get_data_sources, test_connection, update, delete, get_schema, refresh_schema |
+| `fixtures/instruction.py` | create_instruction, create_global_instruction, get/update/delete, bulk operations |
+| `fixtures/eval.py` | create_test_suite, create_test_case, create_test_run, get results |
+| `fixtures/file.py` | upload_file, upload_csv, upload_excel, get_files |
+| `fixtures/connection.py` | create_connection, get/update/delete, test connectivity, refresh schema |
+| `fixtures/api_key.py` | create_api_key, list, delete |
+| `fixtures/build.py` | get_builds, get_build, get_main_build, get_diff, rollback |
+| `fixtures/organization_settings.py` | get/update settings, upload/delete icon |
+| `fixtures/console_metrics.py` | get_console_metrics, timeseries, table_usage, top_users |
+| `fixtures/git_repository.py` | create/get/update/delete repo, index, sync, push |
+
+**Priority 2 — curl (fallback, self-service):**
+
+When no fixture exists for an action, Claude reads the source of truth and constructs a curl call:
+
+1. **Route file** (`backend/app/routes/*.py`) — Shows endpoint path, HTTP method, auth dependencies, query parameters
+2. **Pydantic schema** (`backend/app/schemas/*.py`) — Shows exact request body shape with field types, defaults, and validation
+
+Route files to reference:
+
+| Route file | Endpoints |
+|---|---|
+| `routes/report.py` | `/api/reports` CRUD |
+| `routes/completion.py` | `/api/completions` (chat/stream) |
+| `routes/artifact.py` | `/api/artifacts` CRUD, export, previews |
+| `routes/data_source.py` | `/api/data-sources` CRUD, schema, metadata |
+| `routes/instruction.py` | `/api/instructions` CRUD, bulk ops |
+| `routes/llm.py` | `/api/llm` provider management |
+| `routes/organization.py` | `/api/organizations` CRUD, members |
+| `routes/auth.py` | `/api/auth` register, login, JWT |
+| `routes/query.py` | `/api/queries` CRUD |
+| `routes/step.py` | `/api/steps` execution steps |
+| `routes/test.py` | `/api/test-suites`, `/api/test-runs` evals |
+
+**Auth pattern** (same for all endpoints):
+```bash
+curl -X POST http://localhost:8000/api/{endpoint} \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Organization-Id: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ ... payload matching Pydantic schema ... }'
+```
+
+### Visual Validation
+
+For frontend changes and artifact output, Playwright takes screenshots and Claude evaluates visually.
+
+```bash
+# Take a screenshot of a specific page
+cd frontend
+npx playwright test tests/{relevant_dir}/ --workers=1
+
+# Or use Playwright directly for a quick screenshot:
+# (Claude can write a small script)
+python -c "
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+    page.goto('http://localhost:3000/reports/{report_id}')
+    page.wait_for_load_state('networkidle')
+    page.screenshot(path='/tmp/screenshot.png', full_page=True)
+    browser.close()
+"
+# Claude then reads /tmp/screenshot.png to evaluate the result
+```
+
+### State Inspection
+
+Claude can query the persistent SQLite DB directly to understand what was persisted:
+
+```bash
+sqlite3 backend/db/sandbox.db "SELECT id, title, status FROM reports"
+sqlite3 backend/db/sandbox.db "SELECT id, mode, version FROM artifacts WHERE report_id = '...'"
+sqlite3 backend/db/sandbox.db ".schema artifacts"
+```
+
+### When to Use
+
+- Vue/TypeScript component changes
+- Artifact generation/rendering changes
+- CSS/layout changes
+- Any visual/UX change
+- Flows involving SSE, WebSocket, or real HTTP middleware
+
+## Artifact-Specific Flow
+
+The artifact creation flow is the primary use case for visual validation. The generated UI is non-deterministic (LLM-generated React/HTML), so traditional assertions can't validate it.
+
+```
+Claude edits artifact generation code (e.g. create_artifact.py, prompts)
+  |
+  v
+Trigger artifact creation:
+  curl -X POST localhost:8000/api/completions \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Organization-Id: $ORG_ID" \
+    -d '{"report_id": "...", "message": "Create a revenue dashboard"}'
+  |
+  v
+Wait for completion, then screenshot:
+  Playwright navigates to localhost:3000/reports/{report_id}
+  Takes screenshot of the rendered artifact
+  |
+  v
+Claude looks at the screenshot:
+  - Does the dashboard show data?
+  - Are charts rendered correctly?
+  - Any JS errors visible?
+  - Does the layout match the intent?
+  |
+  v
+If not right: edit code -> servers hot-reload -> re-trigger -> re-screenshot
+```
+
+This mirrors the existing validation loop in `create_artifact.py` (lines 341-430) where Playwright renders artifacts and the LLM evaluates screenshots, but now applied to the development workflow itself.
+
+## Environment Variables
+
+Sandbox uses a minimal set of env vars. Defined in `.env.sandbox`:
+
+```bash
+# Required
+TESTING=true
+ENVIRONMENT=development
+
+# Database (SQLite, no Postgres needed)
+# Uses default from settings — no override needed
+
+# Encryption (auto-generated if not set, per start.sh)
+# BOW_ENCRYPTION_KEY=
+
+# Optional: LLM for artifact generation / AI tests
+# OPENAI_API_KEY_TEST=sk-...
+```
+
+## Decision Matrix: Which Loop to Use
+
+| Files changed | Feedback loop | Command |
+|---|---|---|
+| `backend/app/**` (not ai/) | pytest e2e | `pytest -s -m e2e --db=sqlite` |
+| `backend/app/ai/**` | pytest e2e + ai | `pytest -s -m e2e -s -m ai --db=sqlite` |
+| `frontend/**` | Playwright | Screenshots + Claude evaluates |
+| `backend/` + `frontend/` | Both | pytest first, then Playwright |
+| Artifact prompts/tools | Artifact flow | Create artifact -> screenshot -> evaluate |
+
+## What NOT to Change
+
+- **Existing pytest fixtures** — Stay as-is for CI/CD. Per-test DB isolation is correct for deterministic testing.
+- **CI/CD workflow** (`e2e-tests.yml`) — Unchanged. The sandbox is a separate, complementary workflow.
+- **Fixture structure** — No dual-use refactoring. Fixtures remain pytest-native. Claude reads them as documentation and translates to curl when needed.
+
+## Summary
+
+```
+CI/CD (existing, unchanged)           SANDBOX (new)
+========================               =======
+
+pytest + fixtures + assertions         Servers + seed + fixtures/curl + Claude's eyes
+Fresh DB per test                      Persistent DB per session
+TestClient (in-process)                Real HTTP (SSE, WS, middleware)
+Deterministic pass/fail                Claude judges visual output
+Runs on push/PR                        Runs during development
+
+Shared source of truth:
+  - Route files (backend/app/routes/*.py)
+  - Pydantic schemas (backend/app/schemas/*.py)
+  - Test fixtures (backend/tests/fixtures/*.py)
+```

--- a/SANDBOX_FEEDBACK_LOOP.md
+++ b/SANDBOX_FEEDBACK_LOOP.md
@@ -17,6 +17,65 @@ Claude edits code
       Not sure?        → curl the API and check the response
 ```
 
+## Environment Setup
+
+### Prerequisites
+
+Requires Python 3.12+ (the codebase uses PEP 701 f-string syntax), Node 22, and yarn.
+
+### System Dependencies
+
+```bash
+# Needed for psycopg2 build
+apt-get install -y libpq-dev
+
+# Upgrade setuptools (needed for thrift transitive dep)
+pip install --upgrade setuptools
+```
+
+### Backend
+
+```bash
+cd backend
+
+# Use Python 3.12 venv (system python may be 3.11)
+python3.12 -m venv .venv
+source .venv/bin/activate
+
+# Install deps
+pip install -r requirements_versioned.txt
+
+# Required env vars (dev config references these)
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+export BOW_SMTP_PASSWORD="dummy"
+
+# Create directories and run migrations
+mkdir -p db uploads/files uploads/branding
+alembic upgrade head
+
+# Start server (auto-reloads on .py changes)
+python main.py &
+```
+
+### Frontend
+
+```bash
+cd frontend
+yarn install
+
+# Start dev server (HMR on .vue/.ts changes)
+yarn dev &
+```
+
+### Playwright (for frontend screenshots)
+
+```bash
+cd frontend
+npx playwright install --with-deps chromium
+```
+
+Note: The dev config is loaded from `configs/bow-config.dev.yaml` (not the root `bow-config.yaml`).
+
 ## Sandbox Setup
 
 ### First-Time Setup
@@ -261,14 +320,21 @@ For LLM-generated UI (non-deterministic — can't assert, must look):
 4. If wrong → edit code → servers hot-reload → re-trigger → re-screenshot
 ```
 
-## State Inspection: sqlite3
+## State Inspection: SQLite
 
 ```bash
-# Check what's in the DB
+# If sqlite3 CLI is available:
 sqlite3 backend/db/app.db "SELECT id, title, status FROM reports"
-sqlite3 backend/db/app.db "SELECT id, mode, version FROM artifacts"
 sqlite3 backend/db/app.db ".tables"
-sqlite3 backend/db/app.db ".schema reports"
+
+# If not (common in sandboxes), use Python:
+python -c "
+import sqlite3
+conn = sqlite3.connect('backend/db/app.db')
+for row in conn.execute('SELECT id, title, status FROM reports'):
+    print(row)
+conn.close()
+"
 ```
 
 ## Decision Matrix

--- a/docs/design/sandbox-feedback-loop.md
+++ b/docs/design/sandbox-feedback-loop.md
@@ -76,11 +76,34 @@ npx playwright install --with-deps chromium
 
 Note: The dev config is loaded from `configs/bow-config.dev.yaml` (not the root `bow-config.yaml`).
 
+## Session State: `backend/sandbox_state.json`
+
+All session data (credentials, tokens, IDs) is stored in `backend/sandbox_state.json`. This file is **gitignored** — it never gets committed. Claude reads it at session start and updates it after setup/login.
+
+```json
+{
+  "credentials": {
+    "email": "sandbox@bow.dev",
+    "password": "Sandbox123!"
+  },
+  "session": {
+    "token": "eyJ...",
+    "org_id": "...",
+    "ds_id": "..."
+  },
+  "endpoints": {
+    "backend": "http://localhost:8000",
+    "frontend": "http://localhost:3000"
+  },
+  "db_path": "backend/db/app.db"
+}
+```
+
 ## Sandbox Setup
 
 ### First-Time Setup
 
-If the sandbox user doesn't exist yet, create it:
+If the sandbox user doesn't exist yet (or `sandbox_state.json` has null session values):
 
 ```bash
 # 1. Register sandbox user
@@ -109,27 +132,20 @@ curl -X POST http://localhost:8000/api/data_sources/demos/$DEMO_ID \
   -H "Authorization: Bearer $TOKEN" \
   -H "X-Organization-Id: $ORG_ID"
 # → {"id": "...", "data_source_id": "..."}  — save data source id
+
+# 5. Update sandbox_state.json with token, org_id, ds_id
 ```
 
 ### Returning Session
 
-If the sandbox user already exists, just login:
+If `sandbox_state.json` already has session values, just re-login to refresh the token:
 
 ```bash
 curl -X POST http://localhost:8000/api/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d 'username=sandbox@bow.dev&password=Sandbox123!'
+# Update token in sandbox_state.json
 ```
-
-### Known Credentials
-
-| | Value |
-|---|---|
-| Email | `sandbox@bow.dev` |
-| Password | `Sandbox123!` |
-| DB path | `backend/db/app.db` |
-| Backend | `http://localhost:8000` |
-| Frontend | `http://localhost:3000` |
 
 ## Auth Pattern
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the sandbox feedback loop—a guide for how Claude debugs, iterates, and validates changes in a local development environment.

## Key Changes

- **New documentation file** (`SANDBOX_FEEDBACK_LOOP.md`) covering:
  - Overview of the feedback loop workflow (code editing → auto-reload → validation)
  - Complete environment setup instructions for backend (Python 3.12, venv, dependencies, migrations)
  - Frontend setup (Node 22, yarn, HMR, Playwright)
  - Sandbox user creation and authentication flow
  - Known credentials and configuration for local development
  - Auth pattern for API calls with Bearer tokens and organization headers
  - Popular API command examples (Reports, Completions, Data Sources, Instructions, Artifacts)
  - Guide to finding undocumented endpoints (route files, Pydantic schemas)
  - Backend validation approach using pytest with isolated test databases
  - Frontend validation using Playwright screenshots and manual visual inspection
  - SQLite state inspection techniques for debugging
  - Decision matrix for choosing validation method by change type

## Notable Details

- Documents the persistent SQLite database at `backend/db/app.db` used across iterations
- Clarifies that pytest uses an isolated test DB (not `app.db`), matching CI behavior exactly
- Explains artifact validation workflow for non-deterministic LLM-generated UI
- Provides specific pytest commands for e2e and AI test suites
- Includes Python fallback for SQLite inspection when CLI is unavailable
- Maps route files to their responsibilities for quick endpoint lookup

https://claude.ai/code/session_014YsZdGZxeD5hP2UGCR4xX1