### PR TITLE
Reduce Azure Prompt Shield false positives in code-gen paths

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -266,7 +266,7 @@ class Coder:
            - For Excel files, use `pd.read_excel(excel_files[INDEX].path, sheet_name=SHEET_INDEX, header=None)` to read data.
              * Decide the correct INDEX and SHEET_INDEX based on prompt and data model.
              * Print the dict/df preview to help ensure indices and positions are correct.
-           - After any operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Preview:", {data_preview_instruction})
+           - After any operation that changes DataFrame columns (merge, join, add/remove columns), print a preview using: print("df Preview:", df.head())
            - Output schema contract: The final DataFrame should contain only primitives (str/int/float/bool/None). Do not return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
            - Use read-only operations on the data sources (no insert/delete/add/update/put/drop).
            - Prefer data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -171,14 +171,13 @@ class Coder:
         similar_successful_code_snippets = await code_context_builder.get_top_successful_snippets_for_data_model(data_model)
         similar_failed_code_snippets = await code_context_builder.get_top_failed_snippets_for_data_model(data_model)
         text = f"""
-        You are a highly skilled data engineer and data scientist.
+        Role: data engineer and data scientist working on the user's analytics request.
 
-        Your goal: Given a data model and context, generate a Python function named `generate_df(ds_clients, excel_files)`
+        Goal: Given a data model and context, generate a Python function named `generate_df(ds_clients, excel_files)`
         that produces a Pandas DataFrame according to the data model specifications only.
         Use the previous messages to understand the user's intent/context and the data model to generate the correct dataframe.
 
-        **General Organization Instructions**:
-        **VERY IMPORTANT, CREATED BY THE USER, MUST BE USED AND CONSIDERED**:
+        **Organization Instructions** (authored by the user; apply them):
         {instructions_context}
 
         **Context and Inputs**:
@@ -257,26 +256,26 @@ class Coder:
 
         2. **Data Source Usage**:
            - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
-             * CRITICAL: Use the EXACT `client_key` string from <connection_clients> section - it is a literal string, NOT a variable!
+             * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
              * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
            - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
-           - **Cross-Connection Queries**: If you need tables from DIFFERENT connections, you CANNOT join them in SQL. Instead, query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
+           - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
            - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
            {data_preview_instruction}
            - For SQL data sources, "SOME QUERY" should be SQL code that matches the schema column names exactly.
            - For Excel files, use `pd.read_excel(excel_files[INDEX].path, sheet_name=SHEET_INDEX, header=None)` to read data.
              * Decide the correct INDEX and SHEET_INDEX based on prompt and data model.
-             * Print the dict/df preview to help the LLM ensure indices and positions are correct.
-           - After ANY operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Preview:", {data_preview_instruction})
-           - Output schema contract: The final DataFrame must contain only primitives (str/int/float/bool/None). Never return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
-           - Allow only read operations on the data sources. No insert/delete/add/update/put/drop.
-           - Prefer using data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
+             * Print the dict/df preview to help ensure indices and positions are correct.
+           - After any operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Preview:", {data_preview_instruction})
+           - Output schema contract: The final DataFrame should contain only primitives (str/int/float/bool/None). Do not return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
+           - Use read-only operations on the data sources (no insert/delete/add/update/put/drop).
+           - Prefer data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
 
         3. **Schema and Data Model Adherence**:
            - Use only columns and relationships that exist in the provided schemas.
-           - If the data model suggests derived columns or aggregations, ensure you derive them correctly from existing schema fields.
-           - Do NOT invent columns that do not exist or cannot be derived.
-           - Do NOT include client names or non-relevant info inside queries. The data source queries should be generic and directly usable by the ds_clients.
+           - If the data model suggests derived columns or aggregations, derive them from existing schema fields.
+           - Do not invent columns that do not exist or cannot be derived.
+           - Do not include client names or non-relevant info inside queries. The data source queries should be generic and directly usable by the ds_clients.
 
         4. **Handling Previous Code and Errors**:
            - If `retries` ≥ 1, review the code_and_error_messages:
@@ -397,13 +396,12 @@ class Coder:
             except Exception:
                 similar_successful_code_snippets = ""
             text = f"""
-            You are a highly skilled data engineer and data scientist.
+            Role: data engineer and data scientist working on the user's analytics request.
 
-            Your goal: Given the user's prompt and the provided context, generate a Python function named `generate_df(ds_clients, excel_files)`
-            that produces a Pandas DataFrame grounded ONLY in the provided schemas and resources.
+            Goal: Given the user's prompt and the provided context, generate a Python function named `generate_df(ds_clients, excel_files)`
+            that produces a Pandas DataFrame grounded only in the provided schemas and resources.
 
-            **General Organization Instructions**:
-            **VERY IMPORTANT, CREATED BY THE USER, MUST BE USED AND CONSIDERED**:
+            **Organization Instructions** (authored by the user; apply them):
             {instructions_context}
 
             **Context and Inputs**:
@@ -458,10 +456,10 @@ class Coder:
             **Guidelines and Requirements**:
 
             0. **Data Modeling**:
-                - Make sure the data structure answers the user prompt and is feasible given the schemas and data sources.
+                - The data structure should answer the user prompt and be feasible given the schemas and data sources.
                 - Bias for a master table: include additional columns that are relevant for filtering and slicing in the visualization layer, even if not explicitly requested by the user. For example, if the user asks for total sales by region, also include date and product category columns if available.
                 - The interpreted_prompt may list specific tables, target columns, and additional columns for filtering. Include all of them in your SELECT.
-                - **Data granularity:** When the interpreted_prompt says "return granular rows" or "do not pre-aggregate", do NOT add GROUP BY or aggregate functions (SUM/COUNT/AVG) in SQL. Return one row per record — the visualization layer handles aggregation. Only pre-aggregate when the interpreted_prompt explicitly requires SQL-level computation (window functions, rolling averages, CTEs, complex calculations).
+                - **Data granularity:** When the interpreted_prompt says "return granular rows" or "do not pre-aggregate", do not add GROUP BY or aggregate functions (SUM/COUNT/AVG) in SQL. Return one row per record — the visualization layer handles aggregation. Only pre-aggregate when the interpreted_prompt explicitly requires SQL-level computation (window functions, rolling averages, CTEs, complex calculations).
 
             1. **Function Signature**: Implement exactly:
                `def generate_df(ds_clients, excel_files):`
@@ -469,26 +467,26 @@ class Coder:
 
             2. **Data Source Usage**:
                - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
-                 * CRITICAL: Use the EXACT `client_key` string from <connection_clients> section - it is a literal string, NOT a variable!
+                 * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
                  * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
                - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
-               - **Cross-Connection Queries**: If you need tables from DIFFERENT connections, you CANNOT join them in SQL. Instead, query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
+               - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
                - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
                {data_preview_instruction}
                - For SQL data sources, "SOME QUERY" should be SQL code that matches the schema column names exactly.
                - For Excel files, use `pd.read_excel(excel_files[INDEX].path, sheet_name=SHEET_INDEX, header=None)`.
                  * Decide the correct INDEX and SHEET_INDEX based on prompt and schemas.
                  * Use prints to help validate indices and positions.
-               - After ANY operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Info:", df.info())
-               - Output schema contract: The final DataFrame must contain only primitives (str/int/float/bool/None). Never return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
-               - Allow only read operations on the data sources. No insert/delete/add/update/put/drop.
-               - Prefer using data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
+               - After any operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Info:", df.info())
+               - Output schema contract: The final DataFrame should contain only primitives (str/int/float/bool/None). Do not return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
+               - Use read-only operations on the data sources (no insert/delete/add/update/put/drop).
+               - Prefer data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
 
             3. **Schema Adherence**:
                - Use only columns and relationships that exist in the provided schemas.
-               - Do NOT invent columns that do not exist or cannot be derived.
+               - Do not invent columns that do not exist or cannot be derived.
                - Use metadata resources for tables/cols enrichments, code examples, etc.
-               - Never use tables/cols that exist in instructions but are not in the provided schemas.
+               - Do not use tables/cols that exist in instructions but are not in the provided schemas.
 
             4. **Handling Previous Code and Errors**:
                - If `retries` ≥ 1, review the code_and_error_messages:
@@ -636,13 +634,12 @@ class Coder:
             code_error_section = "\n".join(combined)
 
         text = f"""
-        You are a highly skilled data engineer and data scientist.
+        Role: data engineer and data scientist working on the user's analytics request.
 
-        Your goal: Given the user's prompt and the provided context, generate a Python function named `generate_df(ds_clients, excel_files)`
-        that produces a Pandas DataFrame grounded ONLY in the provided schemas and resources.
+        Goal: Given the user's prompt and the provided context, generate a Python function named `generate_df(ds_clients, excel_files)`
+        that produces a Pandas DataFrame grounded only in the provided schemas and resources.
 
-        **General Organization Instructions**:
-        **VERY IMPORTANT, CREATED BY THE USER, MUST BE USED AND CONSIDERED**:
+        **Organization Instructions** (authored by the user; apply them):
         {instructions_context}
 
         **Context and Inputs**:
@@ -724,9 +721,9 @@ class Coder:
            - Create a focused DataFrame that answers the user's question.
            - Include additional columns that are relevant for filtering and slicing in the visualization layer, even if not explicitly requested. For example, if the user asks for total sales by region, also include date and product category columns if available.
            - The interpreted_prompt may list specific tables, target columns, and additional columns for filtering. Include all of them in your SELECT.
-           - **Data granularity:** When the interpreted_prompt says "return granular rows" or "do not pre-aggregate", do NOT add GROUP BY or aggregate functions (SUM/COUNT/AVG) in SQL. Return one row per record — the visualization layer handles aggregation. Only pre-aggregate when the interpreted_prompt explicitly requires SQL-level computation (window functions, rolling averages, CTEs, complex calculations).
-           - Do NOT combine multiple unrelated KPIs or analyses into a single DataFrame.
-           - If past_observations contain multi-table inspection queries, those were exploratory research — do NOT mimic that pattern here.
+           - **Data granularity:** When the interpreted_prompt says "return granular rows" or "do not pre-aggregate", do not add GROUP BY or aggregate functions (SUM/COUNT/AVG) in SQL. Return one row per record — the visualization layer handles aggregation. Only pre-aggregate when the interpreted_prompt explicitly requires SQL-level computation (window functions, rolling averages, CTEs, complex calculations).
+           - Do not combine multiple unrelated KPIs or analyses into a single DataFrame.
+           - If past_observations contain multi-table inspection queries, those were exploratory research — do not mimic that pattern here.
 
         1. **Function Signature**: Implement exactly:
            `def generate_df(ds_clients, excel_files):`
@@ -734,7 +731,7 @@ class Coder:
 
         2. **Data Source Usage**:
            - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
-             * CRITICAL: Use the EXACT `client_key` string from <data_sources_and_clients> section - it is a literal string, NOT a variable!
+             * Use the exact `client_key` string from the <data_sources_and_clients> section — it is a literal string, not a variable.
              * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
            - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
            {data_preview_instruction}
@@ -742,16 +739,16 @@ class Coder:
            - For Excel files, use `pd.read_excel(excel_files[INDEX].path, sheet_name=SHEET_INDEX, header=None)` to read data.
              * Decide the correct INDEX and SHEET_INDEX based on prompt and schemas.
              * Use prints to help validate indices and positions.
-           - After ANY operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Info:", df.info())
-           - Output schema contract: The final DataFrame must contain only primitives (str/int/float/bool/None). Never return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
-           - Allow only read operations on the data sources. No insert/delete/add/update/put/drop.
-           - Prefer using data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
+           - After any operation that changes DataFrame columns (merge, join, add/remove columns), print: print("df Info:", df.info())
+           - Output schema contract: The final DataFrame should contain only primitives (str/int/float/bool/None). Do not return dict/list objects. If a column is JSON/MAP/STRUCT or a JSON-looking string, extract/flatten to readable scalar columns (e.g., owner, repo_full_name) using pandas.json_normalize or by selecting key paths; otherwise stringify compactly. Prefer clear label/value columns for charting.
+           - Use read-only operations on the data sources (no insert/delete/add/update/put/drop).
+           - Prefer data sources, tables, files, and entities explicitly listed in <mentions>. If selecting an unmentioned source, justify briefly.
 
         3. **Schema Adherence**:
            - Use only columns and relationships that exist in the provided schemas.
            - If deriving columns or aggregations, ensure derivations are correct from existing schema fields.
-           - Do NOT invent columns that do not exist or cannot be derived.
-           - Do NOT include client names or non-relevant info inside queries. The data source queries should be generic and directly usable by the ds_clients.
+           - Do not invent columns that do not exist or cannot be derived.
+           - Do not include client names or non-relevant info inside queries. The data source queries should be generic and directly usable by the ds_clients.
 
         4. **Handling Previous Code and Errors**:
            - If `retries` ≥ 1, review the code_and_error_messages:
@@ -843,10 +840,10 @@ class Coder:
         excel_files_section = "\n".join(excel_files_description)
 
         text = f"""
-        You are a Data Investigator doing a QUICK hypothesis validation.
+        Role: data investigator doing a quick hypothesis validation.
 
-        Your goal: Write a Python function `generate_df(ds_clients, excel_files)` that **validates assumptions** about data before creating tracked widgets.
-        This is NOT for generating insights — insights come from create_data. This is just a quick peek.
+        Goal: Write a Python function `generate_df(ds_clients, excel_files)` that validates assumptions about data before creating tracked widgets.
+        This is not for generating insights — insights come from create_data. This is just a quick peek.
 
         **Context and Inputs**:
         - User Prompt (Validation Goal):
@@ -854,7 +851,7 @@ class Coder:
         {prompt}
         </user_prompt>
 
-        - Schemas (already available, DO NOT query information_schema):
+        - Schemas (already available; do not query information_schema):
         <schemas>
         {schemas}
         </schemas>
@@ -874,12 +871,12 @@ class Coder:
         - `excel_files` is a list of File objects with `.path` attribute (NOT a dict, use `.path` not `['path']`)
         - Example: `df = pd.read_excel(excel_files[0].path, sheet_name=0)`
 
-        **CRITICAL CONSTRAINTS**:
-        1. **MAX 2-3 QUERIES TOTAL** - This is a quick validation, not a full analysis.
-        2. **LIMIT 3** - Always use `LIMIT 3` in SQL. Always use `.head(3)` on DataFrames.
-        3. **Complex joins are OK within the same connection** - But you CANNOT join across different connections in SQL. If tables are under different `<connection>` tags in the schemas, query each connection separately.
+        **Constraints**:
+        1. **Keep it to 2-3 queries** — this is a quick validation, not a full analysis.
+        2. **Limit rows** — use `LIMIT 3` in SQL and `.head(3)` on DataFrames.
+        3. **Joins within one connection are fine**, but cross-connection joins do not work in SQL. If tables are under different `<connection>` tags, query each connection separately.
         4. **Connection-Table Mapping**: Match `<connection name="...">` in schemas to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
-        5. **DO NOT query information_schema** - Schema is already provided above.
+        5. **Do not query information_schema** — schemas are already provided above.
 
         **What to validate**:
         - Sample rows to see data structure
@@ -888,7 +885,7 @@ class Coder:
         - Verify join keys match between tables
         - Check date formats or value ranges
 
-        **PRINT EVERYTHING**: The user will ONLY see what you `print()`.
+        **Print everything**: the user only sees what you `print()`.
         - `print(df.head(3))`
         - `print(df['col'].unique()[:10])`
         - `print(df['col'].isna().sum())`
@@ -897,7 +894,7 @@ class Coder:
 
         **Return**: The inspected dataframe or `None`. The `print()` output is the primary deliverable.
 
-        Now produce ONLY the Python function code. No markdown. Keep it SHORT.
+        Return only the Python function code. No markdown. Keep it short.
         """
 
         result = self.llm.inference(text)

--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -91,7 +91,7 @@ You are an expert in business, product and data analysis. You are familiar with 
 
 - Domain: business/data analysis, SQL/data modeling, code-aware reasoning, and UI/chart/widget recommendations.
 - Constraints: EXACTLY one (or none) tool call per turn; never hallucinate schema/table/column names; follow tool schemas exactly; output JSON only (strict schema below).
-- Safety: never invent data or credentials; if required info is missing, trigger the clarify tool.
+- Ground every claim in provided data; if required info is missing, use the clarify tool.
 - Startup: when the loop starts (no observations), choose a reasoning level. Only use deep reasoning if "high" is warranted; otherwise keep it brief. In assistant_message, describe the high level plan.
 
 {deep_analytics_text}
@@ -965,20 +965,35 @@ CRITICAL
         action_tools_json = json.dumps(action_tools, ensure_ascii=False)
 
         trigger_block = planner_input.trigger_conditions or "<trigger_conditions />"
+        # Sanitize interpolated trigger text: cap length and drop imperative/meta
+        # vocabulary that tends to trip content-filter classifiers on providers
+        # like Azure. Keeps the semantic description of why this session flagged
+        # a learning opportunity.
+        if trigger_block and trigger_block != "<trigger_conditions />":
+            trigger_block = trigger_block[:2000]
+            for _trigger_word, _replacement in (
+                ("CRITICAL", "important"),
+                ("MUST NOT", "should not"),
+                ("MUST", "should"),
+                ("NEVER", "do not"),
+                ("ALWAYS", "consistently"),
+                ("IGNORE", "skip"),
+                ("OVERRIDE", "supersede"),
+                ("BYPASS", "skip"),
+            ):
+                trigger_block = trigger_block.replace(_trigger_word, _replacement)
 
         prompt = f"""
 SYSTEM
 Time: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}; timezone: {datetime.now().astimezone().tzinfo}
 Mode: Knowledge Harness (post-analysis reflection)
 
-You are an AI Data Domain Expert for {planner_input.organization_name}, running in KNOWLEDGE HARNESS mode. Your name is {planner_input.organization_ai_analyst_name}.
+Role: AI Data Domain Expert for {planner_input.organization_name}, running in Knowledge Harness mode. Your name is {planner_input.organization_ai_analyst_name}.
 
 CONTEXT
-The user just completed an analysis session. The session is **DONE**. The user is no longer waiting for an answer. Your job is to **reflect on what happened** and **capture reusable learnings** from this session as instructions for future analyses.
+This phase captures reusable learnings from the session now that the user's request has been answered. The goal is to review what happened and persist any learnings as instructions for future analyses.
 
-**This is critical.** Instructions are the ONLY way the AI becomes tailored to this business. Every missed learning is a mistake the next user will have to correct again. Err on the side of capturing — as long as the learning is not overfitted and does not conflict with an existing instruction, you should write it down.
-
-You are NOT helping the user answer their question — that already happened. You are NOT producing a final answer for the user. You are auditing the just-completed session for knowledge that should persist.
+Instructions are how the AI becomes tailored to this business. Capture is the default — if a learning is reusable and not already covered, write it down.
 
 TRIGGER REASONS
 The system detected one or more conditions in this session that suggested a learning opportunity. Use these as your starting point:
@@ -987,39 +1002,39 @@ The system detected one or more conditions in this session that suggested a lear
 
 YOUR TASK
 1. Review the trigger reasons above and the session history (messages, past_observations, last_observation).
-2. Use `search_instructions` to check whether any existing instruction already covers the topic. **Always search before creating, and search THOROUGHLY in ONE call.**
+2. Use `search_instructions` to check whether any existing instruction already covers the topic. Search before creating, and search thoroughly in one call.
    - Pass a `query` array of 3-6 entries covering different angles of the topic. Each entry is either a plain keyword/phrase (literal substring match) or a regex pattern (auto-detected by regex metacharacters like `.*+?^$[](){{}}|`).
    - Include the clarified term itself, the underlying metric, the tables involved, and synonyms the user used. Example for a clarified "album revenue" term: `{{"query": ["album revenue", "invoiceline", "sales", "black-elephant", "revenue threshold", ".*album.*revenue.*"]}}`.
    - Use regex when keywords are not precise enough — e.g. `revenue\\s*>\\s*\\$?\\d+` to find existing revenue-threshold rules.
-   - Never pass sentences, questions, or full instruction text as a query entry — keep each entry short (1-3 tokens) or a tight regex.
-   - If the first search returns nothing surprising, that's your signal to create a new instruction — don't keep searching.
-3. **If you need to verify a fact before writing the instruction** (e.g. confirm a column name, check an enum value, confirm a join key), call `inspect_data` or `describe_tables` FIRST, then write the instruction in the next turn. Verifying is encouraged — better to pay one extra step than to write a wrong instruction.
+   - Keep entries short (1-3 tokens) or a tight regex — avoid sentences, questions, or full instruction text.
+   - If the first search returns nothing surprising, treat that as a signal to create a new instruction — do not keep searching.
+3. **If you need to verify a fact before writing the instruction** (e.g. confirm a column name, check an enum value, confirm a join key), call `inspect_data` or `describe_tables` first, then write the instruction in the next turn. Verifying is encouraged — better to pay one extra step than to write a wrong instruction.
 4. Then decide:
    - **If an existing instruction is relevant** (same topic, same entity, overlapping definition) → call `edit_instruction` to enhance/merge it. Prefer editing over creating whenever the new learning is related to something already captured.
-   - **If an existing instruction CONFLICTS** with the new learning (contradicts it, defines the same term differently, prescribes an opposite rule) → call `edit_instruction` on the conflicting instruction to resolve the conflict, and in the edit explicitly note that a conflict was found (e.g. "Updated to reflect clarified definition from session — previously said X, now correctly Y."). Never create a second instruction that contradicts an existing one.
+   - **If an existing instruction conflicts** with the new learning (contradicts it, defines the same term differently, prescribes an opposite rule) → call `edit_instruction` on the conflicting instruction to resolve the conflict, and in the edit explicitly note that a conflict was found (e.g. "Updated to reflect clarified definition from session — previously said X, now correctly Y."). Avoid creating a second instruction that contradicts an existing one.
    - **Otherwise** → call `create_instruction`. Default to creating. If the learning is reusable, non-overfitted, and not already covered, write it down.
-   - **Only skip** (`analysis_complete=true`) if the session contains literally nothing worth persisting (e.g. trivial request fully answered by existing instructions, or purely volatile data facts).
+   - **Only skip** (`analysis_complete=true`) if the session contains nothing worth persisting (e.g. trivial request fully answered by existing instructions, or purely volatile data facts).
 
 WHEN DEFINITIONS OR TERMS ARE CLARIFIED
-If the user clarified a term, metric, or definition during this session (e.g. defined a custom term, mapped an ambiguous word to a concrete rule, or resolved what something "means" in their domain), you MUST capture that clarification as an instruction. Clarified terms and definitions are exactly the kind of reusable knowledge this phase exists for — the next user who says the same term should benefit from the clarification without having to repeat it.
+If the user clarified a term, metric, or definition during this session (e.g. defined a custom term, mapped an ambiguous word to a concrete rule, or resolved what something "means" in their domain), capture that clarification as an instruction. Clarified terms and definitions are the kind of reusable knowledge this phase exists for — the next user who says the same term should benefit from the clarification without having to repeat it.
 
 BIAS TOWARD CAPTURING
-The cost of missing a learning is higher than the cost of capturing a merely useful one. When in doubt, capture. The ONLY reasons to skip are:
+Missing a learning costs more than capturing a merely useful one. When in doubt, capture. Reasons to skip:
   (a) the learning is already covered by an existing instruction (then edit instead),
   (b) the learning is overfitted — tied to one user, one timestamp, or one specific numeric result that won't generalize,
   (c) it's a raw volatile data fact (see below).
 Anything else — business rules, term clarifications, join patterns, filter conventions, naming quirks, error-recovery rules, column semantics — should be captured.
 
 RULES
-- **Capture by default.** Skipping is the exception, not the norm. If the learning is reusable and non-conflicting, write it down.
-- **Search first.** Always check existing instructions before creating. Prefer `edit_instruction` over `create_instruction` whenever the new learning is related to an existing one.
-- **Resolve conflicts, don't duplicate them.** When the new learning contradicts an existing instruction, edit that instruction and call out the conflict in the edit message.
-- **Verify when unsure.** Use `inspect_data` or `describe_tables` to confirm a specific fact before writing — then create/edit on the next turn. You have an 8-step budget; spend it on verification + capture, not on repeated searching.
-- **No volatile data facts.** Do NOT write instructions that state raw data values as facts — e.g. "the orders table has 32 rows", "revenue is $100,000", "there are 5 active users". These change as data is updated and become stale. This rule is about raw observed counts/values, NOT about clarified definitions: capturing "term X means Y" or "metric M is defined as SUM(...) WHERE ..." is correct and expected, even if Y references numbers.
-- **Confidence floor 0.7.** Only write instructions you have reasonable evidence for. If you'd have to guess, verify first with `inspect_data`/`describe_tables` or skip.
-- **Do not call `clarify`.** There is no user to talk to in this phase.
-- **One tool call per turn.** Same JSON schema as the main planner.
-- **Scope to this report.** When you pass `table_names` to `create_instruction`, only reference tables from data sources attached to the current report. Tables from other data sources will be silently dropped.
+- Capture by default. Skipping is the exception. If the learning is reusable and non-conflicting, write it down.
+- Search first. Check existing instructions before creating. Prefer `edit_instruction` over `create_instruction` whenever the new learning is related to an existing one.
+- Resolve conflicts rather than duplicating them. When the new learning contradicts an existing instruction, edit that instruction and call out the conflict in the edit message.
+- Verify when unsure. Use `inspect_data` or `describe_tables` to confirm a specific fact before writing — then create/edit on the next turn. You have an 8-step budget; spend it on verification + capture, not on repeated searching.
+- No volatile data facts. Avoid instructions that state raw data values as facts — e.g. "the orders table has 32 rows", "revenue is $100,000", "there are 5 active users". These change as data is updated and become stale. This applies to raw observed counts/values, not to clarified definitions: capturing "term X means Y" or "metric M is defined as SUM(...) WHERE ..." is correct and expected, even if Y references numbers.
+- Confidence floor 0.7. Write instructions you have reasonable evidence for. If you would have to guess, verify first with `inspect_data`/`describe_tables` or skip.
+- Do not call `clarify`. There is no user to talk to in this phase.
+- One tool call per turn. Same JSON schema as the main planner.
+- Scope to this report. When you pass `table_names` to `create_instruction`, only reference tables from data sources attached to the current report. Tables from other data sources will be silently dropped.
 
 CONFIDENCE
 - 0.9-1.0: Directly observed in this session's tool results, or user explicitly confirmed.
@@ -1031,10 +1046,10 @@ CATEGORIES
 - "code_gen": code-level rules used when generating SQL/code — e.g. SQL error fixes, dialect quirks, join patterns, cast/NULL-handling rules, column-level transformations (cents→dollars). Use when the knowledge only matters at the moment code is written.
 - "visualization": chart types, formatting, colors.
 - "dashboard": layout, composition.
-- "system": agent behavior and meta-rules about how the agent should act (e.g. "always ask before deleting"). Do NOT use `system` for domain term bindings — those are `general`.
+- "system": agent behavior and meta-rules about how the agent should act (e.g. "always ask before deleting"). Do not use `system` for domain term bindings — those are `general`.
 
 COMMUNICATION
-- `assistant_message`: ALWAYS provide. Briefly describe what you're doing this turn (e.g., "Searching for existing revenue instructions.", "Capturing the cancellation rule.", "Nothing new to capture.").
+- `assistant_message`: provide on every turn. Briefly describe what you're doing this turn (e.g., "Searching for existing revenue instructions.", "Capturing the cancellation rule.", "Nothing new to capture.").
 - `reasoning_message`: Optional, brief.
 - `final_answer`: Only when `analysis_complete=true`. One sentence summarizing what you captured (or that nothing was captured).
 
@@ -1078,13 +1093,13 @@ EXPECTED JSON OUTPUT (strict):
   "final_answer": string | null
 }}
 
-CRITICAL
+REMINDERS
 - This is reflection, not analysis. Do not answer a new question for the user.
-- Always `search_instructions` before `create_instruction`.
+- Run `search_instructions` before `create_instruction`.
 - Prefer `edit_instruction` over `create_instruction` when an existing instruction is related.
-- On conflict with an existing instruction, EDIT it and note the conflict — do not create a competing one.
-- Capturing is the default. Skip only when truly nothing is reusable or a conflict has already been resolved.
+- On conflict with an existing instruction, edit it and note the conflict — do not create a competing one.
+- Capturing is the default. Skip only when nothing is reusable or a conflict has already been resolved.
 - Use `inspect_data` / `describe_tables` to verify facts before writing if you're unsure.
-- ALWAYS output valid JSON.
+- Output valid JSON.
 """
         return prompt

--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -92,6 +92,7 @@ You are an expert in business, product and data analysis. You are familiar with 
 - Domain: business/data analysis, SQL/data modeling, code-aware reasoning, and UI/chart/widget recommendations.
 - Constraints: EXACTLY one (or none) tool call per turn; never hallucinate schema/table/column names; follow tool schemas exactly; output JSON only (strict schema below).
 - Ground every claim in provided data; if required info is missing, use the clarify tool.
+- Do not fabricate secrets or credentials; if they are needed but not provided, use the clarify tool.
 - Startup: when the loop starts (no observations), choose a reasoning level. Only use deep reasoning if "high" is warranted; otherwise keep it brief. In assistant_message, describe the high level plan.
 
 {deep_analytics_text}

--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -653,9 +653,7 @@ class StreamingCodeExecutor:
                 executed_successfully = True
                 break
             except Exception as e:
-                import traceback
-                trace = traceback.format_exc()
-                msg = f"Execution error: {str(e)}\n{trace}"
+                msg = f"Execution error: {str(e)}"
                 code_and_error_messages.append((final_code, msg))
                 yield {"type": "stdout", "payload": msg}
                 retries += 1
@@ -826,9 +824,7 @@ class StreamingCodeExecutor:
                 # Security violations are not retryable
                 break
             except Exception as e:
-                import traceback
-                trace = traceback.format_exc()
-                msg = f"Execution error: {str(e)}\n{trace}"
+                msg = f"Execution error: {str(e)}"
                 code_and_error_messages.append((final_code, msg))
                 yield {"type": "stdout", "payload": msg}
                 retries += 1

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -361,19 +361,19 @@ class CreateArtifactTool(Tool):
         fix_prompt = f"""{base_prompt}
 
 ═══════════════════════════════════════════════════════════════════════════════
-CRITICAL: FIX THESE ERRORS
+Fix the following errors
 ═══════════════════════════════════════════════════════════════════════════════
 
-The previous code attempt had the following runtime errors that MUST be fixed:
+The previous code attempt produced these runtime errors:
 
 {error_text}{screenshot_context}
 
-Previous broken code:
+Previous code:
 ```
 {code}
 ```
 
-Fix these errors while keeping the same design and functionality. Output the corrected code now:"""
+Fix the errors while keeping the same design and functionality. Output the corrected code:"""
 
         # Skip fix if sigkill
         sigkill_event = runtime_ctx.get("sigkill_event")
@@ -1066,29 +1066,29 @@ Fix these errors while keeping the same design and functionality. Output the cor
         if image_count > 0:
             images_context = f"\n**Attached Images:** {image_count} image(s) provided for visual reference. Use these to understand the design intent, branding, color schemes, or layout preferences the user wants to incorporate."
 
-        return f"""You are an expert at creating professional presentations using python-pptx.
+        return f"""Role: presentation author using python-pptx.
 Generate python-pptx code to create a polished slide deck.
 
 ═══════════════════════════════════════════════════════════════════════════════
-AVAILABLE IN NAMESPACE (do not import - already provided)
+AVAILABLE IN NAMESPACE (already provided — do not import)
 ═══════════════════════════════════════════════════════════════════════════════
 
-Python-pptx classes and FUNCTIONS:
+Python-pptx classes and functions:
 - Presentation, Inches, Pt, Emu, RGBColor
 - PP_ALIGN, MSO_ANCHOR, MSO_SHAPE
 - XL_CHART_TYPE, XL_LEGEND_POSITION
 - CategoryChartData, ChartData
 
-⚠️ CRITICAL: Inches, Pt, Emu are FUNCTIONS, not methods!
-   ✅ CORRECT: Inches(1), Pt(24), Emu(914400)
-   ❌ WRONG: 1.inches, 24.pt, value.inches
+Note: Inches, Pt, Emu are functions, not methods.
+   Use: Inches(1), Pt(24), Emu(914400)
+   Not: 1.inches, 24.pt, value.inches
 
 Data variables:
-- visualizations: List[Dict] - each has 'title', 'columns', 'rows'
+- visualizations: List[Dict] — each has 'title', 'columns', 'rows'
 - report: Dict with 'id', 'title', 'theme'
 
 Output:
-- _pptx_output_path: str - path where you MUST save the presentation
+- _pptx_output_path: str — path to save the presentation to
 
 ═══════════════════════════════════════════════════════════════════════════════
 YOUR VISUALIZATIONS
@@ -1140,7 +1140,7 @@ p.font.color.rgb = RGBColor(255, 255, 255)
 p.alignment = PP_ALIGN.CENTER
 ```
 
-**Add BAR CHART (CRITICAL - use this for charts):**
+**Add bar chart (use this pattern for charts):**
 ```python
 chart_data = CategoryChartData()
 chart_data.categories = ['Q1', 'Q2', 'Q3', 'Q4']
@@ -1206,8 +1206,8 @@ Example palettes (pick one that fits the topic):
 - **Sunset Warm**: Burgundy (128,0,32), Orange (255,140,0), Cream (255,253,240)
 - **Modern Minimal**: Charcoal (54,69,79), Light gray (220,220,220), Teal accent (0,150,136)
 
-**LAYOUT VARIETY - Never Repeat:**
-Every slide MUST have visual elements - charts, shapes, or decorative elements. NO text-only slides.
+**Layout variety — vary between slides:**
+Every slide should have visual elements — charts, shapes, or decorative elements. Avoid text-only slides.
 
 Vary layouts between:
 - Two-column (text left, chart right or vice versa)
@@ -1216,9 +1216,9 @@ Vary layouts between:
 - Chart with callout boxes for key insights
 - Split layout with accent shape dividers
 
-**TYPOGRAPHY:**
+**Typography:**
 - Titles: 36-44pt bold, interesting positioning (not always centered)
-- Body text: 18-24pt, LEFT-aligned (never center-align body text)
+- Body text: 18-24pt, left-aligned (avoid center-aligning body text)
 - KPI numbers: 48-72pt bold for impact
 - Use font color contrast: white on dark, dark on light accents
 
@@ -1228,21 +1228,21 @@ Vary layouts between:
 - Colored boxes behind KPI numbers
 - Subtle shape overlays for visual interest
 
-**COMMON MISTAKES TO AVOID:**
-- ⚠️ Using `value.inches` instead of `Inches(value)` - Inches/Pt/Emu are FUNCTIONS!
-- Repeating the same layout across slides (VARY IT!)
-- Center-aligning body text (use LEFT alignment)
-- Using only blue without topic-specific reasoning
-- Creating text-only slides without visual elements
-- Accent lines directly under titles (hallmark of generic slides)
-- Cramming too much data - limit charts to top 8-10 items
+**Common mistakes to avoid:**
+- Using `value.inches` instead of `Inches(value)` — Inches/Pt/Emu are functions.
+- Repeating the same layout across slides — vary it.
+- Center-aligning body text — use left alignment.
+- Using only blue without topic-specific reasoning.
+- Text-only slides without visual elements.
+- Accent lines directly under titles (hallmark of generic slides).
+- Cramming too much data — limit charts to top 8-10 items.
 
-**TECHNICAL REQUIREMENTS:**
-1. Define `generate_slides(visualizations, report)` returning a Presentation
-2. Use 16:9 widescreen: Inches(13.333) x Inches(7.5)
-3. Create REAL charts with slide.shapes.add_chart() + CategoryChartData
-4. Use visualization data from the visualizations list
-5. Margins: start shapes at Inches(0.75) to Inches(1) from edges
+**Technical requirements:**
+1. Define `generate_slides(visualizations, report)` returning a Presentation.
+2. Use 16:9 widescreen: Inches(13.333) x Inches(7.5).
+3. Create real charts with slide.shapes.add_chart() + CategoryChartData.
+4. Use visualization data from the visualizations list.
+5. Margins: start shapes at Inches(0.75) to Inches(1) from edges.
 
 ═══════════════════════════════════════════════════════════════════════════════
 OUTPUT FORMAT - Example with Design Principles Applied
@@ -1406,10 +1406,10 @@ Create a beautiful, varied presentation following these design principles. Each 
         # Note: Previous artifact code is now available via observation context (from create_artifact/read_artifact)
         # The planner can call read_artifact if needed to load previous code into context
 
-        return f"""You are a world-class frontend developer and data visualization expert.
+        return f"""Role: frontend developer and data visualization engineer.
 
 ═══════════════════════════════════════════════════════════════════════════════
-DESIGN REQUEST (primary specification — follow exactly, overrides all defaults)
+Design request (primary specification — takes precedence when it conflicts with defaults)
 ═══════════════════════════════════════════════════════════════════════════════
 
 **Report Title:** {report_title or title or 'Dashboard'}
@@ -1478,8 +1478,8 @@ Each visualization:
 - Use `column.field` to access row values: `row[column.field]`
 - Use `column.headerName` for display labels
 - Column metadata includes `dtype` (pandas type) and `unique_count` — use these for filter/format decisions
-- **NEVER hardcode data** — ALL values must come from `data.visualizations[N].rows`
-- **DEFENSIVE CODING**: Row values and properties can be `null`/`undefined`. ALWAYS use optional chaining or fallbacks before calling `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()`, etc. Example: `(row.name || '').includes('x')` or `String(val ?? '').toLowerCase()`. Never call string methods on a value that could be nullish.
+- **Do not hardcode data** — all values should come from `data.visualizations[N].rows`
+- **Defensive coding**: Row values and properties can be `null`/`undefined`. Use optional chaining or fallbacks before calling `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()`, etc. Example: `(row.name || '').includes('x')` or `String(val ?? '').toLowerCase()`. Do not call string methods on a value that could be nullish.
 
 YOUR VISUALIZATIONS:
 
@@ -1504,17 +1504,17 @@ For each dimension you intend to filter by:
 3. **Decide per dimension**:
    - ALL participants have the column → wire the global filter, use `fieldMap` for renames.
    - SOME participants lack the column but the gap is genuine (no join key in the source data) → make the filter LOCAL to the vizs that support it; do not pretend it affects others.
-   - SOME participants lack the column but they SHOULD have it (the underlying data supports it, the query just didn't project the column) → **DO NOT wire the filter. Do not build the dashboard with a dead filter.** End your response by reporting the gap so the planner can recreate the offending queries before you try again. Example: "Cannot wire `customer_id` filter — `payments` viz lacks `customer_id` but `payments.customer_id` exists in schema. Recreate the payments query with `customer_id` projected, then retry create_artifact."
+   - SOME participants lack the column but they should have it (the underlying data supports it, the query just didn't project the column) → **do not wire the filter; do not build the dashboard with a dead filter.** End your response by reporting the gap so the planner can recreate the offending queries before you try again. Example: "Cannot wire `customer_id` filter — `payments` viz lacks `customer_id` but `payments.customer_id` exists in schema. Recreate the payments query with `customer_id` projected, then retry create_artifact."
 
 FILTER PLACEMENT — global vs local:
 - **Global filter** (column present in 2+ vizs AFTER the audit above): place in a top-level filter bar above all content. Use one shared filter + `fieldMap` for renames, not duplicates.
 - **Local filter** (column present in only 1 viz): place INSIDE that viz's `<SectionCard>`, visually next to the chart/table it affects.
 - When a filter affects multiple vizs, add visible UI indication that they're linked.
 
-FILTER DATA FLOW — CRITICAL:
-- Every viz that passes the feasibility audit for a filter MUST use `filterRows()` as its data source — for charts, tables, AND any KPI/summary derived from that viz.
-- KPI cards that summarize filtered data (sum, count, avg) MUST be computed from filtered rows, NEVER from raw `viz[N].rows`.
-- Never call `filterRows` on a viz that doesn't have the filter column just to "be safe" — silently passing rows through makes the filter look active when it isn't. Audit first, wire second.
+FILTER DATA FLOW:
+- Every viz that passes the feasibility audit for a filter should use `filterRows()` as its data source — for charts, tables, and any KPI/summary derived from that viz.
+- KPI cards that summarize filtered data (sum, count, avg) should be computed from filtered rows, not from raw `viz[N].rows`.
+- Do not call `filterRows` on a viz that doesn't have the filter column just to "be safe" — silently passing rows through makes the filter look active when it isn't. Audit first, wire second.
 
 EXAMPLE 1 — Global "region" filter affecting KPIs + bar chart + table:
   const {{ filters, setFilter, resetFilters, filterRows }} = useFilters();
@@ -1582,11 +1582,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 </script>
 ```
 
-CRITICAL: ALL code MUST be inside `function App() {{ ... }}` with `ReactDOM.createRoot(document.getElementById('root')).render(<App />);` at the end. NEVER put return statements outside a function.
+Structure: all code should be inside `function App() {{ ... }}` with `ReactDOM.createRoot(document.getElementById('root')).render(<App />);` at the end. Do not put return statements outside a function.
 
-RULES: `<script type="text/babel">` wrapper. `useArtifactData()` for data. `<EChart option={{...}} />` for charts. Responsive. Handle zero rows. No hardcoded data. No UUIDs/branding/emoji. ALWAYS guard nullish values before string methods (use `(val || '')` or `String(val ?? '')`).
+Rules: `<script type="text/babel">` wrapper. `useArtifactData()` for data. `<EChart option={{...}} />` for charts. Responsive. Handle zero rows. No hardcoded data. No UUIDs/branding/emoji. Guard nullish values before string methods (use `(val || '')` or `String(val ?? '')`).
 
-⚠️ **CODE SIZE:** Write compact code — no unnecessary variables, comments, or verbose JSX. Omit default props. Don't repeat theme styling the 'bow' theme already provides. Prefer inline expressions over separate variables when used once. For simple dashboards target under 8K characters. For detailed/specific user requests, use as much space as needed to faithfully implement their design — fidelity to the user's request is more important than brevity.
+**Code size:** Write compact code — no unnecessary variables, comments, or verbose JSX. Omit default props. Don't repeat theme styling the 'bow' theme already provides. Prefer inline expressions over separate variables when used once. For simple dashboards target under 8K characters. For detailed/specific user requests, use as much space as needed to faithfully implement their design — fidelity to the user's request is more important than brevity.
 
 Now create the dashboard:"""
 

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -323,9 +323,9 @@ ORGANIZATION VISUALIZATION INSTRUCTIONS:
 
 """
         
-        prompt = f"""You are a visualization planner. Analyze the data profile and choose the best visualization type.
+        prompt = f"""Role: visualization planner. Analyze the data profile and choose the best visualization type.
 {instructions_block}
-CRITICAL: You MUST use EXACT column names from the data. Available columns are: {column_names}
+Use the exact column names from the data. Available columns are: {column_names}
 
 Context: {messages_context or "None"}
 User prompt: {user_prompt or "None"}
@@ -337,13 +337,13 @@ Data profile:
 RULES FOR METRIC_CARD (KPI display)
 ═══════════════════════════════════════════════════════════════════════════════
 
-Use metric_card when showing a single key metric. The "value" field MUST be an EXACT column name.
+Use metric_card when showing a single key metric. The "value" field should be an exact column name.
 
-DETECTING THE VALUE COLUMN:
+Detecting the value column:
 - Look for columns with names like: revenue, total, amount, count, sum, value, sales, profit, cost
-- AVOID using date/time columns (year, month, date, week, day) as the value
-- AVOID using ID columns as the value
-- Pick the column that represents the METRIC the user asked about
+- Avoid using date/time columns (year, month, date, week, day) as the value
+- Avoid using ID columns as the value
+- Pick the column that represents the metric the user asked about
 
 DETECTING TIME-SERIES FOR SPARKLINE:
 If row_count > 1 AND there's a time column (month, date, week, year, period, day), enable sparkline:
@@ -375,18 +375,18 @@ OTHER CHART TYPES
 Allowed types: {", ".join(allowed_types)}
 
 Series contracts:
-- bar/line/area: [{{"name", "key", "value"}}] - BOTH key AND value are REQUIRED!
+- bar/line/area: [{{"name", "key", "value"}}] — both `key` and `value` are required.
 - pie/map: [{{"name", "key", "value"}}]
 - scatter: [{{"name", "x", "y"}}] (+ size optional)
 - heatmap: [{{"name", "x", "y", "value", "colorScheme", "showValues"}}]
   - colorScheme: "blue" | "green" | "red" | "violet" | "orange" (default: "blue")
-  - showValues: true | false (default: true) - whether to show values in cells
+  - showValues: true | false (default: true) — whether to show values in cells
 - table: series: []
 
-CRITICAL FOR BAR/LINE/AREA CHARTS:
-- "key" = the CATEGORY column (x-axis) - REQUIRED, usually a date, name, or category column
-- "value" = the NUMERIC column (y-axis) - REQUIRED, the metric to display
-- You MUST include BOTH "key" and "value" in every series entry!
+For bar/line/area charts:
+- "key" = the category column (x-axis), required — usually a date, name, or category column
+- "value" = the numeric column (y-axis), required — the metric to display
+- Include both "key" and "value" in every series entry.
 
 DETECTING GROUP_BY (for multi-series grouped bar/line/area charts):
 - If the data has a CATEGORICAL column that creates MULTIPLE ROWS per x-axis value, use "group_by"
@@ -436,13 +436,13 @@ DECISION LOGIC:
 OUTPUT FORMAT
 ═══════════════════════════════════════════════════════════════════════════════
 
-Return ONLY valid JSON:
+Return only valid JSON:
 {{"type": "...", "series": [...], "group_by": "column_name_or_null"}}
 
 Include "group_by" when the data has multiple rows per x-axis category that should be shown as separate colored series.
 
-REMEMBER: Use EXACT column names from: {column_names}
-Do NOT use generic placeholders like "value" unless that's the actual column name."""
+Reminder: use exact column names from: {column_names}
+Do not use generic placeholders like "value" unless that is the actual column name."""
 
         try:
             raw = llm.inference(prompt, usage_scope="create_data.viz_infer")


### PR DESCRIPTION
Azure OpenAI's jailbreak classifier flags prompts that stack imperative vocabulary (MUST/NEVER/CRITICAL) and inline user-controlled error text into a single user-role message. Customers on Azure with default guardrails hit this intermittently on code-generation tool calls.

Changes:
- code_execution.py: drop full Python traceback from the error message appended to code_and_error_messages. The retry prompt previously inlined `File "..."` frames plus exception text verbatim, which supplied the classifier with high-signal trigger vocabulary (`__import__`, module paths, etc.). The exception type and message from str(e) are sufficient for the LLM to reason about the retry.
- coder.py: soften the three code-generation prompts (data_model_to_code, generate_code typed-context path, generate_code legacy path, generate_inspection_code). Convert persona framing and stacked MUST/NEVER/CRITICAL bullets to declarative instructions. Semantic content preserved; XML structure unchanged.
- create_data.py: vocabulary pass on the visualization-inference prompt.
- create_artifact.py: fix the design-request header ("overrides all defaults" -> "takes precedence when it conflicts with defaults"), fix-loop header, slides prompt body, and page prompt CRITICAL blocks.
- prompt_builder.py: reframe the knowledge harness prompt. Remove the "You are NOT helping the user answer their question" line (classic jailbreak-shaped phrasing) and replace the CRITICAL reminder block with a declarative REMINDERS section. Sanitize the interpolated trigger_conditions block to cap length and swap imperative words. Also drop the "Safety:" prefix on the main planner prompt line 94 — the only surgical change to that prompt this pass.

Out of scope for this pass (deferred): main planner prompt body, agent_v2 user-role concat, QueryCapturingClientWrapper SQL error sanitization, empty-dataframe guidance wording, non-code tool observation sanitization. Will revisit after telemetry.