### PR TITLE
feat: add OAuth M2M auth to qlik sense connector

### DIFF
--- a/backend/app/data_sources/clients/qlik_sense_client.py
+++ b/backend/app/data_sources/clients/qlik_sense_client.py
@@ -5,16 +5,23 @@ Discovers Qlik apps (models) via the Qlik Cloud REST API and runs hypercube
 queries against them via the Qlik Engine API (QIX), a JSON-RPC 2.0 protocol
 spoken over WebSocket.
 
+Authentication:
+  - ``api_key`` — long-lived bearer token generated in the tenant UI
+    (Settings > API keys). Fastest to set up; single rotatable secret.
+  - ``oauth_m2m`` — OAuth 2.0 Client Credentials. The tenant issues
+    short-lived access tokens in exchange for ``client_id`` + ``client_secret``.
+    Tokens are cached in-process and refreshed before expiry. Preferred for
+    production deployments with secret-rotation policies.
+
 Scope of v1:
-  - Qlik Cloud (tenant.REGION.qlikcloud.com) with API-key bearer auth
+  - Qlik Cloud (tenant.REGION.qlikcloud.com)
   - REST discovery: GET /api/v1/users/me, /api/v1/items?resourceType=app,
     /api/v1/apps/{appId}/data/metadata
   - QIX fallback + query: OpenDoc, GetTablesAndKeys, GetFieldList,
     CreateSessionObject(qHyperCubeDef), GetHyperCubeData
 
-Out of scope for v1: on-prem Enterprise on Windows, OAuth2 Authorization Code,
-M2M impersonation, JWT — all hooks are structured to slot in later without
-rewriting the discovery/query core.
+Out of scope for v1: on-prem Enterprise on Windows, OAuth2 Authorization Code
+(interactive user login), JWT.
 """
 
 from __future__ import annotations
@@ -22,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse, urlunparse
@@ -39,17 +47,26 @@ logger = logging.getLogger(__name__)
 class QlikSenseClient(DataSourceClient):
     """Qlik Sense Cloud client — REST discovery + QIX query over WebSocket."""
 
+    # OAuth tokens are refreshed this many seconds before their advertised expiry.
+    _TOKEN_REFRESH_SKEW_SEC = 60
+
     def __init__(
         self,
         base_url: str,
         api_key: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        scope: Optional[str] = "user_default",
         verify_ssl: bool = True,
         timeout_sec: int = 30,
         space_filter: Optional[str] = None,
         max_concurrency: int = 10,
     ):
         self.base_url = (base_url or "").rstrip("/")
-        self.api_key = api_key
+        self.api_key = api_key or None
+        self.client_id = client_id or None
+        self.client_secret = client_secret or None
+        self.scope = scope or "user_default"
         self.verify_ssl = verify_ssl
         self.timeout_sec = timeout_sec
         self.max_concurrency = max(1, int(max_concurrency or 10))
@@ -60,10 +77,24 @@ class QlikSenseClient(DataSourceClient):
             self._space_filter = tokens or None
 
         self._http: Optional[requests.Session] = None
+        # OAuth M2M token cache
+        self._access_token: Optional[str] = None
+        self._token_expires_at: float = 0.0
 
     # ------------------------------------------------------------------
     # Connection / auth
     # ------------------------------------------------------------------
+
+    @property
+    def _auth_mode(self) -> str:
+        """Which credential was supplied? 'api_key', 'oauth_m2m', or raises."""
+        if self.api_key:
+            return "api_key"
+        if self.client_id and self.client_secret:
+            return "oauth_m2m"
+        raise RuntimeError(
+            "Qlik Sense requires either api_key or (client_id + client_secret)"
+        )
 
     def connect(self) -> None:
         """Set up the REST HTTP session. QIX connections are opened per call."""
@@ -71,13 +102,58 @@ class QlikSenseClient(DataSourceClient):
             return
         if not self.base_url:
             raise RuntimeError("base_url is required")
-        if not self.api_key:
-            raise RuntimeError("api_key is required")
+        # Validate we have *some* credential path (raises on misconfiguration).
+        _ = self._auth_mode
         self._http = requests.Session()
+
+    def _fetch_oauth_token(self) -> None:
+        """Exchange client_id/client_secret for a bearer token via /oauth/token."""
+        url = f"{self.base_url}/oauth/token"
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": self.scope,
+        }
+        # Use a bare requests.post here (not self._http) so token exchange doesn't
+        # try to call _bearer_token() recursively.
+        resp = requests.post(
+            url,
+            data=body,
+            headers={"Accept": "application/json"},
+            timeout=self.timeout_sec,
+            verify=self.verify_ssl,
+        )
+        if resp.status_code >= 300:
+            raise RuntimeError(
+                f"Qlik Cloud OAuth token exchange failed: POST {url} "
+                f"HTTP {resp.status_code} {resp.text[:500]}"
+            )
+        try:
+            data = resp.json() or {}
+        except ValueError as e:
+            raise RuntimeError(f"Qlik Cloud OAuth returned non-JSON: {e}")
+        token = data.get("access_token")
+        if not token:
+            raise RuntimeError("Qlik Cloud OAuth response missing access_token")
+        expires_in = int(data.get("expires_in") or 3600)
+        self._access_token = token
+        self._token_expires_at = time.time() + expires_in
+
+    def _bearer_token(self) -> str:
+        """Return the current bearer token, refreshing OAuth tokens as needed."""
+        mode = self._auth_mode
+        if mode == "api_key":
+            return self.api_key or ""
+        # oauth_m2m — refresh if close to expiry
+        now = time.time()
+        if not self._access_token or now >= (self._token_expires_at - self._TOKEN_REFRESH_SKEW_SEC):
+            self._fetch_oauth_token()
+        return self._access_token or ""
 
     def _auth_headers(self) -> Dict[str, str]:
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {self._bearer_token()}",
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
@@ -515,7 +591,7 @@ class QlikSenseClient(DataSourceClient):
                 ssl_ctx.verify_mode = ssl.CERT_NONE
         else:
             ssl_ctx = None
-        headers = [("Authorization", f"Bearer {self.api_key}")]
+        headers = [("Authorization", f"Bearer {self._bearer_token()}")]
 
         async with websockets.connect(
             url,
@@ -614,7 +690,7 @@ class QlikSenseClient(DataSourceClient):
                 ssl_ctx.verify_mode = ssl.CERT_NONE
         else:
             ssl_ctx = None
-        headers = [("Authorization", f"Bearer {self.api_key}")]
+        headers = [("Authorization", f"Bearer {self._bearer_token()}")]
 
         async with websockets.connect(
             url,

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -52,6 +52,7 @@ from app.schemas.data_sources.configs import (
     # Qlik Sense (live connector)
     QlikSenseConfig,
     QlikSenseApiKeyCredentials,
+    QlikSenseOAuthM2MCredentials,
     # Microsoft Fabric
     MSFabricConfig,
     MSFabricCredentials,
@@ -519,6 +520,11 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
                 "api_key": AuthVariant(
                     title="API Key",
                     schema=QlikSenseApiKeyCredentials,
+                    scopes=["system", "user"],
+                ),
+                "oauth_m2m": AuthVariant(
+                    title="OAuth 2.0 (Client Credentials)",
+                    schema=QlikSenseOAuthM2MCredentials,
                     scopes=["system", "user"],
                 ),
             },

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -734,6 +734,33 @@ class QlikSenseApiKeyCredentials(BaseModel):
     )
 
 
+class QlikSenseOAuthM2MCredentials(BaseModel):
+    """OAuth 2.0 Client Credentials (machine-to-machine) for Qlik Cloud.
+
+    Register an OAuth client in the tenant ('Management Console > Integrations >
+    OAuth') with grant type 'client_credentials' and copy the client id/secret
+    here. Short-lived access tokens are fetched and refreshed automatically.
+    """
+    client_id: str = Field(
+        ...,
+        title="OAuth Client ID",
+        description="OAuth client ID from the Qlik Cloud Management Console.",
+        json_schema_extra={"ui:type": "string"},
+    )
+    client_secret: str = Field(
+        ...,
+        title="OAuth Client Secret",
+        description="OAuth client secret that pairs with the client ID.",
+        json_schema_extra={"ui:type": "password"},
+    )
+    scope: Optional[str] = Field(
+        "user_default",
+        title="Scope",
+        description="OAuth scope requested at token exchange. Default 'user_default' covers standard Qlik Cloud APIs.",
+        json_schema_extra={"ui:type": "string"},
+    )
+
+
 class QlikSenseConfig(BaseModel):
     base_url: str = Field(
         ...,
@@ -1058,6 +1085,7 @@ __all__ = [
     "QVDConfig",
     # Qlik Sense (live connector)
     "QlikSenseApiKeyCredentials",
+    "QlikSenseOAuthM2MCredentials",
     "QlikSenseConfig",
     # Microsoft Fabric
     "MSFabricCredentials",

--- a/backend/tests/unit/test_qlik_sense_client.py
+++ b/backend/tests/unit/test_qlik_sense_client.py
@@ -139,10 +139,21 @@ class TestTransport:
         with pytest.raises(RuntimeError, match="base_url is required"):
             client.connect()
 
-    def test_connect_requires_api_key(self):
+    def test_connect_requires_some_credential(self):
         client = QlikSenseClient(base_url="https://tenant.qlikcloud.com", api_key=None)
-        with pytest.raises(RuntimeError, match="api_key is required"):
+        with pytest.raises(RuntimeError, match="api_key or .*client_id"):
             client.connect()
+
+    def test_connect_accepts_oauth_without_api_key(self):
+        client = QlikSenseClient(
+            base_url="https://tenant.qlikcloud.com",
+            client_id="cid",
+            client_secret="sec",
+        )
+        # connect() should succeed without touching the network; token is
+        # only fetched lazily when an auth header is actually needed.
+        client.connect()
+        assert client._http is not None
 
     def test_rest_get_sets_bearer_header(self):
         client = QlikSenseClient(base_url="https://tenant.qlikcloud.com", api_key="secret-xyz")
@@ -563,3 +574,168 @@ class TestTagsToDtype:
     ])
     def test_tag_priority(self, tags, expected):
         assert _tags_to_dtype(tags) == expected
+
+
+# ---------------------------------------------------------------------------
+# 9. OAuth M2M (Client Credentials)
+# ---------------------------------------------------------------------------
+
+class TestOAuthM2M:
+    def _oauth_client(self, **overrides):
+        kwargs = dict(
+            base_url="https://tenant.qlikcloud.com",
+            client_id="cid-1",
+            client_secret="sec-1",
+        )
+        kwargs.update(overrides)
+        return QlikSenseClient(**kwargs)
+
+    def test_fetch_token_and_use_it_on_rest_calls(self, monkeypatch):
+        client = self._oauth_client()
+
+        token_calls: List[dict] = []
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            token_calls.append({"url": url, "data": dict(data or {})})
+            return _json_response(
+                {"access_token": "tok-abc", "token_type": "bearer", "expires_in": 3600}
+            )
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        session = _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+
+        client._rest_get("/api/v1/users/me")
+
+        # Token was fetched exactly once
+        assert len(token_calls) == 1
+        assert token_calls[0]["url"] == "https://tenant.qlikcloud.com/oauth/token"
+        assert token_calls[0]["data"]["grant_type"] == "client_credentials"
+        assert token_calls[0]["data"]["client_id"] == "cid-1"
+        assert token_calls[0]["data"]["client_secret"] == "sec-1"
+        # REST call used the fresh token
+        _, kwargs = session.get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok-abc"
+
+    def test_token_is_cached_across_calls(self, monkeypatch):
+        client = self._oauth_client()
+        call_count = {"n": 0}
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            call_count["n"] += 1
+            return _json_response(
+                {"access_token": f"tok-{call_count['n']}", "expires_in": 3600}
+            )
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        _install_rest(client, {
+            "/api/v1/users/me": USERS_ME_OK,
+            "/api/v1/items": {"data": [], "links": {}},
+        })
+
+        client._rest_get("/api/v1/users/me")
+        client._rest_get("/api/v1/users/me")
+        client._rest_get("/api/v1/items")
+        assert call_count["n"] == 1
+        assert client._access_token == "tok-1"
+
+    def test_expired_token_is_refreshed(self, monkeypatch):
+        client = self._oauth_client()
+        tokens = iter(["tok-1", "tok-2"])
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            return _json_response({"access_token": next(tokens), "expires_in": 3600})
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        session = _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+
+        client._rest_get("/api/v1/users/me")
+        assert client._access_token == "tok-1"
+        # Force expiry past the refresh skew window
+        client._token_expires_at = 0.0
+        client._rest_get("/api/v1/users/me")
+        assert client._access_token == "tok-2"
+        # Second REST call used the refreshed token
+        _, kwargs = session.get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok-2"
+
+    def test_token_endpoint_failure_raises(self, monkeypatch):
+        client = self._oauth_client()
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            return _json_response({"error": "invalid_client"}, status=401)
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+        with pytest.raises(RuntimeError, match="OAuth token exchange failed"):
+            client._rest_get("/api/v1/users/me")
+
+    def test_missing_access_token_in_response_raises(self, monkeypatch):
+        client = self._oauth_client()
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            return _json_response({"token_type": "bearer"})  # no access_token
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+        with pytest.raises(RuntimeError, match="missing access_token"):
+            client._rest_get("/api/v1/users/me")
+
+    def test_api_key_takes_priority_over_oauth_when_both_set(self, monkeypatch):
+        """If api_key is present, we never hit /oauth/token."""
+        client = QlikSenseClient(
+            base_url="https://tenant.qlikcloud.com",
+            api_key="direct-key",
+            client_id="cid",
+            client_secret="sec",
+        )
+
+        def _fake_post(*a, **kw):
+            raise AssertionError("OAuth token endpoint must not be called when api_key is set")
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        session = _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+        client._rest_get("/api/v1/users/me")
+        _, kwargs = session.get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer direct-key"
+
+    def test_default_scope_is_user_default(self, monkeypatch):
+        client = self._oauth_client()
+        captured: dict = {}
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            captured.update(data or {})
+            return _json_response({"access_token": "t", "expires_in": 3600})
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+        client._rest_get("/api/v1/users/me")
+        assert captured.get("scope") == "user_default"
+
+    def test_custom_scope_is_forwarded(self, monkeypatch):
+        client = self._oauth_client(scope="admin_classic")
+        captured: dict = {}
+
+        def _fake_post(url, data=None, headers=None, timeout=None, verify=None):
+            captured.update(data or {})
+            return _json_response({"access_token": "t", "expires_in": 3600})
+
+        monkeypatch.setattr(
+            "app.data_sources.clients.qlik_sense_client.requests.post", _fake_post
+        )
+        _install_rest(client, {"/api/v1/users/me": USERS_ME_OK})
+        client._rest_get("/api/v1/users/me")
+        assert captured.get("scope") == "admin_classic"


### PR DESCRIPTION
Adds OAuth 2.0 Client Credentials (machine-to-machine) alongside the existing API-key auth on the Qlik Sense data source.

- New QlikSenseOAuthM2MCredentials schema (client_id, client_secret, scope) registered as the "oauth_m2m" AuthVariant next to "api_key"
- QlikSenseClient now accepts client_id/client_secret/scope kwargs and exchanges them for short-lived access tokens at /oauth/token, caching the token and refreshing 60s before expiry
- Single _bearer_token() helper routes both REST and QIX WebSocket auth through the same code path; api_key takes priority when both are set
- 8 new unit tests: token fetch, caching, refresh on expiry, token endpoint failure, missing access_token, api_key priority, default scope, custom scope