### PR TITLE
Drop unused connection_tables eager-load from /connections list

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -187,14 +187,13 @@ class ConnectionService:
     ) -> List[Connection]:
         """Get all connections for an organization."""
         from sqlalchemy.orm import selectinload
-        # NOTE: Do NOT use selectinload for DataSource.tables here
-        # For data sources with 25K+ tables, this causes severe performance issues
-        # Table counts are fetched separately via COUNT query in the route
+        # The list route never reads connection_tables; it uses a COUNT(*) query
+        # instead. Eager-loading the relationship hydrates every row (25K+ on
+        # large connections) just to discard it.
         result = await db.execute(
             select(Connection)
             .filter(Connection.organization_id == organization.id)
             .options(
-                selectinload(Connection.connection_tables),
                 selectinload(Connection.data_sources),
             )
             .order_by(Connection.name)


### PR DESCRIPTION
## Summary

The `/agents` page was slow to load because `GET /connections` was hydrating every `ConnectionTable` row for every connection on every request — on a connection with 2,500 tables this dominates the page load. The list route never reads the relationship; it uses a `COUNT(*)` query for `table_count`. The eager-load is pure waste.

The neighboring comment in the same method already warned against eager-loading `DataSource.tables` for the same reason; `connection_tables` had the identical problem one line below.

## Change

- `backend/app/services/connection_service.py`: remove `selectinload(Connection.connection_tables)` from `get_connections` (plural). `get_connection` (singular) keeps its eager-load — its detail-view callers do read `connection.connection_tables`.

## Why it's safe

`get_connections` has one caller: the `/connections` list route. It reads `conn.data_sources` (still eager-loaded) and plain columns; `conn.connection_tables` is never accessed there. No other callers exist in the codebase.

## Test plan

- [ ] Load `/agents` on an org with a large-table connection — page should render noticeably faster
- [ ] `/connections` response still returns correct `table_count` (from the COUNT query)
- [ ] `agent_count` / `agent_names` still populate from `conn.data_sources`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CbJogKAU8LtCZmzqfxuHGs)_