### PR TITLE
Stop selectin cascade on /data_sources, /connections, /demos

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -12,7 +12,7 @@ import uuid as uuid_module
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, lazyload
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
@@ -186,15 +186,20 @@ class ConnectionService:
         organization: Organization,
     ) -> List[Connection]:
         """Get all connections for an organization."""
-        from sqlalchemy.orm import selectinload
         # The list route never reads connection_tables; it uses a COUNT(*) query
         # instead. Eager-loading the relationship hydrates every row (25K+ on
         # large connections) just to discard it.
+        #
+        # lazyload("*") suppresses DataSource's model-level lazy="selectin"
+        # cascade (reports → widgets/queries/completions/…) that would
+        # otherwise fire when Connection.data_sources is loaded — the route
+        # only reads ds.id and ds.name for the access filter and agent_names.
         result = await db.execute(
             select(Connection)
             .filter(Connection.organization_id == organization.id)
             .options(
-                selectinload(Connection.data_sources),
+                lazyload("*"),
+                selectinload(Connection.data_sources).options(lazyload("*")),
             )
             .order_by(Connection.name)
         )

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -44,7 +44,7 @@ from app.models.datasource_table import DataSourceTable  # Add this import at th
 from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable, UserDataSourceColumn as UserOverlayColumn
 
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, lazyload
 from app.services.instruction_service import InstructionService
 from app.schemas.instruction_schema import InstructionCreate
 from app.core.telemetry import telemetry
@@ -792,12 +792,17 @@ class DataSourceService:
             db, str(current_user.id), str(organization.id)
         )
 
+        # lazyload("*") suppresses the model-level lazy="selectin" cascade
+        # (reports, instructions, entities, files, …); without it, listing
+        # data sources triggers ~20 SELECTs hauling in the full report/
+        # widget/query graph that this endpoint never returns. We only need
+        # connections, and we suppress the cascade on the loaded Connection
+        # objects too (Connection.data_sources is also lazy="selectin").
         query = (
             select(DataSource)
             .options(
-                selectinload(DataSource.git_repository),
-                selectinload(DataSource.data_source_memberships),
-                selectinload(DataSource.connections),
+                lazyload("*"),
+                selectinload(DataSource.connections).options(lazyload("*")),
             )
             .filter(DataSource.organization_id == organization.id)
         )

--- a/backend/app/services/demo_data_source_service.py
+++ b/backend/app/services/demo_data_source_service.py
@@ -382,12 +382,18 @@ class DemoDataSourceService:
         
         Returns a dict mapping demo_id -> DataSource.
         """
-        from sqlalchemy.orm import selectinload
-        
-        # Query all data sources for this org with their connections
+        from sqlalchemy.orm import selectinload, lazyload
+
+        # Query all data sources for this org with their connections.
+        # lazyload("*") suppresses DataSource's model-level lazy="selectin"
+        # cascade — the demo lookup only needs each connection's config to
+        # find the demo_id marker.
         stmt = select(DataSource).where(
             DataSource.organization_id == organization_id
-        ).options(selectinload(DataSource.connections))
+        ).options(
+            lazyload("*"),
+            selectinload(DataSource.connections).options(lazyload("*")),
+        )
         result = await db.execute(stmt)
         data_sources = result.scalars().all()
 


### PR DESCRIPTION
## Summary

`/agents` is still slow even after #269. Root cause is in the model layer, not at the call sites: `DataSource` has six relationships declared with `lazy="selectin"` (reports, instructions, entities, files, connections, git_repository), and `Connection.data_sources` is `lazy="selectin"` too. Any `select(DataSource)` or `select(Connection)` therefore auto-cascades into the full report → widget → query → completion → step / artifact / share / file graph — tables the list endpoints never return to the client.

## Reproduction

Quantified locally with a script that seeds 5 agents into SQLite and counts the SQL statements fired by `select(DataSource)`:

| seed | current | with `lazyload("*")` |
|---|---:|---:|
| 5 agents, 0 reports | **7** | 2 |
| 5 agents, 10 reports | **22** | 2 |
| 5 agents, 200 reports | **22** | 2 |

Each request hits: `data_sources`, `reports`, `users`, `queries`, `visualizations`, `widgets`, `text_widgets`, `completions`, `artifacts`, `scheduled_prompts`, `report_shares`, `dashboard_layout_versions`, `instructions`, `entities`, `connections`, `files`, `git_repositories`, `user_data_source_credentials`, `user_connection_credentials`, `api_keys`, `external_user_mappings`, and a self-cycle back to `data_sources`. On local SQLite this is fast; on a remote Postgres each round-trip costs network latency, which explains the ~14s observed on `eu.bagofwords.com` for `/data_sources` / `/demos` and ~8s for `/connections`.

## Change

Three list call sites get `lazyload("*")` + explicit `selectinload(...)` for what they actually read. The chained `.options(lazyload("*"))` on the connections / data_sources load is required so the loaded Connection/DataSource objects don't themselves selectin back into the cycle.

- `data_source_service.get_data_sources` (`/data_sources`)
- `connection_service.get_connections` (`/connections`)
- `demo_data_source_service._get_installed_demos` (`/data_sources/demos`)

## Why it's safe — traced every caller

- **`get_data_sources`**: single caller `routes/data_source.py:41`. Builds `DataSourceListItemSchema(...)` field-by-field, reads only column attrs plus `d.connections` (eager-loaded). `data_source_memberships` and `git_repository` selectinloads the code had were unused in this path.
- **`get_connections`**: single caller `routes/connection.py:104`. Reads `conn.data_sources` for the access filter and for `agent_count`/`agent_names` — only `ds.id` and `ds.name` (columns, always loaded).
- **`_get_installed_demos`**: two callers (list + install pre-check). Both read `ds.id` only and iterate `ds.connections[*].config` (column).

Async SQLAlchemy raises `MissingGreenlet` on accidental lazy loads rather than silently re-querying, so any missed relationship access would surface immediately in the e2e suite — not a silent data bug.

## Test plan

- [ ] CI passes (e2e + integration suites)
- [ ] Manually verify `/agents` page renders in ~hundreds of ms instead of seconds
- [ ] `agent_count` / `agent_names` on `/connections` response still populated
- [ ] Demo list still shows installed status correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01CbJogKAU8LtCZmzqfxuHGs)_