### PR TITLE
e2e: fix postgres ci hangs from leaked idle-in-transaction sessions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,11 +10,12 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         db: [sqlite, postgres]
-    
+
     steps:
     - uses: actions/checkout@v4
     
@@ -28,7 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements_versioned.txt
-        
+        pip install pytest-timeout
+
     - name: Check for AI file changes
       id: changes
       uses: dorny/paths-filter@v3
@@ -45,7 +47,7 @@ jobs:
         ENVIRONMENT: "production"
         OPENAI_API_KEY_TEST: ${{ secrets.OPENAI_API_KEY_TEST }}
       run: |
-        pytest -s -m ai --db=${{ matrix.db }} --disable-warnings
+        pytest -s -m ai --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
 
     - name: Run E2E tests
       working-directory: ./backend
@@ -54,7 +56,7 @@ jobs:
         ENVIRONMENT: "production"
         OPENAI_API_KEY_TEST: ${{ secrets.OPENAI_API_KEY_TEST }}
       run: |
-        pytest -s -m e2e --db=${{ matrix.db }} --disable-warnings
+        pytest -s -m e2e --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
 
   playwright-tests:
     runs-on: ubuntu-latest

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -36,11 +36,21 @@ async def get_db():
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_maker() as session:
-        yield session
+        try:
+            yield session
+        finally:
+            # Belt-and-suspenders: ensure the connection isn't returned to the
+            # pool in `idle in transaction` state. Rollback on a committed
+            # session is a no-op; on a read-only session it ends the implicit
+            # transaction asyncpg opened for the SELECT.
+            await session.rollback()
 
 async def get_async_db() -> AsyncSession:
     async with async_session_maker() as session:
-        yield session
+        try:
+            yield session
+        finally:
+            await session.rollback()
 
 async def get_user_db(session: AsyncSession = Depends(get_async_session)):
     yield SQLAlchemyUserDatabase(session, User, OAuthAccount)

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -65,6 +65,38 @@ def _get_background_loop() -> asyncio.AbstractEventLoop:
         return _background_loop
 
 
+def shutdown_background_loop(timeout: float = 5.0) -> None:
+    """Cancel pending tasks on the bg loop and stop it. Used by tests to keep
+    a leaked indexing job from holding a Postgres `idle in transaction` lock
+    across test boundaries (which blocks the per-test schema reset).
+    """
+    global _background_loop
+    with _background_loop_lock:
+        loop = _background_loop
+        if loop is None or loop.is_closed():
+            _background_loop = None
+            return
+
+    async def _cancel_all() -> None:
+        tasks = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await asyncio.wait_for(asyncio.shield(t), timeout=timeout)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                pass
+
+    try:
+        fut = asyncio.run_coroutine_threadsafe(_cancel_all(), loop)
+        fut.result(timeout=timeout + 1.0)
+    except Exception:
+        pass
+    loop.call_soon_threadsafe(loop.stop)
+    with _background_loop_lock:
+        _background_loop = None
+
+
 # How often we flush progress updates to the DB. Progress callbacks from the
 # client loop can fire thousands of times; we coalesce into one write per
 # `_PROGRESS_FLUSH_SECONDS` (plus one final flush at end-of-phase).

--- a/backend/app/settings/database.py
+++ b/backend/app/settings/database.py
@@ -180,8 +180,21 @@ def create_async_database_engine():
             ).replace(
                 "postgresql://", "postgresql+asyncpg://"
             )
-            # NullPool: no connection pooling - avoids stale connection issues with TestClient
-            engine = create_async_engine(database_url, echo=False, future=True, poolclass=NullPool)
+            # NullPool: no connection pooling - avoids stale connection issues with TestClient.
+            # idle_in_transaction_session_timeout: if a leaked session stays idle
+            # in transaction for >60s, Postgres terminates it automatically — keeps
+            # a single bug from blocking DROP SCHEMA in the next test for hours.
+            engine = create_async_engine(
+                database_url,
+                echo=False,
+                future=True,
+                poolclass=NullPool,
+                connect_args={
+                    "server_settings": {
+                        "idle_in_transaction_session_timeout": "60000",
+                    },
+                },
+            )
     else:
         db_config = settings.bow_config.database
         database_url = _get_async_database_url()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -261,10 +261,20 @@ def alembic_config(db_backend):
 
 
 def _reset_postgres_schema(alembic_config):
-    """Drop and recreate public schema to clean up ENUMs, types, etc."""
+    """Drop and recreate public schema to clean up ENUMs, types, etc.
+
+    Terminates any other backends on this database first — without this,
+    a leaked `idle in transaction` session from a prior test holds locks
+    and the DROP SCHEMA blocks indefinitely (was the source of 6h CI hangs).
+    """
     from sqlalchemy import create_engine, text
     engine = create_engine(alembic_config.get_main_option("sqlalchemy.url"))
     with engine.connect() as conn:
+        conn.execute(text(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        ))
+        conn.execute(text("SET statement_timeout = '60s'"))
         conn.execute(text("DROP SCHEMA public CASCADE"))
         conn.execute(text("CREATE SCHEMA public"))
         conn.execute(text("GRANT ALL ON SCHEMA public TO public"))

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -22,6 +22,7 @@ arm, which is the more thorough one.
 import pytest
 
 from app.ee import license as ee_license
+from app.services import connection_indexing_service as _cis
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -49,3 +50,17 @@ def _e2e_force_enterprise_license():
     finally:
         ee_license._cached_license = saved_cached
         ee_license._cache_initialized = saved_initialized
+
+
+@pytest.fixture(autouse=True)
+def _drain_connection_indexing_loop():
+    """Drain the connection-indexing background loop after each test.
+
+    PR #225 introduced a process-wide daemon-thread event loop that runs
+    fire-and-forget indexing jobs. Without an explicit drain, a job can be
+    mid-flight when the test ends, leaving an `idle in transaction` Postgres
+    session that blocks the next test's `DROP SCHEMA` for the connection's
+    full lifetime — the source of the 6h CI timeouts.
+    """
+    yield
+    _cis.shutdown_background_loop()


### PR DESCRIPTION
CI on the postgres matrix was timing out at the 6h job cap. py-spy + pg_stat_activity showed the freeze was always in the per-test schema-reset fixture, blocked by an `idle in transaction` backend the previous test left open (typically holding row/relation locks on git_repositories). DROP SCHEMA serializes behind that and waits forever — sqlite never hits this because its DDL doesn't take long-held shared locks.

- conftest._reset_postgres_schema: pg_terminate_backend any other backends on the test db, then SET statement_timeout='60s' before DROP SCHEMA. Fail fast instead of stalling.
- connection_indexing_service: expose shutdown_background_loop() that cancels in-flight tasks and stops the daemon-thread loop (introduced in PR #225).
- tests/e2e/conftest: autouse function-scoped fixture drains the bg loop after every test so a fire-and-forget indexing job can't outlive its test and hold locks.
- dependencies.get_async_db / get_async_session: explicit await session.rollback() in the cleanup path so a connection never returns to the pool with an open implicit transaction.
- settings/database (testing branch): asyncpg server_settings idle_in_transaction_session_timeout=60s — defense-in-depth so any future leak self-terminates instead of hanging the next test.
- workflow: timeout-minutes 60 on the e2e job, --timeout=600 --timeout-method=thread on both pytest steps. Any future hang surfaces as a 10-min stack dump pointing at the offending test rather than a 6h burn.

https://claude.ai/code/session_011iWUbdD1sVFq3wmqhBdKtG