### PR TITLE
fix: preserve success status when new prompt interrupts knowledge harness tail

### DIFF
--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -2195,10 +2195,21 @@ class CompletionService:
         if not completion:
             raise HTTPException(status_code=404, detail="Completion not found")
 
-        completion.sigkill = datetime.now()
-        completion.status = 'stopped'
+        # If the main analysis has already reached a terminal state (success/error/stopped),
+        # the user-facing result is final — the agent may still be running a background
+        # sub-loop (e.g. knowledge harness) but we must not flip the completion to 'stopped'
+        # or UI would show "Generation stopped" over a successful answer. Still stamp
+        # sigkill so the after_update websocket broadcast signals the agent to break its
+        # current sub-loop at its next cooperative checkpoint.
+        already_terminal = completion.status in ('success', 'error', 'stopped')
 
-        # Also update all in_progress completion blocks to stopped
+        completion.sigkill = datetime.now()
+        if not already_terminal:
+            completion.status = 'stopped'
+
+        # Also update all in_progress completion blocks to stopped — regardless of the
+        # overall completion status, any block that is still in flight has been
+        # interrupted and should be marked as such.
         from app.models.completion_block import CompletionBlock
         blocks_result = await db.execute(
             select(CompletionBlock).where(

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -2195,16 +2195,15 @@ class CompletionService:
         if not completion:
             raise HTTPException(status_code=404, detail="Completion not found")
 
-        # If the main analysis has already reached a terminal state (success/error/stopped),
-        # the user-facing result is final — the agent may still be running a background
-        # sub-loop (e.g. knowledge harness) but we must not flip the completion to 'stopped'
-        # or UI would show "Generation stopped" over a successful answer. Still stamp
-        # sigkill so the after_update websocket broadcast signals the agent to break its
-        # current sub-loop at its next cooperative checkpoint.
-        already_terminal = completion.status in ('success', 'error', 'stopped')
-
+        # If the main analysis has already left 'in_progress' (success/error/stopped or
+        # any future terminal state), the user-facing result is final — the agent may
+        # still be running a background sub-loop (e.g. knowledge harness) but we must
+        # not flip the completion to 'stopped' or UI would show "Generation stopped"
+        # over a successful answer. Still stamp sigkill so the after_update websocket
+        # broadcast signals the agent to break its current sub-loop at its next
+        # cooperative checkpoint.
         completion.sigkill = datetime.now()
-        if not already_terminal:
+        if completion.status == 'in_progress':
             completion.status = 'stopped'
 
         # Also update all in_progress completion blocks to stopped — regardless of the

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -2913,6 +2913,14 @@ async function startStreaming(requestBody: any, sysId: string) {
 				if (err.name === 'AbortError') {
 					// Check if this was a user-initiated stop (sigkill) vs connection abort
 					const sysMsg = messages.value[idx]
+					// If the main analysis already reached a terminal state (success/error),
+					// the SSE stream was only still open for the knowledge-harness tail.
+					// Aborting it on a new user submit should not downgrade the result to
+					// "Generation stopped" — preserve the terminal status the user has
+					// already seen (thumbs up, etc).
+					if (sysMsg && sysMsg.status && sysMsg.status !== 'in_progress') {
+						return
+					}
 					if (sysMsg && sysMsg.system_completion_id) {
 						// This was likely a user stop, mark as stopped without error
 						messages.value[idx] = { ...messages.value[idx], status: 'stopped' }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -2913,11 +2913,11 @@ async function startStreaming(requestBody: any, sysId: string) {
 				if (err.name === 'AbortError') {
 					// Check if this was a user-initiated stop (sigkill) vs connection abort
 					const sysMsg = messages.value[idx]
-					// If the main analysis already reached a terminal state (success/error),
-					// the SSE stream was only still open for the knowledge-harness tail.
-					// Aborting it on a new user submit should not downgrade the result to
-					// "Generation stopped" — preserve the terminal status the user has
-					// already seen (thumbs up, etc).
+					// If the main analysis already left 'in_progress', the SSE stream was
+					// only still open for the knowledge-harness tail. Aborting it on a new
+					// user submit should not downgrade the result to "Generation stopped" —
+					// preserve whatever status the user has already seen (success with
+					// thumbs up, error, or an existing 'stopped').
 					if (sysMsg && sysMsg.status && sysMsg.status !== 'in_progress') {
 						return
 					}


### PR DESCRIPTION
Submitting a new prompt while the knowledge-harness sub-loop is still streaming
aborted the SSE stream and unconditionally flipped the prior completion to
"Generation stopped", even after the main analysis had already emitted
completion.finished with status='success'. Two paths contributed:

- Frontend: the AbortError catch in the streaming loop flipped the sysMsg to
  'stopped' whenever a system_completion_id was present, ignoring whether the
  message had already reached a terminal state. Guard against downgrading a
  'success'/'error' status — the user has already seen the result.
- Backend: update_completion_sigkill overwrote completion.status='stopped'
  unconditionally. Respect an already-terminal status; still stamp the sigkill
  timestamp so the after_update websocket broadcast signals the running agent
  to break its current sub-loop at its next cooperative checkpoint.