### PR TITLE
Add WhatsApp Cloud API integration

### DIFF
--- a/backend/app/routes/external_platform.py
+++ b/backend/app/routes/external_platform.py
@@ -15,6 +15,7 @@ from app.schemas.external_platform_schema import (
     ExternalPlatformSchema,
     SlackConfig,
     TeamsConfig,
+    WhatsAppConfig,
 )
 from app.models.external_platform import ExternalPlatform
 from app.ee.audit.service import audit_service
@@ -122,6 +123,41 @@ async def create_slack_integration(
             resource_type="integration",
             resource_id=result.id if hasattr(result, "id") else None,
             details={"type": "slack"},
+            request=request,
+        )
+    except Exception:
+        pass
+    return result
+
+@router.post("/settings/integrations/whatsapp", response_model=ExternalPlatformSchema)
+@requires_permission('manage_settings')
+async def create_whatsapp_integration(
+    data: WhatsAppConfig,
+    request: Request,
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db)
+):
+    """Create a new WhatsApp integration"""
+    result = await external_platform_service.create_whatsapp_platform(
+        db,
+        organization,
+        data.access_token,
+        data.phone_number_id,
+        data.waba_id,
+        data.app_secret,
+        data.verify_token,
+        current_user,
+    )
+    try:
+        await audit_service.log(
+            db=db,
+            organization_id=organization.id,
+            action="integration.created",
+            user_id=current_user.id,
+            resource_type="integration",
+            resource_id=result.id if hasattr(result, "id") else None,
+            details={"type": "whatsapp"},
             request=request,
         )
     except Exception:

--- a/backend/app/routes/whatsapp_webhook.py
+++ b/backend/app/routes/whatsapp_webhook.py
@@ -1,0 +1,165 @@
+"""WhatsApp Cloud API webhook.
+
+Mirrors slack_webhook.py's style:
+- Router is always mounted; effective "enablement" is the existence of an
+  ExternalPlatform row of type `whatsapp` whose `platform_config.phone_number_id`
+  matches the inbound event's metadata.
+- GET handles Meta's verification handshake.
+- POST verifies X-Hub-Signature-256 (when an app_secret is configured), dedupes
+  by message id, then dispatches to ExternalPlatformManager.
+"""
+
+from fastapi import APIRouter, Request, HTTPException, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import json
+import hmac
+import hashlib
+
+from app.dependencies import get_async_db
+from app.services.external_platform_manager import ExternalPlatformManager
+from app.services.external_platform_service import ExternalPlatformService
+from app.models.external_platform import ExternalPlatform
+
+
+router = APIRouter(tags=["whatsapp-webhook"])
+
+platform_manager = ExternalPlatformManager()
+platform_service = ExternalPlatformService()
+
+# Simple in-memory dedupe (same pattern as Slack webhook)
+processed_message_ids: set = set()
+
+
+async def _list_whatsapp_platforms(db: AsyncSession):
+    """List all WhatsApp ExternalPlatform rows (used by verify handshake)."""
+    stmt = select(ExternalPlatform).where(ExternalPlatform.platform_type == "whatsapp")
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _find_platform_by_phone_number_id(
+    db: AsyncSession, phone_number_id: str
+) -> ExternalPlatform | None:
+    """Look up the WhatsApp ExternalPlatform row for a given phone_number_id."""
+    if not phone_number_id:
+        return None
+    for platform in await _list_whatsapp_platforms(db):
+        config = platform.platform_config or {}
+        if config.get("phone_number_id") == phone_number_id:
+            return platform
+    return None
+
+
+@router.get("/api/settings/integrations/whatsapp/webhook")
+async def whatsapp_webhook_verify(
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Meta verification handshake.
+
+    Meta calls GET with query params:
+      hub.mode=subscribe
+      hub.verify_token=<what-you-configured>
+      hub.challenge=<random>
+    We must echo back the challenge if the verify_token matches any configured
+    WhatsApp platform's stored verify_token.
+    """
+    params = request.query_params
+    mode = params.get("hub.mode")
+    token = params.get("hub.verify_token")
+    challenge = params.get("hub.challenge")
+
+    if mode != "subscribe" or not token:
+        raise HTTPException(status_code=400, detail="Invalid verification request")
+
+    # Match against any configured WhatsApp platform
+    for platform in await _list_whatsapp_platforms(db):
+        try:
+            creds = platform.decrypt_credentials() or {}
+        except Exception:
+            continue
+        if creds.get("verify_token") == token:
+            # Meta expects the bare challenge as plain text
+            from fastapi.responses import PlainTextResponse
+            return PlainTextResponse(challenge or "")
+
+    raise HTTPException(status_code=403, detail="Verify token mismatch")
+
+
+@router.post("/api/settings/integrations/whatsapp/webhook")
+async def whatsapp_webhook(
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Handle WhatsApp inbound events."""
+    try:
+        body = await request.body()
+        try:
+            event_data = json.loads(body.decode("utf-8"))
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+        if event_data.get("object") != "whatsapp_business_account":
+            # Not a WhatsApp payload — acknowledge and ignore
+            return {"ok": True}
+
+        # Extract phone_number_id from the payload to find the right platform
+        entry = (event_data.get("entry") or [{}])[0]
+        change = (entry.get("changes") or [{}])[0]
+        value = change.get("value") or {}
+        metadata = value.get("metadata") or {}
+        phone_number_id = metadata.get("phone_number_id")
+
+        platform = await _find_platform_by_phone_number_id(db, phone_number_id)
+        if not platform:
+            print(f"No WhatsApp platform found for phone_number_id: {phone_number_id}")
+            return {"ok": True}
+
+        # Signature verification
+        signature = request.headers.get("x-hub-signature-256", "")
+        try:
+            creds = platform.decrypt_credentials() or {}
+        except Exception:
+            creds = {}
+        app_secret = creds.get("app_secret")
+        if app_secret:
+            expected = "sha256=" + hmac.new(
+                app_secret.encode("utf-8"), body, hashlib.sha256
+            ).hexdigest()
+            if not signature or not hmac.compare_digest(expected, signature):
+                raise HTTPException(status_code=401, detail="Invalid signature")
+
+        # Status-only payloads (delivered/read/sent) have no `messages`
+        messages = value.get("messages") or []
+        if not messages:
+            return {"ok": True}
+
+        # Dedupe by message id
+        message_id = messages[0].get("id")
+        if message_id and message_id in processed_message_ids:
+            print(f"WhatsApp message {message_id} already processed, skipping")
+            return {"ok": True}
+        if message_id:
+            processed_message_ids.add(message_id)
+            if len(processed_message_ids) > 1000:
+                processed_message_ids.clear()
+
+        # Only text messages flow to the agent in v1
+        if messages[0].get("type") != "text":
+            print(f"Ignoring non-text WhatsApp message type: {messages[0].get('type')}")
+            return {"ok": True}
+
+        if not (messages[0].get("text") or {}).get("body", "").strip():
+            return {"ok": True}
+
+        result = await platform_manager.handle_incoming_message(
+            db, "whatsapp", platform.organization_id, event_data
+        )
+        return {"ok": True, "result": result}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error in WhatsApp webhook: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/schemas/external_platform_schema.py
+++ b/backend/app/schemas/external_platform_schema.py
@@ -6,6 +6,7 @@ from enum import Enum
 class PlatformType(str, Enum):
     SLACK = "slack"
     TEAMS = "teams"
+    WHATSAPP = "whatsapp"
     EMAIL = "email"
     MCP = "mcp"
 
@@ -39,6 +40,14 @@ class TeamsConfig(BaseModel):
     app_id: str
     client_secret: str
     tenant_id: str
+    webhook_url: Optional[str] = None
+
+class WhatsAppConfig(BaseModel):
+    access_token: str
+    phone_number_id: str
+    waba_id: str
+    app_secret: str
+    verify_token: str
     webhook_url: Optional[str] = None
 
 class EmailConfig(BaseModel):

--- a/backend/app/services/external_platform_service.py
+++ b/backend/app/services/external_platform_service.py
@@ -194,6 +194,8 @@ class ExternalPlatformService:
                 return await self._test_slack_connection(platform)
             elif platform.platform_type == "teams":
                 return await self._test_teams_connection(platform)
+            elif platform.platform_type == "whatsapp":
+                return await self._test_whatsapp_connection(platform)
             elif platform.platform_type == "email":
                 return await self._test_email_connection(platform)
             else:
@@ -431,6 +433,124 @@ class ExternalPlatformService:
                 else:
                     error = response.json().get("error_description", "Authentication failed")
                     return {"success": False, "error": error}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def create_whatsapp_platform(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        access_token: str,
+        phone_number_id: str,
+        waba_id: str,
+        app_secret: str,
+        verify_token: str,
+        current_user: User,
+    ) -> ExternalPlatformSchema:
+        """Create a WhatsApp Cloud API platform with proper configuration."""
+        # Test the credentials by fetching the phone number metadata
+        test_result = await self._test_whatsapp_token(access_token, phone_number_id)
+        if not test_result.get("success"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid WhatsApp credentials: {test_result.get('error')}",
+            )
+
+        existing_platform = await self.get_platform_by_type(db, organization.id, "whatsapp")
+        if existing_platform:
+            raise HTTPException(
+                status_code=400,
+                detail="WhatsApp integration already exists for this organization",
+            )
+
+        info = test_result.get("info", {})
+        platform_config = {
+            "phone_number_id": phone_number_id,
+            "waba_id": waba_id,
+            "display_phone_number": info.get("display_phone_number"),
+            "verified_name": info.get("verified_name"),
+        }
+
+        credentials = {
+            "access_token": access_token,
+            "phone_number_id": phone_number_id,
+            "waba_id": waba_id,
+            "app_secret": app_secret,
+            "verify_token": verify_token,
+        }
+
+        platform = ExternalPlatform(
+            organization_id=organization.id,
+            platform_type="whatsapp",
+            platform_config=platform_config,
+            is_active=True,
+        )
+        platform.encrypt_credentials(credentials)
+
+        db.add(platform)
+        await db.commit()
+        await db.refresh(platform)
+
+        try:
+            await telemetry.capture(
+                "external_platform_created",
+                {
+                    "platform_id": str(platform.id),
+                    "platform_type": "whatsapp",
+                    "is_active": True,
+                },
+                user_id=current_user.id,
+                org_id=organization.id,
+            )
+        except Exception:
+            pass
+
+        return ExternalPlatformSchema.from_orm(platform)
+
+    async def _test_whatsapp_connection(self, platform: ExternalPlatform) -> dict:
+        """Test WhatsApp connection using stored credentials."""
+        try:
+            creds = platform.decrypt_credentials()
+            return await self._test_whatsapp_token(
+                creds.get("access_token"), creds.get("phone_number_id")
+            )
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def _test_whatsapp_token(self, access_token: str, phone_number_id: str) -> dict:
+        """Validate a WhatsApp Cloud API token by calling GET /{phone_number_id}."""
+        try:
+            import os
+            import httpx
+
+            if not access_token or not phone_number_id:
+                return {"success": False, "error": "Missing access_token or phone_number_id"}
+
+            base_url = os.environ.get(
+                "WHATSAPP_GRAPH_BASE_URL", "https://graph.facebook.com/v20.0"
+            )
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(
+                    f"{base_url}/{phone_number_id}",
+                    params={"fields": "display_phone_number,verified_name"},
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return {
+                        "success": True,
+                        "info": {
+                            "display_phone_number": data.get("display_phone_number"),
+                            "verified_name": data.get("verified_name"),
+                            "id": data.get("id"),
+                        },
+                    }
+                else:
+                    try:
+                        err = resp.json().get("error", {}).get("message", f"HTTP {resp.status_code}")
+                    except Exception:
+                        err = f"HTTP {resp.status_code}"
+                    return {"success": False, "error": err}
         except Exception as e:
             return {"success": False, "error": str(e)}
 

--- a/backend/app/services/platform_adapters/adapter_factory.py
+++ b/backend/app/services/platform_adapters/adapter_factory.py
@@ -2,6 +2,7 @@ from typing import Dict, Type
 from .base_adapter import PlatformAdapter
 from .slack_adapter import SlackAdapter
 from .teams_adapter import TeamsAdapter
+from .whatsapp_adapter import WhatsAppAdapter
 from app.models.external_platform import ExternalPlatform
 
 class PlatformAdapterFactory:
@@ -10,6 +11,7 @@ class PlatformAdapterFactory:
     _adapters: Dict[str, Type[PlatformAdapter]] = {
         "slack": SlackAdapter,
         "teams": TeamsAdapter,
+        "whatsapp": WhatsAppAdapter,
         # "email": EmailAdapter,  # Future
     }
     

--- a/backend/app/services/platform_adapters/whatsapp_adapter.py
+++ b/backend/app/services/platform_adapters/whatsapp_adapter.py
@@ -1,0 +1,323 @@
+import hmac
+import hashlib
+import os
+import mimetypes
+import httpx
+from typing import Dict, Any, Optional
+from .base_adapter import PlatformAdapter
+from app.settings.config import settings
+
+
+def _graph_base_url() -> str:
+    """Meta Graph API base URL. Overridable via env for sandbox / tests."""
+    return os.environ.get("WHATSAPP_GRAPH_BASE_URL", "https://graph.facebook.com/v20.0")
+
+
+class WhatsAppAdapter(PlatformAdapter):
+    """WhatsApp Cloud API platform adapter.
+
+    Mirrors SlackAdapter's surface area so the ExternalPlatformManager and
+    notification pipeline can drive it unchanged.
+
+    Threading model: WhatsApp has no native thread_ts. We use the *original*
+    inbound message id as the conversational root and stamp it onto
+    Completion.external_thread_ts. All outbound replies set
+    `context.message_id = <root>` so the WhatsApp UI shows quoted replies
+    chained to the root message.
+    """
+
+    def __init__(self, platform):
+        super().__init__(platform)
+
+    # ---------- helpers ----------
+
+    def _phone_number_id(self) -> Optional[str]:
+        return (self.credentials or {}).get("phone_number_id") or (
+            self.config or {}
+        ).get("phone_number_id")
+
+    def _access_token(self) -> Optional[str]:
+        return (self.credentials or {}).get("access_token")
+
+    def _auth_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token()}",
+            "Content-Type": "application/json",
+        }
+
+    async def _post_message(self, payload: Dict[str, Any]) -> bool:
+        phone_number_id = self._phone_number_id()
+        if not phone_number_id or not self._access_token():
+            print("WhatsApp: missing phone_number_id or access_token")
+            return False
+        url = f"{_graph_base_url()}/{phone_number_id}/messages"
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(url, headers=self._auth_headers(), json=payload)
+                if resp.status_code == 200:
+                    return True
+                print(f"WhatsApp API error: {resp.status_code} - {resp.text}")
+                return False
+        except Exception as e:
+            print(f"Error posting WhatsApp message: {e}")
+            return False
+
+    # ---------- PlatformAdapter interface ----------
+
+    async def process_incoming_message(self, event_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Parse a WhatsApp Cloud API webhook payload.
+
+        Expected shape:
+          {"object":"whatsapp_business_account",
+           "entry":[{"id":"<waba_id>",
+                     "changes":[{"field":"messages",
+                                 "value":{"metadata":{"phone_number_id":"...","display_phone_number":"..."},
+                                          "contacts":[{"wa_id":"...","profile":{"name":"..."}}],
+                                          "messages":[{"from":"...","id":"wamid...",
+                                                       "timestamp":"...","type":"text",
+                                                       "text":{"body":"hi"},
+                                                       "context":{"id":"wamid_parent"}}]}}]}]}
+
+        Returns None for statuses-only / unsupported payloads.
+        """
+        try:
+            entry = (event_data.get("entry") or [{}])[0]
+            change = (entry.get("changes") or [{}])[0]
+            value = change.get("value") or {}
+            messages = value.get("messages") or []
+            if not messages:
+                # Status-only payload (delivered/read) or empty
+                return None
+            msg = messages[0]
+            msg_type = msg.get("type")
+            if msg_type != "text":
+                # For v1 we only support inbound text. Non-text messages are
+                # acknowledged but not routed to the agent.
+                print(f"WhatsApp: unsupported inbound message type: {msg_type}")
+                return None
+
+            wa_id = msg.get("from")
+            message_id = msg.get("id")
+            text = (msg.get("text") or {}).get("body", "")
+            context_id = (msg.get("context") or {}).get("id")
+
+            # Threading: if user replied to a previous message, use that id as
+            # thread root; otherwise this message starts a new thread.
+            is_thread_reply = bool(context_id)
+            effective_thread = context_id if is_thread_reply else message_id
+
+            # Populate contact name if present (WhatsApp has no user-info API)
+            contacts = value.get("contacts") or []
+            profile_name = None
+            if contacts:
+                profile_name = (contacts[0].get("profile") or {}).get("name")
+            if profile_name:
+                # stash on adapter for get_user_info()
+                self._last_profile_name = profile_name
+
+            metadata = value.get("metadata") or {}
+
+            return {
+                "platform_type": "whatsapp",
+                "external_user_id": wa_id,
+                "external_message_id": message_id,
+                # WhatsApp has no channels — the wa_id *is* the DM address.
+                "channel_id": wa_id,
+                "channel_type": "im",
+                "message_text": text,
+                "message_type": "message",
+                "timestamp": msg.get("timestamp"),
+                "phone_number_id": metadata.get("phone_number_id"),
+                # Thread context
+                "thread_ts": effective_thread,
+                "message_ts": message_id,
+                "is_thread_reply": is_thread_reply,
+                "profile_name": profile_name,
+            }
+        except Exception as e:
+            print(f"Error processing WhatsApp message: {e}")
+            return None
+
+    async def send_response(self, message_data: Dict[str, Any]) -> bool:
+        """Send a text message via WhatsApp Cloud API."""
+        to = message_data.get("channel") or message_data.get("channel_id") or message_data.get("to")
+        text = message_data.get("text") or message_data.get("content") or ""
+        if not to or not text:
+            print("WhatsApp: send_response missing 'to' or 'text'")
+            return False
+
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": "text",
+            "text": {"body": text[:4096], "preview_url": False},
+        }
+        thread_ts = message_data.get("thread_ts")
+        if thread_ts:
+            payload["context"] = {"message_id": thread_ts}
+        return await self._post_message(payload)
+
+    async def get_user_info(self, external_user_id: str) -> Dict[str, Any]:
+        """WhatsApp Cloud API does not expose a user-info endpoint.
+
+        We return whatever profile name we captured from the last inbound
+        event (if any). Email is never available.
+        """
+        name = getattr(self, "_last_profile_name", None)
+        return {
+            "id": external_user_id,
+            "name": name,
+            "email": None,
+            "real_name": name,
+        }
+
+    async def verify_webhook_signature(
+        self, request_body: bytes, signature: str, timestamp: str
+    ) -> bool:
+        """Verify X-Hub-Signature-256 HMAC-SHA256 header from Meta."""
+        try:
+            app_secret = (self.credentials or {}).get("app_secret")
+            if not app_secret or not signature:
+                return False
+            expected = "sha256=" + hmac.new(
+                app_secret.encode("utf-8"),
+                request_body,
+                hashlib.sha256,
+            ).hexdigest()
+            return hmac.compare_digest(expected, signature)
+        except Exception as e:
+            print(f"Error verifying WhatsApp signature: {e}")
+            return False
+
+    async def send_verification_message(self, channel_id: str, email: str, token: str) -> bool:
+        base_url = settings.bow_config.base_url
+        verification_url = f"{base_url}/settings/integrations/verify/{token}"
+        text = (
+            "Account Verification Required\n\n"
+            "To start using this bot, please verify your account by opening "
+            f"this link:\n{verification_url}"
+        )
+        return await self.send_response({"to": channel_id, "text": text})
+
+    # ---------- convenience methods used by the manager / notification pipeline ----------
+
+    async def add_reaction(self, channel_id: str, timestamp: str, emoji: str) -> bool:
+        """Add a reaction to a WhatsApp message.
+
+        `emoji` is a Slack emoji name (e.g. "eyes"). We map common names to
+        unicode so the SlackAdapter-driven flow works transparently.
+        """
+        emoji_char = _SLACK_EMOJI_MAP.get(emoji, emoji)
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": channel_id,
+            "type": "reaction",
+            "reaction": {"message_id": timestamp, "emoji": emoji_char},
+        }
+        return await self._post_message(payload)
+
+    async def remove_reaction(self, channel_id: str, timestamp: str, emoji: str) -> bool:
+        """Remove a reaction (Cloud API convention: empty emoji string)."""
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": channel_id,
+            "type": "reaction",
+            "reaction": {"message_id": timestamp, "emoji": ""},
+        }
+        return await self._post_message(payload)
+
+    async def send_dm(self, user_id: str, text: str) -> bool:
+        return await self.send_response({"to": user_id, "text": text})
+
+    async def send_dm_in_thread(
+        self,
+        user_id: str,
+        text: str,
+        thread_ts: str = None,
+        channel_id: str = None,
+    ) -> bool:
+        to = channel_id or user_id
+        return await self.send_response({"to": to, "text": text, "thread_ts": thread_ts})
+
+    async def _upload_media(self, file_path: str) -> Optional[str]:
+        """Upload media and return its media id."""
+        phone_number_id = self._phone_number_id()
+        access_token = self._access_token()
+        if not phone_number_id or not access_token:
+            return None
+        if not os.path.exists(file_path):
+            print(f"WhatsApp: file not found at {file_path}")
+            return None
+        mime, _ = mimetypes.guess_type(file_path)
+        mime = mime or "application/octet-stream"
+        url = f"{_graph_base_url()}/{phone_number_id}/media"
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                with open(file_path, "rb") as f:
+                    files = {
+                        "file": (os.path.basename(file_path), f, mime),
+                        "messaging_product": (None, "whatsapp"),
+                        "type": (None, mime),
+                    }
+                    resp = await client.post(
+                        url,
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        files=files,
+                    )
+                if resp.status_code == 200:
+                    return resp.json().get("id")
+                print(f"WhatsApp media upload failed: {resp.status_code} - {resp.text}")
+                return None
+        except Exception as e:
+            print(f"Error uploading WhatsApp media: {e}")
+            return None
+
+    async def send_file_in_thread(
+        self,
+        user_id: str,
+        file_path: str,
+        title: str,
+        thread_ts: str = None,
+        channel_id: str = None,
+    ) -> bool:
+        """Upload a file and send it as a document/image message."""
+        to = channel_id or user_id
+        media_id = await self._upload_media(file_path)
+        if not media_id:
+            return False
+        mime, _ = mimetypes.guess_type(file_path)
+        mime = mime or "application/octet-stream"
+        is_image = mime.startswith("image/")
+        msg_type = "image" if is_image else "document"
+        media_obj: Dict[str, Any] = {"id": media_id, "caption": title[:1024]}
+        if not is_image:
+            media_obj["filename"] = os.path.basename(file_path)
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": msg_type,
+            msg_type: media_obj,
+        }
+        if thread_ts:
+            payload["context"] = {"message_id": thread_ts}
+        return await self._post_message(payload)
+
+    async def send_image_in_dm(self, user_id: str, image_path: str, title: str) -> bool:
+        return await self.send_file_in_thread(user_id, image_path, title)
+
+    async def send_file_in_dm(self, user_id: str, file_path: str, title: str) -> bool:
+        return await self.send_file_in_thread(user_id, file_path, title)
+
+
+# Minimal mapping so Slack-style emoji names used elsewhere work on WhatsApp.
+_SLACK_EMOJI_MAP = {
+    "eyes": "\U0001F440",          # 👀
+    "white_check_mark": "\u2705",  # ✅
+    "x": "\u274C",                 # ❌
+    "warning": "\u26A0\ufe0f",     # ⚠️
+    "hourglass": "\u23F3",         # ⏳
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,6 +61,7 @@ from app.routes import (
     external_user_mapping,
     slack_webhook,
     teams_webhook,
+    whatsapp_webhook,
     step,
     instruction,
     onboarding,
@@ -202,6 +203,7 @@ app.include_router(external_platform.router, prefix="/api")
 app.include_router(external_user_mapping.router, prefix="/api")
 app.include_router(slack_webhook.router)
 app.include_router(teams_webhook.router)
+app.include_router(whatsapp_webhook.router)
 app.include_router(step.router, prefix="/api")
 app.include_router(instruction.router, prefix="/api")
 app.include_router(build.router, prefix="/api")

--- a/backend/scripts/whatsapp_sandbox_debug.py
+++ b/backend/scripts/whatsapp_sandbox_debug.py
@@ -1,0 +1,471 @@
+"""End-to-end sandbox debug harness for the WhatsApp integration.
+
+Runs **without** the full bagofwords app stack. It wires together:
+
+  1. A mock Meta Graph API (captures outbound /messages and /media calls)
+  2. The real `WhatsAppAdapter` pointed at the mock via WHATSAPP_GRAPH_BASE_URL
+  3. The real `whatsapp_webhook` FastAPI route, with an in-memory fake DB
+  4. A scripted sequence of inbound webhooks (new user -> verification ->
+     verified message -> reply-in-thread) exercising every code path
+
+Run:   python backend/scripts/whatsapp_sandbox_debug.py
+"""
+from __future__ import annotations
+
+import asyncio
+import hmac
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# 1. Stub the heavy app dep chain so we can import the adapter + route cleanly
+# ---------------------------------------------------------------------------
+
+
+def _install_stubs():
+    # app.models.external_platform / external_user_mapping
+    models_pkg = types.ModuleType("app.models")
+    ep_mod = types.ModuleType("app.models.external_platform")
+
+    class ExternalPlatform:
+        platform_type = "whatsapp"
+
+        def __init__(self, config, credentials, org_id="org-1"):
+            self.platform_config = config
+            self._credentials = credentials
+            self.organization_id = org_id
+
+        def decrypt_credentials(self):
+            return dict(self._credentials)
+
+    ep_mod.ExternalPlatform = ExternalPlatform
+    eum_mod = types.ModuleType("app.models.external_user_mapping")
+
+    class ExternalUserMapping:  # sentinel
+        pass
+
+    eum_mod.ExternalUserMapping = ExternalUserMapping
+
+    # app.settings.config
+    settings_pkg = types.ModuleType("app.settings")
+    config_mod = types.ModuleType("app.settings.config")
+    config_mod.settings = types.SimpleNamespace(
+        bow_config=types.SimpleNamespace(base_url="http://localhost:3000")
+    )
+
+    # app.dependencies.get_async_db (not actually hit; overridden below)
+    deps_mod = types.ModuleType("app.dependencies")
+
+    async def _fake_db():
+        yield None
+
+    deps_mod.get_async_db = _fake_db
+
+    # app.services.external_platform_manager — record inbound calls and
+    # drive the adapter end-to-end (reply back via the mock Meta).
+    epm_mod = types.ModuleType("app.services.external_platform_manager")
+
+    class ExternalPlatformManager:
+        """Minimal in-process version: verified-user loop only.
+
+        Behaviour:
+          - First inbound from an unknown wa_id -> "send verification message"
+          - Subsequent inbound from a verified wa_id -> "reply with summary"
+        """
+
+        verified_users: set = set()
+        events: list = []
+
+        async def handle_incoming_message(self, db, platform_type, org_id, event_data):
+            # Late import so we use the same stubbed modules.
+            from app.services.platform_adapters.whatsapp_adapter import WhatsAppAdapter  # type: ignore
+
+            # The route already fetched the platform; reconstruct here from the
+            # harness-global `HARNESS_PLATFORM`.
+            adapter = WhatsAppAdapter(HARNESS_PLATFORM)
+            parsed = await adapter.process_incoming_message(event_data)
+            if not parsed:
+                return {"success": True, "action": "noop"}
+            wa_id = parsed["external_user_id"]
+            thread_ts = parsed["thread_ts"]
+            message_ts = parsed["message_ts"]
+
+            if wa_id not in type(self).verified_users:
+                type(self).events.append(("verification_sent", wa_id))
+                await adapter.send_verification_message(wa_id, None, "sandbox-token-123")
+                type(self).verified_users.add(wa_id)  # auto-"verify" for harness
+                return {"success": True, "action": "verification_sent"}
+
+            type(self).events.append(("message_processed", wa_id, parsed["message_text"], thread_ts))
+            await adapter.add_reaction(wa_id, message_ts, "eyes")
+            await adapter.send_dm_in_thread(
+                wa_id,
+                f"You said: {parsed['message_text']}",
+                thread_ts=thread_ts,
+            )
+            await adapter.remove_reaction(wa_id, message_ts, "eyes")
+            return {"success": True, "action": "message_processed"}
+
+    epm_mod.ExternalPlatformManager = ExternalPlatformManager
+
+    # app.services.external_platform_service (only the class ref is needed)
+    eps_mod = types.ModuleType("app.services.external_platform_service")
+
+    class ExternalPlatformService:
+        pass
+
+    eps_mod.ExternalPlatformService = ExternalPlatformService
+
+    # Register everything
+    sys.modules.setdefault("app", types.ModuleType("app"))
+    sys.modules["app.models"] = models_pkg
+    sys.modules["app.models.external_platform"] = ep_mod
+    sys.modules["app.models.external_user_mapping"] = eum_mod
+    sys.modules["app.settings"] = settings_pkg
+    sys.modules["app.settings.config"] = config_mod
+    sys.modules["app.dependencies"] = deps_mod
+    sys.modules["app.services"] = types.ModuleType("app.services")
+    sys.modules["app.services.external_platform_manager"] = epm_mod
+    sys.modules["app.services.external_platform_service"] = eps_mod
+
+    # platform_adapters package path
+    pa_pkg = types.ModuleType("app.services.platform_adapters")
+    pa_pkg.__path__ = [str(BACKEND_ROOT / "app" / "services" / "platform_adapters")]
+    sys.modules["app.services.platform_adapters"] = pa_pkg
+
+    # Load base_adapter and whatsapp_adapter from file
+    def _load(name: str, path: Path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _load(
+        "app.services.platform_adapters.base_adapter",
+        BACKEND_ROOT / "app" / "services" / "platform_adapters" / "base_adapter.py",
+    )
+    _load(
+        "app.services.platform_adapters.whatsapp_adapter",
+        BACKEND_ROOT / "app" / "services" / "platform_adapters" / "whatsapp_adapter.py",
+    )
+
+    # Load the route
+    _load(
+        "app.routes.whatsapp_webhook",
+        BACKEND_ROOT / "app" / "routes" / "whatsapp_webhook.py",
+    )
+
+    return ExternalPlatform, ExternalPlatformManager
+
+
+_ExternalPlatform, _EPM = _install_stubs()
+
+# Harness-global platform row used by both the route (via a patched lookup)
+# and the stub manager (so the adapter gets real creds).
+APP_SECRET = "topsecret"
+VERIFY_TOKEN = "verify-xyz"
+PHONE_NUMBER_ID = "PNID_1"
+HARNESS_PLATFORM = _ExternalPlatform(
+    config={
+        "phone_number_id": PHONE_NUMBER_ID,
+        "waba_id": "WABA_1",
+        "display_phone_number": "+15550000001",
+        "verified_name": "Sandbox Co",
+    },
+    credentials={
+        "access_token": "EAAsandbox",
+        "phone_number_id": PHONE_NUMBER_ID,
+        "waba_id": "WABA_1",
+        "app_secret": APP_SECRET,
+        "verify_token": VERIFY_TOKEN,
+    },
+    org_id="org-1",
+)
+
+
+# ---------------------------------------------------------------------------
+# 2. Mock Meta Graph API server
+# ---------------------------------------------------------------------------
+
+
+mock_meta = FastAPI(title="Mock Meta Graph")
+OUTBOUND: list = []
+
+
+@mock_meta.post("/{phone_number_id}/messages")
+async def mock_messages(phone_number_id: str, request: Request):
+    body = await request.json()
+    OUTBOUND.append(("messages", phone_number_id, body))
+    return {"messages": [{"id": f"wamid.MOCK{len(OUTBOUND)}"}]}
+
+
+@mock_meta.post("/{phone_number_id}/media")
+async def mock_media(phone_number_id: str, request: Request):
+    OUTBOUND.append(("media", phone_number_id, "<multipart>"))
+    return {"id": f"media-mock-{len(OUTBOUND)}"}
+
+
+@mock_meta.get("/{phone_number_id}")
+async def mock_phone_info(phone_number_id: str):
+    return {
+        "id": phone_number_id,
+        "display_phone_number": "+15550000001",
+        "verified_name": "Sandbox Co",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Build the BoW app exposing only the whatsapp_webhook route
+# ---------------------------------------------------------------------------
+
+
+def build_bow_app():
+    wh = sys.modules["app.routes.whatsapp_webhook"]
+    from app.dependencies import get_async_db
+
+    app = FastAPI(title="BoW sandbox")
+    app.include_router(wh.router)
+
+    # Fake DB (never actually queried after our patches)
+    class _FakeDB:
+        async def execute(self, stmt):
+            raise RuntimeError("DB not available in sandbox")
+
+    async def _db_dep():
+        yield _FakeDB()
+
+    app.dependency_overrides[get_async_db] = _db_dep
+
+    # Patch the platform lookup helpers to return our in-memory HARNESS_PLATFORM
+    async def _find(db, phone_number_id):
+        if phone_number_id == PHONE_NUMBER_ID:
+            return HARNESS_PLATFORM
+        return None
+
+    async def _list(db):
+        return [HARNESS_PLATFORM]
+
+    wh._find_platform_by_phone_number_id = _find  # type: ignore
+    wh._list_whatsapp_platforms = _list  # type: ignore
+    wh.processed_message_ids.clear()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# 4. Scripted client: replay inbound events
+# ---------------------------------------------------------------------------
+
+
+def sign(body: bytes) -> str:
+    return "sha256=" + hmac.new(APP_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def make_inbound(text: str, msg_id: str, reply_to: str | None = None):
+    msg = {
+        "from": "15551234567",
+        "id": msg_id,
+        "timestamp": str(int(time.time())),
+        "type": "text",
+        "text": {"body": text},
+    }
+    if reply_to:
+        msg["context"] = {"id": reply_to}
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "WABA_1",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {
+                                "phone_number_id": PHONE_NUMBER_ID,
+                                "display_phone_number": "+15550000001",
+                            },
+                            "contacts": [
+                                {"wa_id": "15551234567", "profile": {"name": "Sandbox User"}}
+                            ],
+                            "messages": [msg],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+async def run_scenarios(bow_base: str):
+    async with httpx.AsyncClient() as client:
+        # --- GET handshake ---
+        r = await client.get(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": VERIFY_TOKEN,
+                "hub.challenge": "sandbox-challenge",
+            },
+        )
+        print(f"[GET handshake]             status={r.status_code} body={r.text!r}")
+        assert r.status_code == 200 and r.text == "sandbox-challenge"
+
+        r = await client.get(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            params={"hub.mode": "subscribe", "hub.verify_token": "wrong"},
+        )
+        print(f"[GET handshake bad token]   status={r.status_code}")
+        assert r.status_code == 403
+
+        # --- POST invalid signature ---
+        body = json.dumps(make_inbound("hi", "wamid.X1")).encode()
+        r = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body,
+            headers={"x-hub-signature-256": "sha256=deadbeef"},
+        )
+        print(f"[POST bad signature]        status={r.status_code}")
+        assert r.status_code == 401
+
+        # --- POST unverified user -> verification sent ---
+        body = json.dumps(make_inbound("hello bot", "wamid.M1")).encode()
+        r = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body,
+            headers={"x-hub-signature-256": sign(body)},
+        )
+        print(f"[POST new user]             status={r.status_code} json={r.json()}")
+        assert r.status_code == 200
+
+        # --- POST verified user top-level message ---
+        body = json.dumps(make_inbound("show orders", "wamid.M2")).encode()
+        r = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body,
+            headers={"x-hub-signature-256": sign(body)},
+        )
+        print(f"[POST verified top-level]   status={r.status_code}")
+
+        # --- POST thread reply ---
+        body = json.dumps(make_inbound("and last month?", "wamid.M3", reply_to="wamid.M2")).encode()
+        r = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body,
+            headers={"x-hub-signature-256": sign(body)},
+        )
+        print(f"[POST thread reply]         status={r.status_code}")
+
+        # --- POST status-only (delivered) — should be no-op ---
+        status_payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "messages",
+                            "value": {
+                                "metadata": {"phone_number_id": PHONE_NUMBER_ID},
+                                "statuses": [{"id": "wamid.S1", "status": "delivered"}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+        body = json.dumps(status_payload).encode()
+        r = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body,
+            headers={"x-hub-signature-256": sign(body)},
+        )
+        print(f"[POST status-only]          status={r.status_code} json={r.json()}")
+
+        # --- POST duplicate (dedupe) ---
+        body = json.dumps(make_inbound("dup", "wamid.DUP")).encode()
+        headers = {"x-hub-signature-256": sign(body)}
+        r1 = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body, headers=headers,
+        )
+        r2 = await client.post(
+            f"{bow_base}/api/settings/integrations/whatsapp/webhook",
+            content=body, headers=headers,
+        )
+        print(f"[POST dedupe]               first={r1.status_code} second={r2.status_code}")
+
+
+def _run_server(app, port: int):
+    cfg = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(cfg)
+    asyncio.run(server.serve())
+
+
+def main():
+    # Point the adapter at our mock Meta server
+    mock_port = 8765
+    bow_port = 8766
+    os.environ["WHATSAPP_GRAPH_BASE_URL"] = f"http://127.0.0.1:{mock_port}"
+
+    # Start mock Meta Graph in a background thread
+    meta_thread = threading.Thread(
+        target=_run_server, args=(mock_meta, mock_port), daemon=True
+    )
+    meta_thread.start()
+
+    # Start BoW webhook server in a background thread
+    bow_app = build_bow_app()
+    bow_thread = threading.Thread(
+        target=_run_server, args=(bow_app, bow_port), daemon=True
+    )
+    bow_thread.start()
+
+    # Wait for both servers
+    time.sleep(1.2)
+
+    print("=" * 70)
+    print("WhatsApp sandbox debug harness")
+    print(f"  Mock Meta Graph: http://127.0.0.1:{mock_port}")
+    print(f"  BoW webhook:     http://127.0.0.1:{bow_port}")
+    print("=" * 70)
+
+    asyncio.run(run_scenarios(f"http://127.0.0.1:{bow_port}"))
+
+    print()
+    print("-- Manager events recorded --")
+    for e in _EPM.events:
+        print(f"  {e}")
+    print()
+    print("-- Outbound calls captured by mock Meta --")
+    for kind, pnid, body in OUTBOUND:
+        if kind == "messages":
+            typ = body.get("type")
+            if typ == "text":
+                print(f"  [text  ] to={body['to']} body={body['text']['body']!r} ctx={body.get('context')}")
+            elif typ == "reaction":
+                print(f"  [react ] to={body['to']} msg={body['reaction']['message_id']} emoji={body['reaction']['emoji']!r}")
+            else:
+                print(f"  [{typ}] {body}")
+        else:
+            print(f"  [media ] pnid={pnid}")
+
+    print()
+    print("PASS — all scenarios executed")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_whatsapp_adapter.py
+++ b/backend/tests/unit/test_whatsapp_adapter.py
@@ -1,0 +1,345 @@
+"""Unit tests for WhatsAppAdapter.
+
+These tests import `WhatsAppAdapter` while stubbing the heavy dependency
+chain (SQLAlchemy models, settings loader) so they run independently of the
+full app stack. This mirrors how Slack is exercised in other unit tests.
+"""
+import hmac
+import hashlib
+import importlib
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def _install_stubs():
+    """Install minimal stand-ins for the app modules the adapter imports."""
+    # app.models.external_platform — only needs ExternalPlatform symbol for type hint
+    models_pkg = types.ModuleType("app.models")
+    ep_mod = types.ModuleType("app.models.external_platform")
+    class _EP:  # noqa: N801
+        pass
+    ep_mod.ExternalPlatform = _EP
+    eum_mod = types.ModuleType("app.models.external_user_mapping")
+    class _EUM:  # noqa: N801
+        pass
+    eum_mod.ExternalUserMapping = _EUM
+
+    # app.settings.config with a minimal settings.bow_config.base_url
+    settings_pkg = types.ModuleType("app.settings")
+    config_mod = types.ModuleType("app.settings.config")
+    bow_cfg = types.SimpleNamespace(base_url="http://localhost:3000")
+    config_mod.settings = types.SimpleNamespace(bow_config=bow_cfg)
+
+    sys.modules.setdefault("app", types.ModuleType("app"))
+    sys.modules["app.models"] = models_pkg
+    sys.modules["app.models.external_platform"] = ep_mod
+    sys.modules["app.models.external_user_mapping"] = eum_mod
+    sys.modules["app.settings"] = settings_pkg
+    sys.modules["app.settings.config"] = config_mod
+
+
+_install_stubs()
+
+# Load base_adapter then whatsapp_adapter directly from file paths so we don't
+# drag in the real `app` package.
+import importlib.util
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_base = _load(
+    "app.services.platform_adapters.base_adapter",
+    BACKEND_ROOT / "app" / "services" / "platform_adapters" / "base_adapter.py",
+)
+# Make the package path resolve so `.base_adapter` works inside whatsapp_adapter.
+pa_pkg = types.ModuleType("app.services")
+pa_pkg2 = types.ModuleType("app.services.platform_adapters")
+pa_pkg2.__path__ = [str(BACKEND_ROOT / "app" / "services" / "platform_adapters")]
+sys.modules["app.services"] = pa_pkg
+sys.modules["app.services.platform_adapters"] = pa_pkg2
+sys.modules["app.services.platform_adapters.base_adapter"] = _base
+
+wa_mod = _load(
+    "app.services.platform_adapters.whatsapp_adapter",
+    BACKEND_ROOT / "app" / "services" / "platform_adapters" / "whatsapp_adapter.py",
+)
+WhatsAppAdapter = wa_mod.WhatsAppAdapter
+
+
+# ---------- Fake platform ----------
+
+
+class FakePlatform:
+    def __init__(self, credentials=None, config=None):
+        self._credentials = credentials or {}
+        self.platform_config = config or {}
+
+    def decrypt_credentials(self):
+        return dict(self._credentials)
+
+
+def make_adapter(creds=None, cfg=None):
+    creds = creds or {
+        "access_token": "EAAtoken",
+        "phone_number_id": "PNID_1",
+        "waba_id": "WABA_1",
+        "app_secret": "topsecret",
+        "verify_token": "verify-xyz",
+    }
+    return WhatsAppAdapter(FakePlatform(credentials=creds, config=cfg or {"phone_number_id": "PNID_1"}))
+
+
+# ---------- process_incoming_message ----------
+
+
+def _inbound_text(wa_id="15551234567", text="hello", msg_id="wamid.AAA", reply_to=None):
+    msg = {
+        "from": wa_id,
+        "id": msg_id,
+        "timestamp": "1700000000",
+        "type": "text",
+        "text": {"body": text},
+    }
+    if reply_to:
+        msg["context"] = {"id": reply_to}
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "WABA_1",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {
+                                "phone_number_id": "PNID_1",
+                                "display_phone_number": "+15550000001",
+                            },
+                            "contacts": [{"wa_id": wa_id, "profile": {"name": "Alice"}}],
+                            "messages": [msg],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_incoming_top_level_message():
+    a = make_adapter()
+    out = await a.process_incoming_message(_inbound_text())
+    assert out["platform_type"] == "whatsapp"
+    assert out["external_user_id"] == "15551234567"
+    assert out["channel_id"] == "15551234567"
+    assert out["channel_type"] == "im"
+    assert out["message_text"] == "hello"
+    assert out["message_ts"] == "wamid.AAA"
+    assert out["thread_ts"] == "wamid.AAA"  # self -> new thread root
+    assert out["is_thread_reply"] is False
+    assert out["phone_number_id"] == "PNID_1"
+    assert out["profile_name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_process_incoming_thread_reply():
+    a = make_adapter()
+    out = await a.process_incoming_message(
+        _inbound_text(msg_id="wamid.BBB", reply_to="wamid.AAA")
+    )
+    assert out["is_thread_reply"] is True
+    assert out["thread_ts"] == "wamid.AAA"
+    assert out["message_ts"] == "wamid.BBB"
+
+
+@pytest.mark.asyncio
+async def test_process_incoming_status_payload_returns_none():
+    a = make_adapter()
+    payload = {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {"phone_number_id": "PNID_1"},
+                            "statuses": [{"id": "wamid.x", "status": "delivered"}],
+                        },
+                    }
+                ]
+            }
+        ],
+    }
+    out = await a.process_incoming_message(payload)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_process_incoming_non_text_returns_none():
+    a = make_adapter()
+    payload = _inbound_text()
+    payload["entry"][0]["changes"][0]["value"]["messages"][0] = {
+        "from": "15551234567",
+        "id": "wamid.IMG",
+        "type": "image",
+        "image": {"id": "media1"},
+    }
+    out = await a.process_incoming_message(payload)
+    assert out is None
+
+
+# ---------- verify_webhook_signature ----------
+
+
+@pytest.mark.asyncio
+async def test_verify_webhook_signature_good():
+    a = make_adapter()
+    body = b'{"hello":"world"}'
+    sig = "sha256=" + hmac.new(b"topsecret", body, hashlib.sha256).hexdigest()
+    assert await a.verify_webhook_signature(body, sig, "") is True
+
+
+@pytest.mark.asyncio
+async def test_verify_webhook_signature_bad():
+    a = make_adapter()
+    assert await a.verify_webhook_signature(b"x", "sha256=deadbeef", "") is False
+    assert await a.verify_webhook_signature(b"x", "", "") is False
+
+
+# ---------- send_response (mock transport) ----------
+
+
+def _mock_client(handler):
+    transport = httpx.MockTransport(handler)
+    # Patch httpx.AsyncClient to always use our transport.
+    original = httpx.AsyncClient
+
+    class _Patched(original):
+        def __init__(self, *a, **kw):
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    return _Patched
+
+
+@pytest.mark.asyncio
+async def test_send_response_posts_text(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"messages": [{"id": "wamid.OUT"}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    ok = await a.send_response({"to": "15551234567", "text": "hi there", "thread_ts": "wamid.AAA"})
+    assert ok is True
+    assert "/PNID_1/messages" in captured["url"]
+    assert captured["auth"] == "Bearer EAAtoken"
+    body = captured["body"]
+    assert body["messaging_product"] == "whatsapp"
+    assert body["to"] == "15551234567"
+    assert body["type"] == "text"
+    assert body["text"]["body"] == "hi there"
+    assert body["context"] == {"message_id": "wamid.AAA"}
+
+
+@pytest.mark.asyncio
+async def test_send_response_handles_api_error(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": {"message": "bad", "code": 131047}})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    ok = await a.send_response({"to": "x", "text": "y"})
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_reaction(monkeypatch):
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json={"messages": [{"id": "wamid.R"}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    assert await a.add_reaction("15551234567", "wamid.AAA", "eyes") is True
+    assert calls[-1]["reaction"]["emoji"] == "\U0001F440"
+    assert calls[-1]["reaction"]["message_id"] == "wamid.AAA"
+    assert await a.remove_reaction("15551234567", "wamid.AAA", "eyes") is True
+    assert calls[-1]["reaction"]["emoji"] == ""
+
+
+@pytest.mark.asyncio
+async def test_send_verification_message(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"messages": [{"id": "wamid.V"}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    ok = await a.send_verification_message("15551234567", None, "tok-123")
+    assert ok is True
+    assert "tok-123" in captured["body"]["text"]["body"]
+    assert "/settings/integrations/verify/tok-123" in captured["body"]["text"]["body"]
+
+
+@pytest.mark.asyncio
+async def test_send_file_in_thread_uploads_and_sends(monkeypatch, tmp_path):
+    f = tmp_path / "report.csv"
+    f.write_text("a,b\n1,2\n")
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path.endswith("/media"):
+            return httpx.Response(200, json={"id": "media-xyz"})
+        # messages endpoint
+        return httpx.Response(200, json={"messages": [{"id": "wamid.F"}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    ok = await a.send_file_in_thread(
+        "15551234567", str(f), "Your CSV", thread_ts="wamid.AAA"
+    )
+    assert ok is True
+    # Two calls: upload then send
+    assert any(r.url.path.endswith("/media") for r in calls)
+    send_req = [r for r in calls if r.url.path.endswith("/messages")][-1]
+    body = json.loads(send_req.content.decode())
+    assert body["type"] == "document"
+    assert body["document"]["id"] == "media-xyz"
+    assert body["document"]["filename"] == "report.csv"
+    assert body["context"] == {"message_id": "wamid.AAA"}
+
+
+@pytest.mark.asyncio
+async def test_process_captures_profile_name_for_get_user_info():
+    a = make_adapter()
+    await a.process_incoming_message(_inbound_text())
+    info = await a.get_user_info("15551234567")
+    assert info["name"] == "Alice"
+    assert info["email"] is None

--- a/backend/tests/unit/test_whatsapp_webhook_route.py
+++ b/backend/tests/unit/test_whatsapp_webhook_route.py
@@ -1,0 +1,352 @@
+"""Route-level tests for the WhatsApp webhook.
+
+Bypasses the full app startup by building a tiny FastAPI app that only mounts
+the `whatsapp_webhook.router`, and stubs the ExternalPlatform DB lookup and
+platform manager so behaviour under various payloads is exercised in
+isolation.
+"""
+import hmac
+import hashlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+# ---------- Stub the dep chain before importing the route ----------
+
+
+def _install_route_stubs():
+    # Stub app.dependencies.get_async_db
+    deps_mod = types.ModuleType("app.dependencies")
+
+    async def _fake_db():  # not actually used because we override via dependency_overrides
+        yield None
+
+    deps_mod.get_async_db = _fake_db
+    sys.modules.setdefault("app", types.ModuleType("app"))
+    sys.modules["app.dependencies"] = deps_mod
+
+    # Stub services.external_platform_manager with a module containing a
+    # controllable class.
+    epm_mod = types.ModuleType("app.services.external_platform_manager")
+
+    class ExternalPlatformManager:
+        last_call = None
+
+        async def handle_incoming_message(self, db, platform_type, org_id, event_data):
+            type(self).last_call = (platform_type, org_id, event_data)
+            return {"success": True, "action": "message_processed"}
+
+    epm_mod.ExternalPlatformManager = ExternalPlatformManager
+    sys.modules["app.services"] = types.ModuleType("app.services")
+    sys.modules["app.services.external_platform_manager"] = epm_mod
+
+    # Stub external_platform_service
+    eps_mod = types.ModuleType("app.services.external_platform_service")
+
+    class ExternalPlatformService:
+        pass
+
+    eps_mod.ExternalPlatformService = ExternalPlatformService
+    sys.modules["app.services.external_platform_service"] = eps_mod
+
+    # Stub models.external_platform
+    models_mod = types.ModuleType("app.models")
+    ep_mod = types.ModuleType("app.models.external_platform")
+
+    class ExternalPlatform:
+        platform_type = "whatsapp"
+
+        def __init__(self, config, credentials, org_id="org-1"):
+            self.platform_config = config
+            self._credentials = credentials
+            self.organization_id = org_id
+
+        def decrypt_credentials(self):
+            return dict(self._credentials)
+
+    ep_mod.ExternalPlatform = ExternalPlatform
+    # Force-replace even if a previous test file already stubbed these.
+    sys.modules["app.models"] = models_mod
+    sys.modules["app.models.external_platform"] = ep_mod
+    return ExternalPlatform
+
+
+_ExternalPlatform = _install_route_stubs()
+
+# Now load the route module directly from file
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "app.routes.whatsapp_webhook",
+    BACKEND_ROOT / "app" / "routes" / "whatsapp_webhook.py",
+)
+wh = importlib.util.module_from_spec(spec)
+sys.modules["app.routes.whatsapp_webhook"] = wh
+spec.loader.exec_module(wh)
+
+
+# ---------- Fixtures ----------
+
+
+@pytest.fixture
+def platform():
+    return _ExternalPlatform(
+        config={"phone_number_id": "PNID_1", "waba_id": "WABA_1"},
+        credentials={"app_secret": "topsecret", "verify_token": "verify-xyz"},
+        org_id="org-1",
+    )
+
+
+@pytest.fixture
+def app(monkeypatch, platform):
+    # Patch the platform lookup to return our fake platform (or None)
+    async def _fake_lookup(db, phone_number_id):
+        if phone_number_id == platform.platform_config["phone_number_id"]:
+            return platform
+        return None
+
+    monkeypatch.setattr(wh, "_find_platform_by_phone_number_id", _fake_lookup)
+
+    async def _fake_list(db):
+        return [platform]
+
+    monkeypatch.setattr(wh, "_list_whatsapp_platforms", _fake_list)
+
+    # Patch the GET-handshake DB scan so no real DB is touched
+    class _Scalars:
+        def __init__(self, items):
+            self._items = items
+
+        def all(self):
+            return self._items
+
+    class _Result:
+        def __init__(self, items):
+            self._items = items
+
+        def scalars(self):
+            return _Scalars(self._items)
+
+    class _FakeDB:
+        platforms = [platform]
+
+        async def execute(self, stmt):
+            return _Result(self.platforms)
+
+    async def _fake_db_dep():
+        yield _FakeDB()
+
+    # Reset dedupe between tests
+    wh.processed_message_ids.clear()
+
+    application = FastAPI()
+    application.include_router(wh.router)
+    # Override the get_async_db dependency the route uses
+    from app.dependencies import get_async_db  # stubbed
+
+    application.dependency_overrides[get_async_db] = _fake_db_dep
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ---------- Helpers ----------
+
+
+def _inbound_text_payload(
+    phone_number_id="PNID_1", msg_id="wamid.AAA", text="hello", msg_type="text"
+):
+    msg = {
+        "from": "15551234567",
+        "id": msg_id,
+        "timestamp": "1700000000",
+        "type": msg_type,
+    }
+    if msg_type == "text":
+        msg["text"] = {"body": text}
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "WABA_1",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {
+                                "phone_number_id": phone_number_id,
+                                "display_phone_number": "+15550000001",
+                            },
+                            "contacts": [
+                                {"wa_id": "15551234567", "profile": {"name": "Alice"}}
+                            ],
+                            "messages": [msg],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _sign(body: bytes, secret="topsecret") -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+# ---------- GET handshake ----------
+
+
+def test_verify_handshake_success(client):
+    r = client.get(
+        "/api/settings/integrations/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe",
+            "hub.verify_token": "verify-xyz",
+            "hub.challenge": "42",
+        },
+    )
+    assert r.status_code == 200
+    assert r.text == "42"
+
+
+def test_verify_handshake_bad_token(client):
+    r = client.get(
+        "/api/settings/integrations/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe",
+            "hub.verify_token": "nope",
+            "hub.challenge": "42",
+        },
+    )
+    assert r.status_code == 403
+
+
+def test_verify_handshake_bad_mode(client):
+    r = client.get(
+        "/api/settings/integrations/whatsapp/webhook",
+        params={"hub.mode": "unsubscribe", "hub.verify_token": "verify-xyz"},
+    )
+    assert r.status_code == 400
+
+
+# ---------- POST webhook ----------
+
+
+def test_post_unknown_phone_number_id_is_noop(client):
+    body = json.dumps(_inbound_text_payload(phone_number_id="UNKNOWN")).encode()
+    r = client.post(
+        "/api/settings/integrations/whatsapp/webhook",
+        content=body,
+        headers={"x-hub-signature-256": _sign(body)},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+def test_post_invalid_signature_rejected(client):
+    body = json.dumps(_inbound_text_payload()).encode()
+    r = client.post(
+        "/api/settings/integrations/whatsapp/webhook",
+        content=body,
+        headers={"x-hub-signature-256": "sha256=deadbeef"},
+    )
+    assert r.status_code == 401
+
+
+def test_post_valid_text_message_dispatches(client):
+    from app.services.external_platform_manager import ExternalPlatformManager  # stubbed
+
+    ExternalPlatformManager.last_call = None
+    body = json.dumps(_inbound_text_payload()).encode()
+    r = client.post(
+        "/api/settings/integrations/whatsapp/webhook",
+        content=body,
+        headers={"x-hub-signature-256": _sign(body)},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert ExternalPlatformManager.last_call is not None
+    platform_type, org_id, event = ExternalPlatformManager.last_call
+    assert platform_type == "whatsapp"
+    assert org_id == "org-1"
+    assert event["entry"][0]["changes"][0]["value"]["messages"][0]["text"]["body"] == "hello"
+
+
+def test_post_status_only_payload_is_noop(client):
+    from app.services.external_platform_manager import ExternalPlatformManager  # stubbed
+
+    ExternalPlatformManager.last_call = None
+    payload = {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {"phone_number_id": "PNID_1"},
+                            "statuses": [
+                                {"id": "wamid.S", "status": "delivered"}
+                            ],
+                        },
+                    }
+                ]
+            }
+        ],
+    }
+    body = json.dumps(payload).encode()
+    r = client.post(
+        "/api/settings/integrations/whatsapp/webhook",
+        content=body,
+        headers={"x-hub-signature-256": _sign(body)},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert ExternalPlatformManager.last_call is None
+
+
+def test_post_non_text_message_is_noop(client):
+    from app.services.external_platform_manager import ExternalPlatformManager  # stubbed
+
+    ExternalPlatformManager.last_call = None
+    body = json.dumps(_inbound_text_payload(msg_type="image")).encode()
+    r = client.post(
+        "/api/settings/integrations/whatsapp/webhook",
+        content=body,
+        headers={"x-hub-signature-256": _sign(body)},
+    )
+    assert r.status_code == 200
+    assert ExternalPlatformManager.last_call is None
+
+
+def test_post_deduplication(client):
+    from app.services.external_platform_manager import ExternalPlatformManager  # stubbed
+
+    calls = []
+
+    async def _tracking(self, db, pt, oid, ev):
+        calls.append(ev["entry"][0]["changes"][0]["value"]["messages"][0]["id"])
+        return {"success": True}
+
+    ExternalPlatformManager.handle_incoming_message = _tracking  # type: ignore
+
+    body = json.dumps(_inbound_text_payload(msg_id="wamid.DEDUP")).encode()
+    headers = {"x-hub-signature-256": _sign(body)}
+    r1 = client.post("/api/settings/integrations/whatsapp/webhook", content=body, headers=headers)
+    r2 = client.post("/api/settings/integrations/whatsapp/webhook", content=body, headers=headers)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert calls == ["wamid.DEDUP"]  # second call skipped

--- a/frontend/components/WhatsAppIntegrationModal.vue
+++ b/frontend/components/WhatsAppIntegrationModal.vue
@@ -1,0 +1,198 @@
+<template>
+    <div class="p-4">
+      <div class="flex items-center gap-2 mb-2">
+        <img src="/icons/whatsapp.png" alt="WhatsApp" class="w-5 h-5" />
+        <h1 class="text-lg font-semibold">WhatsApp Integration</h1>
+      </div>
+      <p class="text-sm text-gray-500">Configure and manage WhatsApp Cloud API integration for your organization</p>
+      <hr class="my-4" />
+
+      <div v-if="integrated" class="mb-4">
+        <p class="text-green-600 mb-4">WhatsApp is currently connected.</p>
+
+        <!-- Usage Notes -->
+        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-blue-800 mb-2">Usage Notes</h3>
+          <ul class="text-sm text-blue-700 space-y-1 list-disc list-inside">
+            <li>Only registered users can message the bot</li>
+            <li>WhatsApp is always a 1:1 DM — <strong>public + private</strong> data sources (that the user has access to) are queried</li>
+            <li>The bot can only reply within 24h of a user's last message (WhatsApp's customer service window)</li>
+          </ul>
+        </div>
+
+        <!-- Integration Details -->
+        <div class="bg-gray-50 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-gray-700 mb-3">Integration Details</h3>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-gray-600">Business Name:</span>
+              <span class="font-medium">{{ integrationData?.platform_config?.verified_name || 'N/A' }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-600">Phone Number:</span>
+              <span class="font-mono text-xs">{{ integrationData?.platform_config?.display_phone_number || 'N/A' }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-600">Phone Number ID:</span>
+              <span class="font-mono text-xs">{{ integrationData?.platform_config?.phone_number_id || 'N/A' }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-600">WABA ID:</span>
+              <span class="font-mono text-xs">{{ integrationData?.platform_config?.waba_id || 'N/A' }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-600">Connected:</span>
+              <span class="font-medium">{{ formatDate(integrationData?.created_at) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-600">Last Updated:</span>
+              <span class="font-medium">{{ formatDate(integrationData?.updated_at) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Webhook Setup Info -->
+        <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-yellow-800 mb-2">Webhook Setup</h3>
+          <p class="text-xs text-yellow-700 mb-1">
+            Configure your Meta app's webhook URL to:
+          </p>
+          <code class="block bg-white border border-yellow-200 rounded px-2 py-1 text-xs break-all">
+            {{ webhookUrl }}
+          </code>
+          <p class="text-xs text-yellow-700 mt-2">
+            Use the same <strong>Verify Token</strong> you entered during setup, and subscribe to the <code>messages</code> field on the WABA.
+          </p>
+        </div>
+
+        <UButton
+          color="red"
+          variant="soft"
+          @click="disconnect"
+        >
+          Disconnect
+        </UButton>
+      </div>
+      <div v-else>
+        <form @submit.prevent="connect">
+          <div class="mb-4">
+            <label class="block text-sm font-medium mb-1">Access Token</label>
+            <input v-model="accessToken" type="password" class="w-full border rounded px-2 py-1" required />
+            <p class="text-xs text-gray-500 mt-1">System User access token with <code>whatsapp_business_messaging</code> and <code>whatsapp_business_management</code>.</p>
+          </div>
+          <div class="mb-4">
+            <label class="block text-sm font-medium mb-1">Phone Number ID</label>
+            <input v-model="phoneNumberId" type="text" class="w-full border rounded px-2 py-1" required />
+          </div>
+          <div class="mb-4">
+            <label class="block text-sm font-medium mb-1">WhatsApp Business Account ID (WABA ID)</label>
+            <input v-model="wabaId" type="text" class="w-full border rounded px-2 py-1" required />
+          </div>
+          <div class="mb-4">
+            <label class="block text-sm font-medium mb-1">App Secret</label>
+            <input v-model="appSecret" type="password" class="w-full border rounded px-2 py-1" required />
+            <p class="text-xs text-gray-500 mt-1">Used to verify <code>X-Hub-Signature-256</code> on inbound webhooks.</p>
+          </div>
+          <div class="mb-4">
+            <label class="block text-sm font-medium mb-1">Verify Token</label>
+            <input v-model="verifyToken" type="text" class="w-full border rounded px-2 py-1" required />
+            <p class="text-xs text-gray-500 mt-1">A string you pick — Meta sends it back during webhook verification.</p>
+          </div>
+
+          <div class="bg-gray-50 border border-gray-200 rounded-lg p-3 mb-4">
+            <p class="text-xs text-gray-600 mb-1">After connecting, set your Meta app's webhook URL to:</p>
+            <code class="block bg-white border border-gray-200 rounded px-2 py-1 text-xs break-all">
+              {{ webhookUrl }}
+            </code>
+          </div>
+
+          <button type="submit" class="bg-blue-500 text-white text-sm px-3 py-1.5 rounded-md">Connect</button>
+        </form>
+      </div>
+      <button class="absolute top-2 right-2 text-gray-400 hover:text-gray-600" @click="$emit('close')">✕</button>
+    </div>
+  </template>
+
+  <script setup lang="ts">
+  import { ref, computed } from 'vue'
+  const props = defineProps<{
+    integrated: boolean
+    integrationData?: any
+  }>()
+  const emit = defineEmits(['close', 'updated'])
+  const toast = useToast()
+
+  const accessToken = ref('')
+  const phoneNumberId = ref('')
+  const wabaId = ref('')
+  const appSecret = ref('')
+  const verifyToken = ref('')
+
+  const webhookUrl = computed(() => {
+    if (typeof window !== 'undefined') {
+      return `${window.location.origin}/api/settings/integrations/whatsapp/webhook`
+    }
+    return '/api/settings/integrations/whatsapp/webhook'
+  })
+
+  function formatDate(dateString: string | undefined) {
+    if (!dateString) return 'N/A'
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  async function connect() {
+      const res = await useMyFetch('/api/settings/integrations/whatsapp', {
+        method: 'POST',
+        body: {
+          access_token: accessToken.value,
+          phone_number_id: phoneNumberId.value,
+          waba_id: wabaId.value,
+          app_secret: appSecret.value,
+          verify_token: verifyToken.value,
+        }
+      })
+      if (res.status.value === 'success') {
+        toast.add({
+          title: 'WhatsApp connected',
+          description: 'WhatsApp integration successful',
+          color: 'green'
+        })
+        emit('updated')
+        emit('close')
+      } else {
+        toast.add({
+          title: 'Failed to connect WhatsApp',
+          description: (res.error.value as any).data?.detail || (res.error.value as any).message,
+          color: 'red'
+        })
+    }
+  }
+
+  async function disconnect() {
+    if (!props.integrationData?.id) return
+    const res = await useMyFetch(`/api/settings/integrations/${props.integrationData.id}`, {
+      method: 'DELETE'
+    })
+    if (res.status.value === 'success') {
+      toast.add({
+        title: 'WhatsApp disconnected',
+        description: 'WhatsApp integration disconnected',
+        color: 'green'
+      })
+      emit('updated')
+      emit('close')
+    } else {
+      toast.add({
+        title: 'Failed to disconnect WhatsApp',
+        description: (res.error.value as any).data?.detail || (res.error.value as any).message,
+        color: 'red'
+      })
+    }
+  }
+  </script>

--- a/frontend/pages/settings/integrations/index.vue
+++ b/frontend/pages/settings/integrations/index.vue
@@ -69,6 +69,37 @@
       </button>
     </div>
 
+    <!-- WhatsApp Integration Row -->
+    <div
+      class="flex items-center justify-between p-4 border rounded-lg cursor-pointer hover:bg-gray-50"
+      @click="showWhatsAppModal = true"
+    >
+      <div class="flex items-center">
+        <img src="/icons/whatsapp.png" alt="WhatsApp" class="w-8 h-8 mr-4" />
+        <div>
+          <div class="font-medium">WhatsApp</div>
+          <div class="text-sm text-gray-500">
+            <span v-if="whatsappIntegrated">
+                <span class="text-green-600">Connected</span>
+            </span>
+            <span v-else>
+                <span class="text-gray-400">Not connected</span>
+            </span>
+          </div>
+          <div v-if="whatsappConfig && whatsappIntegrated" class="text-xs text-gray-400 mt-1">
+            <span>{{ whatsappConfig.verified_name || 'Business' }}</span>
+            <span class="ml-2">{{ whatsappConfig.display_phone_number }}</span>
+          </div>
+        </div>
+      </div>
+      <button
+        class="bg-blue-500 text-white text-sm px-3 py-1.5 rounded-md"
+        @click.stop="showWhatsAppModal = true"
+      >
+        {{ whatsappIntegrated ? 'Settings' : 'Integrate' }}
+      </button>
+    </div>
+
     <!-- MCP Integration Row -->
     <div
       class="flex items-center justify-between p-4 border rounded-lg"
@@ -110,6 +141,16 @@
         @updated="fetchIntegrations"
       />
     </UModal>
+
+    <!-- WhatsApp Integration Modal -->
+    <UModal v-model="showWhatsAppModal" :ui="{ width: 'max-w-lg' }">
+      <WhatsAppIntegrationModal
+        :integrated="whatsappIntegrated"
+        :integration-data="whatsappIntegrationData"
+        @close="showWhatsAppModal = false"
+        @updated="fetchIntegrations"
+      />
+    </UModal>
   </div>
 </template>
 
@@ -117,6 +158,7 @@
 import { ref, onMounted } from 'vue'
 import SlackIntegrationModal from '~/components/SlackIntegrationModal.vue'
 import TeamsIntegrationModal from '~/components/TeamsIntegrationModal.vue'
+import WhatsAppIntegrationModal from '~/components/WhatsAppIntegrationModal.vue'
 import McpIcon from '~/components/icons/McpIcon.vue'
 
 definePageMeta({ auth: true, permissions: ['manage_organization_external_platforms'], layout: 'settings' })
@@ -130,6 +172,11 @@ const showTeamsModal = ref(false)
 const teamsIntegrated = ref(false)
 const teamsConfig = ref<{ tenant_id?: string; app_id?: string } | null>(null)
 const teamsIntegrationData = ref<any>(null)
+
+const showWhatsAppModal = ref(false)
+const whatsappIntegrated = ref(false)
+const whatsappConfig = ref<{ phone_number_id?: string; display_phone_number?: string; verified_name?: string; waba_id?: string } | null>(null)
+const whatsappIntegrationData = ref<any>(null)
 
 // MCP state
 const mcpEnabled = ref(false)
@@ -150,6 +197,11 @@ async function fetchIntegrations() {
   teamsIntegrated.value = !!teams
   teamsConfig.value = teams?.platform_config || null
   teamsIntegrationData.value = teams || null
+
+  const whatsapp = integrations.find((i: any) => i.platform_type === 'whatsapp' && i.is_active)
+  whatsappIntegrated.value = !!whatsapp
+  whatsappConfig.value = whatsapp?.platform_config || null
+  whatsappIntegrationData.value = whatsapp || null
 }
 
 async function loadMcpState() {


### PR DESCRIPTION
Mirrors the Slack/Teams external-platform pattern: a WhatsAppAdapter subclass of PlatformAdapter, registered in the factory; WhatsAppConfig schema; create_whatsapp_platform service with Meta Graph validation; POST /settings/integrations/whatsapp config route; GET/POST /api/settings/integrations/whatsapp/webhook with X-Hub-Signature-256 verification, phone_number_id-based tenant routing, and id-based dedupe.

Adapter parses Cloud API webhooks, sends text replies with context threading, uploads media in two steps, and maps Slack-style emoji reactions to unicode for the manager's processing indicator.

Frontend adds a WhatsApp card and modal to settings/integrations.

Tests: 21 unit tests (adapter parsing, signature verify, send/reaction/ media mocked via httpx MockTransport, and full webhook route behaviour incl. handshake, bad-signature, dedupe, status-only, non-text, dispatch).

Sandbox: backend/scripts/whatsapp_sandbox_debug.py boots the real adapter
+ route against a mock Meta Graph server and replays a full scenario (handshake, unverified->verified, threaded reply, status-only, dedupe).

https://claude.ai/code/session_01XtJkarHadpmRsGU5quSYrY