### PR TITLE
web_fetch: tier-2 stealth Chromium fallback for bot-shielded sites

### DIFF
--- a/backend/app/ai/tools/implementations/web_fetch.py
+++ b/backend/app/ai/tools/implementations/web_fetch.py
@@ -13,6 +13,7 @@ from selectolax.parser import HTMLParser
 
 from app.ai.tools.base import Tool
 from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.implementations.web_fetch_stealth import fetch_via_stealth
 from app.ai.tools.schemas.web_fetch import WebFetchInput, WebFetchOutput
 from app.ai.tools.schemas import (
     ToolEvent,
@@ -46,6 +47,24 @@ TEXT_CONTENT_PREFIXES = (
 STRIP_TAGS = ("script", "style", "noscript", "nav", "footer", "aside", "svg", "template")
 _WHITESPACE_RE = re.compile(r"[ \t\f\v]+")
 _NEWLINE_RE = re.compile(r"\n{3,}")
+
+# Tier-2 (stealth Chromium) escalation thresholds.
+# Status 247 is Reblaze's "challenge issued" code; the others are the usual
+# bot-shield rejections. Body-text floor catches sites that 200 with a
+# JS-only challenge page (Akamai _abck, Cloudflare cf_chl_, etc.).
+BLOCK_STATUS_CODES = frozenset({247, 403, 429, 503})
+BLOCK_BODY_MARKERS = (
+    "rbzns",                  # Reblaze sensor cookie / payload key
+    "kramericaindustries",    # Reblaze script host
+    "_abck",                  # Akamai Bot Manager cookie
+    "cf_chl_",                # Cloudflare challenge token
+    "cf-mitigated",
+    "cdn-cgi/challenge-platform",
+    "bm_sz",                  # Akamai sensor cookie
+    "px-captcha",             # PerimeterX
+    "datadome",               # DataDome
+)
+MIN_VISIBLE_TEXT_CHARS = 200  # Below this on an HTML 200 we assume a JS challenge.
 
 
 def _is_safe_host(hostname: str) -> bool:
@@ -185,6 +204,23 @@ def _parse_html(html: str) -> Dict[str, Any]:
     return parsed
 
 
+def _looks_blocked(
+    status: int, html: str, visible_text: str
+) -> Tuple[bool, Optional[str]]:
+    """Heuristic: does this response look like an anti-bot block page?
+
+    Returns (blocked, reason). Reason is short and goes into the audit log
+    and the progress event so we can attribute failures.
+    """
+    if status in BLOCK_STATUS_CODES:
+        return True, f"status={status}"
+    lower_html = html.lower() if html else ""
+    for marker in BLOCK_BODY_MARKERS:
+        if marker in lower_html and len((visible_text or "").strip()) < MIN_VISIBLE_TEXT_CHARS:
+            return True, f"marker={marker}"
+    return False, None
+
+
 class WebFetchTool(Tool):
     """Fetch the contents of a public HTTP(S) URL."""
 
@@ -215,7 +251,7 @@ Do not use when:
             input_schema=WebFetchInput.model_json_schema(),
             output_schema=WebFetchOutput.model_json_schema(),
             tags=["web", "fetch", "http", "research"],
-            timeout_seconds=REQUEST_TIMEOUT_SECONDS + 5,
+            timeout_seconds=REQUEST_TIMEOUT_SECONDS + 35,
             idempotent=True,
         )
 
@@ -445,6 +481,94 @@ Do not use when:
                             output.truncated = True
                         output.content = body_text
 
+                    blocked, block_reason = (False, None)
+                    if is_html:
+                        blocked, block_reason = _looks_blocked(status, body_text, output.content or "")
+
+                    if blocked:
+                        logger.info(
+                            f"web_fetch: tier-1 blocked for {final_url} ({block_reason}); escalating to stealth"
+                        )
+                        yield ToolProgressEvent(
+                            type="tool.progress",
+                            payload={"stage": "stealth_fallback", "reason": block_reason},
+                        )
+                        stealth_result = await fetch_via_stealth(final_url)
+                        stealth_status = stealth_result.status
+                        stealth_html = stealth_result.html or ""
+                        stealth_text_body = ""
+                        stealth_blocked = True
+                        stealth_block_reason: Optional[str] = stealth_result.error or "no html"
+                        if stealth_html:
+                            try:
+                                parsed_s = _parse_html(stealth_html)
+                            except Exception as exc:
+                                logger.warning(f"web_fetch: stealth HTML parse failed for {final_url}: {exc}")
+                                parsed_s = None
+                            if parsed_s is not None:
+                                stealth_text_body = parsed_s["text"] or ""
+                                stealth_blocked, stealth_block_reason = _looks_blocked(
+                                    stealth_status or 0, stealth_html, stealth_text_body
+                                )
+                                if not stealth_blocked:
+                                    output.title = parsed_s["title"]
+                                    output.description = parsed_s["description"]
+                                    output.metadata = parsed_s["metadata"] or None
+                                    output.json_ld = parsed_s["json_ld"] or None
+                                    output.headings = parsed_s["headings"] or None
+                                    text_body = stealth_text_body
+                                    output.truncated = False
+                                    if len(text_body) > MAX_TEXT_CHARS:
+                                        text_body = text_body[:MAX_TEXT_CHARS]
+                                        output.truncated = True
+                                    output.content = text_body
+                                    output.status_code = stealth_status
+                                    output.final_url = stealth_result.final_url or final_url
+                                    final_url = output.final_url
+                                    status = stealth_status or status
+                                    summary_extras.append(f"stealth: {block_reason}")
+
+                        await log_tool_audit(
+                            runtime_ctx,
+                            action="tool.web_fetch_stealth_escalated",
+                            resource_type="report",
+                            resource_id=report_id,
+                            details={
+                                "tool": "web_fetch",
+                                "url": data.url,
+                                "final_url": final_url,
+                                "tier1_status": status if not stealth_html else None,
+                                "tier1_reason": block_reason,
+                                "tier2_status": stealth_status,
+                                "tier2_blocked": stealth_blocked,
+                                "tier2_reason": stealth_block_reason if stealth_blocked else None,
+                            },
+                        )
+
+                        if stealth_blocked:
+                            yield ToolEndEvent(
+                                type="tool.end",
+                                payload={
+                                    "output": WebFetchOutput(
+                                        success=False,
+                                        url=data.url,
+                                        final_url=stealth_result.final_url or final_url,
+                                        status_code=stealth_status or status,
+                                        content_type=content_type or None,
+                                        error_message=(
+                                            f"Site blocked the request (tier-1: {block_reason}; "
+                                            f"tier-2 stealth: {stealth_block_reason}). "
+                                            "Content not retrievable."
+                                        ),
+                                    ).model_dump(),
+                                    "observation": {
+                                        "summary": f"Blocked after stealth retry ({stealth_block_reason})",
+                                        "success": False,
+                                    },
+                                },
+                            )
+                            return
+
                     await log_tool_audit(
                         runtime_ctx,
                         action="tool.web_fetch_executed",
@@ -459,6 +583,7 @@ Do not use when:
                             "bytes": len(body_bytes),
                             "truncated": output.truncated,
                             "is_html": is_html,
+                            "stealth": blocked,
                         },
                     )
 

--- a/backend/app/ai/tools/implementations/web_fetch_stealth.py
+++ b/backend/app/ai/tools/implementations/web_fetch_stealth.py
@@ -1,0 +1,119 @@
+"""Playwright-driven tier-2 fallback for web_fetch.
+
+Tier-1 uses curl_cffi with a Chrome TLS fingerprint, which beats most JA3
+checks but cannot execute the JS challenges (Reblaze rbzns, Akamai _abck,
+Cloudflare cf_chl_, PerimeterX, DataDome) that some sites use to gate
+content. This module spins up a real headless Chromium with
+playwright-stealth patches applied to the navigator, plugins, WebGL and
+sec-ch-ua surfaces, so those challenges actually run before we read the
+DOM.
+
+Kept in its own module so the playwright/playwright_stealth imports stay
+lazy (the function is called only when tier-1 looks blocked) and so the
+tests can patch a single name without touching the curl_cffi path.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+STEALTH_NAV_TIMEOUT_MS = 30_000
+STEALTH_SETTLE_MS = 2_500
+STEALTH_VIEWPORT = {"width": 1440, "height": 900}
+STEALTH_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+IL_TLDS = (".co.il", ".org.il", ".net.il", ".ac.il", ".gov.il")
+
+
+@dataclass
+class StealthFetchResult:
+    status: Optional[int]
+    final_url: Optional[str]
+    html: Optional[str]
+    error: Optional[str] = None
+
+
+def _locale_for(host: str) -> tuple[tuple[str, str], str, str]:
+    """Bias locale, timezone and language tuple by TLD.
+
+    IL retail (super-pharm, careline, ksp) ships Hebrew pages and some
+    look at Accept-Language. For everything else we keep the en-US/UTC
+    defaults so we don't lie about the visitor in a way the site might
+    score against us.
+    """
+    h = (host or "").lower()
+    if any(h.endswith(tld) for tld in IL_TLDS):
+        return (("he-IL", "he", "en-US", "en"), "he-IL", "Asia/Jerusalem")
+    return (("en-US", "en"), "en-US", "UTC")
+
+
+async def fetch_via_stealth(
+    url: str,
+    *,
+    nav_timeout_ms: int = STEALTH_NAV_TIMEOUT_MS,
+    settle_ms: int = STEALTH_SETTLE_MS,
+    max_html_bytes: int = 1_000_000,
+) -> StealthFetchResult:
+    """Render `url` in a stealth-patched Chromium and return the final HTML.
+
+    Errors during launch / navigation / content-read are captured on the
+    result rather than raised — the caller treats this as a best-effort
+    second tier.
+    """
+    try:
+        from playwright.async_api import async_playwright
+        from playwright_stealth import Stealth
+    except ImportError as exc:
+        return StealthFetchResult(None, None, None, error=f"stealth deps unavailable: {exc}")
+
+    host = urlparse(url).hostname or ""
+    languages, locale, timezone = _locale_for(host)
+
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(
+                headless=True,
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                ],
+            )
+            try:
+                stealth = Stealth(
+                    navigator_languages_override=languages,
+                    navigator_platform_override="MacIntel",
+                )
+                context = await browser.new_context(
+                    viewport=STEALTH_VIEWPORT,
+                    locale=locale,
+                    timezone_id=timezone,
+                    user_agent=STEALTH_USER_AGENT,
+                )
+                await stealth.apply_stealth_async(context)
+                page = await context.new_page()
+
+                response = await page.goto(url, wait_until="domcontentloaded", timeout=nav_timeout_ms)
+                await page.wait_for_timeout(settle_ms)
+
+                html = await page.content()
+                if len(html) > max_html_bytes:
+                    html = html[:max_html_bytes]
+
+                return StealthFetchResult(
+                    status=response.status if response else None,
+                    final_url=page.url,
+                    html=html,
+                )
+            finally:
+                await browser.close()
+    except Exception as exc:
+        logger.warning(f"web_fetch_stealth: navigation failed for {url}: {exc}")
+        return StealthFetchResult(None, None, None, error=f"stealth fetch failed: {exc}")

--- a/backend/requirements_versioned.txt
+++ b/backend/requirements_versioned.txt
@@ -196,6 +196,7 @@ testcontainers[postgres,mysql]==4.13.3
 python-pptx==1.0.2
 pdf2image==1.17.0
 playwright==1.60.0
+playwright-stealth==2.0.3
 databricks-sql-connector==3.6.0
 opentelemetry-api==1.29.0
 opentelemetry-sdk==1.29.0

--- a/backend/scripts/test_stealth_fetch.py
+++ b/backend/scripts/test_stealth_fetch.py
@@ -1,0 +1,167 @@
+"""Standalone test: does Playwright + playwright-stealth defeat Reblaze on
+super-pharm and KSP from your residential IP?
+
+Run from your laptop (not the bagofwords backend) to validate the approach
+before we add code to web_fetch.
+
+    pip install playwright playwright-stealth
+    playwright install chromium
+    python test_stealth_fetch.py
+
+For each URL it prints:
+ - final URL after redirects
+ - HTTP status
+ - whether real product content was extracted (title, h1, body length)
+ - first 400 chars of visible text
+ - whether the page looks like a bot-challenge (small body, mostly scripts)
+
+If you see real titles like 'CARELINE BOLD ...' and body text containing
+the price (₪ symbol + a number), the approach works and we should land it.
+If every page comes back as a challenge / blocked, stealth is insufficient
+and we need to escalate (camoufox, residential proxy, scraping API).
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+from typing import Dict, Optional, Tuple
+
+from playwright.async_api import async_playwright
+from playwright_stealth import Stealth
+
+URLS = [
+    "https://shop.super-pharm.co.il/cosmetics/eye-makeup/mascara/BOLD-%D7%9E%D7%A1%D7%A7%D7%A8%D7%94-%D7%A9%D7%97%D7%95%D7%A8%D7%94/p/449344",
+    "https://ksp.co.il/web/item/251453?appkey=1006",
+    "https://careline.co.il/bold-mascara-2/",  # control: known to work even with plain fetch
+]
+
+NAV_TIMEOUT_MS = 30_000
+SETTLE_MS = 2_500          # wait after load for sensor JS / hydration
+MAX_BODY_BYTES = 1_000_000
+
+
+def looks_like_challenge(html: str, visible_text: str) -> Tuple[bool, str]:
+    """Heuristic: bot-protection pages are small, mostly scripts, no body text."""
+    if len(html) < 5_000 and "<script" in html.lower() and len(visible_text.strip()) < 100:
+        markers = []
+        for needle in ("rbzns", "kramericaindustries", "_abck", "cf_chl_", "bm_sz",
+                       "cf-mitigated", "cdn-cgi/challenge", "px-captcha", "datadome"):
+            if needle in html.lower():
+                markers.append(needle)
+        return True, ", ".join(markers) or "small body + scripts only"
+    return False, ""
+
+
+def extract_visible_text(html: str) -> str:
+    """Very crude tag-stripper for the diagnostic only — production parser
+    is selectolax-based."""
+    no_script = re.sub(r"<script\b[^>]*>.*?</script>", " ", html, flags=re.S | re.I)
+    no_style = re.sub(r"<style\b[^>]*>.*?</style>", " ", no_script, flags=re.S | re.I)
+    text = re.sub(r"<[^>]+>", " ", no_style)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+async def fetch_one(url: str) -> Dict:
+    result: Dict = {"url": url}
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(
+            headless=True,
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+            ],
+        )
+        try:
+            stealth = Stealth(
+                navigator_languages_override=("he-IL", "he", "en-US", "en"),
+                navigator_platform_override="MacIntel",
+            )
+            context = await browser.new_context(
+                viewport={"width": 1440, "height": 900},
+                locale="he-IL",
+                timezone_id="Asia/Jerusalem",
+                user_agent=(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/131.0.0.0 Safari/537.36"
+                ),
+            )
+            await stealth.apply_stealth_async(context)
+            page = await context.new_page()
+
+            response = None
+            try:
+                response = await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+            except Exception as e:
+                result["nav_error"] = repr(e)
+            # Let sensor JS / SPA hydration finish
+            await page.wait_for_timeout(SETTLE_MS)
+
+            try:
+                html = await page.content()
+            except Exception as e:
+                html = ""
+                result["content_error"] = repr(e)
+
+            if len(html) > MAX_BODY_BYTES:
+                html = html[:MAX_BODY_BYTES]
+
+            visible = extract_visible_text(html)
+            title = await page.title()
+
+            result["status"] = response.status if response else None
+            result["final_url"] = page.url
+            result["title"] = title
+            result["html_bytes"] = len(html)
+            result["visible_chars"] = len(visible)
+            result["visible_preview"] = visible[:400]
+
+            challenge, markers = looks_like_challenge(html, visible)
+            result["looks_like_challenge"] = challenge
+            result["challenge_markers"] = markers
+
+            # h1 heuristic — products usually have one
+            h1_match = re.search(r"<h1[^>]*>(.*?)</h1>", html, re.S | re.I)
+            result["h1"] = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", h1_match.group(1))).strip()[:120] if h1_match else None
+
+            # Price heuristic — look for ₪ or ILS near a number
+            price = re.search(r"(₪\s*\d[\d,.]*|\d[\d,.]*\s*₪|\bILS\s*\d[\d,.]*)", visible)
+            result["price_hit"] = price.group(0) if price else None
+        finally:
+            await browser.close()
+    return result
+
+
+def print_result(r: Dict) -> None:
+    print(f"\n=== {r['url']}")
+    if r.get("fatal_error"):
+        print(f"  FATAL: {r['fatal_error']}")
+        return
+    print(f"  status           : {r.get('status')}")
+    print(f"  final_url        : {r.get('final_url')}")
+    print(f"  title            : {r.get('title')!r}")
+    print(f"  html_bytes       : {r.get('html_bytes')}")
+    print(f"  visible_chars    : {r.get('visible_chars')}")
+    print(f"  h1               : {r.get('h1')!r}")
+    print(f"  price_hit        : {r.get('price_hit')!r}")
+    print(f"  looks_like_challenge: {r.get('looks_like_challenge')}  ({r.get('challenge_markers')})")
+    if r.get("nav_error"): print(f"  nav_error        : {r['nav_error']}")
+    if r.get("content_error"): print(f"  content_error    : {r['content_error']}")
+    print(f"  visible_preview  : {r.get('visible_preview')!r}")
+
+
+async def main():
+    for url in URLS:
+        try:
+            r = await fetch_one(url)
+        except Exception as e:
+            import traceback
+            r = {"url": url, "fatal_error": f"{type(e).__name__}: {e}\n{traceback.format_exc()}"}
+        print_result(r)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/unit/test_web_fetch_tool.py
+++ b/backend/tests/unit/test_web_fetch_tool.py
@@ -26,8 +26,10 @@ from app.ai.tools.implementations.web_fetch import (
     MAX_TEXT_CHARS,
     WebFetchTool,
     _is_safe_host,
+    _looks_blocked,
     _parse_html,
 )
+from app.ai.tools.implementations.web_fetch_stealth import StealthFetchResult
 from app.ai.tools.schemas.web_fetch import WebFetchInput
 
 
@@ -404,6 +406,165 @@ async def test_blocks_redirect_to_private_host():
     out = _end_payload(events)["output"]
     assert out["success"] is False
     assert "redirect" in out["error_message"].lower()
+
+
+# --- tier-2 stealth fallback ------------------------------------------------
+
+
+def test_looks_blocked_status_codes():
+    assert _looks_blocked(247, "", "")[0] is True
+    assert _looks_blocked(403, "", "")[0] is True
+    assert _looks_blocked(429, "", "")[0] is True
+    assert _looks_blocked(503, "", "")[0] is True
+
+
+def test_looks_blocked_marker_with_small_body():
+    html = '<html><head><script src="//rbzns.kramericaindustries.com/sensor.js"></script></head><body></body></html>'
+    blocked, reason = _looks_blocked(200, html, "")
+    assert blocked is True
+    assert "marker=" in reason
+
+
+def test_looks_blocked_marker_with_real_content_is_not_blocked():
+    # Page contains the marker (some Reblaze beacons survive even on real pages),
+    # but the visible text is long enough that we trust the page.
+    html = '<html><body>rbzns ignored<p>actual content here</p></body></html>'
+    visible = "actual content here. " * 50
+    assert _looks_blocked(200, html, visible)[0] is False
+
+
+def test_healthy_response_not_blocked():
+    assert _looks_blocked(200, "<html><body>fine</body></html>", "fine body text " * 30)[0] is False
+
+
+@pytest.mark.asyncio
+async def test_stealth_escalates_on_247_and_returns_content():
+    # Tier-1: Reblaze challenge page, status 247, JS-only body.
+    tier1_body = (
+        b'<html><head><script src="//rbzns.kramericaindustries.com/sensor.js"></script></head>'
+        b'<body></body></html>'
+    )
+    tier1 = _FakeResponse(
+        status_code=247,
+        headers={"content-type": "text/html; charset=utf-8"},
+        content=tier1_body,
+        url="https://shop.super-pharm.co.il/p/449344",
+    )
+    # Tier-2 stealth: real product page.
+    stealth_html = (
+        '<html><head><title>CARELINE - BOLD מסקרה</title>'
+        '<meta name="description" content="Mascara product page">'
+        '<script type="application/ld+json">{"@type":"Product","name":"BOLD","offers":{"price":99,"priceCurrency":"ILS"}}</script>'
+        '</head><body><h1>BOLD מסקרה שחורה</h1>'
+        + '<p>Real product body text describing the item in detail. </p>' * 20
+        + '</body></html>'
+    )
+    stealth_result = StealthFetchResult(
+        status=200,
+        final_url="https://shop.super-pharm.co.il/p/449344",
+        html=stealth_html,
+    )
+
+    ctx_p, _ = _patched_session(tier1)
+    tool = WebFetchTool()
+    with (
+        patch.object(web_fetch_module, "_is_safe_host", return_value=True),
+        patch.object(web_fetch_module, "fetch_via_stealth", AsyncMock(return_value=stealth_result)) as mock_stealth,
+        ctx_p,
+    ):
+        events = await _collect(tool, {"url": "https://shop.super-pharm.co.il/p/449344"}, _runtime_ctx())
+
+    mock_stealth.assert_awaited_once()
+    out = _end_payload(events)["output"]
+    assert out["success"] is True
+    assert out["status_code"] == 200
+    assert out["title"] == "CARELINE - BOLD מסקרה"
+    assert "BOLD מסקרה שחורה" in (out["headings"] or [])
+    assert out["json_ld"][0]["@type"] == "Product"
+    assert "Real product body text" in out["content"]
+
+
+@pytest.mark.asyncio
+async def test_stealth_escalates_on_marker_in_small_body():
+    # 200 OK but body is empty + Reblaze marker → escalate.
+    tier1 = _FakeResponse(
+        status_code=200,
+        headers={"content-type": "text/html"},
+        content=b'<html><head><script src="https://rbzns.example/s.js"></script></head><body></body></html>',
+        url="https://example.com/p",
+    )
+    stealth_result = StealthFetchResult(
+        status=200,
+        final_url="https://example.com/p",
+        html='<html><head><title>Real</title></head><body>' + 'real content ' * 50 + '</body></html>',
+    )
+
+    ctx_p, _ = _patched_session(tier1)
+    tool = WebFetchTool()
+    with (
+        patch.object(web_fetch_module, "_is_safe_host", return_value=True),
+        patch.object(web_fetch_module, "fetch_via_stealth", AsyncMock(return_value=stealth_result)) as mock_stealth,
+        ctx_p,
+    ):
+        events = await _collect(tool, {"url": "https://example.com/p"}, _runtime_ctx())
+
+    mock_stealth.assert_awaited_once()
+    out = _end_payload(events)["output"]
+    assert out["success"] is True
+    assert out["title"] == "Real"
+
+
+@pytest.mark.asyncio
+async def test_stealth_surfaces_failure_when_still_blocked():
+    # KSP-style: tier-1 403, tier-2 stealth ALSO 403 (geo-block survives both tiers).
+    tier1 = _FakeResponse(
+        status_code=403,
+        headers={"content-type": "text/html"},
+        content=b"<html><body>Forbidden</body></html>",
+        url="https://ksp.co.il/web/item/1",
+    )
+    stealth_result = StealthFetchResult(
+        status=403,
+        final_url="https://ksp.co.il/web/item/1",
+        html="<html><body>KSP Forbidden 403</body></html>",
+    )
+
+    ctx_p, _ = _patched_session(tier1)
+    tool = WebFetchTool()
+    with (
+        patch.object(web_fetch_module, "_is_safe_host", return_value=True),
+        patch.object(web_fetch_module, "fetch_via_stealth", AsyncMock(return_value=stealth_result)),
+        ctx_p,
+    ):
+        events = await _collect(tool, {"url": "https://ksp.co.il/web/item/1"}, _runtime_ctx())
+
+    out = _end_payload(events)["output"]
+    assert out["success"] is False
+    assert "blocked" in (out["error_message"] or "").lower()
+    assert out["status_code"] == 403
+
+
+@pytest.mark.asyncio
+async def test_stealth_not_invoked_for_healthy_response():
+    fake = _FakeResponse(
+        status_code=200,
+        headers={"content-type": "text/html"},
+        content=b"<html><head><title>Fine</title></head><body>" + b"plenty of content " * 50 + b"</body></html>",
+        url="https://example.com/ok",
+    )
+    ctx_p, _ = _patched_session(fake)
+    tool = WebFetchTool()
+    with (
+        patch.object(web_fetch_module, "_is_safe_host", return_value=True),
+        patch.object(web_fetch_module, "fetch_via_stealth", AsyncMock()) as mock_stealth,
+        ctx_p,
+    ):
+        events = await _collect(tool, {"url": "https://example.com/ok"}, _runtime_ctx())
+
+    mock_stealth.assert_not_awaited()
+    out = _end_payload(events)["output"]
+    assert out["success"] is True
+    assert out["title"] == "Fine"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a second tier to `web_fetch` that renders the page in a stealth-patched headless Chromium when tier-1 (curl_cffi + `chrome131` TLS impersonation) hits an anti-bot wall.

