### PR TITLE
Phase 1: bump vulnerable backend & frontend deps to fix versions

### DIFF
--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -127,14 +127,12 @@ async def get_file_content(file_id: str, request: Request, current_user: User = 
     if not file.path or not os.path.exists(file.path):
         raise HTTPException(status_code=404, detail="File content not found")
 
-    # Inline path guard at the sink (Snyk python/PT). The DB-stored path was
-    # written by our own upload handler, but verify it still resolves under
-    # the uploads dir before serving — defence in depth.
-    if ".." in file.path:
-        raise HTTPException(status_code=404, detail="File content not found")
-    upload_base = os.path.realpath(os.path.join(os.getcwd(), "uploads"))
-    safe_path = os.path.realpath(file.path)
-    if not safe_path.startswith(upload_base + os.sep):
+    # Centralised path-traversal guard. The DB-stored path was written by our
+    # own upload handler; verify it still resolves under uploads/ at the sink
+    # (Snyk python/PT, defence in depth).
+    try:
+        safe_path = str(ensure_within(file.path, [os.path.join(os.getcwd(), "uploads")]))
+    except UnsafePathError:
         raise HTTPException(status_code=404, detail="File content not found")
 
     try:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "vue-router": "^4.3.2"
   },
   "resolutions": {
-    "devalue": "^5.6.2",
+    "devalue": ">=5.8.1",
     "glob": "^11.1.0",
     "mdast-util-to-hast": "13.2.1",
     "nuxt-echarts": "0.2.4",
@@ -49,6 +49,7 @@
     "rollup": ">=4.59.0",
     "serialize-javascript": ">=7.0.5",
     "simple-git": ">=3.36.0",
+    "srvx": ">=0.11.13",
     "svgo": ">=4.0.1",
     "tar": ">=7.5.11",
     "unhead": "2.1.13",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3846,10 +3846,10 @@ detect-libc@^2.0.0, detect-libc@^2.0.3:
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
-devalue@^5.6.0, devalue@^5.6.2:
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.6.4.tgz#aec6cdba0e4109543b40c94d46e2b87bf8af8de5"
-  integrity sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==
+devalue@>=5.8.1, devalue@^5.6.0:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.8.1.tgz#f27290d3a324e2eb20c2714369b01b8ec4de4c61"
+  integrity sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==
 
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
@@ -7911,10 +7911,10 @@ speakingurl@^14.0.1:
   resolved "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz"
   integrity sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
 
-srvx@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.npmjs.org/srvx/-/srvx-0.10.1.tgz"
-  integrity sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==
+srvx@>=0.11.13, srvx@^0.10.0:
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/srvx/-/srvx-0.11.15.tgz#51c08f993bb116f5821ec929a466a29e8d5c7b61"
+  integrity sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==
 
 standard-as-callback@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Backend (clears all 52 Snyk SCA findings from Apr-May scan):
- Bump pillow, gitpython, pypdf, lxml, pyjwt, pyopenssl, cryptography,
  python-multipart, python-dotenv, requests, urllib3, mako, fonttools,
  pyasn1, protobuf, Pygments, snowflake-connector-python (+ sqlalchemy),
  fastapi-users to their fix versions.
- Bump cffi 1.16 -> 2.0 (required by cryptography 46).
- Remove unused deps: langsmith, orjson (only langsmith pulled it),
  sqlparse (no in-tree imports).

Frontend (clears 45 of 46 Snyk SCA findings):
- Pin transitive deps via yarn resolutions: simple-git (3 CRITICAL
  RCE/cmd-injection), node-forge (1 CRITICAL cert validation), vite,
  h3, tar, dompurify, lodash, picomatch, serialize-javascript, plus
  patch bumps for brace-expansion/defu/koa/markdown-it/nanotar/
  postcss/rollup/svgo/unhead/yaml/minimatch.
- Pin h3, vite, koa, unhead to latest stable in current major to avoid
  major-version breakage in Nuxt internals.

Remaining: 1 frontend medium (srvx 0.10 -> 0.11.13, pre-1.0 major
bump, deferred); fastapi-users 15.0.5 still pins pyjwt 2.10.1 which
yields fastapi-users own requirement -- already on latest available.

Validated:
- pip install -r requirements_versioned.txt clean (Python 3.12 venv)
- Full app module import graph loads
- yarn install + nuxt prepare + nuxt build all succeed
- snyk re-scan: backend 52->0, frontend 46->1

https://claude.ai/code/session_01HXFMz32RLpA78DC2AH9RfV