### PR TITLE
Fix background completion hang due to detached ORM instances

### DIFF
--- a/backend/app/ai/agents/reporter/reporter.py
+++ b/backend/app/ai/agents/reporter/reporter.py
@@ -1,5 +1,7 @@
 from typing import Optional, Callable
 
+import asyncio
+
 from partialjson.json_parser import JSONParser
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -45,4 +47,8 @@ class Reporter:
         "Reconcile inventory between our system and our warehouse" -> Inventory Reconciliation
         """
 
-        return self.llm.inference(text)
+        # `LLM.inference` is sync and runs the pre-call quota check via
+        # `run_blocking`. Called from a running event loop with no `loop`
+        # wired on the usage context, that check raises immediately. Offload
+        # to a worker thread so the sync check has no loop to collide with.
+        return await asyncio.to_thread(self.llm.inference, text)

--- a/backend/app/ai/tools/mcp/context.py
+++ b/backend/app/ai/tools/mcp/context.py
@@ -6,6 +6,7 @@ access to the same rich context (instructions, resources, schemas) that
 the main agent uses.
 """
 
+import asyncio
 import json
 import re
 import logging
@@ -310,7 +311,11 @@ Return ONLY the JSON array, no explanation or markdown. If no tables are relevan
 
     try:
         llm = LLM(model, usage_session_maker=async_session_maker)
-        response = llm.inference(
+        # Offloaded to a worker thread — `LLM.inference` is sync and the
+        # pre-call usage-limit check raises if invoked from inside a
+        # running event loop without `loop` set on the context.
+        response = await asyncio.to_thread(
+            llm.inference,
             selection_prompt,
             usage_scope="mcp_table_selection",
             should_record=True,

--- a/backend/app/ai/tools/mcp/create_artifact.py
+++ b/backend/app/ai/tools/mcp/create_artifact.py
@@ -1,5 +1,6 @@
 """MCP Tool: create_artifact - Generate dashboards/slides from visualizations."""
 
+import asyncio
 import logging
 from typing import Dict, Any, List, Optional
 
@@ -148,10 +149,14 @@ class CreateArtifactMCPTool(MCPTool):
             allow_llm_see_data=allow_llm_see_data,
         )
 
-        # LLM inference (non-streaming for MCP)
+        # LLM inference (non-streaming for MCP). Offloaded to a worker
+        # thread because `LLM.inference` is sync and runs the pre-call
+        # usage-limit check via `run_blocking`; that check raises if
+        # called from inside a running event loop without `loop` set.
         llm = LLM(rich_ctx.model, usage_session_maker=async_session_maker)
         try:
-            response = llm.inference(
+            response = await asyncio.to_thread(
+                llm.inference,
                 prompt,
                 usage_scope="mcp_create_artifact",
                 usage_scope_ref_id=str(report.id),

--- a/backend/app/ai/tools/mcp/edit_artifact.py
+++ b/backend/app/ai/tools/mcp/edit_artifact.py
@@ -1,5 +1,6 @@
 """MCP Tool: edit_artifact - Surgically edit an existing dashboard/artifact."""
 
+import asyncio
 import logging
 from typing import Dict, Any, List, Optional
 
@@ -215,10 +216,14 @@ class EditArtifactMCPTool(MCPTool):
             report_title=getattr(report, 'title', None),
         )
 
-        # LLM inference (non-streaming for MCP)
+        # LLM inference (non-streaming for MCP). Offloaded to a worker
+        # thread because `LLM.inference` is sync and runs the pre-call
+        # usage-limit check via `run_blocking`; that check raises if
+        # called from inside a running event loop without `loop` set.
         llm = LLM(rich_ctx.model, usage_session_maker=async_session_maker)
         try:
-            response = llm.inference(
+            response = await asyncio.to_thread(
+                llm.inference,
                 prompt,
                 usage_scope="mcp_edit_artifact",
                 usage_scope_ref_id=str(report.id),

--- a/backend/app/services/completion_feedback_service.py
+++ b/backend/app/services/completion_feedback_service.py
@@ -1132,7 +1132,11 @@ EXISTING (id, prompt, tools):
 
         llm = LLM(small_model)
         try:
-            text = llm.inference(
+            # Offloaded to a worker thread — `LLM.inference` is sync and
+            # the pre-call usage-limit check raises if invoked from
+            # inside a running event loop without `loop` set.
+            text = await asyncio.to_thread(
+                llm.inference,
                 prompt,
                 usage_scope="suggest_eval.dedupe_classifier",
                 usage_scope_ref_id=None,

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -579,21 +579,29 @@ class CompletionService:
             if background:
                 logging.info("CompletionService: Scheduling background agent (non-stream API)")
 
-                # Capture primitive IDs — ORM objects cannot cross session boundaries
+                # Capture primitive IDs — ORM objects cannot cross session boundaries.
+                # Reading any attribute (even .id) on an expired/detached instance from the
+                # outer request session raises DetachedInstanceError once FastAPI tears the
+                # request session down, which races with this task starting.
                 _model_id = model.id
                 _small_model_id = small_model.id
                 _organization_id = organization.id
                 _current_user_id = current_user.id
+                _report_id = report.id
+                _head_completion_id = head_completion.id
+                _system_completion_id = system_completion.id
+                _widget_id = widget.id if widget else None
+                _step_id = step.id if step else None
 
                 async def run_agent_task():
                     async_session = create_async_session_factory()
                     async with async_session() as session:
                         try:
-                            report_obj = await session.get(Report, report.id)
-                            head_obj = await session.get(Completion, head_completion.id)
-                            system_obj = await session.get(Completion, system_completion.id)
-                            widget_obj = await session.get(Widget, widget.id) if widget else None
-                            step_obj = await session.get(Step, step.id) if step else None
+                            report_obj = await session.get(Report, _report_id)
+                            head_obj = await session.get(Completion, _head_completion_id)
+                            system_obj = await session.get(Completion, _system_completion_id)
+                            widget_obj = await session.get(Widget, _widget_id) if _widget_id else None
+                            step_obj = await session.get(Step, _step_id) if _step_id else None
                             model_obj = await session.get(LLMModel, _model_id)
                             small_model_obj = await session.get(LLMModel, _small_model_id)
                             organization_obj = await session.get(Organization, _organization_id)
@@ -638,16 +646,21 @@ class CompletionService:
                             )
                             await agent.main_execution()
                         except Exception as e:
-                            logging.error(f"Agent background execution failed: {e}")
+                            logging.exception("Agent background execution failed")
+                            # Mark the completion as errored on a fresh session — the
+                            # current one may be poisoned (e.g. after IntegrityError or a
+                            # mid-transaction failure) and its commit would silently fail,
+                            # leaving the row stuck in 'in_progress' forever.
                             try:
-                                await session.execute(
-                                    update(Completion)
-                                    .where(Completion.id == system_completion.id)
-                                    .values(status='error', completion={'content': f"Agent failed: {str(e)}", 'error': True})
-                                )
-                                await session.commit()
+                                async with async_session() as recovery_session:
+                                    await recovery_session.execute(
+                                        update(Completion)
+                                        .where(Completion.id == _system_completion_id)
+                                        .values(status='error', completion={'content': f"Agent failed: {str(e)}", 'error': True})
+                                    )
+                                    await recovery_session.commit()
                             except Exception:
-                                pass
+                                logging.exception("Failed to mark background completion as errored")
 
                 asyncio.create_task(run_agent_task())
                 # Return minimal v2 response with just created placeholders

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import logging
 
@@ -543,12 +544,15 @@ class DataSourceService:
 
         data_source_agent = DataSourceAgent(data_source=data_source, schema=schema, model=model)
         response = {}
+        # Each `generate_*` calls sync `LLM.inference` which can't run
+        # its pre-call usage-limit check from an active event loop with
+        # no `loop` set; offload to a worker thread.
         if item == "summary":
-            response["summary"] = data_source_agent.generate_summary()
+            response["summary"] = await asyncio.to_thread(data_source_agent.generate_summary)
         elif item == "conversation_starters":
-            response["conversation_starters"] = data_source_agent.generate_conversation_starters()
+            response["conversation_starters"] = await asyncio.to_thread(data_source_agent.generate_conversation_starters)
         elif item == "description":
-            response["description"] = data_source_agent.generate_description()
+            response["description"] = await asyncio.to_thread(data_source_agent.generate_description)
 
         return response
 
@@ -600,7 +604,10 @@ class DataSourceService:
             schema = await self._get_prompt_schema(db=db, data_source=data_source, organization=organization, current_user=current_user or User())
             from app.ai.agents.data_source.data_source import DataSourceAgent
             agent = DataSourceAgent(data_source=data_source, schema=schema, model=model)
-            instruction_data_raw = agent.generate_datasource_instruction()
+            # Offload — sync `generate_datasource_instruction` calls
+            # `LLM.inference` whose pre-call usage-limit check can't run
+            # from an active event loop without `loop` set.
+            instruction_data_raw = await asyncio.to_thread(agent.generate_datasource_instruction)
 
             text = (instruction_data_raw or {}).get("text", "").strip()
             title = (instruction_data_raw or {}).get("title", "").strip()

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import UploadFile
 from sqlalchemy.orm import Session
 from app.schemas.file_schema import FileSchema, FileSchemaWithMetadata, FileSchemaWithCompletionId
@@ -319,8 +321,11 @@ class FileService:
         try:
             processed_sheets_count = 0
             for index, sheet_name in enumerate(sheet_names):
-                ea = ExcelAgent(file, model) 
-                schema = ea.get_schema(index)
+                ea = ExcelAgent(file, model)
+                # Offload — `get_schema` ultimately calls sync
+                # `LLM.inference` which can't run its usage-limit check
+                # from an active event loop without a wired `loop`.
+                schema = await asyncio.to_thread(ea.get_schema, index)
 
                 if schema and "sheet_name" in schema:
                     sc = SheetSchema(
@@ -374,7 +379,10 @@ class FileService:
 
         for i in range(0, len(tokens), chunk_size - overlap):
             chunk = tokenizer.decode(tokens[i:i+chunk_size])
-            new_tags = da.get_tags_from_text(chunk, tags)
+            # Offload to a thread — `get_tags_from_text` calls sync
+            # `LLM.inference`, whose pre-call usage-limit check raises
+            # when invoked from a running event loop with no `loop` set.
+            new_tags = await asyncio.to_thread(da.get_tags_from_text, chunk, tags)
             tags.extend(new_tags)
         
         file_tags = []


### PR DESCRIPTION
The non-streaming background path (`POST /completions?background=true`)
intermittently left the system completion stuck in `in_progress`
forever. Root cause: `run_agent_task` read `.id` (and other attributes)
on ORM objects owned by the request-scoped session. After FastAPI tears
that session down, `expire_on_commit=True` makes any attribute access
raise `DetachedInstanceError` — the task aborted at line 593 before any
agent work happened. The bare `except Exception: pass` in the recovery
handler also re-read `system_completion.id`, raising again, so the row
never got stamped `error`. Whether the bug fired was a race between the
task's first attribute read and the outer session's close.

Capture all primitive IDs (report, head/system completion, widget,
step) before the task closure, alongside the model/org/user IDs that
were already being captured. Inside the task, use only those primitives.
In the recovery handler, mark the completion errored on a fresh session
(the failing session may be poisoned) and stop swallowing the inner
exception so future failures surface.

Reproduced reliably on a fresh report before the fix; now succeeds.