### PR TITLE
hide timbr_a2a data source from non-dev environments

### DIFF
--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -600,6 +600,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         ),
         client_path="app.data_sources.clients.timbr_a2a_client.TimbrA2aClient",
         requires_license="enterprise",
+        dev_only=True,
     ),
     "sisense": DataSourceRegistryEntry(
         type="sisense",


### PR DESCRIPTION
Mark the timbr_a2a registry entry as dev_only so it is filtered out of
list_available_data_sources and rejected by get_entry outside of dev/test
environments.

https://claude.ai/code/session_01K5FZaP8PkfbyAhPyBDsPCs