### PR TITLE
Bump idna to 3.15 to fix CVE-2026-45409 ReDoS

### DIFF
--- a/backend/requirements_versioned.txt
+++ b/backend/requirements_versioned.txt
@@ -69,7 +69,7 @@ httplib2==0.22.0
 httptools==0.6.1
 httpx==0.28.1
 httpx-oauth==0.16.1
-idna==3.7
+idna==3.15
 iniconfig==2.0.0
 ipython==8.22.2
 isodate==0.7.2


### PR DESCRIPTION
Snyk advisory SNYK-PYTHON-IDNA-16769942 (disclosed May 12, 2026)
affects idna < 3.15.

CVE-2026-44431 against urllib3 has no fixed version on PyPI yet
(latest is 2.7.0); leaving urllib3 pin unchanged until a release lands.