### PR TITLE
Surface Power BI Report Server metadata in table schema context

### DIFF
--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -115,12 +115,29 @@ class TablesSchemaContext(ContextSection):
                     metadata_xml = xml_tag("metadata", "", attrs)
             except Exception:
                 metadata_xml = ""
+            # PowerBI Report Server metadata — surface queryability so the planner
+            # knows pbix model tables, RDL reports, and shared datasets can be queried.
+            pbi_xml = ""
+            try:
+                pbi = (t.metadata_json or {}).get("powerbi_report_server") if isinstance(t.metadata_json, dict) else None
+                if isinstance(pbi, dict):
+                    pbi_attrs = {}
+                    for k in ("queryable", "report_type", "upstream_source"):
+                        v = pbi.get(k)
+                        if v is not None and v != "":
+                            pbi_attrs[k] = str(v).lower() if isinstance(v, bool) else str(v)
+                    pbi_note = pbi.get("query_note")
+                    pbi_inner = xml_escape(pbi_note) if pbi_note else ""
+                    if pbi_attrs or pbi_inner:
+                        pbi_xml = xml_tag("powerbi_report_server", pbi_inner, pbi_attrs)
+            except Exception:
+                pbi_xml = ""
             # Add query instructions for semantic views
             is_semantic_view = isinstance(t.metadata_json, dict) and t.metadata_json.get("type") == "semantic_view"
             note_xml = ""
             if is_semantic_view:
                 note_xml = xml_tag("note", "Snowflake Semantic View: query with SELECT * FROM SEMANTIC_VIEW(view_name DIMENSIONS dim1, dim2 METRICS metric1, metric2 WHERE condition). Use DIMENSIONS for role=dimension columns, METRICS for role=measure/metric columns.")
-            inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), metadata_xml, metrics_xml]))
+            inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), metadata_xml, pbi_xml, metrics_xml]))
             table_attrs = {"name": t.name}
             # Mark semantic views
             if is_semantic_view:
@@ -320,7 +337,24 @@ class TablesSchemaContext(ContextSection):
                 note_xml = ""
                 if is_sv:
                     note_xml = xml_tag("note", "Snowflake Semantic View: query with SELECT * FROM SEMANTIC_VIEW(view_name DIMENSIONS dim1, dim2 METRICS metric1, metric2 WHERE condition). Use DIMENSIONS for role=dimension columns, METRICS for role=measure/metric columns.")
-                inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), xml_tag("pks", pks) if pks else "", xml_tag("fks", fks) if fks else ""]))
+                # PowerBI Report Server metadata — surface queryability so the planner
+                # knows pbix model tables / RDL reports / datasets are queryable here.
+                pbi_xml = ""
+                try:
+                    pbi = (t.metadata_json or {}).get("powerbi_report_server") if isinstance(getattr(t, 'metadata_json', None), dict) else None
+                    if isinstance(pbi, dict):
+                        pbi_attrs = {}
+                        for k in ("queryable", "report_type", "upstream_source"):
+                            v = pbi.get(k)
+                            if v is not None and v != "":
+                                pbi_attrs[k] = str(v).lower() if isinstance(v, bool) else str(v)
+                        pbi_note = pbi.get("query_note")
+                        pbi_inner = xml_escape(pbi_note) if pbi_note else ""
+                        if pbi_attrs or pbi_inner:
+                            pbi_xml = xml_tag("powerbi_report_server", pbi_inner, pbi_attrs)
+                except Exception:
+                    pbi_xml = ""
+                inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), xml_tag("pks", pks) if pks else "", xml_tag("fks", fks) if fks else "", pbi_xml]))
                 return xml_tag("table", inner, attrs)
 
             if has_multi_connection:

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -1086,9 +1086,16 @@ class PowerBIReportServerClient(DataSourceClient):
                                 references_column=TableColumn(name=rel["to_column"], dtype="unknown"),
                             ))
 
+                        pbix_table_desc = (
+                            f"Internal table in Power BI report '{name}'. Queryable via DuckDB over a "
+                            "cached Parquet snapshot of the PBIX semantic model (reflects last PBIX refresh, "
+                            "not live upstream)."
+                            if self.enable_pbix_query
+                            else f"Internal table in Power BI report '{name}'. Not queryable via PBIRS (PBIX query disabled)."
+                        )
                         tables.append(Table(
                             name=f"pbix:{name}/{tname}",
-                            description=f"Internal table in Power BI report '{name}'. Not queryable via PBIRS.",
+                            description=pbix_table_desc,
                             columns=columns,
                             pks=[],
                             fks=fks,


### PR DESCRIPTION
## Summary
This PR adds support for surfacing Power BI Report Server metadata in the AI context's table schema section, allowing the planner to understand which PBIX model tables, RDL reports, and shared datasets are queryable.

## Key Changes
- **Schema context rendering**: Added PowerBI Report Server metadata extraction and XML rendering in two table rendering functions (`_render_table_xml` and `render_table`). The metadata includes:
  - `queryable`: Whether the table can be queried
  - `report_type`: Type of the Power BI resource
  - `upstream_source`: Source information
  - `query_note`: Additional query instructions

- **Metadata handling**: Implemented safe extraction of `powerbi_report_server` metadata from table metadata JSON with proper error handling and XML escaping

- **PBIX query descriptions**: Updated PBIX table descriptions in `get_schemas()` to reflect whether PBIX query is enabled, providing clearer context about queryability and data freshness (cached Parquet snapshot vs. disabled)

## Implementation Details
- PowerBI metadata is extracted from `t.metadata_json["powerbi_report_server"]` when present
- Boolean values are converted to lowercase strings for XML representation
- Empty or None values are filtered out to keep XML clean
- The PowerBI metadata XML element is inserted into the table schema between metadata and metrics sections
- Duplicate logic is applied in both rendering paths to ensure consistent behavior
- All operations are wrapped in try-except blocks to gracefully handle missing or malformed metadata

https://claude.ai/code/session_012NX2jFFdKDhmcHXKkTB2HY