### PR TITLE
Fix Slack disconnect 404 — use platform UUID instead of literal "slack"

### DIFF
--- a/frontend/components/SlackIntegrationModal.vue
+++ b/frontend/components/SlackIntegrationModal.vue
@@ -118,7 +118,8 @@
   }
   
   async function disconnect() {
-    const res = await useMyFetch('/api/settings/integrations/slack', {
+    if (!props.integrationData?.id) return
+    const res = await useMyFetch(`/api/settings/integrations/${props.integrationData.id}`, {
       method: 'DELETE'
     })
     if (res.status.value === 'success') {


### PR DESCRIPTION
## Summary
- Fix "Failed to disconnect Slack — External platform not found" by calling the real platform UUID instead of the literal string `"slack"`.
- Match the convention already used by the Teams and WhatsApp integration modals.

## Root cause
The Slack disconnect button has been calling `DELETE /api/settings/integrations/slack` since July 2025. Back then the backend's `delete_platform` looked up rows by `platform_type`, so the literal `"slack"` happened to match. On **Jan 31, 2026** commit `83130201` *"feat: teams support"* refactored `delete_platform` to look up by `platform_id` (UUID), so the literal `"slack"` stopped matching anything and the service started returning 404 "External platform not found". Every Slack disconnect click has failed since.

The same commit introduced `TeamsIntegrationModal.vue` using `` `${integrationData?.id}` `` correctly, and the later WhatsApp modal followed the same pattern — only the Slack modal was never migrated.

## Fix
One-liner in `frontend/components/SlackIntegrationModal.vue`: use `props.integrationData.id` in the URL, with a guard so the button is a no-op if the component is somehow rendered without integration data.

```diff
 async function disconnect() {
-  const res = await useMyFetch('/api/settings/integrations/slack', {
+  if (!props.integrationData?.id) return
+  const res = await useMyFetch(`/api/settings/integrations/${props.integrationData.id}`, {
     method: 'DELETE'
   })
```

## Test plan
- [ ] Connect Slack integration in the UI.
- [ ] Open the Slack Integration modal from Settings → Integrations, verify "Slack is currently connected" shows.
- [ ] Click **Disconnect**, verify the request goes to `DELETE /api/settings/integrations/<uuid>` (not `/slack`).
- [ ] Verify success toast "Slack disconnected" appears and the integration disappears from the list.
- [ ] Confirm the `external_platforms` row and any `external_user_mappings` for it are removed.
- [ ] Reconnect to confirm the create flow (`POST /settings/integrations/slack`) is unaffected.

https://claude.ai/code/session_016i8rt1nQaLGWvj4EGmSdrv