### PR TITLE
tests: flush UsageLimitContext before reading the token counter

### DIFF
--- a/backend/tests/e2e/test_usage_limits.py
+++ b/backend/tests/e2e/test_usage_limits.py
@@ -594,14 +594,25 @@ def test_llm_success_counts_tokens_and_failed_provider_counts_nothing(create_use
     ))
 
     success_client = _SuccessfulLLMClient()
-    assert _quota_llm(org_id, user_id, success_client).inference("hello") == "ok"
+    success_llm = _quota_llm(org_id, user_id, success_client)
+    assert success_llm.inference("hello") == "ok"
     assert success_client.calls == 1
+    # `_record_usage_limit_*` buffers token writes on the
+    # UsageLimitContext and lets the agent run flush them in one go
+    # at end-of-execution. This test wires an LLM directly without an
+    # agent, so we drive the flush ourselves before reading the
+    # counter.
+    _run(success_llm._usage_limit_context.flush())
     assert _run(_counter_used(org_id, user_id, METRIC_LLM_TOKENS)) == 5
 
     failing_client = _FailingLLMClient()
+    failing_llm = _quota_llm(org_id, user_id, failing_client)
     with pytest.raises(RuntimeError):
-        _quota_llm(org_id, user_id, failing_client).inference("hello")
+        failing_llm.inference("hello")
     assert failing_client.calls == 1
+    # Provider error short-circuits before the buffer ever sees those
+    # tokens, so this flush is a no-op - kept for symmetry.
+    _run(failing_llm._usage_limit_context.flush())
     assert _run(_counter_used(org_id, user_id, METRIC_LLM_TOKENS)) == 5
 
 


### PR DESCRIPTION
## Summary

`test_llm_success_counts_tokens_and_failed_provider_counts_nothing` started failing on main after [c20b5a8](https://github.com/bagofwords1/bagofwords/commit/c20b5a8) ("quota: drop SELECT FOR UPDATE, batch token writes"). That commit moved per-LLM-call quota writes from "DB UPDATE inside `_record_usage_limit_*`" to "buffered on `UsageLimitContext._pending_tokens`, flushed once per agent run from `agent_v2.main_execution`'s `finally` block."

The test wires an `LLM` directly with `_quota_llm(...)` — there's no agent, and nothing else is calling `flush()`. So `_counter_used()` was reading the row before any DB write happened and getting `0` instead of `5`.

CI failure being addressed:

```
tests/e2e/test_usage_limits.py:599: AssertionError
assert _run(_counter_used(org_id, user_id, METRIC_LLM_TOKENS)) == 5
AssertionError: assert 0 == 5
```

## Fix

Hold the `LLM` instance and call `success_llm._usage_limit_context.flush()` (and the failing one, for symmetry) before each counter assertion. No production code changes — the agent path already flushes at end-of-run.

## Test plan

- [x] `pytest -s -m e2e tests/e2e/test_usage_limits.py::test_llm_success_counts_tokens_and_failed_provider_counts_nothing --db=sqlite` — passes.
- [x] Full `tests/e2e/test_usage_limits.py` suite (13 tests) — passes on sqlite.

https://claude.ai/code/session_01XcJQMhwUsdQ88KSY1pM9uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcJQMhwUsdQ88KSY1pM9uM)_