### PR TITLE
feat(viz): support aggregation + default filters for granular data

### DIFF
--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -1497,21 +1497,21 @@ Each visualization:
 - **Do not hardcode data** — all values should come from `data.visualizations[N].rows`
 - **Defensive coding**: Row values and properties can be `null`/`undefined`. Use optional chaining or fallbacks before calling `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()`, etc. Example: `(row.name || '').includes('x')` or `String(val ?? '').toLowerCase()`. Do not call string methods on a value that could be nullish.
 
-VIEW HINTS — HONOR THE VIZ CONFIG:
-The `view_config` on each visualization tells you HOW the author wants the data rendered. Do NOT ignore it.
+View hints — honor the viz config:
+The `view_config` on each visualization describes how the author wants the data rendered. Follow it when generating code.
 
-- `view_config.aggregation` (`"sum" | "avg" | "count" | "min" | "max"`): the raw rows are granular and must be aggregated before rendering (especially for `count`, `metric_card`, `pie_chart`, `heatmap`). Apply the aggregation with a `rows.reduce(...)` over the relevant value column. Example for a metric card with aggregation=sum:
+- `view_config.aggregation` (`"sum" | "avg" | "count" | "min" | "max"`): the raw rows are granular, so aggregate the relevant value column before rendering (especially for `count`, `metric_card`, `pie_chart`, `heatmap`). Use `rows.reduce(...)`. Example for a metric card with aggregation=sum:
   ```js
   const total = useMemo(
     () => viz[0].rows.reduce((s, r) => s + (Number(r.revenue) || 0), 0),
     [viz]
   );
   ```
-  For pie/heatmap/bar where we group by a category, group first and aggregate the value per group — never pick the first matching row.
+  For pie/heatmap/bar charts that group by a category, group first and aggregate the value per group rather than using the first matching row.
 
 - `view_config.series_aggregations` (array of `{{key, aggregation}}`): apply the given aggregation per series when building multi-series bar/line/area charts.
 
-- `view_config.default_filters` (array of `{{column, operator, value}}`): the author wants the dashboard to OPEN with these filters already applied. Seed them on first mount so the initial view matches the intent, for example:
+- `view_config.default_filters` (array of `{{column, operator, value}}`): the author wants the dashboard to open with these filters already applied. Seed them on first mount so the initial view matches the intent, for example:
   ```js
   const {{ filters, setFilter, filterRows }} = useFilters();
   useEffect(() => {{
@@ -1520,7 +1520,7 @@ The `view_config` on each visualization tells you HOW the author wants the data 
     setFilter('column_name', value);
   }}, []);
   ```
-  If the underlying runtime uses richer operators (`equals`, `greater_than`, etc.), either call `setFilter` with the operator-aware object it expects, or compute the filtered rows directly via `filterRows(viz[N].rows)` once the filter is seeded. Never render an unfiltered view when defaults are present — the dashboard would show the wrong numbers on load.
+  If the underlying runtime uses richer operators (`equals`, `greater_than`, etc.), either call `setFilter` with the operator-aware object it expects, or compute the filtered rows directly via `filterRows(viz[N].rows)` once the filter is seeded. Render the filtered view when defaults are present so the initial numbers match the author's intent.
 
 YOUR VISUALIZATIONS:
 

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -454,6 +454,22 @@ Fix these errors while keeping the same design and functionality. Output the cor
                 "category": inner_view.get("category"),
                 "value": inner_view.get("value"),
             }
+            # Surface aggregation (top-level) + per-series aggregations so the
+            # artifact can honor granular-data handling rather than reading
+            # the first row.
+            if inner_view.get("aggregation"):
+                profile["view_config"]["aggregation"] = inner_view.get("aggregation")
+            series_styles = inner_view.get("seriesStyles") or []
+            series_aggs = [
+                {"key": s.get("key"), "aggregation": s.get("aggregation")}
+                for s in series_styles
+                if isinstance(s, dict) and s.get("aggregation")
+            ]
+            if series_aggs:
+                profile["view_config"]["series_aggregations"] = series_aggs
+            default_filters = inner_view.get("defaultFilters") or []
+            if default_filters:
+                profile["view_config"]["default_filters"] = default_filters
             # Include palette if present
             palette = inner_view.get("palette") or {}
             if palette.get("colors"):
@@ -1480,6 +1496,31 @@ Each visualization:
 - Column metadata includes `dtype` (pandas type) and `unique_count` — use these for filter/format decisions
 - **NEVER hardcode data** — ALL values must come from `data.visualizations[N].rows`
 - **DEFENSIVE CODING**: Row values and properties can be `null`/`undefined`. ALWAYS use optional chaining or fallbacks before calling `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()`, etc. Example: `(row.name || '').includes('x')` or `String(val ?? '').toLowerCase()`. Never call string methods on a value that could be nullish.
+
+VIEW HINTS — HONOR THE VIZ CONFIG:
+The `view_config` on each visualization tells you HOW the author wants the data rendered. Do NOT ignore it.
+
+- `view_config.aggregation` (`"sum" | "avg" | "count" | "min" | "max"`): the raw rows are granular and must be aggregated before rendering (especially for `count`, `metric_card`, `pie_chart`, `heatmap`). Apply the aggregation with a `rows.reduce(...)` over the relevant value column. Example for a metric card with aggregation=sum:
+  ```js
+  const total = useMemo(
+    () => viz[0].rows.reduce((s, r) => s + (Number(r.revenue) || 0), 0),
+    [viz]
+  );
+  ```
+  For pie/heatmap/bar where we group by a category, group first and aggregate the value per group — never pick the first matching row.
+
+- `view_config.series_aggregations` (array of `{{key, aggregation}}`): apply the given aggregation per series when building multi-series bar/line/area charts.
+
+- `view_config.default_filters` (array of `{{column, operator, value}}`): the author wants the dashboard to OPEN with these filters already applied. Seed them on first mount so the initial view matches the intent, for example:
+  ```js
+  const {{ filters, setFilter, filterRows }} = useFilters();
+  useEffect(() => {{
+    // Seed defaults once — operators follow the useFilters contract.
+    {{/* for each entry in view_config.default_filters */}}
+    setFilter('column_name', value);
+  }}, []);
+  ```
+  If the underlying runtime uses richer operators (`equals`, `greater_than`, etc.), either call `setFilter` with the operator-aware object it expects, or compute the filtered rows directly via `filterRows(viz[N].rows)` once the filter is seeded. Never render an unfiltered view when defaults are present — the dashboard would show the wrong numbers on load.
 
 YOUR VISUALIZATIONS:
 

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -430,7 +430,7 @@ OTHER CHART TYPES
 Allowed types: {", ".join(allowed_types)}
 
 Series contracts:
-- bar/line/area: [{{"name", "key", "value", "aggregation?"}}] - BOTH key AND value are REQUIRED!
+- bar/line/area: [{{"name", "key", "value", "aggregation?"}}] — both `key` and `value` are required.
 - pie/map: [{{"name", "key", "value", "aggregation?"}}]
 - scatter: [{{"name", "x", "y", "aggregation?"}}] (+ size optional)
 - heatmap: [{{"name", "x", "y", "value", "colorScheme", "showValues", "aggregation?"}}]
@@ -488,61 +488,63 @@ DECISION LOGIC:
 7. Raw data display → table
 
 ═══════════════════════════════════════════════════════════════════════════════
-GRANULARITY: AGGREGATION AND DEFAULT FILTERS
+Granularity: aggregation and default filters
 ═══════════════════════════════════════════════════════════════════════════════
 
-Data is often GRANULAR — many rows per x-axis category or per metric value. Decide how
-to collapse rows by either setting an "aggregation" on each series OR emitting
-"filters" that reduce the data to one row per bucket.
+Data is often granular — many rows per x-axis category or per metric value. Pick
+an "aggregation" on each series or emit top-level "filters" to reduce the rows
+to one per bucket.
 
-DETECT GRANULARITY:
+Detecting granularity:
 - Compute expected_rows = unique_count(chosen_key) × unique_count(group_by or 1).
-- If row_count > expected_rows, the data has multiple rows per bucket — you MUST pick an
-  aggregation or a filter. Not doing so makes the chart show the first row silently.
+- If row_count exceeds expected_rows, the data has multiple rows per bucket —
+  pick an aggregation or a filter. Without one the chart shows only the first
+  row per bucket, which is usually wrong.
 
-AGGREGATION VALUES: "sum" | "avg" | "count" | "min" | "max"
+Aggregation values: "sum" | "avg" | "count" | "min" | "max"
 - sum: totals (revenue, amount, qty) — the common default
 - avg: averages (price, score, rating)
 - count: row counts (transactions, events) — rarely the `value` column itself
 - min/max: extrema (latest price, highest score)
 
-AGGREGATION EXAMPLE (cartesian, granular transactions):
+Aggregation example (cartesian, granular transactions):
 Columns: ["transaction_date", "amount", "region"]
 row_count: 5,000; unique_count(transaction_date): 30; unique_count(region): 4
-Expected rows without aggregation: 30 × 4 = 120 — but we have 5,000 → GRANULAR.
-CORRECT (aggregate sum per date+region):
+Expected rows without aggregation: 30 × 4 = 120, but the profile shows 5,000 — granular.
+Recommended (aggregate sum per date+region):
 {{"type": "bar_chart", "series": [{{"name": "Revenue", "key": "transaction_date", "value": "amount", "aggregation": "sum"}}], "group_by": "region"}}
 
-AGGREGATION EXAMPLE (metric_card, granular daily sales):
+Aggregation example (metric_card, granular daily sales):
 Columns: ["date", "sales"]
 row_count: 365; unique_count(date): 365
 Without aggregation, metric_card shows the first row's sales only (not a KPI).
-CORRECT:
+Recommended:
 {{"type": "metric_card", "series": [{{"name": "Total Sales", "value": "sales", "aggregation": "sum"}}]}}
 
-DEFAULT FILTERS (alternative to aggregation):
-Use "filters" at the top level to reduce granular data down to a single row per bucket
-when the user's intent is clearly "just the latest" or "just this one segment". Filters
-open the widget in a pre-filtered state and remain user-editable.
+Default filters (alternative to aggregation):
+Use "filters" at the top level to reduce granular data down to a single row per
+bucket when the user's intent is clearly "just the latest" or "just this one
+segment". Filters open the widget pre-filtered and remain user-editable.
 
 Filter shape: [{{"column": "<column>", "operator": "<op>", "value": <value>}}]
-Operators: "equals", "not_equals", "contains", "not_contains", "starts_with", "ends_with",
-  "greater_than", "less_than", "gte", "lte", "before", "after", "is_empty", "is_not_empty".
+Operators: "equals", "not_equals", "contains", "not_contains", "starts_with",
+"ends_with", "greater_than", "less_than", "gte", "lte", "before", "after",
+"is_empty", "is_not_empty".
 
-DEFAULT FILTERS EXAMPLE (pick latest period):
+Default filters example (pick latest period):
 Columns: ["month", "revenue"]
 User prompt: "show this month's revenue"
 {{"type": "metric_card", "series": [{{"name": "Revenue", "value": "revenue"}}],
   "filters": [{{"column": "month", "operator": "equals", "value": "2024-06"}}]}}
 
-Prefer aggregation over filters when the intent is "all data, summarized". Prefer
-filters when the intent is "this specific slice". Don't set both unless you need to.
+Prefer aggregation when the intent is "all data, summarized". Prefer filters
+when the intent is "this specific slice". Setting both is rarely useful.
 
 ═══════════════════════════════════════════════════════════════════════════════
 OUTPUT FORMAT
 ═══════════════════════════════════════════════════════════════════════════════
 
-Return ONLY valid JSON:
+Return only valid JSON:
 {{"type": "...", "series": [...], "group_by": "column_name_or_null", "filters": [...]}}
 
 Include "group_by" when the data has multiple rows per x-axis category that should be shown as separate colored series.

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -61,6 +61,9 @@ def _infer_palette_theme(runtime_ctx: Dict[str, Any]) -> Optional[str]:
         return None
 
 
+_VALID_AGGREGATIONS = {"sum", "avg", "count", "min", "max"}
+
+
 def _build_series_styles(series: List[Dict[str, Any]]) -> List[SeriesStyle]:
     styles: List[SeriesStyle] = []
     for entry in series or []:
@@ -68,11 +71,17 @@ def _build_series_styles(series: List[Dict[str, Any]]) -> List[SeriesStyle]:
         if not key:
             continue
         label = entry.get("name")
-        agg = entry.get("aggregation")
+        raw_agg = entry.get("aggregation")
+        # Drop unknown aggregation values instead of failing construction, so a
+        # bad hint doesn't erase the label/color fields for this series.
+        agg = raw_agg if raw_agg in _VALID_AGGREGATIONS else None
         try:
             styles.append(SeriesStyle(key=str(key), label=label, aggregation=agg))
         except Exception:
-            continue
+            try:
+                styles.append(SeriesStyle(key=str(key), label=label))
+            except Exception:
+                continue
     return styles
 
 
@@ -104,7 +113,7 @@ def _first_series_aggregation(series: List[Dict[str, Any]]) -> Optional[str]:
         return None
     first = series[0] if isinstance(series[0], dict) else {}
     agg = first.get("aggregation")
-    if agg in {"sum", "avg", "count", "min", "max"}:
+    if agg in _VALID_AGGREGATIONS:
         return agg
     return None
 

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -68,11 +68,45 @@ def _build_series_styles(series: List[Dict[str, Any]]) -> List[SeriesStyle]:
         if not key:
             continue
         label = entry.get("name")
+        agg = entry.get("aggregation")
         try:
-            styles.append(SeriesStyle(key=str(key), label=label))
+            styles.append(SeriesStyle(key=str(key), label=label, aggregation=agg))
         except Exception:
             continue
     return styles
+
+
+def _build_default_filters(data_model: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract default filters from a DataModel dict into the view shape.
+
+    Stored as flat dicts matching DefaultFilterCondition. The runtime is
+    responsible for wrapping them into a FilterGroup with the proper
+    vizId:column encoding when seeding shared filters.
+    """
+    raw = (data_model or {}).get("filters") or []
+    out: List[Dict[str, Any]] = []
+    if not isinstance(raw, list):
+        return out
+    for f in raw:
+        if not isinstance(f, dict):
+            continue
+        col = f.get("column") or f.get("field")
+        op = f.get("operator") or f.get("op")
+        if not col or not op:
+            continue
+        out.append({"column": str(col), "operator": str(op), "value": f.get("value")})
+    return out
+
+
+def _first_series_aggregation(series: List[Dict[str, Any]]) -> Optional[str]:
+    """Pull an aggregation hint from the first series entry if present."""
+    if not series:
+        return None
+    first = series[0] if isinstance(series[0], dict) else {}
+    agg = first.get("aggregation")
+    if agg in {"sum", "avg", "count", "min", "max"}:
+        return agg
+    return None
 
 
 def build_view_from_data_model(
@@ -88,17 +122,18 @@ def build_view_from_data_model(
 
     palette = Palette(theme=(palette_theme or "default"))
     series = data_model.get("series") or []
+    default_filters = _build_default_filters(data_model)
 
     if chart_type in {"bar_chart", "line_chart", "area_chart"}:
         x_key = next((s.get("key") for s in series if s.get("key")), None)
         value_cols = [s.get("value") for s in series if s.get("value")]
-        
+
         # Fallback: infer x_key from available columns when missing
         # Pick the first column that's not used as a value
         if not x_key and value_cols and available_columns:
             value_cols_set = set(value_cols)
             x_key = next((col for col in available_columns if col not in value_cols_set), None)
-        
+
         if not x_key or not value_cols:
             return None
         # Use list when multiple measures exist
@@ -119,6 +154,7 @@ def build_view_from_data_model(
             palette=palette,
             seriesStyles=series_styles,
             legend=LegendOptions(show=bool(has_multiple_series)),
+            defaultFilters=default_filters,
         )
         # Slightly different axis defaults for time series vs categorical
         view.axisX = AxisOptions(rotate=45, interval=0)
@@ -137,6 +173,8 @@ def build_view_from_data_model(
             value=str(value),
             palette=palette,
             legend=LegendOptions(show=True, position="right"),  # Pie charts benefit from legend
+            aggregation=_first_series_aggregation(series),
+            defaultFilters=default_filters,
         )
         return ViewSchema(view=view)
 
@@ -153,6 +191,8 @@ def build_view_from_data_model(
             size=base.get("size"),
             colorBy=base.get("color"),
             palette=palette,
+            aggregation=_first_series_aggregation(series),
+            defaultFilters=default_filters,
         )
         return ViewSchema(view=view)
 
@@ -180,11 +220,13 @@ def build_view_from_data_model(
             showValues=bool(show_values),
             axisX=AxisOptions(rotate=45, interval=0),
             axisY=AxisOptions(rotate=0, interval=0),
+            aggregation=_first_series_aggregation(series),
+            defaultFilters=default_filters,
         )
         return ViewSchema(view=view)
 
     if chart_type == "table":
-        view = TableView(title=title)
+        view = TableView(title=title, defaultFilters=default_filters)
         return ViewSchema(view=view)
 
     # CountView - simple single value display (value is optional)
@@ -195,6 +237,8 @@ def build_view_from_data_model(
             title=title,
             value=str(value_key) if value_key else None,
             palette=palette,
+            aggregation=_first_series_aggregation(series),
+            defaultFilters=default_filters,
         )
         return ViewSchema(view=view)
 
@@ -206,15 +250,15 @@ def build_view_from_data_model(
         if not value_key:
             # Try to use first available column name from series
             value_key = base.get("key") or base.get("name")
-        
+
         # Extract comparison/trend column
         comparison_key = base.get("comparison") or base.get("trend") or base.get("change")
-        
+
         # Build sparkline config if LLM specified time-series columns
         sparkline = None
         sparkline_col = base.get("sparkline_column") or base.get("time_series")
         sparkline_x = base.get("sparkline_x") or base.get("date") or base.get("time")
-        
+
         # Only enable sparkline if LLM explicitly configured it
         if sparkline_col or data_model.get("has_time_series"):
             sparkline = SparklineConfig(
@@ -223,17 +267,17 @@ def build_view_from_data_model(
                 xColumn=sparkline_x,
                 type="area",
             )
-        
+
         # Determine if trend should be inverted (down is good)
         # Use `or False` because base.get returns None if key exists with None value
         invert_trend = base.get("invert_trend") or False
         comparison_label = base.get("comparison_label") or base.get("trend_label")
-        
+
         # value is REQUIRED for MetricCardView - if we don't have it, fall back to CountView
         if not value_key:
-            view = CountView(title=title, palette=palette)
+            view = CountView(title=title, palette=palette, defaultFilters=default_filters)
             return ViewSchema(view=view)
-        
+
         view = MetricCardView(
             title=title,
             value=str(value_key),
@@ -242,6 +286,8 @@ def build_view_from_data_model(
             invertTrend=invert_trend,
             sparkline=sparkline,
             palette=palette,
+            aggregation=_first_series_aggregation(series),
+            defaultFilters=default_filters,
         )
         return ViewSchema(view=view)
 
@@ -375,10 +421,10 @@ OTHER CHART TYPES
 Allowed types: {", ".join(allowed_types)}
 
 Series contracts:
-- bar/line/area: [{{"name", "key", "value"}}] - BOTH key AND value are REQUIRED!
-- pie/map: [{{"name", "key", "value"}}]
-- scatter: [{{"name", "x", "y"}}] (+ size optional)
-- heatmap: [{{"name", "x", "y", "value", "colorScheme", "showValues"}}]
+- bar/line/area: [{{"name", "key", "value", "aggregation?"}}] - BOTH key AND value are REQUIRED!
+- pie/map: [{{"name", "key", "value", "aggregation?"}}]
+- scatter: [{{"name", "x", "y", "aggregation?"}}] (+ size optional)
+- heatmap: [{{"name", "x", "y", "value", "colorScheme", "showValues", "aggregation?"}}]
   - colorScheme: "blue" | "green" | "red" | "violet" | "orange" (default: "blue")
   - showValues: true | false (default: true) - whether to show values in cells
 - table: series: []
@@ -433,13 +479,66 @@ DECISION LOGIC:
 7. Raw data display → table
 
 ═══════════════════════════════════════════════════════════════════════════════
+GRANULARITY: AGGREGATION AND DEFAULT FILTERS
+═══════════════════════════════════════════════════════════════════════════════
+
+Data is often GRANULAR — many rows per x-axis category or per metric value. Decide how
+to collapse rows by either setting an "aggregation" on each series OR emitting
+"filters" that reduce the data to one row per bucket.
+
+DETECT GRANULARITY:
+- Compute expected_rows = unique_count(chosen_key) × unique_count(group_by or 1).
+- If row_count > expected_rows, the data has multiple rows per bucket — you MUST pick an
+  aggregation or a filter. Not doing so makes the chart show the first row silently.
+
+AGGREGATION VALUES: "sum" | "avg" | "count" | "min" | "max"
+- sum: totals (revenue, amount, qty) — the common default
+- avg: averages (price, score, rating)
+- count: row counts (transactions, events) — rarely the `value` column itself
+- min/max: extrema (latest price, highest score)
+
+AGGREGATION EXAMPLE (cartesian, granular transactions):
+Columns: ["transaction_date", "amount", "region"]
+row_count: 5,000; unique_count(transaction_date): 30; unique_count(region): 4
+Expected rows without aggregation: 30 × 4 = 120 — but we have 5,000 → GRANULAR.
+CORRECT (aggregate sum per date+region):
+{{"type": "bar_chart", "series": [{{"name": "Revenue", "key": "transaction_date", "value": "amount", "aggregation": "sum"}}], "group_by": "region"}}
+
+AGGREGATION EXAMPLE (metric_card, granular daily sales):
+Columns: ["date", "sales"]
+row_count: 365; unique_count(date): 365
+Without aggregation, metric_card shows the first row's sales only (not a KPI).
+CORRECT:
+{{"type": "metric_card", "series": [{{"name": "Total Sales", "value": "sales", "aggregation": "sum"}}]}}
+
+DEFAULT FILTERS (alternative to aggregation):
+Use "filters" at the top level to reduce granular data down to a single row per bucket
+when the user's intent is clearly "just the latest" or "just this one segment". Filters
+open the widget in a pre-filtered state and remain user-editable.
+
+Filter shape: [{{"column": "<column>", "operator": "<op>", "value": <value>}}]
+Operators: "equals", "not_equals", "contains", "not_contains", "starts_with", "ends_with",
+  "greater_than", "less_than", "gte", "lte", "before", "after", "is_empty", "is_not_empty".
+
+DEFAULT FILTERS EXAMPLE (pick latest period):
+Columns: ["month", "revenue"]
+User prompt: "show this month's revenue"
+{{"type": "metric_card", "series": [{{"name": "Revenue", "value": "revenue"}}],
+  "filters": [{{"column": "month", "operator": "equals", "value": "2024-06"}}]}}
+
+Prefer aggregation over filters when the intent is "all data, summarized". Prefer
+filters when the intent is "this specific slice". Don't set both unless you need to.
+
+═══════════════════════════════════════════════════════════════════════════════
 OUTPUT FORMAT
 ═══════════════════════════════════════════════════════════════════════════════
 
 Return ONLY valid JSON:
-{{"type": "...", "series": [...], "group_by": "column_name_or_null"}}
+{{"type": "...", "series": [...], "group_by": "column_name_or_null", "filters": [...]}}
 
 Include "group_by" when the data has multiple rows per x-axis category that should be shown as separate colored series.
+Include "aggregation" on each series entry when rows are granular.
+Include "filters" only when narrowing the data to a specific slice.
 
 REMEMBER: Use EXACT column names from: {column_names}
 Do NOT use generic placeholders like "value" unless that's the actual column name."""
@@ -458,7 +557,7 @@ Do NOT use generic placeholders like "value" unless that's the actual column nam
                 candidate_json = None
             if isinstance(candidate_json, dict):
                 try:
-                    dm = DataModel(**{k: v for k, v in candidate_json.items() if k in {"type", "series", "group_by", "sort", "limit"}})
+                    dm = DataModel(**{k: v for k, v in candidate_json.items() if k in {"type", "series", "group_by", "sort", "limit", "filters"}})
                     candidate = dm.model_dump()
                 except Exception:
                     candidate = {"type": "table", "series": []}

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -419,6 +419,13 @@ DATA ACCESS:
 - **NEVER hardcode data** — ALL values from `data.visualizations[N].rows`
 - **DEFENSIVE CODING**: Row values can be `null`/`undefined`. ALWAYS guard before string methods: `(val || '').includes('x')` or `String(val ?? '').toLowerCase()`. Never call `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()` on a potentially nullish value.
 
+VIEW HINTS — HONOR THE VIZ CONFIG:
+Inspect `view.aggregation`, `view.seriesStyles[i].aggregation`, and `view.defaultFilters` before rendering. These tell you the author's intent for granular data:
+
+- `view.aggregation` (`"sum"|"avg"|"count"|"min"|"max"`): aggregate rows with `reduce`/`Map` before rendering (e.g. metric cards, pies, heatmaps). NEVER read `rows[0]` as the value when aggregation is set.
+- `view.seriesStyles[i].aggregation`: per-series aggregation — apply when building each series in multi-series bar/line/area charts.
+- `view.defaultFilters` (array of `{{column, operator, value}}`): seed these into `useFilters()` on first mount with `setFilter()` so the dashboard opens already filtered. Do not render the unfiltered data when defaults are declared.
+
 AVAILABLE COMPONENTS (convenience shortcuts — not requirements):
 - `<KPICard>` — `className` replaces default theme (bg-white, border, text-slate-900). `titleClassName`/`subtitleClassName` replace text defaults. `style` for inline overrides. Theme to match the dashboard's color story.
 - `<SectionCard>` — same theming props as KPICard. `className` replaces defaults.

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -419,12 +419,12 @@ DATA ACCESS:
 - **NEVER hardcode data** — ALL values from `data.visualizations[N].rows`
 - **DEFENSIVE CODING**: Row values can be `null`/`undefined`. ALWAYS guard before string methods: `(val || '').includes('x')` or `String(val ?? '').toLowerCase()`. Never call `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()` on a potentially nullish value.
 
-VIEW HINTS — HONOR THE VIZ CONFIG:
-Inspect `view.aggregation`, `view.seriesStyles[i].aggregation`, and `view.defaultFilters` before rendering. These tell you the author's intent for granular data:
+View hints — follow the viz config:
+Inspect `view.aggregation`, `view.seriesStyles[i].aggregation`, and `view.defaultFilters` before rendering. These describe the author's intent for granular data:
 
-- `view.aggregation` (`"sum"|"avg"|"count"|"min"|"max"`): aggregate rows with `reduce`/`Map` before rendering (e.g. metric cards, pies, heatmaps). NEVER read `rows[0]` as the value when aggregation is set.
+- `view.aggregation` (`"sum"|"avg"|"count"|"min"|"max"`): aggregate rows with `reduce`/`Map` before rendering (e.g. metric cards, pies, heatmaps). Avoid reading `rows[0]` as the value when aggregation is set.
 - `view.seriesStyles[i].aggregation`: per-series aggregation — apply when building each series in multi-series bar/line/area charts.
-- `view.defaultFilters` (array of `{{column, operator, value}}`): seed these into `useFilters()` on first mount with `setFilter()` so the dashboard opens already filtered. Do not render the unfiltered data when defaults are declared.
+- `view.defaultFilters` (array of `{{column, operator, value}}`): seed these into `useFilters()` on first mount with `setFilter()` so the dashboard opens already filtered. Render the filtered rows when defaults are declared.
 
 AVAILABLE COMPONENTS (convenience shortcuts — not requirements):
 - `<KPICard>` — `className` replaces default theme (bg-white, border, text-slate-900). `titleClassName`/`subtitleClassName` replace text defaults. `style` for inline overrides. Theme to match the dashboard's color story.

--- a/backend/app/ai/tools/schemas/create_data_model.py
+++ b/backend/app/ai/tools/schemas/create_data_model.py
@@ -22,10 +22,21 @@ class DataModelColumn(BaseModel):
     )
 
 
+AggregationFn = Literal["sum", "avg", "count", "min", "max"]
+
+
+class DefaultFilter(BaseModel):
+    """A filter to apply by default when rendering this visualization."""
+    column: str
+    operator: str
+    value: Any = None
+
+
 class SeriesBarLinePieArea(BaseModel):
     name: str
     key: str
     value: str
+    aggregation: Optional[AggregationFn] = None
 
 
 class SeriesCandlestick(BaseModel):
@@ -42,6 +53,7 @@ class SeriesHeatmap(BaseModel):
     x: str
     y: str
     value: str
+    aggregation: Optional[AggregationFn] = None
 
 
 class SeriesScatter(BaseModel):
@@ -49,12 +61,14 @@ class SeriesScatter(BaseModel):
     x: str
     y: str
     size: Optional[str] = None
+    aggregation: Optional[AggregationFn] = None
 
 
 class SeriesMap(BaseModel):
     name: str
     key: str
     value: str
+    aggregation: Optional[AggregationFn] = None
 
 
 class SeriesTreemap(BaseModel):
@@ -63,6 +77,7 @@ class SeriesTreemap(BaseModel):
     parentId: str
     value: str
     key: Optional[str] = None
+    aggregation: Optional[AggregationFn] = None
 
 
 class SeriesRadar(BaseModel):
@@ -96,6 +111,7 @@ class SeriesMetricCard(BaseModel):
     time_series: Optional[str] = None
     date: Optional[str] = None
     time: Optional[str] = None
+    aggregation: Optional[AggregationFn] = None
 
 
 SeriesItem = Union[
@@ -132,7 +148,13 @@ class DataModel(BaseModel):
         "scatter_plot",
     ] = Field(..., description="Visualization/data type")
     columns: List[DataModelColumn] = Field(default_factory=list)
-    #filters: Optional[List[Dict[str, Any]]] = Field(default=None, description="Filter predicates")
+    filters: Optional[List[DefaultFilter]] = Field(
+        default=None,
+        description=(
+            "Default filters applied when rendering this visualization. "
+            "Used when raw data is granular and should open in a filtered state."
+        ),
+    )
     group_by: Optional[List[str]] = Field(default=None, description="Group-by fields")
     #sort: Optional[List[SortSpec]] = Field(default=None, description="Sorting specifications")
     #limit: Optional[int] = Field(default=100, description="Row limit")

--- a/backend/app/schemas/view_schema.py
+++ b/backend/app/schemas/view_schema.py
@@ -103,12 +103,27 @@ class LegendOptions(BaseModel):
     position: Literal["top", "bottom", "left", "right"] = "bottom"
 
 
+AggregationFn = Literal["sum", "avg", "count", "min", "max"]
+
+
+class DefaultFilterCondition(BaseModel):
+    """A single filter condition applied by default when rendering a view.
+
+    Column is a plain column name (no 'vizId:' prefix). Runtime seeding is
+    responsible for wrapping these into the shared-filter format.
+    """
+    column: str
+    operator: str
+    value: Any = None
+
+
 class SeriesStyle(BaseModel):
     key: str
     label: Optional[str] = None
     color: Optional[str] = None
     gradient: Optional[GradientConfig] = None
     showValues: Optional[bool] = None
+    aggregation: Optional[AggregationFn] = None
 
 
 class BaseView(BaseModel):
@@ -116,6 +131,7 @@ class BaseView(BaseModel):
     title: Optional[str] = None
     subtitle: Optional[str] = None
     description: Optional[str] = None
+    defaultFilters: List[DefaultFilterCondition] = Field(default_factory=list)
 
 
 class CartesianView(BaseView):
@@ -164,6 +180,7 @@ class PieChartView(BaseView):
     palette: Palette = Field(default_factory=Palette)
     showLabels: bool = True
     legend: LegendOptions = Field(default_factory=lambda: LegendOptions(position="right"))
+    aggregation: Optional[AggregationFn] = None
 
 
 class ScatterPlotView(BaseView):
@@ -175,6 +192,7 @@ class ScatterPlotView(BaseView):
     palette: Palette = Field(default_factory=Palette)
     axisX: AxisOptions = Field(default_factory=lambda: AxisOptions(rotate=0))
     axisY: AxisOptions = Field(default_factory=lambda: AxisOptions(rotate=0))
+    aggregation: Optional[AggregationFn] = None
 
 
 class HeatmapView(BaseView):
@@ -186,6 +204,7 @@ class HeatmapView(BaseView):
     showValues: bool = True
     axisX: AxisOptions = Field(default_factory=lambda: AxisOptions(rotate=45))
     axisY: AxisOptions = Field(default_factory=lambda: AxisOptions(rotate=0))
+    aggregation: Optional[AggregationFn] = None
 
 
 class CountView(BaseView):
@@ -195,6 +214,7 @@ class CountView(BaseView):
     prefix: Optional[str] = None
     suffix: Optional[str] = None
     palette: Palette = Field(default_factory=Palette)
+    aggregation: Optional[AggregationFn] = None
 
 
 class SparklineConfig(BaseModel):
@@ -223,6 +243,7 @@ class MetricCardView(BaseView):
     # Sparkline configuration
     sparkline: Optional[SparklineConfig] = None
     palette: Palette = Field(default_factory=Palette)
+    aggregation: Optional[AggregationFn] = None
 
 
 class TableView(BaseView):

--- a/frontend/components/dashboard/charts/EChartsVisual.vue
+++ b/frontend/components/dashboard/charts/EChartsVisual.vue
@@ -91,6 +91,36 @@ function getSafeValue(row: any, key: string | undefined, type: 'string' | 'numbe
   return val
 }
 
+// ---------------------------------------------------------------------------
+// Aggregation helpers
+// Applied when view.seriesStyles[i].aggregation, view.aggregation or
+// dm.series[i].aggregation is set. When absent, callers preserve the legacy
+// first-row-wins behavior (no silent default).
+// ---------------------------------------------------------------------------
+type AggregationFn = 'sum' | 'avg' | 'count' | 'min' | 'max'
+
+function aggregateValues(values: number[], fn?: AggregationFn | null | undefined): number | null {
+  if (!values.length) return null
+  if (!fn) return values[0]
+  switch (fn) {
+    case 'sum': return values.reduce((a, b) => a + b, 0)
+    case 'avg': return values.reduce((a, b) => a + b, 0) / values.length
+    case 'count': return values.length
+    case 'min': return values.reduce((a, b) => (a < b ? a : b))
+    case 'max': return values.reduce((a, b) => (a > b ? a : b))
+    default: return values[0]
+  }
+}
+
+function resolveSeriesAggregation(viewV2: any, dm: any, seriesKey: string, seriesIdx: number): AggregationFn | undefined {
+  const style = viewV2?.seriesStyles?.find((s: any) => s.key === seriesKey)
+  if (style?.aggregation) return style.aggregation as AggregationFn
+  if (viewV2?.aggregation) return viewV2.aggregation as AggregationFn
+  const dmSeries = Array.isArray(dm?.series) ? dm.series[seriesIdx] : null
+  if (dmSeries?.aggregation) return dmSeries.aggregation as AggregationFn
+  return undefined
+}
+
 // Get colors from view, theme, or fallback
 function getColors(): any[] {
   // Check view.view (new v2 schema)
@@ -202,16 +232,42 @@ function getBaseOptions(): EChartsOption {
 function buildPieOptions(rows: any[], dm: any): EChartsOption {
   const cfg = dm?.series?.[0] || {}
   if (!cfg?.key || !cfg?.value) return {}
-  
+
+  const viewV2 = props.view?.view
+  const aggFn = (viewV2?.aggregation || cfg?.aggregation) as AggregationFn | undefined
+  const keyLower = String(cfg.key).toLowerCase()
+  const valLower = String(cfg.value).toLowerCase()
   const colors = getColors()
-  const data = rows
-    .map((r: any, i: number) => ({
-      name: r[cfg.key.toLowerCase()],
-      value: Number(r[cfg.value.toLowerCase()]),
-      itemStyle: { color: resolveColorInput(colors[i % colors.length]) }
-    }))
-    .filter((d: any) => d.name != null && !Number.isNaN(d.value))
-  
+
+  let data: any[]
+  if (aggFn) {
+    const grouped = new Map<string, number[]>()
+    rows.forEach((r: any) => {
+      const rawName = r[keyLower]
+      if (rawName == null) return
+      const val = Number(r[valLower])
+      if (Number.isNaN(val)) return
+      const k = String(rawName)
+      if (!grouped.has(k)) grouped.set(k, [])
+      grouped.get(k)!.push(val)
+    })
+    data = Array.from(grouped.entries())
+      .map(([name, vals], i: number) => ({
+        name,
+        value: aggregateValues(vals, aggFn),
+        itemStyle: { color: resolveColorInput(colors[i % colors.length]) }
+      }))
+      .filter((d: any) => d.name != null && d.value != null && !Number.isNaN(d.value))
+  } else {
+    data = rows
+      .map((r: any, i: number) => ({
+        name: r[keyLower],
+        value: Number(r[valLower]),
+        itemStyle: { color: resolveColorInput(colors[i % colors.length]) }
+      }))
+      .filter((d: any) => d.name != null && !Number.isNaN(d.value))
+  }
+
   return {
     tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
     series: [{ name: cfg.name, type: 'pie', radius: ['40%', '70%'], center: ['50%', '60%'], data }]
@@ -267,12 +323,16 @@ function buildCartesianOptions(rows: any[], dm: any): EChartsOption {
     if (!valueKey) return {}
 
     series = groups.map((group: string, i: number) => {
+      const aggFn = resolveSeriesAggregation(viewV2, dm, group, i)
       const data = categories.map(cat => {
-        const row = rows.find((r: any) => 
+        const matching = rows.filter((r: any) =>
           String(r[categoryKey] ?? '') === cat && String(r[groupByKey] ?? '') === group
         )
-        const v = row ? Number(row[valueKey]) : null
-        return Number.isNaN(v as number) ? null : v
+        if (!matching.length) return null
+        const values = matching
+          .map((r: any) => Number(r[valueKey]))
+          .filter((v: number) => !Number.isNaN(v))
+        return aggregateValues(values, aggFn)
       })
 
       // Find series style override from v2 schema
@@ -307,13 +367,17 @@ function buildCartesianOptions(rows: any[], dm: any): EChartsOption {
       .map((s: any, i: number) => {
         const valueKey = s?.value?.toLowerCase()
         if (!valueKey) return null
-        
+
+        const aggFn = resolveSeriesAggregation(viewV2, dm, s?.name, i)
         const data = categories.map(cat => {
-          const row = rows.find((r: any) => String(r[categoryKey] ?? '') === cat)
-          const v = row ? Number(row[valueKey]) : null
-          return Number.isNaN(v as number) ? null : v
+          const matching = rows.filter((r: any) => String(r[categoryKey] ?? '') === cat)
+          if (!matching.length) return null
+          const values = matching
+            .map((r: any) => Number(r[valueKey]))
+            .filter((v: number) => !Number.isNaN(v))
+          return aggregateValues(values, aggFn)
         })
-        
+
         const styleOverride = viewV2?.seriesStyles?.find((st: any) => st.key === s.name)
         const color = resolveColorInput(styleOverride?.color || colors[i % colors.length])
         
@@ -399,11 +463,31 @@ function buildScatterOptions(rows: any[], dm: any): EChartsOption {
   const xKey = (viewV2?.x || s?.x || s?.key || '').toLowerCase()
   const yKey = (viewV2?.y || s?.y || s?.value || '').toLowerCase()
   if (!xKey || !yKey) return {}
-  
+
   const colors = getColors()
-  const data = rows
-    .map((r: any) => [Number(r[xKey]), Number(r[yKey])])
-    .filter((d: any[]) => !d.some(v => Number.isNaN(v)))
+  const aggFn = (viewV2?.aggregation || s?.aggregation) as AggregationFn | undefined
+  let data: number[][]
+  if (aggFn) {
+    const grouped = new Map<string, { x: number; ys: number[] }>()
+    rows.forEach((r: any) => {
+      const x = Number(r[xKey])
+      const y = Number(r[yKey])
+      if (Number.isNaN(x) || Number.isNaN(y)) return
+      const k = String(x)
+      if (!grouped.has(k)) grouped.set(k, { x, ys: [] })
+      grouped.get(k)!.ys.push(y)
+    })
+    data = Array.from(grouped.values())
+      .map(g => {
+        const agg = aggregateValues(g.ys, aggFn)
+        return agg == null ? null : [g.x, agg]
+      })
+      .filter(Boolean) as number[][]
+  } else {
+    data = rows
+      .map((r: any) => [Number(r[xKey]), Number(r[yKey])])
+      .filter((d: any[]) => !d.some(v => Number.isNaN(v)))
+  }
 
   const axisColors = props.view?.style?.axis || tokens.value?.axis || {}
   const xVisible = props.view?.xAxisVisible ?? viewV2?.axisX?.show ?? true
@@ -435,15 +519,36 @@ function buildHeatmapOptions(rows: any[], dm: any): EChartsOption {
   const yAxisConfig = viewV2?.axisY
   const { interval: defaultInterval, rotate: defaultRotate, hideOverlap } = getAxisLabelConfig(xCats.length)
 
-  const seriesData = rows
-    .map((r: any) => {
+  const aggFn = (viewV2?.aggregation || cfg?.aggregation) as AggregationFn | undefined
+  let seriesData: any[]
+  if (aggFn) {
+    const grouped = new Map<string, { xi: number; yi: number; vals: number[] }>()
+    rows.forEach((r: any) => {
       const xi = xCats.indexOf(String(r[xKey] ?? ''))
       const yi = yCats.indexOf(String(r[yKey] ?? ''))
       const val = Number(r[vKey])
-      if (xi === -1 || yi === -1 || Number.isNaN(val)) return null
-      return [xi, yi, val]
+      if (xi === -1 || yi === -1 || Number.isNaN(val)) return
+      const k = `${xi}:${yi}`
+      if (!grouped.has(k)) grouped.set(k, { xi, yi, vals: [] })
+      grouped.get(k)!.vals.push(val)
     })
-    .filter(Boolean)
+    seriesData = Array.from(grouped.values())
+      .map(g => {
+        const v = aggregateValues(g.vals, aggFn)
+        return v == null ? null : [g.xi, g.yi, v]
+      })
+      .filter(Boolean)
+  } else {
+    seriesData = rows
+      .map((r: any) => {
+        const xi = xCats.indexOf(String(r[xKey] ?? ''))
+        const yi = yCats.indexOf(String(r[yKey] ?? ''))
+        const val = Number(r[vKey])
+        if (xi === -1 || yi === -1 || Number.isNaN(val)) return null
+        return [xi, yi, val]
+      })
+      .filter(Boolean)
+  }
 
   const maxVal = seriesData.reduce((m: number, d: any) => Math.max(m, d![2]), 0)
   const minVal = seriesData.reduce((m: number, d: any) => Math.min(m, d![2]), maxVal)

--- a/frontend/components/dashboard/charts/EChartsVisual.vue
+++ b/frontend/components/dashboard/charts/EChartsVisual.vue
@@ -314,24 +314,33 @@ function buildCartesianOptions(rows: any[], dm: any): EChartsOption {
   if (groupByKey) {
     // GroupBy mode: create one series per unique group value
     const groups = Array.from(new Set(rows.map((r: any) => String(r[groupByKey] ?? '')))).filter(Boolean)
-    
-    const valueKey = (viewV2?.y 
+
+    const valueKey = (viewV2?.y
       ? (Array.isArray(viewV2.y) ? viewV2.y[0] : viewV2.y)
       : dm?.series?.[0]?.value
     )?.toLowerCase()
 
     if (!valueKey) return {}
 
+    // Pre-index rows into a Map<`${cat}::${group}`, number[]> in one pass so the
+    // per-cell lookup is O(1) instead of scanning all rows for each bucket.
+    const bucketed = new Map<string, number[]>()
+    for (const r of rows) {
+      const cat = String(r[categoryKey] ?? '')
+      const grp = String(r[groupByKey] ?? '')
+      const v = Number(r[valueKey])
+      if (Number.isNaN(v)) continue
+      const k = `${cat}::${grp}`
+      const arr = bucketed.get(k)
+      if (arr) arr.push(v)
+      else bucketed.set(k, [v])
+    }
+
     series = groups.map((group: string, i: number) => {
       const aggFn = resolveSeriesAggregation(viewV2, dm, group, i)
       const data = categories.map(cat => {
-        const matching = rows.filter((r: any) =>
-          String(r[categoryKey] ?? '') === cat && String(r[groupByKey] ?? '') === group
-        )
-        if (!matching.length) return null
-        const values = matching
-          .map((r: any) => Number(r[valueKey]))
-          .filter((v: number) => !Number.isNaN(v))
+        const values = bucketed.get(`${cat}::${group}`)
+        if (!values || !values.length) return null
         return aggregateValues(values, aggFn)
       })
 
@@ -362,23 +371,37 @@ function buildCartesianOptions(rows: any[], dm: any): EChartsOption {
       return base
     })
   } else {
-    // Traditional mode: each series config is a series
+    // Traditional mode: each series config is a series.
+    // Pre-index rows by category once so every series reuses the same buckets.
+    const rowsByCategory = new Map<string, any[]>()
+    for (const r of rows) {
+      const cat = String(r[categoryKey] ?? '')
+      const arr = rowsByCategory.get(cat)
+      if (arr) arr.push(r)
+      else rowsByCategory.set(cat, [r])
+    }
+
     series = (dm?.series || [])
       .map((s: any, i: number) => {
         const valueKey = s?.value?.toLowerCase()
         if (!valueKey) return null
 
-        const aggFn = resolveSeriesAggregation(viewV2, dm, s?.name, i)
+        // Match the key used by the editor when writing seriesStyles so blank
+        // names still resolve aggregation/color overrides.
+        const seriesKey = s?.name || s?.value
+        const aggFn = resolveSeriesAggregation(viewV2, dm, seriesKey, i)
         const data = categories.map(cat => {
-          const matching = rows.filter((r: any) => String(r[categoryKey] ?? '') === cat)
-          if (!matching.length) return null
-          const values = matching
-            .map((r: any) => Number(r[valueKey]))
-            .filter((v: number) => !Number.isNaN(v))
+          const matching = rowsByCategory.get(cat)
+          if (!matching || !matching.length) return null
+          const values: number[] = []
+          for (const r of matching) {
+            const v = Number(r[valueKey])
+            if (!Number.isNaN(v)) values.push(v)
+          }
           return aggregateValues(values, aggFn)
         })
 
-        const styleOverride = viewV2?.seriesStyles?.find((st: any) => st.key === s.name)
+        const styleOverride = viewV2?.seriesStyles?.find((st: any) => st.key === seriesKey)
         const color = resolveColorInput(styleOverride?.color || colors[i % colors.length])
         
         const base: any = {

--- a/frontend/components/dashboard/kpi/MetricCard.vue
+++ b/frontend/components/dashboard/kpi/MetricCard.vue
@@ -132,6 +132,20 @@ const rawValue = computed(() => {
   const fn = aggregationFn.value
 
   if (col && fn) {
+    // `count` is row-cardinality, not a numeric reduction. Counting only
+    // parseable numbers would undercount string/boolean columns, so special-
+    // case it to non-null occurrences of the selected column.
+    if (fn === 'count') {
+      let n = 0
+      for (const row of rows) {
+        if (!row) continue
+        const key = Object.keys(row).find(k => k.toLowerCase() === col)
+        if (!key) continue
+        const v = row[key]
+        if (v !== null && v !== undefined && v !== '') n += 1
+      }
+      return n
+    }
     const values: number[] = []
     for (const row of rows) {
       if (!row) continue

--- a/frontend/components/dashboard/kpi/MetricCard.vue
+++ b/frontend/components/dashboard/kpi/MetricCard.vue
@@ -101,21 +101,56 @@ const comparisonColumn = computed(() => {
   return c ? c.toLowerCase() : null
 })
 
+// Optional aggregation function from view schema. When absent the metric is
+// read from the first row (legacy behaviour). When set, aggregate across all
+// rows so granular source data renders a correct card value.
+type MetricAggregationFn = 'sum' | 'avg' | 'count' | 'min' | 'max'
+const aggregationFn = computed<MetricAggregationFn | null>(() => {
+  const fn = viewConfig.value?.aggregation
+  return (fn as MetricAggregationFn) || null
+})
+
+function aggregateNumbers(values: number[], fn?: MetricAggregationFn | null): number | null {
+  if (!values.length) return null
+  if (!fn) return values[0]
+  switch (fn) {
+    case 'sum': return values.reduce((a, b) => a + b, 0)
+    case 'avg': return values.reduce((a, b) => a + b, 0) / values.length
+    case 'count': return values.length
+    case 'min': return values.reduce((a, b) => (a < b ? a : b))
+    case 'max': return values.reduce((a, b) => (a > b ? a : b))
+    default: return values[0]
+  }
+}
+
 // Extract raw values
 const rawValue = computed(() => {
   const rows = props.data?.rows
   if (!Array.isArray(rows) || rows.length === 0) return null
-  
+
+  const col = valueColumn.value
+  const fn = aggregationFn.value
+
+  if (col && fn) {
+    const values: number[] = []
+    for (const row of rows) {
+      if (!row) continue
+      const key = Object.keys(row).find(k => k.toLowerCase() === col)
+      if (!key) continue
+      const num = Number(row[key])
+      if (!Number.isNaN(num)) values.push(num)
+    }
+    return aggregateNumbers(values, fn)
+  }
+
   const firstRow = rows[0]
   if (!firstRow) return null
-  
-  if (valueColumn.value) {
-    // Case-insensitive lookup
-    const key = Object.keys(firstRow).find(k => k.toLowerCase() === valueColumn.value)
+
+  if (col) {
+    const key = Object.keys(firstRow).find(k => k.toLowerCase() === col)
     if (key) return firstRow[key]
   }
-  
-  // Fallback to first value
+
   return Object.values(firstRow)[0]
 })
 

--- a/frontend/components/dashboard/regular/RegularWidgetView.vue
+++ b/frontend/components/dashboard/regular/RegularWidgetView.vue
@@ -143,9 +143,14 @@ function seedDefaultFiltersFromView() {
 }
 
 watch(
-  () => [widget.value?.id, widget.value?.view],
+  () => {
+    const viewObj = widget.value?.view as any
+    const viewInner = viewObj?.view || viewObj
+    const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
+    return [widget.value?.id, JSON.stringify(defaults)]
+  },
   () => { seedDefaultFiltersFromView() },
-  { immediate: true, deep: true }
+  { immediate: true }
 )
 
 // Check if we have data to filter

--- a/frontend/components/dashboard/regular/RegularWidgetView.vue
+++ b/frontend/components/dashboard/regular/RegularWidgetView.vue
@@ -47,12 +47,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref, onMounted, onUnmounted } from 'vue'
+import { computed, defineAsyncComponent, ref, onMounted, onUnmounted, watch } from 'vue'
 import SpinnerComponent from '@/components/SpinnerComponent.vue'
 import { resolveEntryByType } from '@/components/dashboard/registry'
 import TableAgGrid from '@/components/dashboard/table/TableAgGrid.vue'
 import VisualizationFilter from '@/components/dashboard/VisualizationFilter.vue'
-import { evaluateFilters, type FilterGroup } from '~/composables/useSharedFilters'
+import { evaluateFilters, parseColumnKey, type FilterGroup } from '~/composables/useSharedFilters'
 
 const props = defineProps<{
   widget: any
@@ -88,6 +88,65 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('filter:updated', handleFilterUpdate)
 })
+
+// Seed shared filters from view.defaultFilters once per widget id. This lets a
+// granular-data visualization open in a filtered state without the user having
+// to click through the filter UI.
+const seededDefaultsFor = ref<Set<string>>(new Set())
+
+function seedDefaultFiltersFromView() {
+  const vizId = String(widget.value?.id || '')
+  if (!vizId || seededDefaultsFor.value.has(vizId)) return
+
+  const viewObj = widget.value?.view as any
+  const viewInner = viewObj?.view || viewObj
+  const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
+  if (!defaults.length) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  const alreadyHasConditions = filters.value.some(g =>
+    g.conditions.some(c => parseColumnKey(c.column).vizId === vizId)
+  )
+  if (alreadyHasConditions) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  const conditions = defaults
+    .filter((d: any) => d && typeof d.column === 'string' && d.column.length > 0)
+    .map((d: any, i: number) => ({
+      id: `default-${vizId}-${i}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      column: `${vizId}:${d.column}`,
+      operator: String(d.operator || 'equals'),
+      value: d.value
+    }))
+  if (!conditions.length) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  const group: FilterGroup = {
+    id: `default-group-${vizId}-${Date.now()}`,
+    conditions
+  }
+  const next = [...filters.value, group]
+  filters.value = next
+  seededDefaultsFor.value.add(vizId)
+
+  try {
+    window.dispatchEvent(new CustomEvent('filter:updated', {
+      detail: { reportId: reportId.value, filters: next, source: filterInstanceId }
+    }))
+  } catch {}
+}
+
+watch(
+  () => [widget.value?.id, widget.value?.view],
+  () => { seedDefaultFiltersFromView() },
+  { immediate: true, deep: true }
+)
 
 // Check if we have data to filter
 const hasData = computed(() => {

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -445,11 +445,76 @@ const filteredRows = computed(() => {
   const rows = effectiveStep.value?.data?.rows
   if (!Array.isArray(rows)) return []
   if (sharedFilters.value.length === 0 || !visualizationId.value) return rows
-  
-  return rows.filter((row: any) => 
+
+  return rows.filter((row: any) =>
     sharedEvaluateFilters(row, sharedFilters.value, visualizationId.value)
   )
 })
+
+// ------------------------------------------------------------------
+// Default-filter seeding
+// When a visualization declares `view.defaultFilters`, push them into the
+// shared-filter runtime on first paint so the viz opens filtered. We only
+// seed once per viz id so clearing filters doesn't re-seed.
+// ------------------------------------------------------------------
+const seededDefaultsFor = ref<Set<string>>(new Set())
+
+function seedDefaultFiltersFromView() {
+  const vizId = visualizationId.value
+  if (!vizId || seededDefaultsFor.value.has(vizId)) return
+
+  const v = normalizedView.value as any
+  const viewInner = v?.view || v
+  const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
+  if (!defaults.length) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  // Respect existing user-authored filters for this viz
+  const alreadyHasConditions = sharedFilters.value.some(g =>
+    g.conditions.some(c => parseColumnKey(c.column).vizId === vizId)
+  )
+  if (alreadyHasConditions) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  const conditions = defaults
+    .filter((d: any) => d && typeof d.column === 'string' && d.column.length > 0)
+    .map((d: any, i: number) => ({
+      id: `default-${vizId}-${i}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      column: `${vizId}:${d.column}`,
+      operator: String(d.operator || 'equals'),
+      value: d.value
+    }))
+
+  if (!conditions.length) {
+    seededDefaultsFor.value.add(vizId)
+    return
+  }
+
+  const group: FilterGroup = {
+    id: `default-group-${vizId}-${Date.now()}`,
+    conditions
+  }
+  const next = [...sharedFilters.value, group]
+  sharedFilters.value = next
+  seededDefaultsFor.value.add(vizId)
+
+  // Broadcast so VisualizationFilter/FilterBuilder receive the seeded state
+  try {
+    window.dispatchEvent(new CustomEvent('filter:updated', {
+      detail: { reportId: reportId.value, filters: next, source: filterInstanceId }
+    }))
+  } catch {}
+}
+
+watch(
+  () => [visualizationId.value, normalizedView.value],
+  () => { seedDefaultFiltersFromView() },
+  { immediate: true, deep: true }
+)
 
 const filteredRowCount = computed(() => filteredRows.value.length)
 

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -511,9 +511,16 @@ function seedDefaultFiltersFromView() {
 }
 
 watch(
-  () => [visualizationId.value, normalizedView.value],
+  () => {
+    const v = normalizedView.value as any
+    const viewInner = v?.view || v
+    const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
+    // Stringify so the watcher only fires when the seed-relevant fields change,
+    // avoiding deep traversal of the full normalized view.
+    return [visualizationId.value, JSON.stringify(defaults)]
+  },
   () => { seedDefaultFiltersFromView() },
-  { immediate: true, deep: true }
+  { immediate: true }
 )
 
 const filteredRowCount = computed(() => filteredRows.value.length)

--- a/frontend/components/tools/VisualizationConfigEditor.vue
+++ b/frontend/components/tools/VisualizationConfigEditor.vue
@@ -36,7 +36,7 @@
           <div class="space-y-2">
             <div v-for="(s, idx) in encoding.series" :key="idx" class="flex items-center space-x-2">
               <input v-model="s.name" placeholder="name" class="flex-1 border rounded px-2 py-1" />
-              <select v-model="s.value" class="w-40 border rounded px-2 py-1 bg-white">
+              <select v-model="s.value" class="w-32 border rounded px-2 py-1 bg-white">
                 <option value="">value</option>
                 <optgroup label="Suggested">
                   <option v-for="c in numericColumns" :key="`val-s-${c}`" :value="c">{{ c }}</option>
@@ -44,6 +44,9 @@
                 <optgroup label="All columns">
                   <option v-for="c in otherNumericColumns" :key="`val-a-${c}`" :value="c">{{ c }}</option>
                 </optgroup>
+              </select>
+              <select v-model="s.aggregation" class="w-24 border rounded px-2 py-1 bg-white" title="Aggregation applied to duplicate category rows">
+                <option v-for="o in aggregationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
               </select>
               <button class="px-2 py-1 text-[11px] border rounded text-gray-600 hover:bg-gray-50" @click="removeSeries(idx)">Remove</button>
             </div>
@@ -79,6 +82,12 @@
             </optgroup>
           </select>
         </div>
+        <div>
+          <div class="text-gray-600 mb-1">Aggregation</div>
+          <select v-model="local.aggregation" class="w-full border rounded px-2 py-1 bg-white">
+            <option v-for="o in aggregationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+          </select>
+        </div>
       </div>
 
       <!-- Scatter -->
@@ -108,6 +117,12 @@
               </optgroup>
             </select>
           </div>
+        </div>
+        <div>
+          <div class="text-gray-600 mb-1">Aggregation (groups duplicate X)</div>
+          <select v-model="local.aggregation" class="w-full border rounded px-2 py-1 bg-white">
+            <option v-for="o in aggregationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+          </select>
         </div>
       </div>
 
@@ -150,6 +165,12 @@
               </optgroup>
             </select>
           </div>
+        </div>
+        <div>
+          <div class="text-gray-600 mb-1">Aggregation</div>
+          <select v-model="local.aggregation" class="w-full border rounded px-2 py-1 bg-white">
+            <option v-for="o in aggregationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+          </select>
         </div>
       </div>
 
@@ -323,6 +344,14 @@
           </select>
         </div>
 
+        <!-- Aggregation -->
+        <div>
+          <div class="text-gray-600 mb-1">Aggregation (required for granular rows)</div>
+          <select v-model="local.aggregation" class="w-full border rounded px-2 py-1 bg-white">
+            <option v-for="o in aggregationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+          </select>
+        </div>
+
         <!-- Format -->
         <div>
           <div class="text-gray-600 mb-1">Format</div>
@@ -433,6 +462,39 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <!-- Default Filters -->
+    <div v-if="showEncoding">
+      <div class="flex items-center cursor-pointer text-[11px] uppercase tracking-wide text-gray-500 mb-2" @click="expanded.defaultFilters = !expanded.defaultFilters">
+        <Icon :name="expanded.defaultFilters ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 mr-1" />
+        Default Filters
+        <span v-if="defaultFilters.length" class="ml-2 text-[10px] text-gray-400 normal-case">({{ defaultFilters.length }})</span>
+      </div>
+      <Transition name="fade">
+        <div v-if="expanded.defaultFilters" class="space-y-2">
+          <div class="text-[10px] text-gray-500 mb-1">
+            Applied automatically when this visualization renders (e.g. to focus a granular dataset on the latest period).
+          </div>
+          <div v-for="(f, idx) in defaultFilters" :key="idx" class="flex items-center space-x-1.5">
+            <select v-model="f.column" class="flex-1 border rounded px-2 py-1 bg-white text-[11px]">
+              <option value="">-- Column --</option>
+              <option v-for="c in allColumns" :key="`df-col-${idx}-${c}`" :value="c">{{ c }}</option>
+            </select>
+            <select v-model="f.operator" class="w-28 border rounded px-2 py-1 bg-white text-[11px]">
+              <option v-for="op in filterOperators" :key="op.value" :value="op.value">{{ op.label }}</option>
+            </select>
+            <input
+              v-if="!['is_empty','is_not_empty','is_true','is_false'].includes(f.operator)"
+              v-model="f.value"
+              placeholder="value"
+              class="w-24 border rounded px-2 py-1 text-[11px]"
+            />
+            <button class="px-1.5 py-1 text-[11px] border rounded text-gray-600 hover:bg-gray-50" @click="removeDefaultFilter(idx)">×</button>
+          </div>
+          <button class="mt-1 px-2 py-1 text-[11px] border rounded text-gray-600 hover:bg-gray-50" @click="addDefaultFilter">Add filter</button>
+        </div>
+      </Transition>
     </div>
 
     <!-- Styling -->
@@ -584,7 +646,37 @@ const saving = ref(false)
 const error = ref('')
 
 // UI section expand/collapse state
-const expanded = reactive<{ typeData: boolean; style: boolean; xAxisLabels: boolean; yAxisLabels: boolean }>({ typeData: true, style: true, xAxisLabels: false, yAxisLabels: false })
+const expanded = reactive<{ typeData: boolean; style: boolean; xAxisLabels: boolean; yAxisLabels: boolean; defaultFilters: boolean }>({
+  typeData: true,
+  style: true,
+  xAxisLabels: false,
+  yAxisLabels: false,
+  defaultFilters: false,
+})
+
+// Aggregation + default-filter options (aligned with useSharedFilters operators)
+const aggregationOptions = [
+  { label: 'None', value: '' },
+  { label: 'Sum', value: 'sum' },
+  { label: 'Avg', value: 'avg' },
+  { label: 'Count', value: 'count' },
+  { label: 'Min', value: 'min' },
+  { label: 'Max', value: 'max' },
+]
+const filterOperators = [
+  { label: 'equals', value: 'equals' },
+  { label: 'not equals', value: 'not_equals' },
+  { label: 'contains', value: 'contains' },
+  { label: 'not contains', value: 'not_contains' },
+  { label: 'starts with', value: 'starts_with' },
+  { label: 'ends with', value: 'ends_with' },
+  { label: '>', value: 'greater_than' },
+  { label: '<', value: 'less_than' },
+  { label: '>=', value: 'gte' },
+  { label: '<=', value: 'lte' },
+  { label: 'is empty', value: 'is_empty' },
+  { label: 'is not empty', value: 'is_not_empty' },
+]
 
 function deepClone<T>(v: T): T { return JSON.parse(JSON.stringify(v || {})) }
 
@@ -655,7 +747,35 @@ function initFromView(view: any, step: any) {
       enc.dimensions = s0.dimensions
     }
   }
-  
+
+  // Hydrate per-series aggregation from view.seriesStyles onto encoding.series
+  // so the editor template (`s.aggregation`) binds correctly.
+  const styles: any[] = Array.isArray(v.seriesStyles) ? v.seriesStyles : []
+  if (Array.isArray(enc.series) && styles.length) {
+    enc.series = enc.series.map((s: any) => {
+      if (s?.aggregation) return s
+      const match = styles.find((st: any) => st.key === s.name || st.key === s.value)
+      return match?.aggregation ? { ...s, aggregation: match.aggregation } : s
+    })
+  }
+  // Also fall back to data_model.series[i].aggregation
+  if (Array.isArray(enc.series) && Array.isArray(dm.series)) {
+    enc.series = enc.series.map((s: any, idx: number) => {
+      if (s?.aggregation) return s
+      const dmAgg = dm.series[idx]?.aggregation
+      return dmAgg ? { ...s, aggregation: dmAgg } : s
+    })
+  }
+
+  // Default filters (flat list on view; legacy views won't have this)
+  const defaultFilters = Array.isArray(v.defaultFilters)
+    ? v.defaultFilters.map((d: any) => ({
+        column: String(d?.column || ''),
+        operator: String(d?.operator || 'equals'),
+        value: d?.value ?? ''
+      }))
+    : []
+
   return {
     type: v.type || dm.type || 'table',
     // Encoding for UI binding
@@ -701,12 +821,17 @@ function initFromView(view: any, step: any) {
     variant: v.variant || null,
     style: deepClone(style),
     options: deepClone(v.options || {}),
+    // Top-level aggregation (pie, heatmap, scatter, metric_card, count).
+    // Empty string means "no aggregation — render first row" to match runtime.
+    aggregation: v.aggregation || '',
+    // Flat list of default filters; seeded into shared-filters runtime at render time.
+    defaultFilters,
   }
 }
 
-// Initialize local state - but keep encoding separate for reactivity
+// Initialize local state - but keep encoding/defaultFilters separate for reactivity
 const initialState = initFromView(props.viz?.view, props.step)
-const { encoding: initialEncoding, ...restInitial } = initialState
+const { encoding: initialEncoding, defaultFilters: initialDefaultFilters, ...restInitial } = initialState
 
 const local = reactive<any>({
   ...restInitial,
@@ -715,6 +840,18 @@ const local = reactive<any>({
 
 // Encoding is a separate reactive for proper v-model binding in template
 const encoding = reactive<any>(initialEncoding || {})
+
+// Default filters reactive array for v-model binding in the template
+const defaultFilters = ref<any[]>(Array.isArray(initialDefaultFilters) ? [...initialDefaultFilters] : [])
+
+function addDefaultFilter() {
+  defaultFilters.value = [...defaultFilters.value, { column: '', operator: 'equals', value: '' }]
+}
+function removeDefaultFilter(idx: number) {
+  const next = [...defaultFilters.value]
+  next.splice(idx, 1)
+  defaultFilters.value = next
+}
 const dimensions = computed<string[]>({
   get: () => Array.isArray(encoding.dimensions) ? encoding.dimensions : (encoding.dimensions = []),
   set: (v: string[]) => { encoding.dimensions = v }
@@ -963,7 +1100,41 @@ function toViewPayload() {
   if (local.variant) {
     view.variant = local.variant
   }
-  
+
+  // --- Aggregation + default filters (v2) ---
+  // Top-level aggregation applies to pie/heatmap/scatter/count/metric_card.
+  if (local.aggregation && ['pie_chart','heatmap','scatter_plot','count','metric_card'].includes(t)) {
+    view.aggregation = local.aggregation
+  }
+  // Per-series aggregation for cartesian charts goes onto seriesStyles[i].aggregation.
+  if (['bar_chart','line_chart','area_chart'].includes(t) && Array.isArray(encoding.series)) {
+    const styles = encoding.series
+      .filter((s: any) => s && (s.name || s.value) && s.aggregation)
+      .map((s: any) => ({ key: s.name || s.value, label: s.name, aggregation: s.aggregation }))
+    if (styles.length) {
+      const existing = Array.isArray(view.seriesStyles) ? view.seriesStyles : []
+      // Merge: preserve existing style entries (color, etc.) by key when possible.
+      const merged = [...existing]
+      styles.forEach((st: any) => {
+        const match = merged.find((m: any) => m.key === st.key)
+        if (match) Object.assign(match, st)
+        else merged.push(st)
+      })
+      view.seriesStyles = merged
+    }
+  }
+  // Default filters (flat list; runtime wraps with vizId prefix on mount)
+  const filters = (defaultFilters.value || [])
+    .filter((f: any) => f && typeof f.column === 'string' && f.column.length)
+    .map((f: any) => {
+      const op = String(f.operator || 'equals')
+      const needsValue = !['is_empty','is_not_empty','is_true','is_false'].includes(op)
+      return needsValue ? { column: f.column, operator: op, value: f.value } : { column: f.column, operator: op }
+    })
+  if (filters.length) {
+    view.defaultFilters = filters
+  }
+
   return view
 }
 
@@ -1022,24 +1193,26 @@ async function save() {
 
 function reset() {
   const fresh = initFromView(props.viz?.view, props.step)
-  const { encoding: freshEnc, ...rest } = fresh
+  const { encoding: freshEnc, defaultFilters: freshDefaults, ...rest } = fresh
   // Update local (except encoding placeholder)
   Object.assign(local, rest)
   // Sync encoding reactive in-place
   Object.keys(encoding).forEach(k => delete encoding[k])
   Object.assign(encoding, freshEnc || {})
+  defaultFilters.value = Array.isArray(freshDefaults) ? [...freshDefaults] : []
 }
 
 watch(() => props.viz?.view, (v) => {
   if (!v) return
   // When parent replaces viz.view (e.g., after save), sync local state using v2-aware init
   const fresh = initFromView(v, props.step)
-  const { encoding: freshEnc, ...rest } = fresh
+  const { encoding: freshEnc, defaultFilters: freshDefaults, ...rest } = fresh
   // Update local (except encoding placeholder)
   Object.assign(local, rest)
   // Sync encoding reactive in-place
   Object.keys(encoding).forEach(k => delete encoding[k])
   Object.assign(encoding, freshEnc || {})
+  defaultFilters.value = Array.isArray(freshDefaults) ? [...freshDefaults] : []
   // Auto-detect missing encoding pieces after sync
   try {
     const t = local.type

--- a/frontend/components/tools/VisualizationConfigEditor.vue
+++ b/frontend/components/tools/VisualizationConfigEditor.vue
@@ -596,6 +596,12 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch, onMounted } from 'vue'
 import { useMyFetch } from '~/composables/useMyFetch'
+import {
+  stringOperators,
+  numberOperators,
+  dateOperators,
+  booleanOperators,
+} from '~/composables/useSharedFilters'
 
 interface Props {
   viz: any
@@ -663,20 +669,19 @@ const aggregationOptions = [
   { label: 'Min', value: 'min' },
   { label: 'Max', value: 'max' },
 ]
-const filterOperators = [
-  { label: 'equals', value: 'equals' },
-  { label: 'not equals', value: 'not_equals' },
-  { label: 'contains', value: 'contains' },
-  { label: 'not contains', value: 'not_contains' },
-  { label: 'starts with', value: 'starts_with' },
-  { label: 'ends with', value: 'ends_with' },
-  { label: '>', value: 'greater_than' },
-  { label: '<', value: 'less_than' },
-  { label: '>=', value: 'gte' },
-  { label: '<=', value: 'lte' },
-  { label: 'is empty', value: 'is_empty' },
-  { label: 'is not empty', value: 'is_not_empty' },
-]
+// Union of every operator the shared-filter runtime evaluates, de-duplicated
+// by value. The defaults editor doesn't know the column's data type, so we
+// expose the full set and let the runtime reject unsupported pairings.
+const filterOperators = (() => {
+  const seen = new Set<string>()
+  const merged: { label: string; value: string }[] = []
+  for (const op of [...stringOperators, ...numberOperators, ...dateOperators, ...booleanOperators]) {
+    if (seen.has(op.value)) continue
+    seen.add(op.value)
+    merged.push(op)
+  }
+  return merged
+})()
 
 function deepClone<T>(v: T): T { return JSON.parse(JSON.stringify(v || {})) }
 


### PR DESCRIPTION
When create_data infers a visualization over row-level data, the renderer previously took the first row per group, producing misleading charts. This adds per-series aggregation and seedable default filters end-to-end:

- view_schema / create_data_model: add AggregationFn, DefaultFilterCondition, SeriesStyle.aggregation, BaseView.defaultFilters, and top-level aggregation on pie/scatter/heatmap/count/metric_card.
- create_data: infer aggregation and defaultFilters, propagate to view.
- EChartsVisual / MetricCard: aggregate rows per series (sum/avg/count/ min/max) when declared; fall back to first-row when unset.
- ToolWidgetPreview / RegularWidgetView: seed view.defaultFilters into the shared-filter runtime on first mount via filter:updated, tracked per viz.
- VisualizationConfigEditor: UI for per-series aggregation, top-level aggregation, and a default-filters section.
- create_artifact / edit_artifact: prompt hints so generated JSX honors view.aggregation, seriesStyles[i].aggregation, and view.defaultFilters.

https://claude.ai/code/session_019q69iCDP9y7tKavTUytzuw