### PR TITLE
fix(docker): copy repo-root locales/ into frontend-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,10 @@ COPY ./bow-config.yaml /app/bow-config.yaml
 # Copy the frontend directory contents
 COPY ./frontend /app/frontend
 
+# `frontend/plugins/i18n.ts` imports `../../locales/*.json` at build time,
+# so the repo-root `locales/` dir must be present for Rollup to resolve them.
+COPY ./locales /app/locales
+
 # Set working directory for frontend
 WORKDIR /app/frontend
 


### PR DESCRIPTION
frontend/plugins/i18n.ts imports ../../locales/*.json, which resolves to /app/locales/ during `nuxt generate`. Without this COPY the Rollup build fails with "Could not resolve ../../locales/en.json".