### PR TITLE
Move OAuth clients to org Integrations settings; make OAuth server ge…

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -76,7 +76,7 @@ from app.models.llm_usage_record import LLMUsageRecord
 from app.models.api_key import ApiKey
 from app.models.scheduled_prompt import ScheduledPrompt
 from app.models.instruction_build import InstructionBuild
-from app.models.oauth_server import OAuthMCPClient, OAuthMCPAuthorizationCode, OAuthMCPAccessToken
+from app.models.oauth_server import OAuthClient, OAuthAuthorizationCode, OAuthAccessToken
 from app.ee.scim.models import ScimToken
 from app.models.role import Role
 from app.models.group import Group

--- a/backend/app/models/oauth_server.py
+++ b/backend/app/models/oauth_server.py
@@ -1,8 +1,11 @@
 """OAuth 2.1 Authorization Server models.
 
-Used when BOW acts as an OAuth Authorization Server for external MCP clients
-like Claude Web. Not to be confused with OAuthAccount which stores BOW's
-OAuth *client* credentials for SSO login providers.
+Used when BOW acts as an OAuth Authorization Server for external apps
+(e.g., Claude Web for the MCP connector). Not to be confused with OAuthAccount,
+which stores BOW's OAuth *client* credentials for SSO login providers.
+
+Table names are prefixed ``oauth_mcp_*`` for historical reasons; the underlying
+schema is generic OAuth 2.1 and can back any protected resource.
 """
 
 from sqlalchemy import Column, String, DateTime, ForeignKey, Text
@@ -10,21 +13,21 @@ from sqlalchemy.orm import relationship
 from app.models.base import BaseSchema
 
 
-class OAuthMCPClient(BaseSchema):
-    """A registered OAuth client (e.g., Claude Web) that can request access to the MCP API."""
+class OAuthClient(BaseSchema):
+    """A registered OAuth client that can request access to a protected resource."""
     __tablename__ = "oauth_mcp_clients"
 
     organization_id = Column(String(36), ForeignKey("organizations.id"), nullable=False, index=True)
     client_id = Column(String(64), nullable=False, unique=True, index=True)
     client_secret_hash = Column(String(64), nullable=False)  # SHA-256
-    name = Column(String(255), nullable=False)  # e.g. "Claude Web"
+    name = Column(String(255), nullable=False)
     redirect_uris = Column(Text, nullable=False)  # JSON array of allowed redirect URIs
-    scopes = Column(String(255), nullable=False, default="mcp")
+    scopes = Column(String(255), nullable=False)
 
     organization = relationship("Organization")
 
 
-class OAuthMCPAuthorizationCode(BaseSchema):
+class OAuthAuthorizationCode(BaseSchema):
     """Short-lived authorization code issued during the OAuth consent flow."""
     __tablename__ = "oauth_mcp_authorization_codes"
 
@@ -33,7 +36,7 @@ class OAuthMCPAuthorizationCode(BaseSchema):
     user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
     organization_id = Column(String(36), ForeignKey("organizations.id"), nullable=False)
     redirect_uri = Column(String(2048), nullable=False)
-    scope = Column(String(255), nullable=False, default="mcp")
+    scope = Column(String(255), nullable=False)
     code_challenge = Column(String(128), nullable=False)  # PKCE S256
     expires_at = Column(DateTime, nullable=False)
 
@@ -41,15 +44,15 @@ class OAuthMCPAuthorizationCode(BaseSchema):
     organization = relationship("Organization")
 
 
-class OAuthMCPAccessToken(BaseSchema):
-    """Access and refresh tokens issued to OAuth clients for MCP API access."""
+class OAuthAccessToken(BaseSchema):
+    """Access and refresh tokens issued to OAuth clients."""
     __tablename__ = "oauth_mcp_access_tokens"
 
     token_hash = Column(String(64), nullable=False, unique=True, index=True)  # SHA-256
     client_id = Column(String(64), nullable=False, index=True)
     user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
     organization_id = Column(String(36), ForeignKey("organizations.id"), nullable=False)
-    scope = Column(String(255), nullable=False, default="mcp")
+    scope = Column(String(255), nullable=False)
     expires_at = Column(DateTime, nullable=False)
     refresh_token_hash = Column(String(64), nullable=True, unique=True, index=True)  # SHA-256
     refresh_expires_at = Column(DateTime, nullable=True)

--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -133,7 +133,7 @@ async def authorize_approve(
     client_id = body.get("client_id")
     redirect_uri = body.get("redirect_uri")
     state = body.get("state")
-    scope = body.get("scope") or DEFAULT_SCOPE
+    raw_scope = body.get("scope")
     code_challenge = body.get("code_challenge")
     code_challenge_method = body.get("code_challenge_method", "S256")
 
@@ -153,6 +153,18 @@ async def authorize_approve(
     # Validate redirect_uri
     if not service.validate_redirect_uri(client, redirect_uri):
         raise HTTPException(status_code=400, detail="Invalid redirect_uri")
+
+    # Validate requested scope: must be a non-empty subset of both the server's
+    # SUPPORTED_SCOPES and the client's registered scopes.
+    scope_source = raw_scope if isinstance(raw_scope, str) and raw_scope.strip() else DEFAULT_SCOPE
+    requested_scopes = scope_source.split()
+    if not requested_scopes:
+        raise HTTPException(status_code=400, detail="invalid_scope")
+    client_scopes = set((client.scopes or "").split())
+    for s in requested_scopes:
+        if s not in SUPPORTED_SCOPES or s not in client_scopes:
+            raise HTTPException(status_code=400, detail=f"invalid_scope: {s}")
+    scope = " ".join(requested_scopes)
 
     # Create authorization code
     code = await service.create_authorization_code(
@@ -276,14 +288,23 @@ async def create_client(
     if not name:
         raise HTTPException(status_code=400, detail="name is required")
 
-    scopes = body.get("scopes") or DEFAULT_SCOPE
-    # Validate scopes
-    requested = [s for s in scopes.split() if s]
+    raw_scopes = body.get("scopes")
+    scopes_source = raw_scopes if isinstance(raw_scopes, str) and raw_scopes.strip() else DEFAULT_SCOPE
+    requested = scopes_source.split()
+    if not requested:
+        raise HTTPException(status_code=400, detail="scopes must include at least one supported scope")
     for s in requested:
         if s not in SUPPORTED_SCOPES:
             raise HTTPException(status_code=400, detail=f"Unsupported scope: {s}")
+    scopes = " ".join(requested)
 
-    redirect_uris = body.get("redirect_uris")  # Optional; service falls back to defaults.
+    redirect_uris = body.get("redirect_uris")
+    if redirect_uris is not None:
+        if not isinstance(redirect_uris, list) or not redirect_uris:
+            raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
+        for uri in redirect_uris:
+            if not isinstance(uri, str) or not uri.strip():
+                raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
 
     service = OAuthServerService()
     return await service.create_client(

--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -1,7 +1,9 @@
 """OAuth 2.1 Authorization Server routes.
 
-Provides the endpoints needed for Claude Web (and other MCP clients) to
-authenticate via OAuth 2.1 Authorization Code + PKCE.
+Provides the endpoints external apps use to obtain access tokens via the
+OAuth 2.1 Authorization Code + PKCE flow. Currently the only protected
+resource is the MCP endpoint; additional resources can be added without
+changing the auth flow.
 
 Two routers:
   - well_known_router: mounted at root for /.well-known/* metadata
@@ -26,6 +28,11 @@ from app.settings.config import settings
 
 logger = logging.getLogger(__name__)
 
+# Scopes this authorization server can issue. Extend this list when adding a
+# new protected resource; the well-known metadata handlers read from it.
+SUPPORTED_SCOPES = ["mcp"]
+DEFAULT_SCOPE = SUPPORTED_SCOPES[0]
+
 # ── Well-known metadata (mounted at root, no /api prefix) ──────────
 
 well_known_router = APIRouter(tags=["oauth-metadata"])
@@ -44,7 +51,7 @@ async def protected_resource_metadata(request: Request):
     return JSONResponse({
         "resource": f"{base}/api/mcp",
         "authorization_servers": [base],
-        "scopes_supported": ["mcp", "claudeai"],
+        "scopes_supported": list(SUPPORTED_SCOPES),
     })
 
 
@@ -60,7 +67,7 @@ async def authorization_server_metadata(request: Request):
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
-        "scopes_supported": ["mcp", "claudeai"],
+        "scopes_supported": list(SUPPORTED_SCOPES),
     })
 
 
@@ -76,7 +83,7 @@ async def authorize_redirect(
     redirect_uri: str,
     response_type: str = "code",
     state: Optional[str] = None,
-    scope: Optional[str] = "mcp",
+    scope: Optional[str] = None,
     code_challenge: Optional[str] = None,
     code_challenge_method: Optional[str] = None,
 ):
@@ -97,7 +104,7 @@ async def authorize_redirect(
         "client_id": client_id,
         "redirect_uri": redirect_uri,
         "response_type": response_type,
-        "scope": scope or "mcp",
+        "scope": scope or DEFAULT_SCOPE,
     }
     if state:
         params["state"] = state
@@ -126,7 +133,7 @@ async def authorize_approve(
     client_id = body.get("client_id")
     redirect_uri = body.get("redirect_uri")
     state = body.get("state")
-    scope = body.get("scope", "mcp")
+    scope = body.get("scope") or DEFAULT_SCOPE
     code_challenge = body.get("code_challenge")
     code_challenge_method = body.get("code_challenge_method", "S256")
 
@@ -241,7 +248,7 @@ async def token_endpoint(
         )
 
 
-# ── Client CRUD (used by McpModal) ─────────────────────────────────
+# ── Client CRUD ────────────────────────────────────────────────────
 
 @router.get("/clients")
 @requires_permission("manage_settings")
@@ -265,14 +272,25 @@ async def create_client(
 ):
     """Create an OAuth client for the current organization."""
     body = await request.json()
-    name = body.get("name", "Claude Web")
-    redirect_uris = body.get("redirect_uris")  # Optional, defaults to Claude URIs
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+
+    scopes = body.get("scopes") or DEFAULT_SCOPE
+    # Validate scopes
+    requested = [s for s in scopes.split() if s]
+    for s in requested:
+        if s not in SUPPORTED_SCOPES:
+            raise HTTPException(status_code=400, detail=f"Unsupported scope: {s}")
+
+    redirect_uris = body.get("redirect_uris")  # Optional; service falls back to defaults.
 
     service = OAuthServerService()
     return await service.create_client(
         db=db,
         organization_id=organization.id,
         name=name,
+        scopes=scopes,
         redirect_uris=redirect_uris,
     )
 

--- a/backend/app/services/oauth_server_service.py
+++ b/backend/app/services/oauth_server_service.py
@@ -1,7 +1,7 @@
 """OAuth 2.1 Authorization Server service.
 
 Handles client registration, authorization code issuance, token exchange,
-and token validation for external MCP clients (e.g., Claude Web).
+and token validation for external OAuth clients.
 """
 
 import json
@@ -18,9 +18,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.models.oauth_server import (
-    OAuthMCPClient,
-    OAuthMCPAuthorizationCode,
-    OAuthMCPAccessToken,
+    OAuthClient,
+    OAuthAuthorizationCode,
+    OAuthAccessToken,
 )
 from app.models.user import User
 from app.models.organization import Organization
@@ -34,8 +34,8 @@ ACCESS_TOKEN_LIFETIME = timedelta(days=365)
 REFRESH_TOKEN_LIFETIME = timedelta(days=365)
 AUTHORIZATION_CODE_LIFETIME = timedelta(minutes=5)
 
-# Claude's known callback URLs
-CLAUDE_REDIRECT_URIS = [
+# Default redirect URIs (covers Claude Web and common MCP inspector tools).
+DEFAULT_REDIRECT_URIS = [
     "https://claude.ai/api/mcp/auth_callback",
     "https://claude.com/api/mcp/auth_callback",
     "http://localhost:6274/oauth/callback",
@@ -70,6 +70,7 @@ class OAuthServerService:
         db: AsyncSession,
         organization_id: str,
         name: str,
+        scopes: str,
         redirect_uris: Optional[list[str]] = None,
     ) -> dict:
         """Create an OAuth client for an organization.
@@ -77,19 +78,19 @@ class OAuthServerService:
         Returns dict with client_id, client_secret (plaintext, shown only once), and name.
         """
         if redirect_uris is None:
-            redirect_uris = list(CLAUDE_REDIRECT_URIS)
+            redirect_uris = list(DEFAULT_REDIRECT_URIS)
 
         client_id = f"bow_client_{secrets.token_urlsafe(16)}"
         client_secret = f"bow_secret_{secrets.token_urlsafe(32)}"
         secret_hash = _hash(client_secret)
 
-        client = OAuthMCPClient(
+        client = OAuthClient(
             organization_id=organization_id,
             client_id=client_id,
             client_secret_hash=secret_hash,
             name=name,
             redirect_uris=json.dumps(redirect_uris),
-            scopes="mcp",
+            scopes=scopes,
         )
         db.add(client)
         await db.commit()
@@ -110,10 +111,10 @@ class OAuthServerService:
         organization_id: str,
     ) -> list[dict]:
         result = await db.execute(
-            select(OAuthMCPClient)
-            .where(OAuthMCPClient.organization_id == organization_id)
-            .where(OAuthMCPClient.deleted_at.is_(None))
-            .order_by(OAuthMCPClient.created_at.desc())
+            select(OAuthClient)
+            .where(OAuthClient.organization_id == organization_id)
+            .where(OAuthClient.deleted_at.is_(None))
+            .order_by(OAuthClient.created_at.desc())
         )
         clients = result.scalars().all()
         return [
@@ -134,9 +135,9 @@ class OAuthServerService:
     ) -> Optional[dict]:
         """Public info about a client (for consent screen)."""
         result = await db.execute(
-            select(OAuthMCPClient)
-            .where(OAuthMCPClient.client_id == client_id)
-            .where(OAuthMCPClient.deleted_at.is_(None))
+            select(OAuthClient)
+            .where(OAuthClient.client_id == client_id)
+            .where(OAuthClient.deleted_at.is_(None))
         )
         client = result.scalar_one_or_none()
         if not client:
@@ -150,10 +151,10 @@ class OAuthServerService:
         organization_id: str,
     ) -> bool:
         result = await db.execute(
-            select(OAuthMCPClient)
-            .where(OAuthMCPClient.id == client_db_id)
-            .where(OAuthMCPClient.organization_id == organization_id)
-            .where(OAuthMCPClient.deleted_at.is_(None))
+            select(OAuthClient)
+            .where(OAuthClient.id == client_db_id)
+            .where(OAuthClient.organization_id == organization_id)
+            .where(OAuthClient.deleted_at.is_(None))
         )
         client = result.scalar_one_or_none()
         if not client:
@@ -170,10 +171,10 @@ class OAuthServerService:
     ) -> Optional[dict]:
         """Rotate client_secret. Returns new secret (plaintext, shown once)."""
         result = await db.execute(
-            select(OAuthMCPClient)
-            .where(OAuthMCPClient.id == client_db_id)
-            .where(OAuthMCPClient.organization_id == organization_id)
-            .where(OAuthMCPClient.deleted_at.is_(None))
+            select(OAuthClient)
+            .where(OAuthClient.id == client_db_id)
+            .where(OAuthClient.organization_id == organization_id)
+            .where(OAuthClient.deleted_at.is_(None))
         )
         client = result.scalar_one_or_none()
         if not client:
@@ -197,12 +198,12 @@ class OAuthServerService:
         db: AsyncSession,
         client_id: str,
         client_secret: Optional[str] = None,
-    ) -> Optional[OAuthMCPClient]:
+    ) -> Optional[OAuthClient]:
         """Validate client credentials. If client_secret is None, only validate client_id."""
         result = await db.execute(
-            select(OAuthMCPClient)
-            .where(OAuthMCPClient.client_id == client_id)
-            .where(OAuthMCPClient.deleted_at.is_(None))
+            select(OAuthClient)
+            .where(OAuthClient.client_id == client_id)
+            .where(OAuthClient.deleted_at.is_(None))
         )
         client = result.scalar_one_or_none()
         if not client:
@@ -214,7 +215,7 @@ class OAuthServerService:
 
         return client
 
-    def validate_redirect_uri(self, client: OAuthMCPClient, redirect_uri: str) -> bool:
+    def validate_redirect_uri(self, client: OAuthClient, redirect_uri: str) -> bool:
         allowed = json.loads(client.redirect_uris)
         return redirect_uri in allowed
 
@@ -233,7 +234,7 @@ class OAuthServerService:
         """Create and return an authorization code."""
         code = secrets.token_urlsafe(32)
 
-        auth_code = OAuthMCPAuthorizationCode(
+        auth_code = OAuthAuthorizationCode(
             code=code,
             client_id=client_id,
             user_id=user_id,
@@ -270,10 +271,10 @@ class OAuthServerService:
 
         # Look up the authorization code
         result = await db.execute(
-            select(OAuthMCPAuthorizationCode)
-            .where(OAuthMCPAuthorizationCode.code == code)
-            .where(OAuthMCPAuthorizationCode.client_id == client_id)
-            .where(OAuthMCPAuthorizationCode.deleted_at.is_(None))
+            select(OAuthAuthorizationCode)
+            .where(OAuthAuthorizationCode.code == code)
+            .where(OAuthAuthorizationCode.client_id == client_id)
+            .where(OAuthAuthorizationCode.deleted_at.is_(None))
         )
         auth_code = result.scalar_one_or_none()
         if not auth_code:
@@ -304,7 +305,7 @@ class OAuthServerService:
         access_token, access_hash = _generate_token(ACCESS_TOKEN_PREFIX)
         refresh_token, refresh_hash = _generate_token(REFRESH_TOKEN_PREFIX)
 
-        token_record = OAuthMCPAccessToken(
+        token_record = OAuthAccessToken(
             token_hash=access_hash,
             client_id=client_id,
             user_id=auth_code.user_id,
@@ -342,10 +343,10 @@ class OAuthServerService:
         refresh_hash = _hash(refresh_token)
 
         result = await db.execute(
-            select(OAuthMCPAccessToken)
-            .where(OAuthMCPAccessToken.refresh_token_hash == refresh_hash)
-            .where(OAuthMCPAccessToken.client_id == client_id)
-            .where(OAuthMCPAccessToken.deleted_at.is_(None))
+            select(OAuthAccessToken)
+            .where(OAuthAccessToken.refresh_token_hash == refresh_hash)
+            .where(OAuthAccessToken.client_id == client_id)
+            .where(OAuthAccessToken.deleted_at.is_(None))
         )
         token_record = result.scalar_one_or_none()
         if not token_record:
@@ -364,7 +365,7 @@ class OAuthServerService:
         new_access, new_access_hash = _generate_token(ACCESS_TOKEN_PREFIX)
         new_refresh, new_refresh_hash = _generate_token(REFRESH_TOKEN_PREFIX)
 
-        new_record = OAuthMCPAccessToken(
+        new_record = OAuthAccessToken(
             token_hash=new_access_hash,
             client_id=client_id,
             user_id=token_record.user_id,
@@ -402,9 +403,9 @@ class OAuthServerService:
         token_hash = _hash(token)
 
         result = await db.execute(
-            select(OAuthMCPAccessToken)
-            .where(OAuthMCPAccessToken.token_hash == token_hash)
-            .where(OAuthMCPAccessToken.deleted_at.is_(None))
+            select(OAuthAccessToken)
+            .where(OAuthAccessToken.token_hash == token_hash)
+            .where(OAuthAccessToken.deleted_at.is_(None))
         )
         token_record = result.scalar_one_or_none()
         if not token_record:

--- a/frontend/components/McpModal.vue
+++ b/frontend/components/McpModal.vue
@@ -16,11 +16,11 @@
                     />
                 </div>
                 <p class="text-sm text-gray-500 mt-2">
-                    Connect Claude, Cursor, or any MCP client to query your data via the Bag of words MCP Server.
+                    Generate an access token to connect Claude, Cursor, or any MCP client to your data.
                 </p>
             </template>
 
-            <!-- Tabs -->
+            <!-- Content -->
             <div v-if="loading" class="py-12 flex items-center justify-center">
                 <div class="text-center">
                     <Spinner class="w-8 h-8 mx-auto mb-4 text-gray-400" />
@@ -28,261 +28,128 @@
                 </div>
             </div>
 
-            <div v-else>
-                <!-- Tab buttons -->
-                <div class="flex border-b border-gray-200 mb-5">
-                    <button
-                        @click="activeTab = 'mcp'"
-                        :class="[
-                            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
-                            activeTab === 'mcp'
-                                ? 'border-blue-500 text-blue-600'
-                                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                        ]"
-                    >
-                        MCP Clients
-                    </button>
-                    <button
-                        @click="activeTab = 'claude-web'"
-                        :class="[
-                            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
-                            activeTab === 'claude-web'
-                                ? 'border-blue-500 text-blue-600'
-                                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                        ]"
-                    >
-                        OAuth
-                    </button>
-                </div>
-
-                <!-- Tab: MCP Clients (existing) -->
-                <div v-show="activeTab === 'mcp'" class="space-y-5">
-                    <!-- Top bar: Server status left, Generate/Regenerate right -->
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-2 text-xs text-gray-500">
-                            <div class="w-1.5 h-1.5 rounded-full bg-green-500"></div>
-                            <code class="font-mono text-gray-700">{{ mcpServerUrl }}</code>
-                        </div>
-                        <UButton
-                            size="xs"
-                            color="blue"
-                            @click="regenerateToken"
-                            :loading="creating"
-                        >
-                            <UIcon :name="apiKeys.length === 0 ? 'heroicons-plus' : 'heroicons-arrow-path'" class="w-3.5 h-3.5 mr-1" />
-                            {{ apiKeys.length === 0 ? 'Generate Token' : 'Regenerate Token' }}
-                        </UButton>
-                    </div>
-
-                    <!-- Configuration -->
-                    <div>
-                        <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-2">Configuration</div>
-                        <div class="relative bg-gray-50 rounded-lg border border-gray-200">
-                            <pre class="px-3 py-2.5 pr-20 font-mono text-xs text-gray-700 overflow-x-auto">{{ mcpConfig }}</pre>
-                            <div class="absolute top-2 right-2">
-                                <UTooltip
-                                    :text="currentToken ? '' : (apiKeys.length === 0 ? 'Generate token to copy' : 'Regenerate token to copy')"
-                                    :popper="{ placement: 'top' }"
-                                >
-                                    <button
-                                        @click="currentToken && copy(mcpConfig)"
-                                        :class="[
-                                            'flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors',
-                                            currentToken
-                                                ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
-                                                : 'text-gray-300 cursor-not-allowed'
-                                        ]"
-                                        :disabled="!currentToken"
-                                    >
-                                        <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
-                                        Copy
-                                    </button>
-                                </UTooltip>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Token display -->
-                    <div>
-                        <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-2">Access Token</div>
-                        <!-- No tokens exist yet -->
-                        <div v-if="apiKeys.length === 0 && !currentToken" class="bg-gray-50 rounded-lg border border-gray-200 border-dashed px-4 py-6 text-center">
-                            <p class="text-sm text-gray-500 mb-3">No access token generated yet</p>
-                            <UButton
-                                size="sm"
-                                color="blue"
-                                @click="regenerateToken"
-                                :loading="creating"
-                            >
-                                <UIcon name="heroicons-plus" class="w-4 h-4 mr-1" />
-                                Generate Token
-                            </UButton>
-                        </div>
-                        <!-- Token exists -->
-                        <div v-else class="relative bg-gray-50 rounded-lg border border-gray-200">
-                            <div class="px-3 py-2 pr-20 flex items-center gap-3">
-                                <code class="font-mono text-xs text-gray-700">{{ currentToken || '••••••••••••••••••••••••••••••••' }}</code>
-                                <span v-if="!currentToken && apiKeys.length > 0" class="text-[10px] text-gray-400">{{ formatDate(apiKeys[0].created_at) }}</span>
-                            </div>
-                            <div class="absolute top-1/2 -translate-y-1/2 right-2">
-                                <UTooltip
-                                    :text="currentToken ? '' : 'Regenerate token to copy'"
-                                    :popper="{ placement: 'top' }"
-                                >
-                                    <button
-                                        @click="currentToken && copy(currentToken)"
-                                        :class="[
-                                            'flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors',
-                                            currentToken
-                                                ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
-                                                : 'text-gray-300 cursor-not-allowed'
-                                        ]"
-                                        :disabled="!currentToken"
-                                    >
-                                        <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
-                                        Copy
-                                    </button>
-                                </UTooltip>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Manage tokens (collapsed) -->
-                    <div v-if="apiKeys.length > 0" class="pt-2 border-t border-gray-100">
-                        <button
-                            @click="showTokens = !showTokens"
-                            class="flex items-center gap-2 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                        >
-                            <UIcon
-                                :name="showTokens ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
-                                class="w-3 h-3"
-                            />
-                            Manage tokens ({{ apiKeys.length }})
-                        </button>
-
-                        <div v-if="showTokens" class="mt-3 border border-gray-200 rounded-lg divide-y divide-gray-200">
-                            <div
-                                v-for="key in apiKeys"
-                                :key="key.id"
-                                class="flex items-center justify-between px-3 py-2 hover:bg-gray-50 transition-colors group"
-                            >
-                                <div class="flex items-center gap-3 min-w-0">
-                                    <code class="font-mono text-xs text-gray-700">{{ key.key_prefix }}•••••••••</code>
-                                    <span class="text-[10px] text-gray-400">{{ formatDate(key.created_at) }}</span>
-                                </div>
-                                <button
-                                    @click="deleteApiKey(key)"
-                                    class="text-gray-400 hover:text-red-500 p-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-                                    title="Delete token"
-                                >
-                                    <UIcon name="heroicons-trash" class="w-3.5 h-3.5" />
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Tab: OAuth -->
-                <div v-show="activeTab === 'claude-web'" class="space-y-5">
-                    <!-- Server URL -->
+            <div v-else class="space-y-5">
+                <!-- Top bar: Server status left, Generate/Regenerate right -->
+                <div class="flex items-center justify-between">
                     <div class="flex items-center gap-2 text-xs text-gray-500">
                         <div class="w-1.5 h-1.5 rounded-full bg-green-500"></div>
                         <code class="font-mono text-gray-700">{{ mcpServerUrl }}</code>
                     </div>
+                    <UButton
+                        size="xs"
+                        color="blue"
+                        @click="regenerateToken"
+                        :loading="creating"
+                    >
+                        <UIcon :name="apiKeys.length === 0 ? 'heroicons-plus' : 'heroicons-arrow-path'" class="w-3.5 h-3.5 mr-1" />
+                        {{ apiKeys.length === 0 ? 'Generate Token' : 'Regenerate Token' }}
+                    </UButton>
+                </div>
 
-                    <!-- OAuth Credentials -->
-                    <div>
-                        <div class="flex items-center justify-between mb-2">
-                            <div class="text-[11px] uppercase tracking-wide text-gray-500">OAuth Credentials</div>
-                            <UButton
-                                v-if="oauthClients.length > 0"
-                                size="xs"
-                                color="blue"
-                                @click="rotateOAuthSecret"
-                                :loading="oauthCreating"
+                <!-- Configuration -->
+                <div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-2">Configuration</div>
+                    <div class="relative bg-gray-50 rounded-lg border border-gray-200">
+                        <pre class="px-3 py-2.5 pr-20 font-mono text-xs text-gray-700 overflow-x-auto">{{ mcpConfig }}</pre>
+                        <div class="absolute top-2 right-2">
+                            <UTooltip
+                                :text="currentToken ? '' : (apiKeys.length === 0 ? 'Generate token to copy' : 'Regenerate token to copy')"
+                                :popper="{ placement: 'top' }"
                             >
-                                <UIcon name="heroicons-arrow-path" class="w-3.5 h-3.5 mr-1" />
-                                Regenerate Secret
-                            </UButton>
-                        </div>
-
-                        <!-- No credentials yet -->
-                        <div v-if="oauthClients.length === 0 && !oauthCurrentSecret" class="bg-gray-50 rounded-lg border border-gray-200 border-dashed px-4 py-6 text-center">
-                            <p class="text-sm text-gray-500 mb-3">No OAuth credentials generated yet</p>
-                            <UButton
-                                size="sm"
-                                color="blue"
-                                @click="generateOAuthClient"
-                                :loading="oauthCreating"
-                            >
-                                <UIcon name="heroicons-plus" class="w-4 h-4 mr-1" />
-                                Generate Credentials
-                            </UButton>
-                        </div>
-
-                        <!-- Credentials exist -->
-                        <div v-else class="space-y-3">
-                            <!-- Client ID -->
-                            <div class="relative bg-gray-50 rounded-lg border border-gray-200">
-                                <div class="px-3 py-2 pr-20">
-                                    <div class="text-[10px] text-gray-400 mb-0.5">Client ID</div>
-                                    <code class="font-mono text-xs text-gray-700">{{ oauthClients[0]?.client_id || '' }}</code>
-                                </div>
-                                <div class="absolute top-1/2 -translate-y-1/2 right-2">
-                                    <button
-                                        @click="copy(oauthClients[0]?.client_id)"
-                                        class="flex items-center gap-1 px-2 py-1 rounded text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 transition-colors"
-                                    >
-                                        <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
-                                        Copy
-                                    </button>
-                                </div>
-                            </div>
-
-                            <!-- Client Secret -->
-                            <div class="relative bg-gray-50 rounded-lg border border-gray-200">
-                                <div class="px-3 py-2 pr-20">
-                                    <div class="text-[10px] text-gray-400 mb-0.5">Client Secret</div>
-                                    <code class="font-mono text-xs text-gray-700">{{ oauthCurrentSecret || '••••••••••••••••••••••••••••••••••••••••' }}</code>
-                                </div>
-                                <div class="absolute top-1/2 -translate-y-1/2 right-2">
-                                    <UTooltip
-                                        :text="oauthCurrentSecret ? '' : 'Regenerate secret to copy'"
-                                        :popper="{ placement: 'top' }"
-                                    >
-                                        <button
-                                            @click="oauthCurrentSecret && copy(oauthCurrentSecret)"
-                                            :class="[
-                                                'flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors',
-                                                oauthCurrentSecret
-                                                    ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
-                                                    : 'text-gray-300 cursor-not-allowed'
-                                            ]"
-                                            :disabled="!oauthCurrentSecret"
-                                        >
-                                            <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
-                                            Copy
-                                        </button>
-                                    </UTooltip>
-                                </div>
-                            </div>
-
-                            <p v-if="oauthCurrentSecret" class="text-xs text-amber-600">
-                                Save the Client Secret now — it won't be shown again.
-                            </p>
+                                <button
+                                    @click="currentToken && copy(mcpConfig)"
+                                    :class="[
+                                        'flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors',
+                                        currentToken
+                                            ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+                                            : 'text-gray-300 cursor-not-allowed'
+                                    ]"
+                                    :disabled="!currentToken"
+                                >
+                                    <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
+                                    Copy
+                                </button>
+                            </UTooltip>
                         </div>
                     </div>
+                </div>
 
-                    <!-- Setup Instructions -->
-                    <div class="pt-2 border-t border-gray-100">
-                        <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-2">Setup Instructions</div>
-                        <ol class="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
-                            <li>In Claude Web, go to <strong>Settings → Connectors → Add</strong></li>
-                            <li>Enter the MCP server URL: <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{{ mcpServerUrl }}</code></li>
-                            <li>Click <strong>Advanced Settings</strong></li>
-                            <li>Enter the <strong>Client ID</strong> and <strong>Client Secret</strong> from above</li>
-                            <li>Click <strong>Connect</strong> — you'll be redirected to approve access</li>
-                        </ol>
+                <!-- Token display -->
+                <div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-2">Access Token</div>
+                    <!-- No tokens exist yet -->
+                    <div v-if="apiKeys.length === 0 && !currentToken" class="bg-gray-50 rounded-lg border border-gray-200 border-dashed px-4 py-6 text-center">
+                        <p class="text-sm text-gray-500 mb-3">No access token generated yet</p>
+                        <UButton
+                            size="sm"
+                            color="blue"
+                            @click="regenerateToken"
+                            :loading="creating"
+                        >
+                            <UIcon name="heroicons-plus" class="w-4 h-4 mr-1" />
+                            Generate Token
+                        </UButton>
+                    </div>
+                    <!-- Token exists -->
+                    <div v-else class="relative bg-gray-50 rounded-lg border border-gray-200">
+                        <div class="px-3 py-2 pr-20 flex items-center gap-3">
+                            <code class="font-mono text-xs text-gray-700">{{ currentToken || '••••••••••••••••••••••••••••••••' }}</code>
+                            <span v-if="!currentToken && apiKeys.length > 0" class="text-[10px] text-gray-400">{{ formatDate(apiKeys[0].created_at) }}</span>
+                        </div>
+                        <div class="absolute top-1/2 -translate-y-1/2 right-2">
+                            <UTooltip
+                                :text="currentToken ? '' : 'Regenerate token to copy'"
+                                :popper="{ placement: 'top' }"
+                            >
+                                <button
+                                    @click="currentToken && copy(currentToken)"
+                                    :class="[
+                                        'flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors',
+                                        currentToken
+                                            ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+                                            : 'text-gray-300 cursor-not-allowed'
+                                    ]"
+                                    :disabled="!currentToken"
+                                >
+                                    <UIcon name="heroicons-clipboard-document" class="w-3.5 h-3.5" />
+                                    Copy
+                                </button>
+                            </UTooltip>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Manage tokens (collapsed) -->
+                <div v-if="apiKeys.length > 0" class="pt-2 border-t border-gray-100">
+                    <button
+                        @click="showTokens = !showTokens"
+                        class="flex items-center gap-2 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                    >
+                        <UIcon
+                            :name="showTokens ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+                            class="w-3 h-3"
+                        />
+                        Manage tokens ({{ apiKeys.length }})
+                    </button>
+
+                    <div v-if="showTokens" class="mt-3 border border-gray-200 rounded-lg divide-y divide-gray-200">
+                        <div
+                            v-for="key in apiKeys"
+                            :key="key.id"
+                            class="flex items-center justify-between px-3 py-2 hover:bg-gray-50 transition-colors group"
+                        >
+                            <div class="flex items-center gap-3 min-w-0">
+                                <code class="font-mono text-xs text-gray-700">{{ key.key_prefix }}•••••••••</code>
+                                <span class="text-[10px] text-gray-400">{{ formatDate(key.created_at) }}</span>
+                            </div>
+                            <button
+                                @click="deleteApiKey(key)"
+                                class="text-gray-400 hover:text-red-500 p-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                                title="Delete token"
+                            >
+                                <UIcon name="heroicons-trash" class="w-3.5 h-3.5" />
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -317,30 +184,13 @@ interface ApiKey {
     created_at: string
 }
 
-interface OAuthClient {
-    id: string
-    client_id: string
-    client_secret?: string
-    name: string
-    redirect_uris: string[]
-    created_at: string
-}
-
-// Shared state
 const loading = ref(false)
 const baseUrl = ref('')
-const activeTab = ref<'mcp' | 'claude-web'>('mcp')
 
-// MCP Clients tab state
 const apiKeys = ref<ApiKey[]>([])
 const creating = ref(false)
 const currentToken = ref<string | null>(null)
 const showTokens = ref(false)
-
-// Claude Web tab state
-const oauthClients = ref<OAuthClient[]>([])
-const oauthCreating = ref(false)
-const oauthCurrentSecret = ref<string | null>(null)
 
 const mcpServerUrl = computed(() => {
     const base = baseUrl.value || window.location.origin
@@ -375,8 +225,6 @@ function formatDate(dateStr: string) {
         minute: '2-digit'
     })
 }
-
-// ── MCP Clients tab ────────────────────────────────────────────
 
 async function regenerateToken() {
     await createApiKey()
@@ -426,62 +274,6 @@ async function deleteApiKey(key: ApiKey) {
     }
 }
 
-// ── Claude Web tab ─────────────────────────────────────────────
-
-async function loadOAuthClients() {
-    try {
-        const res = await useMyFetch('/api/oauth/clients')
-        if (res.data.value) {
-            oauthClients.value = res.data.value as OAuthClient[]
-        }
-    } catch (e) {
-        // Endpoint might not exist yet
-    }
-}
-
-async function generateOAuthClient() {
-    oauthCreating.value = true
-    try {
-        const res = await useMyFetch('/api/oauth/clients', {
-            method: 'POST',
-            body: { name: 'Claude Web' }
-        })
-        if (res.data.value) {
-            const client = res.data.value as OAuthClient
-            oauthClients.value = [client]
-            oauthCurrentSecret.value = client.client_secret || null
-            toast.add({ title: 'OAuth credentials generated', icon: 'i-heroicons-check-circle', color: 'green' })
-        }
-    } catch (e) {
-        toast.add({ title: 'Failed to generate credentials', icon: 'i-heroicons-x-circle', color: 'red' })
-    } finally {
-        oauthCreating.value = false
-    }
-}
-
-async function rotateOAuthSecret() {
-    if (!oauthClients.value.length) return
-    oauthCreating.value = true
-    try {
-        const clientId = oauthClients.value[0].id
-        const res = await useMyFetch(`/api/oauth/clients/${clientId}/rotate`, {
-            method: 'POST'
-        })
-        if (res.data.value) {
-            const updated = res.data.value as OAuthClient
-            oauthClients.value[0].client_id = updated.client_id
-            oauthCurrentSecret.value = updated.client_secret || null
-            toast.add({ title: 'Secret regenerated', icon: 'i-heroicons-check-circle', color: 'green' })
-        }
-    } catch (e) {
-        toast.add({ title: 'Failed to regenerate secret', icon: 'i-heroicons-x-circle', color: 'red' })
-    } finally {
-        oauthCreating.value = false
-    }
-}
-
-// ── Settings ───────────────────────────────────────────────────
-
 async function loadSettings() {
     try {
         const res = await useMyFetch('/settings')
@@ -493,19 +285,14 @@ async function loadSettings() {
     }
 }
 
-// ── Lifecycle ──────────────────────────────────────────────────
-
 watch(isOpen, async (open) => {
     if (open) {
         loading.value = true
         currentToken.value = null
-        oauthCurrentSecret.value = null
         showTokens.value = false
-        activeTab.value = 'mcp'
         await Promise.all([
             loadSettings(),
-            loadApiKeys(),
-            loadOAuthClients()
+            loadApiKeys()
         ])
         loading.value = false
     }

--- a/frontend/components/OAuthClientsModal.vue
+++ b/frontend/components/OAuthClientsModal.vue
@@ -1,0 +1,277 @@
+<template>
+  <div class="p-4">
+    <div class="flex items-center gap-2 mb-2">
+      <UIcon name="heroicons-key" class="w-5 h-5 text-gray-700" />
+      <h1 class="text-lg font-semibold">OAuth Clients</h1>
+    </div>
+    <p class="text-sm text-gray-500">
+      Register external apps that connect to this workspace via OAuth 2.1 (e.g. Claude Web's MCP connector).
+    </p>
+    <hr class="my-4" />
+
+    <!-- Loading -->
+    <div v-if="loading" class="py-8 flex items-center justify-center">
+      <Spinner class="w-6 h-6 text-gray-400" />
+    </div>
+
+    <div v-else>
+      <!-- Clients list / empty state -->
+      <div v-if="clients.length === 0" class="bg-gray-50 rounded-lg border border-gray-200 border-dashed px-4 py-6 text-center mb-4">
+        <p class="text-sm text-gray-500 mb-3">No OAuth clients registered yet</p>
+      </div>
+
+      <div v-else class="border border-gray-200 rounded-lg divide-y divide-gray-200 mb-4">
+        <div
+          v-for="client in clients"
+          :key="client.id"
+          class="px-3 py-2 hover:bg-gray-50 transition-colors"
+        >
+          <div class="flex items-center justify-between">
+            <div class="min-w-0 flex-1">
+              <div class="text-sm font-medium text-gray-800 truncate">{{ client.name }}</div>
+              <div class="flex items-center gap-2 mt-0.5">
+                <code class="font-mono text-[11px] text-gray-600 truncate">{{ client.client_id }}</code>
+                <span class="text-[10px] text-gray-400">{{ formatDate(client.created_at) }}</span>
+              </div>
+            </div>
+            <div class="flex items-center gap-1 flex-shrink-0 ml-3">
+              <UButton
+                size="xs"
+                color="gray"
+                variant="ghost"
+                @click="copy(client.client_id)"
+                title="Copy Client ID"
+              >
+                <UIcon name="heroicons-clipboard-document" class="w-4 h-4" />
+              </UButton>
+              <UButton
+                size="xs"
+                color="gray"
+                variant="ghost"
+                @click="rotate(client)"
+                :loading="rotatingId === client.id"
+                title="Rotate secret"
+              >
+                <UIcon name="heroicons-arrow-path" class="w-4 h-4" />
+              </UButton>
+              <UButton
+                size="xs"
+                color="red"
+                variant="ghost"
+                @click="remove(client)"
+                title="Delete"
+              >
+                <UIcon name="heroicons-trash" class="w-4 h-4" />
+              </UButton>
+            </div>
+          </div>
+
+          <!-- Show freshly generated secret inline -->
+          <div v-if="freshSecretByClientId[client.client_id]" class="mt-2 bg-amber-50 border border-amber-200 rounded p-2">
+            <div class="text-[10px] text-amber-700 uppercase tracking-wide mb-1">Client Secret (shown once)</div>
+            <div class="flex items-center justify-between gap-2">
+              <code class="font-mono text-xs text-amber-900 break-all">{{ freshSecretByClientId[client.client_id] }}</code>
+              <UButton
+                size="xs"
+                color="gray"
+                variant="ghost"
+                @click="copy(freshSecretByClientId[client.client_id])"
+              >
+                <UIcon name="heroicons-clipboard-document" class="w-4 h-4" />
+              </UButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Add new client form -->
+      <form @submit.prevent="submit" class="space-y-3">
+        <div>
+          <label class="block text-sm font-medium mb-1">Add a client</label>
+          <div class="flex gap-2">
+            <input
+              v-model="newName"
+              type="text"
+              class="flex-1 border rounded px-2 py-1 text-sm"
+              placeholder="e.g. Claude Web"
+              required
+            />
+            <UButton
+              type="submit"
+              size="sm"
+              color="blue"
+              :loading="creating"
+              :disabled="!newName.trim()"
+            >
+              <UIcon name="heroicons-plus" class="w-4 h-4 mr-1" />
+              Add
+            </UButton>
+          </div>
+        </div>
+      </form>
+
+      <!-- Claude Web setup instructions -->
+      <details class="mt-5 text-sm">
+        <summary class="cursor-pointer text-gray-500 hover:text-gray-700">
+          Claude Web setup instructions
+        </summary>
+        <div class="mt-3 bg-gray-50 border border-gray-200 rounded-lg p-3 space-y-2">
+          <div class="flex items-center gap-2 text-xs text-gray-500">
+            <div class="w-1.5 h-1.5 rounded-full bg-green-500"></div>
+            <code class="font-mono text-gray-700">{{ mcpServerUrl }}</code>
+          </div>
+          <ol class="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+            <li>In Claude Web, go to <strong>Settings → Connectors → Add</strong></li>
+            <li>Enter the MCP server URL above</li>
+            <li>Click <strong>Advanced Settings</strong></li>
+            <li>Enter the <strong>Client ID</strong> and <strong>Client Secret</strong> from a client above</li>
+            <li>Click <strong>Connect</strong> — you'll be redirected to approve access</li>
+          </ol>
+        </div>
+      </details>
+    </div>
+
+    <button class="absolute top-2 right-2 text-gray-400 hover:text-gray-600" @click="$emit('close')">✕</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import Spinner from '~/components/Spinner.vue'
+
+const emit = defineEmits<{
+  close: []
+  updated: []
+}>()
+
+interface OAuthClient {
+  id: string
+  client_id: string
+  client_secret?: string
+  name: string
+  redirect_uris: string[]
+  created_at: string
+}
+
+const toast = useToast()
+
+const loading = ref(true)
+const clients = ref<OAuthClient[]>([])
+const creating = ref(false)
+const rotatingId = ref<string | null>(null)
+const newName = ref('')
+const baseUrl = ref('')
+
+// Map of client_id → freshly revealed secret (shown until modal closes or user dismisses)
+const freshSecretByClientId = ref<Record<string, string>>({})
+
+const mcpServerUrl = computed(() => {
+  const base = baseUrl.value || window.location.origin
+  return `${base}/api/mcp`
+})
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+async function copy(text: string | undefined) {
+  if (!text) return
+  await navigator.clipboard.writeText(text)
+  toast.add({ title: 'Copied', icon: 'i-heroicons-check-circle', color: 'green' })
+}
+
+async function loadBaseUrl() {
+  try {
+    const res = await useMyFetch('/settings')
+    if (res.data.value) {
+      baseUrl.value = (res.data.value as any).base_url || ''
+    }
+  } catch (e) {
+    // fall back to window.location.origin
+  }
+}
+
+async function loadClients() {
+  try {
+    const res = await useMyFetch('/api/oauth/clients')
+    clients.value = (res.data.value as OAuthClient[]) || []
+  } catch (e) {
+    clients.value = []
+  }
+}
+
+async function submit() {
+  const name = newName.value.trim()
+  if (!name) return
+  creating.value = true
+  try {
+    const res = await useMyFetch('/api/oauth/clients', {
+      method: 'POST',
+      body: { name }
+    })
+    if (res.data.value) {
+      const created = res.data.value as OAuthClient
+      clients.value = [created, ...clients.value]
+      if (created.client_secret) {
+        freshSecretByClientId.value[created.client_id] = created.client_secret
+      }
+      newName.value = ''
+      toast.add({ title: 'OAuth client created', icon: 'i-heroicons-check-circle', color: 'green' })
+      emit('updated')
+    }
+  } catch (e) {
+    toast.add({ title: 'Failed to create client', icon: 'i-heroicons-x-circle', color: 'red' })
+  } finally {
+    creating.value = false
+  }
+}
+
+async function rotate(client: OAuthClient) {
+  rotatingId.value = client.id
+  try {
+    const res = await useMyFetch(`/api/oauth/clients/${client.id}/rotate`, {
+      method: 'POST'
+    })
+    if (res.data.value) {
+      const updated = res.data.value as OAuthClient
+      const idx = clients.value.findIndex(c => c.id === client.id)
+      if (idx !== -1) {
+        clients.value[idx].client_id = updated.client_id
+      }
+      if (updated.client_secret) {
+        freshSecretByClientId.value[updated.client_id] = updated.client_secret
+      }
+      toast.add({ title: 'Secret rotated', icon: 'i-heroicons-check-circle', color: 'green' })
+      emit('updated')
+    }
+  } catch (e) {
+    toast.add({ title: 'Failed to rotate secret', icon: 'i-heroicons-x-circle', color: 'red' })
+  } finally {
+    rotatingId.value = null
+  }
+}
+
+async function remove(client: OAuthClient) {
+  if (!confirm(`Delete OAuth client "${client.name}"?`)) return
+  try {
+    await useMyFetch(`/api/oauth/clients/${client.id}`, { method: 'DELETE' })
+    clients.value = clients.value.filter(c => c.id !== client.id)
+    delete freshSecretByClientId.value[client.client_id]
+    toast.add({ title: 'OAuth client deleted', icon: 'i-heroicons-check-circle', color: 'green' })
+    emit('updated')
+  } catch (e) {
+    toast.add({ title: 'Failed to delete client', icon: 'i-heroicons-x-circle', color: 'red' })
+  }
+}
+
+onMounted(async () => {
+  loading.value = true
+  await Promise.all([loadBaseUrl(), loadClients()])
+  loading.value = false
+})
+</script>

--- a/frontend/pages/settings/integrations/index.vue
+++ b/frontend/pages/settings/integrations/index.vue
@@ -145,6 +145,36 @@
       />
     </div>
 
+    <!-- OAuth Clients Row -->
+    <div
+      class="flex items-center justify-between p-4 border rounded-lg cursor-pointer hover:bg-gray-50"
+      @click="showOAuthModal = true"
+    >
+      <div class="flex items-center">
+        <div class="w-8 h-8 mr-4 flex items-center justify-center rounded bg-gray-100">
+          <UIcon name="heroicons-key" class="w-5 h-5 text-gray-700" />
+        </div>
+        <div>
+          <div class="font-medium">OAuth Clients</div>
+          <div class="text-sm text-gray-500">
+            <span v-if="oauthClientCount > 0">
+              <span class="text-green-600">{{ oauthClientCount }} connected</span>
+            </span>
+            <span v-else>
+              <span class="text-gray-400">Not connected</span>
+            </span>
+            <span class="ml-2">— register external apps that access this workspace via OAuth 2.1 (e.g. Claude Web)</span>
+          </div>
+        </div>
+      </div>
+      <button
+        class="bg-blue-500 text-white text-sm px-3 py-1.5 rounded-md"
+        @click.stop="showOAuthModal = true"
+      >
+        {{ oauthClientCount > 0 ? 'Manage' : 'Add' }}
+      </button>
+    </div>
+
     <!-- Slack Integration Modal -->
     <UModal v-model="showSlackModal" :ui="{ width: 'max-w-lg' }">
       <SlackIntegrationModal
@@ -181,6 +211,15 @@
         @close="showExcelModal = false"
       />
     </UModal>
+
+    <!-- OAuth Clients Modal -->
+    <UModal v-model="showOAuthModal" :ui="{ width: 'sm:max-w-2xl' }">
+      <OAuthClientsModal
+        v-if="showOAuthModal"
+        @close="showOAuthModal = false"
+        @updated="fetchOAuthClientCount"
+      />
+    </UModal>
   </div>
 </template>
 
@@ -190,6 +229,7 @@ import SlackIntegrationModal from '~/components/SlackIntegrationModal.vue'
 import TeamsIntegrationModal from '~/components/TeamsIntegrationModal.vue'
 import WhatsAppIntegrationModal from '~/components/WhatsAppIntegrationModal.vue'
 import ExcelAddinModal from '~/components/ExcelAddinModal.vue'
+import OAuthClientsModal from '~/components/OAuthClientsModal.vue'
 import McpIcon from '~/components/icons/McpIcon.vue'
 
 definePageMeta({ auth: true, permissions: ['manage_settings'], layout: 'settings' })
@@ -215,6 +255,10 @@ const whatsappIntegrationData = ref<any>(null)
 // MCP state
 const mcpEnabled = ref(false)
 const mcpUpdating = ref(false)
+
+// OAuth clients
+const showOAuthModal = ref(false)
+const oauthClientCount = ref(0)
 
 const { settings, fetchSettings } = useOrgSettings()
 
@@ -275,8 +319,19 @@ async function toggleMcp(value: boolean) {
   }
 }
 
+async function fetchOAuthClientCount() {
+  try {
+    const res = await useMyFetch('/api/oauth/clients')
+    const clients = (res.data.value as any[]) || []
+    oauthClientCount.value = clients.length
+  } catch (e) {
+    oauthClientCount.value = 0
+  }
+}
+
 onMounted(() => {
   fetchIntegrations()
   loadMcpState()
+  fetchOAuthClientCount()
 })
 </script>


### PR DESCRIPTION
…neric

Splits the two concerns that were conflated in the MCP modal:
- OAuth clients are org-scoped (server-side registrations for external apps like Claude Web) — moved to a new OAuthClientsModal accessible from Settings → Integrations, still gated by manage_settings.
- API tokens remain per-user and stay in McpModal.

Also drops the "mcp" hardcoding from the OAuth server so it can back any protected resource: models no longer default scope to "mcp", routes expose SUPPORTED_SCOPES/DEFAULT_SCOPE, and the client service takes scopes as a required argument. Table names (oauth_mcp_*) are preserved to avoid a migration.