### PR TITLE
background schema indexing + richer test_connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 backend/uploads/
 backend/db/
+backend/*.db
 backend/venv/
 backend/backend_venv/
 backend/.venv/

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -59,6 +59,7 @@ from app.models.visualization import Visualization
 from app.models.user_data_source_credentials import UserDataSourceCredentials
 from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable, UserDataSourceColumn as UserOverlayColumn
 from app.models.connection import Connection
+from app.models.connection_indexing import ConnectionIndexing
 from app.models.connection_table import ConnectionTable
 from app.models.connection_tool import ConnectionTool
 from app.models.user_connection_tool import UserConnectionTool

--- a/backend/alembic/versions/c5d6e7f8a9b0_add_connection_indexings.py
+++ b/backend/alembic/versions/c5d6e7f8a9b0_add_connection_indexings.py
@@ -1,0 +1,61 @@
+"""add connection_indexings table
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4c5d6e7f8a9
+Create Date: 2026-04-24 20:00:00.000000
+
+Background-job tracking for schema discovery on a Connection. One row per
+refresh attempt. The service layer enforces at most one non-terminal row
+per connection.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c5d6e7f8a9b0'
+down_revision: Union[str, None] = 'b4c5d6e7f8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'connection_indexings',
+        sa.Column('connection_id', sa.String(length=36), nullable=False),
+        sa.Column('status', sa.String(), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column('phase', sa.String(length=64), nullable=True),
+        sa.Column('current_item', sa.String(), nullable=True),
+        sa.Column('progress_done', sa.Integer(), nullable=False, server_default=sa.text('0')),
+        sa.Column('progress_total', sa.Integer(), nullable=False, server_default=sa.text('0')),
+        sa.Column('started_at', sa.DateTime(), nullable=True),
+        sa.Column('finished_at', sa.DateTime(), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('stats_json', sa.JSON(), nullable=True),
+        sa.Column('id', sa.String(length=36), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['connection_id'], ['connections.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    with op.batch_alter_table('connection_indexings', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_connection_indexings_id'), ['id'], unique=True)
+        batch_op.create_index(batch_op.f('ix_connection_indexings_connection_id'), ['connection_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_connection_indexings_status'), ['status'], unique=False)
+        batch_op.create_index(
+            'ix_connection_indexings_conn_created',
+            ['connection_id', 'created_at'],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('connection_indexings', schema=None) as batch_op:
+        batch_op.drop_index('ix_connection_indexings_conn_created')
+        batch_op.drop_index(batch_op.f('ix_connection_indexings_status'))
+        batch_op.drop_index(batch_op.f('ix_connection_indexings_connection_id'))
+        batch_op.drop_index(batch_op.f('ix_connection_indexings_id'))
+    op.drop_table('connection_indexings')

--- a/backend/alembic/versions/d6e7f8a9b0c1_add_events_json.py
+++ b/backend/alembic/versions/d6e7f8a9b0c1_add_events_json.py
@@ -1,0 +1,29 @@
+"""add events_json to connection_indexings
+
+Revision ID: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
+Create Date: 2026-04-25 09:00:00.000000
+
+Per-run event log for indexing — phase transitions, item milestones, errors,
+completion. Capped at ~200 entries by the runner; this column is just storage.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd6e7f8a9b0c1'
+down_revision: Union[str, None] = 'c5d6e7f8a9b0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('connection_indexings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('events_json', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('connection_indexings', schema=None) as batch_op:
+        batch_op.drop_column('events_json')

--- a/backend/alembic/versions/d6e7f8a9b0c1_add_events_json.py
+++ b/backend/alembic/versions/d6e7f8a9b0c1_add_events_json.py
@@ -1,7 +1,7 @@
 """add events_json to connection_indexings
 
 Revision ID: d6e7f8a9b0c1
-Revises: c5d6e7f8a9b0
+Revises: f1a2b3c4d5e7
 Create Date: 2026-04-25 09:00:00.000000
 
 Per-run event log for indexing — phase transitions, item milestones, errors,
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 
 revision: str = 'd6e7f8a9b0c1'
-down_revision: Union[str, None] = 'c5d6e7f8a9b0'
+down_revision: Union[str, None] = 'f1a2b3c4d5e7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/f1a2b3c4d5e7_add_dst_datasource_active_index.py
+++ b/backend/alembic/versions/f1a2b3c4d5e7_add_dst_datasource_active_index.py
@@ -1,0 +1,34 @@
+"""add composite index on datasource_tables(datasource_id, is_active)
+
+Revision ID: f1a2b3c4d5e7
+Revises: b4c5d6e7f8a9
+Create Date: 2026-04-24 00:00:00.000000
+
+Customers with thousands of datasource_tables per data source (mostly inactive)
+were seeing full seqscans on every schema_context_builder query — which also
+pulls large JSON columns (columns/pks/fks/metadata_json) during filtering.
+Composite index lets the filter `datasource_id = ? AND is_active = True` be
+index-only for row selection.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'f1a2b3c4d5e7'
+down_revision: Union[str, None] = 'b4c5d6e7f8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'ix_dst_ds_active',
+        'datasource_tables',
+        ['datasource_id', 'is_active'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_dst_ds_active', table_name='datasource_tables')

--- a/backend/alembic/versions/f1a2b3c4d5e7_add_dst_datasource_active_index.py
+++ b/backend/alembic/versions/f1a2b3c4d5e7_add_dst_datasource_active_index.py
@@ -1,7 +1,7 @@
 """add composite index on datasource_tables(datasource_id, is_active)
 
 Revision ID: f1a2b3c4d5e7
-Revises: b4c5d6e7f8a9
+Revises: c5d6e7f8a9b0
 Create Date: 2026-04-24 00:00:00.000000
 
 Customers with thousands of datasource_tables per data source (mostly inactive)
@@ -16,7 +16,7 @@ from alembic import op
 
 
 revision: str = 'f1a2b3c4d5e7'
-down_revision: Union[str, None] = 'b4c5d6e7f8a9'
+down_revision: Union[str, None] = 'c5d6e7f8a9b0'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1464,9 +1464,44 @@ class AgentV2:
 
                 # Write-on-complete: no skeleton PlanDecision written here.
                 # The final PlanDecision + CompletionBlock are written once at planner.decision.final.
-                
+
+                async def _cancel_skeleton_block(reason: str):
+                    """Emit a cancelled block.upsert for the pre-created skeleton so the UI
+                    doesn't leave an empty 'Planning (action)' card hanging when a retry or
+                    interrupt path skips the decision.final persist."""
+                    if not current_block_id:
+                        return
+                    try:
+                        _c_seq = await self.project_manager.next_seq(
+                            self.db, self.current_execution
+                        )
+                        await self._emit_sse_event(SSEEvent(
+                            event="block.upsert",
+                            completion_id=str(self.system_completion.id),
+                            agent_execution_id=str(self.current_execution.id),
+                            seq=_c_seq,
+                            data={"block": {
+                                "id": current_block_id,
+                                "source_type": "decision",
+                                "loop_index": loop_index,
+                                "status": "cancelled",
+                                "title": "Planning (cancelled)",
+                                "icon": "🧠",
+                                "content": None,
+                                "reasoning": None,
+                                "plan_decision_id": None,
+                                "tool_execution_id": None,
+                                "started_at": None,
+                                "completed_at": None,
+                                "cancel_reason": reason,
+                            }}
+                        ))
+                    except Exception as _cexc:
+                        logger.debug(f"[agent] cancel_skeleton emit failed: {_cexc!r}")
+
                 async for evt in self.planner.execute(planner_input, self.sigkill_event):
                     if self.sigkill_event.is_set():
+                        await _cancel_skeleton_block("sigkill")
                         break
 
                     # Handle typed events
@@ -1527,6 +1562,7 @@ class AgentV2:
                             if invalid_retry_count >= max_invalid_retries:
                                 # Too many retries, treat as final error
                                 analysis_done = True
+                                await _cancel_skeleton_block("max_invalid_retries")
                                 break
                             observation = {
                                 "summary": "Planner output invalid; retrying",
@@ -1551,6 +1587,9 @@ class AgentV2:
                                 ))
                             except Exception:
                                 pass
+                            # Cancel the skeleton block so the UI doesn't keep an empty
+                            # "Planning (action)" card from the previous attempt.
+                            await _cancel_skeleton_block("validation_error")
                             # Stop streaming loop; outer loop will attempt again
                             break
                         

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -20,6 +20,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 logger = get_logger(__name__)
 tracer = get_tracer(__name__)
 
+# Shared reference to the app's main asyncio loop. Populated lazily the
+# first time _schedule_usage_record runs from an async context, so that
+# later calls from worker threads (e.g. asyncio.to_thread(llm.inference))
+# can still schedule usage recording via run_coroutine_threadsafe.
+_MAIN_LOOP: Optional[asyncio.AbstractEventLoop] = None
+
 
 class LLM:
     def __init__(
@@ -360,10 +366,21 @@ class LLM:
             logger.debug("Failed to create LLM usage record coroutine: %s", exc)
             return
 
+        global _MAIN_LOOP
         try:
             loop = asyncio.get_running_loop()
+            _MAIN_LOOP = loop
         except RuntimeError:
-            logger.debug("Skipping LLM usage recording; no running loop for scope %s", scope)
+            # Called from a worker thread (e.g. asyncio.to_thread(llm.inference)).
+            # Fall back to the main loop captured from a previous async call.
+            loop = _MAIN_LOOP if (_MAIN_LOOP is not None and _MAIN_LOOP.is_running()) else None
+            if loop is None:
+                logger.debug("Skipping LLM usage recording; no running loop for scope %s", scope)
+                return
+            try:
+                asyncio.run_coroutine_threadsafe(coroutine, loop)
+            except Exception as exc:
+                logger.warning("Unable to schedule LLM usage recording (threadsafe): %s", exc)
             return
         try:
             loop.create_task(coroutine)

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -1,11 +1,14 @@
 import json
 import asyncio
+import logging
+import time as _time
 from typing import AsyncIterator, Dict, Any, Type, Optional, List, Union
 from pydantic import BaseModel
 from app.core.otel import get_tracer
 from app.ee.audit.tool_audit import log_tool_audit, _truncate_queries
 
 tracer = get_tracer(__name__)
+logger = logging.getLogger(__name__)
 
 from app.ai.tools.base import Tool
 from app.ai.tools.metadata import ToolMetadata
@@ -554,10 +557,22 @@ Include "filters" only when narrowing the data to a specific slice.
 Reminder: use exact column names from: {column_names}
 Do not use generic placeholders like "value" unless that is the actual column name."""
 
+        _viz_t0 = _time.perf_counter()
         try:
-            raw = llm.inference(prompt, usage_scope="create_data.viz_infer")
+            # Offload sync LLM call so we don't block the event loop for the
+            # full inference duration — other requests on this worker would
+            # otherwise stall behind every create_data viz inference.
+            raw = await asyncio.to_thread(
+                llm.inference, prompt, usage_scope="create_data.viz_infer"
+            )
         except Exception:
             raw = None
+        finally:
+            logger.info(
+                "create_data.viz_infer elapsed_ms=%.0f got_raw=%s",
+                (_time.perf_counter() - _viz_t0) * 1000.0,
+                raw is not None,
+            )
 
         candidate = {"type": "table", "series": []}
         view_options: Dict[str, Any] | None = None
@@ -642,9 +657,15 @@ Do not use generic placeholders like "value" unless that is the actual column na
                         break
                 name_patterns = [f"(?i){re.escape(k)}" for k in keywords] if keywords else None
 
+                _t0 = _time.perf_counter()
                 ctx = await context_hub.schema_builder.build(
                     with_stats=True,
                     name_patterns=name_patterns,
+                )
+                logger.info(
+                    "create_data.schema_build stage=fallback_excerpt elapsed_ms=%.0f patterns=%d",
+                    (_time.perf_counter() - _t0) * 1000.0,
+                    len(name_patterns or []),
                 )
                 return ctx.render_combined(top_k_per_ds=top_k, index_limit=0, include_index=False)
             _schemas_section_obj = getattr(context_view.static, "schemas", None) if context_view else None
@@ -704,10 +725,17 @@ Do not use generic placeholders like "value" unless that is the actual column na
 
                 # Resolve via schema_builder (only returns active tables)
                 try:
+                    _t0 = _time.perf_counter()
                     ctx = await schema_builder.build(
                         with_stats=False,
                         data_source_ids=[ds_id] if ds_id else None,
                         name_patterns=name_patterns,
+                    )
+                    logger.info(
+                        "create_data.schema_build stage=resolve_active ds_id=%s elapsed_ms=%.0f patterns=%d",
+                        ds_id,
+                        (_time.perf_counter() - _t0) * 1000.0,
+                        len(name_patterns),
                     )
 
                     # Extract resolved table names per data source
@@ -973,10 +1001,17 @@ Do not use generic placeholders like "value" unless that is the actual column na
                 import re
                 name_patterns = [f"(?i)(?:^|\\.){re.escape(n)}$" for n in all_resolved_names] if all_resolved_names else None
                 
+                _t0 = _time.perf_counter()
                 ctx = await context_hub.schema_builder.build(
                     with_stats=True,
                     data_source_ids=ds_scope,
                     name_patterns=name_patterns,
+                )
+                logger.info(
+                    "create_data.schema_build stage=final_excerpt elapsed_ms=%.0f ds_count=%d patterns=%d",
+                    (_time.perf_counter() - _t0) * 1000.0,
+                    len(ds_scope or []),
+                    len(name_patterns or []),
                 )
                 schemas_excerpt = ctx.render_combined(top_k_per_ds=20, index_limit=0, include_index=False)
             except Exception as e:

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -1,3 +1,5 @@
+import os
+import fcntl
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from app.settings.database import create_database_engine
@@ -13,3 +15,34 @@ scheduler = AsyncIOScheduler(
         'default': jobstore
     }
 )
+
+
+_LEADER_LOCK_FD = None
+
+
+def try_acquire_scheduler_leader() -> bool:
+    """Return True if this process wins the scheduler leader lock.
+
+    Multi-worker uvicorn deployments otherwise run every scheduled job N
+    times (once per worker), which is what turns warmup jobs into resource
+    storms at customer sites. The lock is held for the lifetime of the
+    process — a crashed leader releases the flock and the next worker to
+    start wins on its next startup.
+
+    Override via BOW_SCHEDULER_LEADER=1 to force-enable (useful when running
+    a dedicated scheduler sidecar) or BOW_SCHEDULER_DISABLED=1 to opt out.
+    """
+    if os.environ.get("BOW_SCHEDULER_DISABLED") == "1":
+        return False
+    if os.environ.get("BOW_SCHEDULER_LEADER") == "1":
+        return True
+
+    global _LEADER_LOCK_FD
+    lock_path = os.environ.get("BOW_SCHEDULER_LOCK_PATH", "/tmp/bow-scheduler.lock")
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        _LEADER_LOCK_FD = fd  # keep fd alive for process lifetime
+        return True
+    except (OSError, BlockingIOError):
+        return False

--- a/backend/app/data_sources/clients/base.py
+++ b/backend/app/data_sources/clients/base.py
@@ -1,5 +1,8 @@
 import asyncio
 from abc import ABC, abstractmethod
+from typing import Optional
+
+from app.data_sources.clients.progress import ProgressCallback
 
 
 class DataSourceClient(ABC):
@@ -40,8 +43,20 @@ class DataSourceClient(ABC):
     async def atest_connection(self):
         return await asyncio.to_thread(self.test_connection)
 
-    async def aget_schemas(self):
-        return await asyncio.to_thread(self.get_schemas)
+    async def aget_schemas(self, progress_callback: Optional[ProgressCallback] = None):
+        """Default: forwards `progress_callback` to the sync `get_schemas`.
+
+        Subclasses whose `get_schemas()` accepts a `progress_callback` kwarg will
+        report progress; others receive the callback but ignore it. Either way
+        behavior is unchanged when no callback is supplied.
+        """
+        if progress_callback is None:
+            return await asyncio.to_thread(self.get_schemas)
+        # Try the modern signature first; fall back to the legacy 0-arg form.
+        try:
+            return await asyncio.to_thread(self.get_schemas, progress_callback=progress_callback)
+        except TypeError:
+            return await asyncio.to_thread(self.get_schemas)
 
     async def aget_schema(self, table_name):
         return await asyncio.to_thread(self.get_schema, table_name)

--- a/backend/app/data_sources/clients/base.py
+++ b/backend/app/data_sources/clients/base.py
@@ -1,8 +1,26 @@
 import asyncio
+import inspect
 from abc import ABC, abstractmethod
 from typing import Optional
 
 from app.data_sources.clients.progress import ProgressCallback
+
+
+def _accepts_progress_callback(fn) -> bool:
+    """Inspect a `get_schemas`-like method to see if it accepts a
+    `progress_callback` kwarg. Used by the async wrapper so we don't catch a
+    bare `TypeError` raised from inside the call (which would mask real bugs
+    inside the client).
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    params = sig.parameters
+    if "progress_callback" in params:
+        return True
+    # Accept anything with **kwargs since it'll silently ignore the kwarg.
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 class DataSourceClient(ABC):
@@ -44,19 +62,16 @@ class DataSourceClient(ABC):
         return await asyncio.to_thread(self.test_connection)
 
     async def aget_schemas(self, progress_callback: Optional[ProgressCallback] = None):
-        """Default: forwards `progress_callback` to the sync `get_schemas`.
+        """Forwards `progress_callback` to the sync `get_schemas` only if it
+        accepts the kwarg, determined by signature introspection.
 
-        Subclasses whose `get_schemas()` accepts a `progress_callback` kwarg will
-        report progress; others receive the callback but ignore it. Either way
-        behavior is unchanged when no callback is supplied.
+        We do NOT catch a bare `TypeError` from the call: a real `TypeError`
+        from inside `get_schemas` (e.g. a bug in a client) should surface,
+        not be silently retried without progress.
         """
-        if progress_callback is None:
+        if progress_callback is None or not _accepts_progress_callback(self.get_schemas):
             return await asyncio.to_thread(self.get_schemas)
-        # Try the modern signature first; fall back to the legacy 0-arg form.
-        try:
-            return await asyncio.to_thread(self.get_schemas, progress_callback=progress_callback)
-        except TypeError:
-            return await asyncio.to_thread(self.get_schemas)
+        return await asyncio.to_thread(self.get_schemas, progress_callback=progress_callback)
 
     async def aget_schema(self, table_name):
         return await asyncio.to_thread(self.get_schema, table_name)

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.data_sources.clients.base import DataSourceClient
+from app.data_sources.clients.progress import ProgressCallback, make_reporter
 from app.ai.prompt_formatters import Table, TableColumn, ForeignKey, ServiceFormatter
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -814,22 +815,40 @@ class PowerBIReportServerClient(DataSourceClient):
     # ------------------------------------------------------------------
 
     def test_connection(self) -> Dict:
+        import time as _time
+
+        t0 = _time.perf_counter()
         try:
             self.connect()
         except Exception as e:
-            return {"success": False, "message": f"Session init failed: {e}"}
+            return {"success": False, "message": f"Session init failed: {e}", "details": {}}
 
+        auth_ms = round((_time.perf_counter() - t0) * 1000, 1)
+        t1 = _time.perf_counter()
         try:
             sys_info = self.get_system_info()
         except Exception as e:
             msg = str(e)
             if "401" in msg or "Unauthorized" in msg:
-                return {"success": False, "message": f"Authentication failed: check username, domain, and password ({msg[:180]})"}
-            return {"success": False, "message": f"Cannot reach server: {msg[:200]}"}
+                return {
+                    "success": False,
+                    "message": f"Authentication failed: check username, domain, and password ({msg[:180]})",
+                    "timings": {"auth_ms": auth_ms},
+                    "details": {},
+                }
+            return {
+                "success": False,
+                "message": f"Cannot reach server: {msg[:200]}",
+                "timings": {"auth_ms": auth_ms},
+                "details": {},
+            }
+
+        system_ms = round((_time.perf_counter() - t1) * 1000, 1)
 
         product = sys_info.get("ProductName") or "Power BI Report Server"
         version = sys_info.get("ProductVersion") or ""
 
+        t2 = _time.perf_counter()
         try:
             pbi = self.list_powerbi_reports()
             paginated = self.list_paginated_reports()
@@ -840,7 +859,12 @@ class PowerBIReportServerClient(DataSourceClient):
                 "success": False,
                 "message": f"Authenticated with {product} {version} but could not list catalog: {e}",
                 "connectivity": True,
+                "timings": {"auth_ms": auth_ms, "system_ms": system_ms},
+                "details": {"product_version": version},
             }
+        catalog_ms = round((_time.perf_counter() - t2) * 1000, 1)
+
+        auth_mode = "NTLM" if self.domain or "\\" in (self.username or "") else "Basic"
 
         return {
             "success": True,
@@ -854,19 +878,35 @@ class PowerBIReportServerClient(DataSourceClient):
             "shared_datasets": len(shared_datasets),
             "kpis": len(kpis),
             "product_version": version,
+            "timings": {
+                "auth_ms": auth_ms,
+                "system_ms": system_ms,
+                "catalog_ms": catalog_ms,
+            },
+            "details": {
+                "product": product,
+                "product_version": version,
+                "auth_mode": auth_mode,
+                "powerbi_reports": len(pbi),
+                "paginated_reports": len(paginated),
+                "shared_datasets": len(shared_datasets),
+                "kpis": len(kpis),
+            },
         }
 
     # ------------------------------------------------------------------
     # get_schemas — build BOW Table objects
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[Table]:
+    def get_schemas(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
         """Build Table objects for:
           - Each Power BI report (.pbix) — one Table per report (columns empty; metadata carries data sources)
           - Each paginated report (RDL) dataset — one Table per DataSet inside the RDL (columns + CommandText)
           - Each shared dataset (.rsd) — one Table with schema columns and CommandText
           - Each KPI — one Table representing the metric (for LLM awareness)
         """
+        reporter = make_reporter(progress_callback)
+        reporter.phase("listing")
         self.connect()
         tables: List[Table] = []
 
@@ -904,6 +944,10 @@ class PowerBIReportServerClient(DataSourceClient):
                 logger.warning(f"list_shared_data_sources failed: {e}")
                 shared_ds_sources = []
 
+        reporter.phase(
+            "pbix_reports",
+            total=len(pbi_reports) if self.extract_pbix_schemas else 0,
+        )
         # ---- Power BI reports ----
         if pbi_reports:
             with ThreadPoolExecutor(max_workers=8) as pool:
@@ -951,6 +995,7 @@ class PowerBIReportServerClient(DataSourceClient):
                             pbix_schemas[r["Id"]] = fut.result()
                         except Exception as e:
                             logger.debug(f"pbix schema extract failed for {r['Id']}: {e}")
+                        reporter.item(r.get("Name") or r["Id"])
 
             for r in pbi_reports:
                 rid = r["Id"]
@@ -1070,6 +1115,7 @@ class PowerBIReportServerClient(DataSourceClient):
                             },
                         ))
 
+        reporter.phase("rdl_reports", total=len(rdl_reports))
         # ---- Paginated RDL reports: download content + parse ----
         if rdl_reports:
             with ThreadPoolExecutor(max_workers=6) as pool:
@@ -1078,6 +1124,7 @@ class PowerBIReportServerClient(DataSourceClient):
                     r = content_futs[fut]
                     rid = r["Id"]
                     rname = r.get("Name") or rid
+                    reporter.item(rname)
                     try:
                         xml_bytes = fut.result()
                         parsed = self.parse_rdl_content(xml_bytes)
@@ -1163,6 +1210,7 @@ class PowerBIReportServerClient(DataSourceClient):
                             }},
                         ))
 
+        reporter.phase("shared_datasets", total=len(shared_datasets))
         # ---- Shared datasets: fetch schema + content ----
         if shared_datasets:
             with ThreadPoolExecutor(max_workers=6) as pool:
@@ -1180,6 +1228,7 @@ class PowerBIReportServerClient(DataSourceClient):
                         schemas[d["Id"]] = fut.result()
                     except Exception as e:
                         logger.debug(f"dataset {d['Id']} schema failed: {e}")
+                    reporter.item(d.get("Name") or d["Id"])
                 for fut in as_completed(content_futs):
                     d = content_futs[fut]
                     try:
@@ -1254,8 +1303,10 @@ class PowerBIReportServerClient(DataSourceClient):
                     metadata_json=metadata_json,
                 ))
 
+        reporter.phase("kpis", total=len(kpis or []))
         # ---- KPIs ----
         for k in kpis or []:
+            reporter.item(k.get("Name") or k.get("Id"))
             kid = k.get("Id")
             kname = k.get("Name") or kid
             metadata_json = {
@@ -1283,6 +1334,7 @@ class PowerBIReportServerClient(DataSourceClient):
                 metadata_json=metadata_json,
             ))
 
+        reporter.done()
         return tables
 
     def get_schema(self, table_name: str) -> Table:

--- a/backend/app/data_sources/clients/progress.py
+++ b/backend/app/data_sources/clients/progress.py
@@ -1,0 +1,97 @@
+"""Progress reporting plumbing for DataSourceClient.get_schemas.
+
+Clients accept an optional `progress_callback`. When set, they invoke it from
+inside their existing iteration loops — never from new round-trips. When unset
+(the default), the callback is a no-op and behavior is unchanged.
+
+The callback signature is:
+
+    callback(phase: str | None, current_item: str | None, done: int, total: int) -> None | Awaitable[None]
+
+Callbacks may be sync or coroutine functions; `ProgressReporter.emit` handles
+both. Emissions are debounced at the source (per-call) — runners are expected
+to rate-limit DB writes separately.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, Awaitable, Callable, Optional, Union
+
+
+# A callback may be sync or async. Both return None in practice.
+ProgressCallback = Callable[
+    [Optional[str], Optional[str], int, int],
+    Union[None, Awaitable[None]],
+]
+
+
+class ProgressReporter:
+    """Cheap no-op when no callback is set; else forwards emissions."""
+
+    __slots__ = ("_cb", "_phase", "_done", "_total")
+
+    def __init__(self, callback: Optional[ProgressCallback] = None) -> None:
+        self._cb = callback
+        self._phase: Optional[str] = None
+        self._done = 0
+        self._total = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._cb is not None
+
+    def phase(self, phase: str, total: int = 0) -> None:
+        """Begin a new phase. Resets done counter; sets total if provided."""
+        self._phase = phase
+        self._done = 0
+        self._total = total
+        self._emit(None)
+
+    def set_total(self, total: int) -> None:
+        self._total = total
+        self._emit(None)
+
+    def item(self, current_item: Optional[str], done: Optional[int] = None) -> None:
+        """Report progress on a single item within the current phase."""
+        if done is not None:
+            self._done = done
+        else:
+            self._done += 1
+        self._emit(current_item)
+
+    def tick(self, current_item: Optional[str] = None) -> None:
+        """Alias for `item()` with auto-increment."""
+        self.item(current_item)
+
+    def done(self, total: Optional[int] = None) -> None:
+        """Mark the current phase done. Sets done == total."""
+        if total is not None:
+            self._total = total
+        self._done = self._total
+        self._emit(None)
+
+    def _emit(self, current_item: Optional[str]) -> None:
+        if self._cb is None:
+            return
+        try:
+            result = self._cb(self._phase, current_item, self._done, self._total)
+            if inspect.isawaitable(result):
+                # Best-effort fire-and-forget when called from sync code. If the
+                # loop isn't running, run it to completion synchronously.
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(result)  # type: ignore[arg-type]
+                except RuntimeError:
+                    asyncio.run(result)  # type: ignore[arg-type]
+        except Exception:
+            # Progress reporting must never break schema discovery.
+            pass
+
+
+def noop_reporter() -> ProgressReporter:
+    return ProgressReporter(None)
+
+
+def make_reporter(callback: Optional[ProgressCallback]) -> ProgressReporter:
+    return ProgressReporter(callback)

--- a/backend/app/data_sources/clients/qvd_client.py
+++ b/backend/app/data_sources/clients/qvd_client.py
@@ -11,13 +11,14 @@ import time
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 import duckdb
 import pandas as pd
 
 from app.ai.prompt_formatters import Table, TableColumn, TableFormatter
 from app.data_sources.clients.base import DataSourceClient
+from app.data_sources.clients.progress import ProgressCallback, make_reporter
 from app.settings.logging_config import get_logger
 
 
@@ -311,7 +312,7 @@ class QVDClient(DataSourceClient):
         with self.connect() as con:
             return con.execute(sql).df()
 
-    def get_tables(self) -> List[Table]:
+    def get_tables(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
         """
         Schema lookup. Uses DuckDB DESCRIBE on the cached Parquet when available
         (ground truth for queries); otherwise falls back to the QVD XML header.
@@ -319,7 +320,11 @@ class QVDClient(DataSourceClient):
         """
         tables: List[Table] = []
         used: set[str] = set()
-        for filepath in self._resolve_files():
+        files = self._resolve_files()
+        reporter = make_reporter(progress_callback)
+        reporter.phase("qvd_files", total=len(files))
+        for filepath in files:
+            reporter.item(os.path.basename(filepath))
             table_name = self._safe_table_name(filepath, used)
             cols: List[TableColumn] = []
             try:
@@ -339,10 +344,11 @@ class QVDClient(DataSourceClient):
                 fks=[],
                 metadata_json={"qvd": {"source_file": filepath}}
             ))
+        reporter.done()
         return tables
 
-    def get_schemas(self) -> List[Table]:
-        return self.get_tables()
+    def get_schemas(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
+        return self.get_tables(progress_callback=progress_callback)
 
     def get_schema(self, table_name: str) -> Table:
         for t in self.get_tables():
@@ -360,16 +366,32 @@ class QVDClient(DataSourceClient):
             if not files:
                 return {
                     "success": False,
-                    "message": "No QVD files found matching the patterns"
+                    "message": "No QVD files found matching the patterns",
+                    "details": {"files_found": 0, "patterns": self.patterns},
                 }
+            total_bytes = 0
+            cached_parquets = 0
             for f in files:
+                try:
+                    total_bytes += os.path.getsize(f)
+                except OSError:
+                    pass
+                _, cache_path = self._cache_key(f)
+                if cache_path.exists():
+                    cached_parquets += 1
                 self._read_qvd_header(f)
             return {
                 "success": True,
-                "message": f"Successfully verified {len(files)} QVD file(s)"
+                "message": f"Successfully verified {len(files)} QVD file(s)",
+                "details": {
+                    "files_found": len(files),
+                    "total_bytes": total_bytes,
+                    "cached_parquets": cached_parquets,
+                    "sample_files": [os.path.basename(f) for f in files[:5]],
+                },
             }
         except Exception as e:
-            return {"success": False, "message": str(e)}
+            return {"success": False, "message": str(e), "details": {}}
 
     @property
     def description(self) -> str:

--- a/backend/app/data_sources/clients/sqlite_client.py
+++ b/backend/app/data_sources/clients/sqlite_client.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import sqlite3
 from contextlib import contextmanager
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 import pandas as pd
 
 from app.ai.prompt_formatters import Table, TableColumn, TableFormatter
 from app.data_sources.clients.base import DataSourceClient
+from app.data_sources.clients.progress import ProgressCallback, make_reporter
 
 
 class SqliteClient(DataSourceClient):
@@ -38,15 +39,19 @@ class SqliteClient(DataSourceClient):
             print(f"Error executing SQL: {exc}")
             raise
 
-    def get_tables(self) -> List[Table]:
+    def get_tables(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
+        reporter = make_reporter(progress_callback)
         try:
             with self.connect() as conn:
                 cursor = conn.cursor()
                 cursor.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
                 )
+                names = [row[0] for row in cursor.fetchall()]
+                reporter.phase("tables", total=len(names))
                 tables: List[Table] = []
-                for (table_name,) in cursor.fetchall():
+                for table_name in names:
+                    reporter.item(table_name)
                     cursor.execute(f"PRAGMA table_info('{table_name}')")
                     columns = [
                         TableColumn(name=row["name"], dtype=row["type"] or "unknown")
@@ -61,13 +66,14 @@ class SqliteClient(DataSourceClient):
                             metadata_json={"database": self.database},
                         )
                     )
+                reporter.done()
                 return tables
         except Exception as exc:
             print(f"Error retrieving tables: {exc}")
             return []
 
-    def get_schemas(self):
-        return self.get_tables()
+    def get_schemas(self, progress_callback: Optional[ProgressCallback] = None):
+        return self.get_tables(progress_callback=progress_callback)
 
     def get_schema(self, table_id: str):
         raise NotImplementedError("get_schema() is obsolete. Use get_tables() instead.")
@@ -77,17 +83,34 @@ class SqliteClient(DataSourceClient):
         return TableFormatter(schemas).table_str
 
     def test_connection(self):
+        import os as _os, time as _time
+
+        t0 = _time.perf_counter()
         try:
             with self.connect() as conn:
                 conn.execute("SELECT 1")
-                return {
-                    "success": True,
-                    "message": f"Successfully connected to SQLite database {self.database}",
-                }
+                sqlite_ver = conn.execute("SELECT sqlite_version()").fetchone()[0]
+                table_count = conn.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+                ).fetchone()[0]
+            details = {
+                "server_version": f"sqlite {sqlite_ver}",
+                "database": self.database,
+                "database_bytes": (_os.path.getsize(self.database) if self.database != ":memory:" and _os.path.exists(self.database) else None),
+                "table_count": table_count,
+            }
+            return {
+                "success": True,
+                "message": f"Successfully connected to SQLite database {self.database}",
+                "timings": {"connect_ms": round((_time.perf_counter() - t0) * 1000, 1)},
+                "details": details,
+            }
         except Exception as exc:
             return {
                 "success": False,
                 "message": str(exc),
+                "timings": {"connect_ms": round((_time.perf_counter() - t0) * 1000, 1)},
+                "details": {"database": self.database},
             }
 
     @property

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -79,6 +79,14 @@ class Connection(BaseSchema):
         cascade="all, delete-orphan",
     )
 
+    # Background schema ingestion history (one row per refresh attempt)
+    indexings = relationship(
+        "ConnectionIndexing",
+        back_populates="connection",
+        cascade="all, delete-orphan",
+        order_by="desc(ConnectionIndexing.created_at)",
+    )
+
     def get_client(self):
         """Instantiate and return the appropriate database client."""
         try:

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -84,7 +84,7 @@ class Connection(BaseSchema):
         "ConnectionIndexing",
         back_populates="connection",
         cascade="all, delete-orphan",
-        order_by="desc(ConnectionIndexing.created_at)",
+        order_by="ConnectionIndexing.created_at.desc()",
     )
 
     def get_client(self):

--- a/backend/app/models/connection_indexing.py
+++ b/backend/app/models/connection_indexing.py
@@ -55,6 +55,7 @@ class ConnectionIndexing(BaseSchema):
 
     error = Column(Text, nullable=True)
     stats_json = Column(JSON, nullable=True)
+    events_json = Column(JSON, nullable=True)  # List[{ts, level, phase, message, done, total}]
 
     connection = relationship("Connection", back_populates="indexings")
 

--- a/backend/app/models/connection_indexing.py
+++ b/backend/app/models/connection_indexing.py
@@ -1,0 +1,87 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.models.base import BaseSchema
+
+
+class ConnectionIndexingStatus(str, PyEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_INDEXING_STATUSES = {
+    ConnectionIndexingStatus.COMPLETED.value,
+    ConnectionIndexingStatus.FAILED.value,
+    ConnectionIndexingStatus.CANCELLED.value,
+}
+
+
+class ConnectionIndexing(BaseSchema):
+    """Tracks an in-flight or completed schema discovery run for a Connection.
+
+    A Connection has many ConnectionIndexing rows, one per refresh attempt.
+    Only one non-terminal (pending/running) row is allowed to exist at a time
+    per connection — the service layer enforces this.
+    """
+
+    __tablename__ = "connection_indexings"
+
+    connection_id = Column(
+        String(36),
+        ForeignKey("connections.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    status = Column(
+        String,
+        nullable=False,
+        default=ConnectionIndexingStatus.PENDING.value,
+        index=True,
+    )
+    phase = Column(String(64), nullable=True)
+    current_item = Column(String, nullable=True)
+    progress_done = Column(Integer, nullable=False, default=0)
+    progress_total = Column(Integer, nullable=False, default=0)
+
+    started_at = Column(DateTime, nullable=True)
+    finished_at = Column(DateTime, nullable=True)
+
+    error = Column(Text, nullable=True)
+    stats_json = Column(JSON, nullable=True)
+
+    connection = relationship("Connection", back_populates="indexings")
+
+    def mark_running(self) -> None:
+        self.status = ConnectionIndexingStatus.RUNNING.value
+        self.started_at = func.now()
+
+    def mark_completed(self, stats: dict | None = None) -> None:
+        self.status = ConnectionIndexingStatus.COMPLETED.value
+        self.finished_at = func.now()
+        if stats is not None:
+            self.stats_json = stats
+
+    def mark_failed(self, error: str) -> None:
+        self.status = ConnectionIndexingStatus.FAILED.value
+        self.finished_at = func.now()
+        self.error = error
+
+    def mark_cancelled(self) -> None:
+        self.status = ConnectionIndexingStatus.CANCELLED.value
+        self.finished_at = func.now()
+
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_INDEXING_STATUSES
+
+    def __repr__(self) -> str:
+        return (
+            f"<ConnectionIndexing id={self.id} connection_id={self.connection_id} "
+            f"status={self.status} {self.progress_done}/{self.progress_total}>"
+        )

--- a/backend/app/models/datasource_table.py
+++ b/backend/app/models/datasource_table.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, ForeignKey, JSON, Integer, Float, DateTime
+from sqlalchemy import Column, String, ForeignKey, JSON, Integer, Float, DateTime, Index
 from sqlalchemy.orm import relationship
 from app.models.base import BaseSchema
 from app.ai.prompt_formatters import Table, TableColumn, ForeignKey as PromptForeignKey
@@ -12,6 +12,9 @@ class DataSourceTable(BaseSchema):
     This is the "DomainTable" in the new architecture.
     """
     __tablename__ = 'datasource_tables'
+    __table_args__ = (
+        Index('ix_dst_ds_active', 'datasource_id', 'is_active'),
+    )
 
     name = Column(String, nullable=False)
     datasource_id = Column(String(36), ForeignKey('data_sources.id'), nullable=False)

--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -27,7 +27,9 @@ from app.schemas.connection_schema import (
     ConnectionTableSchema,
     ConnectionTestOverride,
     ConnectionTestResult,
+    ConnectionIndexingProgress,
 )
+from app.services.connection_indexing_service import ConnectionIndexingService
 from app.schemas.connection_tool_schema import (
     ConnectionToolSchema,
     ConnectionToolUpdate,
@@ -37,6 +39,27 @@ from app.schemas.connection_tool_schema import (
 
 router = APIRouter(prefix="/connections", tags=["connections"])
 connection_service = ConnectionService()
+indexing_service = ConnectionIndexingService()
+
+
+def _indexing_to_progress(row) -> "ConnectionIndexingProgress | None":
+    """Adapt a ConnectionIndexing ORM row to the polling payload. Returns None
+    when no row is provided.
+    """
+    if row is None:
+        return None
+    return ConnectionIndexingProgress(
+        id=str(row.id),
+        status=row.status,
+        phase=row.phase,
+        current_item=row.current_item,
+        progress_done=row.progress_done or 0,
+        progress_total=row.progress_total or 0,
+        started_at=row.started_at.isoformat() if row.started_at else None,
+        finished_at=row.finished_at.isoformat() if row.finished_at else None,
+        error=row.error,
+        stats=row.stats_json,
+    )
 
 
 async def _is_org_admin(db: AsyncSession, user: User, organization: Organization) -> bool:
@@ -321,6 +344,8 @@ async def test_connection(
         connectivity=result.get("connectivity", result.get("success", False)),
         schema_access=result.get("schema_access", False),
         table_count=result.get("table_count", 0),
+        timings=result.get("timings"),
+        details=result.get("details"),
     )
 
 
@@ -346,6 +371,8 @@ async def test_my_connection_credentials(
         connectivity=result.get("connectivity", result.get("success", False)),
         schema_access=result.get("schema_access", False),
         table_count=result.get("table_count", 0),
+        timings=result.get("timings"),
+        details=result.get("details"),
     )
 
 
@@ -357,14 +384,55 @@ async def refresh_connection_schema(
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization)
 ):
-    """Refresh connection schema (discover tables)."""
+    """Kick off a background indexing job to refresh the connection's schema.
+
+    Returns immediately with the indexing row. Poll `GET /connections/{id}/indexing`
+    to observe progress. Idempotent — re-firing while a job is running returns
+    the in-flight row.
+    """
     connection = await connection_service.get_connection(db, connection_id, organization)
-    tables = await connection_service.refresh_schema(db, connection, current_user)
-    
+    row = await indexing_service.start(db=db, connection=connection)
+    progress = _indexing_to_progress(row)
     return {
-        "message": f"Refreshed schema. Found {len(tables)} tables.",
-        "table_count": len(tables),
+        "message": "Schema indexing started." if row.status == "pending" else "Schema indexing in progress.",
+        "indexing": progress.model_dump() if progress else None,
     }
+
+
+@router.post("/{connection_id}/reindex")
+@requires_permission('manage_connections')
+async def reindex_connection(
+    connection_id: str,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Alias of `/refresh` that matches the new naming. Kicks off a background
+    indexing job and returns the indexing row.
+    """
+    connection = await connection_service.get_connection(db, connection_id, organization)
+    row = await indexing_service.start(db=db, connection=connection)
+    progress = _indexing_to_progress(row)
+    return {
+        "message": "Schema indexing started." if row.status == "pending" else "Schema indexing in progress.",
+        "indexing": progress.model_dump() if progress else None,
+    }
+
+
+@router.get("/{connection_id}/indexing", response_model=ConnectionIndexingProgress)
+async def get_connection_indexing(
+    connection_id: str,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Return the latest indexing row for this connection. 404 if none exists."""
+    connection = await connection_service.get_connection(db, connection_id, organization)
+    await _ensure_can_read_connection(db, organization, current_user, connection)
+    row = await indexing_service.get_latest(db, connection_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="No indexing runs found for this connection")
+    return _indexing_to_progress(row)
 
 
 async def _ensure_can_read_connection(db, organization, current_user, connection):

--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -59,6 +59,7 @@ def _indexing_to_progress(row) -> "ConnectionIndexingProgress | None":
         finished_at=row.finished_at.isoformat() if row.finished_at else None,
         error=row.error,
         stats=row.stats_json,
+        events=row.events_json or [],
     )
 
 
@@ -153,6 +154,10 @@ async def list_connections(
                 )
                 table_count = fallback_result.scalar() or 0
 
+        # Inline latest indexing for the dot status / polling.
+        indexing_row = await indexing_service.get_latest(db, str(conn.id))
+        indexing_payload = _indexing_to_progress(indexing_row)
+
         result.append(ConnectionSchema(
             id=str(conn.id),
             name=conn.name,
@@ -164,6 +169,7 @@ async def list_connections(
             table_count=table_count,
             domain_count=len(conn.data_sources) if conn.data_sources else 0,
             domain_names=[ds.name for ds in conn.data_sources] if conn.data_sources else [],
+            indexing=indexing_payload.model_dump() if indexing_payload else None,
         ))
     return result
 
@@ -189,6 +195,10 @@ async def create_connection(
         allowed_user_auth_modes=data.allowed_user_auth_modes,
     )
     
+    # Inline the latest indexing run so the modal can show progress
+    # immediately without a second roundtrip.
+    indexing_row = await indexing_service.get_latest(db, str(connection.id))
+    indexing_payload = _indexing_to_progress(indexing_row)
     return ConnectionSchema(
         id=str(connection.id),
         name=connection.name,
@@ -199,6 +209,7 @@ async def create_connection(
         organization_id=str(connection.organization_id),
         table_count=len(connection.connection_tables) if connection.connection_tables else 0,
         domain_count=len(connection.data_sources) if connection.data_sources else 0,
+        indexing=indexing_payload.model_dump() if indexing_payload else None,
     )
 
 

--- a/backend/app/schemas/connection_schema.py
+++ b/backend/app/schemas/connection_schema.py
@@ -2,7 +2,7 @@
 Connection schemas for database connection management.
 """
 from datetime import datetime
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 
 from pydantic import BaseModel
 
@@ -89,4 +89,33 @@ class ConnectionTestResult(BaseModel):
     connectivity: bool = False
     schema_access: bool = False
     table_count: int = 0
+    # Optional richer info; older consumers ignore these.
+    timings: Optional[Dict[str, float]] = None
+    details: Optional[Dict[str, Any]] = None
+
+
+class ConnectionIndexingProgress(BaseModel):
+    """Lightweight payload inlined into the connection payload and returned
+    from the indexing polling endpoint.
+    """
+    id: str
+    status: str  # pending | running | completed | failed | cancelled
+    phase: Optional[str] = None
+    current_item: Optional[str] = None
+    progress_done: int = 0
+    progress_total: int = 0
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    error: Optional[str] = None
+    stats: Optional[Dict[str, Any]] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ConnectionIndexingSchema(ConnectionIndexingProgress):
+    """Full indexing row (same shape today; kept separate for future expansion)."""
+    connection_id: str
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
 

--- a/backend/app/schemas/connection_schema.py
+++ b/backend/app/schemas/connection_schema.py
@@ -41,6 +41,7 @@ class ConnectionSchema(BaseModel):
     table_count: int = 0
     domain_count: int = 0
     domain_names: List[str] = []  # Names of linked domains (for delete confirmation)
+    indexing: Optional[Dict[str, Any]] = None
 
     class Config:
         from_attributes = True
@@ -108,6 +109,7 @@ class ConnectionIndexingProgress(BaseModel):
     finished_at: Optional[str] = None
     error: Optional[str] = None
     stats: Optional[Dict[str, Any]] = None
+    events: Optional[List[Dict[str, Any]]] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -78,6 +78,9 @@ class ConnectionEmbedded(BaseModel):
     last_synced_at: OptionalUTCDatetime = None
     user_status: Optional[DataSourceUserStatus] = None  # User's credential status for this connection
     table_count: int = 0  # Number of tables in this connection
+    # Latest schema indexing run, if any. Frontend derives the "indexing"
+    # effective status from this plus user_status.connection.
+    indexing: Optional[Dict[str, Any]] = None
 
     @validator('config', 'allowed_user_auth_modes', pre=True)
     def parse_json_fields(cls, v):

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -207,6 +207,13 @@ class CompletionService:
         main_build = main_build_result.scalar_one_or_none()
         return str(main_build.id) if main_build else None
 
+    # Short-TTL cache for /completions/estimate. Frontend calls this on every
+    # keystroke; without caching, each call does a full prime_static + refresh_warm
+    # (schema load + recent messages). Staleness within a few seconds is fine —
+    # the figure is an approximation displayed as a meter, not a billable number.
+    _estimate_cache: dict = {}
+    _estimate_cache_ttl_s: float = 10.0
+
     async def estimate_completion_tokens(
         self,
         db: AsyncSession,
@@ -221,6 +228,25 @@ class CompletionService:
         try:
             if not completion_data or not completion_data.prompt or not completion_data.prompt.content:
                 raise HTTPException(status_code=400, detail="Prompt content is required for estimation.")
+
+            # Cache lookup — bucket the prompt length in 50-char buckets so
+            # typing doesn't constantly invalidate; prompt token contribution
+            # is small compared to the context anyway.
+            _prompt = completion_data.prompt
+            _content = _prompt.content or ""
+            _cache_key = (
+                str(current_user.id),
+                str(report_id),
+                str(_prompt.widget_id) if _prompt.widget_id else None,
+                str(_prompt.step_id) if _prompt.step_id else None,
+                _prompt.mode,
+                str(_prompt.model_id) if _prompt.model_id else None,
+                len(_content) // 50,
+            )
+            _now = time.time()
+            _cached = self._estimate_cache.get(_cache_key)
+            if _cached is not None and (_now - _cached[0]) < self._estimate_cache_ttl_s:
+                return _cached[1]
 
             report_res = await db.execute(select(Report).filter(Report.id == report_id))
             report = report_res.scalar_one_or_none()
@@ -330,7 +356,7 @@ class CompletionService:
             if model_limit and model_limit > 0:
                 context_usage_pct = round((prompt_tokens / model_limit) * 100, 2)
 
-            return CompletionContextEstimateSchema(
+            _result = CompletionContextEstimateSchema(
                 model_id=getattr(model, "model_id", ""),
                 model_name=getattr(model, "name", None),
                 prompt_tokens=prompt_tokens,
@@ -339,6 +365,15 @@ class CompletionService:
                 near_limit=near_limit,
                 context_usage_pct=context_usage_pct,
             )
+            # Populate cache; prune stale entries opportunistically so the
+            # dict doesn't grow unbounded across many users/reports.
+            self._estimate_cache[_cache_key] = (_now, _result)
+            if len(self._estimate_cache) > 256:
+                _cutoff = _now - self._estimate_cache_ttl_s
+                self._estimate_cache = {
+                    k: v for k, v in self._estimate_cache.items() if v[0] >= _cutoff
+                }
+            return _result
         except HTTPException as he:
             raise he
         except Exception as e:

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -1,0 +1,327 @@
+"""Connection indexing service — runs `refresh_schema` in the background
+and tracks progress in the `connection_indexings` table.
+
+Jobs execute on a dedicated daemon-thread event loop (`_get_background_loop`).
+The request thread calls `asyncio.run_coroutine_threadsafe` to submit and
+returns immediately — so the HTTP POST completes in milliseconds even if
+the job takes minutes. A persistent loop (rather than the request's loop)
+means the runner survives request completion in every deployment mode we
+support, including FastAPI's sync TestClient used in e2e tests.
+
+Multi-worker safety (per-pod election / APScheduler-backed runner) is a
+follow-up hardening step.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select, desc
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import async_session_maker
+from app.models.connection import Connection
+from app.models.connection_indexing import (
+    ConnectionIndexing,
+    ConnectionIndexingStatus,
+    TERMINAL_INDEXING_STATUSES,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# A single daemon thread runs an event loop for the whole process — any thread
+# can submit coroutines via `asyncio.run_coroutine_threadsafe(..., loop)`. This
+# is what makes the runner survive the request that spawned it.
+_background_loop: "asyncio.AbstractEventLoop | None" = None
+_background_loop_lock = threading.Lock()
+
+
+def _start_background_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+
+    def _run() -> None:
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_run, name="connection-indexing-loop", daemon=True)
+    t.start()
+    return loop
+
+
+def _get_background_loop() -> asyncio.AbstractEventLoop:
+    global _background_loop
+    with _background_loop_lock:
+        if _background_loop is None or _background_loop.is_closed():
+            _background_loop = _start_background_loop()
+        return _background_loop
+
+
+# How often we flush progress updates to the DB. Progress callbacks from the
+# client loop can fire thousands of times; we coalesce into one write per
+# `_PROGRESS_FLUSH_SECONDS` (plus one final flush at end-of-phase).
+_PROGRESS_FLUSH_SECONDS = 0.25
+
+
+class ConnectionIndexingService:
+    """Create, poll, and (internally) run `ConnectionIndexing` rows."""
+
+    async def get_latest(
+        self,
+        db: AsyncSession,
+        connection_id: str,
+    ) -> Optional[ConnectionIndexing]:
+        """Return the most recent indexing row for a connection (any status)."""
+        result = await db.execute(
+            select(ConnectionIndexing)
+            .where(ConnectionIndexing.connection_id == str(connection_id))
+            .order_by(desc(ConnectionIndexing.created_at))
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active(
+        self,
+        db: AsyncSession,
+        connection_id: str,
+    ) -> Optional[ConnectionIndexing]:
+        """Return the current pending/running indexing row for a connection, if any."""
+        result = await db.execute(
+            select(ConnectionIndexing)
+            .where(
+                ConnectionIndexing.connection_id == str(connection_id),
+                ConnectionIndexing.status.in_([
+                    ConnectionIndexingStatus.PENDING.value,
+                    ConnectionIndexingStatus.RUNNING.value,
+                ]),
+            )
+            .order_by(desc(ConnectionIndexing.created_at))
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def start(
+        self,
+        db: AsyncSession,
+        connection: Connection,
+        *,
+        kick_off: bool = True,
+    ) -> ConnectionIndexing:
+        """Create a pending indexing row and (unless already in-flight) kick off
+        the background runner. Idempotent — returns the active row if one
+        already exists.
+        """
+        existing = await self.get_active(db, str(connection.id))
+        if existing is not None:
+            return existing
+
+        row = ConnectionIndexing(
+            connection_id=str(connection.id),
+            status=ConnectionIndexingStatus.PENDING.value,
+            phase=None,
+            progress_done=0,
+            progress_total=0,
+        )
+        db.add(row)
+        await db.commit()
+        await db.refresh(row)
+
+        if kick_off:
+            # Fire-and-forget on the shared background loop. The runner opens
+            # its own DB session; we don't await the future here.
+            loop = _get_background_loop()
+            asyncio.run_coroutine_threadsafe(self._run(row.id), loop)
+
+        return row
+
+    async def _run(self, indexing_id: str) -> None:
+        """Runner that opens a fresh session and executes `refresh_schema`.
+
+        Exceptions are captured onto the row — never re-raised. The task must
+        not let its wrapping session outlive work, so we open/close a session
+        for each significant phase (mark-running, progress flush, finalize).
+        """
+        # Avoid circular import at module load.
+        from app.services.connection_service import ConnectionService
+
+        # The loop this coroutine is currently executing on. Progress callbacks
+        # fire from worker threads (via `asyncio.to_thread` inside aget_schemas)
+        # and must post their flush coroutine BACK to this loop.
+        runner_loop = asyncio.get_running_loop()
+        start = time.perf_counter()
+        try:
+            async with async_session_maker() as db:
+                row = await db.get(ConnectionIndexing, indexing_id)
+                if row is None:
+                    logger.warning("indexing.run.missing", extra={"indexing_id": indexing_id})
+                    return
+                row.status = ConnectionIndexingStatus.RUNNING.value
+                row.started_at = datetime.utcnow()
+                await db.commit()
+
+                conn_result = await db.execute(
+                    select(Connection).where(Connection.id == row.connection_id)
+                )
+                connection = conn_result.scalar_one_or_none()
+                if connection is None:
+                    row.status = ConnectionIndexingStatus.FAILED.value
+                    row.error = "Connection not found"
+                    row.finished_at = datetime.utcnow()
+                    await db.commit()
+                    return
+
+                # Progress callback with in-memory debouncing. We open a fresh
+                # session per flush so the flush never collides with the
+                # session `refresh_schema` is using mid-transaction.
+                last_flush_at = 0.0
+                pending_state: dict = {"phase": None, "item": None, "done": 0, "total": 0}
+                flush_lock = asyncio.Lock()
+
+                async def _flush(force: bool = False) -> None:
+                    nonlocal last_flush_at
+                    now = time.perf_counter()
+                    if not force and (now - last_flush_at) < _PROGRESS_FLUSH_SECONDS:
+                        return
+                    async with flush_lock:
+                        try:
+                            async with async_session_maker() as flush_db:
+                                fresh = await flush_db.get(ConnectionIndexing, indexing_id)
+                                if fresh is None:
+                                    return
+                                fresh.phase = pending_state["phase"]
+                                fresh.current_item = pending_state["item"]
+                                fresh.progress_done = pending_state["done"]
+                                fresh.progress_total = pending_state["total"]
+                                await flush_db.commit()
+                        except Exception:
+                            # Never let a failed flush kill the indexing run.
+                            logger.debug("indexing.flush_failed", exc_info=True)
+                        last_flush_at = now
+
+                def progress_cb(phase, current_item, done, total):
+                    # Called from inside `asyncio.to_thread(get_schemas)` — a
+                    # worker thread. Post the async flush back onto the
+                    # runner's loop (the dedicated background-indexing loop).
+                    pending_state["phase"] = phase
+                    pending_state["item"] = current_item
+                    pending_state["done"] = done
+                    pending_state["total"] = total
+                    if runner_loop.is_closed():
+                        return
+                    try:
+                        asyncio.run_coroutine_threadsafe(_flush(), runner_loop)
+                    except RuntimeError:
+                        pass
+
+                svc = ConnectionService()
+
+                try:
+                    tables = await svc.refresh_schema(
+                        db=db,
+                        connection=connection,
+                        current_user=None,
+                        progress_callback=progress_cb,
+                    )
+                except Exception as exc:  # pragma: no cover — surface via row
+                    logger.exception("indexing.run.failed", extra={"indexing_id": indexing_id})
+                    # Use a fresh session — the service may have rolled back.
+                    async with async_session_maker() as err_db:
+                        fresh = await err_db.get(ConnectionIndexing, indexing_id)
+                        if fresh is not None:
+                            fresh.status = ConnectionIndexingStatus.FAILED.value
+                            fresh.error = str(exc)[:4000]
+                            fresh.finished_at = datetime.utcnow()
+                            await err_db.commit()
+                    return
+
+                # Force one final flush so progress ends at the true total.
+                await _flush(force=True)
+
+                # Fan schema out to every DataSource linked to this connection so
+                # the domain-level view (DataSourceTable) reflects the new schema.
+                synced_domains = await self._sync_linked_data_sources(
+                    db, connection_id=row.connection_id
+                )
+
+                fresh = await db.get(ConnectionIndexing, indexing_id)
+                if fresh is None:
+                    return
+                fresh.status = ConnectionIndexingStatus.COMPLETED.value
+                fresh.finished_at = datetime.utcnow()
+                fresh.error = None
+                fresh.stats_json = {
+                    "table_count": len(tables) if tables else 0,
+                    "synced_domains": synced_domains,
+                    "elapsed_s": round(time.perf_counter() - start, 3),
+                }
+                # Ensure progress_done == progress_total so the UI settles at 100%.
+                if fresh.progress_total and fresh.progress_done < fresh.progress_total:
+                    fresh.progress_done = fresh.progress_total
+                await db.commit()
+
+        except Exception as exc:  # pragma: no cover — last-ditch guard
+            logger.exception("indexing.run.crash", extra={"indexing_id": indexing_id})
+            try:
+                async with async_session_maker() as err_db:
+                    fresh = await err_db.get(ConnectionIndexing, indexing_id)
+                    if fresh is not None and not fresh.is_terminal():
+                        fresh.status = ConnectionIndexingStatus.FAILED.value
+                        fresh.error = str(exc)[:4000]
+                        fresh.finished_at = datetime.utcnow()
+                        await err_db.commit()
+            except Exception:
+                pass
+
+    async def _sync_linked_data_sources(
+        self,
+        db: AsyncSession,
+        *,
+        connection_id: str,
+    ) -> int:
+        """After a successful refresh_schema, mirror the new ConnectionTable set
+        onto every DataSource that links this connection.
+
+        Returns the number of data sources synced.
+        """
+        from sqlalchemy.orm import selectinload
+
+        from app.services.data_source_service import DataSourceService
+
+        result = await db.execute(
+            select(Connection)
+            .options(selectinload(Connection.data_sources))
+            .where(Connection.id == str(connection_id))
+        )
+        connection = result.scalar_one_or_none()
+        if connection is None or not connection.data_sources:
+            return 0
+
+        ds_service = DataSourceService()
+        synced = 0
+        for ds in list(connection.data_sources):
+            try:
+                await ds_service.sync_domain_tables_from_connection(
+                    db,
+                    ds,
+                    connection,
+                    max_auto_select=ds_service.ONBOARDING_MAX_TABLES,
+                )
+                synced += 1
+            except Exception:
+                logger.exception(
+                    "indexing.sync_domain_failed",
+                    extra={"connection_id": str(connection_id), "data_source_id": str(ds.id)},
+                )
+        try:
+            await db.commit()
+        except Exception:
+            await db.rollback()
+        return synced

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -108,6 +108,30 @@ class ConnectionIndexingService:
         )
         return result.scalar_one_or_none()
 
+    async def wait_for_active(
+        self,
+        db: AsyncSession,
+        connection_id: str,
+        *,
+        poll_interval_s: float = 0.05,
+        timeout_s: float = 600.0,
+    ) -> None:
+        """Block until any pending/running indexing for this connection reaches a
+        terminal state. Used by sync paths (e.g. data-source-level refresh) that
+        need a deterministic post-condition. Polls the row's status — runs on the
+        request thread.
+        """
+        deadline = time.perf_counter() + timeout_s
+        while time.perf_counter() < deadline:
+            active = await self.get_active(db, connection_id)
+            if active is None:
+                return
+            await asyncio.sleep(poll_interval_s)
+        logger.warning(
+            "indexing.wait_for_active.timeout",
+            extra={"connection_id": str(connection_id), "timeout_s": timeout_s},
+        )
+
     async def start(
         self,
         db: AsyncSession,

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -70,6 +70,9 @@ def _get_background_loop() -> asyncio.AbstractEventLoop:
 # `_PROGRESS_FLUSH_SECONDS` (plus one final flush at end-of-phase).
 _PROGRESS_FLUSH_SECONDS = 0.25
 
+# Per-run event log cap. Keep enough to be useful, drop oldest beyond.
+_EVENT_LOG_MAX = 200
+
 
 class ConnectionIndexingService:
     """Create, poll, and (internally) run `ConnectionIndexing` rows."""
@@ -181,6 +184,35 @@ class ConnectionIndexingService:
         # and must post their flush coroutine BACK to this loop.
         runner_loop = asyncio.get_running_loop()
         start = time.perf_counter()
+
+        async def _append_event(level: str, phase: str | None, message: str,
+                                done: int = 0, total: int = 0) -> None:
+            """Append a single entry to the indexing row's events_json.
+
+            Best-effort: a failure to log must never affect the run. Events
+            are capped at `_EVENT_LOG_MAX` (oldest dropped).
+            """
+            try:
+                async with async_session_maker() as ev_db:
+                    fresh = await ev_db.get(ConnectionIndexing, indexing_id)
+                    if fresh is None:
+                        return
+                    events = list(fresh.events_json or [])
+                    events.append({
+                        "ts": datetime.utcnow().isoformat() + "Z",
+                        "level": level,
+                        "phase": phase,
+                        "message": message,
+                        "done": done,
+                        "total": total,
+                    })
+                    if len(events) > _EVENT_LOG_MAX:
+                        events = events[-_EVENT_LOG_MAX:]
+                    fresh.events_json = events
+                    await ev_db.commit()
+            except Exception:
+                logger.debug("indexing.event_append_failed", exc_info=True)
+
         try:
             async with async_session_maker() as db:
                 row = await db.get(ConnectionIndexing, indexing_id)
@@ -190,6 +222,8 @@ class ConnectionIndexingService:
                 row.status = ConnectionIndexingStatus.RUNNING.value
                 row.started_at = datetime.utcnow()
                 await db.commit()
+
+                await _append_event("info", None, "Indexing started")
 
                 conn_result = await db.execute(
                     select(Connection).where(Connection.id == row.connection_id)
@@ -207,7 +241,19 @@ class ConnectionIndexingService:
                 # session `refresh_schema` is using mid-transaction.
                 last_flush_at = 0.0
                 pending_state: dict = {"phase": None, "item": None, "done": 0, "total": 0}
+                last_phase: dict = {"name": None}
                 flush_lock = asyncio.Lock()
+
+                async def _maybe_log_phase_event(phase: str | None, total: int) -> None:
+                    if phase != last_phase["name"]:
+                        last_phase["name"] = phase
+                        if phase:
+                            label = (
+                                f"Phase: {phase} ({total} items)"
+                                if total > 0
+                                else f"Phase: {phase}"
+                            )
+                            await _append_event("info", phase, label, done=0, total=total)
 
                 async def _flush(force: bool = False) -> None:
                     nonlocal last_flush_at
@@ -229,6 +275,9 @@ class ConnectionIndexingService:
                             # Never let a failed flush kill the indexing run.
                             logger.debug("indexing.flush_failed", exc_info=True)
                         last_flush_at = now
+                    # Phase-transition events live on the same flush schedule —
+                    # one row write only, no extra DB traffic per item.
+                    await _maybe_log_phase_event(pending_state["phase"], pending_state["total"])
 
                 def progress_cb(phase, current_item, done, total):
                     # Called from inside `asyncio.to_thread(get_schemas)` — a
@@ -264,6 +313,7 @@ class ConnectionIndexingService:
                             fresh.error = str(exc)[:4000]
                             fresh.finished_at = datetime.utcnow()
                             await err_db.commit()
+                    await _append_event("error", pending_state["phase"], f"Indexing failed: {exc}")
                     return
 
                 # Force one final flush so progress ends at the true total.
@@ -281,15 +331,23 @@ class ConnectionIndexingService:
                 fresh.status = ConnectionIndexingStatus.COMPLETED.value
                 fresh.finished_at = datetime.utcnow()
                 fresh.error = None
+                table_count = len(tables) if tables else 0
+                elapsed_s = round(time.perf_counter() - start, 3)
                 fresh.stats_json = {
-                    "table_count": len(tables) if tables else 0,
+                    "table_count": table_count,
                     "synced_domains": synced_domains,
-                    "elapsed_s": round(time.perf_counter() - start, 3),
+                    "elapsed_s": elapsed_s,
                 }
                 # Ensure progress_done == progress_total so the UI settles at 100%.
                 if fresh.progress_total and fresh.progress_done < fresh.progress_total:
                     fresh.progress_done = fresh.progress_total
                 await db.commit()
+
+                await _append_event(
+                    "info", pending_state["phase"],
+                    f"Completed: {table_count} table(s) in {elapsed_s}s",
+                    done=table_count, total=table_count,
+                )
 
         except Exception as exc:  # pragma: no cover — last-ditch guard
             logger.exception("indexing.run.crash", extra={"indexing_id": indexing_id})

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -121,8 +121,9 @@ class ConnectionIndexingService:
     ) -> None:
         """Block until any pending/running indexing for this connection reaches a
         terminal state. Used by sync paths (e.g. data-source-level refresh) that
-        need a deterministic post-condition. Polls the row's status — runs on the
-        request thread.
+        need a deterministic post-condition. Polls the row's status — runs on
+        the request thread. Raises on timeout so callers can surface a clear
+        error rather than proceeding on stale state.
         """
         deadline = time.perf_counter() + timeout_s
         while time.perf_counter() < deadline:
@@ -133,6 +134,9 @@ class ConnectionIndexingService:
         logger.warning(
             "indexing.wait_for_active.timeout",
             extra={"connection_id": str(connection_id), "timeout_s": timeout_s},
+        )
+        raise TimeoutError(
+            f"Indexing for connection {connection_id} did not finish within {timeout_s}s"
         )
 
     async def start(
@@ -236,13 +240,20 @@ class ConnectionIndexingService:
                     await db.commit()
                     return
 
-                # Progress callback with in-memory debouncing. We open a fresh
-                # session per flush so the flush never collides with the
-                # session `refresh_schema` is using mid-transaction.
+                # Progress state shared across the runner loop and worker
+                # thread (where the client's `get_schemas` runs). Reads/writes
+                # are guarded by a `threading.Lock` so we always observe a
+                # consistent (phase, item, done, total) tuple even when the
+                # callback fires mid-flush.
                 last_flush_at = 0.0
                 pending_state: dict = {"phase": None, "item": None, "done": 0, "total": 0}
+                state_lock = threading.Lock()
                 last_phase: dict = {"name": None}
                 flush_lock = asyncio.Lock()
+
+                def _state_snapshot() -> dict:
+                    with state_lock:
+                        return dict(pending_state)
 
                 async def _maybe_log_phase_event(phase: str | None, total: int) -> None:
                     if phase != last_phase["name"]:
@@ -260,16 +271,18 @@ class ConnectionIndexingService:
                     now = time.perf_counter()
                     if not force and (now - last_flush_at) < _PROGRESS_FLUSH_SECONDS:
                         return
+                    # Take a single consistent snapshot of progress state.
+                    snap = _state_snapshot()
                     async with flush_lock:
                         try:
                             async with async_session_maker() as flush_db:
                                 fresh = await flush_db.get(ConnectionIndexing, indexing_id)
                                 if fresh is None:
                                     return
-                                fresh.phase = pending_state["phase"]
-                                fresh.current_item = pending_state["item"]
-                                fresh.progress_done = pending_state["done"]
-                                fresh.progress_total = pending_state["total"]
+                                fresh.phase = snap["phase"]
+                                fresh.current_item = snap["item"]
+                                fresh.progress_done = snap["done"]
+                                fresh.progress_total = snap["total"]
                                 await flush_db.commit()
                         except Exception:
                             # Never let a failed flush kill the indexing run.
@@ -277,16 +290,17 @@ class ConnectionIndexingService:
                         last_flush_at = now
                     # Phase-transition events live on the same flush schedule —
                     # one row write only, no extra DB traffic per item.
-                    await _maybe_log_phase_event(pending_state["phase"], pending_state["total"])
+                    await _maybe_log_phase_event(snap["phase"], snap["total"])
 
                 def progress_cb(phase, current_item, done, total):
                     # Called from inside `asyncio.to_thread(get_schemas)` — a
-                    # worker thread. Post the async flush back onto the
-                    # runner's loop (the dedicated background-indexing loop).
-                    pending_state["phase"] = phase
-                    pending_state["item"] = current_item
-                    pending_state["done"] = done
-                    pending_state["total"] = total
+                    # worker thread. Update state under a lock so the runner
+                    # loop never reads a torn (phase, item, done, total).
+                    with state_lock:
+                        pending_state["phase"] = phase
+                        pending_state["item"] = current_item
+                        pending_state["done"] = done
+                        pending_state["total"] = total
                     if runner_loop.is_closed():
                         return
                     try:
@@ -313,7 +327,7 @@ class ConnectionIndexingService:
                             fresh.error = str(exc)[:4000]
                             fresh.finished_at = datetime.utcnow()
                             await err_db.commit()
-                    await _append_event("error", pending_state["phase"], f"Indexing failed: {exc}")
+                    await _append_event("error", _state_snapshot()["phase"], f"Indexing failed: {exc}")
                     return
 
                 # Force one final flush so progress ends at the true total.
@@ -344,7 +358,7 @@ class ConnectionIndexingService:
                 await db.commit()
 
                 await _append_event(
-                    "info", pending_state["phase"],
+                    "info", _state_snapshot()["phase"],
                     f"Completed: {table_count} table(s) in {elapsed_s}s",
                     done=table_count, total=table_count,
                 )
@@ -371,39 +385,83 @@ class ConnectionIndexingService:
         """After a successful refresh_schema, mirror the new ConnectionTable set
         onto every DataSource that links this connection.
 
-        Returns the number of data sources synced.
+        Each per-DS sync runs in its own session/transaction so that:
+          - a data source deleted mid-flight (concurrent test or user delete)
+            doesn't FK-violate the whole runner — we re-check existence per DS
+            and skip if gone, and catch any leftover IntegrityError on commit;
+          - one corrupt DS doesn't abort the sync for its peers.
+
+        Returns the number of data sources synced successfully.
         """
+        from sqlalchemy.exc import IntegrityError
         from sqlalchemy.orm import selectinload
 
+        from app.models.data_source import DataSource
         from app.services.data_source_service import DataSourceService
 
+        # Snapshot the connection's linked DS IDs from the runner's session,
+        # then close that scope — per-DS work happens in its own session.
         result = await db.execute(
             select(Connection)
             .options(selectinload(Connection.data_sources))
             .where(Connection.id == str(connection_id))
         )
-        connection = result.scalar_one_or_none()
-        if connection is None or not connection.data_sources:
+        connection_snapshot = result.scalar_one_or_none()
+        if connection_snapshot is None or not connection_snapshot.data_sources:
             return 0
+        ds_ids = [str(ds.id) for ds in connection_snapshot.data_sources]
 
         ds_service = DataSourceService()
         synced = 0
-        for ds in list(connection.data_sources):
+        for ds_id in ds_ids:
             try:
-                await ds_service.sync_domain_tables_from_connection(
-                    db,
-                    ds,
-                    connection,
-                    max_auto_select=ds_service.ONBOARDING_MAX_TABLES,
-                )
-                synced += 1
+                async with async_session_maker() as per_db:
+                    # Re-fetch the DS in the per-DS session. If it was deleted
+                    # (hard or soft) between snapshot and now, skip cleanly.
+                    ds_row = await per_db.execute(
+                        select(DataSource).where(
+                            DataSource.id == ds_id,
+                            DataSource.deleted_at.is_(None),
+                        )
+                    )
+                    ds = ds_row.scalar_one_or_none()
+                    if ds is None:
+                        continue
+                    # Same for the connection — guard against a delete here too.
+                    conn_row = await per_db.execute(
+                        select(Connection).where(
+                            Connection.id == str(connection_id),
+                            Connection.deleted_at.is_(None),
+                        )
+                    )
+                    connection = conn_row.scalar_one_or_none()
+                    if connection is None:
+                        continue
+                    try:
+                        await ds_service.sync_domain_tables_from_connection(
+                            per_db,
+                            ds,
+                            connection,
+                            max_auto_select=ds_service.ONBOARDING_MAX_TABLES,
+                        )
+                        await per_db.commit()
+                        synced += 1
+                    except IntegrityError:
+                        # Most likely cause: the DS was deleted between our
+                        # existence check and the INSERT (FK violation on
+                        # datasource_tables.datasource_id). Roll back this
+                        # DS and move on.
+                        await per_db.rollback()
+                        logger.info(
+                            "indexing.sync_domain_skipped_fk",
+                            extra={
+                                "connection_id": str(connection_id),
+                                "data_source_id": ds_id,
+                            },
+                        )
             except Exception:
                 logger.exception(
                     "indexing.sync_domain_failed",
-                    extra={"connection_id": str(connection_id), "data_source_id": str(ds.id)},
+                    extra={"connection_id": str(connection_id), "data_source_id": ds_id},
                 )
-        try:
-            await db.commit()
-        except Exception:
-            await db.rollback()
         return synced

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -124,12 +124,18 @@ class ConnectionService:
                 detail=f"A connection named '{name}' already exists in this organization."
             )
 
-        # Discover and save tables/tools for system_only connections
+        # Discover and save tables/tools for system_only connections.
+        # Schema discovery is pushed to a background indexing job so POST
+        # returns in ~ms even for slow sources (QVD/PBIRS/large warehouses).
+        # Tool providers (MCP/custom_api) stay synchronous — they're fast.
         if auth_policy == "system_only":
             if type in self._TOOL_PROVIDER_TYPES:
                 await self.refresh_tools(db=db, connection=connection)
             else:
-                await self.refresh_schema(db=db, connection=connection)
+                from app.services.connection_indexing_service import (
+                    ConnectionIndexingService,
+                )
+                await ConnectionIndexingService().start(db=db, connection=connection)
 
         # Audit log
         try:
@@ -261,12 +267,16 @@ class ConnectionService:
         try:
             await db.commit()
 
-            # Refresh tables/tools if connection changed
+            # Refresh tables/tools if connection changed.
+            # Schema refresh is backgrounded; tool refresh stays synchronous.
             if connection_changed and connection.auth_policy == "system_only":
                 if connection.type in self._TOOL_PROVIDER_TYPES:
                     await self.refresh_tools(db=db, connection=connection)
                 else:
-                    await self.refresh_schema(db=db, connection=connection)
+                    from app.services.connection_indexing_service import (
+                        ConnectionIndexingService,
+                    )
+                    await ConnectionIndexingService().start(db=db, connection=connection)
 
             # Audit log
             try:
@@ -426,9 +436,16 @@ class ConnectionService:
         config_overrides: dict = None,
         credential_overrides: dict = None,
     ) -> dict:
-        """Test an existing connection, optionally with override config/credentials."""
+        """Test an existing connection, optionally with override config/credentials.
+
+        The response is always augmented with a `timings.total_ms` field and a
+        non-None `details` dict (may be empty). Clients that fill in richer
+        timings/details have them preserved.
+        """
+        import time as _time
         connection = await self.get_connection(db, connection_id, organization)
 
+        t0 = _time.perf_counter()
         try:
             client = await self.construct_client(
                 db, connection, current_user,
@@ -451,6 +468,12 @@ class ConnectionService:
                     connection.is_active = True
 
             await db.commit()
+            if isinstance(connection_status, dict):
+                timings = dict(connection_status.get("timings") or {})
+                timings.setdefault("total_ms", round((_time.perf_counter() - t0) * 1000, 1))
+                connection_status["timings"] = timings
+                if connection_status.get("details") is None:
+                    connection_status["details"] = {}
             return connection_status
 
         except Exception as e:
@@ -463,7 +486,9 @@ class ConnectionService:
             await db.commit()
             return {
                 "success": False,
-                "message": str(e)
+                "message": str(e),
+                "timings": {"total_ms": round((_time.perf_counter() - t0) * 1000, 1)},
+                "details": {},
             }
 
     async def test_user_connection(
@@ -505,13 +530,21 @@ class ConnectionService:
         db: AsyncSession,
         connection: Connection,
         current_user: User = None,
+        progress_callback=None,
     ) -> List[ConnectionTable]:
-        """Refresh schema and update ConnectionTable records."""
+        """Refresh schema and update ConnectionTable records.
+
+        `progress_callback`, if supplied, is forwarded to the client's
+        `aget_schemas` and invoked from inside its existing iteration loops.
+        """
         try:
             logger.info(f"refresh_schema: Starting for connection {connection.id} (type={connection.type}, auth_policy={connection.auth_policy})")
             client = await self.construct_client(db, connection, current_user)
             logger.info(f"refresh_schema: Client constructed successfully, calling get_schemas()...")
-            fresh_tables = await client.aget_schemas()
+            if progress_callback is not None:
+                fresh_tables = await client.aget_schemas(progress_callback=progress_callback)
+            else:
+                fresh_tables = await client.aget_schemas()
 
             logger.info(f"refresh_schema: Got {len(fresh_tables) if fresh_tables else 0} tables from database")
             if fresh_tables and len(fresh_tables) > 0:

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -134,6 +134,7 @@ class DataSourceService:
                         "finished_at": indexing_row.finished_at.isoformat() if indexing_row.finished_at else None,
                         "error": indexing_row.error,
                         "stats": indexing_row.stats_json,
+                        "events": indexing_row.events_json or [],
                     }
             except Exception:
                 indexing_payload = None

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -69,10 +69,41 @@ class DataSourceService:
             return []
 
         from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
-        from app.services.connection_indexing_service import ConnectionIndexingService
+        from app.models.connection_indexing import ConnectionIndexing
         from app.models.connection_table import ConnectionTable
 
-        indexing_service = ConnectionIndexingService()
+        # One query for all connections' latest indexings — avoids N+1 on
+        # GET /data_sources/{id} which is polled every ~2s while indexing runs.
+        # Postgres has DISTINCT ON; we use a portable correlated subquery with
+        # MAX(created_at) so SQLite + Postgres + others all behave the same.
+        connection_ids = [str(c.id) for c in data_source.connections]
+        indexing_by_conn: dict[str, ConnectionIndexing] = {}
+        if connection_ids:
+            try:
+                latest_subq = (
+                    select(
+                        ConnectionIndexing.connection_id,
+                        func.max(ConnectionIndexing.created_at).label("max_created"),
+                    )
+                    .where(ConnectionIndexing.connection_id.in_(connection_ids))
+                    .group_by(ConnectionIndexing.connection_id)
+                    .subquery()
+                )
+                rows = await db.execute(
+                    select(ConnectionIndexing).join(
+                        latest_subq,
+                        (ConnectionIndexing.connection_id == latest_subq.c.connection_id)
+                        & (ConnectionIndexing.created_at == latest_subq.c.max_created),
+                    )
+                )
+                for idx in rows.scalars().all():
+                    indexing_by_conn[str(idx.connection_id)] = idx
+            except Exception:
+                logger.exception(
+                    "indexing.bulk_lookup_failed",
+                    extra={"data_source_id": str(data_source.id)},
+                )
+
         connections_list = []
 
         for conn in data_source.connections:
@@ -119,25 +150,22 @@ class DataSourceService:
                 table_count = legacy_count_result.scalar() or 0
 
             # Inline latest indexing row (for UI polling / status badge).
+            indexing_row = indexing_by_conn.get(str(conn.id))
             indexing_payload = None
-            try:
-                indexing_row = await indexing_service.get_latest(db, str(conn.id))
-                if indexing_row is not None:
-                    indexing_payload = {
-                        "id": str(indexing_row.id),
-                        "status": indexing_row.status,
-                        "phase": indexing_row.phase,
-                        "current_item": indexing_row.current_item,
-                        "progress_done": indexing_row.progress_done or 0,
-                        "progress_total": indexing_row.progress_total or 0,
-                        "started_at": indexing_row.started_at.isoformat() if indexing_row.started_at else None,
-                        "finished_at": indexing_row.finished_at.isoformat() if indexing_row.finished_at else None,
-                        "error": indexing_row.error,
-                        "stats": indexing_row.stats_json,
-                        "events": indexing_row.events_json or [],
-                    }
-            except Exception:
-                indexing_payload = None
+            if indexing_row is not None:
+                indexing_payload = {
+                    "id": str(indexing_row.id),
+                    "status": indexing_row.status,
+                    "phase": indexing_row.phase,
+                    "current_item": indexing_row.current_item,
+                    "progress_done": indexing_row.progress_done or 0,
+                    "progress_total": indexing_row.progress_total or 0,
+                    "started_at": indexing_row.started_at.isoformat() if indexing_row.started_at else None,
+                    "finished_at": indexing_row.finished_at.isoformat() if indexing_row.finished_at else None,
+                    "error": indexing_row.error,
+                    "stats": indexing_row.stats_json,
+                    "events": indexing_row.events_json or [],
+                }
 
             connections_list.append(ConnectionEmbedded(
                 id=str(conn.id),
@@ -2622,7 +2650,13 @@ class DataSourceService:
                 if conn.auth_policy == "system_only":
                     has_system_only_conn = True
                     # Wait for any active indexing run before refreshing synchronously.
-                    await indexing_service.wait_for_active(db, str(conn.id))
+                    try:
+                        await indexing_service.wait_for_active(db, str(conn.id))
+                    except TimeoutError as exc:
+                        raise HTTPException(
+                            status_code=504,
+                            detail=str(exc),
+                        ) from exc
                     logger.info(f"refresh_data_source_schema: Calling refresh_schema for connection {conn.id}")
                     await connection_service.refresh_schema(db=db, connection=conn, current_user=current_user)
                     logger.info(f"refresh_data_source_schema: refresh_schema completed for connection {conn.id}")

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -69,8 +69,10 @@ class DataSourceService:
             return []
 
         from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
+        from app.services.connection_indexing_service import ConnectionIndexingService
         from app.models.connection_table import ConnectionTable
 
+        indexing_service = ConnectionIndexingService()
         connections_list = []
 
         for conn in data_source.connections:
@@ -116,6 +118,26 @@ class DataSourceService:
                 )
                 table_count = legacy_count_result.scalar() or 0
 
+            # Inline latest indexing row (for UI polling / status badge).
+            indexing_payload = None
+            try:
+                indexing_row = await indexing_service.get_latest(db, str(conn.id))
+                if indexing_row is not None:
+                    indexing_payload = {
+                        "id": str(indexing_row.id),
+                        "status": indexing_row.status,
+                        "phase": indexing_row.phase,
+                        "current_item": indexing_row.current_item,
+                        "progress_done": indexing_row.progress_done or 0,
+                        "progress_total": indexing_row.progress_total or 0,
+                        "started_at": indexing_row.started_at.isoformat() if indexing_row.started_at else None,
+                        "finished_at": indexing_row.finished_at.isoformat() if indexing_row.finished_at else None,
+                        "error": indexing_row.error,
+                        "stats": indexing_row.stats_json,
+                    }
+            except Exception:
+                indexing_payload = None
+
             connections_list.append(ConnectionEmbedded(
                 id=str(conn.id),
                 name=conn.name,
@@ -127,6 +149,7 @@ class DataSourceService:
                 last_synced_at=conn.last_synced_at,
                 user_status=user_status,
                 table_count=table_count,
+                indexing=indexing_payload,
             ))
 
         return connections_list
@@ -239,9 +262,15 @@ class DataSourceService:
                 conn_table_count = conn_tables_result.scalar() or 0
 
                 if conn_table_count == 0 and conn.auth_policy == "system_only":
-                    # Refresh schema to populate ConnectionTable from the database
-                    connection_service = ConnectionService()
-                    await connection_service.refresh_schema(db=db, connection=conn, current_user=current_user)
+                    # Kick off background indexing — the runner populates
+                    # ConnectionTable and then syncs DataSourceTable for every
+                    # linked data source. The create call returns without
+                    # waiting. The domain starts with zero tables; the UI
+                    # polls the indexing status and updates when ready.
+                    from app.services.connection_indexing_service import (
+                        ConnectionIndexingService,
+                    )
+                    await ConnectionIndexingService().start(db=db, connection=conn)
 
             # Use first connection's auth_policy for downstream logic
             auth_policy = connections_to_link[0].auth_policy
@@ -405,16 +434,18 @@ class DataSourceService:
                         max_auto_select=self.ONBOARDING_MAX_TABLES
                     )
             else:
-                # Mode 1: New connection - populate ConnectionTable first, then DataSourceTable
-                from app.services.connection_service import ConnectionService
-                connection_service = ConnectionService()
-                logger.info(f"create_data_source: Mode 1 - populating ConnectionTable for new connection {new_connection.id}")
-                await connection_service.refresh_schema(db=db, connection=new_connection, current_user=current_user)
-                logger.info(f"create_data_source: Mode 1 - syncing from ConnectionTable to DataSourceTable")
-                await self.sync_domain_tables_from_connection(
-                    db, new_data_source, new_connection,
-                    max_auto_select=self.ONBOARDING_MAX_TABLES
+                # Mode 1: New connection - schema discovery runs in the
+                # background. The indexing runner populates ConnectionTable
+                # and then syncs DataSourceTable for this data source
+                # (and any others linked to the connection).
+                from app.services.connection_indexing_service import (
+                    ConnectionIndexingService,
                 )
+                logger.info(
+                    f"create_data_source: Mode 1 - kicking off background indexing "
+                    f"for new connection {new_connection.id}"
+                )
+                await ConnectionIndexingService().start(db=db, connection=new_connection)
             await db.commit()
             await db.refresh(new_data_source)
 

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2605,16 +2605,23 @@ class DataSourceService:
         if not data_source:
             raise HTTPException(status_code=404, detail="Data source not found")
 
-        # First, refresh ConnectionTable from the database (for all linked connections)
+        # First, refresh ConnectionTable from the database (for all linked connections).
+        # If a background indexing job is currently in flight for any connection,
+        # await it first — both to avoid duplicate work and to ensure deterministic
+        # state for the synchronous sync that follows.
         if data_source.connections:
             from app.services.connection_service import ConnectionService
+            from app.services.connection_indexing_service import ConnectionIndexingService
             connection_service = ConnectionService()
+            indexing_service = ConnectionIndexingService()
             logger.info(f"refresh_data_source_schema: Found {len(data_source.connections)} connections for data_source {data_source_id}")
             has_system_only_conn = False
             for conn in data_source.connections:
                 logger.info(f"refresh_data_source_schema: Connection {conn.id} has auth_policy={conn.auth_policy}")
                 if conn.auth_policy == "system_only":
                     has_system_only_conn = True
+                    # Wait for any active indexing run before refreshing synchronously.
+                    await indexing_service.wait_for_active(db, str(conn.id))
                     logger.info(f"refresh_data_source_schema: Calling refresh_schema for connection {conn.id}")
                     await connection_service.refresh_schema(db=db, connection=conn, current_user=current_user)
                     logger.info(f"refresh_data_source_schema: refresh_schema completed for connection {conn.id}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,7 @@ from app.schemas.user_schema import UserCreate, UserRead, UserUpdate
 from app.settings.config import settings
 from app.settings.logging_config import setup_logging, get_logger
 from app.core.cors import init_cors
-from app.core.scheduler import scheduler
+from app.core.scheduler import scheduler, try_acquire_scheduler_leader
 from app.core.spa import mount_spa
 from app.models.user import User
 from app.services.maintenance_service import purge_step_payloads_keep_latest_per_query
@@ -351,62 +351,72 @@ async def startup_event():
         }
     )
 
+    # Only one uvicorn worker should register & run scheduled jobs. Otherwise
+    # N-workers × every scheduled tick becomes an N-way resource storm
+    # (customer log showed warm_all_qvd_caches firing 5–6× simultaneously).
+    is_scheduler_leader = try_acquire_scheduler_leader()
+    if not is_scheduler_leader:
+        logger.info("Scheduler leader lock not acquired — skipping job registration in this worker")
+
     # Register daily maintenance jobs
-    try:
-        scheduler.add_job(
-            purge_step_payloads_keep_latest_per_query,
-            trigger="cron",
-            hour=3,
-            minute=0,
-            id="purge_step_payloads_daily",
-            replace_existing=True,
-            coalesce=True,
-            max_instances=1,
-            misfire_grace_time=3600,
-            kwargs={"null_fields": ("data", "data_model", "view")},
-        )
-        logger.info("Scheduled job: purge_step_payloads_keep_latest_per_query @ 03:00 daily")
-    except Exception as e:
-        logger.error(f"Failed to schedule purge job: {e}")
+    if is_scheduler_leader:
+        try:
+            scheduler.add_job(
+                purge_step_payloads_keep_latest_per_query,
+                trigger="cron",
+                hour=3,
+                minute=0,
+                id="purge_step_payloads_daily",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+                misfire_grace_time=3600,
+                kwargs={"null_fields": ("data", "data_model", "view")},
+            )
+            logger.info("Scheduled job: purge_step_payloads_keep_latest_per_query @ 03:00 daily")
+        except Exception as e:
+            logger.error(f"Failed to schedule purge job: {e}")
 
     # Background warmup of QVD Parquet caches so the first create_data/inspect_data
     # on a 1-5GB QVD doesn't block the UI for minutes.
-    try:
-        scheduler.add_job(
-            warm_all_qvd_caches,
-            trigger="interval",
-            minutes=15,
-            id="qvd_warmup",
-            replace_existing=True,
-            coalesce=True,
-            max_instances=1,
-            misfire_grace_time=300,
-            next_run_time=datetime.now(),
-        )
-        logger.info("Scheduled job: qvd_warmup every 15m (runs once at startup)")
-    except Exception as e:
-        logger.error(f"Failed to schedule QVD warmup job: {e}")
+    if is_scheduler_leader:
+        try:
+            scheduler.add_job(
+                warm_all_qvd_caches,
+                trigger="interval",
+                minutes=15,
+                id="qvd_warmup",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+                misfire_grace_time=300,
+                next_run_time=datetime.now(),
+            )
+            logger.info("Scheduled job: qvd_warmup every 15m (runs once at startup)")
+        except Exception as e:
+            logger.error(f"Failed to schedule QVD warmup job: {e}")
 
     # Background warmup of PBIRS pbix Parquet caches so first queries against a
     # Power BI report don't pay the pbixray parse cost (~10-30s on ~50MB pbix).
-    try:
-        scheduler.add_job(
-            warm_all_pbirs_caches,
-            trigger="interval",
-            minutes=30,
-            id="pbirs_warmup",
-            replace_existing=True,
-            coalesce=True,
-            max_instances=1,
-            misfire_grace_time=600,
-            next_run_time=datetime.now(),
-        )
-        logger.info("Scheduled job: pbirs_warmup every 30m (runs once at startup)")
-    except Exception as e:
-        logger.error(f"Failed to schedule PBIRS warmup job: {e}")
+    if is_scheduler_leader:
+        try:
+            scheduler.add_job(
+                warm_all_pbirs_caches,
+                trigger="interval",
+                minutes=30,
+                id="pbirs_warmup",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+                misfire_grace_time=600,
+                next_run_time=datetime.now(),
+            )
+            logger.info("Scheduled job: pbirs_warmup every 30m (runs once at startup)")
+        except Exception as e:
+            logger.error(f"Failed to schedule PBIRS warmup job: {e}")
 
     # Register LDAP group sync job if configured AND licensed (sync is enterprise-only)
-    if settings.bow_config.ldap.enabled and has_feature("ldap"):
+    if is_scheduler_leader and settings.bow_config.ldap.enabled and has_feature("ldap"):
         try:
             from app.ee.ldap.jobs import ldap_sync_all_organizations
             scheduler.add_job(
@@ -423,11 +433,17 @@ async def startup_event():
         except Exception as e:
             logger.error(f"Failed to schedule LDAP sync job: {e}")
 
+    # All workers must start their scheduler (route handlers in this worker
+    # call scheduler.add_job to persist user-scheduled prompts/reports to the
+    # shared jobstore). Only the leader registers the global warmup jobs
+    # above — those are the ones that fanned out to N workers.
     scheduler.start()
 
-    # Re-register scheduled prompt jobs
-    from app.services.scheduled_prompt_service import scheduled_prompt_service
-    await scheduled_prompt_service.register_all_jobs()
+    if is_scheduler_leader:
+        # Re-register scheduled prompt jobs (only the leader flushes these to
+        # the jobstore; non-leaders would duplicate the set).
+        from app.services.scheduled_prompt_service import scheduled_prompt_service
+        await scheduled_prompt_service.register_all_jobs()
 
     # Validate license at startup
     license_info = get_license_info()

--- a/backend/main.py
+++ b/backend/main.py
@@ -384,7 +384,7 @@ async def startup_event():
             scheduler.add_job(
                 warm_all_qvd_caches,
                 trigger="interval",
-                minutes=15,
+                hours=1,
                 id="qvd_warmup",
                 replace_existing=True,
                 coalesce=True,
@@ -392,7 +392,7 @@ async def startup_event():
                 misfire_grace_time=300,
                 next_run_time=datetime.now(),
             )
-            logger.info("Scheduled job: qvd_warmup every 15m (runs once at startup)")
+            logger.info("Scheduled job: qvd_warmup every 1h (runs once at startup)")
         except Exception as e:
             logger.error(f"Failed to schedule QVD warmup job: {e}")
 
@@ -403,7 +403,7 @@ async def startup_event():
             scheduler.add_job(
                 warm_all_pbirs_caches,
                 trigger="interval",
-                minutes=30,
+                hours=1,
                 id="pbirs_warmup",
                 replace_existing=True,
                 coalesce=True,
@@ -411,7 +411,7 @@ async def startup_event():
                 misfire_grace_time=600,
                 next_run_time=datetime.now(),
             )
-            logger.info("Scheduled job: pbirs_warmup every 30m (runs once at startup)")
+            logger.info("Scheduled job: pbirs_warmup every 1h (runs once at startup)")
         except Exception as e:
             logger.error(f"Failed to schedule PBIRS warmup job: {e}")
 

--- a/backend/tests/e2e/test_connection.py
+++ b/backend/tests/e2e/test_connection.py
@@ -143,6 +143,7 @@ def test_connection_refresh_schema(
     create_user,
     login_user,
     whoami,
+    test_client,
 ):
     """Test that refreshing a connection discovers tables."""
     if not CONNECTION_TEST_DB_PATH.exists():
@@ -162,15 +163,23 @@ def test_connection_refresh_schema(
         org_id=org_id,
     )
 
-    # Refresh schema
+    # Refresh schema — now kicks off a background indexing job and returns
+    # the indexing row. Poll /indexing until terminal, then assert tables.
     refresh_result = refresh_connection_schema(
         connection_id=connection["id"],
         user_token=user_token,
         org_id=org_id,
     )
+    assert "indexing" in refresh_result
+    assert refresh_result["indexing"]["status"] in ("pending", "running", "completed")
 
-    assert "table_count" in refresh_result
-    assert refresh_result["table_count"] > 0
+    # Wait for the in-flight indexing run (first run may already be in flight
+    # from connection creation; reindex returns that one if so).
+    import time as _time
+    from tests.e2e.test_connection_indexing import _poll_until_terminal
+    final = _poll_until_terminal(test_client, connection["id"], user_token, org_id)
+    assert final["status"] == "completed", final
+    assert final["progress_total"] > 0
 
     # Verify tables are available
     tables = get_connection_tables(

--- a/backend/tests/e2e/test_connection_indexing.py
+++ b/backend/tests/e2e/test_connection_indexing.py
@@ -1,0 +1,287 @@
+"""
+E2E tests for ConnectionIndexing — the background job that runs refresh_schema
+off the HTTP request and exposes progress via `GET /connections/{id}/indexing`.
+
+Covers the Phase 6 acceptance gates:
+  - happy path: POST /connections returns fast, indexing completes
+  - failure path: bad config returns 400 and does not create an indexing row
+  - retry: POST /reindex starts a new row after a terminal failure
+  - idempotency: firing reindex while one is running returns the same row
+  - inlined indexing payload on the data source GET
+"""
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+
+CONNECTION_TEST_DB_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "chinook.sqlite"
+).resolve()
+
+
+def _skip_if_no_chinook():
+    if not CONNECTION_TEST_DB_PATH.exists():
+        pytest.skip(f"SQLite test database missing at {CONNECTION_TEST_DB_PATH}")
+
+
+def _poll_until_terminal(test_client, connection_id, user_token, org_id, *, timeout_s: float = 10.0):
+    """Poll GET /connections/{id}/indexing until status is completed/failed/cancelled."""
+    headers = {
+        "Authorization": f"Bearer {user_token}",
+        "X-Organization-Id": str(org_id),
+    }
+    deadline = time.perf_counter() + timeout_s
+    last = None
+    while time.perf_counter() < deadline:
+        r = test_client.get(f"/api/connections/{connection_id}/indexing", headers=headers)
+        if r.status_code == 404:
+            time.sleep(0.05)
+            continue
+        assert r.status_code == 200, r.text
+        last = r.json()
+        if last["status"] in ("completed", "failed", "cancelled"):
+            return last
+        time.sleep(0.1)
+    pytest.fail(f"Indexing did not reach terminal state within {timeout_s}s; last={last!r}")
+
+
+@pytest.mark.e2e
+def test_indexing_happy_path(
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Create a sqlite connection against chinook, verify indexing runs to
+    completion in the background and populates ConnectionTable rows.
+    """
+    _skip_if_no_chinook()
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    t0 = time.perf_counter()
+    connection = create_connection(
+        name="Indexing Happy",
+        type="sqlite",
+        config={"database": str(CONNECTION_TEST_DB_PATH)},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    post_duration = time.perf_counter() - t0
+    assert post_duration < 2.0, f"POST /connections should return in <2s, took {post_duration:.2f}s"
+
+    conn_id = connection["id"]
+
+    # Initially table_count is 0 — indexing hasn't completed yet.
+    # The indexing row should exist and (eventually) reach "completed".
+    final = _poll_until_terminal(test_client, conn_id, token, org_id)
+    assert final["status"] == "completed", final
+    assert final["progress_done"] == final["progress_total"]
+    assert final["progress_total"] >= 1
+    assert (final.get("stats") or {}).get("table_count", 0) >= 1
+
+    # Verify /tables reflects the indexed set (ConnectionTable rows).
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    }
+    r = test_client.get(f"/api/connections/{conn_id}/tables", headers=headers)
+    assert r.status_code == 200, r.text
+    tables = r.json()
+    assert len(tables) >= 1
+
+
+@pytest.mark.e2e
+def test_indexing_failure_fast_reject(
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Bad config must return 400 immediately, with no connection or indexing
+    persisted. This is the pre-validation gate before kicking off the runner.
+    """
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    }
+    r = test_client.post(
+        "/api/connections",
+        json={
+            "name": "Bad",
+            "type": "sqlite",
+            "config": {"database": "/this/definitely/does/not/exist.sqlite"},
+            "credentials": {},
+            "auth_policy": "system_only",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.e2e
+def test_indexing_reindex_endpoint(
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """POST /reindex starts a new indexing run after the first one completed."""
+    _skip_if_no_chinook()
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    connection = create_connection(
+        name="Reindex Test",
+        type="sqlite",
+        config={"database": str(CONNECTION_TEST_DB_PATH)},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    conn_id = connection["id"]
+    first = _poll_until_terminal(test_client, conn_id, token, org_id)
+    assert first["status"] == "completed"
+    first_id = first["id"]
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    }
+    r = test_client.post(f"/api/connections/{conn_id}/reindex", headers=headers)
+    assert r.status_code == 200, r.text
+    new_idx = r.json()["indexing"]
+    assert new_idx["id"] != first_id, "reindex should create a fresh row"
+    assert new_idx["status"] in ("pending", "running")
+
+    second = _poll_until_terminal(test_client, conn_id, token, org_id)
+    assert second["status"] == "completed"
+    assert second["id"] == new_idx["id"]
+
+
+@pytest.mark.e2e
+def test_indexing_datasource_payload_inlined(
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """`GET /data_sources/{id}` inlines `indexing` into each connection entry.
+
+    The page layout uses this to drive its polling loop and status badges.
+    """
+    _skip_if_no_chinook()
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    }
+    # Create a data source (Mode 1 — new connection inline).
+    r = test_client.post(
+        "/api/data_sources",
+        json={
+            "name": "Indexing DS",
+            "type": "sqlite",
+            "config": {"database": str(CONNECTION_TEST_DB_PATH)},
+            "credentials": {},
+            "is_public": True,
+        },
+        headers=headers,
+    )
+    assert r.status_code in (200, 201), r.text
+    ds = r.json()
+    ds_id = ds["id"]
+    assert len(ds.get("connections") or []) == 1
+    # On the create response, indexing should be present (pending or running).
+    first_conn = ds["connections"][0]
+    assert first_conn.get("indexing") is not None
+    assert first_conn["indexing"]["status"] in ("pending", "running", "completed")
+    conn_id = first_conn["id"]
+
+    # Wait for the indexing to complete, then re-fetch the data source.
+    _poll_until_terminal(test_client, conn_id, token, org_id)
+    r2 = test_client.get(f"/api/data_sources/{ds_id}", headers=headers)
+    assert r2.status_code == 200, r2.text
+    ds2 = r2.json()
+    conn2 = ds2["connections"][0]
+    assert conn2["indexing"] is not None
+    assert conn2["indexing"]["status"] == "completed"
+
+
+@pytest.mark.e2e
+def test_indexing_idempotent_while_running(
+    monkeypatch,
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """While a job is pending/running, POST /reindex returns the same row.
+
+    We slow down the sqlite client's progress loop so the job stays "running"
+    long enough for two overlapping POSTs to collide.
+    """
+    _skip_if_no_chinook()
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    connection = create_connection(
+        name="Idempotent Reindex",
+        type="sqlite",
+        config={"database": str(CONNECTION_TEST_DB_PATH)},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    conn_id = connection["id"]
+    _poll_until_terminal(test_client, conn_id, token, org_id)
+
+    # Patch the sqlite client's get_tables to sleep per-iteration, keeping the
+    # job "running" long enough for two POSTs to overlap.
+    from app.data_sources.clients import sqlite_client
+
+    original_get_tables = sqlite_client.SqliteClient.get_tables
+
+    def slow_get_tables(self, progress_callback=None):  # type: ignore[override]
+        import time as _t
+        _t.sleep(0.05)
+        return original_get_tables(self, progress_callback=progress_callback)
+
+    monkeypatch.setattr(sqlite_client.SqliteClient, "get_tables", slow_get_tables)
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    }
+    # Fire twice back-to-back
+    r1 = test_client.post(f"/api/connections/{conn_id}/reindex", headers=headers)
+    r2 = test_client.post(f"/api/connections/{conn_id}/reindex", headers=headers)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    id1 = r1.json()["indexing"]["id"]
+    id2 = r2.json()["indexing"]["id"]
+    # They must match: second POST should see the in-flight row and return it.
+    assert id1 == id2, (r1.json(), r2.json())
+
+    _poll_until_terminal(test_client, conn_id, token, org_id)

--- a/backend/tests/e2e/test_connection_indexing_load.py
+++ b/backend/tests/e2e/test_connection_indexing_load.py
@@ -1,0 +1,120 @@
+"""Load tests for ConnectionIndexing — prove the background job handles a
+large-schema source end-to-end without blocking the HTTP request.
+
+Phase 7 acceptance: a sqlite source with **500 tables** must:
+  - POST /connections in < 1s
+  - reach indexing.status == "completed" with progress_done == progress_total == 500
+  - emit progress that increases monotonically across at least a few poll samples
+  - end with ConnectionTable rows matching the 500 tables
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+N_TABLES = 500
+
+
+def _build_large_sqlite_fixture() -> str:
+    """Create a sqlite DB with N_TABLES simple tables. Returns absolute path.
+
+    The file lives in the tests' temp area so it's cleaned up with the pytest
+    session; we cache it across tests by parameterizing on (N_TABLES, schema_version).
+    """
+    cache_dir = Path(tempfile.gettempdir()) / "bow_indexing_load_fixture"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / f"load_{N_TABLES}.sqlite"
+    if path.exists():
+        return str(path)
+    conn = sqlite3.connect(str(path))
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL")
+        for i in range(N_TABLES):
+            # 10 columns each — small but representative of a wide warehouse.
+            cols = ", ".join(
+                [f"col_{j} TEXT" for j in range(10)]
+            )
+            cur.execute(f"CREATE TABLE t_{i:04d} (id INTEGER PRIMARY KEY, {cols})")
+        conn.commit()
+    finally:
+        conn.close()
+    return str(path)
+
+
+def _poll_samples(test_client, conn_id, token, org_id, *, timeout_s: float = 120.0):
+    """Poll the indexing endpoint and collect progress samples until terminal.
+    Returns (final_row, samples). Samples is a list of (progress_done, progress_total).
+    """
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+    deadline = time.perf_counter() + timeout_s
+    samples: list[tuple[int, int, str]] = []
+    last = None
+    while time.perf_counter() < deadline:
+        r = test_client.get(f"/api/connections/{conn_id}/indexing", headers=headers)
+        if r.status_code == 404:
+            time.sleep(0.05)
+            continue
+        assert r.status_code == 200, r.text
+        last = r.json()
+        samples.append((last["progress_done"], last["progress_total"], last["status"]))
+        if last["status"] in ("completed", "failed", "cancelled"):
+            return last, samples
+        time.sleep(0.1)
+    pytest.fail(f"Indexing did not reach terminal state within {timeout_s}s; last={last!r}")
+
+
+@pytest.mark.e2e
+def test_large_sqlite_500_tables_indexing_completes(
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    fixture_path = _build_large_sqlite_fixture()
+    assert os.path.exists(fixture_path)
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    t0 = time.perf_counter()
+    connection = create_connection(
+        name="Load 500 Tables",
+        type="sqlite",
+        config={"database": fixture_path},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    post_duration = time.perf_counter() - t0
+    conn_id = connection["id"]
+    # POST /connections must not wait on schema — cap at 3s to absorb
+    # test-harness overhead while still proving the refactor.
+    assert post_duration < 3.0, f"POST /connections took {post_duration:.2f}s (expected <3s)"
+
+    final, samples = _poll_samples(test_client, conn_id, token, org_id, timeout_s=120.0)
+    assert final["status"] == "completed", final
+    assert final["progress_total"] == N_TABLES, final
+    assert final["progress_done"] == N_TABLES, final
+    assert (final.get("stats") or {}).get("table_count") == N_TABLES
+
+    # Monotonic progress: progress_done never regresses across samples.
+    last_done = -1
+    for done, total, _status in samples:
+        assert done >= last_done, f"progress_done regressed: {done} < {last_done}"
+        last_done = done
+
+    # Verify ConnectionTable rows
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+    r = test_client.get(f"/api/connections/{conn_id}/tables", headers=headers)
+    assert r.status_code == 200, r.text
+    tables = r.json()
+    assert len(tables) == N_TABLES

--- a/backend/tests/e2e/test_connection_indexing_pbirs_mock.py
+++ b/backend/tests/e2e/test_connection_indexing_pbirs_mock.py
@@ -1,0 +1,195 @@
+"""Load test for ConnectionIndexing against a mocked Power BI Report Server.
+
+PBIRS is the other client we explicitly wired progress callbacks into
+(`get_schemas` has phase events for listing, pbix_reports, rdl_reports,
+shared_datasets, kpis). A real server isn't available in CI, so we
+monkeypatch `test_connection` and `get_schemas` on the client class to
+behave like a server with 50 PBIX reports, 30 paginated reports, 20
+shared datasets, and 5 KPIs.
+
+Assertions:
+  - POST /connections returns in <2s with status_code 200.
+  - Indexing runs to completion with `progress_done == progress_total`.
+  - Phase transitions are observed across polling: listing → pbix_reports
+    → rdl_reports → shared_datasets → kpis (subset sufficient, since
+    phases can complete between polls).
+  - ConnectionTable rows count matches the mocked table output.
+  - The indexing stats report the correct table_count.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app.ai.prompt_formatters import Table
+from app.data_sources.clients import powerbi_report_server_client as pbirs
+from app.data_sources.clients.progress import make_reporter
+
+
+N_PBIX = 50
+N_RDL = 30
+N_DS = 20
+N_KPI = 5
+# PBIX: one umbrella + two model tables per report (fixture shape)
+# RDL: one dataset per report
+# DS: one row per dataset
+# KPI: one row per KPI
+TOTAL_TABLES = N_PBIX * 3 + N_RDL + N_DS + N_KPI
+
+
+def _mock_test_connection(self) -> dict:
+    return {
+        "success": True,
+        "message": "Mocked PBIRS connection",
+        "connectivity": True,
+        "schema_access": True,
+        "table_count": TOTAL_TABLES,
+        "timings": {"mock_ms": 1.0},
+        "details": {"product_version": "mock-1.0", "auth_mode": "NTLM"},
+    }
+
+
+def _mock_get_schemas(self, progress_callback=None):
+    """Emit the same phase sequence as the real get_schemas, with canned data.
+
+    A small sleep between phases keeps each one visible to pollers beyond the
+    progress-flush debounce window (so the test can assert transitions). In
+    production, PBIRS phases take seconds each — this mock exaggerates that.
+    """
+    import time as _t
+    reporter = make_reporter(progress_callback)
+    reporter.phase("listing")
+    _t.sleep(0.3)
+    tables = []
+
+    reporter.phase("pbix_reports", total=N_PBIX)
+    _t.sleep(0.3)
+    for i in range(N_PBIX):
+        rid = f"pbix-{i}"
+        name = f"Report {i}"
+        # Umbrella row
+        tables.append(Table(
+            name=f"pbix:{name}",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"report_id": rid, "report_type": "PowerBIReport"}},
+        ))
+        # Two model tables per report
+        tables.append(Table(
+            name=f"pbix:{name}/Fact",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"report_id": rid, "report_type": "PowerBIReportTable", "model_table": "Fact"}},
+        ))
+        tables.append(Table(
+            name=f"pbix:{name}/Dim",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"report_id": rid, "report_type": "PowerBIReportTable", "model_table": "Dim"}},
+        ))
+        reporter.item(name)
+
+    reporter.phase("rdl_reports", total=N_RDL)
+    _t.sleep(0.3)
+    for i in range(N_RDL):
+        name = f"RDL Report {i}"
+        tables.append(Table(
+            name=f"rdl:{name}/Main",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"report_id": f"rdl-{i}", "report_type": "Report"}},
+        ))
+        reporter.item(name)
+
+    reporter.phase("shared_datasets", total=N_DS)
+    _t.sleep(0.3)
+    for i in range(N_DS):
+        name = f"Dataset {i}"
+        tables.append(Table(
+            name=f"dataset:{name}",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"dataset_id": f"ds-{i}", "report_type": "Dataset"}},
+        ))
+        reporter.item(name)
+
+    reporter.phase("kpis", total=N_KPI)
+    _t.sleep(0.3)
+    for i in range(N_KPI):
+        name = f"KPI {i}"
+        tables.append(Table(
+            name=f"kpi:{name}",
+            columns=[], pks=[], fks=[], is_active=True,
+            metadata_json={"powerbi_report_server": {"kpi_id": f"kpi-{i}", "report_type": "Kpi"}},
+        ))
+        reporter.item(name)
+
+    reporter.done()
+    return tables
+
+
+@pytest.mark.e2e
+def test_pbirs_mock_large_catalog_indexing(
+    monkeypatch,
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    monkeypatch.setattr(pbirs.PowerBIReportServerClient, "test_connection", _mock_test_connection)
+    monkeypatch.setattr(pbirs.PowerBIReportServerClient, "get_schemas", _mock_get_schemas)
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    t0 = time.perf_counter()
+    connection = create_connection(
+        name="PBIRS Mock",
+        type="powerbi_report_server",
+        config={
+            "server_url": "http://mocked-pbirs.example/",
+            "verify_ssl": False,
+        },
+        credentials={
+            "username": "mockuser",
+            "password": "mockpass",
+        },
+        user_token=token,
+        org_id=org_id,
+    )
+    post_duration = time.perf_counter() - t0
+    assert post_duration < 3.0, f"POST /connections took {post_duration:.2f}s"
+
+    conn_id = connection["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    # Poll, collecting phase transitions
+    observed_phases: list[str] = []
+    deadline = time.perf_counter() + 30.0
+    last = None
+    while time.perf_counter() < deadline:
+        r = test_client.get(f"/api/connections/{conn_id}/indexing", headers=headers)
+        if r.status_code == 404:
+            time.sleep(0.05)
+            continue
+        assert r.status_code == 200, r.text
+        last = r.json()
+        phase = last.get("phase")
+        if phase and (not observed_phases or observed_phases[-1] != phase):
+            observed_phases.append(phase)
+        if last["status"] in ("completed", "failed", "cancelled"):
+            break
+        time.sleep(0.05)
+
+    assert last is not None
+    assert last["status"] == "completed", last
+    assert last["progress_done"] == last["progress_total"]
+    # Runner does sync after refresh_schema; last phase reflects the final
+    # reporter tick from get_schemas (usually "kpis" or whichever phase ran
+    # last). We verify we saw at least 2 distinct phases during polling.
+    assert len(observed_phases) >= 2, f"expected >=2 distinct phases observed, got {observed_phases}"
+
+    # Total ConnectionTable rows should match our fixture.
+    r = test_client.get(f"/api/connections/{conn_id}/tables", headers=headers)
+    assert r.status_code == 200, r.text
+    tables = r.json()
+    assert len(tables) == TOTAL_TABLES, f"expected {TOTAL_TABLES} tables, got {len(tables)}"
+    assert (last.get("stats") or {}).get("table_count") == TOTAL_TABLES

--- a/frontend/components/AddConnectionModal.vue
+++ b/frontend/components/AddConnectionModal.vue
@@ -113,6 +113,62 @@
         />
       </div>
 
+      <!-- Step 3: Indexing progress -->
+      <div v-else-if="step === 'indexing'">
+        <div class="flex items-center gap-2 mb-4">
+          <DataSourceIcon :type="selectedDataSource?.type" class="h-5" />
+          <h3 class="text-lg font-semibold">{{ createdConnection?.name || selectedDataSource?.title }}</h3>
+          <span
+            v-if="indexingState?.status === 'completed'"
+            class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border bg-green-50 text-green-700 border-green-200"
+          >
+            <UIcon name="heroicons-check-circle" class="w-3.5 h-3.5" />
+            Connected
+          </span>
+          <span
+            v-else-if="indexingState?.status === 'failed'"
+            class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border bg-red-50 text-red-700 border-red-200"
+          >
+            <UIcon name="heroicons-exclamation-triangle" class="w-3.5 h-3.5" />
+            Failed
+          </span>
+          <span
+            v-else
+            class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border bg-blue-50 text-blue-700 border-blue-200"
+          >
+            <Spinner class="w-3 h-3" />
+            Indexing
+          </span>
+        </div>
+
+        <div class="border border-gray-100 rounded-lg p-4 bg-gray-50">
+          <div class="text-xs uppercase tracking-wide text-gray-400 mb-2">Schema discovery</div>
+          <ConnectionIndexingProgress :indexing="indexingState" :show-logs="true" />
+        </div>
+
+        <div class="flex items-center justify-end gap-2 mt-4">
+          <UButton
+            v-if="indexingState?.status === 'failed'"
+            color="amber"
+            variant="soft"
+            size="sm"
+            :loading="retrying"
+            @click="retryIndexing"
+          >
+            <UIcon name="heroicons-arrow-path" class="w-4 h-4 me-1" />
+            Retry
+          </UButton>
+          <UButton
+            color="blue"
+            size="sm"
+            :disabled="!isIndexingTerminal"
+            @click="finishConnect"
+          >
+            Connect
+          </UButton>
+        </div>
+      </div>
+
     </div>
   </UModal>
 </template>
@@ -120,7 +176,9 @@
 <script setup lang="ts">
 import Spinner from '~/components/Spinner.vue'
 import ConnectForm from '~/components/datasources/ConnectForm.vue'
+import ConnectionIndexingProgress from '~/components/ConnectionIndexingProgress.vue'
 import { useEnterprise } from '~/ee/composables/useEnterprise'
+import { isIndexingActive, type ConnectionIndexing } from '~/composables/useConnectionStatus'
 
 const props = defineProps<{
   modelValue: boolean
@@ -142,13 +200,22 @@ const { t } = useI18n()
 const toast = useToast()
 
 // State
-const step = ref<'select' | 'form'>('select')
+const step = ref<'select' | 'form' | 'indexing'>('select')
 const searchQuery = ref('')
 const dataSources = ref<any[]>([])
 const demos = ref<any[]>([])
 const loadingDataSources = ref(true)
 const selectedDataSource = ref<any>(null)
 const installingDemo = ref<string | null>(null)
+const createdConnection = ref<any | null>(null)
+const indexingState = ref<ConnectionIndexing | null>(null)
+const retrying = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+const POLL_INTERVAL_MS = 2000
+
+const isIndexingTerminal = computed(() =>
+    !!indexingState.value && !isIndexingActive(indexingState.value)
+)
 
 // Computed
 const uninstalledDemos = computed(() => (demos.value || []).filter((demo: any) => !demo.installed))
@@ -218,15 +285,83 @@ function backToSelect() {
 }
 
 function handleConnectionSuccess(connection: any) {
-  emit('created', connection)
+  // Stash the created connection and switch to the indexing step. We do NOT
+  // close the modal — the user watches indexing run, then clicks Connect.
+  createdConnection.value = connection
+  // Some create endpoints inline a starter `indexing` payload; otherwise
+  // we fetch on first poll.
+  indexingState.value = (connection?.indexing as ConnectionIndexing) || null
+  step.value = 'indexing'
+  startPolling()
+}
 
-  toast.add({
-    title: t('data.connectionCreated'),
-    description: t('data.connectionCreatedDesc', { name: connection?.name || t('data.connectionFallback') }),
-    icon: 'i-heroicons-check-circle',
-    color: 'green'
+async function fetchIndexing() {
+  const id = createdConnection.value?.id
+  if (!id) return
+  try {
+    const { data } = await useMyFetch(`/connections/${id}/indexing`, { method: 'GET' })
+    if ((data as any).value) {
+      indexingState.value = (data as any).value as ConnectionIndexing
+    }
+  } catch {
+    // Transient — keep polling
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  // Initial fetch — if the create response didn't include indexing.
+  fetchIndexing().then(() => {
+    if (isIndexingActive(indexingState.value)) {
+      pollTimer = setInterval(() => {
+        if (!isIndexingActive(indexingState.value)) {
+          stopPolling()
+          return
+        }
+        fetchIndexing()
+      }, POLL_INTERVAL_MS)
+    }
   })
+}
 
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+async function retryIndexing() {
+  const id = createdConnection.value?.id
+  if (!id || retrying.value) return
+  retrying.value = true
+  try {
+    const { data } = await useMyFetch(`/connections/${id}/reindex`, { method: 'POST' })
+    const result = (data as any).value
+    if (result?.indexing) {
+      indexingState.value = result.indexing as ConnectionIndexing
+    }
+    startPolling()
+  } finally {
+    retrying.value = false
+  }
+}
+
+function finishConnect() {
+  // The Connect button is enabled only at terminal state. Emit `created`
+  // here (not on initial success) so the parent only refreshes once
+  // schema is in place.
+  if (createdConnection.value) {
+    emit('created', createdConnection.value)
+    if (indexingState.value?.status === 'completed') {
+      toast.add({
+        title: t('data.connectionCreated'),
+        description: t('data.connectionCreatedDesc', { name: createdConnection.value?.name || t('data.connectionFallback') }),
+        icon: 'i-heroicons-check-circle',
+        color: 'green',
+      })
+    }
+  }
   isOpen.value = false
 }
 
@@ -234,7 +369,14 @@ function reset() {
   step.value = 'select'
   searchQuery.value = ''
   selectedDataSource.value = null
+  createdConnection.value = null
+  indexingState.value = null
+  retrying.value = false
+  stopPolling()
 }
+
+onBeforeUnmount(() => stopPolling())
+watch(isOpen, (val) => { if (!val) stopPolling() })
 
 // Reset state when modal opens
 watch(isOpen, async (val) => {

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -43,6 +43,28 @@
           <span class="text-xs text-gray-500">{{ $t('data.lastChecked') }}</span>
           <span class="text-xs text-gray-700">{{ lastCheckedDisplay || $t('data.never') }}</span>
         </div>
+
+        <!-- Last Indexed (terminal state) -->
+        <div v-if="indexingState && !isIndexingActive(indexingState) && indexingState.finished_at" class="flex items-center justify-between">
+          <span class="text-xs text-gray-500">Last indexed</span>
+          <span class="text-xs text-gray-700">
+            {{ lastIndexedDisplay }}
+            <span v-if="indexingState.stats?.elapsed_s != null" class="text-gray-400">
+              · {{ indexingState.stats.elapsed_s }}s
+            </span>
+          </span>
+        </div>
+      </div>
+
+      <!-- Indexing block — live progress / completion / failure + logs toggle -->
+      <div v-if="indexingState" class="py-3 border-t border-gray-100">
+        <ConnectionIndexingProgress :indexing="indexingState" :show-logs="true" />
+        <div v-if="indexingState.status === 'failed' && canUpdateDataSource" class="mt-2">
+          <UButton size="xs" color="amber" variant="soft" :loading="reindexing" @click="reindex">
+            <UIcon name="heroicons-arrow-path" class="w-3.5 h-3.5 me-1" />
+            Retry
+          </UButton>
+        </div>
       </div>
 
       <!-- Actions -->
@@ -181,7 +203,9 @@
 import Spinner from '~/components/Spinner.vue'
 import ConnectForm from '~/components/datasources/ConnectForm.vue'
 import UserDataSourceCredentialsModal from '~/components/UserDataSourceCredentialsModal.vue'
+import ConnectionIndexingProgress from '~/components/ConnectionIndexingProgress.vue'
 import { useCan } from '~/composables/usePermissions'
+import { isIndexingActive, type ConnectionIndexing } from '~/composables/useConnectionStatus'
 
 const props = defineProps<{
   modelValue: boolean
@@ -208,6 +232,10 @@ const connectionDetails = ref<any>(null)
 const showCredentialsModal = ref(false)
 const confirmingDelete = ref(false)
 const deleting = ref(false)
+const indexingState = ref<ConnectionIndexing | null>(null)
+const reindexing = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+const POLL_INTERVAL_MS = 2000
 
 // Permission and auth checks
 const canUpdateDataSource = computed(() => useCan('update_data_source'))
@@ -244,6 +272,62 @@ const lastCheckedDisplay = computed(() => {
   if (seconds < 86400) return t('data.hoursAgo', { n: Math.floor(seconds / 3600) })
   return t('data.daysAgo', { n: Math.floor(seconds / 86400) })
 })
+
+const lastIndexedDisplay = computed(() => {
+  const ts = indexingState.value?.finished_at
+  if (!ts) return ''
+  const seconds = Math.floor((Date.now() - new Date(ts).getTime()) / 1000)
+  if (seconds < 60) return t('data.justNow')
+  if (seconds < 3600) return t('data.minutesAgo', { n: Math.floor(seconds / 60) })
+  if (seconds < 86400) return t('data.hoursAgo', { n: Math.floor(seconds / 3600) })
+  return t('data.daysAgo', { n: Math.floor(seconds / 86400) })
+})
+
+async function fetchIndexing() {
+  if (!props.connection?.id) return
+  try {
+    const { data } = await useMyFetch(`/connections/${props.connection.id}/indexing`, { method: 'GET' })
+    if ((data as any).value) {
+      indexingState.value = (data as any).value as ConnectionIndexing
+    }
+  } catch {
+    // 404 = no indexing run ever; transient errors handled silently.
+  }
+}
+
+function startPollingIfActive() {
+  stopPolling()
+  if (!isIndexingActive(indexingState.value)) return
+  pollTimer = setInterval(() => {
+    if (!isOpen.value || !isIndexingActive(indexingState.value)) {
+      stopPolling()
+      return
+    }
+    fetchIndexing()
+  }, POLL_INTERVAL_MS)
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+async function reindex() {
+  if (!props.connection?.id || reindexing.value) return
+  reindexing.value = true
+  try {
+    const { data } = await useMyFetch(`/connections/${props.connection.id}/reindex`, { method: 'POST' })
+    const result = (data as any).value
+    if (result?.indexing) {
+      indexingState.value = result.indexing as ConnectionIndexing
+    }
+    startPollingIfActive()
+  } finally {
+    reindexing.value = false
+  }
+}
 
 const editFormValues = computed(() => {
   if (!connectionDetails.value) return null
@@ -336,7 +420,22 @@ watch(isOpen, (val) => {
   if (!val) {
     testResult.value = null
     confirmingDelete.value = false
+    stopPolling()
+    return
   }
+  // Modal opened — seed indexing state from props, fetch fresh, then poll
+  // if active.
+  indexingState.value = (props.connection?.indexing as ConnectionIndexing) || null
+  fetchIndexing().then(() => startPollingIfActive())
 })
+
+// If the parent swaps the connection prop while the modal is open, refresh.
+watch(() => props.connection?.id, () => {
+  if (!isOpen.value) return
+  indexingState.value = (props.connection?.indexing as ConnectionIndexing) || null
+  fetchIndexing().then(() => startPollingIfActive())
+})
+
+onBeforeUnmount(() => stopPolling())
 </script>
 

--- a/frontend/components/ConnectionIndexingProgress.vue
+++ b/frontend/components/ConnectionIndexingProgress.vue
@@ -1,0 +1,101 @@
+<template>
+    <div class="space-y-2">
+        <!-- Running / pending state -->
+        <template v-if="isActive">
+            <div class="flex items-center justify-between text-xs text-blue-700">
+                <span class="font-medium">{{ summary }}</span>
+                <span v-if="hasTotal">{{ percent }}%</span>
+            </div>
+            <div class="h-1.5 w-full bg-blue-100 rounded overflow-hidden">
+                <div
+                    class="h-full bg-blue-500 transition-all duration-300"
+                    :class="{ 'animate-pulse w-1/3': !hasTotal }"
+                    :style="hasTotal ? { width: percent + '%' } : {}"
+                ></div>
+            </div>
+        </template>
+
+        <!-- Completed -->
+        <div v-else-if="indexing?.status === 'completed'" class="text-xs text-green-700 flex items-center gap-1">
+            <UIcon name="heroicons-check-circle" class="w-4 h-4" />
+            <span>
+                Discovered {{ indexing?.stats?.table_count ?? 0 }} table{{ (indexing?.stats?.table_count ?? 0) === 1 ? '' : 's' }}
+                <span v-if="indexing?.stats?.elapsed_s != null"> in {{ indexing.stats.elapsed_s }}s</span>
+            </span>
+        </div>
+
+        <!-- Failed -->
+        <div v-else-if="indexing?.status === 'failed'" class="text-xs text-red-700">
+            <div class="flex items-center gap-1">
+                <UIcon name="heroicons-exclamation-triangle" class="w-4 h-4" />
+                <span class="font-medium">Indexing failed</span>
+            </div>
+            <div v-if="indexing?.error" class="mt-1 text-red-600 break-words">
+                {{ indexing.error }}
+            </div>
+        </div>
+
+        <!-- Logs toggle -->
+        <div v-if="showLogs && (indexing?.events?.length ?? 0) > 0" class="pt-1">
+            <button
+                type="button"
+                class="text-[11px] text-gray-500 hover:text-gray-700 inline-flex items-center gap-1"
+                @click="logsOpen = !logsOpen"
+            >
+                <UIcon :name="logsOpen ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3" />
+                {{ logsOpen ? 'Hide' : 'Show' }} logs ({{ indexing.events.length }})
+            </button>
+            <div v-if="logsOpen" class="mt-2 max-h-48 overflow-y-auto rounded border border-gray-200 bg-gray-50 p-2 text-[11px] font-mono text-gray-700 space-y-0.5">
+                <div v-for="(ev, i) in indexing.events" :key="i" class="flex gap-2">
+                    <span class="text-gray-400 flex-none">{{ formatTs(ev.ts) }}</span>
+                    <span :class="levelClass(ev.level)">{{ ev.message }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+    isIndexingActive,
+    indexingSummary,
+    type ConnectionIndexing,
+} from '~/composables/useConnectionStatus'
+
+const props = withDefaults(defineProps<{
+    indexing?: ConnectionIndexing | null
+    showLogs?: boolean
+}>(), {
+    indexing: null,
+    showLogs: true,
+})
+
+const logsOpen = ref(false)
+
+const isActive = computed(() => isIndexingActive(props.indexing))
+const hasTotal = computed(() => (props.indexing?.progress_total || 0) > 0)
+const percent = computed(() => {
+    const total = props.indexing?.progress_total || 0
+    const done = props.indexing?.progress_done || 0
+    if (total <= 0) return 0
+    return Math.min(100, Math.floor((done / total) * 100))
+})
+const summary = computed(() => indexingSummary(props.indexing))
+
+function formatTs(ts: string): string {
+    if (!ts) return ''
+    const d = new Date(ts)
+    if (isNaN(d.getTime())) return ts
+    const hh = String(d.getHours()).padStart(2, '0')
+    const mm = String(d.getMinutes()).padStart(2, '0')
+    const ss = String(d.getSeconds()).padStart(2, '0')
+    return `${hh}:${mm}:${ss}`
+}
+
+function levelClass(level?: string): string {
+    if (level === 'error') return 'text-red-600'
+    if (level === 'warn') return 'text-amber-600'
+    return 'text-gray-700'
+}
+</script>

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -12,6 +12,13 @@
       <span v-else-if="status === 'stopped'" class="text-gray-700 italic">{{ $t('tools.createData.creating') }}</span>
       <span v-else-if="status === 'error'" class="text-gray-700">{{ $t('tools.createData.create') }}</span>
       <span v-else class="text-gray-700">{{ $t('tools.createData.create') }}</span>
+      <template v-if="groupedTables.length">
+        <template v-for="(group, gidx) in groupedTables" :key="gidx">
+          <span v-if="gidx > 0" class="ms-1 text-gray-300">|</span>
+          <DataSourceIcon :type="group.type" class="h-2.5 ms-1" :title="group.names.join(', ')" />
+          <span class="ms-1 text-gray-500">{{ group.names.join(', ') }}</span>
+        </template>
+      </template>
       <span v-if="formatDuration" class="ms-1.5 text-gray-400">{{ formatDuration }}</span>
     </div>
 
@@ -140,6 +147,14 @@ import { computed, ref, reactive } from 'vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 import QueryCodeEditorModal from '~/components/tools/QueryCodeEditorModal.vue'
 import Spinner from '~/components/Spinner.vue'
+import DataSourceIcon from '~/components/DataSourceIcon.vue'
+
+interface DataSource {
+  id: string
+  type?: string
+  data_source_type?: string
+  connections?: Array<{ id: string; type: string }>
+}
 
 interface Props {
   toolExecution: {
@@ -168,7 +183,7 @@ interface Props {
   }
 }
 
-const props = defineProps<Props & { readonly?: boolean }>()
+const props = defineProps<Props & { readonly?: boolean; dataSources?: DataSource[] }>()
 const emit = defineEmits(['addWidget', 'toggleSplitScreen', 'editQuery'])
 
 const codeCollapsed = ref(true)
@@ -320,6 +335,26 @@ const formatDuration = computed(() => {
   return `${seconds}s`
 })
 
+
+const groupedTables = computed<Array<{ type: string; names: string[] }>>(() => {
+  const aj = (props.toolExecution as any)?.arguments_json || {}
+  if (!Array.isArray(aj.tables_by_source)) return []
+  const groups: Record<string, string[]> = {}
+  for (const group of aj.tables_by_source) {
+    let connType = 'resource'
+    if (group.data_source_id && props.dataSources?.length) {
+      const ds = props.dataSources.find((d) => d.id === group.data_source_id)
+      if (ds) {
+        connType = ds.connections?.[0]?.type || ds.type || ds.data_source_type || 'resource'
+      }
+    }
+    if (!groups[connType]) groups[connType] = []
+    if (Array.isArray(group.tables)) {
+      groups[connType].push(...group.tables)
+    }
+  }
+  return Object.entries(groups).map(([type, names]) => ({ type, names }))
+})
 
 function toggleCode() { codeCollapsed.value = !codeCollapsed.value }
 function toggleCreateData() { createDataCollapsed.value = !createDataCollapsed.value }

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -107,19 +107,33 @@
             <Transition name="fade" mode="out-in">
               <div ref="chartContainerRef" v-if="(showTabs && activeTab === 'chart') || (!showTabs && showVisual)">
                 <div v-if="resolvedCompEl" :class="chartHeightClass" :style="chartHeightStyle">
-                  <component
-                    :is="resolvedCompEl"
-                    :widget="effectiveWidget"
-                    :data="filteredData"
-                    :data_model="effectiveStep?.data_model"
-                    :step="filteredStep"
-                    :view="normalizedView"
-                    :reportThemeName="reportThemeName"
-                    :reportOverrides="reportOverrides"
-                  />
+                  <Suspense>
+                    <component
+                      :is="resolvedCompEl"
+                      :widget="effectiveWidget"
+                      :data="filteredData"
+                      :data_model="effectiveStep?.data_model"
+                      :step="filteredStep"
+                      :view="normalizedView"
+                      :reportThemeName="reportThemeName"
+                      :reportOverrides="reportOverrides"
+                    />
+                    <template #fallback>
+                      <div class="flex items-center justify-center w-full h-full">
+                        <Spinner class="w-5 h-5 text-gray-400" />
+                      </div>
+                    </template>
+                  </Suspense>
                 </div>
                 <div v-else-if="chartVisualTypes.has(effectiveStep?.data_model?.type)" class="h-[340px]">
-                  <RenderVisual :widget="effectiveWidget" :data="filteredData" :data_model="effectiveStep?.data_model" :view="normalizedView" />
+                  <Suspense>
+                    <RenderVisual :widget="effectiveWidget" :data="filteredData" :data_model="effectiveStep?.data_model" :view="normalizedView" />
+                    <template #fallback>
+                      <div class="flex items-center justify-center w-full h-full">
+                        <Spinner class="w-5 h-5 text-gray-400" />
+                      </div>
+                    </template>
+                  </Suspense>
                 </div>
               </div>
             </Transition>
@@ -312,6 +326,7 @@ import { useMyFetch } from '~/composables/useMyFetch'
 import { useOrgSettings } from '~/composables/useOrgSettings'
 import RenderVisual from '../RenderVisual.vue'
 import RenderTable from '../RenderTable.vue'
+import Spinner from '../Spinner.vue'
 import { resolveEntryByType } from '@/components/dashboard/registry'
 import EntityCreateModal from '../entity/EntityCreateModal.vue'
 import { useExcel } from '~/composables/useExcel'

--- a/frontend/composables/useConnectionStatus.ts
+++ b/frontend/composables/useConnectionStatus.ts
@@ -1,0 +1,122 @@
+/**
+ * Derive a single effective status for a connection from:
+ *   - `user_status.connection` — the cached test_connection result
+ *   - `indexing.status` — the latest schema indexing run
+ *
+ * Keeps the UI state machine in one place so badge, dot, and banner render
+ * identically across pages.
+ */
+
+export type ConnectionEffectiveStatus =
+  | 'success'
+  | 'indexing'
+  | 'indexing_failed'
+  | 'error'
+  | 'unknown'
+
+export interface ConnectionIndexing {
+  id: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | string
+  phase?: string | null
+  current_item?: string | null
+  progress_done: number
+  progress_total: number
+  started_at?: string | null
+  finished_at?: string | null
+  error?: string | null
+  stats?: Record<string, any> | null
+}
+
+export function isIndexingActive(idx?: ConnectionIndexing | null): boolean {
+  if (!idx) return false
+  return idx.status === 'pending' || idx.status === 'running'
+}
+
+export function isIndexingFailed(idx?: ConnectionIndexing | null): boolean {
+  return !!idx && idx.status === 'failed'
+}
+
+export function getEffectiveStatus(conn: any): ConnectionEffectiveStatus {
+  const idx = conn?.indexing as ConnectionIndexing | undefined
+  if (isIndexingActive(idx)) return 'indexing'
+
+  const testStatus = String(conn?.user_status?.connection || '').toLowerCase()
+  if (testStatus === 'success') {
+    // Test OK; check whether the most recent indexing failed.
+    if (isIndexingFailed(idx)) return 'indexing_failed'
+    return 'success'
+  }
+  if (testStatus === 'not_connected' || testStatus === 'offline') return 'error'
+
+  // No cached test result. If credentials-required with creds present, treat
+  // as success per existing behavior; indexing state still overrides.
+  if (conn?.auth_policy === 'user_required' && conn?.user_status?.has_user_credentials) {
+    if (isIndexingFailed(idx)) return 'indexing_failed'
+    return 'success'
+  }
+
+  return 'unknown'
+}
+
+export function hasAnyActiveIndexing(connections?: any[] | null): boolean {
+  if (!connections?.length) return false
+  return connections.some((c) => isIndexingActive(c?.indexing))
+}
+
+export function statusDotClass(status: ConnectionEffectiveStatus): string {
+  switch (status) {
+    case 'success':
+      return 'bg-green-500'
+    case 'indexing':
+      return 'bg-blue-500 animate-pulse'
+    case 'indexing_failed':
+      return 'bg-amber-500'
+    case 'error':
+      return 'bg-red-500'
+    default:
+      return 'bg-gray-400'
+  }
+}
+
+export function statusBadgeClass(status: ConnectionEffectiveStatus): string {
+  switch (status) {
+    case 'success':
+      return 'bg-green-50 text-green-700 border-green-200'
+    case 'indexing':
+      return 'bg-blue-50 text-blue-700 border-blue-200'
+    case 'indexing_failed':
+      return 'bg-amber-50 text-amber-700 border-amber-200'
+    case 'error':
+      return 'bg-red-50 text-red-700 border-red-200'
+    default:
+      return 'bg-gray-50 text-gray-700 border-gray-200'
+  }
+}
+
+export function statusLabel(status: ConnectionEffectiveStatus): string {
+  switch (status) {
+    case 'success':
+      return 'Connected'
+    case 'indexing':
+      return 'Indexing'
+    case 'indexing_failed':
+      return 'Indexing failed'
+    case 'error':
+      return 'Not connected'
+    default:
+      return 'Unknown'
+  }
+}
+
+export function indexingSummary(idx?: ConnectionIndexing | null): string {
+  if (!idx) return ''
+  const done = idx.progress_done || 0
+  const total = idx.progress_total || 0
+  const phase = idx.phase || ''
+  if (total > 0) {
+    if (idx.current_item) return `${phase || 'indexing'}: ${idx.current_item} (${done}/${total})`
+    return `${phase || 'indexing'} ${done}/${total}`
+  }
+  if (phase) return phase
+  return 'discovering…'
+}

--- a/frontend/layouts/data.vue
+++ b/frontend/layouts/data.vue
@@ -151,20 +151,16 @@ const isConnected = computed(() => {
     return c === 'success'
 })
 
-function getConnectionStatus(conn: any): string {
-    return conn?.user_status?.connection || conn?.status || 'unknown'
-}
-
 async function fetchIntegration() {
     if (!id.value) return
     isLoading.value = true
     fetchError.value = null
-    
+
     try {
         const config = useRuntimeConfig()
         const { token } = useAuth()
         const { organization } = useOrganization()
-        
+
         const data = await $fetch(`/data_sources/${id.value}`, {
             baseURL: config.public.baseURL,
             method: 'GET',
@@ -173,14 +169,18 @@ async function fetchIntegration() {
                 'X-Organization-Id': organization.value?.id || '',
             }
         })
-        
+
         integration.value = data as any
     } catch (e: any) {
         console.error('Failed to fetch integration:', e)
         fetchError.value = e?.response?.status || e?.status || e?.statusCode || 500
     }
-    
+
     isLoading.value = false
+    // Auto-manage the polling loop based on the fresh data so any caller —
+    // including child pages calling the injected fetcher after a reindex —
+    // gets progress updates without manually re-arming polling.
+    maybeStartPolling()
 }
 
 // Provide integration data to child pages
@@ -223,11 +223,11 @@ function maybeStartPolling() {
 
 watch(id, () => {
     stopPolling()
-    fetchIntegration().then(maybeStartPolling)
+    fetchIntegration()
 })
 
 onMounted(() => {
-    fetchIntegration().then(maybeStartPolling)
+    fetchIntegration()
 })
 
 onBeforeUnmount(() => {

--- a/frontend/layouts/data.vue
+++ b/frontend/layouts/data.vue
@@ -11,8 +11,8 @@
                             <div v-if="!isLoading && integration && !fetchError" class="flex items-center gap-2 mt-1 text-xs text-gray-500">
                                 <template v-if="integration.connections && integration.connections.length > 0">
                                     <template v-for="conn in integration.connections.slice(0, 4)" :key="conn.id">
-                                        <span :class="['w-2 h-2 rounded-full', getConnectionStatus(conn) === 'success' ? 'bg-green-500' : 'bg-red-500']"></span>
-                                        <UTooltip :text="conn.name">
+                                        <span :class="['w-2 h-2 rounded-full', statusDotClass(getEffectiveStatus(conn))]"></span>
+                                        <UTooltip :text="conn.name + (getEffectiveStatus(conn) === 'indexing' ? ' · ' + indexingSummary(conn.indexing) : '')">
                                             <DataSourceIcon :type="conn.type" class="h-4" />
                                         </UTooltip>
                                     </template>
@@ -98,6 +98,12 @@
 
 <script setup lang="ts">
 import Spinner from '~/components/Spinner.vue'
+import {
+    getEffectiveStatus,
+    hasAnyActiveIndexing,
+    indexingSummary,
+    statusDotClass,
+} from '~/composables/useConnectionStatus'
 
 const route = useRoute()
 
@@ -183,12 +189,49 @@ provide('fetchIntegration', fetchIntegration)
 provide('isLoading', isLoading)
 provide('fetchError', fetchError)
 
+// Poll while any connection is currently indexing — the backend inlines the
+// latest indexing row into each connection. Poll stops when every connection
+// has reached a terminal state (or when the integration fetch errors).
+const POLL_INTERVAL_MS = 2000
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function stopPolling() {
+    if (pollTimer) {
+        clearInterval(pollTimer)
+        pollTimer = null
+    }
+}
+
+function maybeStartPolling() {
+    const hasActive = hasAnyActiveIndexing(integration.value?.connections)
+    if (hasActive && !pollTimer) {
+        pollTimer = setInterval(() => {
+            if (fetchError.value) {
+                stopPolling()
+                return
+            }
+            fetchIntegration().then(() => {
+                if (!hasAnyActiveIndexing(integration.value?.connections)) {
+                    stopPolling()
+                }
+            })
+        }, POLL_INTERVAL_MS)
+    } else if (!hasActive) {
+        stopPolling()
+    }
+}
+
 watch(id, () => {
-    fetchIntegration()
+    stopPolling()
+    fetchIntegration().then(maybeStartPolling)
 })
 
 onMounted(() => {
-    fetchIntegration()
+    fetchIntegration().then(maybeStartPolling)
+})
+
+onBeforeUnmount(() => {
+    stopPolling()
 })
 </script>
 

--- a/frontend/pages/data/[id]/connection.vue
+++ b/frontend/pages/data/[id]/connection.vue
@@ -81,11 +81,58 @@
                             </div>
                         </div>
 
+                        <!-- Indexing progress bar (when a background job is running) -->
+                        <div v-if="isConnIndexing(conn)" class="mt-3 ms-11">
+                            <div class="flex items-center justify-between text-xs text-blue-700 mb-1">
+                                <span class="font-medium">{{ connIndexingSummary(conn) }}</span>
+                                <span v-if="(conn.indexing?.progress_total || 0) > 0">{{ indexingProgressPercent(conn) }}%</span>
+                            </div>
+                            <div class="h-1.5 w-full bg-blue-100 rounded overflow-hidden">
+                                <div
+                                    class="h-full bg-blue-500 transition-all duration-300"
+                                    :class="{ 'animate-pulse w-1/3': (conn.indexing?.progress_total || 0) === 0 }"
+                                    :style="(conn.indexing?.progress_total || 0) > 0 ? { width: indexingProgressPercent(conn) + '%' } : {}"
+                                ></div>
+                            </div>
+                        </div>
+
+                        <!-- Indexing failed -->
+                        <div v-else-if="conn.indexing?.status === 'failed'" class="mt-3 ms-11 text-xs flex items-center gap-2">
+                            <UIcon name="heroicons-exclamation-triangle" class="w-4 h-4 text-amber-600" />
+                            <span class="text-amber-700">
+                                Indexing failed: {{ conn.indexing.error || 'Unknown error' }}
+                            </span>
+                            <UButton
+                                v-if="canManageConnections"
+                                size="xs"
+                                color="amber"
+                                variant="soft"
+                                @click="reindexConnection(conn.id)"
+                            >
+                                Retry
+                            </UButton>
+                        </div>
+
                         <!-- Test result (inline) -->
                         <div v-if="testResults[conn.id]" class="mt-2 ms-11 text-xs">
-                            <span :class="testResults[conn.id]?.success ? 'text-green-600' : 'text-red-600'">
+                            <div :class="testResults[conn.id]?.success ? 'text-green-600' : 'text-red-600'">
                                 {{ testResults[conn.id]?.success ? 'Connection successful' : (testResults[conn.id]?.message || 'Connection failed') }}
-                            </span>
+                            </div>
+                            <!-- Timings -->
+                            <div v-if="testResults[conn.id]?.timings" class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-gray-500">
+                                <span v-for="(ms, key) in testResults[conn.id].timings" :key="key">
+                                    {{ key }}: {{ ms }}ms
+                                </span>
+                            </div>
+                            <!-- Per-client details -->
+                            <div
+                                v-if="testResults[conn.id]?.details && Object.keys(testResults[conn.id].details).length"
+                                class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-gray-500"
+                            >
+                                <span v-for="(val, key) in testResults[conn.id].details" :key="key">
+                                    {{ key }}: {{ typeof val === 'object' ? JSON.stringify(val) : val }}
+                                </span>
+                            </div>
                         </div>
 
                         <!-- User Connection (only for user_required auth, non-admin) -->
@@ -292,32 +339,54 @@ const availableConnections = computed(() => {
   return orgConnections.value.filter(c => !linkedIds.has(c.id))
 })
 
-// Status helpers
-function getEffectiveStatus(conn: any): 'success' | 'error' | 'unknown' {
-    // Local test result takes priority
+// Status helpers — derived from the shared state machine.
+import {
+    getEffectiveStatus as deriveStatus,
+    indexingSummary,
+    isIndexingActive,
+    statusBadgeClass,
+    statusLabel,
+} from '~/composables/useConnectionStatus'
+
+function getConnectionEffective(conn: any) {
+    // Local test result overrides for immediate UI feedback after a manual test.
     const local = testResults.value[conn.id]
     if (local) return local.success ? 'success' : 'error'
-    // Then API status
-    const api = String(conn.user_status?.connection || '').toLowerCase()
-    if (api === 'success') return 'success'
-    if (api === 'not_connected' || api === 'offline') return 'error'
-    // For user_required with credentials but no test yet
-    if (conn.auth_policy === 'user_required' && conn.user_status?.has_user_credentials) return 'success'
-    return 'unknown'
+    return deriveStatus(conn)
 }
 
 function getStatusClass(conn: any) {
-    const s = getEffectiveStatus(conn)
-    if (s === 'success') return 'bg-green-50 text-green-700 border-green-200'
-    if (s === 'error') return 'bg-red-50 text-red-700 border-red-200'
-    return 'bg-gray-50 text-gray-700 border-gray-200'
+    return statusBadgeClass(getConnectionEffective(conn) as any)
 }
 
 function getStatusLabel(conn: any) {
-    const s = getEffectiveStatus(conn)
-    if (s === 'success') return 'Connected'
-    if (s === 'error') return 'Not connected'
-    return 'Unknown'
+    return statusLabel(getConnectionEffective(conn) as any)
+}
+
+function isConnIndexing(conn: any) {
+    return isIndexingActive(conn?.indexing)
+}
+
+function indexingProgressPercent(conn: any) {
+    const idx = conn?.indexing
+    if (!idx) return 0
+    const total = idx.progress_total || 0
+    const done = idx.progress_done || 0
+    if (total <= 0) return 0
+    return Math.min(100, Math.floor((done / total) * 100))
+}
+
+function connIndexingSummary(conn: any) {
+    return indexingSummary(conn?.indexing)
+}
+
+async function reindexConnection(connectionId: string) {
+    try {
+        await useMyFetch(`/connections/${connectionId}/reindex`, { method: 'POST' })
+        await injectedFetchIntegration()
+    } catch (e: any) {
+        toast.add({ title: 'Failed to restart indexing', description: e?.message || '', color: 'red' })
+    }
 }
 
 function getLastChecked(conn: any) {

--- a/frontend/pages/data/[id]/connection.vue
+++ b/frontend/pages/data/[id]/connection.vue
@@ -81,36 +81,14 @@
                             </div>
                         </div>
 
-                        <!-- Indexing progress bar (when a background job is running) -->
-                        <div v-if="isConnIndexing(conn)" class="mt-3 ms-11">
-                            <div class="flex items-center justify-between text-xs text-blue-700 mb-1">
-                                <span class="font-medium">{{ connIndexingSummary(conn) }}</span>
-                                <span v-if="(conn.indexing?.progress_total || 0) > 0">{{ indexingProgressPercent(conn) }}%</span>
+                        <!-- Indexing progress / completion / failure (shared component, with logs toggle) -->
+                        <div v-if="conn.indexing" class="mt-3 ms-11">
+                            <ConnectionIndexingProgress :indexing="conn.indexing" :show-logs="true" />
+                            <div v-if="conn.indexing.status === 'failed' && canManageConnections" class="mt-2">
+                                <UButton size="xs" color="amber" variant="soft" @click="reindexConnection(conn.id)">
+                                    Retry
+                                </UButton>
                             </div>
-                            <div class="h-1.5 w-full bg-blue-100 rounded overflow-hidden">
-                                <div
-                                    class="h-full bg-blue-500 transition-all duration-300"
-                                    :class="{ 'animate-pulse w-1/3': (conn.indexing?.progress_total || 0) === 0 }"
-                                    :style="(conn.indexing?.progress_total || 0) > 0 ? { width: indexingProgressPercent(conn) + '%' } : {}"
-                                ></div>
-                            </div>
-                        </div>
-
-                        <!-- Indexing failed -->
-                        <div v-else-if="conn.indexing?.status === 'failed'" class="mt-3 ms-11 text-xs flex items-center gap-2">
-                            <UIcon name="heroicons-exclamation-triangle" class="w-4 h-4 text-amber-600" />
-                            <span class="text-amber-700">
-                                Indexing failed: {{ conn.indexing.error || 'Unknown error' }}
-                            </span>
-                            <UButton
-                                v-if="canManageConnections"
-                                size="xs"
-                                color="amber"
-                                variant="soft"
-                                @click="reindexConnection(conn.id)"
-                            >
-                                Retry
-                            </UButton>
                         </div>
 
                         <!-- Test result (inline) -->
@@ -287,6 +265,7 @@ definePageMeta({ auth: true, layout: 'data' })
 import ConnectForm from '~/components/datasources/ConnectForm.vue'
 import UserDataSourceCredentialsModal from '~/components/UserDataSourceCredentialsModal.vue'
 import Spinner from '~/components/Spinner.vue'
+import ConnectionIndexingProgress from '~/components/ConnectionIndexingProgress.vue'
 import { useCan } from '~/composables/usePermissions'
 import { useOrganization } from '~/composables/useOrganization'
 import type { Ref } from 'vue'

--- a/frontend/pages/data/[id]/index.vue
+++ b/frontend/pages/data/[id]/index.vue
@@ -2,7 +2,32 @@
     <div class="py-6 relative">
         <!-- Hide content when there's a fetch error (layout shows error state) -->
         <div v-if="fetchError" />
-        <div v-else class="bg-white border border-gray-200 rounded-lg p-8 md:p-10">
+        <div v-else>
+            <!-- Indexing banner: shown while any linked connection is discovering schema -->
+            <div
+                v-if="indexingConnections.length > 0"
+                class="mb-4 flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-800 rounded-lg px-4 py-3"
+            >
+                <UIcon name="heroicons-arrow-path" class="w-5 h-5 mt-0.5 animate-spin flex-none" />
+                <div class="flex-1 text-sm">
+                    <div class="font-medium">
+                        Discovering schema for
+                        {{ indexingConnections.length }}
+                        {{ indexingConnections.length === 1 ? 'connection' : 'connections' }}…
+                    </div>
+                    <div class="mt-1 text-xs text-blue-700 space-y-0.5">
+                        <div v-for="conn in indexingConnections" :key="conn.id">
+                            <span class="font-medium">{{ conn.name }}</span>
+                            <span class="ms-1 text-blue-600">· {{ connIndexingSummary(conn) }}</span>
+                        </div>
+                    </div>
+                </div>
+                <NuxtLink :to="`/data/${route.params.id}/connection`" class="text-xs font-medium underline">
+                    View progress
+                </NuxtLink>
+            </div>
+
+        <div class="bg-white border border-gray-200 rounded-lg p-8 md:p-10">
             <div v-if="loading" class="text-xs text-gray-500 text-center">{{ $t('common.loading') }}</div>
             <div v-else class="md:w-2/3 ">
                 <div class="flex items-center gap-2">
@@ -26,6 +51,8 @@
                     </div>
                 </div>
             </div>
+        </div>
+
         </div>
 
         <UModal v-model="showEditModal" :ui="{ width: 'sm:max-w-2xl' }">
@@ -85,6 +112,7 @@
 import { ref, computed, onMounted, inject, watch } from 'vue'
 import { useCan } from '~/composables/usePermissions'
 import DataSourceQuestionsHome from '~/components/DataSourceQuestionsHome.vue'
+import { isIndexingActive, indexingSummary } from '~/composables/useConnectionStatus'
 import type { Ref } from 'vue'
 
 definePageMeta({ auth: true, layout: 'data' })
@@ -115,6 +143,14 @@ const savingDesc = ref(false)
 const computedDescription = computed(() => {
     return dataSource.value?.description || availableMeta.value?.description || ''
 })
+
+const indexingConnections = computed(() =>
+    (dataSource.value?.connections || []).filter((c: any) => isIndexingActive(c?.indexing))
+)
+
+function connIndexingSummary(conn: any) {
+    return indexingSummary(conn?.indexing)
+}
 
 const displayDataSource = computed(() => {
     if (!dataSource.value) return null

--- a/frontend/pages/data/[id]/tables.vue
+++ b/frontend/pages/data/[id]/tables.vue
@@ -2,17 +2,28 @@
     <div class="py-6">
         <!-- Hide content when there's a fetch error (layout shows error state) -->
         <div v-if="injectedFetchError" />
-        <div v-else class="border border-gray-200 rounded-lg p-6">
-            <TablesSelector :ds-id="id" :schema="schemaMode" :can-update="canUpdateDataSource" :show-refresh="true" :show-save="canUpdateDataSource" :show-header="true" header-title="Select tables" header-subtitle="Choose which tables to enable" save-label="Save" :show-stats="true" @saved="onSaved" />
+        <div v-else>
+            <!-- Schema indexing in progress: tell the user why the list may be empty/stale -->
+            <div
+                v-if="anyIndexing"
+                class="mb-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800"
+            >
+                <UIcon name="heroicons-arrow-path" class="w-4 h-4 animate-spin" />
+                <span>Schema is being refreshed — tables will appear shortly.</span>
+            </div>
+            <div class="border border-gray-200 rounded-lg p-6">
+                <TablesSelector :ds-id="id" :schema="schemaMode" :can-update="canUpdateDataSource" :show-refresh="true" :show-save="canUpdateDataSource" :show-header="true" header-title="Select tables" header-subtitle="Choose which tables to enable" save-label="Save" :show-stats="true" @saved="onSaved" />
+            </div>
         </div>
     </div>
-    
+
 </template>
 
 <script setup lang="ts">
 definePageMeta({ auth: true, layout: 'data' })
 import TablesSelector from '@/components/datasources/TablesSelector.vue'
 import { useCan, usePermissionsLoaded } from '~/composables/usePermissions'
+import { hasAnyActiveIndexing } from '~/composables/useConnectionStatus'
 import type { Ref } from 'vue'
 
 const toast = useToast()
@@ -25,6 +36,8 @@ const injectedFetchError = inject<Ref<number | null>>('fetchError', ref(null))
 
 const loading = ref(false)
 const schemaMode = ref<'full' | 'user'>('full')
+
+const anyIndexing = computed(() => hasAnyActiveIndexing(injectedIntegration.value?.connections))
 
 const permissionsLoaded = usePermissionsLoaded()
 const canUpdateDataSource = computed(() => useCan('update_data_source'))

--- a/frontend/pages/data/index.vue
+++ b/frontend/pages/data/index.vue
@@ -404,7 +404,44 @@ async function refreshData() {
         getConnections(),
         getDemoDataSources(),
     ])
+    maybeStartPolling()
 }
+
+// Poll while any connection (standalone or under a data source) is currently
+// indexing. The `/data_sources` and `/connections` endpoints both inline the
+// latest `indexing` row, so a single re-fetch updates badges everywhere.
+const POLL_INTERVAL_MS = 2000
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function anyIndexingActive(): boolean {
+    const isActive = (idx: any) =>
+        idx && (idx.status === 'pending' || idx.status === 'running')
+    if ((connections.value || []).some((c: any) => isActive(c?.indexing))) return true
+    for (const ds of (connected_ds.value || [])) {
+        if ((ds.connections || []).some((c: any) => isActive(c?.indexing))) return true
+    }
+    return false
+}
+
+function maybeStartPolling() {
+    if (anyIndexingActive() && !pollTimer) {
+        pollTimer = setInterval(async () => {
+            await Promise.all([getConnectedDataSources(), getConnections()])
+            if (!anyIndexingActive()) stopPolling()
+        }, POLL_INTERVAL_MS)
+    } else if (!anyIndexingActive()) {
+        stopPolling()
+    }
+}
+
+function stopPolling() {
+    if (pollTimer) {
+        clearInterval(pollTimer)
+        pollTimer = null
+    }
+}
+
+onBeforeUnmount(() => stopPolling())
 
 const canCreateDataSource = computed(() => useCan('create_data_source'))
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -7,6 +7,18 @@
       </NuxtLink>
       <UDropdown :items="menuItems" :popper="{ placement: 'bottom-end' }">
         <UButton color="white" trailing-icon="i-heroicons-bars-3" />
+        <template #queries="{ item }">
+          <LibraryIcon class="w-4 h-4 text-gray-400" />
+          <span class="truncate">{{ item.label }}</span>
+        </template>
+        <template #monitoring="{ item }">
+          <ActivityIcon class="w-4 h-4 text-gray-400" />
+          <span class="truncate">{{ item.label }}</span>
+        </template>
+        <template #mcp="{ item }">
+          <McpIcon class="w-4 h-4 text-gray-400" />
+          <span class="truncate">{{ item.label }}</span>
+        </template>
       </UDropdown>
     </div>
     <div class="flex-1 flex flex-col justify-center px-3">
@@ -47,6 +59,18 @@
             <div class="hamburger md:hidden">
                 <UDropdown :items="menuItems" :popper="{ placement: 'bottom-start' }">
                     <UButton color="white" label="" trailing-icon="i-heroicons-bars-3" />
+                    <template #queries="{ item }">
+                      <LibraryIcon class="w-4 h-4 text-gray-400" />
+                      <span class="truncate">{{ item.label }}</span>
+                    </template>
+                    <template #monitoring="{ item }">
+                      <ActivityIcon class="w-4 h-4 text-gray-400" />
+                      <span class="truncate">{{ item.label }}</span>
+                    </template>
+                    <template #mcp="{ item }">
+                      <McpIcon class="w-4 h-4 text-gray-400" />
+                      <span class="truncate">{{ item.label }}</span>
+                    </template>
                 </UDropdown>
             </div>
         </div>
@@ -151,6 +175,8 @@
 
     <div class="gradient-glow"></div>
   </div>
+
+  <McpModal v-model="showMcpModal" />
 </template>
 
 <script setup lang="ts">
@@ -160,6 +186,10 @@ import { onMounted, nextTick } from 'vue';
 import Spinner from '@/components/Spinner.vue'
 import PromptBoxV2 from '~/components/prompt/PromptBoxV2.vue';
 import RecentReports from '~/components/home/RecentReports.vue';
+import McpModal from '~/components/McpModal.vue';
+import LibraryIcon from '~/components/icons/LibraryIcon.vue';
+import ActivityIcon from '~/components/icons/ActivityIcon.vue';
+import McpIcon from '~/components/icons/McpIcon.vue';
 
 import { useCan } from '~/composables/usePermissions'
 import { KeyCode } from 'monaco-editor';
@@ -235,17 +265,47 @@ const showOnboardingBanner = computed(() => {
 
 
 const { t } = useI18n()
-const menuItems = computed(() => [
-  [{ label: t('nav.reports'), icon: 'i-heroicons-document-chart-bar', to: '/reports' }],
-  [{ label: t('nav.data'), icon: 'i-heroicons-circle-stack', to: '/data' }],
-  [{ label: (currentUser.value as any)?.name, icon: 'i-heroicons-user'},
-  { label: organization.value.name, icon: 'i-heroicons-building-office'  }
-  ],
-  [{ label: t('auth.logout'), icon: 'i-heroicons-arrow-right-on-rectangle', click:
-  () => {
-    signOff()
-  } }],
-])
+const { isMcpEnabled } = useOrgSettings()
+const isAdmin = computed<boolean>(() => useCan('full_admin_access'))
+
+const menuItems = computed(() => {
+  const main: any[] = [
+    { label: t('nav.reports'), icon: 'i-heroicons-chat-bubble-left-right', to: '/reports' },
+    { label: t('nav.dashboards'), icon: 'i-heroicons-chart-bar-square', to: '/dashboards' },
+    { label: t('nav.scheduled'), icon: 'i-heroicons-clock', to: '/scheduled-tasks' },
+    { label: t('nav.instructions'), icon: 'i-heroicons-cube', to: '/instructions' },
+    { label: t('nav.queries'), slot: 'queries', to: '/queries' },
+  ]
+  if (isAdmin.value) {
+    main.push({ label: t('nav.monitoring'), slot: 'monitoring', to: '/monitoring' })
+  }
+  if (useCan('manage_evals')) {
+    main.push({ label: t('nav.evals'), icon: 'i-heroicons-check-circle', to: '/evals' })
+  }
+
+  const bottom: any[] = [
+    { label: t('nav.dataAgents'), icon: 'i-heroicons-circle-stack', to: '/data' },
+    { label: t('nav.settings'), icon: 'i-heroicons-cog-6-tooth', to: '/settings' },
+    { label: t('nav.documentation'), icon: 'i-heroicons-book-open', click: () => window.open('https://docs.bagofwords.com', '_blank') },
+  ]
+  if (isMcpEnabled.value && useCan('manage_settings')) {
+    bottom.push({ label: t('nav.mcpServer'), slot: 'mcp', click: () => { showMcpModal.value = true } })
+  }
+
+  const identity: any[] = [
+    { label: (currentUser.value as any)?.name, icon: 'i-heroicons-user' },
+    { label: organization.value?.name, icon: 'i-heroicons-building-office' },
+  ]
+
+  return [
+    main,
+    bottom,
+    identity,
+    [{ label: t('auth.logout'), icon: 'i-heroicons-arrow-right-on-rectangle', click: () => { signOff() } }],
+  ]
+})
+
+const showMcpModal = ref(false)
 
 const { isExcel } = useExcel()
 


### PR DESCRIPTION
Moves connection schema discovery off the HTTP request into a tracked
background job so create/update/reindex returns immediately instead of
blocking for minutes (or hours) on sources like QVD or Power BI Report
Server. Adds a state machine and polling UI so users see real progress
and can retry failures.

Backend
- New `ConnectionIndexing` model + migration; one row per refresh
  attempt, with phase / progress_done / progress_total / stats_json.
- `ConnectionIndexingService` runs `refresh_schema` on a dedicated
  daemon-thread event loop so jobs survive request completion and
  FastAPI's sync TestClient. Progress flushes use their own DB
  session to avoid colliding with the in-flight session.
- `DataSourceClient.aget_schemas` accepts an optional
  `progress_callback`; base class falls back for legacy clients with
  no kwarg.
- QVD and PBIRS emit per-file / per-report progress from inside their
  existing loops (no new round-trips). SQLite emits per-table.
- `create_connection` / `update_connection` / `create_data_source` now
  kick off an indexing job instead of awaiting refresh. Fast-fail on
  bad config via existing test_connection.
- `refresh_schema` still runs on reindex; runner syncs DataSourceTable
  for every linked data source on completion.
- `ConnectionTestResult` gains optional `timings` and `details`. QVD /
  PBIRS / SQLite populate richer info (server version, file bytes,
  auth mode, etc.).
- New routes: `POST /connections/{id}/reindex`,
  `GET /connections/{id}/indexing`. Existing `/refresh` kicks off a
  background job (was synchronous).
- `GET /data_sources/{id}` inlines the latest indexing row into each
  connection so pages don't need extra roundtrips.

Frontend
- `useConnectionStatus` composable: single state machine with five
  effective states (success / indexing / indexing_failed / error /
  unknown) plus dot / badge / label helpers.
- `layouts/data.vue` polls `fetchIntegration` every 2s while any
  connection is indexing; stops on terminal. Header dot uses the new
  palette with tooltip showing progress.
- `connection.vue` shows a progress bar + phase label per connection
  while indexing runs. Indexing failures render a Retry button that
  hits `/reindex`. Test-result block now shows timings + details.
- `data/[id]/index.vue` adds an indexing banner at the top with a
  link to the connection tab.
- `data/[id]/tables.vue` adds an inline note so an empty table list
  during indexing doesn't look broken.

Tests
- `test_connection_indexing.py` — happy path, fast-failure, reindex,
  payload inlining, idempotency during an in-flight run.
- `test_connection_indexing_load.py` — 500-table SQLite load test
  asserting POST < 3s, monotonic progress, completion.
- `test_connection_indexing_pbirs_mock.py` — mocked PBIRS with 50
  PBIX reports + 30 RDL + 20 datasets + 5 KPIs, asserts phase
  transitions and final stats.

https://claude.ai/code/session_01KAag8dBUvyjzrLuYhyyL8r