### PR TITLE
Fix missing ConnectionTool migration and webhook test stubs

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -60,6 +60,8 @@ from app.models.user_data_source_credentials import UserDataSourceCredentials
 from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable, UserDataSourceColumn as UserOverlayColumn
 from app.models.connection import Connection
 from app.models.connection_table import ConnectionTable
+from app.models.connection_tool import ConnectionTool
+from app.models.user_connection_tool import UserConnectionTool
 from app.models.domain_connection import domain_connection
 from app.models.user_connection_credentials import UserConnectionCredentials
 from app.models.user_connection_overlay import UserConnectionTable, UserConnectionColumn

--- a/backend/tests/unit/test_whatsapp_webhook_route.py
+++ b/backend/tests/unit/test_whatsapp_webhook_route.py
@@ -33,7 +33,7 @@ def _install_route_stubs():
 
     deps_mod.get_async_db = _fake_db
     sys.modules.setdefault("app", types.ModuleType("app"))
-    sys.modules["app.dependencies"] = deps_mod
+    sys.modules.setdefault("app.dependencies", deps_mod)
 
     # Stub services.external_platform_manager with a module containing a
     # controllable class.
@@ -47,8 +47,8 @@ def _install_route_stubs():
             return {"success": True, "action": "message_processed"}
 
     epm_mod.ExternalPlatformManager = ExternalPlatformManager
-    sys.modules["app.services"] = types.ModuleType("app.services")
-    sys.modules["app.services.external_platform_manager"] = epm_mod
+    sys.modules.setdefault("app.services", types.ModuleType("app.services"))
+    sys.modules.setdefault("app.services.external_platform_manager", epm_mod)
 
     # Stub external_platform_service
     eps_mod = types.ModuleType("app.services.external_platform_service")
@@ -57,7 +57,7 @@ def _install_route_stubs():
         pass
 
     eps_mod.ExternalPlatformService = ExternalPlatformService
-    sys.modules["app.services.external_platform_service"] = eps_mod
+    sys.modules.setdefault("app.services.external_platform_service", eps_mod)
 
     # Stub models.external_platform
     models_mod = types.ModuleType("app.models")
@@ -75,9 +75,8 @@ def _install_route_stubs():
             return dict(self._credentials)
 
     ep_mod.ExternalPlatform = ExternalPlatform
-    # Force-replace even if a previous test file already stubbed these.
-    sys.modules["app.models"] = models_mod
-    sys.modules["app.models.external_platform"] = ep_mod
+    sys.modules.setdefault("app.models", models_mod)
+    sys.modules.setdefault("app.models.external_platform", ep_mod)
     return ExternalPlatform
 
 


### PR DESCRIPTION
## Summary

- **Add `ConnectionTool` and `UserConnectionTool` imports to `alembic/env.py`** so their tables are created via `Base.metadata.create_all()` in tests. The migration file existed but the models were never imported into `env.py`, so the tables were silently skipped. This caused `SchemaContextBuilder._build_mcp_tools()` to crash in Postgres because `connection_tools` didn't exist.

- **Use `setdefault` for all `sys.modules` entries in `test_whatsapp_webhook_route.py`** (same fix as the previous PR for `test_whatsapp_adapter.py`). Unconditional assignment was clobbering real modules like `app.dependencies`, causing `ImportError: cannot import name 'engine'` in downstream tests.

## Test plan

- [ ] Postgres CI: `test_mcp_get_context` and `test_mcp_get_context_with_patterns` should pass
- [ ] SQLite CI: tests should no longer fail with `ImportError: cannot import name 'engine' from 'app.dependencies'`
- [ ] WhatsApp unit tests still pass standalone

https://claude.ai/code/session_01VH93DMJEx8Kn1brn4pep69