### PR TITLE
helm: align chart with bow-config schema and harden secret handling

### DIFF
--- a/k8s/AGENTS.md
+++ b/k8s/AGENTS.md
@@ -37,11 +37,25 @@ Concise overview of `@k8s/` with emphasis on the Helm chart layout, how values m
   - `postgresql.auth.existingSecret`: Use an existing secret instead of inline values.
 - **App configuration & secrets**
   - `config.secretRef`: Name of an existing `Secret` whose keys override defaults from the `ConfigMap`.
-  - Environment keys commonly used by the app (set via Secret):
-    - `BOW_DATABASE_URL`, `BOW_BASE_URL`, `BOW_ENCRYPTION_KEY`
+  - Sensitive fields use a `${VAR}` placeholder pattern: when a value in `values.yaml`
+    starts with `${`, the chart skips emitting it to the ConfigMap and the backend
+    resolves it from the env at startup (provided by `secretRef`). Plaintext values
+    still work but land in the ConfigMap and trigger a NOTES warning.
+  - Environment keys commonly used by the app (provide via Secret):
+    - Core: `BOW_DATABASE_URL`, `BOW_BASE_URL`, `BOW_ENCRYPTION_KEY`
+    - Auth mode: `BOW_AUTH_MODE` (`hybrid` | `local_only` | `sso_only`)
     - Google OAuth: `BOW_GOOGLE_AUTH_ENABLED`, `BOW_GOOGLE_CLIENT_ID`, `BOW_GOOGLE_CLIENT_SECRET`
+    - OIDC providers: `BOW_OIDC_<NAME>_CLIENT_SECRET` per `config.oidcProviders[].name`
+    - LDAP / AD: `BOW_LDAP_BIND_PASSWORD` (Secret-only — never in `values.yaml`)
+    - License: `BOW_LICENSE_KEY`
     - Signup/options: `BOW_ALLOW_UNINVITED_SIGNUPS`, `BOW_ALLOW_MULTIPLE_ORGANIZATIONS`, `BOW_VERIFY_EMAILS`
     - SMTP: `BOW_SMTP_HOST`, `BOW_SMTP_PORT`, `BOW_SMTP_USERNAME`, `BOW_SMTP_PASSWORD`, `BOW_SMTP_FROM_NAME`, `BOW_SMTP_FROM_EMAIL`, `BOW_SMTP_USE_TLS`, `BOW_SMTP_USE_SSL`, `BOW_SMTP_USE_CREDENTIALS`, `BOW_SMTP_VALIDATE_CERTS`
+- **Identity providers**
+  - `config.oidcProviders[]`: Okta, Entra/Azure AD, Auth0, etc. Supports
+    group sync (`syncGroups`, `groupClaim`, `resolveGroupNames` for Entra
+    UUID-to-name resolution via Microsoft Graph).
+  - `config.ldap`: LDAP / Active Directory bind, user/group search, periodic
+    sync, optional auto-provisioning. Bind password is Secret-only.
 - **ServiceAccount**
   - `serviceAccount.annotations`: Arbitrary annotations map.
 - **Scheduling**

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -129,54 +129,143 @@ helm upgrade -i --create-namespace \
  -f aurora-values.yaml
 ```
 
-### Use existing Secret
-1. Make sure the namespace exists, if not create it
+### Secrets handling
+
+Sensitive values must be provided via a Kubernetes `Secret`, not via the
+ConfigMap that the chart renders by default. The recommended pattern is:
+
+1. Put the placeholder `${ENV_VAR}` in `values.yaml` (or `--set ...`).
+2. Create a `Secret` whose keys match those env-var names.
+3. Reference it via `--set config.secretRef=<secret-name>`.
+
+Sensitive keys consumed by the app:
+
+| Key                                | Source field in `values.yaml`                | Notes |
+| ---                                | ---                                          | --- |
+| `BOW_ENCRYPTION_KEY`               | `config.encryptionKey`                       | Required for stable installs — see warning below. |
+| `BOW_DATABASE_URL`                 | bundled-Postgres path only                   | Embeds the DB password; prefer a Secret. |
+| `BOW_GOOGLE_CLIENT_SECRET`         | `config.googleClientSecret`                  | Plaintext in ConfigMap if set inline. |
+| `BOW_GOOGLE_CLIENT_ID`             | `config.googleClientId`                      | Public-ish; treat like a secret if your IdP requires. |
+| `BOW_OIDC_<NAME>_CLIENT_SECRET`    | `config.oidcProviders[].clientSecret`        | Use a placeholder per provider (uppercase, alnum + `_`). |
+| `BOW_LDAP_BIND_PASSWORD`           | `config.ldap` (never in values)              | Always Secret-only. |
+| `BOW_SMTP_PASSWORD`                | `config.smtp.password`                       | Always Secret-only. |
+| `BOW_LICENSE_KEY`                  | `config.licenseKey`                          | Always Secret-only. |
+
+> **Encryption key is required.** If neither `config.encryptionKey` nor a
+> `BOW_ENCRYPTION_KEY` in your Secret is set, the backend generates a new
+> Fernet key on every pod start, which makes previously-encrypted data
+> (LLM credentials, OAuth tokens, etc.) unreadable after a restart. Generate
+> one once and persist it: `openssl rand -base64 32`.
+
+#### Step-by-step
+
+1. Create the namespace if it doesn't exist:
 ```bash
-   kubectl create namespace <namespace>
+kubectl create namespace <namespace>
 ```
-2. Create the secret with the environment variables you want to override
+
+2. Create the `Secret` with the sensitive keys you want to inject:
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <secret-name>
+  name: bowapp-secrets
   namespace: <namespace>
 stringData:
-  postgres-password: "<postgres-password>"
-  BOW_DATABASE_URL: "postgresql://<postgres-user>:<postgres-password>@<postgres-host>:5432/<postgres-database>"
-  BOW_BASE_URL: "<base-url>"
-  BOW_ENCRYPTION_KEY: "<encryption-key>"
-  BOW_GOOGLE_AUTH_ENABLED: "false"
-  BOW_GOOGLE_CLIENT_ID: "<client-id>"
-  BOW_GOOGLE_CLIENT_SECRET: "<client-secret>"
-  BOW_ALLOW_UNINVITED_SIGNUPS: "false"
-  BOW_ALLOW_MULTIPLE_ORGANIZATIONS: "false"
-  BOW_VERIFY_EMAILS: "false"
-  BOW_INTERCOM_ENABLED: "false"
+  # App-wide
+  BOW_ENCRYPTION_KEY: "<fernet-key>"
+  BOW_DATABASE_URL: "postgresql://<user>:<pass>@<host>:5432/<db>"
 
-  # SMTP Configuration
-  BOW_SMTP_HOST: "<smtp-host>"
-  BOW_SMTP_PORT: "<smtp-port>"
-  BOW_SMTP_USERNAME: "<smtp-username>"
+  # Google OAuth
+  BOW_GOOGLE_CLIENT_SECRET: "<google-client-secret>"
+
+  # OIDC (one per provider name; uppercase + underscores)
+  BOW_OIDC_OKTA_CLIENT_SECRET: "<okta-client-secret>"
+  BOW_OIDC_ENTRA_CLIENT_SECRET: "<entra-client-secret>"
+
+  # LDAP / Active Directory
+  BOW_LDAP_BIND_PASSWORD: "<service-account-password>"
+
+  # SMTP
   BOW_SMTP_PASSWORD: "<smtp-password>"
-  BOW_SMTP_FROM_NAME: "<from-name>"
-  BOW_SMTP_FROM_EMAIL: "<from-email>"
-  BOW_SMTP_USE_TLS: "true"
-  BOW_SMTP_USE_SSL: "false"
-  BOW_SMTP_USE_CREDENTIALS: "true"
-  BOW_SMTP_VALIDATE_CERTS: "true"
+
+  # License
+  BOW_LICENSE_KEY: "<license-key>"
+
+  # Bundled-Postgres (subchart)
+  postgres-password: "<postgres-password>"
 ```
 
-**Note**: When using an existing secret, the values in the secret will override the default values from the ConfigMap. You only need to include the environment variables you want to override.
-
-3. Deploy BoW Application
+3. Reference the Secret in your install:
 ```bash
-helm install \
-  bowapp ./chart \
- -n bowapp-1 \
- --set postgresql.auth.existingSecret=existing-bowapp-secret \
- --set config.secretRef=existing-bowapp-secret
+helm upgrade -i \
+  bowapp bow/bagofwords \
+ -n <namespace> \
+ --set postgresql.auth.existingSecret=bowapp-secrets \
+ --set config.secretRef=bowapp-secrets
 ```
+
+The `Secret` is loaded after the ConfigMap via `envFrom`, so its values
+override any plaintext defaults from the ConfigMap. You only need to include
+the keys you want to set/override.
+
+### Microsoft Entra (Azure AD) with group sync
+
+```yaml
+# values.yaml
+config:
+  secretRef: bowapp-secrets       # contains BOW_OIDC_ENTRA_CLIENT_SECRET
+  authMode: hybrid                # or sso_only
+
+  oidcProviders:
+    - name: entra
+      enabled: true
+      label: "Sign in with Microsoft"
+      icon: microsoft
+      issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
+      clientId: "<entra-client-id>"
+      clientSecret: "${BOW_OIDC_ENTRA_CLIENT_SECRET}"
+      scopes: ["openid", "profile", "email"]
+      pkce: true
+      clientAuthMethod: post
+      discovery: true
+      uidClaim: sub
+      # Sync the `groups` claim from the id_token into BOW Groups on login.
+      syncGroups: true
+      groupClaim: groups
+      # Entra returns group object IDs (UUIDs); resolve display names via Graph.
+      resolveGroupNames: true
+```
+
+### LDAP / Active Directory
+
+```yaml
+# values.yaml
+config:
+  secretRef: bowapp-secrets       # contains BOW_LDAP_BIND_PASSWORD
+
+  ldap:
+    enabled: true
+    url: ldaps://ad.corp.com:636
+    bindDn: "cn=service-account,ou=Services,dc=corp,dc=com"
+    useSsl: true
+    startTls: false
+    baseDn: "dc=corp,dc=com"
+    userSearchBase: "ou=Users,dc=corp,dc=com"
+    userSearchFilter: "(objectClass=person)"
+    userEmailAttribute: mail
+    userNameAttribute: displayName
+    groupSearchBase: "ou=Groups,dc=corp,dc=com"
+    groupSearchFilter: "(objectClass=group)"
+    groupNameAttribute: cn
+    groupMemberAttribute: member        # "member" (AD/DN) or "memberUid" (OpenLDAP)
+    groupMemberFormat: dn               # "dn" or "uid"
+    syncIntervalMinutes: 60
+    autoProvisionUsers: false
+```
+
+The bind password is never accepted via `values.yaml` — it must be set as
+`BOW_LDAP_BIND_PASSWORD` in the Secret referenced by `config.secretRef`.
 
 
 ### Service Account annotations

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bagofwords
 description: Bag of words - a new ai data tool
 type: application
-version: 1.0.14
+version: 1.1.0
 appVersion: 1.0.1
 dependencies:
   - name: postgresql

--- a/k8s/chart/templates/NOTES.txt
+++ b/k8s/chart/templates/NOTES.txt
@@ -1,0 +1,76 @@
+Bag of Words has been deployed to namespace "{{ .Release.Namespace }}" as release "{{ .Release.Name }}".
+
+Host: https://{{ .Values.host }}
+
+{{- $hasSecretRef := .Values.config.secretRef -}}
+{{- $plaintext := list -}}
+{{- if and .Values.config.encryptionKey (not (hasPrefix "${" .Values.config.encryptionKey)) -}}
+{{- $plaintext = append $plaintext "config.encryptionKey" -}}
+{{- end -}}
+{{- if and .Values.config.googleClientSecret (not (hasPrefix "${" .Values.config.googleClientSecret)) -}}
+{{- $plaintext = append $plaintext "config.googleClientSecret" -}}
+{{- end -}}
+{{- if and .Values.config.licenseKey (not (hasPrefix "${" .Values.config.licenseKey)) -}}
+{{- $plaintext = append $plaintext "config.licenseKey" -}}
+{{- end -}}
+{{- if and .Values.config.smtp.password (not (hasPrefix "${" .Values.config.smtp.password)) -}}
+{{- $plaintext = append $plaintext "config.smtp.password" -}}
+{{- end -}}
+{{- range $p := .Values.config.oidcProviders -}}
+{{- if and $p.clientSecret (not (hasPrefix "${" $p.clientSecret)) -}}
+{{- $plaintext = append $plaintext (printf "config.oidcProviders[%s].clientSecret" $p.name) -}}
+{{- end -}}
+{{- end }}
+
+{{- if not .Values.config.encryptionKey }}
+{{- if not $hasSecretRef }}
+
+WARNING: no encryption key configured.
+  config.encryptionKey is empty and config.secretRef is not set, so a fresh
+  Fernet key will be generated on every pod start. Existing encrypted data
+  (LLM credentials, OAuth tokens, etc.) will become unreadable after a
+  restart or scale event.
+
+  Fix one of:
+    --set config.encryptionKey="$(openssl rand -base64 32)"
+    --set config.secretRef=<secret-name>   # with key BOW_ENCRYPTION_KEY
+{{- end }}
+{{- end }}
+
+{{- if $plaintext }}
+
+WARNING: plaintext sensitive values detected in values:
+{{- range $f := $plaintext }}
+  - {{ $f }}
+{{- end }}
+
+  These values will be stored in a ConfigMap, which is NOT a Secret. They are
+  visible to anyone with read access to the namespace and may be captured by
+  cluster snapshots, GitOps tooling, and log aggregators.
+
+  Recommended: move them to a Kubernetes Secret and reference it via
+  config.secretRef. Use the ${VAR} placeholder pattern in values, for example:
+    config:
+      secretRef: bowapp-secrets
+      googleClientSecret: "${BOW_GOOGLE_CLIENT_SECRET}"
+  ...with a Secret named "bowapp-secrets" containing key BOW_GOOGLE_CLIENT_SECRET.
+{{- end }}
+
+{{- if .Values.config.ldap.enabled }}
+
+LDAP is enabled. Make sure config.secretRef points to a Secret containing
+BOW_LDAP_BIND_PASSWORD — the chart does not put the bind password in the
+ConfigMap.
+{{- end }}
+
+{{- if .Values.config.oidcProviders }}
+
+OIDC providers are configured. For each provider, store the client secret in
+the Secret referenced by config.secretRef using the key referenced by your
+clientSecret placeholder (e.g. ${BOW_OIDC_OKTA_CLIENT_SECRET} → Secret key
+BOW_OIDC_OKTA_CLIENT_SECRET).
+{{- end }}
+
+To check status:
+  kubectl get pods -n {{ .Release.Namespace }}
+  kubectl logs -n {{ .Release.Namespace }} -l app=bowapp --tail=100

--- a/k8s/chart/templates/config.yml
+++ b/k8s/chart/templates/config.yml
@@ -27,41 +27,57 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
-  
-  # Application configuration - always include these
-  BOW_BASE_URL: {{.Values.config.baseUrl | quote}}
-  BOW_ENCRYPTION_KEY: {{.Values.config.encryptionKey | quote}}
+
+  # Application configuration
+  BOW_BASE_URL: {{ .Values.config.baseUrl | quote }}
   BOW_AUTH_MODE: {{ .Values.config.authMode | quote }}
-  BOW_GOOGLE_CLIENT_ID: {{.Values.config.googleClientId | quote}}
-  BOW_GOOGLE_CLIENT_SECRET: {{.Values.config.googleClientSecret | quote}}
-  BOW_GOOGLE_AUTH_ENABLED: {{.Values.config.googleOauthEnabled | quote}}
-  {{- if or .Values.config.smtp.host .Values.config.smtp.enabled }}
-  BOW_SMTP_HOST: {{.Values.config.smtp.host | quote}}
-  BOW_SMTP_PORT: {{.Values.config.smtp.port | quote}}
-  BOW_SMTP_USERNAME: {{.Values.config.smtp.username | quote}}
-  BOW_SMTP_PASSWORD: {{.Values.config.smtp.password | quote}}
-  BOW_SMTP_FROM_NAME: {{.Values.config.smtp.from_name | quote}}
-  BOW_SMTP_FROM_EMAIL: {{.Values.config.smtp.from_email | quote}}
-  BOW_SMTP_USE_TLS: {{.Values.config.smtp.use_tls | quote}}
-  BOW_SMTP_USE_SSL: {{.Values.config.smtp.use_ssl | quote}}
-  BOW_SMTP_USE_CREDENTIALS: {{.Values.config.smtp.use_credentials | quote}}
-  BOW_SMTP_VALIDATE_CERTS: {{.Values.config.smtp.validate_certs | quote}}
+  BOW_GOOGLE_AUTH_ENABLED: {{ .Values.config.googleOauthEnabled | quote }}
+  BOW_INTERCOM_ENABLED: {{ .Values.config.intercomEnabled | quote }}
+  BOW_TELEMETRY_ENABLED: {{ .Values.config.telemetryEnabled | quote }}
+  BOW_ALLOW_UNINVITED_SIGNUPS: {{ .Values.config.allowUninvitedSignups | quote }}
+  BOW_ALLOW_MULTIPLE_ORGANIZATIONS: {{ .Values.config.allowMultipleOrganizations | quote }}
+  BOW_VERIFY_EMAILS: {{ .Values.config.verifyEmails | quote }}
+
+  # Sensitive values: emit to ConfigMap only when set as a literal (not a ${VAR} placeholder).
+  # Recommended pattern is to provide these via config.secretRef; see README.md.
+  {{- if and .Values.config.encryptionKey (not (hasPrefix "${" .Values.config.encryptionKey)) }}
+  BOW_ENCRYPTION_KEY: {{ .Values.config.encryptionKey | quote }}
   {{- end }}
-  BOW_INTERCOM_ENABLED: {{.Values.config.intercomEnabled | quote}}
-  BOW_TELEMETRY_ENABLED: {{.Values.config.telemetryEnabled | quote }}
-  BOW_ALLOW_UNINVITED_SIGNUPS: {{.Values.config.allowUninvitedSignups | quote}}
-  BOW_ALLOW_MULTIPLE_ORGANIZATIONS: {{.Values.config.allowMultipleOrganizations | quote}}
-  BOW_VERIFY_EMAILS: {{.Values.config.verifyEmails | quote}}
+  {{- if and .Values.config.googleClientId (not (hasPrefix "${" .Values.config.googleClientId)) }}
+  BOW_GOOGLE_CLIENT_ID: {{ .Values.config.googleClientId | quote }}
+  {{- end }}
+  {{- if and .Values.config.googleClientSecret (not (hasPrefix "${" .Values.config.googleClientSecret)) }}
+  BOW_GOOGLE_CLIENT_SECRET: {{ .Values.config.googleClientSecret | quote }}
+  {{- end }}
+  {{- if and .Values.config.licenseKey (not (hasPrefix "${" .Values.config.licenseKey)) }}
+  BOW_LICENSE_KEY: {{ .Values.config.licenseKey | quote }}
+  {{- end }}
+
+  # SMTP — Helm-only `enabled` is a render gate; SMTPSettings has no `enabled` field.
+  # `host` is required when SMTP is on (also implicitly enabled if `host` is set).
+  {{- $smtpOn := or .Values.config.smtp.enabled .Values.config.smtp.host -}}
+  {{- if $smtpOn }}
+  {{- if not .Values.config.smtp.host }}
+  {{- fail "config.smtp.host is required when SMTP is enabled" }}
+  {{- end }}
+  BOW_SMTP_HOST: {{ .Values.config.smtp.host | quote }}
+  BOW_SMTP_PORT: {{ .Values.config.smtp.port | quote }}
+  BOW_SMTP_USERNAME: {{ .Values.config.smtp.username | quote }}
+  BOW_SMTP_FROM_NAME: {{ .Values.config.smtp.from_name | quote }}
+  BOW_SMTP_FROM_EMAIL: {{ .Values.config.smtp.from_email | quote }}
+  BOW_SMTP_USE_TLS: {{ .Values.config.smtp.use_tls | quote }}
+  BOW_SMTP_USE_SSL: {{ .Values.config.smtp.use_ssl | quote }}
+  BOW_SMTP_USE_CREDENTIALS: {{ .Values.config.smtp.use_credentials | quote }}
+  BOW_SMTP_VALIDATE_CERTS: {{ .Values.config.smtp.validate_certs | quote }}
+  {{- if and .Values.config.smtp.password (not (hasPrefix "${" .Values.config.smtp.password)) }}
+  BOW_SMTP_PASSWORD: {{ .Values.config.smtp.password | quote }}
+  {{- end }}
+  {{- end }}
+
   {{- if .Values.config.uvicornWorkers }}
   UVICORN_WORKERS: {{ .Values.config.uvicornWorkers | quote }}
   {{- end }}
-  # OIDC providers rendered as YAML inside the config file
-  BOW_OIDC_JSON: {{ .Values.config.oidcProviders | toJson | quote }}
-  # Enterprise license key (optional - prefer using secretRef for security)
-  {{- if .Values.config.licenseKey }}
-  BOW_LICENSE_KEY: {{.Values.config.licenseKey | quote}}
-  {{- end }}
-  
+
   bowConfig: |
     # Deployment Configuration
     base_url: ${BOW_BASE_URL}
@@ -72,14 +88,17 @@ data:
       allow_multiple_organizations: ${BOW_ALLOW_MULTIPLE_ORGANIZATIONS}
       verify_emails: ${BOW_VERIFY_EMAILS}
 
+    auth:
+      mode: ${BOW_AUTH_MODE}
+
     google_oauth:
       enabled: ${BOW_GOOGLE_AUTH_ENABLED}
       client_id: ${BOW_GOOGLE_CLIENT_ID}
       client_secret: ${BOW_GOOGLE_CLIENT_SECRET}
 
     encryption_key: ${BOW_ENCRYPTION_KEY}
-    
-{{- if or .Values.config.smtp.host .Values.config.smtp.enabled }}
+
+{{- if $smtpOn }}
     smtp_settings:
       host: ${BOW_SMTP_HOST}
       port: ${BOW_SMTP_PORT}
@@ -102,16 +121,44 @@ data:
     license:
       key: ${BOW_LICENSE_KEY}
 
-    features:
-      auth:
-        mode: ${BOW_AUTH_MODE}
-
     otel:
       enabled: {{ .Values.config.otel.enabled | quote }}
       serviceName: {{ .Values.config.otel.serviceName | quote }}
       tracesEndpoint: {{ .Values.config.otel.tracesEndpoint | quote }}
-      protocol: {{ .Values.config.otel.protocol | quote}}
+      protocol: {{ .Values.config.otel.protocol | quote }}
       headers: {{ .Values.config.otel.headers | quote }}
+
+{{- if .Values.config.ldap.enabled }}
+    # LDAP / Active Directory
+    # bind_password is read from env BOW_LDAP_BIND_PASSWORD — provide via config.secretRef
+    ldap:
+      enabled: true
+      url: {{ .Values.config.ldap.url | quote }}
+{{- if .Values.config.ldap.bindDn }}
+      bind_dn: {{ .Values.config.ldap.bindDn | quote }}
+{{- end }}
+      bind_password: ${BOW_LDAP_BIND_PASSWORD}
+      use_ssl: {{ .Values.config.ldap.useSsl }}
+      start_tls: {{ .Values.config.ldap.startTls }}
+      base_dn: {{ .Values.config.ldap.baseDn | quote }}
+{{- if .Values.config.ldap.userSearchBase }}
+      user_search_base: {{ .Values.config.ldap.userSearchBase | quote }}
+{{- end }}
+      user_search_filter: {{ .Values.config.ldap.userSearchFilter | quote }}
+      user_email_attribute: {{ .Values.config.ldap.userEmailAttribute | quote }}
+      user_name_attribute: {{ .Values.config.ldap.userNameAttribute | quote }}
+{{- if .Values.config.ldap.groupSearchBase }}
+      group_search_base: {{ .Values.config.ldap.groupSearchBase | quote }}
+{{- end }}
+      group_search_filter: {{ .Values.config.ldap.groupSearchFilter | quote }}
+      group_name_attribute: {{ .Values.config.ldap.groupNameAttribute | quote }}
+      group_member_attribute: {{ .Values.config.ldap.groupMemberAttribute | quote }}
+      group_member_format: {{ .Values.config.ldap.groupMemberFormat | quote }}
+      sync_interval_minutes: {{ .Values.config.ldap.syncIntervalMinutes }}
+      auto_provision_users: {{ .Values.config.ldap.autoProvisionUsers }}
+      connection_timeout: {{ .Values.config.ldap.connectionTimeout }}
+      page_size: {{ .Values.config.ldap.pageSize }}
+{{- end }}
 
     # OpenID Connect providers
     oidc_providers:
@@ -127,6 +174,12 @@ data:
         client_auth_method: {{ (default "basic" $p.clientAuthMethod) | quote }}
         discovery: {{ (default true $p.discovery) }}
         uid_claim: {{ (default "sub" $p.uidClaim) | quote }}
+{{- if $p.label }}
+        label: {{ $p.label | quote }}
+{{- end }}
+{{- if $p.icon }}
+        icon: {{ $p.icon | quote }}
+{{- end }}
 {{- if $p.redirectPath }}
         redirect_path: {{ $p.redirectPath | quote }}
 {{- end }}
@@ -136,6 +189,9 @@ data:
 {{- if $p.extraTokenParams }}
         extra_token_params: {{ $p.extraTokenParams | toJson }}
 {{- end }}
+        sync_groups: {{ default false $p.syncGroups }}
+        group_claim: {{ default "groups" $p.groupClaim | quote }}
+        resolve_group_names: {{ default false $p.resolveGroupNames }}
 {{- end }}
 {{- else }}
       []

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -44,6 +44,17 @@ serviceAccount:
   name: bowapp
   imagePullSecret: ""
   annotations: {}
+
+# Application configuration.
+#
+# Sensitive fields (encryptionKey, googleClientSecret, smtp.password, licenseKey,
+# oidcProviders[].clientSecret, ldap.bindPassword) should be provided via a
+# Kubernetes Secret referenced by `config.secretRef`. Use the ${VAR} placeholder
+# pattern (e.g. clientSecret: "${BOW_OIDC_OKTA_CLIENT_SECRET}") and put the real
+# value in the Secret with the matching key. See README.md for details.
+#
+# Plaintext values are still accepted for backward compatibility, but they will
+# land in a ConfigMap (not a Secret) and trigger a warning in helm NOTES.
 config:
   secretRef: ""
   googleOauthEnabled: false
@@ -53,7 +64,7 @@ config:
   intercomEnabled: false
   telemetryEnabled: true
   baseUrl: ""
-  authMode: "hybrid"
+  authMode: "hybrid"   # hybrid | local_only | sso_only
   allowUninvitedSignups: false
   allowMultipleOrganizations: false
   verifyEmails: false
@@ -65,26 +76,74 @@ config:
     protocol: "grpc" # grpc or http/protobuf
     headers: "" # format: key1=value1,key2=value2
 
-  # List of OIDC providers to enable (empty by default)
-  # Example:
+  # OpenID Connect providers (Okta, Microsoft Entra, Auth0, etc.).
+  # `clientSecret` should always use the ${BOW_OIDC_<NAME>_CLIENT_SECRET}
+  # placeholder pattern — the real secret is provided via config.secretRef.
+  #
+  # Example — Okta:
   # oidcProviders:
   #   - name: okta
   #     enabled: true
   #     issuer: https://YOUR_OKTA_DOMAIN.okta.com/oauth2/default
-  #     clientId: "${BOW_OIDC_OKTA_CLIENT_ID}"   # or plain value
-  #     clientSecret: "${BOW_OIDC_OKTA_CLIENT_SECRET}" # or plain value
+  #     clientId: "<okta-client-id>"
+  #     clientSecret: "${BOW_OIDC_OKTA_CLIENT_SECRET}"
   #     scopes: ["openid", "profile", "email"]
   #     pkce: true
-  #     clientAuthMethod: basic   # or post
+  #     clientAuthMethod: basic   # basic | post
   #     discovery: true
   #     uidClaim: sub
-  #     redirectPath: /api/auth/okta/callback
-  #     extraAuthorizeParams: {}
-  #     extraTokenParams: {}
+  #
+  # Example — Microsoft Entra (Azure AD) with group sync:
+  # oidcProviders:
+  #   - name: entra
+  #     enabled: true
+  #     label: "Sign in with Microsoft"
+  #     icon: microsoft
+  #     issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
+  #     clientId: "<entra-client-id>"
+  #     clientSecret: "${BOW_OIDC_ENTRA_CLIENT_SECRET}"
+  #     scopes: ["openid", "profile", "email"]
+  #     pkce: true
+  #     clientAuthMethod: post
+  #     discovery: true
+  #     uidClaim: sub
+  #     # Sync groups from id_token's `groups` claim into BOW Groups on login.
+  #     syncGroups: true
+  #     groupClaim: groups
+  #     # Entra returns group UUIDs; resolve display names via Microsoft Graph.
+  #     resolveGroupNames: true
   oidcProviders: []
-  # Enterprise license key (optional)
-  # For security, prefer using secretRef to store the license key
+
+  # LDAP / Active Directory.
+  # bindPassword is NOT set here — provide it as BOW_LDAP_BIND_PASSWORD in
+  # the Secret referenced by config.secretRef.
+  ldap:
+    enabled: false
+    url: ""                                  # e.g. ldaps://ad.corp.com:636
+    bindDn: ""                               # service account DN (optional)
+    useSsl: true
+    startTls: false
+    baseDn: ""                               # e.g. dc=corp,dc=com
+    userSearchBase: ""                       # defaults to baseDn when empty
+    userSearchFilter: "(objectClass=person)"
+    userEmailAttribute: "mail"
+    userNameAttribute: "displayName"
+    groupSearchBase: ""                      # defaults to baseDn when empty
+    groupSearchFilter: "(objectClass=group)"
+    groupNameAttribute: "cn"
+    groupMemberAttribute: "member"            # "member" (AD/DN) or "memberUid" (OpenLDAP)
+    groupMemberFormat: "dn"                  # "dn" or "uid"
+    syncIntervalMinutes: 60
+    autoProvisionUsers: false
+    connectionTimeout: 10
+    pageSize: 500
+
+  # Enterprise license key. Prefer config.secretRef with key BOW_LICENSE_KEY.
   licenseKey: ""
+
+  # SMTP — `enabled` is a Helm-only render gate (SMTPSettings has no `enabled`
+  # field). Setting `host` also implicitly enables the block. `password` should
+  # be provided via config.secretRef as BOW_SMTP_PASSWORD.
   smtp:
     enabled: false
     host: ""


### PR DESCRIPTION
- fix auth.mode rendering at top level (was nested under features:, silently dropped)
- remove duplicate features: block that was clobbering allow_* feature flags
- add LDAP / Active Directory support (config.ldap.* with bind_password Secret-only)
- add OIDC group-sync fields (label, icon, sync_groups, group_claim, resolve_group_names) required for Microsoft Entra installs
- gate sensitive ConfigMap envs (encryptionKey, googleClientSecret, smtp.password, licenseKey, googleClientId) on hasPrefix "\${" so placeholder values don't land in the ConfigMap as literal strings; real values come from config.secretRef
- drop dead BOW_OIDC_JSON env var (never read by backend, leaked oidc secrets)
- clean up SMTP gate: enabled or host implies on; fail if enabled without host
- add NOTES.txt with plaintext-secret detection and missing-encryption-key warning
- bump chart 1.0.14 -> 1.1.0 (additive: new ldap block, new oidc fields, conditional secret emission; keeps backward compat for plaintext values)
- README: new Secrets handling section, Entra and LDAP install examples