### PR TITLE
fix: validate org_id in usage_limits routes and 409 on duplicate names

### DIFF
--- a/backend/app/routes/usage_limits.py
+++ b/backend/app/routes/usage_limits.py
@@ -35,6 +35,14 @@ def _quota_http_error(exc: UsageLimitExceeded) -> HTTPException:
     )
 
 
+def _ensure_org_match(organization_id: str, organization: Organization) -> None:
+    # Permission check authorizes against `organization` (resolved from header
+    # / API key). Reject any request whose path org_id doesn't match so a
+    # caller authorized for org A can't operate on org B's policies.
+    if str(organization_id) != str(organization.id):
+        raise HTTPException(status_code=403, detail="Organization mismatch")
+
+
 @router.get("/organizations/{organization_id}/usage-policies", response_model=List[UsagePolicySchema])
 @require_enterprise(feature="usage_limits")
 @requires_permission("manage_settings")
@@ -44,6 +52,7 @@ async def list_usage_policies(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     return await usage_policy_service.list_policies(db, organization_id)
 
 
@@ -57,6 +66,7 @@ async def create_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     return await usage_policy_service.create_policy(db, organization_id, data)
 
 
@@ -70,6 +80,7 @@ async def get_effective_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     effective = await usage_policy_service.resolve_effective_limits(db, organization_id, user_id)
     return effective.to_schema()
 
@@ -87,6 +98,7 @@ async def set_principal_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     return await usage_policy_service.set_principal_policy(
         db,
         organization_id,
@@ -106,6 +118,7 @@ async def get_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     return await usage_policy_service.get_policy(db, organization_id, policy_id)
 
 
@@ -120,6 +133,7 @@ async def update_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     try:
         return await usage_policy_service.update_policy(db, organization_id, policy_id, data)
     except UsageLimitExceeded as exc:
@@ -136,4 +150,5 @@ async def delete_usage_policy(
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    _ensure_org_match(organization_id, organization)
     await usage_policy_service.delete_policy(db, organization_id, policy_id)

--- a/backend/app/services/usage_policy_service.py
+++ b/backend/app/services/usage_policy_service.py
@@ -172,11 +172,18 @@ class UsagePolicyService:
             enabled=data.enabled,
         )
         db.add(policy)
-        await db.flush()
-        await self._sync_assignments(db, org_id, policy.id, data.assignments)
-        await self._sync_connection_overrides(db, org_id, policy.id, data.connection_overrides)
-        policy_id = policy.id
-        await db.commit()
+        try:
+            await db.flush()
+            await self._sync_assignments(db, org_id, policy.id, data.assignments)
+            await self._sync_connection_overrides(db, org_id, policy.id, data.connection_overrides)
+            policy_id = policy.id
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail=f"A usage policy named '{data.name}' already exists.",
+            )
         db.expire_all()
         return await self.get_policy(db, org_id, policy_id)
 
@@ -210,7 +217,15 @@ class UsagePolicyService:
         if data.connection_overrides is not None:
             await self._sync_connection_overrides(db, org_id, policy.id, data.connection_overrides)
         policy_id = policy.id
-        await db.commit()
+        attempted_name = policy.name
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail=f"A usage policy named '{attempted_name}' already exists.",
+            )
         db.expire_all()
         return await self.get_policy(db, org_id, policy_id)
 


### PR DESCRIPTION
Address PR #239 review feedback:
- Reject requests where path organization_id doesn't match the header / API key resolved organization, preventing a caller authorized for org A from operating on org B's policies.
- Catch IntegrityError on create/update policy and return 409 with a clear message instead of bubbling up as 500 (uq_usage_policies_org_name).