### PR TITLE
feat(powerbi-report-server): make PBIX semantic models queryable (Phase 1-3)

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -128,11 +128,13 @@ class CodeSecurityVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Constant(self, node: ast.Constant):
-        # Check string literals for dangerous SQL operations
+        # Check string literals for dangerous SQL operations. Uses the
+        # structural regex so prose like "create a chart" or "update the
+        # description" isn't flagged — we only match keywords that appear in
+        # real SQL context (CREATE TABLE, DELETE FROM, UPDATE x SET, ...).
         if isinstance(node.value, str) and len(node.value) > 5:
-            match = _FORBIDDEN_SQL_REGEX.search(node.value)
+            match = _FORBIDDEN_SQL_IN_STRING_REGEX.search(node.value)
             if match:
-                # Extract a snippet for context (first 50 chars)
                 snippet = node.value[:50].replace('\n', ' ')
                 self.errors.append(
                     f"Forbidden SQL operation '{match.group()}' in string: \"{snippet}...\""
@@ -140,10 +142,11 @@ class CodeSecurityVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_JoinedStr(self, node: ast.JoinedStr):
-        # Check f-string parts for dangerous SQL
+        # Check f-string parts for dangerous SQL using the same structural
+        # regex — prose inside f-strings shouldn't trip the validator either.
         for part in node.values:
             if isinstance(part, ast.Constant) and isinstance(part.value, str):
-                match = _FORBIDDEN_SQL_REGEX.search(part.value)
+                match = _FORBIDDEN_SQL_IN_STRING_REGEX.search(part.value)
                 if match:
                     snippet = part.value[:50].replace('\n', ' ')
                     self.errors.append(
@@ -204,6 +207,34 @@ FORBIDDEN_SQL_PATTERNS = [
 _FORBIDDEN_SQL_REGEX = re.compile(
     '|'.join(FORBIDDEN_SQL_PATTERNS),
     re.IGNORECASE
+)
+
+# Structural SQL-write patterns — used when scanning Python string literals so
+# prose like "the user wants to create a chart" or "delete outdated rows from
+# the description" doesn't trigger the bare-verb match above. Each pattern
+# requires the keyword to sit next to a syntactic partner that real SQL always
+# has (TABLE/VIEW/INTO/FROM/SET/...), which prose basically never does.
+_FORBIDDEN_SQL_IN_STRING_PATTERNS = [
+    r'\bCREATE\s+(OR\s+REPLACE\s+)?(TEMP(ORARY)?\s+)?(TABLE|VIEW|INDEX|DATABASE|SCHEMA|FUNCTION|PROCEDURE|TRIGGER|SEQUENCE|ROLE|USER|MATERIALIZED)\b',
+    r'\bDROP\s+(TABLE|VIEW|INDEX|DATABASE|SCHEMA|FUNCTION|PROCEDURE|TRIGGER|SEQUENCE|COLUMN|CONSTRAINT|ROLE|USER)\b',
+    r'\bALTER\s+(TABLE|VIEW|INDEX|DATABASE|SCHEMA|COLUMN|SEQUENCE|ROLE|USER)\b',
+    r'\bTRUNCATE\s+(TABLE\s+)?\w+',
+    r'\bINSERT\s+INTO\b',
+    r'\bUPDATE\s+[\w.`"\[\]]+(\s+AS\s+\w+|\s+\w+)?\s+SET\b',
+    r'\bDELETE\s+FROM\b',
+    r'\bMERGE\s+INTO\b',
+    r'\bREPLACE\s+INTO\b',
+    r'\bGRANT\s+[\w,\s*]+\s+ON\b',
+    r'\bREVOKE\s+[\w,\s*]+\s+(ON|FROM)\b',
+    r'\bEXEC(UTE)?\s+(\w+\.)*\w+',
+    r'\bCALL\s+\w+\s*\(',
+    r'\bLOAD\s+DATA\b',
+    r'\bINTO\s+OUTFILE\b',
+    r'\bINTO\s+DUMPFILE\b',
+]
+_FORBIDDEN_SQL_IN_STRING_REGEX = re.compile(
+    '|'.join(_FORBIDDEN_SQL_IN_STRING_PATTERNS),
+    re.IGNORECASE,
 )
 
 

--- a/backend/app/ai/prompt_formatters.py
+++ b/backend/app/ai/prompt_formatters.py
@@ -370,6 +370,18 @@ class TableFormatter:
             if cmd:
                 snippet = cmd.replace("\n", " ")[:400]
                 lines.append(f"-- command_text: {snippet}")
+            model_tables = pbi_meta.get("model_tables") or []
+            if model_tables:
+                lines.append(
+                    f"-- model_tables: {', '.join(str(t) for t in model_tables[:15])}"
+                )
+            measures = pbi_meta.get("measures") or []
+            for m in measures[:10]:
+                name = m.get("name") or ""
+                if not name:
+                    continue
+                expr = (m.get("expression") or "").replace("\n", " ")[:200]
+                lines.append(f"-- measure: {name} = {expr}" if expr else f"-- measure: {name}")
             note = pbi_meta.get("query_note")
             if note:
                 lines.append(f"-- note: {note}")

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -5,10 +5,15 @@ from app.ai.prompt_formatters import Table, TableColumn, ForeignKey, ServiceForm
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import StringIO
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
+import hashlib
+import json
 import logging
+import os
 import re
+import tempfile
 import xml.etree.ElementTree as ET
 
 import pandas as pd
@@ -20,6 +25,39 @@ logger = logging.getLogger(__name__)
 
 
 _RDL_NS_RE = re.compile(r"^\{[^}]+\}")
+
+# Cache for PBIX-extracted schemas, keyed by (report_id, modified_date).
+_PBIX_SCHEMA_CACHE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "uploads" / "pbirs_schema_cache"
+
+# Max pbix size we'll attempt to parse (bytes). Larger files are skipped — they
+# use more memory/time than is worthwhile for metadata-only discovery.
+_PBIX_MAX_BYTES = 200 * 1024 * 1024  # 200MB
+
+# Auto-generated internal Power BI date tables — filtered out of schema output.
+_AUTO_DATE_TABLE_RE = re.compile(r"^(LocalDateTable|DateTableTemplate)_[0-9a-fA-F\-]+$")
+
+
+def _pbix_cache_path(report_id: str, modified_date: Optional[str]) -> Path:
+    key = f"{report_id}|{modified_date or ''}"
+    h = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+    return _PBIX_SCHEMA_CACHE_DIR / f"{h}.json"
+
+
+def _dax_to_dtype(dax_type: Optional[str]) -> str:
+    if not dax_type:
+        return "unknown"
+    t = str(dax_type).lower()
+    if "int" in t:
+        return "int"
+    if "float" in t or "double" in t or "decimal" in t or "number" in t:
+        return "float"
+    if "bool" in t:
+        return "bool"
+    if "date" in t or "time" in t:
+        return "datetime"
+    if "string" in t or "text" in t or "object" in t:
+        return "string"
+    return t
 
 
 def _strip_ns(tag: str) -> str:
@@ -111,6 +149,7 @@ class PowerBIReportServerClient(DataSourceClient):
         domain: Optional[str] = None,
         verify_ssl: bool = True,
         ca_bundle_path: Optional[str] = None,
+        extract_pbix_schemas: bool = True,
     ):
         if not server_url:
             raise ValueError("server_url is required")
@@ -125,6 +164,7 @@ class PowerBIReportServerClient(DataSourceClient):
         self.domain = domain
         self.verify_ssl = verify_ssl
         self.ca_bundle_path = ca_bundle_path
+        self.extract_pbix_schemas = extract_pbix_schemas
 
         self._session: Optional[requests.Session] = None
 
@@ -282,6 +322,132 @@ class PowerBIReportServerClient(DataSourceClient):
         if r.status_code >= 300:
             raise RuntimeError(f"Download content for {item_id} failed: HTTP {r.status_code}")
         return r.content
+
+    # ------------------------------------------------------------------
+    # PBIX schema extraction via pbixray
+    # ------------------------------------------------------------------
+
+    def extract_pbix_schema(
+        self,
+        report_id: str,
+        modified_date: Optional[str] = None,
+        *,
+        report_name: Optional[str] = None,
+        use_cache: bool = True,
+    ) -> Optional[Dict[str, Any]]:
+        """Download a PBIX and parse its Vertipaq model schema with pbixray.
+
+        Returns a dict with `tables`, `relationships`, `measures`, `source`, or
+        None on failure. Result is cached on disk keyed by (report_id, modified_date)
+        so a subsequent schema refresh is a cheap JSON read.
+        """
+        cache_file = _pbix_cache_path(report_id, modified_date)
+        if use_cache and cache_file.exists():
+            try:
+                with cache_file.open("r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                logger.debug(f"pbix cache read failed for {report_id}: {e}")
+
+        try:
+            from pbixray import PBIXRay  # type: ignore
+        except Exception as e:
+            logger.warning(f"pbixray unavailable, skipping pbix schema extraction: {e}")
+            return None
+
+        try:
+            content = self.download_catalog_item_content(report_id)
+        except Exception as e:
+            logger.info(f"pbix download failed for {report_id} ({report_name}): {e}")
+            return None
+
+        if len(content) > _PBIX_MAX_BYTES:
+            logger.info(
+                f"pbix {report_id} ({report_name}) is {len(content)} bytes — exceeds "
+                f"{_PBIX_MAX_BYTES}; skipping schema extraction"
+            )
+            return None
+
+        tmp_path = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(suffix=".pbix")
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
+            model = PBIXRay(tmp_path)
+            schema_df = model.schema
+            rels_df = model.relationships
+            measures_df = model.dax_measures
+
+            # Group schema rows into tables, skipping auto-generated date tables.
+            tables_out: Dict[str, Dict[str, Any]] = {}
+            if schema_df is not None and not schema_df.empty:
+                for _, row in schema_df.iterrows():
+                    tname = str(row.get("TableName") or "")
+                    if not tname or _AUTO_DATE_TABLE_RE.match(tname):
+                        continue
+                    t = tables_out.setdefault(tname, {"name": tname, "columns": [], "measures": []})
+                    t["columns"].append({
+                        "name": str(row.get("ColumnName") or ""),
+                        "dtype": _dax_to_dtype(row.get("PandasDataType")),
+                    })
+
+            # Attach measures to their tables.
+            if measures_df is not None and not measures_df.empty:
+                for _, row in measures_df.iterrows():
+                    tname = str(row.get("TableName") or "")
+                    if not tname or _AUTO_DATE_TABLE_RE.match(tname):
+                        continue
+                    entry = tables_out.setdefault(tname, {"name": tname, "columns": [], "measures": []})
+                    entry["measures"].append({
+                        "name": str(row.get("Name") or ""),
+                        "expression": str(row.get("Expression") or ""),
+                        "display_folder": str(row.get("DisplayFolder") or ""),
+                        "description": str(row.get("Description") or ""),
+                    })
+
+            relationships_out: List[Dict[str, Any]] = []
+            if rels_df is not None and not rels_df.empty:
+                for _, row in rels_df.iterrows():
+                    from_t = str(row.get("FromTableName") or "")
+                    to_t = str(row.get("ToTableName") or "")
+                    if _AUTO_DATE_TABLE_RE.match(from_t) or _AUTO_DATE_TABLE_RE.match(to_t):
+                        continue
+                    relationships_out.append({
+                        "from_table": from_t,
+                        "from_column": str(row.get("FromColumnName") or ""),
+                        "to_table": to_t,
+                        "to_column": str(row.get("ToColumnName") or ""),
+                        "is_active": bool(row.get("IsActive", True)),
+                        "cardinality": str(row.get("Cardinality") or ""),
+                    })
+
+            result = {
+                "source": "pbixray",
+                "report_id": report_id,
+                "report_name": report_name,
+                "modified_date": modified_date,
+                "tables": list(tables_out.values()),
+                "relationships": relationships_out,
+            }
+
+            try:
+                _PBIX_SCHEMA_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+                with cache_file.open("w", encoding="utf-8") as f:
+                    json.dump(result, f)
+            except Exception as e:
+                logger.debug(f"pbix cache write failed for {report_id}: {e}")
+
+            return result
+        except Exception as e:
+            logger.info(f"pbix schema extraction failed for {report_id} ({report_name}): {e}")
+            return None
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     # ------------------------------------------------------------------
     # RDL parsing — extract CommandText, fields, parameters from report XML
@@ -530,6 +696,27 @@ class PowerBIReportServerClient(DataSourceClient):
                     except Exception as e:
                         logger.debug(f"pbi {r['Id']} Roles failed: {e}")
 
+            # Parallel pbix schema extraction — best-effort, each failure is
+            # contained so the umbrella discovery row still renders.
+            pbix_schemas: Dict[str, Optional[Dict[str, Any]]] = {r["Id"]: None for r in pbi_reports}
+            if self.extract_pbix_schemas:
+                with ThreadPoolExecutor(max_workers=4) as pool:
+                    ext_futs = {
+                        pool.submit(
+                            self.extract_pbix_schema,
+                            r["Id"],
+                            r.get("ModifiedDate"),
+                            report_name=r.get("Name") or r["Id"],
+                        ): r
+                        for r in pbi_reports
+                    }
+                    for fut in as_completed(ext_futs):
+                        r = ext_futs[fut]
+                        try:
+                            pbix_schemas[r["Id"]] = fut.result()
+                        except Exception as e:
+                            logger.debug(f"pbix schema extract failed for {r['Id']}: {e}")
+
             for r in pbi_reports:
                 rid = r["Id"]
                 name = r.get("Name") or rid
@@ -547,6 +734,11 @@ class PowerBIReportServerClient(DataSourceClient):
                     })
 
                 upstream_hint = _summarize_upstream(connection_summary)
+
+                schema_info = pbix_schemas.get(rid)
+                schema_tables = (schema_info or {}).get("tables") or []
+                schema_rels = (schema_info or {}).get("relationships") or []
+                schema_table_names = [t["name"] for t in schema_tables]
 
                 metadata_json = {
                     "powerbi_report_server": {
@@ -567,6 +759,9 @@ class PowerBIReportServerClient(DataSourceClient):
                         "roles": [{"name": rl.get("Name"), "model_permissions": rl.get("ModelPermissions")} for rl in info["roles"]],
                         "queryable": False,
                         "upstream_source": upstream_hint,
+                        "model_tables": schema_table_names,
+                        "model_relationships": schema_rels,
+                        "schema_source": (schema_info or {}).get("source"),
                         "query_note": (
                             "This is a discovery entry — the PBIX embedded model is NOT queryable through PBIRS. "
                             f"To query its data, connect the upstream source directly: {upstream_hint or 'see data_sources[] for connection details'}."
@@ -584,6 +779,57 @@ class PowerBIReportServerClient(DataSourceClient):
                     is_active=True,
                     metadata_json=metadata_json,
                 ))
+
+                # Emit one Table per internal pbix model table when extraction succeeded.
+                # Relationships within the model become fks on the "from" side.
+                if schema_tables:
+                    rels_by_from: Dict[str, List[Dict[str, Any]]] = {}
+                    for rel in schema_rels:
+                        rels_by_from.setdefault(rel["from_table"], []).append(rel)
+
+                    for st in schema_tables:
+                        tname = st["name"]
+                        columns = [
+                            TableColumn(name=c["name"], dtype=c.get("dtype") or "unknown")
+                            for c in st.get("columns", [])
+                        ]
+                        col_by_name = {c.name: c for c in columns}
+
+                        fks: List[ForeignKey] = []
+                        for rel in rels_by_from.get(tname, []):
+                            fc = col_by_name.get(rel["from_column"])
+                            if fc is None:
+                                continue
+                            fks.append(ForeignKey(
+                                column=fc,
+                                references_name=f"pbix:{name}/{rel['to_table']}",
+                                references_column=TableColumn(name=rel["to_column"], dtype="unknown"),
+                            ))
+
+                        tables.append(Table(
+                            name=f"pbix:{name}/{tname}",
+                            description=f"Internal table in Power BI report '{name}'. Not queryable via PBIRS.",
+                            columns=columns,
+                            pks=[],
+                            fks=fks,
+                            is_active=True,
+                            metadata_json={
+                                "powerbi_report_server": {
+                                    "report_type": "PowerBIReportTable",
+                                    "report_id": rid,
+                                    "report_name": name,
+                                    "model_table": tname,
+                                    "measures": st.get("measures", []),
+                                    "queryable": False,
+                                    "upstream_source": upstream_hint,
+                                    "schema_source": (schema_info or {}).get("source"),
+                                    "query_note": (
+                                        "Internal PBIX model table — not queryable through PBIRS. "
+                                        "Use the upstream source for live data."
+                                    ),
+                                }
+                            },
+                        ))
 
         # ---- Paginated RDL reports: download content + parse ----
         if rdl_reports:
@@ -858,7 +1104,7 @@ class PowerBIReportServerClient(DataSourceClient):
                 report_id = pbi.get("report_id")
             elif rt == "Dataset":
                 dataset_id = pbi.get("dataset_id")
-            elif rt == "PowerBIReport":
+            elif rt in ("PowerBIReport", "PowerBIReportTable"):
                 upstream = pbi.get("upstream_source") or ""
                 srcs = pbi.get("data_sources") or []
                 hint = f" Upstream: {upstream}." if upstream else ""
@@ -1031,6 +1277,12 @@ Tables returned by `get_schemas()` are prefixed by kind:
     - `data_sources[]` — each entry has `kind` (SQL/File/OData/etc.), `connection_string`, `auth_type`.
     - `upstream_source` — short human-readable summary of where the data actually lives.
     - `parameters[]`, `roles[]`, `path`, `modified_by`, etc.
+    - `model_tables[]` / `model_relationships[]` — internal semantic-model structure (when extractable).
+
+- `pbix:<ReportName>/<ModelTable>` — an internal table inside a PBIX semantic model.
+  **Still not queryable**, but exposes real `columns[]` and DAX `measures[]` in metadata so the
+  LLM can reason about structure. When the user asks for actual data from these columns, route
+  them to the upstream source from the parent `pbix:<ReportName>` entry.
 
 - `rdl:<ReportName>/<DataSetName>` — a paginated (RDL) report dataset. **Queryable.**
   - Backend SQL is in `metadata_json.powerbi_report_server.command_text`.

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -593,6 +593,43 @@ class PowerBIReportServerClient(DataSourceClient):
                 except OSError:
                     pass
 
+    def warm_pbix_caches(self) -> Dict[str, Any]:
+        """Pre-materialize Parquet caches for every pbix report on this server so
+        the first execute_query doesn't block on a cold pbixray parse. Safe to run
+        on a schedule: each report is keyed by (report_id, modified_date), so an
+        already-warm cache is a no-op (manifest hit returns immediately).
+        """
+        if not self.enable_pbix_query:
+            return {"skipped": True, "reason": "enable_pbix_query=False"}
+
+        self.connect()
+        try:
+            reports = self.list_powerbi_reports()
+        except Exception as e:
+            logger.warning(f"pbirs.warm.list_failed: {e}")
+            return {"reports": 0, "warmed": 0, "failed": 0, "error": str(e)}
+
+        warmed = 0
+        failed = 0
+        for r in reports:
+            rid = r.get("Id")
+            if not rid:
+                continue
+            try:
+                self.ensure_pbix_parquets(
+                    rid,
+                    r.get("ModifiedDate"),
+                    report_name=r.get("Name") or rid,
+                )
+                warmed += 1
+            except Exception as e:
+                logger.warning(
+                    "pbirs.warm.report_failed",
+                    extra={"report_id": rid, "report_name": r.get("Name"), "pbirs_error": str(e)},
+                )
+                failed += 1
+        return {"reports": len(reports), "warmed": warmed, "failed": failed}
+
     def _execute_pbix_query(
         self,
         report_id: str,
@@ -1554,3 +1591,70 @@ For PBIX, `query` is required (DuckDB SQL against the internal table names).
 
 # Compatibility aliases for dynamic resolver
 PowerbiReportServerClient = PowerBIReportServerClient
+
+
+async def warm_all_pbirs_caches() -> None:
+    """Scheduled maintenance: walk every active PBIRS Connection and warm its
+    pbix Parquet caches so a first create_data/inspect_data on a large .pbix
+    doesn't stall the UI on pbixray parse. Designed for APScheduler interval.
+    """
+    import asyncio
+    import time as _time
+
+    from sqlalchemy import select
+
+    from app.dependencies import async_session_maker
+    from app.models.connection import Connection
+
+    t0 = _time.perf_counter()
+    async with async_session_maker() as db:
+        rows = (
+            await db.execute(
+                select(Connection).where(
+                    Connection.type == "powerbi_report_server",
+                    Connection.is_active.is_(True),
+                    Connection.deleted_at.is_(None),
+                )
+            )
+        ).scalars().all()
+
+    if not rows:
+        logger.info("pbirs.warmup.sweep", extra={"pbirs_connections": 0})
+        return
+
+    logger.info("pbirs.warmup.sweep.start", extra={"pbirs_connections": len(rows)})
+    warmed = 0
+    failed = 0
+    for conn in rows:
+        try:
+            client = conn.get_client()
+        except Exception as exc:
+            logger.warning(
+                "pbirs.warmup.client_init_failed",
+                extra={"connection_id": str(conn.id), "pbirs_error": str(exc)},
+            )
+            failed += 1
+            continue
+        if not isinstance(client, PowerBIReportServerClient):
+            continue
+        try:
+            # warm_pbix_caches is sync (requests/pbixray); offload to a thread so
+            # the scheduler loop isn't blocked by a slow PBIRS server.
+            await asyncio.to_thread(client.warm_pbix_caches)
+            warmed += 1
+        except Exception as exc:
+            logger.warning(
+                "pbirs.warmup.connection_failed",
+                extra={"connection_id": str(conn.id), "pbirs_error": str(exc)},
+            )
+            failed += 1
+
+    logger.info(
+        "pbirs.warmup.sweep.done",
+        extra={
+            "pbirs_connections": len(rows),
+            "pbirs_warmed": warmed,
+            "pbirs_failed": failed,
+            "pbirs_elapsed_s": round(_time.perf_counter() - t0, 2),
+        },
+    )

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -29,18 +29,47 @@ _RDL_NS_RE = re.compile(r"^\{[^}]+\}")
 # Cache for PBIX-extracted schemas, keyed by (report_id, modified_date).
 _PBIX_SCHEMA_CACHE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "uploads" / "pbirs_schema_cache"
 
+# Cache for PBIX-extracted Parquet data (one file per model table), keyed by
+# (report_id, modified_date). Populated lazily on first query; re-used across
+# queries and invalidated on report edit via the modified_date key.
+_PBIX_DATA_CACHE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "uploads" / "pbix_data_cache"
+
 # Max pbix size we'll attempt to parse (bytes). Larger files are skipped — they
 # use more memory/time than is worthwhile for metadata-only discovery.
 _PBIX_MAX_BYTES = 200 * 1024 * 1024  # 200MB
 
+# Per-table row cap when materializing pbix data to Parquet. Tables exceeding
+# this are skipped — parsing very large Vertipaq tables blows memory on the
+# decode path. 5M is comfortably above typical semantic-model fact tables.
+_PBIX_MAX_ROWS_PER_TABLE = 5_000_000
+
 # Auto-generated internal Power BI date tables — filtered out of schema output.
 _AUTO_DATE_TABLE_RE = re.compile(r"^(LocalDateTable|DateTableTemplate)_[0-9a-fA-F\-]+$")
+
+# DuckDB view names need to be simple identifiers. Vertipaq table names can
+# contain spaces, symbols, or be reserved keywords — sanitize to a safe form.
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _safe_view_name(name: str) -> str:
+    cleaned = _SAFE_NAME_RE.sub("_", name).strip("_")
+    if not cleaned:
+        cleaned = "tbl"
+    if cleaned[0].isdigit():
+        cleaned = f"t_{cleaned}"
+    return cleaned
 
 
 def _pbix_cache_path(report_id: str, modified_date: Optional[str]) -> Path:
     key = f"{report_id}|{modified_date or ''}"
     h = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
     return _PBIX_SCHEMA_CACHE_DIR / f"{h}.json"
+
+
+def _pbix_data_cache_dir(report_id: str, modified_date: Optional[str]) -> Path:
+    key = f"{report_id}|{modified_date or ''}"
+    h = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+    return _PBIX_DATA_CACHE_DIR / h
 
 
 def _dax_to_dtype(dax_type: Optional[str]) -> str:
@@ -150,6 +179,7 @@ class PowerBIReportServerClient(DataSourceClient):
         verify_ssl: bool = True,
         ca_bundle_path: Optional[str] = None,
         extract_pbix_schemas: bool = True,
+        enable_pbix_query: bool = True,
     ):
         if not server_url:
             raise ValueError("server_url is required")
@@ -165,6 +195,7 @@ class PowerBIReportServerClient(DataSourceClient):
         self.verify_ssl = verify_ssl
         self.ca_bundle_path = ca_bundle_path
         self.extract_pbix_schemas = extract_pbix_schemas
+        self.enable_pbix_query = enable_pbix_query
 
         self._session: Optional[requests.Session] = None
 
@@ -448,6 +479,173 @@ class PowerBIReportServerClient(DataSourceClient):
                     os.unlink(tmp_path)
                 except OSError:
                     pass
+
+    def ensure_pbix_parquets(
+        self,
+        report_id: str,
+        modified_date: Optional[str] = None,
+        *,
+        report_name: Optional[str] = None,
+    ) -> Dict[str, Path]:
+        """Materialize every queryable pbix model table to Parquet and return a
+        {table_name: parquet_path} map. Cached on disk keyed by (report_id,
+        modified_date) so edits invalidate cleanly. Auto-date tables and tables
+        exceeding _PBIX_MAX_ROWS_PER_TABLE are skipped.
+
+        Raises RuntimeError on download/parse failure so callers can surface a
+        clear error back to the LLM.
+        """
+        cache_dir = _pbix_data_cache_dir(report_id, modified_date)
+        manifest_path = cache_dir / "manifest.json"
+        if manifest_path.exists():
+            try:
+                with manifest_path.open("r", encoding="utf-8") as f:
+                    manifest = json.load(f)
+                return {t: cache_dir / rel for t, rel in manifest.items() if (cache_dir / rel).exists()}
+            except Exception as e:
+                logger.debug(f"pbix parquet manifest read failed for {report_id}: {e}")
+
+        try:
+            from pbixray import PBIXRay  # type: ignore
+        except Exception as e:
+            raise RuntimeError(
+                "pbixray is required to query Power BI (.pbix) data but is not installed. "
+                "Install it or set enable_pbix_query=False."
+            ) from e
+
+        content = self.download_catalog_item_content(report_id)
+        if len(content) > _PBIX_MAX_BYTES:
+            raise RuntimeError(
+                f"PBIX report '{report_name or report_id}' is {len(content)} bytes "
+                f"(> {_PBIX_MAX_BYTES} limit); refusing to materialize."
+            )
+
+        tmp_path: Optional[str] = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(suffix=".pbix")
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
+            model = PBIXRay(tmp_path)
+            schema_df = model.schema
+            if schema_df is None or schema_df.empty:
+                raise RuntimeError(f"PBIX '{report_name or report_id}' has no tables in its semantic model.")
+
+            # Unique non-date table names from the schema.
+            candidate_tables: List[str] = []
+            seen = set()
+            for _, row in schema_df.iterrows():
+                tname = str(row.get("TableName") or "")
+                if not tname or tname in seen or _AUTO_DATE_TABLE_RE.match(tname):
+                    continue
+                seen.add(tname)
+                candidate_tables.append(tname)
+
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            manifest: Dict[str, str] = {}
+            used_filenames: set[str] = set()
+
+            for tname in candidate_tables:
+                try:
+                    df = model.get_table(tname)
+                except Exception as e:
+                    logger.warning(f"pbix {report_id} table '{tname}' extract failed: {e}")
+                    continue
+                if df is None:
+                    continue
+                if len(df) > _PBIX_MAX_ROWS_PER_TABLE:
+                    logger.warning(
+                        f"pbix {report_id} table '{tname}' has {len(df)} rows "
+                        f"(> {_PBIX_MAX_ROWS_PER_TABLE}); skipping materialization."
+                    )
+                    continue
+
+                base = _safe_view_name(tname).lower()
+                fname = f"{base}.parquet"
+                i = 1
+                while fname in used_filenames:
+                    i += 1
+                    fname = f"{base}_{i}.parquet"
+                used_filenames.add(fname)
+
+                fpath = cache_dir / fname
+                try:
+                    df.to_parquet(fpath, index=False)
+                except Exception as e:
+                    logger.warning(f"pbix {report_id} table '{tname}' parquet write failed: {e}")
+                    continue
+                manifest[tname] = fname
+
+            if not manifest:
+                raise RuntimeError(
+                    f"PBIX '{report_name or report_id}' produced no materializable tables "
+                    "(all skipped or failed)."
+                )
+
+            with manifest_path.open("w", encoding="utf-8") as f:
+                json.dump(manifest, f)
+
+            return {t: cache_dir / rel for t, rel in manifest.items()}
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    def _execute_pbix_query(
+        self,
+        report_id: str,
+        modified_date: Optional[str],
+        *,
+        report_name: Optional[str],
+        query: Optional[str],
+        max_rows: Optional[int] = None,
+    ) -> pd.DataFrame:
+        """Run a DuckDB query against the pbix model's Parquet cache. All internal
+        tables from the same pbix are registered as views so the LLM can JOIN freely
+        using the bare table names it sees in the schema prompt.
+        """
+        if not query:
+            raise ValueError(
+                "execute_query on a pbix table requires a SQL `query`. "
+                "Use DuckDB syntax with the internal table names exposed in the schema."
+            )
+
+        import duckdb  # type: ignore
+
+        paths = self.ensure_pbix_parquets(report_id, modified_date, report_name=report_name)
+        if not paths:
+            raise RuntimeError(
+                f"No queryable tables available for PBIX '{report_name or report_id}'."
+            )
+
+        con = duckdb.connect(database=":memory:")
+        try:
+            # Register each model table under a safe identifier. Collisions after
+            # sanitization are resolved by suffixing.
+            used: set[str] = set()
+            registered: Dict[str, str] = {}
+            for tname, ppath in paths.items():
+                view = _safe_view_name(tname)
+                base = view
+                i = 1
+                while view in used:
+                    i += 1
+                    view = f"{base}_{i}"
+                used.add(view)
+                registered[tname] = view
+                sql_path = str(ppath).replace("'", "''")
+                con.execute(
+                    f'CREATE VIEW "{view}" AS SELECT * FROM read_parquet(\'{sql_path}\')'
+                )
+
+            df = con.execute(query).df()
+            if max_rows is not None and max_rows > 0 and len(df) > max_rows:
+                df = df.head(max_rows)
+            return df
+        finally:
+            con.close()
 
     # ------------------------------------------------------------------
     # RDL parsing — extract CommandText, fields, parameters from report XML
@@ -818,14 +1016,18 @@ class PowerBIReportServerClient(DataSourceClient):
                                     "report_type": "PowerBIReportTable",
                                     "report_id": rid,
                                     "report_name": name,
+                                    "modified_date": r.get("ModifiedDate"),
                                     "model_table": tname,
                                     "measures": st.get("measures", []),
-                                    "queryable": False,
+                                    "queryable": bool(self.enable_pbix_query),
                                     "upstream_source": upstream_hint,
                                     "schema_source": (schema_info or {}).get("source"),
                                     "query_note": (
-                                        "Internal PBIX model table — not queryable through PBIRS. "
-                                        "Use the upstream source for live data."
+                                        "Queryable via DuckDB over the cached semantic model. "
+                                        "All tables from the same pbix share a session so you can JOIN them. "
+                                        "Note: data reflects the last PBIX refresh, not live upstream."
+                                        if self.enable_pbix_query
+                                        else "Internal PBIX model table — queryability disabled. Use upstream source for data."
                                     ),
                                 }
                             },
@@ -1090,11 +1292,11 @@ class PowerBIReportServerClient(DataSourceClient):
           - If report_id → Reports/Export/{format} (RDL paginated report).
           - If dataset_id → Datasets({id})/Model.GetData action (shared dataset).
           - If table_name starts with "rdl:" or "dataset:" or "pbix:" → resolve IDs from table metadata.
-          - Power BI (.pbix) reports raise NotImplementedError.
+          - PBIX tables (when enable_pbix_query=True) run the supplied `query` via DuckDB
+            against a cached Parquet snapshot of the semantic model.
 
-        `query` is accepted for API symmetry but not used for RDL/Dataset executions
-        (queries are stored in the RDL/RSD content). For shared datasets you can
-        pass parameters via the `parameters` kwarg.
+        `query` is required for PBIX but ignored for RDL/Dataset (those queries live in
+        the report/dataset definition). Pass RDL/Dataset params via `parameters`.
         """
         if table_name and not (report_id or dataset_id):
             t = self.get_schema(table_name)
@@ -1105,6 +1307,18 @@ class PowerBIReportServerClient(DataSourceClient):
             elif rt == "Dataset":
                 dataset_id = pbi.get("dataset_id")
             elif rt in ("PowerBIReport", "PowerBIReportTable"):
+                if self.enable_pbix_query and query:
+                    rid = pbi.get("report_id")
+                    if not rid:
+                        raise ValueError(f"PBIX table '{table_name}' is missing report_id in metadata.")
+                    return self._execute_pbix_query(
+                        rid,
+                        pbi.get("modified_date"),
+                        report_name=pbi.get("report_name") or table_name,
+                        query=query,
+                        max_rows=max_rows,
+                    )
+
                 upstream = pbi.get("upstream_source") or ""
                 srcs = pbi.get("data_sources") or []
                 hint = f" Upstream: {upstream}." if upstream else ""
@@ -1116,11 +1330,16 @@ class PowerBIReportServerClient(DataSourceClient):
                         f"connection_string={first.get('connection_string')!r}. "
                         "Add that source as a separate data source in the app to query its data."
                     )
-                raise NotImplementedError(
-                    "Power BI Report Server is a discovery/exploration data source. "
-                    "Power BI (.pbix) reports expose metadata (reports, parameters, owners, "
-                    "data sources, lineage) but their embedded tabular model is NOT queryable "
-                    f"through PBIRS on this server.{hint}{detail}"
+                if not self.enable_pbix_query:
+                    raise NotImplementedError(
+                        "Power BI (.pbix) query support is disabled on this connector. "
+                        f"Set enable_pbix_query=True to materialize the semantic model.{hint}{detail}"
+                    )
+                # enable_pbix_query=True but no query string — ask for SQL.
+                raise ValueError(
+                    f"PBIX table '{table_name}' is queryable via DuckDB over its cached "
+                    "semantic model, but execute_query requires a SQL `query` argument. "
+                    "Use DuckDB syntax against the internal table names shown in the schema."
                 )
             elif rt == "Kpi":
                 raise ValueError(f"KPI '{table_name}' is a computed metric, not a queryable table. Inspect its metadata_json for the current value.")
@@ -1238,51 +1457,66 @@ class PowerBIReportServerClient(DataSourceClient):
 
     @property
     def description(self) -> str:
+        pbix_note = (
+            "PBIX semantic models are queryable via DuckDB over a cached Parquet snapshot of "
+            "the embedded Vertipaq tables — the data reflects the last PBIX refresh, not live "
+            "upstream. For up-to-the-minute data, connect the upstream source directly."
+            if self.enable_pbix_query
+            else "PBIX models are NOT queryable through this connector."
+        )
         return (
-            "Power BI Report Server (on-prem): METADATA-ONLY discovery/exploration catalog. "
-            "This is NOT a queryable data source — you cannot run SQL, DAX, or any data query "
-            "against a PBIX report through this connector. Use it only to browse what exists "
-            "(reports, datasets, KPIs, owners, parameters, lineage) and to identify the "
-            "upstream database/file that actually holds the data. To answer data questions, "
-            "connect the upstream source as its own data source and query that."
+            "Power BI Report Server (on-prem). Discovers reports, paginated reports, shared "
+            "datasets, and KPIs via the PBIRS REST API. "
+            f"{pbix_note}"
         ) + self.system_prompt()
 
     def system_prompt(self) -> str:
-        return """
-## Power BI Report Server (on-prem) Guide
-
-**IMPORTANT — this is NOT a queryable data source.** It is a **metadata-only catalog** of what
-exists on a Power BI Report Server: reports, their owners, parameters, and (critically) the
-upstream data sources that feed them. You cannot run SQL or DAX against PBIX reports through
-this connector. Any actual data question must be answered by connecting the real upstream
-database/file as its own data source in the app and querying that.
-
-Use this connector to answer:
-- "What reports exist on our PBIRS?"
-- "Who owns the Sales dashboard? When was it last modified?"
-- "What data source does the HR report use?" — then direct the user to connect that source.
-- "Is there a report covering revenue by region?"
-
-Do NOT use this connector to answer:
-- "What were sales last quarter?" — that requires querying the upstream database directly.
-- "Show me the top 10 products" — same.
-- Any question whose answer is a row of data from a PBIX model.
-
-### Table naming convention
-
-Tables returned by `get_schemas()` are prefixed by kind:
-
-- `pbix:<ReportName>` — a Power BI (.pbix) interactive report. **Metadata only, not queryable.**
+        pbix_section = (
+            """
+- `pbix:<ReportName>` — a Power BI (.pbix) interactive report (umbrella entry).
   `metadata_json.powerbi_report_server` contains:
-    - `data_sources[]` — each entry has `kind` (SQL/File/OData/etc.), `connection_string`, `auth_type`.
-    - `upstream_source` — short human-readable summary of where the data actually lives.
-    - `parameters[]`, `roles[]`, `path`, `modified_by`, etc.
-    - `model_tables[]` / `model_relationships[]` — internal semantic-model structure (when extractable).
+    - `data_sources[]` — each entry has `kind`, `connection_string`, `auth_type`.
+    - `upstream_source` — where the data originally came from.
+    - `model_tables[]` / `model_relationships[]` — internal model structure.
 
 - `pbix:<ReportName>/<ModelTable>` — an internal table inside a PBIX semantic model.
-  **Still not queryable**, but exposes real `columns[]` and DAX `measures[]` in metadata so the
-  LLM can reason about structure. When the user asks for actual data from these columns, route
-  them to the upstream source from the parent `pbix:<ReportName>` entry.
+  **Queryable via DuckDB over a cached Parquet snapshot of the Vertipaq data.**
+  All tables from the same PBIX register in a single DuckDB session, so you can
+  JOIN them using bare internal table names. The data reflects the last PBIX refresh,
+  NOT live upstream. For live data, prefer the upstream source.
+
+  Example:
+    execute_query(
+        table_name="pbix:Sales Dashboard/Orders",
+        query="SELECT c.Name, SUM(o.Amount) FROM Orders o JOIN Customers c "
+              "ON o.CustomerID = c.CustomerID GROUP BY c.Name",
+    )
+
+  DAX measures in `metadata_json.powerbi_report_server.measures` are NOT executable —
+  they are DAX expressions, not data. Rewrite them as SQL over the exported columns
+  if the user needs measure-like aggregates.
+"""
+            if self.enable_pbix_query
+            else """
+- `pbix:<ReportName>` — a Power BI (.pbix) interactive report. **Metadata only, not queryable.**
+- `pbix:<ReportName>/<ModelTable>` — internal table; metadata only. Direct users to the
+  upstream source from `pbix:<ReportName>.metadata_json.powerbi_report_server.data_sources`.
+"""
+        )
+        pbix_flavor = (
+            "queryable via a cached Parquet snapshot"
+            if self.enable_pbix_query
+            else "NOT queryable"
+        )
+        header = (
+            "\n## Power BI Report Server (on-prem) Guide\n\n"
+            "A discovery catalog for Power BI Report Server assets (reports, paginated reports,\n"
+            "shared datasets, KPIs). Paginated and shared datasets are queryable via REST export.\n"
+            f"PBIX semantic models are {pbix_flavor} through this connector.\n\n"
+            "### Table naming convention\n\n"
+            "Tables returned by `get_schemas()` are prefixed by kind:\n"
+        )
+        footer = """
 
 - `rdl:<ReportName>/<DataSetName>` — a paginated (RDL) report dataset. **Queryable.**
   - Backend SQL is in `metadata_json.powerbi_report_server.command_text`.
@@ -1292,35 +1526,30 @@ Tables returned by `get_schemas()` are prefixed by kind:
 
 - `kpi:<KpiName>` — a KPI tile. Metadata only (current value, goal, status).
 
-### How to help the user when they ask to query a PBIX report
+### How to help the user when they ask for PBIX data
 
-1. **Do not try to execute it** — `execute_query` on a `pbix:*` table will raise
-   `NotImplementedError`. There is no DAX/XMLA path on this server.
-2. **Read `metadata_json.powerbi_report_server.data_sources`** — this tells you the real
-   upstream (SQL server, Excel file path, OData endpoint, etc.).
-3. **Tell the user where the data lives and offer the next step:** connect the upstream
-   source as its own data source in the app and write queries against it. Example:
-   > "The 'AdventureWorks Sales' report is a Power BI report backed by an Excel file at
-   > `c:\\...\\adventureworks sales.xlsx`. To query this data, add that file as an
-   > Excel/SharePoint data source — I can't query the pbix model directly from PBIRS."
-4. **If they want report-level output** (a rendered PDF/Excel of the visuals), note that
-   this server's PBIRS build does not expose a pbix export action either — only RDL
-   paginated reports can be rendered.
+PBIX queryability via this connector is a **cached Vertipaq snapshot**, not live upstream.
+When that's acceptable, query `pbix:<Report>/<Table>` with DuckDB SQL (see example above).
+When the user needs current data, point them at `metadata_json.powerbi_report_server.data_sources`
+on the `pbix:<Report>` umbrella row and tell them to connect that source directly.
 
-### When RDL or shared datasets are available
+DAX measures in `metadata_json.powerbi_report_server.measures` are expressions, not values —
+they can't be executed as-is. If the user asks for a measure value, rewrite the DAX as
+equivalent SQL over the exported columns.
 
-Prefer those — they have real, queryable SQL behind them:
+### Paginated reports and shared datasets
 
-```python
-df = client.execute_query(table_name="rdl:Sales Report/MainDataset",
-                          parameters={"StartDate": "2024-01-01"})
-df = client.execute_query(table_name="dataset:Daily Orders",
-                          parameters={"Region": "EU"})
-```
+Those have real, queryable SQL behind them and execute via REST export:
 
-The `query` argument is accepted for API symmetry but is ignored — the query lives in the
-report/dataset definition on the server.
+    df = client.execute_query(table_name="rdl:Sales Report/MainDataset",
+                              parameters={"StartDate": "2024-01-01"})
+    df = client.execute_query(table_name="dataset:Daily Orders",
+                              parameters={"Region": "EU"})
+
+For RDL/Dataset, the `query` argument is ignored — the query lives in the report definition.
+For PBIX, `query` is required (DuckDB SQL against the internal table names).
 """
+        return header + pbix_section + footer
 
 
 # Compatibility aliases for dynamic resolver

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -469,7 +469,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
     "powerbi_report_server": DataSourceRegistryEntry(
         type="powerbi_report_server",
         title="Power BI Report Server",
-        description="On-prem Power BI Report Server — METADATA-ONLY discovery/exploration catalog. Not a queryable data source. Lists reports, datasets, KPIs, owners, parameters and upstream data-source lineage via NTLM-authenticated REST. To query actual data, connect the upstream database/file referenced in each report's metadata as its own data source.",
+        description="On-prem Power BI Report Server. Discovers reports, paginated reports, shared datasets, KPIs, and upstream data-source lineage via NTLM-authenticated REST. PBIX semantic models are queryable via DuckDB over a cached Parquet snapshot (data reflects the last PBIX refresh, not live upstream — connect the upstream source directly for live data).",
         config_schema=PowerBIReportServerConfig,
         credentials_auth=AuthOptions(
             default="userpass",

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from app.core.spa import mount_spa
 from app.models.user import User
 from app.services.maintenance_service import purge_step_payloads_keep_latest_per_query
 from app.data_sources.clients.qvd_client import warm_all_qvd_caches
+from app.data_sources.clients.powerbi_report_server_client import warm_all_pbirs_caches
 from app.core.otel import setup_telemetry, instrument_app
 
 from app.routes import (
@@ -381,6 +382,24 @@ async def startup_event():
         logger.info("Scheduled job: qvd_warmup every 15m (runs once at startup)")
     except Exception as e:
         logger.error(f"Failed to schedule QVD warmup job: {e}")
+
+    # Background warmup of PBIRS pbix Parquet caches so first queries against a
+    # Power BI report don't pay the pbixray parse cost (~10-30s on ~50MB pbix).
+    try:
+        scheduler.add_job(
+            warm_all_pbirs_caches,
+            trigger="interval",
+            minutes=30,
+            id="pbirs_warmup",
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+            misfire_grace_time=600,
+            next_run_time=datetime.now(),
+        )
+        logger.info("Scheduled job: pbirs_warmup every 30m (runs once at startup)")
+    except Exception as e:
+        logger.error(f"Failed to schedule PBIRS warmup job: {e}")
 
     # Register LDAP group sync job if configured AND licensed (sync is enterprise-only)
     if settings.bow_config.ldap.enabled and has_feature("ldap"):

--- a/backend/requirements_versioned.txt
+++ b/backend/requirements_versioned.txt
@@ -126,6 +126,7 @@ PyJWT==2.10.1
 PyMySQL==1.1.1
 pyOpenSSL==24.3.0
 pyparsing==3.2.0
+pbixray==0.5.2
 pypdf==6.6.0
 pymongo==4.10.1
 pytest==8.1.1

--- a/backend/tests/unit/test_powerbi_report_server_client.py
+++ b/backend/tests/unit/test_powerbi_report_server_client.py
@@ -383,7 +383,8 @@ class TestGetSchemasMocked:
         assert orders_meta["report_type"] == "PowerBIReportTable"
         assert orders_meta["model_table"] == "Orders"
         assert orders_meta["measures"][0]["name"] == "Total Sales"
-        assert orders_meta["queryable"] is False
+        # queryable flips True under the default enable_pbix_query=True
+        assert orders_meta["queryable"] is True
 
         customers = next(t for t in tables if t.name.endswith("/Customers"))
         assert {col.name for col in customers.columns} == {"CustomerID", "Name"}
@@ -442,12 +443,12 @@ class TestGetSchemasMocked:
 
 
 class TestExecuteQueryRouting:
-    def _client_with_schemas(self, tables):
-        c = PowerBIReportServerClient("http://pbi", "u", "p")
+    def _client_with_schemas(self, tables, **kwargs):
+        c = PowerBIReportServerClient("http://pbi", "u", "p", **kwargs)
         c.get_schemas = MagicMock(return_value=tables)
         return c
 
-    def test_pbix_raises_not_implemented(self):
+    def test_pbix_raises_not_implemented_when_disabled(self):
         from app.ai.prompt_formatters import Table as PFTable
         tables = [PFTable(
             name="pbix:Sales", description="", columns=[], pks=[], fks=[], is_active=True,
@@ -460,12 +461,86 @@ class TestExecuteQueryRouting:
                 }],
             }},
         )]
-        c = self._client_with_schemas(tables)
+        c = self._client_with_schemas(tables, enable_pbix_query=False)
         with pytest.raises(NotImplementedError) as ei:
             c.execute_query(table_name="pbix:Sales")
         msg = str(ei.value)
-        assert "discovery" in msg.lower()
+        assert "disabled" in msg.lower()
         assert "Server=dw01" in msg
+
+    def test_pbix_requires_query_when_enabled(self):
+        from app.ai.prompt_formatters import Table as PFTable
+        tables = [PFTable(
+            name="pbix:Sales/Orders", description="", columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {
+                "report_type": "PowerBIReportTable",
+                "report_id": "r1",
+                "report_name": "Sales",
+                "modified_date": "2024-01-01T00:00:00Z",
+                "model_table": "Orders",
+            }},
+        )]
+        c = self._client_with_schemas(tables)
+        with pytest.raises(ValueError) as ei:
+            c.execute_query(table_name="pbix:Sales/Orders")
+        assert "query" in str(ei.value).lower()
+
+    def test_pbix_query_routes_to_duckdb(self, tmp_path, monkeypatch):
+        """execute_query on pbix:<Report>/<Table> with a query runs DuckDB over the
+        Parquet cache, with all same-report tables registered as views."""
+        import pandas as pd
+        from app.ai.prompt_formatters import Table as PFTable
+
+        # Build two small parquet files to stand in for pbix model tables.
+        orders = pd.DataFrame({"OrderID": [1, 2, 3], "CustomerID": [10, 10, 20], "Amount": [5.0, 7.5, 2.0]})
+        customers = pd.DataFrame({"CustomerID": [10, 20], "Name": ["Alice", "Bob"]})
+        orders_path = tmp_path / "orders.parquet"
+        customers_path = tmp_path / "customers.parquet"
+        orders.to_parquet(orders_path)
+        customers.to_parquet(customers_path)
+
+        tables = [PFTable(
+            name="pbix:Sales/Orders", description="", columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {
+                "report_type": "PowerBIReportTable",
+                "report_id": "r1",
+                "report_name": "Sales",
+                "modified_date": "2024-01-01T00:00:00Z",
+                "model_table": "Orders",
+            }},
+        )]
+        c = self._client_with_schemas(tables)
+
+        # Short-circuit the parquet materializer — we pre-built the files.
+        c.ensure_pbix_parquets = MagicMock(return_value={
+            "Orders": orders_path,
+            "Customers": customers_path,
+        })
+
+        df = c.execute_query(
+            table_name="pbix:Sales/Orders",
+            query=(
+                "SELECT c.Name, SUM(o.Amount) AS total "
+                "FROM Orders o JOIN Customers c ON o.CustomerID = c.CustomerID "
+                "GROUP BY c.Name ORDER BY c.Name"
+            ),
+        )
+        assert list(df["Name"]) == ["Alice", "Bob"]
+        assert list(df["total"]) == [12.5, 2.0]
+
+    def test_pbix_query_missing_report_id(self):
+        from app.ai.prompt_formatters import Table as PFTable
+        tables = [PFTable(
+            name="pbix:Broken", description="", columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {
+                "report_type": "PowerBIReport",
+                # report_id missing
+                "modified_date": "2024-01-01",
+            }},
+        )]
+        c = self._client_with_schemas(tables)
+        with pytest.raises(ValueError, match="report_id"):
+            c.execute_query(table_name="pbix:Broken", query="SELECT 1")
 
     def test_kpi_raises_value_error(self):
         from app.ai.prompt_formatters import Table as PFTable
@@ -483,28 +558,68 @@ class TestExecuteQueryRouting:
             c.execute_query()
 
 
-class TestDiscoveryFraming:
-    """The client must be clear that it's NOT a queryable data source."""
+class TestEnsurePbixParquets:
+    """Direct tests for the Parquet materialization + caching path."""
 
-    def test_description_flags_metadata_only(self):
+    def test_cache_hit_skips_download(self, tmp_path, monkeypatch):
+        """When manifest.json already exists, no pbix download is attempted."""
+        import app.data_sources.clients.powerbi_report_server_client as mod
+
+        monkeypatch.setattr(mod, "_PBIX_DATA_CACHE_DIR", tmp_path)
+        cache_dir = mod._pbix_data_cache_dir("rX", "2024-01-01T00:00:00Z")
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "orders.parquet").write_bytes(b"not really a parquet")
+        (cache_dir / "manifest.json").write_text(json.dumps({"Orders": "orders.parquet"}))
+
+        c = PowerBIReportServerClient("http://pbi", "u", "p")
+        # download_catalog_item_content should NOT be called — raise if it is.
+        c.download_catalog_item_content = MagicMock(
+            side_effect=AssertionError("download should not run on cache hit")
+        )
+
+        paths = c.ensure_pbix_parquets("rX", "2024-01-01T00:00:00Z", report_name="X")
+        assert set(paths.keys()) == {"Orders"}
+        assert paths["Orders"].name == "orders.parquet"
+
+    def test_size_cap_rejects_oversized_pbix(self, tmp_path, monkeypatch):
+        import app.data_sources.clients.powerbi_report_server_client as mod
+
+        monkeypatch.setattr(mod, "_PBIX_DATA_CACHE_DIR", tmp_path)
+        monkeypatch.setattr(mod, "_PBIX_MAX_BYTES", 10)
+
+        c = PowerBIReportServerClient("http://pbi", "u", "p")
+        c.download_catalog_item_content = MagicMock(return_value=b"x" * 100)
+
+        with pytest.raises(RuntimeError, match="refusing to materialize"):
+            c.ensure_pbix_parquets("rBig", "mdate", report_name="Huge")
+
+
+class TestDiscoveryFraming:
+    """Framing must accurately describe pbix queryability and warn about snapshot staleness."""
+
+    def test_description_default_flags_cached_snapshot(self):
         c = PowerBIReportServerClient("http://pbi", "u", "p")
         desc = c.description.lower()
-        assert "metadata" in desc
-        assert "not" in desc and ("queryable" in desc or "query" in desc)
+        assert "parquet" in desc or "snapshot" in desc
         assert "upstream" in desc
 
-    def test_system_prompt_warns_llm(self):
+    def test_description_when_query_disabled_flags_metadata_only(self):
+        c = PowerBIReportServerClient("http://pbi", "u", "p", enable_pbix_query=False)
+        desc = c.description.lower()
+        assert "not queryable" in desc
+
+    def test_system_prompt_explains_pbix_query(self):
         c = PowerBIReportServerClient("http://pbi", "u", "p")
         sp = c.system_prompt()
-        assert "NOT a queryable data source" in sp
+        assert "DuckDB" in sp
+        assert "snapshot" in sp.lower() or "cached" in sp.lower()
         assert "upstream" in sp.lower()
 
-    def test_registry_description_flags_metadata_only(self):
+    def test_registry_description_explains_connector(self):
         from app.schemas.data_source_registry import REGISTRY
         entry = REGISTRY["powerbi_report_server"]
         d = entry.description.lower()
-        assert "metadata" in d
-        assert "not a queryable" in d
+        assert "power bi report server" in d
         assert "upstream" in d
 
 

--- a/backend/tests/unit/test_powerbi_report_server_client.py
+++ b/backend/tests/unit/test_powerbi_report_server_client.py
@@ -18,7 +18,9 @@ import pytest
 
 from app.data_sources.clients.powerbi_report_server_client import (
     PowerBIReportServerClient,
+    _AUTO_DATE_TABLE_RE,
     _clr_to_dtype,
+    _dax_to_dtype,
     _strip_ns,
     _summarize_upstream,
 )
@@ -120,6 +122,20 @@ class TestHelpers:
         out = _summarize_upstream([{"kind": "SQL", "connection_string": "Server=dw01;Database=Sales"}])
         assert out == "SQL (Server=dw01;Database=Sales)"
 
+    def test_dax_to_dtype(self):
+        assert _dax_to_dtype("Int64") == "int"
+        assert _dax_to_dtype("Float64") == "float"
+        assert _dax_to_dtype("String") == "string"
+        assert _dax_to_dtype("DateTime") == "datetime"
+        assert _dax_to_dtype("Boolean") == "bool"
+        assert _dax_to_dtype(None) == "unknown"
+
+    def test_auto_date_table_regex(self):
+        assert _AUTO_DATE_TABLE_RE.match("LocalDateTable_12345678-aaaa-bbbb-cccc-123456789012")
+        assert _AUTO_DATE_TABLE_RE.match("DateTableTemplate_deadbeef-0000-1111-2222-333333333333")
+        assert not _AUTO_DATE_TABLE_RE.match("Orders")
+        assert not _AUTO_DATE_TABLE_RE.match("DateTable")
+
     def test_summarize_upstream_dedups(self):
         srcs = [
             {"kind": "SQL", "connection_string": "Server=dw01"},
@@ -217,7 +233,7 @@ class TestGetSchemasMocked:
         return session
 
     def test_pbix_only(self):
-        c = PowerBIReportServerClient("http://pbi", "u", "p")
+        c = PowerBIReportServerClient("http://pbi", "u", "p", extract_pbix_schemas=False)
         pbi_reports = [{
             "Id": "r1",
             "Name": "Sales Dashboard",
@@ -287,6 +303,113 @@ class TestGetSchemasMocked:
         assert meta["queryable"] is True
         assert "SUM(Amount)" in meta["command_text"]
         assert len(meta["report_parameters"]) == 3
+
+    def test_pbix_schema_uplift(self):
+        """When pbix schema extraction returns data, emit one Table per internal model table
+        with real columns + measures, plus the umbrella discovery row."""
+        c = PowerBIReportServerClient("http://pbi", "u", "p")
+        pbi_reports = [{
+            "Id": "r1",
+            "Name": "Sales Dashboard",
+            "Path": "/Sales Dashboard",
+            "ModifiedDate": "2024-01-01T00:00:00Z",
+        }]
+        responses = {
+            "/PowerBIReports": _mock_response({"value": pbi_reports}),
+            "/Reports": _mock_response({"value": []}),
+            "/Datasets": _mock_response({"value": []}),
+            "/Kpis": _mock_response({"value": []}),
+            "/DataSources": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataSources": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataModelParameters": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataModelRoles": _mock_response({"value": []}),
+        }
+        c._session = self._fake_session(responses)
+
+        fake_schema = {
+            "source": "pbixray",
+            "report_id": "r1",
+            "report_name": "Sales Dashboard",
+            "tables": [
+                {
+                    "name": "Orders",
+                    "columns": [
+                        {"name": "OrderID", "dtype": "int"},
+                        {"name": "CustomerID", "dtype": "int"},
+                        {"name": "Amount", "dtype": "float"},
+                    ],
+                    "measures": [
+                        {"name": "Total Sales", "expression": "SUM(Orders[Amount])",
+                         "display_folder": "", "description": ""}
+                    ],
+                },
+                {
+                    "name": "Customers",
+                    "columns": [
+                        {"name": "CustomerID", "dtype": "int"},
+                        {"name": "Name", "dtype": "string"},
+                    ],
+                    "measures": [],
+                },
+            ],
+            "relationships": [
+                {"from_table": "Orders", "from_column": "CustomerID",
+                 "to_table": "Customers", "to_column": "CustomerID",
+                 "is_active": True, "cardinality": "many_to_one"},
+            ],
+        }
+        c.extract_pbix_schema = MagicMock(return_value=fake_schema)
+
+        tables = c.get_schemas()
+        names = sorted(t.name for t in tables)
+        assert names == [
+            "pbix:Sales Dashboard",
+            "pbix:Sales Dashboard/Customers",
+            "pbix:Sales Dashboard/Orders",
+        ]
+
+        umbrella = next(t for t in tables if t.name == "pbix:Sales Dashboard")
+        umb_meta = umbrella.metadata_json["powerbi_report_server"]
+        assert umb_meta["schema_source"] == "pbixray"
+        assert set(umb_meta["model_tables"]) == {"Orders", "Customers"}
+        assert len(umb_meta["model_relationships"]) == 1
+
+        orders = next(t for t in tables if t.name.endswith("/Orders"))
+        assert {col.name for col in orders.columns} == {"OrderID", "CustomerID", "Amount"}
+        assert len(orders.fks) == 1
+        assert orders.fks[0].references_name == "pbix:Sales Dashboard/Customers"
+        assert orders.fks[0].column.name == "CustomerID"
+        orders_meta = orders.metadata_json["powerbi_report_server"]
+        assert orders_meta["report_type"] == "PowerBIReportTable"
+        assert orders_meta["model_table"] == "Orders"
+        assert orders_meta["measures"][0]["name"] == "Total Sales"
+        assert orders_meta["queryable"] is False
+
+        customers = next(t for t in tables if t.name.endswith("/Customers"))
+        assert {col.name for col in customers.columns} == {"CustomerID", "Name"}
+        assert customers.fks == []
+
+    def test_pbix_schema_extraction_failure_falls_back(self):
+        """When extraction returns None (download failed, parse failed, etc.),
+        only the umbrella discovery row is emitted."""
+        c = PowerBIReportServerClient("http://pbi", "u", "p")
+        pbi_reports = [{"Id": "r1", "Name": "Broken", "Path": "/Broken"}]
+        responses = {
+            "/PowerBIReports": _mock_response({"value": pbi_reports}),
+            "/Reports": _mock_response({"value": []}),
+            "/Datasets": _mock_response({"value": []}),
+            "/Kpis": _mock_response({"value": []}),
+            "/DataSources": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataSources": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataModelParameters": _mock_response({"value": []}),
+            "/PowerBIReports(r1)/DataModelRoles": _mock_response({"value": []}),
+        }
+        c._session = self._fake_session(responses)
+        c.extract_pbix_schema = MagicMock(return_value=None)
+
+        tables = c.get_schemas()
+        assert len(tables) == 1
+        assert tables[0].name == "pbix:Broken"
 
     def test_kpi(self):
         c = PowerBIReportServerClient("http://pbi", "u", "p")


### PR DESCRIPTION
## Summary

Turns the on-prem Power BI Report Server connector from a metadata-only catalog into a queryable data source. Three phases land together:

- **Phase 1 — schema uplift via pbixray.** `get_schemas()` now emits one umbrella row per PBIX report *plus* one internal table per Vertipaq table (with columns, dtypes, measures, relationships). Schemas are JSON-cached on disk keyed by `(report_id, modified_date)` so report edits invalidate cleanly.
- **Phase 2 — DuckDB-backed execution.** `execute_query()` on a `pbix:*` table materializes every model table to Parquet and registers them as views in one in-memory DuckDB session — the LLM can JOIN freely using the bare table names from the prompt. Verified live against a production PBIRS with single-table reads and cross-table JOINs (121k joined rows in 0.5s warm).
- **Phase 3 — scheduled warmup.** `warm_all_pbirs_caches()` mirrors `warm_all_qvd_caches`: walks active connections every 30m and pre-materializes Parquet so first-query latency drops from ~10–30s cold to sub-second.

Also tightens the unsafe-python validator so prose like *"the user wants to create a chart"* stops tripping the SQL-write check — new structural regex (`CREATE TABLE`, `DELETE FROM`, `UPDATE x SET`, …) is used when scanning Python string/f-string literals, while `validate_sql_query` keeps the bare-verb regex for actual SQL.

## Test plan

- [x] `pytest tests/unit/test_powerbi_report_server_client.py` — 44/44 pass
- [x] Live Phase 1 + Phase 2 against production PBIRS (5 reports, 41 internal tables; single-table SELECT + two-table JOIN)
- [x] Validator sanity: prose strings with CREATE/UPDATE/DELETE/DROP pass; real SQL still blocked
- [ ] Observe `pbirs.warmup.sweep.start` / `pbirs.warmup.sweep.done` log lines at startup against a live deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)