### PR TITLE
Fix clarify tool rendering empty action in UI

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -128,8 +128,7 @@ PLAN TYPE DECISION FRAMEWORK
 - Use inspect_data ONLY for quick hypothesis validation (max 2-3 queries, LIMIT 3 rows): check nulls, distinct values, join keys, date formats. It's a peek, not analysis.
 - Do not base your analysis/insights on inspect_data output, always use the create_data tool to generate the actual tracked insight.
 - After inspect_data, move to create_data to generate the actual tracked insight.
-- If schemas are empty/insufficient, output your clarifying questions in assistant_message and call the clarify tool to pause for user response.
-- If the user's request is ambiguous, output your questions in assistant_message and call the clarify tool.
+- If schemas are empty/insufficient OR the request is ambiguous, call the clarify tool. Put the full user-facing clarification in the tool's `question` argument (required). The clarify tool's `question` field is what the user sees — do not also duplicate it in assistant_message.
 - When schemas show tables under different `<connection>` tags, those are separate databases. Queries CANNOT join across connections. Plan accordingly: either scope to one connection, or instruct the coder (via interpreted_prompt) to query each connection separately and merge in Python.
 - If you have enough information, go ahead and execute — prefer create_data for generating insights.
 - If the user attached a screenshot or an image -- describe it in reasoning - don't use inspect_data for images
@@ -151,7 +150,7 @@ ERROR HANDLING (robust; no blind retries)
 - **If code execution fails** (SQL error, column not found, type mismatch, etc.), consider using inspect_data on the relevant table(s) to check actual data values, column formats, or nulls and decide if you want to retry or pivot to ask a clarifying question.
 
 {row_limit_text}ANALYTICS & RELIABILITY
-- Ground reasoning in provided context (schemas, history, last_observation). If context is missing, output clarifying questions in assistant_message and call the clarify tool.
+- Ground reasoning in provided context (schemas, history, last_observation). If context is missing, call the clarify tool (put questions in its `question` arg).
 - Use the describe_tables tool to get more information about the tables and columns before creating a widget.
 - Use the read_resources tool to get more information about the resources names, context, semantic layers, etc. If metadata resources are available, always use this tool before the next step (clarify/create_data/answer etc)
 - Prefer the smallest next action that produces observable progress.
@@ -224,7 +223,7 @@ ERROR HANDLING (robust; no blind retries)
   - **Success with no screenshot issues:** set `analysis_complete=true`, put a brief summary in `final_answer`, do not loop.
   - **Screenshot shows visual bugs** (misalignment, overlap, cut-off, wrong colors): use `edit_artifact` (not another `create_artifact`) with a specific, code-level instruction ("the bar chart is cut off on the right", "KPI cards are overlapping").
   - **User reports something missing after an edit** ("I don't see filters", "no gradient"): call `read_artifact` with `load_screenshot=true` first, then `edit_artifact` with a specific, code-level fix ("add a FilterSelect component above the grid"). Vague edit prompts are the #1 cause of failed edits.
-- If the user is asking for a subjective metric or uses a semantic metric that is not well defined (in instructions or schema or context), output your clarifying questions in assistant_message and call the clarify tool.
+- If the user is asking for a subjective metric or uses a semantic metric that is not well defined (in instructions or schema or context), call the clarify tool (put questions in its `question` arg).
 - **Clarify discipline.** Clarify when the *user's intent* is ambiguous — not when you're unsure about implementation details you can resolve yourself.
   - **Clarify**: scalar-vs-dashboard ambiguity, "top X" without a specified metric, entity/time-window ambiguity, Step B consolidation judgment calls you can't resolve from context, undefined semantic metrics.
   - **Don't clarify** (resolve yourself instead): column semantics (`describe_tables`), resource context (`read_resources`), current artifact code (`read_artifact`), anything already answered in past_observations or earlier messages.
@@ -258,8 +257,8 @@ Example of a good communication:
 - User: "I want to know how many active users we have."
 - Assistant:
   Reasoning: "I do not know what active users means in this context. I need to ask for clarification."
-  Message: "I'd like to help you with that! Could you clarify what defines an 'active user' for your business? For example:\n1. Users who logged in within a certain time period?\n2. Users who performed a specific action?\n3. Users with a particular status in the database?"
-  Action: clarify tool (to pause and wait for user response)
+  Message: null
+  Action: clarify tool with question="Could you clarify what defines an 'active user' for your business?\n- Users who logged in within the last 30 days\n- Users who performed a specific action recently\n- Users with an active status in the database\n- or specify your own."
 - User: "Active users are defined as users who have logged in at least once in the last 30 days."
 - Assistant: 
   Reasoning: None

--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -121,7 +121,7 @@ OUTPUT PROTOCOL (native tool calling — no JSON envelope)
 - To take an action, call exactly ONE tool by emitting a tool_use block. Tool arguments must satisfy the tool's input_schema.
 - HARD RULE: Emit AT MOST ONE tool_use block per response. NEVER emit multiple tool_use blocks in parallel — even if the user asks for "multiple things in parallel" or "all of these at once". The agent loop will call you again after each tool completes; that is how multi-step work gets done. Emitting parallel tool_use blocks causes only the first to run and silently drops the rest.
 - To finish without a tool, respond with text. It becomes your message to the user.
-- You MAY also write a short message before a tool call (≤2 sentences) — this becomes your in-progress message to the user explaining the next step. exception: when calling `clarify`, this message must contain the full clarification (see clarify protocol below).
+- You MAY also write a short message before a tool call (≤2 sentences) — this becomes your in-progress message to the user explaining the next step.
 - Pick the smallest next action that produces observable progress.
 
 {deep_analytics_text}
@@ -161,11 +161,11 @@ when to call clarify (mandatory — do not skip and do not guess):
 - never invent a definition. never silently pick one interpretation when multiple are plausible. when in doubt, clarify — one clarify turn beats building the wrong thing.
 
 how to write a clarify call:
-- the message text you write before the clarify tool_use MUST contain the full clarification for the user. never write a meta-preamble like "i need to clarify two things" without listing them.
-- the ≤2 sentence pre-tool message limit does NOT apply to clarify — write as much as the user needs to answer.
-- format: one numbered question per ambiguity. when you can enumerate 2-4 plausible interpretations, list them as bullets under the question and end the bullet list with "or specify your own.". when the answer space is open (date ranges, specific names, custom thresholds), just ask the question — no bullets.
+- put the entire user-facing clarification into the tool's `question` argument. this is what the user sees. do NOT split the question across pre-tool text and the tool args — keep it all in `question`.
+- pre-tool text is optional for clarify; if you write any, keep it to ≤1 short sentence of preamble. don't repeat the question there.
+- format inside `question`: one numbered question per ambiguity. when you can enumerate 2-4 plausible interpretations, list them as bullets under the question and end the bullet list with "or specify your own.". when the answer space is open (date ranges, specific names, custom thresholds), just ask the question — no bullets.
 - offer concrete candidate answers grounded in the schema, instructions, or domain context. do not invent options.
-- the clarify tool itself only takes an optional `context` field (a brief internal note about why you're asking). the user-facing questions live entirely in your message text.
+- the optional `context` arg is a brief internal note about why you're asking — not shown to the user.
 
 ERROR HANDLING (robust; no blind retries)
 - If ANY tool error occurred, start your message text with: "I see the previous attempt failed: <specific error>."
@@ -228,8 +228,8 @@ COMMUNICATION
 
 Examples of good behavior:
 - User: "I want to know how many active users we have."
-  - Message: "before i count, which definition of \"active user\" should i use?\n- logged in within the last 30 days\n- performed any tracked action within the last 30 days\n- has an active subscription\n- or specify your own"
-  - Tool: clarify
+  - Message: (none)
+  - Tool: clarify with question="Which definition of \"active user\" should I use?\n- logged in within the last 30 days\n- performed any tracked action within the last 30 days\n- has an active subscription\n- or specify your own."
 - User: "Active users are users who logged in in the last 30 days."
   - Message: "Creating a widget with that definition."
   - Tool: create_data

--- a/backend/app/ai/tools/implementations/clarify.py
+++ b/backend/app/ai/tools/implementations/clarify.py
@@ -12,11 +12,11 @@ from app.ai.tools.schemas.events import (
 
 
 class ClarifyTool(Tool):
-    """Clarify tool - signals that the planner needs user clarification.
+    """Clarify tool — pause and ask the user a question.
 
-    The user-facing questions live in the model's message text (preceding this
-    tool_use). This tool only marks analysis_complete=True to stop the loop and
-    wait for the user's response.
+    The user-facing text lives in ``question`` (required tool input). Emits
+    ``final_answer`` in the observation so the existing terminal-tool path in
+    ``agent_v2`` routes it into the block's content and the completion message.
     """
 
     @property
@@ -24,10 +24,9 @@ class ClarifyTool(Tool):
         return ToolMetadata(
             name="clarify",
             description=(
-                "Pause and wait for the user to clarify. "
-                "Your message text must contain the full clarification questions for the user — "
-                "see the clarify protocol in the system prompt for the required format. "
-                "This tool's `context` arg is an optional internal note, not shown to the user."
+                "Pause and ask the user a clarifying question. "
+                "Put the full user-facing message in `question` (markdown OK). "
+                "The agent loop stops after this tool runs and waits for the user's reply."
             ),
             category="action",
             version="1.0.0",
@@ -41,14 +40,17 @@ class ClarifyTool(Tool):
             examples=[
                 {
                     "input": {
-                        "context": "user requested revenue analysis but didn't specify time period"
+                        "question": (
+                            "Which definition of \"active user\" should I use?\n"
+                            "- logged in within the last 30 days\n"
+                            "- performed any tracked action within the last 30 days\n"
+                            "- has an active subscription\n"
+                            "- or specify your own."
+                        ),
+                        "context": "user asked about active users; not defined in instructions",
                     },
-                    "description": "pause for clarification (questions live in the model's message text, not here)"
+                    "description": "ask the user to pick a definition before computing",
                 },
-                {
-                    "input": {},
-                    "description": "pause for clarification with no internal context note"
-                }
             ]
         )
 
@@ -65,26 +67,25 @@ class ClarifyTool(Tool):
 
         yield ToolStartEvent(
             type="tool.start",
-            payload={"context": data.context}
+            payload={"question": data.question, "context": data.context},
         )
 
-        # Simple observation - just mark that we're waiting for user response
-        # The actual questions are in the planner's assistant_message
-        summary = "Waiting for user clarification"
+        summary = "Awaiting user clarification"
         if data.context:
-            summary = f"Waiting for user clarification: {data.context}"
+            summary = f"Awaiting user clarification: {data.context}"
 
         yield ToolEndEvent(
             type="tool.end",
             payload={
-                "output": {
-                    "status": "awaiting_response"
-                },
+                "output": {"status": "awaiting_response"},
                 "observation": {
                     "summary": summary,
                     "artifacts": [],
                     "analysis_complete": True,
-                    # No final_answer - the planner's assistant_message has the questions
+                    # final_answer carries the question text → agent_v2's
+                    # terminal-tool branch updates the completion message
+                    # and re-upserts the block with this as its content.
+                    "final_answer": data.question,
                 },
             }
         )

--- a/backend/app/ai/tools/schemas/clarify.py
+++ b/backend/app/ai/tools/schemas/clarify.py
@@ -5,14 +5,24 @@ from pydantic import BaseModel, Field
 class ClarifyInput(BaseModel):
     """Input schema for clarify tool - signals that clarification is needed.
 
-    The user-facing questions live in the model's message text, not in this
-    tool's input. This tool only carries an optional internal note and marks
-    that we're waiting for the user's response.
+    The user-facing clarification text lives in ``question`` — this is what
+    the user sees. Required because a clarify call with no question is
+    useless to the user.
     """
 
+    question: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The clarifying message shown to the user. Markdown OK. "
+            "Use a numbered list for multiple questions and bullets to "
+            "enumerate concrete options under a question (end the bullets "
+            "with 'or specify your own.' when listing options)."
+        ),
+    )
     context: Optional[str] = Field(
         None,
-        description="Brief internal note about why clarification is needed (optional, not shown to the user)"
+        description="Brief internal note about why clarification is needed (optional, not shown to the user)",
     )
 
 


### PR DESCRIPTION
The v3 planner relied on the model emitting clarifying questions in pre-tool
text, but the Anthropic tool_use API doesn't require any preamble — when the
model skipped it, the block content ended up empty and the UI showed only an
empty tool widget.

Add a required `question: str` field to ClarifyInput so the model can't
silently omit the user-facing text. The tool emits it as `final_answer` in
its observation, which the existing terminal-tool branch in agent_v2 already
routes into the block content and completion message — no streamer or
frontend changes needed.

https://claude.ai/code/session_01RePGQLoVhh6ej5YoHvztnA