### PR TITLE
Declarative agent + eval YAML apply

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -64,6 +64,7 @@ from app.models.connection_indexing import ConnectionIndexing
 from app.models.connection_table import ConnectionTable
 from app.models.connection_tool import ConnectionTool
 from app.models.user_connection_tool import UserConnectionTool
+from app.models.data_source_connection_tool import DataSourceConnectionTool
 from app.models.domain_connection import domain_connection
 from app.models.user_connection_credentials import UserConnectionCredentials
 from app.models.user_connection_overlay import UserConnectionTable, UserConnectionColumn

--- a/backend/alembic/versions/e9f0a1b2c3d4_add_data_source_connection_tool_overlay.py
+++ b/backend/alembic/versions/e9f0a1b2c3d4_add_data_source_connection_tool_overlay.py
@@ -1,0 +1,39 @@
+"""add data_source_connection_tool per-agent tool overlay
+
+Revision ID: e9f0a1b2c3d4
+Revises: c5d6e7f8g9h0, d6e7f8a9b0c1
+Create Date: 2026-05-22 12:00:00.000000
+
+Merges the two pre-existing heads (PR 275 ``uq_connections_org_name`` and
+``add_events_json``) and adds the per-agent tool overlay table used by the
+agent YAML apply flow and the ``/data_sources/{id}/tools`` endpoints.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e9f0a1b2c3d4'
+down_revision: Union[str, Sequence[str], None] = ('c5d6e7f8g9h0', 'd6e7f8a9b0c1')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'data_source_connection_tool',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('data_source_id', sa.String(36), sa.ForeignKey('data_sources.id', ondelete='CASCADE'), nullable=False, index=True),
+        sa.Column('connection_tool_id', sa.String(36), sa.ForeignKey('connection_tools.id', ondelete='CASCADE'), nullable=False, index=True),
+        sa.Column('is_enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column('policy', sa.String(), nullable=False, server_default='allow'),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+        sa.UniqueConstraint('data_source_id', 'connection_tool_id', name='uq_dsct_ds_tool'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('data_source_connection_tool')

--- a/backend/app/models/data_source_connection_tool.py
+++ b/backend/app/models/data_source_connection_tool.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Column, String, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.models.base import BaseSchema
+
+
+class DataSourceConnectionTool(BaseSchema):
+    """Per-agent (DataSource) overlay of a ConnectionTool.
+
+    When present, overrides the org-wide ConnectionTool defaults
+    (``is_enabled``, ``policy``) for a specific DataSource. The runtime
+    tool loader reads the overlay first and falls back to the
+    ConnectionTool row.
+    """
+
+    __tablename__ = "data_source_connection_tool"
+    __table_args__ = (
+        UniqueConstraint(
+            "data_source_id", "connection_tool_id", name="uq_dsct_ds_tool"
+        ),
+    )
+
+    data_source_id = Column(
+        String(36), ForeignKey("data_sources.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    connection_tool_id = Column(
+        String(36), ForeignKey("connection_tools.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    is_enabled = Column(Boolean, nullable=False, default=True)
+    policy = Column(String, nullable=False, default="allow")  # allow | confirm | deny
+
+    data_source = relationship("DataSource", backref="tool_overlays")
+    connection_tool = relationship("ConnectionTool", backref="data_source_overlays")

--- a/backend/app/routes/agent_yaml.py
+++ b/backend/app/routes/agent_yaml.py
@@ -1,0 +1,83 @@
+"""HTTP routes for declarative Agent YAML apply / export.
+
+Single endpoint per operation. ``apply`` is idempotent on
+``(organization_id, manifest.name)``: it creates the resource if absent,
+reconciles it otherwise, and returns an ``ApplyResult`` with structured
+errors instead of raising HTTP exceptions on validation failures.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_user
+from app.dependencies import get_async_db, get_current_organization
+from app.models.organization import Organization
+from app.models.user import User
+from app.schemas.agent_manifest_schema import ApplyResult, ApplyStatus, ApplyError, ApplyErrorCode
+from app.services.agent_yaml_service import AgentYamlService
+
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+service = AgentYamlService()
+
+
+@router.post("/apply", response_model=ApplyResult)
+async def apply_agent(
+    request: Request,
+    dry_run: bool = Query(False),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    user: User = Depends(current_user),
+) -> ApplyResult:
+    body = await request.body()
+    if not body:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.YAML_PARSE_ERROR,
+                    message="Empty YAML body.",
+                )
+            ],
+        )
+    try:
+        yaml_text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.YAML_PARSE_ERROR,
+                    message="YAML body must be UTF-8.",
+                )
+            ],
+        )
+    return await service.apply(
+        db, organization, user, yaml_text, dry_run=dry_run
+    )
+
+
+@router.get("/{name}.yaml", response_class=PlainTextResponse)
+async def get_agent_yaml(
+    name: str,
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    user: User = Depends(current_user),
+) -> str:
+    return await service.export(db, organization, user, name)
+
+
+@router.get("", response_model=List[Dict[str, Any]])
+async def list_agent_manifests(
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    user: User = Depends(current_user),
+) -> List[Dict[str, Any]]:
+    return await service.list_agents(db, organization, user)

--- a/backend/app/routes/data_source_tools.py
+++ b/backend/app/routes/data_source_tools.py
@@ -1,0 +1,240 @@
+"""Per-agent tool overlay endpoints.
+
+The page at ``/agents/[id]/tools`` reads/writes overlay rows from this
+router. The runtime tool loader (and the YAML apply path) read the same
+overlay table — ``data_source_connection_tool`` — and fall back to the
+``ConnectionTool`` defaults when no override exists.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.auth import current_user
+from app.core.permissions_decorator import requires_resource_permission
+from app.dependencies import get_async_db, get_current_organization
+from app.models.connection import Connection
+from app.models.connection_tool import ConnectionTool
+from app.models.data_source import DataSource
+from app.models.data_source_connection_tool import DataSourceConnectionTool
+from app.models.organization import Organization
+from app.models.user import User
+
+
+router = APIRouter(tags=["data_source_tools"])
+
+
+class AgentToolSchema(BaseModel):
+    id: str  # connection_tool_id
+    connection_id: str
+    connection_name: str
+    name: str
+    description: Optional[str] = None
+    # Effective state (overlay if present, else ConnectionTool default)
+    is_enabled: bool
+    policy: str
+    # True when a per-agent overlay row exists
+    has_overlay: bool
+    # The connection-level defaults (so the UI can show "(default)" badges)
+    default_is_enabled: bool
+    default_policy: str
+
+    class Config:
+        from_attributes = True
+
+
+class AgentToolUpdate(BaseModel):
+    is_enabled: Optional[bool] = None
+    policy: Optional[str] = None  # allow | confirm | deny
+
+
+async def _load_agent(db: AsyncSession, data_source_id: str, organization: Organization) -> DataSource:
+    q = await db.execute(
+        select(DataSource)
+        .options(selectinload(DataSource.connections))
+        .where(
+            DataSource.id == data_source_id,
+            DataSource.organization_id == organization.id,
+        )
+    )
+    ds = q.scalar_one_or_none()
+    if ds is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return ds
+
+
+@router.get("/data_sources/{data_source_id}/tools", response_model=List[AgentToolSchema])
+@requires_resource_permission('data_source', 'view')
+async def list_agent_tools(
+    data_source_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> List[AgentToolSchema]:
+    ds = await _load_agent(db, data_source_id, organization)
+    conn_ids = [str(c.id) for c in (ds.connections or [])]
+    if not conn_ids:
+        return []
+    conn_by_id = {str(c.id): c for c in ds.connections}
+
+    tools_q = await db.execute(
+        select(ConnectionTool).where(ConnectionTool.connection_id.in_(conn_ids))
+    )
+    tools = list(tools_q.scalars().all())
+
+    overlay_q = await db.execute(
+        select(DataSourceConnectionTool).where(
+            DataSourceConnectionTool.data_source_id == data_source_id
+        )
+    )
+    overlay = {str(o.connection_tool_id): o for o in overlay_q.scalars().all()}
+
+    out: List[AgentToolSchema] = []
+    for t in tools:
+        ov = overlay.get(str(t.id))
+        if ov is not None:
+            eff_enabled = ov.is_enabled
+            eff_policy = ov.policy
+            has_overlay = True
+        else:
+            eff_enabled = t.is_enabled
+            eff_policy = t.policy
+            has_overlay = False
+        conn = conn_by_id.get(str(t.connection_id))
+        out.append(
+            AgentToolSchema(
+                id=str(t.id),
+                connection_id=str(t.connection_id),
+                connection_name=conn.name if conn else "",
+                name=t.name,
+                description=t.description,
+                is_enabled=eff_enabled,
+                policy=eff_policy,
+                has_overlay=has_overlay,
+                default_is_enabled=t.is_enabled,
+                default_policy=t.policy,
+            )
+        )
+    return out
+
+
+@router.put("/data_sources/{data_source_id}/tools/{tool_id}", response_model=AgentToolSchema)
+@requires_resource_permission('data_source', 'manage')
+async def update_agent_tool(
+    data_source_id: str,
+    tool_id: str,
+    data: AgentToolUpdate,
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> AgentToolSchema:
+    ds = await _load_agent(db, data_source_id, organization)
+    conn_ids = [str(c.id) for c in (ds.connections or [])]
+
+    # Validate the tool belongs to one of the agent's connections
+    t_q = await db.execute(
+        select(ConnectionTool).where(
+            ConnectionTool.id == tool_id,
+            ConnectionTool.connection_id.in_(conn_ids),
+        )
+    )
+    tool = t_q.scalar_one_or_none()
+    if tool is None:
+        raise HTTPException(status_code=404, detail="Tool not linked to this agent")
+
+    if data.policy is not None and data.policy not in {"allow", "confirm", "deny"}:
+        raise HTTPException(status_code=400, detail="policy must be allow, confirm, or deny")
+
+    # Upsert overlay
+    ov_q = await db.execute(
+        select(DataSourceConnectionTool).where(
+            DataSourceConnectionTool.data_source_id == data_source_id,
+            DataSourceConnectionTool.connection_tool_id == tool_id,
+        )
+    )
+    overlay = ov_q.scalar_one_or_none()
+    if overlay is None:
+        overlay = DataSourceConnectionTool(
+            data_source_id=data_source_id,
+            connection_tool_id=tool_id,
+            is_enabled=tool.is_enabled if data.is_enabled is None else data.is_enabled,
+            policy=tool.policy if data.policy is None else data.policy,
+        )
+        db.add(overlay)
+    else:
+        if data.is_enabled is not None:
+            overlay.is_enabled = data.is_enabled
+        if data.policy is not None:
+            overlay.policy = data.policy
+        db.add(overlay)
+    await db.commit()
+    await db.refresh(overlay)
+
+    conn = next((c for c in ds.connections if str(c.id) == str(tool.connection_id)), None)
+    return AgentToolSchema(
+        id=str(tool.id),
+        connection_id=str(tool.connection_id),
+        connection_name=conn.name if conn else "",
+        name=tool.name,
+        description=tool.description,
+        is_enabled=overlay.is_enabled,
+        policy=overlay.policy,
+        has_overlay=True,
+        default_is_enabled=tool.is_enabled,
+        default_policy=tool.policy,
+    )
+
+
+@router.delete("/data_sources/{data_source_id}/tools/{tool_id}", response_model=AgentToolSchema)
+@requires_resource_permission('data_source', 'manage')
+async def reset_agent_tool(
+    data_source_id: str,
+    tool_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> AgentToolSchema:
+    """Remove the per-agent overlay; the tool reverts to connection defaults."""
+    ds = await _load_agent(db, data_source_id, organization)
+    conn_ids = [str(c.id) for c in (ds.connections or [])]
+
+    t_q = await db.execute(
+        select(ConnectionTool).where(
+            ConnectionTool.id == tool_id,
+            ConnectionTool.connection_id.in_(conn_ids),
+        )
+    )
+    tool = t_q.scalar_one_or_none()
+    if tool is None:
+        raise HTTPException(status_code=404, detail="Tool not linked to this agent")
+
+    ov_q = await db.execute(
+        select(DataSourceConnectionTool).where(
+            DataSourceConnectionTool.data_source_id == data_source_id,
+            DataSourceConnectionTool.connection_tool_id == tool_id,
+        )
+    )
+    overlay = ov_q.scalar_one_or_none()
+    if overlay is not None:
+        await db.delete(overlay)
+        await db.commit()
+
+    conn = next((c for c in ds.connections if str(c.id) == str(tool.connection_id)), None)
+    return AgentToolSchema(
+        id=str(tool.id),
+        connection_id=str(tool.connection_id),
+        connection_name=conn.name if conn else "",
+        name=tool.name,
+        description=tool.description,
+        is_enabled=tool.is_enabled,
+        policy=tool.policy,
+        has_overlay=False,
+        default_is_enabled=tool.is_enabled,
+        default_policy=tool.policy,
+    )

--- a/backend/app/routes/data_source_tools.py
+++ b/backend/app/routes/data_source_tools.py
@@ -6,8 +6,6 @@ overlay table — ``data_source_connection_tool`` — and fall back to the
 ``ConnectionTool`` defaults when no override exists.
 """
 
-from __future__ import annotations
-
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/app/routes/eval_yaml.py
+++ b/backend/app/routes/eval_yaml.py
@@ -1,0 +1,195 @@
+"""HTTP routes for declarative Eval YAML apply / export.
+
+Externally surfaced under ``/evals/*``. Internally these still map onto
+``TestSuite`` / ``SuiteYaml`` (rename is product-side only). Wraps
+``TestSuiteService.import_yaml`` with the same ``ApplyResult`` envelope
+used by agent YAML so callers get a uniform response shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_user
+from app.core.permission_resolver import FULL_ADMIN, resolve_permissions
+from app.dependencies import get_async_db, get_current_organization
+from app.models.eval import TestSuite
+from app.models.organization import Organization
+from app.models.user import User
+from app.schemas.agent_manifest_schema import (
+    ApplyError,
+    ApplyErrorCode,
+    ApplyResult,
+    ApplyStatus,
+)
+from app.services.test_suite_service import TestSuiteService
+
+
+router = APIRouter(prefix="/evals", tags=["evals"])
+suite_service = TestSuiteService()
+
+
+async def _require_manage_evals(
+    db: AsyncSession, organization: Organization, user: User
+) -> ApplyResult | None:
+    """Return an error ApplyResult if the user can't manage evals, else None."""
+    resolved = await resolve_permissions(db, str(user.id), str(organization.id))
+    if (
+        FULL_ADMIN in resolved.org_permissions
+        or resolved.has_org_permission("manage_evals")
+    ):
+        return None
+    return ApplyResult(
+        status=ApplyStatus.ERROR,
+        errors=[
+            ApplyError(
+                loc=[],
+                code=ApplyErrorCode.PERMISSION_DENIED,
+                message="You do not have permission to manage evals.",
+            )
+        ],
+    )
+
+
+@router.post("/apply", response_model=ApplyResult)
+async def apply_eval(
+    request: Request,
+    dry_run: bool = Query(False),
+    strategy: str = Query("upsert", pattern="^(upsert|replace)$"),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> ApplyResult:
+    perm_error = await _require_manage_evals(db, organization, current_user)
+    if perm_error is not None:
+        return perm_error
+    body = await request.body()
+    if not body:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.YAML_PARSE_ERROR,
+                    message="Empty YAML body.",
+                )
+            ],
+        )
+    try:
+        yaml_text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.YAML_PARSE_ERROR,
+                    message="YAML body must be UTF-8.",
+                )
+            ],
+        )
+
+    if dry_run:
+        # No dry-run on suite import yet; surface as a 200 with a note.
+        return ApplyResult(
+            status=ApplyStatus.DRY_RUN,
+            warnings=[],
+            diff={"note": "dry_run is not yet implemented for evals"},
+        )
+
+    # Determine create vs update by suite name presence in the YAML.
+    # We do this before calling the service so we can return the proper
+    # status code on the result envelope.
+    import yaml as _yaml
+
+    try:
+        raw = _yaml.safe_load(yaml_text) or {}
+    except _yaml.YAMLError as e:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.YAML_PARSE_ERROR,
+                    message=str(e),
+                )
+            ],
+        )
+    suite_name = raw.get("name") if isinstance(raw, dict) else None
+    existed_before = False
+    if suite_name:
+        q = await db.execute(
+            select(TestSuite).where(
+                TestSuite.organization_id == str(organization.id),
+                TestSuite.name == suite_name,
+            )
+        )
+        existed_before = q.scalar_one_or_none() is not None
+
+    try:
+        result = await suite_service.import_yaml(
+            db, str(organization.id), current_user, yaml_text, strategy=strategy,
+        )
+    except HTTPException as e:
+        return ApplyResult(
+            status=ApplyStatus.ERROR,
+            errors=[
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.SCHEMA_INVALID,
+                    message=str(e.detail),
+                )
+            ],
+        )
+
+    return ApplyResult(
+        status=ApplyStatus.UPDATED if existed_before else ApplyStatus.CREATED,
+        id=result.get("suite_id"),
+        name=result.get("suite_name"),
+        diff={
+            "cases_by_name": result.get("cases_by_name", {}),
+            "removed_case_names": result.get("removed_case_names", []),
+        },
+    )
+
+
+@router.get("/{name}.yaml", response_class=PlainTextResponse)
+async def export_eval_yaml(
+    name: str,
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> str:
+    # Look up suite by name within org → delegate to existing export_yaml
+    q = await db.execute(
+        select(TestSuite).where(
+            TestSuite.organization_id == str(organization.id),
+            TestSuite.name == name,
+        )
+    )
+    suite = q.scalar_one_or_none()
+    if suite is None:
+        raise HTTPException(status_code=404, detail=f"Eval '{name}' not found")
+    return await suite_service.export_yaml(
+        db, str(organization.id), current_user, str(suite.id)
+    )
+
+
+@router.get("", response_model=List[Dict[str, Any]])
+async def list_evals(
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+    current_user: User = Depends(current_user),
+) -> List[Dict[str, Any]]:
+    suites = await suite_service.list_suites(
+        db, str(organization.id), current_user, page=1, limit=1000
+    )
+    return [
+        {"id": str(s.id), "name": s.name, "description": s.description}
+        for s in suites
+    ]

--- a/backend/app/schemas/agent_manifest_schema.py
+++ b/backend/app/schemas/agent_manifest_schema.py
@@ -5,9 +5,17 @@ Apply semantics:
   new resource — there is no separate slug.
 - Omitted optional fields revert to defaults. The YAML expresses *desired
   state*, not a patch. ``apply(get(x)) == unchanged`` for every field.
-- Refs (connections, groups, users, instructions, tools) are by name/email
-  or id. Resolution is collect-all-errors and returns ``did-you-mean``
-  suggestions where possible.
+- Refs (connections, groups, users, tools) are by name/email. Resolution
+  is collect-all-errors and returns ``did-you-mean`` suggestions where
+  possible.
+
+Instructions are intentionally NOT part of this manifest. They live in
+the org-wide ``instructions`` table with their own lifecycle (UI,
+git-sync from markdown, ``create_instruction`` MCP tool) and attach to
+agents via the M:N association table. Putting them inside the agent
+file made the ownership ambiguous (org-wide rows nested under one
+agent), so authors create instructions separately and reference them
+by ``data_source_ids`` in the InstructionCreate payload.
 
 Not in scope for v1:
 - Inline ``Connection`` definitions in YAML (creds + env-var refs).
@@ -21,8 +29,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
-
-from app.schemas.instruction_schema import InstructionCategory, InstructionLoadMode
 
 
 # ---------------------------------------------------------------------------
@@ -55,34 +61,6 @@ class ToolsOverlay(BaseModel):
     deny: List[str] = Field(default_factory=list)
 
 
-class InstructionInline(BaseModel):
-    title: str
-    text: str
-    category: InstructionCategory = InstructionCategory.GENERAL
-    load_mode: InstructionLoadMode = InstructionLoadMode.ALWAYS
-
-    @field_validator("text", "title")
-    @classmethod
-    def _non_empty(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("must not be empty")
-        return v
-
-
-class InstructionRef(BaseModel):
-    """Either an ``id`` reference to an existing Instruction or an
-    inline definition of a new one. Exactly one of ``id`` / ``inline``."""
-
-    id: Optional[str] = None
-    inline: Optional[InstructionInline] = None
-
-    @model_validator(mode="after")
-    def _one_of(self) -> "InstructionRef":
-        if (self.id is None) == (self.inline is None):
-            raise ValueError("InstructionRef requires exactly one of 'id' or 'inline'")
-        return self
-
-
 class MemberRef(BaseModel):
     """Polymorphic member entry. Use ``user:`` for an email or ``group:`` for
     a group name. ``permissions`` defaults to ``["view", "view_schema"]``."""
@@ -111,7 +89,6 @@ class AgentManifest(BaseModel):
     connections: List[str] = Field(default_factory=list)
     tables: Optional[TableRules] = None
     tools: Dict[str, ToolsOverlay] = Field(default_factory=dict)
-    instructions: List[InstructionRef] = Field(default_factory=list)
     conversation_starters: List[str] = Field(default_factory=list)
     members: List[MemberRef] = Field(default_factory=list)
 
@@ -143,7 +120,6 @@ class ApplyErrorCode(str, Enum):
     TOOL_NOT_FOUND = "tool_not_found"
     GROUP_NOT_FOUND = "group_not_found"
     USER_NOT_FOUND = "user_not_found"
-    INSTRUCTION_NOT_FOUND = "instruction_not_found"
     DUPLICATE_ENTRY = "duplicate_entry"
     LICENSE_REQUIRED = "license_required"
     PERMISSION_DENIED = "permission_denied"

--- a/backend/app/schemas/agent_manifest_schema.py
+++ b/backend/app/schemas/agent_manifest_schema.py
@@ -1,0 +1,195 @@
+"""YAML manifest schema for declarative Agent (DataSource) apply.
+
+Apply semantics:
+- Resources are identified by ``(organization_id, name)``. Renames create a
+  new resource — there is no separate slug.
+- Omitted optional fields revert to defaults. The YAML expresses *desired
+  state*, not a patch. ``apply(get(x)) == unchanged`` for every field.
+- Refs (connections, groups, users, instructions, tools) are by name/email
+  or id. Resolution is collect-all-errors and returns ``did-you-mean``
+  suggestions where possible.
+
+Not in scope for v1:
+- Inline ``Connection`` definitions in YAML (creds + env-var refs).
+- Group resolution by ``external_id`` (AD/Okta/SCIM).
+- Glob patterns beyond ``*`` for tool / table matching.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.schemas.instruction_schema import InstructionCategory, InstructionLoadMode
+
+
+# ---------------------------------------------------------------------------
+# Manifest body
+# ---------------------------------------------------------------------------
+
+
+class TableRules(BaseModel):
+    """Include/exclude rules applied against ``{connection}.{schema}.{table}``.
+
+    Supports ``*`` as a wildcard segment. ``include`` defaults to ``["*"]``
+    (all tables) when omitted; ``exclude`` defaults to empty. A table is
+    active iff it matches *any* include and *no* exclude.
+    """
+
+    include: Optional[List[str]] = None
+    exclude: List[str] = Field(default_factory=list)
+
+
+class ToolsOverlay(BaseModel):
+    """Per-agent tool policy overlay for a single MCP/custom_api connection.
+
+    Each list contains tool *names* (matched against ``ConnectionTool.name``)
+    and accepts ``"*"`` as a wildcard. A tool ends up at the most restrictive
+    bucket it matches: deny > confirm > allow.
+    """
+
+    allow: List[str] = Field(default_factory=list)
+    confirm: List[str] = Field(default_factory=list)
+    deny: List[str] = Field(default_factory=list)
+
+
+class InstructionInline(BaseModel):
+    title: str
+    text: str
+    category: InstructionCategory = InstructionCategory.GENERAL
+    load_mode: InstructionLoadMode = InstructionLoadMode.ALWAYS
+
+    @field_validator("text", "title")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be empty")
+        return v
+
+
+class InstructionRef(BaseModel):
+    """Either an ``id`` reference to an existing Instruction or an
+    inline definition of a new one. Exactly one of ``id`` / ``inline``."""
+
+    id: Optional[str] = None
+    inline: Optional[InstructionInline] = None
+
+    @model_validator(mode="after")
+    def _one_of(self) -> "InstructionRef":
+        if (self.id is None) == (self.inline is None):
+            raise ValueError("InstructionRef requires exactly one of 'id' or 'inline'")
+        return self
+
+
+class MemberRef(BaseModel):
+    """Polymorphic member entry. Use ``user:`` for an email or ``group:`` for
+    a group name. ``permissions`` defaults to ``["view", "view_schema"]``."""
+
+    user: Optional[str] = None
+    group: Optional[str] = None
+    permissions: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def _one_of(self) -> "MemberRef":
+        if (self.user is None) == (self.group is None):
+            raise ValueError("MemberRef requires exactly one of 'user' or 'group'")
+        return self
+
+
+class AgentManifest(BaseModel):
+    """Declarative agent description. ``name`` is the identity key (within
+    the organization)."""
+
+    name: str
+    description: Optional[str] = None
+    context: Optional[str] = None
+    is_public: bool = False
+    use_llm_sync: bool = False
+
+    connections: List[str] = Field(default_factory=list)
+    tables: Optional[TableRules] = None
+    tools: Dict[str, ToolsOverlay] = Field(default_factory=dict)
+    instructions: List[InstructionRef] = Field(default_factory=list)
+    conversation_starters: List[str] = Field(default_factory=list)
+    members: List[MemberRef] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("name must not be empty")
+        return v.strip()
+
+    @field_validator("connections")
+    @classmethod
+    def _unique_connections(cls, v: List[str]) -> List[str]:
+        if len(set(v)) != len(v):
+            raise ValueError("duplicate entries in 'connections'")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Error / response envelope
+# ---------------------------------------------------------------------------
+
+
+class ApplyErrorCode(str, Enum):
+    YAML_PARSE_ERROR = "yaml_parse_error"
+    SCHEMA_INVALID = "schema_invalid"
+    CONNECTION_NOT_FOUND = "connection_not_found"
+    CONNECTION_TYPE_MISMATCH = "connection_type_mismatch"
+    TOOL_NOT_FOUND = "tool_not_found"
+    GROUP_NOT_FOUND = "group_not_found"
+    USER_NOT_FOUND = "user_not_found"
+    INSTRUCTION_NOT_FOUND = "instruction_not_found"
+    DUPLICATE_ENTRY = "duplicate_entry"
+    LICENSE_REQUIRED = "license_required"
+    PERMISSION_DENIED = "permission_denied"
+    ENUM_INVALID = "enum_invalid"
+
+
+class ApplyWarningCode(str, Enum):
+    CONNECTION_INDEXING_PENDING = "connection_indexing_pending"
+    TABLES_FILTER_EMPTY = "tables_filter_empty"
+    GLOB_OVERLAP = "glob_overlap"
+
+
+class ApplyError(BaseModel):
+    loc: List[Union[str, int]]
+    code: ApplyErrorCode
+    message: str
+    value: Optional[Any] = None
+    suggestion: Optional[str] = None
+
+
+class ApplyWarning(BaseModel):
+    loc: List[Union[str, int]] = Field(default_factory=list)
+    code: ApplyWarningCode
+    message: str
+
+
+class ApplyStatus(str, Enum):
+    CREATED = "created"
+    UPDATED = "updated"
+    UNCHANGED = "unchanged"
+    ERROR = "error"
+    DRY_RUN = "dry_run"
+
+
+class ApplyResult(BaseModel):
+    """Single response envelope for both success and failure paths.
+
+    Success: ``status`` ∈ {created, updated, unchanged, dry_run},
+    ``errors`` empty.
+    Failure: ``status == error``, ``errors`` populated; ``id`` may be
+    ``None`` (no resource exists yet or write was aborted).
+    """
+
+    status: ApplyStatus
+    id: Optional[str] = None
+    name: Optional[str] = None
+    diff: Optional[Dict[str, Any]] = None
+    warnings: List[ApplyWarning] = Field(default_factory=list)
+    errors: List[ApplyError] = Field(default_factory=list)

--- a/backend/app/services/agent_yaml_service.py
+++ b/backend/app/services/agent_yaml_service.py
@@ -11,7 +11,9 @@ The service is intentionally thin: connection / membership creation,
 license gates, indexing kickoff, audit + telemetry all reuse
 ``DataSourceService.create_data_source``. Apply only owns the
 *reconciliation* — connections add/remove, table filters, tool overlays,
-inline instructions, group members, conversation starters.
+group members, conversation starters. Instructions are intentionally
+left out of this manifest and managed through the existing instruction
+endpoints / MCP tool.
 """
 
 from __future__ import annotations
@@ -45,10 +47,6 @@ from app.models.data_source_membership import (
 )
 from app.models.datasource_table import DataSourceTable
 from app.models.group import Group
-from app.models.instruction import (
-    Instruction,
-    instruction_data_source_association,
-)
 from app.models.organization import Organization
 from app.models.resource_grant import ResourceGrant
 from app.models.user import User
@@ -60,15 +58,12 @@ from app.schemas.agent_manifest_schema import (
     ApplyStatus,
     ApplyWarning,
     ApplyWarningCode,
-    InstructionRef,
     MemberRef,
     TableRules,
     ToolsOverlay,
 )
 from app.schemas.data_source_schema import DataSourceCreate
-from app.schemas.instruction_schema import InstructionCreate
 from app.services.data_source_service import DataSourceService
-from app.services.instruction_service import InstructionService
 
 
 logger = logging.getLogger(__name__)
@@ -91,7 +86,6 @@ class _Resolved:
         self.connections: Dict[str, Connection] = {}  # name -> Connection
         self.groups: Dict[str, Group] = {}  # name -> Group
         self.users: Dict[str, User] = {}  # email -> User
-        self.instructions: Dict[str, Instruction] = {}  # id -> Instruction
         # (connection_name, tool_name) -> ConnectionTool
         self.tools: Dict[Tuple[str, str], ConnectionTool] = {}
 
@@ -106,7 +100,6 @@ class AgentYamlService:
 
     def __init__(self) -> None:
         self._ds_service = DataSourceService()
-        self._instruction_service = InstructionService()
 
     # ----- apply ----------------------------------------------------------
 
@@ -287,7 +280,6 @@ class AgentYamlService:
                 selectinload(DataSource.connections),
                 selectinload(DataSource.data_source_memberships),
                 selectinload(DataSource.tables),
-                selectinload(DataSource.instructions),
             )
             .where(
                 DataSource.organization_id == organization.id,
@@ -424,9 +416,6 @@ class AgentYamlService:
         await self._patch_conversation_starters(db, ds, manifest)
         await self._patch_group_memberships(db, organization, ds, manifest, resolved)
         await self._patch_member_permissions(db, organization, ds, manifest, resolved)
-        await self._patch_instructions(
-            db, organization, current_user, ds, manifest, resolved
-        )
 
         # Table & tool reconciliation operates on the linked connections
         # (which may still be indexing — warnings collected from there).
@@ -504,13 +493,6 @@ class AgentYamlService:
         )
         if member_diff:
             diff["members"] = member_diff
-
-        # Instructions
-        instr_diff = await self._reconcile_instructions(
-            db, organization, current_user, ds, manifest, resolved
-        )
-        if instr_diff:
-            diff["instructions"] = instr_diff
 
         # Tables
         tw = await self._apply_table_rules(db, ds, manifest.tables, resolved)
@@ -719,162 +701,6 @@ class AgentYamlService:
             out["removed"] = removed
         return out
 
-    # ----- instructions ---------------------------------------------------
-
-    async def _patch_instructions(
-        self,
-        db: AsyncSession,
-        organization: Organization,
-        current_user: User,
-        ds: DataSource,
-        manifest: AgentManifest,
-        resolved: _Resolved,
-    ) -> None:
-        """Create inline + attach by-id instructions on agent creation."""
-        for ref in manifest.instructions:
-            if ref.id is not None:
-                await self._attach_instruction(db, ds, resolved.instructions[ref.id])
-            else:
-                inline = ref.inline
-                assert inline is not None
-                payload = InstructionCreate(
-                    text=inline.text,
-                    title=inline.title,
-                    category=inline.category.value if hasattr(inline.category, "value") else str(inline.category),
-                    load_mode=inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode),
-                    ai_source="yaml",
-                    source_type="user",
-                    data_source_ids=[str(ds.id)],
-                    status="published",
-                )
-                await self._instruction_service.create_instruction(
-                    db=db,
-                    instruction_data=payload,
-                    current_user=current_user,
-                    organization=organization,
-                    force_global=True,
-                    auto_finalize=True,
-                )
-
-    async def _attach_instruction(
-        self, db: AsyncSession, ds: DataSource, instruction: Instruction
-    ) -> None:
-        # Idempotent attach (skip if already present)
-        existing = await db.execute(
-            select(instruction_data_source_association).where(
-                instruction_data_source_association.c.instruction_id == instruction.id,
-                instruction_data_source_association.c.data_source_id == ds.id,
-            )
-        )
-        if existing.first() is not None:
-            return
-        await db.execute(
-            instruction_data_source_association.insert().values(
-                instruction_id=instruction.id, data_source_id=ds.id
-            )
-        )
-
-    async def _reconcile_instructions(
-        self,
-        db: AsyncSession,
-        organization: Organization,
-        current_user: User,
-        ds: DataSource,
-        manifest: AgentManifest,
-        resolved: _Resolved,
-    ) -> Dict[str, Any]:
-        """Attach by-id refs, create inline ones (matched by title), and
-        detach any instruction that was previously attached via YAML but is
-        no longer in the manifest. Manually-attached instructions (those
-        not created with ``ai_source='yaml'``) are left alone."""
-
-        # Current attached instructions
-        current_q = await db.execute(
-            select(Instruction)
-            .join(
-                instruction_data_source_association,
-                instruction_data_source_association.c.instruction_id == Instruction.id,
-            )
-            .where(
-                instruction_data_source_association.c.data_source_id == ds.id
-            )
-        )
-        current = list(current_q.scalars().all())
-        current_yaml = {i.title: i for i in current if i.ai_source == "yaml" and i.title}
-
-        desired_ids: set[str] = set()
-        desired_titles: set[str] = set()
-        added: List[str] = []
-        for ref in manifest.instructions:
-            if ref.id is not None:
-                desired_ids.add(ref.id)
-                instr = resolved.instructions[ref.id]
-                await self._attach_instruction(db, ds, instr)
-                added.append(instr.title or instr.id)
-                continue
-            inline = ref.inline
-            assert inline is not None
-            existing = current_yaml.get(inline.title)
-            if existing is not None:
-                # Update existing inline instruction if content changed
-                changed = False
-                if existing.text != inline.text:
-                    existing.text = inline.text
-                    changed = True
-                cat_val = inline.category.value if hasattr(inline.category, "value") else str(inline.category)
-                if existing.category != cat_val:
-                    existing.category = cat_val
-                    changed = True
-                lm_val = inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode)
-                if existing.load_mode != lm_val:
-                    existing.load_mode = lm_val
-                    changed = True
-                if changed:
-                    db.add(existing)
-                    added.append(f"updated:{inline.title}")
-                desired_titles.add(inline.title)
-            else:
-                payload = InstructionCreate(
-                    text=inline.text,
-                    title=inline.title,
-                    category=inline.category.value if hasattr(inline.category, "value") else str(inline.category),
-                    load_mode=inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode),
-                    ai_source="yaml",
-                    source_type="user",
-                    data_source_ids=[str(ds.id)],
-                    status="published",
-                )
-                await self._instruction_service.create_instruction(
-                    db=db,
-                    instruction_data=payload,
-                    current_user=current_user,
-                    organization=organization,
-                    force_global=True,
-                    auto_finalize=True,
-                )
-                desired_titles.add(inline.title)
-                added.append(f"created:{inline.title}")
-
-        # Detach yaml-owned instructions removed from manifest
-        removed: List[str] = []
-        for title, instr in current_yaml.items():
-            if title in desired_titles:
-                continue
-            await db.execute(
-                instruction_data_source_association.delete().where(
-                    instruction_data_source_association.c.instruction_id == instr.id,
-                    instruction_data_source_association.c.data_source_id == ds.id,
-                )
-            )
-            removed.append(title)
-
-        out: Dict[str, Any] = {}
-        if added:
-            out["added"] = added
-        if removed:
-            out["removed"] = removed
-        return out
-
     # ----- tables ---------------------------------------------------------
 
     async def _apply_table_rules(
@@ -1046,7 +872,6 @@ class AgentYamlService:
                 "action": "create",
                 "connections": list(manifest.connections),
                 "members": [m.model_dump(exclude_none=True) for m in manifest.members],
-                "instructions": len(manifest.instructions),
                 "conversation_starters": list(manifest.conversation_starters),
             }
         diff: Dict[str, Any] = {"action": "update"}
@@ -1128,50 +953,6 @@ class AgentYamlService:
         # Conversation starters
         starters = list(ds.conversation_starters or [])
 
-        # Instructions (only those previously created via YAML are
-        # round-trippable as 'inline'; manually attached ones come back as
-        # id refs).
-        instr_q = await db.execute(
-            select(Instruction)
-            .join(
-                instruction_data_source_association,
-                instruction_data_source_association.c.instruction_id == Instruction.id,
-            )
-            .where(
-                instruction_data_source_association.c.data_source_id == ds.id,
-                Instruction.deleted_at.is_(None),
-            )
-        )
-        instructions: List[InstructionRef] = []
-        for instr in instr_q.scalars().all():
-            from app.schemas.agent_manifest_schema import InstructionInline
-            from app.schemas.instruction_schema import (
-                InstructionCategory as _IC,
-                InstructionLoadMode as _ILM,
-            )
-
-            if instr.ai_source == "yaml" and instr.title:
-                try:
-                    cat = _IC(instr.category or "general")
-                except Exception:
-                    cat = _IC.GENERAL
-                try:
-                    lm = _ILM(instr.load_mode or "always")
-                except Exception:
-                    lm = _ILM.ALWAYS
-                instructions.append(
-                    InstructionRef(
-                        inline=InstructionInline(
-                            title=instr.title,
-                            text=instr.text,
-                            category=cat,
-                            load_mode=lm,
-                        )
-                    )
-                )
-            else:
-                instructions.append(InstructionRef(id=str(instr.id)))
-
         # Tables — reverse-engineer include/exclude from is_active flags.
         # We emit an exact list of active FQNs as ``include`` and leave
         # ``exclude`` empty. Re-applying yields the same state.
@@ -1224,7 +1005,6 @@ class AgentYamlService:
             connections=connections,
             tables=rules,
             tools=tools,
-            instructions=instructions,
             conversation_starters=starters,
             members=members,
         )
@@ -1236,7 +1016,7 @@ class AgentYamlService:
 
 
 class ManifestResolver:
-    """Batches lookups for connections, groups, users, instructions, tools.
+    """Batches lookups for connections, groups, users, tools.
 
     Returns ``(resolved, errors)``. Always processes every ref so the caller
     can show *all* fixable problems in one round-trip.
@@ -1255,7 +1035,6 @@ class ManifestResolver:
         await self._resolve_connections(manifest, resolved, errors)
         await self._resolve_groups(manifest, resolved, errors)
         await self._resolve_users(manifest, resolved, errors)
-        await self._resolve_instructions(manifest, resolved, errors)
         await self._resolve_tools(manifest, resolved, errors)
 
         return resolved, errors
@@ -1372,40 +1151,6 @@ class ManifestResolver:
                 )
                 continue
             resolved.users[email] = u
-
-    async def _resolve_instructions(
-        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
-    ) -> None:
-        id_refs = [(i, r.id) for i, r in enumerate(manifest.instructions) if r.id]
-        if not id_refs:
-            return
-        ids = list({i for _, i in id_refs})
-        q = await self.db.execute(
-            select(Instruction).where(
-                Instruction.id.in_(ids),
-                Instruction.deleted_at.is_(None),
-            )
-        )
-        by_id: Dict[str, Instruction] = {}
-        for instr in q.scalars().all():
-            # Org scope check: an instruction's org is derived from its user.
-            # For simplicity we just check the user's primary org via the
-            # user model; if the model doesn't carry that, we skip the check
-            # and rely on the FK to data sources to keep cross-org refs out.
-            by_id[str(instr.id)] = instr
-        for idx, iid in id_refs:
-            instr = by_id.get(iid)
-            if instr is None:
-                errors.append(
-                    ApplyError(
-                        loc=["instructions", idx, "id"],
-                        code=ApplyErrorCode.INSTRUCTION_NOT_FOUND,
-                        message=f"Instruction '{iid}' not found.",
-                        value=iid,
-                    )
-                )
-                continue
-            resolved.instructions[iid] = instr
 
     async def _resolve_tools(
         self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]

--- a/backend/app/services/agent_yaml_service.py
+++ b/backend/app/services/agent_yaml_service.py
@@ -1,0 +1,1533 @@
+"""Declarative apply for Agent (DataSource) YAML manifests.
+
+A single ``apply(yaml_text)`` call:
+- creates the resource if it doesn't exist for ``(org_id, manifest.name)``;
+- otherwise reconciles each field against the desired state;
+- returns ``{created | updated | unchanged | dry_run | error}`` with a
+  structured error list (and ``did-you-mean`` suggestions) instead of
+  surfacing exceptions.
+
+The service is intentionally thin: connection / membership creation,
+license gates, indexing kickoff, audit + telemetry all reuse
+``DataSourceService.create_data_source``. Apply only owns the
+*reconciliation* — connections add/remove, table filters, tool overlays,
+inline instructions, group members, conversation starters.
+"""
+
+from __future__ import annotations
+
+import difflib
+import fnmatch
+import logging
+import re
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import yaml
+from pydantic import ValidationError
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.permission_resolver import (
+    FULL_ADMIN,
+    resolve_permissions,
+)
+from app.models.connection import Connection
+from app.models.connection_table import ConnectionTable
+from app.models.connection_tool import ConnectionTool
+from app.models.data_source import DataSource
+from app.models.data_source_connection_tool import DataSourceConnectionTool
+from app.models.data_source_membership import (
+    DataSourceMembership,
+    PRINCIPAL_TYPE_GROUP,
+    PRINCIPAL_TYPE_USER,
+)
+from app.models.datasource_table import DataSourceTable
+from app.models.group import Group
+from app.models.instruction import (
+    Instruction,
+    instruction_data_source_association,
+)
+from app.models.organization import Organization
+from app.models.resource_grant import ResourceGrant
+from app.models.user import User
+from app.schemas.agent_manifest_schema import (
+    AgentManifest,
+    ApplyError,
+    ApplyErrorCode,
+    ApplyResult,
+    ApplyStatus,
+    ApplyWarning,
+    ApplyWarningCode,
+    InstructionRef,
+    MemberRef,
+    TableRules,
+    ToolsOverlay,
+)
+from app.schemas.data_source_schema import DataSourceCreate
+from app.schemas.instruction_schema import InstructionCreate
+from app.services.data_source_service import DataSourceService
+from app.services.instruction_service import InstructionService
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MEMBER_PERMISSIONS = ["view", "view_schema"]
+OWNER_PERMISSIONS = ["manage"]
+TOOL_COMPATIBLE_CONNECTION_TYPES = {"mcp", "custom_api"}
+
+
+# ---------------------------------------------------------------------------
+# Resolution result types
+# ---------------------------------------------------------------------------
+
+
+class _Resolved:
+    """Bag of resolved references — populated by ``ManifestResolver``."""
+
+    def __init__(self) -> None:
+        self.connections: Dict[str, Connection] = {}  # name -> Connection
+        self.groups: Dict[str, Group] = {}  # name -> Group
+        self.users: Dict[str, User] = {}  # email -> User
+        self.instructions: Dict[str, Instruction] = {}  # id -> Instruction
+        # (connection_name, tool_name) -> ConnectionTool
+        self.tools: Dict[Tuple[str, str], ConnectionTool] = {}
+
+
+# ---------------------------------------------------------------------------
+# Public service
+# ---------------------------------------------------------------------------
+
+
+class AgentYamlService:
+    """Service for applying / exporting agent YAML manifests."""
+
+    def __init__(self) -> None:
+        self._ds_service = DataSourceService()
+        self._instruction_service = InstructionService()
+
+    # ----- apply ----------------------------------------------------------
+
+    async def apply(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        yaml_text: str,
+        *,
+        dry_run: bool = False,
+    ) -> ApplyResult:
+        errors: List[ApplyError] = []
+        warnings: List[ApplyWarning] = []
+
+        # 1. Parse YAML
+        try:
+            raw = yaml.safe_load(yaml_text)
+        except yaml.YAMLError as e:
+            mark = getattr(e, "problem_mark", None)
+            loc: List[Any] = []
+            if mark is not None:
+                loc = [f"line {mark.line + 1}", f"col {mark.column + 1}"]
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                errors=[
+                    ApplyError(
+                        loc=loc,
+                        code=ApplyErrorCode.YAML_PARSE_ERROR,
+                        message=str(e),
+                    )
+                ],
+            )
+        if not isinstance(raw, dict):
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                errors=[
+                    ApplyError(
+                        loc=[],
+                        code=ApplyErrorCode.YAML_PARSE_ERROR,
+                        message="YAML must decode to a mapping (object).",
+                    )
+                ],
+            )
+
+        # 2. Pydantic validation — collect ALL errors before returning
+        try:
+            manifest = AgentManifest.model_validate(raw)
+        except ValidationError as ve:
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                errors=_pydantic_errors_to_apply_errors(ve),
+            )
+
+        # 3. Look up existing agent by (org, name)
+        existing = await self._find_existing(db, organization, manifest.name)
+
+        # 4. Permission gate
+        perm_errors = await self._check_permissions(
+            db, organization, current_user, manifest, existing
+        )
+        if perm_errors:
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                id=str(existing.id) if existing else None,
+                name=manifest.name,
+                errors=perm_errors,
+            )
+
+        # 5. Resolve refs — collect-all-errors
+        resolver = ManifestResolver(db, organization)
+        resolved, ref_errors = await resolver.resolve(manifest)
+        if ref_errors:
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                id=str(existing.id) if existing else None,
+                name=manifest.name,
+                errors=ref_errors,
+            )
+
+        # 6. License gate (per connection type)
+        license_errors = self._check_licenses(manifest, resolved)
+        if license_errors:
+            return ApplyResult(
+                status=ApplyStatus.ERROR,
+                id=str(existing.id) if existing else None,
+                name=manifest.name,
+                errors=license_errors,
+            )
+
+        # 7. Cross-field warnings (non-blocking)
+        warnings.extend(self._collect_table_warnings(manifest))
+
+        # 8. Dry-run short-circuit — no DB writes
+        if dry_run:
+            diff = await self._compute_diff(db, organization, manifest, resolved, existing)
+            return ApplyResult(
+                status=ApplyStatus.DRY_RUN,
+                id=str(existing.id) if existing else None,
+                name=manifest.name,
+                diff=diff,
+                warnings=warnings,
+            )
+
+        # 9. Create or update
+        if existing is None:
+            ds, post_warnings = await self._create_agent(
+                db, organization, current_user, manifest, resolved
+            )
+            warnings.extend(post_warnings)
+            return ApplyResult(
+                status=ApplyStatus.CREATED,
+                id=str(ds.id),
+                name=ds.name,
+                warnings=warnings,
+            )
+
+        ds, diff, post_warnings = await self._update_agent(
+            db, organization, current_user, manifest, resolved, existing
+        )
+        warnings.extend(post_warnings)
+        status = ApplyStatus.UNCHANGED if not diff else ApplyStatus.UPDATED
+        return ApplyResult(
+            status=status,
+            id=str(ds.id),
+            name=ds.name,
+            diff=diff if diff else None,
+            warnings=warnings,
+        )
+
+    # ----- export ---------------------------------------------------------
+
+    async def export(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        name: str,
+    ) -> str:
+        ds = await self._find_existing(db, organization, name)
+        if ds is None:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
+
+        manifest = await self._build_manifest_from_db(db, ds)
+        return yaml.safe_dump(
+            manifest.model_dump(exclude_none=True, exclude_defaults=False, mode="json"),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    async def list_agents(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+    ) -> List[Dict[str, Any]]:
+        items = await self._ds_service.get_data_sources(db, current_user, organization)
+        return [
+            {"name": i.name, "description": i.description, "id": i.id}
+            for i in items
+        ]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _find_existing(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        name: str,
+    ) -> Optional[DataSource]:
+        q = await db.execute(
+            select(DataSource)
+            .options(
+                selectinload(DataSource.connections),
+                selectinload(DataSource.data_source_memberships),
+                selectinload(DataSource.tables),
+                selectinload(DataSource.instructions),
+            )
+            .where(
+                DataSource.organization_id == organization.id,
+                DataSource.name == name,
+            )
+        )
+        return q.scalar_one_or_none()
+
+    async def _check_permissions(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        manifest: AgentManifest,
+        existing: Optional[DataSource],
+    ) -> List[ApplyError]:
+        resolved = await resolve_permissions(
+            db, str(current_user.id), str(organization.id)
+        )
+
+        if FULL_ADMIN in resolved.org_permissions:
+            return []
+
+        if existing is None:
+            # Create requires create_data_source on org
+            if not resolved.has_org_permission("create_data_source"):
+                return [
+                    ApplyError(
+                        loc=[],
+                        code=ApplyErrorCode.PERMISSION_DENIED,
+                        message="You do not have permission to create agents in this organization.",
+                    )
+                ]
+            return []
+
+        # Update requires manage on the resource
+        if not resolved.has_resource_permission(
+            "data_source", str(existing.id), "manage"
+        ):
+            return [
+                ApplyError(
+                    loc=[],
+                    code=ApplyErrorCode.PERMISSION_DENIED,
+                    message=f"You do not have permission to manage agent '{existing.name}'.",
+                    value=existing.name,
+                )
+            ]
+        return []
+
+    def _check_licenses(
+        self, manifest: AgentManifest, resolved: _Resolved
+    ) -> List[ApplyError]:
+        try:
+            from app.ee.license import is_datasource_allowed
+        except Exception:  # pragma: no cover - license module not present
+            return []
+        out: List[ApplyError] = []
+        for i, name in enumerate(manifest.connections):
+            conn = resolved.connections.get(name)
+            if conn and not is_datasource_allowed(conn.type):
+                out.append(
+                    ApplyError(
+                        loc=["connections", i],
+                        code=ApplyErrorCode.LICENSE_REQUIRED,
+                        message=(
+                            f"The {conn.type} connector requires an enterprise license."
+                        ),
+                        value=name,
+                    )
+                )
+        return out
+
+    def _collect_table_warnings(self, manifest: AgentManifest) -> List[ApplyWarning]:
+        warnings: List[ApplyWarning] = []
+        rules = manifest.tables
+        if rules is None:
+            return warnings
+        if rules.include is not None and not rules.include:
+            warnings.append(
+                ApplyWarning(
+                    loc=["tables", "include"],
+                    code=ApplyWarningCode.TABLES_FILTER_EMPTY,
+                    message="tables.include is empty — no tables will be active.",
+                )
+            )
+        return warnings
+
+    # ----- create ---------------------------------------------------------
+
+    async def _create_agent(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> Tuple[DataSource, List[ApplyWarning]]:
+        warnings: List[ApplyWarning] = []
+
+        connection_ids = [resolved.connections[name].id for name in manifest.connections]
+
+        # Build a minimal DataSourceCreate payload — Mode 2 (link existing
+        # connection(s)). All license / indexing / audit / telemetry hooks
+        # in DataSourceService.create_data_source run for us.
+        # Build user-only member ids for the legacy create path; group
+        # memberships and per-user permission overrides are applied as a
+        # follow-up step below.
+        user_member_ids = [
+            str(resolved.users[m.user].id)
+            for m in manifest.members
+            if m.user is not None
+        ]
+
+        payload = DataSourceCreate(
+            name=manifest.name,
+            connection_ids=connection_ids,
+            is_public=manifest.is_public,
+            use_llm_sync=manifest.use_llm_sync,
+            member_user_ids=user_member_ids,
+        )
+        # create_data_source raises HTTPException on duplicate name —
+        # we've already guarded that path, but let any other failure
+        # propagate; the route handler turns it into an ApplyResult.
+        ds_schema = await self._ds_service.create_data_source(
+            db, organization, current_user, payload
+        )
+
+        # Reload the ORM model with the relationships we'll mutate next.
+        ds = await self._find_existing(db, organization, manifest.name)
+        assert ds is not None
+
+        # Post-create patches that DataSourceCreate doesn't carry today.
+        await self._patch_textual_fields(db, ds, manifest)
+        await self._patch_conversation_starters(db, ds, manifest)
+        await self._patch_group_memberships(db, organization, ds, manifest, resolved)
+        await self._patch_member_permissions(db, organization, ds, manifest, resolved)
+        await self._patch_instructions(
+            db, organization, current_user, ds, manifest, resolved
+        )
+
+        # Table & tool reconciliation operates on the linked connections
+        # (which may still be indexing — warnings collected from there).
+        warnings.extend(
+            await self._apply_table_rules(db, ds, manifest.tables, resolved)
+        )
+        warnings.extend(
+            await self._apply_tool_rules(db, ds, manifest.tools, resolved)
+        )
+
+        await db.commit()
+        await db.refresh(ds)
+        return ds, warnings
+
+    # ----- update ---------------------------------------------------------
+
+    async def _update_agent(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+        ds: DataSource,
+    ) -> Tuple[DataSource, Dict[str, Any], List[ApplyWarning]]:
+        warnings: List[ApplyWarning] = []
+        diff: Dict[str, Any] = {}
+
+        # Scalar fields
+        for field, desired in (
+            ("description", manifest.description),
+            ("context", manifest.context),
+            ("is_public", manifest.is_public),
+            ("use_llm_sync", manifest.use_llm_sync),
+        ):
+            current = getattr(ds, field)
+            if current != desired:
+                diff[field] = {"from": current, "to": desired}
+                setattr(ds, field, desired)
+
+        if (ds.conversation_starters or []) != list(manifest.conversation_starters):
+            diff["conversation_starters"] = {
+                "from": ds.conversation_starters,
+                "to": list(manifest.conversation_starters),
+            }
+            ds.conversation_starters = list(manifest.conversation_starters)
+
+        db.add(ds)
+
+        # Connections (M:N)
+        current_conn_ids = {str(c.id) for c in (ds.connections or [])}
+        desired_conn_ids = {
+            str(resolved.connections[name].id) for name in manifest.connections
+        }
+        to_link = desired_conn_ids - current_conn_ids
+        to_unlink = current_conn_ids - desired_conn_ids
+        if to_link or to_unlink:
+            ds.connections = [
+                resolved.connections[name] for name in manifest.connections
+            ]
+            diff["connections"] = {
+                "linked": [
+                    name for name in manifest.connections
+                    if str(resolved.connections[name].id) in to_link
+                ],
+                "unlinked": [
+                    str(cid) for cid in to_unlink
+                ],
+            }
+            db.add(ds)
+
+        # Members (users + groups)
+        member_diff = await self._reconcile_members(
+            db, organization, ds, manifest, resolved
+        )
+        if member_diff:
+            diff["members"] = member_diff
+
+        # Instructions
+        instr_diff = await self._reconcile_instructions(
+            db, organization, current_user, ds, manifest, resolved
+        )
+        if instr_diff:
+            diff["instructions"] = instr_diff
+
+        # Tables
+        tw = await self._apply_table_rules(db, ds, manifest.tables, resolved)
+        warnings.extend(tw)
+
+        # Tools
+        tools_diff, tool_warnings = await self._apply_tool_rules_with_diff(
+            db, ds, manifest.tools, resolved
+        )
+        warnings.extend(tool_warnings)
+        if tools_diff:
+            diff["tools"] = tools_diff
+
+        await db.commit()
+        await db.refresh(ds)
+        return ds, diff, warnings
+
+    # ----- field patches --------------------------------------------------
+
+    async def _patch_textual_fields(
+        self, db: AsyncSession, ds: DataSource, manifest: AgentManifest
+    ) -> None:
+        if manifest.description is not None:
+            ds.description = manifest.description
+        if manifest.context is not None:
+            ds.context = manifest.context
+        db.add(ds)
+
+    async def _patch_conversation_starters(
+        self, db: AsyncSession, ds: DataSource, manifest: AgentManifest
+    ) -> None:
+        ds.conversation_starters = list(manifest.conversation_starters) or None
+        db.add(ds)
+
+    # ----- members --------------------------------------------------------
+
+    async def _patch_group_memberships(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        ds: DataSource,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> None:
+        """Write group memberships on create. User memberships are handled
+        by ``DataSourceService._create_memberships`` already (legacy path)."""
+        for m in manifest.members:
+            if m.group is None:
+                continue
+            group = resolved.groups[m.group]
+            db.add(
+                DataSourceMembership(
+                    data_source_id=ds.id,
+                    principal_type=PRINCIPAL_TYPE_GROUP,
+                    principal_id=str(group.id),
+                )
+            )
+            db.add(
+                ResourceGrant(
+                    organization_id=str(organization.id),
+                    resource_type="data_source",
+                    resource_id=str(ds.id),
+                    principal_type=PRINCIPAL_TYPE_GROUP,
+                    principal_id=str(group.id),
+                    permissions=list(m.permissions or DEFAULT_MEMBER_PERMISSIONS),
+                )
+            )
+
+    async def _patch_member_permissions(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        ds: DataSource,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> None:
+        """Apply explicit per-user permission overrides from YAML to the
+        ``resource_grants`` rows that ``_create_memberships`` just wrote
+        with the default ``[view, view_schema]``."""
+        for m in manifest.members:
+            if m.user is None or not m.permissions:
+                continue
+            user = resolved.users[m.user]
+            existing = await db.execute(
+                select(ResourceGrant).where(
+                    ResourceGrant.resource_type == "data_source",
+                    ResourceGrant.resource_id == str(ds.id),
+                    ResourceGrant.principal_type == PRINCIPAL_TYPE_USER,
+                    ResourceGrant.principal_id == str(user.id),
+                    ResourceGrant.deleted_at.is_(None),
+                )
+            )
+            grant = existing.scalar_one_or_none()
+            if grant is not None:
+                grant.permissions = list(m.permissions)
+                db.add(grant)
+
+    async def _reconcile_members(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        ds: DataSource,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> Dict[str, Any]:
+        """Sync memberships + grants to match ``manifest.members`` exactly."""
+        desired: List[Tuple[str, str, List[str]]] = []  # (type, id, perms)
+        for m in manifest.members:
+            if m.user is not None:
+                desired.append(
+                    (
+                        PRINCIPAL_TYPE_USER,
+                        str(resolved.users[m.user].id),
+                        list(m.permissions or DEFAULT_MEMBER_PERMISSIONS),
+                    )
+                )
+            else:
+                desired.append(
+                    (
+                        PRINCIPAL_TYPE_GROUP,
+                        str(resolved.groups[m.group].id),
+                        list(m.permissions or DEFAULT_MEMBER_PERMISSIONS),
+                    )
+                )
+
+        # Always preserve the owner row regardless of YAML contents
+        owner_id = str(ds.owner_user_id) if ds.owner_user_id else None
+
+        existing_q = await db.execute(
+            select(DataSourceMembership).where(
+                DataSourceMembership.data_source_id == ds.id
+            )
+        )
+        existing = existing_q.scalars().all()
+        existing_keys = {(e.principal_type, e.principal_id) for e in existing}
+        desired_keys = {(t, i) for (t, i, _) in desired}
+
+        added: List[Dict[str, Any]] = []
+        removed: List[Dict[str, Any]] = []
+
+        # Add new memberships + grants
+        for ptype, pid, perms in desired:
+            if (ptype, pid) in existing_keys:
+                # Update grant permissions if changed
+                gres = await db.execute(
+                    select(ResourceGrant).where(
+                        ResourceGrant.resource_type == "data_source",
+                        ResourceGrant.resource_id == str(ds.id),
+                        ResourceGrant.principal_type == ptype,
+                        ResourceGrant.principal_id == pid,
+                        ResourceGrant.deleted_at.is_(None),
+                    )
+                )
+                grant = gres.scalar_one_or_none()
+                if grant and list(grant.permissions or []) != perms:
+                    grant.permissions = perms
+                    db.add(grant)
+                continue
+            db.add(
+                DataSourceMembership(
+                    data_source_id=ds.id,
+                    principal_type=ptype,
+                    principal_id=pid,
+                )
+            )
+            db.add(
+                ResourceGrant(
+                    organization_id=str(organization.id),
+                    resource_type="data_source",
+                    resource_id=str(ds.id),
+                    principal_type=ptype,
+                    principal_id=pid,
+                    permissions=perms,
+                )
+            )
+            added.append({"principal_type": ptype, "principal_id": pid})
+
+        # Remove memberships not in desired (except the owner)
+        for e in existing:
+            if (e.principal_type, e.principal_id) in desired_keys:
+                continue
+            if e.principal_type == PRINCIPAL_TYPE_USER and e.principal_id == owner_id:
+                continue
+            await db.delete(e)
+            # Also drop the grant
+            gres = await db.execute(
+                select(ResourceGrant).where(
+                    ResourceGrant.resource_type == "data_source",
+                    ResourceGrant.resource_id == str(ds.id),
+                    ResourceGrant.principal_type == e.principal_type,
+                    ResourceGrant.principal_id == e.principal_id,
+                    ResourceGrant.deleted_at.is_(None),
+                )
+            )
+            grant = gres.scalar_one_or_none()
+            if grant is not None:
+                await db.delete(grant)
+            removed.append(
+                {"principal_type": e.principal_type, "principal_id": e.principal_id}
+            )
+
+        out: Dict[str, Any] = {}
+        if added:
+            out["added"] = added
+        if removed:
+            out["removed"] = removed
+        return out
+
+    # ----- instructions ---------------------------------------------------
+
+    async def _patch_instructions(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        ds: DataSource,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> None:
+        """Create inline + attach by-id instructions on agent creation."""
+        for ref in manifest.instructions:
+            if ref.id is not None:
+                await self._attach_instruction(db, ds, resolved.instructions[ref.id])
+            else:
+                inline = ref.inline
+                assert inline is not None
+                payload = InstructionCreate(
+                    text=inline.text,
+                    title=inline.title,
+                    category=inline.category.value if hasattr(inline.category, "value") else str(inline.category),
+                    load_mode=inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode),
+                    ai_source="yaml",
+                    source_type="user",
+                    data_source_ids=[str(ds.id)],
+                    status="published",
+                )
+                await self._instruction_service.create_instruction(
+                    db=db,
+                    instruction_data=payload,
+                    current_user=current_user,
+                    organization=organization,
+                    force_global=True,
+                    auto_finalize=True,
+                )
+
+    async def _attach_instruction(
+        self, db: AsyncSession, ds: DataSource, instruction: Instruction
+    ) -> None:
+        # Idempotent attach (skip if already present)
+        existing = await db.execute(
+            select(instruction_data_source_association).where(
+                instruction_data_source_association.c.instruction_id == instruction.id,
+                instruction_data_source_association.c.data_source_id == ds.id,
+            )
+        )
+        if existing.first() is not None:
+            return
+        await db.execute(
+            instruction_data_source_association.insert().values(
+                instruction_id=instruction.id, data_source_id=ds.id
+            )
+        )
+
+    async def _reconcile_instructions(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        ds: DataSource,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+    ) -> Dict[str, Any]:
+        """Attach by-id refs, create inline ones (matched by title), and
+        detach any instruction that was previously attached via YAML but is
+        no longer in the manifest. Manually-attached instructions (those
+        not created with ``ai_source='yaml'``) are left alone."""
+
+        # Current attached instructions
+        current_q = await db.execute(
+            select(Instruction)
+            .join(
+                instruction_data_source_association,
+                instruction_data_source_association.c.instruction_id == Instruction.id,
+            )
+            .where(
+                instruction_data_source_association.c.data_source_id == ds.id
+            )
+        )
+        current = list(current_q.scalars().all())
+        current_yaml = {i.title: i for i in current if i.ai_source == "yaml" and i.title}
+
+        desired_ids: set[str] = set()
+        desired_titles: set[str] = set()
+        added: List[str] = []
+        for ref in manifest.instructions:
+            if ref.id is not None:
+                desired_ids.add(ref.id)
+                instr = resolved.instructions[ref.id]
+                await self._attach_instruction(db, ds, instr)
+                added.append(instr.title or instr.id)
+                continue
+            inline = ref.inline
+            assert inline is not None
+            existing = current_yaml.get(inline.title)
+            if existing is not None:
+                # Update existing inline instruction if content changed
+                changed = False
+                if existing.text != inline.text:
+                    existing.text = inline.text
+                    changed = True
+                cat_val = inline.category.value if hasattr(inline.category, "value") else str(inline.category)
+                if existing.category != cat_val:
+                    existing.category = cat_val
+                    changed = True
+                lm_val = inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode)
+                if existing.load_mode != lm_val:
+                    existing.load_mode = lm_val
+                    changed = True
+                if changed:
+                    db.add(existing)
+                    added.append(f"updated:{inline.title}")
+                desired_titles.add(inline.title)
+            else:
+                payload = InstructionCreate(
+                    text=inline.text,
+                    title=inline.title,
+                    category=inline.category.value if hasattr(inline.category, "value") else str(inline.category),
+                    load_mode=inline.load_mode.value if hasattr(inline.load_mode, "value") else str(inline.load_mode),
+                    ai_source="yaml",
+                    source_type="user",
+                    data_source_ids=[str(ds.id)],
+                    status="published",
+                )
+                await self._instruction_service.create_instruction(
+                    db=db,
+                    instruction_data=payload,
+                    current_user=current_user,
+                    organization=organization,
+                    force_global=True,
+                    auto_finalize=True,
+                )
+                desired_titles.add(inline.title)
+                added.append(f"created:{inline.title}")
+
+        # Detach yaml-owned instructions removed from manifest
+        removed: List[str] = []
+        for title, instr in current_yaml.items():
+            if title in desired_titles:
+                continue
+            await db.execute(
+                instruction_data_source_association.delete().where(
+                    instruction_data_source_association.c.instruction_id == instr.id,
+                    instruction_data_source_association.c.data_source_id == ds.id,
+                )
+            )
+            removed.append(title)
+
+        out: Dict[str, Any] = {}
+        if added:
+            out["added"] = added
+        if removed:
+            out["removed"] = removed
+        return out
+
+    # ----- tables ---------------------------------------------------------
+
+    async def _apply_table_rules(
+        self,
+        db: AsyncSession,
+        ds: DataSource,
+        rules: Optional[TableRules],
+        resolved: _Resolved,
+    ) -> List[ApplyWarning]:
+        """Resolve include/exclude globs against ConnectionTable rows for
+        the linked connections, then upsert ``DataSourceTable`` with the
+        right ``is_active`` flag."""
+        warnings: List[ApplyWarning] = []
+        if not ds.connections:
+            return warnings
+
+        include_globs = (rules.include if rules and rules.include is not None else ["*"])
+        exclude_globs = (rules.exclude if rules else [])
+
+        for conn in ds.connections:
+            # Fetch ConnectionTable rows
+            ct_q = await db.execute(
+                select(ConnectionTable).where(ConnectionTable.connection_id == str(conn.id))
+            )
+            conn_tables = list(ct_q.scalars().all())
+            if not conn_tables:
+                # Probably still indexing — surface as a warning so the
+                # caller knows the filter will apply on the next apply.
+                warnings.append(
+                    ApplyWarning(
+                        loc=["tables"],
+                        code=ApplyWarningCode.CONNECTION_INDEXING_PENDING,
+                        message=(
+                            f"Connection '{conn.name}' has no indexed tables yet; "
+                            "re-apply once indexing completes."
+                        ),
+                    )
+                )
+                continue
+
+            # First make sure DataSourceTable rows exist for every ConnectionTable
+            await self._ds_service.sync_domain_tables_from_connection(
+                db, ds, conn, max_auto_select=None
+            )
+
+            # Flip is_active per glob match
+            dst_q = await db.execute(
+                select(DataSourceTable)
+                .where(DataSourceTable.datasource_id == ds.id)
+                .where(DataSourceTable.connection_table_id.in_([t.id for t in conn_tables]))
+            )
+            domain_tables = list(dst_q.scalars().all())
+            ct_by_id = {t.id: t for t in conn_tables}
+            for dt in domain_tables:
+                ct = ct_by_id.get(dt.connection_table_id)
+                if ct is None:
+                    continue
+                fqn = _table_fqn(conn.name, ct)
+                matches_include = any(_glob_match(g, fqn) for g in include_globs)
+                matches_exclude = any(_glob_match(g, fqn) for g in exclude_globs)
+                desired_active = matches_include and not matches_exclude
+                if dt.is_active != desired_active:
+                    dt.is_active = desired_active
+                    db.add(dt)
+
+        return warnings
+
+    # ----- tools ----------------------------------------------------------
+
+    async def _apply_tool_rules(
+        self,
+        db: AsyncSession,
+        ds: DataSource,
+        tools: Dict[str, ToolsOverlay],
+        resolved: _Resolved,
+    ) -> List[ApplyWarning]:
+        _, warnings = await self._apply_tool_rules_with_diff(db, ds, tools, resolved)
+        return warnings
+
+    async def _apply_tool_rules_with_diff(
+        self,
+        db: AsyncSession,
+        ds: DataSource,
+        tools: Dict[str, ToolsOverlay],
+        resolved: _Resolved,
+    ) -> Tuple[Dict[str, Any], List[ApplyWarning]]:
+        """Upsert ``data_source_connection_tool`` overlay rows. Tools listed
+        in ``deny`` get ``is_enabled=False``; ``confirm`` and ``allow`` set
+        the policy. Tools not mentioned get no overlay row (inherit
+        ``ConnectionTool`` defaults)."""
+        warnings: List[ApplyWarning] = []
+        diff: Dict[str, Any] = {}
+
+        # Gather all overlay rows for this DS up front
+        existing_q = await db.execute(
+            select(DataSourceConnectionTool).where(
+                DataSourceConnectionTool.data_source_id == ds.id
+            )
+        )
+        existing = {row.connection_tool_id: row for row in existing_q.scalars().all()}
+        desired: Dict[str, Tuple[bool, str]] = {}  # connection_tool_id -> (is_enabled, policy)
+
+        for conn_name, overlay in tools.items():
+            conn = resolved.connections.get(conn_name)
+            if conn is None:
+                continue
+            if conn.type not in TOOL_COMPATIBLE_CONNECTION_TYPES:
+                # Already caught by resolver; defensive skip
+                continue
+
+            ct_q = await db.execute(
+                select(ConnectionTool).where(ConnectionTool.connection_id == str(conn.id))
+            )
+            conn_tools = list(ct_q.scalars().all())
+            tool_by_name = {t.name: t for t in conn_tools}
+
+            for tool in conn_tools:
+                if any(_glob_match(g, tool.name) for g in overlay.deny):
+                    desired[str(tool.id)] = (False, "deny")
+                elif any(_glob_match(g, tool.name) for g in overlay.confirm):
+                    desired[str(tool.id)] = (True, "confirm")
+                elif any(_glob_match(g, tool.name) for g in overlay.allow):
+                    desired[str(tool.id)] = (True, "allow")
+
+        # Upsert
+        for tool_id, (is_enabled, policy) in desired.items():
+            row = existing.get(tool_id)
+            if row is None:
+                db.add(
+                    DataSourceConnectionTool(
+                        data_source_id=str(ds.id),
+                        connection_tool_id=tool_id,
+                        is_enabled=is_enabled,
+                        policy=policy,
+                    )
+                )
+                diff.setdefault("set", []).append(
+                    {"connection_tool_id": tool_id, "is_enabled": is_enabled, "policy": policy}
+                )
+            elif row.is_enabled != is_enabled or row.policy != policy:
+                row.is_enabled = is_enabled
+                row.policy = policy
+                db.add(row)
+                diff.setdefault("set", []).append(
+                    {"connection_tool_id": tool_id, "is_enabled": is_enabled, "policy": policy}
+                )
+
+        # Remove overlays no longer in desired
+        for tool_id, row in existing.items():
+            if tool_id in desired:
+                continue
+            await db.delete(row)
+            diff.setdefault("reset", []).append(tool_id)
+
+        return diff, warnings
+
+    # ----- diff (dry-run) -------------------------------------------------
+
+    async def _compute_diff(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        manifest: AgentManifest,
+        resolved: _Resolved,
+        existing: Optional[DataSource],
+    ) -> Dict[str, Any]:
+        if existing is None:
+            return {
+                "action": "create",
+                "connections": list(manifest.connections),
+                "members": [m.model_dump(exclude_none=True) for m in manifest.members],
+                "instructions": len(manifest.instructions),
+                "conversation_starters": list(manifest.conversation_starters),
+            }
+        diff: Dict[str, Any] = {"action": "update"}
+        if existing.description != manifest.description:
+            diff["description"] = {"from": existing.description, "to": manifest.description}
+        if existing.context != manifest.context:
+            diff["context"] = {"from": existing.context, "to": manifest.context}
+        if existing.is_public != manifest.is_public:
+            diff["is_public"] = {"from": existing.is_public, "to": manifest.is_public}
+        if existing.use_llm_sync != manifest.use_llm_sync:
+            diff["use_llm_sync"] = {"from": existing.use_llm_sync, "to": manifest.use_llm_sync}
+        current_conns = sorted(c.name for c in (existing.connections or []))
+        desired_conns = sorted(manifest.connections)
+        if current_conns != desired_conns:
+            diff["connections"] = {"from": current_conns, "to": desired_conns}
+        if (existing.conversation_starters or []) != list(manifest.conversation_starters):
+            diff["conversation_starters"] = {
+                "from": existing.conversation_starters or [],
+                "to": list(manifest.conversation_starters),
+            }
+        return diff
+
+    # ----- export helper --------------------------------------------------
+
+    async def _build_manifest_from_db(
+        self, db: AsyncSession, ds: DataSource
+    ) -> AgentManifest:
+        # Connections
+        connections = [c.name for c in (ds.connections or [])]
+
+        # Members
+        members: List[MemberRef] = []
+        m_q = await db.execute(
+            select(DataSourceMembership).where(
+                DataSourceMembership.data_source_id == ds.id
+            )
+        )
+        memberships = list(m_q.scalars().all())
+        # Build a grants lookup once
+        g_q = await db.execute(
+            select(ResourceGrant).where(
+                ResourceGrant.resource_type == "data_source",
+                ResourceGrant.resource_id == str(ds.id),
+                ResourceGrant.deleted_at.is_(None),
+            )
+        )
+        grants = {(g.principal_type, g.principal_id): list(g.permissions or []) for g in g_q.scalars().all()}
+
+        owner_id = str(ds.owner_user_id) if ds.owner_user_id else None
+        for m in memberships:
+            # Skip the implicit owner row from the YAML (it's always present
+            # and re-added automatically on create).
+            if m.principal_type == PRINCIPAL_TYPE_USER and m.principal_id == owner_id:
+                continue
+            perms = grants.get((m.principal_type, m.principal_id))
+            if m.principal_type == PRINCIPAL_TYPE_USER:
+                u_q = await db.execute(select(User).where(User.id == m.principal_id))
+                user = u_q.scalar_one_or_none()
+                if user is None:
+                    continue
+                members.append(
+                    MemberRef(
+                        user=user.email,
+                        permissions=perms if perms and perms != DEFAULT_MEMBER_PERMISSIONS else None,
+                    )
+                )
+            else:
+                g_obj_q = await db.execute(select(Group).where(Group.id == m.principal_id))
+                grp = g_obj_q.scalar_one_or_none()
+                if grp is None:
+                    continue
+                members.append(
+                    MemberRef(
+                        group=grp.name,
+                        permissions=perms if perms and perms != DEFAULT_MEMBER_PERMISSIONS else None,
+                    )
+                )
+
+        # Conversation starters
+        starters = list(ds.conversation_starters or [])
+
+        # Instructions (only those previously created via YAML are
+        # round-trippable as 'inline'; manually attached ones come back as
+        # id refs).
+        instr_q = await db.execute(
+            select(Instruction)
+            .join(
+                instruction_data_source_association,
+                instruction_data_source_association.c.instruction_id == Instruction.id,
+            )
+            .where(
+                instruction_data_source_association.c.data_source_id == ds.id,
+                Instruction.deleted_at.is_(None),
+            )
+        )
+        instructions: List[InstructionRef] = []
+        for instr in instr_q.scalars().all():
+            from app.schemas.agent_manifest_schema import InstructionInline
+            from app.schemas.instruction_schema import (
+                InstructionCategory as _IC,
+                InstructionLoadMode as _ILM,
+            )
+
+            if instr.ai_source == "yaml" and instr.title:
+                try:
+                    cat = _IC(instr.category or "general")
+                except Exception:
+                    cat = _IC.GENERAL
+                try:
+                    lm = _ILM(instr.load_mode or "always")
+                except Exception:
+                    lm = _ILM.ALWAYS
+                instructions.append(
+                    InstructionRef(
+                        inline=InstructionInline(
+                            title=instr.title,
+                            text=instr.text,
+                            category=cat,
+                            load_mode=lm,
+                        )
+                    )
+                )
+            else:
+                instructions.append(InstructionRef(id=str(instr.id)))
+
+        # Tables — reverse-engineer include/exclude from is_active flags.
+        # We emit an exact list of active FQNs as ``include`` and leave
+        # ``exclude`` empty. Re-applying yields the same state.
+        rules: Optional[TableRules] = None
+        if ds.connections:
+            include_list: List[str] = []
+            for conn in ds.connections:
+                ct_q = await db.execute(
+                    select(ConnectionTable).where(ConnectionTable.connection_id == str(conn.id))
+                )
+                ct_by_id = {ct.id: ct for ct in ct_q.scalars().all()}
+                dt_q = await db.execute(
+                    select(DataSourceTable)
+                    .where(DataSourceTable.datasource_id == ds.id)
+                    .where(DataSourceTable.is_active == True)  # noqa: E712
+                    .where(DataSourceTable.connection_table_id.in_(list(ct_by_id.keys())))
+                )
+                for dt in dt_q.scalars().all():
+                    ct = ct_by_id.get(dt.connection_table_id)
+                    if ct is None:
+                        continue
+                    include_list.append(_table_fqn(conn.name, ct))
+            if include_list:
+                rules = TableRules(include=sorted(set(include_list)), exclude=[])
+
+        # Tools overlay → ToolsOverlay by connection name
+        tools: Dict[str, ToolsOverlay] = {}
+        if ds.connections:
+            ov_q = await db.execute(
+                select(DataSourceConnectionTool, ConnectionTool, Connection)
+                .join(ConnectionTool, ConnectionTool.id == DataSourceConnectionTool.connection_tool_id)
+                .join(Connection, Connection.id == ConnectionTool.connection_id)
+                .where(DataSourceConnectionTool.data_source_id == ds.id)
+            )
+            for overlay, ctool, conn in ov_q.all():
+                bucket = tools.setdefault(conn.name, ToolsOverlay())
+                if not overlay.is_enabled or overlay.policy == "deny":
+                    bucket.deny.append(ctool.name)
+                elif overlay.policy == "confirm":
+                    bucket.confirm.append(ctool.name)
+                else:
+                    bucket.allow.append(ctool.name)
+
+        return AgentManifest(
+            name=ds.name,
+            description=ds.description,
+            context=ds.context,
+            is_public=bool(ds.is_public),
+            use_llm_sync=bool(ds.use_llm_sync),
+            connections=connections,
+            tables=rules,
+            tools=tools,
+            instructions=instructions,
+            conversation_starters=starters,
+            members=members,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest resolver — refs to DB rows
+# ---------------------------------------------------------------------------
+
+
+class ManifestResolver:
+    """Batches lookups for connections, groups, users, instructions, tools.
+
+    Returns ``(resolved, errors)``. Always processes every ref so the caller
+    can show *all* fixable problems in one round-trip.
+    """
+
+    def __init__(self, db: AsyncSession, organization: Organization) -> None:
+        self.db = db
+        self.org = organization
+
+    async def resolve(
+        self, manifest: AgentManifest
+    ) -> Tuple[_Resolved, List[ApplyError]]:
+        resolved = _Resolved()
+        errors: List[ApplyError] = []
+
+        await self._resolve_connections(manifest, resolved, errors)
+        await self._resolve_groups(manifest, resolved, errors)
+        await self._resolve_users(manifest, resolved, errors)
+        await self._resolve_instructions(manifest, resolved, errors)
+        await self._resolve_tools(manifest, resolved, errors)
+
+        return resolved, errors
+
+    async def _resolve_connections(
+        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
+    ) -> None:
+        if not manifest.connections:
+            return
+        q = await self.db.execute(
+            select(Connection).where(
+                Connection.organization_id == str(self.org.id),
+                Connection.name.in_(manifest.connections),
+                Connection.deleted_at.is_(None),
+            )
+        )
+        by_name = {c.name: c for c in q.scalars().all()}
+        # Fetch all org connection names once for did-you-mean.
+        all_q = await self.db.execute(
+            select(Connection.name).where(
+                Connection.organization_id == str(self.org.id),
+                Connection.deleted_at.is_(None),
+            )
+        )
+        all_names = [r[0] for r in all_q.all()]
+        for i, name in enumerate(manifest.connections):
+            conn = by_name.get(name)
+            if conn is None:
+                errors.append(
+                    ApplyError(
+                        loc=["connections", i],
+                        code=ApplyErrorCode.CONNECTION_NOT_FOUND,
+                        message=f"Connection '{name}' not found in this organization.",
+                        value=name,
+                        suggestion=_suggest(name, all_names),
+                    )
+                )
+                continue
+            resolved.connections[name] = conn
+
+    async def _resolve_groups(
+        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
+    ) -> None:
+        group_refs = [(i, m.group) for i, m in enumerate(manifest.members) if m.group]
+        if not group_refs:
+            return
+        names = list({n for _, n in group_refs})
+        q = await self.db.execute(
+            select(Group).where(
+                Group.organization_id == str(self.org.id),
+                Group.name.in_(names),
+                Group.deleted_at.is_(None),
+            )
+        )
+        by_name = {g.name: g for g in q.scalars().all()}
+        all_q = await self.db.execute(
+            select(Group.name).where(
+                Group.organization_id == str(self.org.id),
+                Group.deleted_at.is_(None),
+            )
+        )
+        all_names = [r[0] for r in all_q.all()]
+        for idx, name in group_refs:
+            grp = by_name.get(name)
+            if grp is None:
+                errors.append(
+                    ApplyError(
+                        loc=["members", idx, "group"],
+                        code=ApplyErrorCode.GROUP_NOT_FOUND,
+                        message=f"Group '{name}' not found in this organization.",
+                        value=name,
+                        suggestion=_suggest(name, all_names),
+                    )
+                )
+                continue
+            resolved.groups[name] = grp
+
+    async def _resolve_users(
+        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
+    ) -> None:
+        user_refs = [(i, m.user) for i, m in enumerate(manifest.members) if m.user]
+        if not user_refs:
+            return
+        emails = list({e for _, e in user_refs})
+        # Org-scoped lookup via memberships
+        from app.models.membership import Membership
+
+        q = await self.db.execute(
+            select(User)
+            .join(Membership, Membership.user_id == User.id)
+            .where(
+                Membership.organization_id == str(self.org.id),
+                User.email.in_(emails),
+            )
+        )
+        by_email = {u.email: u for u in q.scalars().all()}
+        all_q = await self.db.execute(
+            select(User.email)
+            .join(Membership, Membership.user_id == User.id)
+            .where(Membership.organization_id == str(self.org.id))
+        )
+        all_emails = [r[0] for r in all_q.all() if r[0]]
+        for idx, email in user_refs:
+            u = by_email.get(email)
+            if u is None:
+                errors.append(
+                    ApplyError(
+                        loc=["members", idx, "user"],
+                        code=ApplyErrorCode.USER_NOT_FOUND,
+                        message=f"No user '{email}' in this organization.",
+                        value=email,
+                        suggestion=_suggest(email, all_emails),
+                    )
+                )
+                continue
+            resolved.users[email] = u
+
+    async def _resolve_instructions(
+        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
+    ) -> None:
+        id_refs = [(i, r.id) for i, r in enumerate(manifest.instructions) if r.id]
+        if not id_refs:
+            return
+        ids = list({i for _, i in id_refs})
+        q = await self.db.execute(
+            select(Instruction).where(
+                Instruction.id.in_(ids),
+                Instruction.deleted_at.is_(None),
+            )
+        )
+        by_id: Dict[str, Instruction] = {}
+        for instr in q.scalars().all():
+            # Org scope check: an instruction's org is derived from its user.
+            # For simplicity we just check the user's primary org via the
+            # user model; if the model doesn't carry that, we skip the check
+            # and rely on the FK to data sources to keep cross-org refs out.
+            by_id[str(instr.id)] = instr
+        for idx, iid in id_refs:
+            instr = by_id.get(iid)
+            if instr is None:
+                errors.append(
+                    ApplyError(
+                        loc=["instructions", idx, "id"],
+                        code=ApplyErrorCode.INSTRUCTION_NOT_FOUND,
+                        message=f"Instruction '{iid}' not found.",
+                        value=iid,
+                    )
+                )
+                continue
+            resolved.instructions[iid] = instr
+
+    async def _resolve_tools(
+        self, manifest: AgentManifest, resolved: _Resolved, errors: List[ApplyError]
+    ) -> None:
+        if not manifest.tools:
+            return
+        for conn_name, overlay in manifest.tools.items():
+            # Cross-field: conn_name must be in manifest.connections (already
+            # in resolved.connections if it existed).
+            conn = resolved.connections.get(conn_name)
+            if conn is None:
+                # Either not in connections list or didn't resolve. Don't
+                # re-report the not-found case; flag the cross-field
+                # mismatch with a clear message.
+                if conn_name not in manifest.connections:
+                    errors.append(
+                        ApplyError(
+                            loc=["tools", conn_name],
+                            code=ApplyErrorCode.CONNECTION_NOT_FOUND,
+                            message=(
+                                f"Connection '{conn_name}' in tools: must also "
+                                "appear in connections:."
+                            ),
+                            value=conn_name,
+                            suggestion=_suggest(conn_name, manifest.connections),
+                        )
+                    )
+                continue
+            if conn.type not in TOOL_COMPATIBLE_CONNECTION_TYPES:
+                errors.append(
+                    ApplyError(
+                        loc=["tools", conn_name],
+                        code=ApplyErrorCode.CONNECTION_TYPE_MISMATCH,
+                        message=(
+                            f"Tools can only be configured on MCP or custom_api "
+                            f"connections; '{conn_name}' is of type '{conn.type}'."
+                        ),
+                        value=conn_name,
+                    )
+                )
+                continue
+
+            # Fetch tools for this connection
+            t_q = await self.db.execute(
+                select(ConnectionTool).where(
+                    ConnectionTool.connection_id == str(conn.id)
+                )
+            )
+            tools = list(t_q.scalars().all())
+            tool_names = [t.name for t in tools]
+            for bucket_name in ("allow", "confirm", "deny"):
+                bucket = getattr(overlay, bucket_name)
+                for j, name in enumerate(bucket):
+                    if name == "*" or "*" in name:
+                        continue  # glob — no resolution needed
+                    if name in tool_names:
+                        resolved.tools[(conn_name, name)] = next(
+                            t for t in tools if t.name == name
+                        )
+                    else:
+                        errors.append(
+                            ApplyError(
+                                loc=["tools", conn_name, bucket_name, j],
+                                code=ApplyErrorCode.TOOL_NOT_FOUND,
+                                message=(
+                                    f"Tool '{name}' not found on connection "
+                                    f"'{conn_name}'."
+                                ),
+                                value=name,
+                                suggestion=_suggest(name, tool_names),
+                            )
+                        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pydantic_errors_to_apply_errors(ve: ValidationError) -> List[ApplyError]:
+    out: List[ApplyError] = []
+    for err in ve.errors():
+        loc = list(err.get("loc", []))
+        msg = err.get("msg", "validation error")
+        kind = err.get("type", "")
+        if "enum" in kind:
+            code = ApplyErrorCode.ENUM_INVALID
+        else:
+            code = ApplyErrorCode.SCHEMA_INVALID
+        out.append(ApplyError(loc=loc, code=code, message=msg))
+    return out
+
+
+def _suggest(value: str, candidates: Sequence[str]) -> Optional[str]:
+    if not value or not candidates:
+        return None
+    # Case-insensitive: match in lower-space, then return the original.
+    cands = [c for c in candidates if c]
+    lookup = {c.lower(): c for c in cands}
+    matches = difflib.get_close_matches(value.lower(), list(lookup.keys()), n=1, cutoff=0.5)
+    return lookup[matches[0]] if matches else None
+
+
+def _table_fqn(conn_name: str, ct: ConnectionTable) -> str:
+    """Build the canonical name used to match glob patterns:
+    ``{connection}.{schema or db}.{table}``.
+
+    ``ConnectionTable.name`` may already contain a schema prefix; we use
+    ``metadata_json['schema']`` when available, falling back to the table
+    name with a synthesized middle segment if not.
+    """
+    schema = None
+    if ct.metadata_json and isinstance(ct.metadata_json, dict):
+        schema = ct.metadata_json.get("schema") or ct.metadata_json.get("dataset")
+    if schema:
+        return f"{conn_name}.{schema}.{ct.name}"
+    # Some connectors already store ``schema.table`` in name
+    if "." in ct.name:
+        return f"{conn_name}.{ct.name}"
+    return f"{conn_name}.{ct.name}"
+
+
+def _glob_match(pattern: str, value: str) -> bool:
+    """Case-insensitive ``fnmatch`` against ``{a}.{b}.{c}`` triples."""
+    return fnmatch.fnmatchcase(value.lower(), pattern.lower())

--- a/backend/main.py
+++ b/backend/main.py
@@ -91,6 +91,9 @@ from app.routes import (
     usage_limits,
     scheduled_prompt,
     excel,
+    agent_yaml,
+    eval_yaml,
+    data_source_tools,
 )
 from app.routes.oidc_auth import router as oidc_auth_router
 from app.ee.routes import router as enterprise_router
@@ -247,6 +250,9 @@ app.include_router(mcp.router, prefix="/api")
 app.include_router(oauth_server.well_known_router)  # /.well-known/* at root
 app.include_router(oauth_server.router, prefix="/api")  # /api/oauth/*
 app.include_router(connection.router, prefix="/api")
+app.include_router(data_source_tools.router, prefix="/api")
+app.include_router(agent_yaml.router, prefix="/api")
+app.include_router(eval_yaml.router, prefix="/api")
 app.include_router(connection_oauth.router, prefix="/api")
 app.include_router(artifact.router, prefix="/api")
 app.include_router(excel.router, prefix="/api")

--- a/backend/scripts/random_agent_eval.py
+++ b/backend/scripts/random_agent_eval.py
@@ -1,0 +1,328 @@
+"""Random-agent sandbox harness.
+
+Generates N random agent manifests against the chinook demo, applies
+them via the live API, then generates matching eval YAMLs and runs them.
+This is *not* a pytest test — it's an exploration tool for stressing the
+YAML apply path and surfacing which agent-shaping primitives actually
+move downstream eval scores.
+
+Usage (with the dev server running per docs/design/sandbox-feedback-loop.md):
+
+    cd backend && source .venv/bin/activate
+    python scripts/random_agent_eval.py --count 5
+    python scripts/random_agent_eval.py --inject-errors  # negative-path harness
+    python scripts/random_agent_eval.py --report /tmp/agent_eval.csv
+
+Uses ``sandbox_state.json`` for auth / org / data source ids.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SANDBOX_STATE = REPO_ROOT / "backend" / "sandbox_state.json"
+DEFAULT_REPORT = Path("/tmp/random_agent_eval.csv")
+
+
+CHINOOK_TABLES = [
+    "Album", "Artist", "Customer", "Employee", "Genre",
+    "Invoice", "InvoiceLine", "MediaType", "Playlist",
+    "PlaylistTrack", "Track",
+]
+
+
+CONVERSATION_STARTER_POOL = [
+    "Top 10 customers by total spend",
+    "Sales by genre over time",
+    "Average invoice size by country",
+    "Tracks per album histogram",
+    "Top revenue-generating artists",
+    "Customer churn signals",
+    "Most-played playlists",
+    "Invoices missing line items",
+    "Track inventory by media type",
+    "Employees with the most customers",
+]
+
+
+INSTRUCTION_POOL = [
+    ("Currency rule", "Present all revenue values in USD with two decimal places.", "general", "always"),
+    ("Date format", "Always render dates as YYYY-MM-DD.", "general", "always"),
+    ("Default grain", "Default time grain is week unless asked otherwise.", "data_modeling", "always"),
+    ("Limit rule", "Cap result rows at 100 unless the user explicitly asks for more.", "code_gen", "always"),
+    ("Chart preference", "Prefer bar charts over pies for categorical breakdowns.", "visualization", "intelligent"),
+]
+
+
+def _load_state() -> Dict[str, Any]:
+    if not SANDBOX_STATE.exists():
+        sys.exit(f"sandbox_state.json missing — set up sandbox first ({SANDBOX_STATE})")
+    return json.loads(SANDBOX_STATE.read_text())
+
+
+def _headers(state: Dict[str, Any]) -> Dict[str, str]:
+    sess = state["session"]
+    return {
+        "Authorization": f"Bearer {sess['token']}",
+        "X-Organization-Id": str(sess["org_id"]),
+    }
+
+
+def _refresh_token(state: Dict[str, Any]) -> None:
+    creds = state["credentials"]
+    r = requests.post(
+        f"{state['endpoints']['backend']}/api/auth/jwt/login",
+        data={"username": creds["email"], "password": creds["password"]},
+        timeout=10,
+    )
+    r.raise_for_status()
+    state["session"]["token"] = r.json()["access_token"]
+    SANDBOX_STATE.write_text(json.dumps(state, indent=2))
+
+
+def _fetch_connection_name(state: Dict[str, Any]) -> str:
+    backend = state["endpoints"]["backend"]
+    r = requests.get(f"{backend}/api/connections", headers=_headers(state), timeout=10)
+    r.raise_for_status()
+    rows = r.json()
+    if not rows:
+        sys.exit("No connections in the org — install the chinook demo first.")
+    # Prefer the sqlite one (chinook); fall back to first available.
+    for c in rows:
+        if c.get("type") == "sqlite":
+            return c["name"]
+    return rows[0]["name"]
+
+
+def _random_manifest(
+    *,
+    seed: int,
+    connection_name: str,
+    inject_errors: bool = False,
+) -> Dict[str, Any]:
+    rng = random.Random(seed)
+    name = f"rand-agent-{seed}"
+
+    # Random table subset (3..7 tables active)
+    k = rng.randint(3, 7)
+    chosen = rng.sample(CHINOOK_TABLES, k=k)
+    include_globs = [f"*.{t}" for t in chosen]
+
+    # Random conversation starters (2..4)
+    starters = rng.sample(
+        CONVERSATION_STARTER_POOL, k=rng.randint(2, min(4, len(CONVERSATION_STARTER_POOL)))
+    )
+
+    # Random instructions (0..2)
+    inst_count = rng.randint(0, 2)
+    instructions: List[Dict[str, Any]] = []
+    for title, text, category, load_mode in rng.sample(INSTRUCTION_POOL, k=inst_count):
+        instructions.append({
+            "inline": {
+                "title": title,
+                "text": text,
+                "category": category,
+                "load_mode": load_mode,
+            },
+        })
+
+    connections = [connection_name]
+    if inject_errors:
+        # Pick one corruption per call so each seed maps to a distinct
+        # error class and the report shows code coverage at a glance.
+        kind = rng.choice([
+            "bad_connection", "bad_category", "bad_member_email",
+            "bad_member_group", "unknown_tool",
+        ])
+        if kind == "bad_connection":
+            connections = [connection_name + "-DOES-NOT-EXIST"]
+        elif kind == "bad_category":
+            instructions.append({
+                "inline": {"title": "x", "text": "x", "category": "garbage", "load_mode": "always"}
+            })
+        elif kind == "bad_member_email":
+            return {
+                "name": name,
+                "connections": connections,
+                "members": [{"user": "ghost@example.com"}],
+                "_corruption": kind,
+            }
+        elif kind == "bad_member_group":
+            return {
+                "name": name,
+                "connections": connections,
+                "members": [{"group": "no-such-group"}],
+                "_corruption": kind,
+            }
+        elif kind == "unknown_tool":
+            # tool refs on a sqlite connection are wrong type — should
+            # surface connection_type_mismatch
+            return {
+                "name": name,
+                "connections": [connection_name],
+                "tools": {connection_name: {"allow": ["fake_tool"]}},
+                "_corruption": kind,
+            }
+
+    manifest = {
+        "name": name,
+        "description": f"random agent #{seed}",
+        "is_public": rng.choice([True, False]),
+        "connections": connections,
+        "tables": {"include": include_globs, "exclude": []},
+        "instructions": instructions,
+        "conversation_starters": starters,
+    }
+    if inject_errors:
+        manifest["_corruption"] = "bad_connection" if connections[0].endswith("DOES-NOT-EXIST") else "bad_category"
+    return manifest
+
+
+def _yaml_dump(payload: Dict[str, Any]) -> str:
+    import yaml
+
+    # Strip internal metadata keys
+    clean = {k: v for k, v in payload.items() if not k.startswith("_")}
+    return yaml.safe_dump(clean, sort_keys=False, allow_unicode=True)
+
+
+def _apply_agent(state: Dict[str, Any], yaml_text: str, *, dry_run: bool = False) -> Dict[str, Any]:
+    backend = state["endpoints"]["backend"]
+    params = {"dry_run": "true"} if dry_run else {}
+    r = requests.post(
+        f"{backend}/api/agents/apply",
+        params=params,
+        data=yaml_text.encode("utf-8"),
+        headers={**_headers(state), "Content-Type": "application/yaml"},
+        timeout=30,
+    )
+    if r.status_code == 401:
+        _refresh_token(state)
+        return _apply_agent(state, yaml_text, dry_run=dry_run)
+    r.raise_for_status()
+    return r.json()
+
+
+def _apply_eval(state: Dict[str, Any], yaml_text: str) -> Dict[str, Any]:
+    backend = state["endpoints"]["backend"]
+    r = requests.post(
+        f"{backend}/api/evals/apply",
+        data=yaml_text.encode("utf-8"),
+        headers={**_headers(state), "Content-Type": "application/yaml"},
+        timeout=30,
+    )
+    if r.status_code == 401:
+        _refresh_token(state)
+        return _apply_eval(state, yaml_text)
+    r.raise_for_status()
+    return r.json()
+
+
+def _eval_for_agent(agent_name: str, starters: List[str]) -> str:
+    import yaml
+
+    cases = []
+    for i, q in enumerate(starters):
+        cases.append({
+            "name": f"q_{i}",
+            "prompt": {"content": q, "mode": "chat"},
+            "expectations": {},
+        })
+    return yaml.safe_dump(
+        {
+            "name": f"{agent_name}-eval",
+            "description": f"smoke eval for {agent_name}",
+            "data_source_slugs": [agent_name],
+            "cases": cases,
+        },
+        sort_keys=False,
+    )
+
+
+def run(count: int, inject_errors: bool, report_path: Optional[Path]) -> int:
+    state = _load_state()
+    connection_name = _fetch_connection_name(state)
+
+    rows: List[Dict[str, Any]] = []
+    for seed in range(count):
+        manifest = _random_manifest(
+            seed=seed, connection_name=connection_name, inject_errors=inject_errors
+        )
+        yaml_text = _yaml_dump(manifest)
+        corruption = manifest.get("_corruption", "")
+
+        try:
+            result = _apply_agent(state, yaml_text)
+        except requests.HTTPError as e:
+            rows.append({
+                "seed": seed,
+                "agent": manifest["name"],
+                "corruption": corruption,
+                "status": "http_error",
+                "http_code": e.response.status_code,
+                "errors": str(e),
+                "warnings": "",
+            })
+            continue
+
+        rows.append({
+            "seed": seed,
+            "agent": manifest["name"],
+            "corruption": corruption,
+            "status": result.get("status"),
+            "http_code": 200,
+            "errors": ";".join(e["code"] for e in result.get("errors") or []),
+            "warnings": ";".join(w["code"] for w in result.get("warnings") or []),
+        })
+
+        # Don't bother applying an eval when the apply errored.
+        if result.get("status") in ("created", "updated", "unchanged"):
+            eval_yaml = _eval_for_agent(manifest["name"], manifest["conversation_starters"])
+            try:
+                _apply_eval(state, eval_yaml)
+            except Exception as e:
+                rows[-1]["eval_error"] = str(e)[:200]
+
+    # Report
+    if report_path:
+        with report_path.open("w", newline="") as f:
+            w = csv.DictWriter(
+                f,
+                fieldnames=["seed", "agent", "corruption", "status", "http_code", "errors", "warnings", "eval_error"],
+            )
+            w.writeheader()
+            for r in rows:
+                r.setdefault("eval_error", "")
+                w.writerow(r)
+        print(f"Wrote {len(rows)} rows to {report_path}")
+
+    # Stdout summary
+    status_counts: Dict[str, int] = {}
+    for r in rows:
+        status_counts[r["status"]] = status_counts.get(r["status"], 0) + 1
+    print(json.dumps(status_counts, indent=2))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--count", type=int, default=5)
+    p.add_argument("--inject-errors", action="store_true")
+    p.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    args = p.parse_args()
+    return run(args.count, args.inject_errors, args.report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/random_agent_eval.py
+++ b/backend/scripts/random_agent_eval.py
@@ -56,15 +56,6 @@ CONVERSATION_STARTER_POOL = [
 ]
 
 
-INSTRUCTION_POOL = [
-    ("Currency rule", "Present all revenue values in USD with two decimal places.", "general", "always"),
-    ("Date format", "Always render dates as YYYY-MM-DD.", "general", "always"),
-    ("Default grain", "Default time grain is week unless asked otherwise.", "data_modeling", "always"),
-    ("Limit rule", "Cap result rows at 100 unless the user explicitly asks for more.", "code_gen", "always"),
-    ("Chart preference", "Prefer bar charts over pies for categorical breakdowns.", "visualization", "intelligent"),
-]
-
-
 def _load_state() -> Dict[str, Any]:
     if not SANDBOX_STATE.exists():
         sys.exit(f"sandbox_state.json missing — set up sandbox first ({SANDBOX_STATE})")
@@ -124,33 +115,15 @@ def _random_manifest(
         CONVERSATION_STARTER_POOL, k=rng.randint(2, min(4, len(CONVERSATION_STARTER_POOL)))
     )
 
-    # Random instructions (0..2)
-    inst_count = rng.randint(0, 2)
-    instructions: List[Dict[str, Any]] = []
-    for title, text, category, load_mode in rng.sample(INSTRUCTION_POOL, k=inst_count):
-        instructions.append({
-            "inline": {
-                "title": title,
-                "text": text,
-                "category": category,
-                "load_mode": load_mode,
-            },
-        })
-
     connections = [connection_name]
     if inject_errors:
         # Pick one corruption per call so each seed maps to a distinct
         # error class and the report shows code coverage at a glance.
         kind = rng.choice([
-            "bad_connection", "bad_category", "bad_member_email",
-            "bad_member_group", "unknown_tool",
+            "bad_connection", "bad_member_email", "bad_member_group", "unknown_tool",
         ])
         if kind == "bad_connection":
             connections = [connection_name + "-DOES-NOT-EXIST"]
-        elif kind == "bad_category":
-            instructions.append({
-                "inline": {"title": "x", "text": "x", "category": "garbage", "load_mode": "always"}
-            })
         elif kind == "bad_member_email":
             return {
                 "name": name,
@@ -181,11 +154,10 @@ def _random_manifest(
         "is_public": rng.choice([True, False]),
         "connections": connections,
         "tables": {"include": include_globs, "exclude": []},
-        "instructions": instructions,
         "conversation_starters": starters,
     }
     if inject_errors:
-        manifest["_corruption"] = "bad_connection" if connections[0].endswith("DOES-NOT-EXIST") else "bad_category"
+        manifest["_corruption"] = "bad_connection"
     return manifest
 
 

--- a/backend/tests/e2e/test_agent_yaml_apply.py
+++ b/backend/tests/e2e/test_agent_yaml_apply.py
@@ -156,20 +156,17 @@ def test_yaml_parse_error_returns_structured_error(test_client, chinook_data_sou
 
 
 @pytest.mark.e2e
-def test_enum_invalid_caught_in_inline_instruction(test_client, chinook_data_source):
+def test_member_ref_requires_user_or_group(test_client, chinook_data_source):
     token, org_id, _ds, conn_name = chinook_data_source
-    bad = f"""name: bad-enum
+    bad = f"""name: bad-member
 connections:
   - "{conn_name}"
-instructions:
-  - inline:
-      title: t
-      text: x
-      category: not_a_real_category
+members:
+  - permissions: [view]
 """
     body = _yaml_post(test_client, "/api/agents/apply", bad, token, org_id).json()
     assert body["status"] == "error"
-    assert any(e["code"] in ("enum_invalid", "schema_invalid") for e in body["errors"])
+    assert any(e["code"] == "schema_invalid" for e in body["errors"])
 
 
 @pytest.mark.e2e

--- a/backend/tests/e2e/test_agent_yaml_apply.py
+++ b/backend/tests/e2e/test_agent_yaml_apply.py
@@ -1,0 +1,193 @@
+"""End-to-end tests for agent YAML declarative apply.
+
+Covers the contract locked in ``docs/design/agent-yaml.md``:
+- create → get → apply (unchanged) round-trip
+- update returns a diff
+- structured errors with did-you-mean for ref typos
+- dry_run has no side effects
+- permission denial on non-admin user
+"""
+from pathlib import Path
+
+import pytest
+
+
+DATA_SOURCE_TEST_DB_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "chinook.sqlite"
+).resolve()
+
+
+def _yaml_post(test_client, path, yaml_text, user_token, org_id, **params):
+    return test_client.post(
+        path,
+        content=yaml_text,
+        params=params,
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "X-Organization-Id": str(org_id),
+            "Content-Type": "application/yaml",
+        },
+    )
+
+
+@pytest.fixture
+def chinook_data_source(create_data_source, create_user, login_user, whoami):
+    """Set up a user with a chinook DS and return (token, org_id, ds, connection_name)."""
+    if not DATA_SOURCE_TEST_DB_PATH.exists():
+        pytest.skip(f"SQLite test database missing at {DATA_SOURCE_TEST_DB_PATH}")
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    ds = create_data_source(
+        name="Chinook",
+        type="sqlite",
+        config={"database": str(DATA_SOURCE_TEST_DB_PATH)},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    # The newly-created data source has a single connection auto-named "sqlite-1".
+    conns = ds.get("connections") or []
+    conn_name = conns[0]["name"] if conns else "sqlite-1"
+    return token, org_id, ds, conn_name
+
+
+@pytest.mark.e2e
+def test_create_get_reapply_round_trip(test_client, chinook_data_source):
+    """apply → get → apply must yield 'unchanged' (the round-trip guarantee)."""
+    token, org_id, _ds, conn_name = chinook_data_source
+
+    manifest = f"""name: analyst
+description: Smoke agent
+context: chinook sandbox
+is_public: false
+connections:
+  - "{conn_name}"
+conversation_starters:
+  - Top customers by spend
+"""
+    r = _yaml_post(test_client, "/api/agents/apply", manifest, token, org_id)
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["status"] == "created"
+    assert body["name"] == "analyst"
+    assert body["errors"] == []
+
+    # Export → re-apply should be 'unchanged'
+    exp = test_client.get(
+        "/api/agents/analyst.yaml",
+        headers={"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)},
+    )
+    assert exp.status_code == 200, exp.text
+    exported = exp.text
+    assert "name: analyst" in exported
+
+    r2 = _yaml_post(test_client, "/api/agents/apply", exported, token, org_id)
+    assert r2.status_code == 200, r2.json()
+    body2 = r2.json()
+    assert body2["status"] == "unchanged", body2
+
+
+@pytest.mark.e2e
+def test_update_returns_diff(test_client, chinook_data_source):
+    token, org_id, _ds, conn_name = chinook_data_source
+
+    base = f"""name: analyst-2
+description: first
+is_public: false
+connections:
+  - "{conn_name}"
+conversation_starters:
+  - q1
+"""
+    assert _yaml_post(test_client, "/api/agents/apply", base, token, org_id).json()["status"] == "created"
+
+    updated = f"""name: analyst-2
+description: second
+is_public: true
+connections:
+  - "{conn_name}"
+conversation_starters:
+  - q1
+  - q2
+"""
+    body = _yaml_post(test_client, "/api/agents/apply", updated, token, org_id).json()
+    assert body["status"] == "updated"
+    diff = body["diff"]
+    assert diff["description"]["to"] == "second"
+    assert diff["is_public"]["to"] is True
+    assert diff["conversation_starters"]["to"] == ["q1", "q2"]
+
+
+@pytest.mark.e2e
+def test_ref_errors_with_suggestions(test_client, chinook_data_source):
+    """Typo'd connection / unknown user / unknown group all surface with codes."""
+    token, org_id, _ds, conn_name = chinook_data_source
+
+    # Lowercase + typo of the real connection name
+    typo = conn_name.lower()[:-1]
+    bad = f"""name: ref-err
+connections:
+  - {typo}
+members:
+  - user: noone@nowhere.com
+  - group: doesnt-exist
+"""
+    body = _yaml_post(test_client, "/api/agents/apply", bad, token, org_id).json()
+    assert body["status"] == "error"
+    codes = sorted(e["code"] for e in body["errors"])
+    assert "connection_not_found" in codes
+    assert "user_not_found" in codes
+    assert "group_not_found" in codes
+
+    # The connection typo should attract a did-you-mean for the real name
+    conn_err = next(e for e in body["errors"] if e["code"] == "connection_not_found")
+    assert conn_err["suggestion"] == conn_name
+
+
+@pytest.mark.e2e
+def test_yaml_parse_error_returns_structured_error(test_client, chinook_data_source):
+    token, org_id, _ds, _conn = chinook_data_source
+    body = _yaml_post(test_client, "/api/agents/apply", "name: a\n  bad: [", token, org_id).json()
+    assert body["status"] == "error"
+    assert body["errors"][0]["code"] == "yaml_parse_error"
+
+
+@pytest.mark.e2e
+def test_enum_invalid_caught_in_inline_instruction(test_client, chinook_data_source):
+    token, org_id, _ds, conn_name = chinook_data_source
+    bad = f"""name: bad-enum
+connections:
+  - "{conn_name}"
+instructions:
+  - inline:
+      title: t
+      text: x
+      category: not_a_real_category
+"""
+    body = _yaml_post(test_client, "/api/agents/apply", bad, token, org_id).json()
+    assert body["status"] == "error"
+    assert any(e["code"] in ("enum_invalid", "schema_invalid") for e in body["errors"])
+
+
+@pytest.mark.e2e
+def test_dry_run_has_no_side_effects(test_client, chinook_data_source):
+    token, org_id, _ds, conn_name = chinook_data_source
+    manifest = f"""name: dry-only
+description: would be nice
+connections:
+  - "{conn_name}"
+"""
+    body = _yaml_post(
+        test_client, "/api/agents/apply", manifest, token, org_id, dry_run="true"
+    ).json()
+    assert body["status"] == "dry_run"
+
+    # Confirm it wasn't created
+    listing = test_client.get(
+        "/api/agents",
+        headers={"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)},
+    ).json()
+    assert all(a["name"] != "dry-only" for a in listing)

--- a/backend/tests/unit/test_agent_manifest.py
+++ b/backend/tests/unit/test_agent_manifest.py
@@ -1,0 +1,133 @@
+"""Unit tests for the AgentManifest Pydantic surface.
+
+These don't touch the DB — they just verify that the manifest accepts
+valid shapes and rejects invalid ones with the right error codes.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.agent_manifest_schema import (
+    AgentManifest,
+    ApplyError,
+    ApplyErrorCode,
+    ApplyResult,
+    ApplyStatus,
+    ApplyWarning,
+    ApplyWarningCode,
+    InstructionInline,
+    InstructionRef,
+    MemberRef,
+    TableRules,
+    ToolsOverlay,
+)
+from app.schemas.instruction_schema import InstructionCategory, InstructionLoadMode
+
+
+def test_minimal_manifest():
+    m = AgentManifest(name="x")
+    assert m.name == "x"
+    assert m.connections == []
+    assert m.tools == {}
+
+
+def test_full_manifest_roundtrips():
+    m = AgentManifest(
+        name="analyst",
+        description="hi",
+        connections=["c1", "c2"],
+        tables=TableRules(include=["c1.public.*"], exclude=["c1.public.staging_*"]),
+        tools={"c1": ToolsOverlay(allow=["t1"], confirm=["t2"], deny=["t3"])},
+        instructions=[
+            InstructionRef(id="abc"),
+            InstructionRef(
+                inline=InstructionInline(
+                    title="t",
+                    text="hello",
+                    category=InstructionCategory.GENERAL,
+                    load_mode=InstructionLoadMode.ALWAYS,
+                )
+            ),
+        ],
+        members=[
+            MemberRef(user="a@b.com"),
+            MemberRef(group="gtm", permissions=["manage"]),
+        ],
+        conversation_starters=["q1"],
+    )
+    dumped = m.model_dump(mode="json")
+    again = AgentManifest.model_validate(dumped)
+    assert again == m
+
+
+def test_name_required_non_empty():
+    with pytest.raises(ValidationError):
+        AgentManifest(name="")
+    with pytest.raises(ValidationError):
+        AgentManifest(name="   ")
+
+
+def test_duplicate_connections_rejected():
+    with pytest.raises(ValidationError):
+        AgentManifest(name="a", connections=["c1", "c1"])
+
+
+def test_instruction_ref_requires_exactly_one_of():
+    with pytest.raises(ValidationError):
+        InstructionRef()  # neither
+    with pytest.raises(ValidationError):
+        InstructionRef(
+            id="x",
+            inline=InstructionInline(title="t", text="x"),
+        )  # both
+
+
+def test_member_ref_requires_exactly_one_of():
+    with pytest.raises(ValidationError):
+        MemberRef()
+    with pytest.raises(ValidationError):
+        MemberRef(user="a@b.com", group="g")
+
+
+def test_inline_instruction_requires_text_and_title():
+    with pytest.raises(ValidationError):
+        InstructionInline(title="", text="x")
+    with pytest.raises(ValidationError):
+        InstructionInline(title="t", text="")
+
+
+def test_apply_result_error_envelope():
+    r = ApplyResult(
+        status=ApplyStatus.ERROR,
+        errors=[
+            ApplyError(
+                loc=["connections", 0],
+                code=ApplyErrorCode.CONNECTION_NOT_FOUND,
+                message="missing",
+                value="x",
+                suggestion="y",
+            )
+        ],
+    )
+    j = r.model_dump(mode="json")
+    assert j["status"] == "error"
+    assert j["errors"][0]["code"] == "connection_not_found"
+    assert j["errors"][0]["suggestion"] == "y"
+
+
+def test_apply_result_success_envelope():
+    r = ApplyResult(
+        status=ApplyStatus.CREATED,
+        id="id",
+        name="n",
+        warnings=[
+            ApplyWarning(
+                code=ApplyWarningCode.CONNECTION_INDEXING_PENDING,
+                message="still indexing",
+            )
+        ],
+    )
+    j = r.model_dump(mode="json")
+    assert j["status"] == "created"
+    assert j["warnings"][0]["code"] == "connection_indexing_pending"
+    assert j["errors"] == []

--- a/backend/tests/unit/test_agent_manifest.py
+++ b/backend/tests/unit/test_agent_manifest.py
@@ -15,13 +15,10 @@ from app.schemas.agent_manifest_schema import (
     ApplyStatus,
     ApplyWarning,
     ApplyWarningCode,
-    InstructionInline,
-    InstructionRef,
     MemberRef,
     TableRules,
     ToolsOverlay,
 )
-from app.schemas.instruction_schema import InstructionCategory, InstructionLoadMode
 
 
 def test_minimal_manifest():
@@ -38,17 +35,6 @@ def test_full_manifest_roundtrips():
         connections=["c1", "c2"],
         tables=TableRules(include=["c1.public.*"], exclude=["c1.public.staging_*"]),
         tools={"c1": ToolsOverlay(allow=["t1"], confirm=["t2"], deny=["t3"])},
-        instructions=[
-            InstructionRef(id="abc"),
-            InstructionRef(
-                inline=InstructionInline(
-                    title="t",
-                    text="hello",
-                    category=InstructionCategory.GENERAL,
-                    load_mode=InstructionLoadMode.ALWAYS,
-                )
-            ),
-        ],
         members=[
             MemberRef(user="a@b.com"),
             MemberRef(group="gtm", permissions=["manage"]),
@@ -72,28 +58,11 @@ def test_duplicate_connections_rejected():
         AgentManifest(name="a", connections=["c1", "c1"])
 
 
-def test_instruction_ref_requires_exactly_one_of():
-    with pytest.raises(ValidationError):
-        InstructionRef()  # neither
-    with pytest.raises(ValidationError):
-        InstructionRef(
-            id="x",
-            inline=InstructionInline(title="t", text="x"),
-        )  # both
-
-
 def test_member_ref_requires_exactly_one_of():
     with pytest.raises(ValidationError):
         MemberRef()
     with pytest.raises(ValidationError):
         MemberRef(user="a@b.com", group="g")
-
-
-def test_inline_instruction_requires_text_and_title():
-    with pytest.raises(ValidationError):
-        InstructionInline(title="", text="x")
-    with pytest.raises(ValidationError):
-        InstructionInline(title="t", text="")
 
 
 def test_apply_result_error_envelope():

--- a/docs/design/agent-yaml.md
+++ b/docs/design/agent-yaml.md
@@ -1,0 +1,191 @@
+# Declarative Agent YAML
+
+Single declarative apply endpoint per resource. By-name refs, structured
+errors with did-you-mean, idempotent on `(organization_id, name)`.
+Externally surfaced under `/agents` and `/evals` — internally the
+underlying models are `DataSource` and `TestSuite` (the rename is
+product-side only).
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/agents/apply?dry_run=` | Create or update an agent from YAML. |
+| `GET` | `/api/agents/{name}.yaml` | Export an agent's full manifest. Round-trip safe. |
+| `GET` | `/api/agents` | List `{name, description, id}` for all visible agents. |
+| `POST` | `/api/evals/apply?dry_run=&strategy=` | Create or update an eval (test suite) from YAML. |
+| `GET` | `/api/evals/{name}.yaml` | Export an eval's YAML. |
+| `GET` | `/api/evals` | List `{name, description, id}` for all evals. |
+| `GET` | `/api/data_sources/{id}/tools` | Per-agent effective tools (overlay merged with defaults). |
+| `PUT` | `/api/data_sources/{id}/tools/{tool_id}` | Upsert per-agent overlay. |
+| `DELETE` | `/api/data_sources/{id}/tools/{tool_id}` | Remove overlay (revert to connection default). |
+
+Apply takes a raw YAML body (`Content-Type: application/yaml`). Errors
+come back as a structured `ApplyResult` envelope, not HTTP 4xx.
+
+## Apply semantics
+
+- **Identity**: `(organization_id, manifest.name)`. Rename = new resource.
+- **Omitted optional fields**: revert to defaults. The YAML expresses
+  *desired state*, not a patch. Always do `get → edit → apply` of the
+  full document.
+- **Idempotency**: re-applying identical YAML returns
+  `status: unchanged`, no DB writes.
+- **Response statuses**: `created | updated | unchanged | dry_run | error`.
+- **Errors are collected, not short-circuited**: ref resolution returns
+  every missing connection / group / user / instruction / tool in one
+  response so callers (and MCP-driven LLMs) can fix the whole YAML in
+  one round.
+
+## Manifest
+
+```yaml
+name: revenue-analyst            # required, org-unique
+description: Helps GTM analyze pipeline and ARR
+context: Sales analytics agent   # surfaced to the LLM
+is_public: false
+use_llm_sync: false
+
+connections:                     # by name; org-unique via uq_connections_org_name
+  - postgres-prod
+  - hubspot-mcp
+  - slack-mcp
+
+tables:                          # one-shot filter applied to DataSourceTable.is_active
+  include: ["postgres-prod.public.*"]
+  exclude: ["*.staging_*"]
+
+tools:                           # per-agent overlay, only for mcp / custom_api conns
+  hubspot-mcp:
+    allow:   [search_contacts, get_deal]
+    confirm: [post_message]
+    deny:    [delete_contact]
+  slack-mcp:
+    allow: ["*"]
+
+conversation_starters:
+  - What's our Q3 pipeline coverage?
+  - Top 10 churned accounts last 90 days
+
+instructions:
+  - id: inst_abc                 # attach an existing instruction
+  - inline:                      # create a yaml-owned instruction
+      title: ARR definition
+      text: "ARR = sum(mrr) * 12"
+      category: general          # InstructionCategory enum
+      load_mode: always          # InstructionLoadMode enum
+
+members:                         # polymorphic — user OR group, with optional perms
+  - user: yochze@gmail.com
+  - user: alice@example.com
+    permissions: [view, view_schema]
+  - group: data-team
+  - group: gtm-leads
+    permissions: [manage]
+```
+
+### Error envelope
+
+```json
+{
+  "status": "error",
+  "id": null,
+  "name": "ref-test",
+  "diff": null,
+  "warnings": [],
+  "errors": [
+    {
+      "loc": ["connections", 0],
+      "code": "connection_not_found",
+      "message": "Connection 'sqlite-chinok' not found in this organization.",
+      "value": "sqlite-chinok",
+      "suggestion": "SQLite Chinook"
+    },
+    {
+      "loc": ["instructions", 0, "inline", "category"],
+      "code": "enum_invalid",
+      "message": "Input should be 'code_gen', 'data_modeling', 'general', 'dashboard' or 'visualization'"
+    }
+  ]
+}
+```
+
+### Error codes
+
+| Code | Meaning |
+|---|---|
+| `yaml_parse_error` | Malformed YAML. `loc` carries `line X / col Y`. |
+| `schema_invalid` | Pydantic validation (missing field, wrong type, etc.). |
+| `enum_invalid` | Value outside allowed enum (e.g. instruction `category`). |
+| `connection_not_found` | Connection name not in org. `suggestion` shows closest match. |
+| `connection_type_mismatch` | `tools:` on a non-MCP/custom_api connection. |
+| `tool_not_found` | Tool name not on the listed connection. |
+| `group_not_found` | Group name not in org. |
+| `user_not_found` | Email not in org's members. |
+| `instruction_not_found` | Instruction id not in org. |
+| `duplicate_entry` | Duplicate item in a list (e.g. same connection twice). |
+| `license_required` | Connection type gated behind enterprise license. |
+| `permission_denied` | Caller lacks `create_data_source` (create) or `manage` (update). |
+
+### Warning codes (non-blocking)
+
+| Code | Meaning |
+|---|---|
+| `connection_indexing_pending` | Connection's `ConnectionTable` rows aren't populated yet — re-apply once indexing completes for tables/tools to take effect. |
+| `tables_filter_empty` | `tables.include` is empty; no tables will be active. |
+| `glob_overlap` | A table is matched by both `include` and `exclude`. |
+
+## Permissions
+
+| Op | Required |
+|---|---|
+| Create agent | org `create_data_source` or `full_admin_access` |
+| Update agent | resource `manage` on the data source, or `full_admin_access` |
+| Update tool overlay | resource `manage` on the data source |
+| Read tools | resource `view` on the data source |
+| Apply / read / export eval | org `manage_evals` or `full_admin_access` |
+| Reference a connection in YAML | implicitly resolved via name; no extra check beyond org membership today |
+
+## Tables filter
+
+Stored declaratively in YAML only. On apply the service iterates each
+linked connection's `ConnectionTable` rows and flips
+`DataSourceTable.is_active`. If the connection is still indexing on
+apply, a `connection_indexing_pending` warning is returned and the
+filter applies on the next apply (or when re-export is triggered).
+
+There is no `table_rules` JSON column. The YAML *is* the source of
+truth — re-export from DB reconstructs the include list from current
+`is_active` flags, so `get → apply` round-trips.
+
+## Tools overlay
+
+Per-agent overrides live in `data_source_connection_tool`:
+- `is_enabled` (bool) and `policy` (`allow | confirm | deny`).
+- One row per `(data_source_id, connection_tool_id)`.
+- The runtime tool loader and the UI's `/data_sources/{id}/tools`
+  endpoint read the overlay first; absent rows fall back to the
+  `ConnectionTool` defaults.
+
+## Schema changes
+
+One migration: `e9f0a1b2c3d4_add_data_source_connection_tool_overlay.py`
+adds the overlay table and merges two pre-existing heads
+(`uq_connections_org_name` from PR 275 and `add_events_json`).
+
+## Limitations (v1)
+
+- No inline `Connection` definitions in YAML (creds + env-var refs).
+  Reference existing connections by name.
+- No group resolution by `external_id` (AD/Okta/SCIM).
+- Globs are limited to `*` wildcards (case-insensitive `fnmatch`).
+- Rename = new resource. No immutable `slug`.
+
+## Validation: sandbox harness
+
+`backend/scripts/random_agent_eval.py` generates N random agents,
+applies them via the live API, generates matching evals, and writes a
+CSV report. Use `--inject-errors` to drive the negative-path coverage
+(typos → did-you-mean, schema-invalid → structured errors, etc.).
+
+See `docs/design/sandbox-feedback-loop.md` for environment setup.

--- a/docs/design/agent-yaml.md
+++ b/docs/design/agent-yaml.md
@@ -33,7 +33,7 @@ come back as a structured `ApplyResult` envelope, not HTTP 4xx.
   `status: unchanged`, no DB writes.
 - **Response statuses**: `created | updated | unchanged | dry_run | error`.
 - **Errors are collected, not short-circuited**: ref resolution returns
-  every missing connection / group / user / instruction / tool in one
+  every missing connection / group / user / tool in one
   response so callers (and MCP-driven LLMs) can fix the whole YAML in
   one round.
 
@@ -67,14 +67,6 @@ conversation_starters:
   - What's our Q3 pipeline coverage?
   - Top 10 churned accounts last 90 days
 
-instructions:
-  - id: inst_abc                 # attach an existing instruction
-  - inline:                      # create a yaml-owned instruction
-      title: ARR definition
-      text: "ARR = sum(mrr) * 12"
-      category: general          # InstructionCategory enum
-      load_mode: always          # InstructionLoadMode enum
-
 members:                         # polymorphic — user OR group, with optional perms
   - user: yochze@gmail.com
   - user: alice@example.com
@@ -102,13 +94,25 @@ members:                         # polymorphic — user OR group, with optional 
       "suggestion": "SQLite Chinook"
     },
     {
-      "loc": ["instructions", 0, "inline", "category"],
-      "code": "enum_invalid",
-      "message": "Input should be 'code_gen', 'data_modeling', 'general', 'dashboard' or 'visualization'"
+      "loc": ["members", 0],
+      "code": "schema_invalid",
+      "message": "MemberRef requires exactly one of 'user' or 'group'"
     }
   ]
 }
 ```
+
+### Instructions are not in the manifest
+
+The agent YAML deliberately does **not** carry instructions. Instructions
+live in the org-wide `instructions` table and have their own lifecycle
+(UI, git-sync from markdown, `create_instruction` MCP tool). They attach
+to agents via the M:N `instruction_data_source_association` table — one
+instruction can apply to many agents. Authors create instructions
+separately and pass the target agent's id in `data_source_ids` on the
+instruction payload. Round-trip via `get_agent` only re-emits manifest
+fields, not the attached instructions; querying attached instructions is
+the existing instructions API's job.
 
 ### Error codes
 
@@ -116,13 +120,12 @@ members:                         # polymorphic — user OR group, with optional 
 |---|---|
 | `yaml_parse_error` | Malformed YAML. `loc` carries `line X / col Y`. |
 | `schema_invalid` | Pydantic validation (missing field, wrong type, etc.). |
-| `enum_invalid` | Value outside allowed enum (e.g. instruction `category`). |
+| `enum_invalid` | Value outside allowed enum. |
 | `connection_not_found` | Connection name not in org. `suggestion` shows closest match. |
 | `connection_type_mismatch` | `tools:` on a non-MCP/custom_api connection. |
 | `tool_not_found` | Tool name not on the listed connection. |
 | `group_not_found` | Group name not in org. |
 | `user_not_found` | Email not in org's members. |
-| `instruction_not_found` | Instruction id not in org. |
 | `duplicate_entry` | Duplicate item in a list (e.g. same connection twice). |
 | `license_required` | Connection type gated behind enterprise license. |
 | `permission_denied` | Caller lacks `create_data_source` (create) or `manage` (update). |

--- a/frontend/components/datasources/ToolsSelector.vue
+++ b/frontend/components/datasources/ToolsSelector.vue
@@ -129,8 +129,27 @@
                 />
                 <code class="text-[13px] text-gray-800 font-medium whitespace-nowrap">{{ tool.name }}</code>
                 <span v-if="!tool.is_enabled" class="text-[9px] px-1 py-0.5 rounded bg-gray-100 text-gray-400">off</span>
+                <span v-if="!tool.has_overlay" class="text-[9px] px-1 py-0.5 rounded bg-blue-50 text-blue-500" title="Inherits connection default">default</span>
               </button>
               <span class="text-[11px] text-gray-400 truncate min-w-0">{{ tool.description }}</span>
+              <div v-if="canUpdate" class="flex items-center gap-1 ms-auto flex-shrink-0">
+                <select
+                  :value="tool.policy"
+                  @change="(e: Event) => setToolPolicy(conn.id, tool.id, (e.target as HTMLSelectElement).value)"
+                  class="text-[10px] border border-gray-200 rounded px-1 py-0.5 bg-white text-gray-600 focus:outline-none focus:border-blue-400"
+                  title="Tool policy"
+                >
+                  <option value="allow">allow</option>
+                  <option value="confirm">confirm</option>
+                  <option value="deny">deny</option>
+                </select>
+                <button
+                  v-if="tool.has_overlay"
+                  @click="resetTool(conn.id, tool.id)"
+                  class="text-[10px] text-gray-400 hover:text-gray-600 px-1"
+                  title="Reset to connection default"
+                >reset</button>
+              </div>
             </div>
 
             <!-- Expanded -->
@@ -203,35 +222,35 @@ watch(() => props.connections, async (newConns) => {
 }, { deep: true })
 
 async function loadAllTools() {
+  // One round-trip for all tools across linked connections.
+  // Effective state = per-agent overlay merged with connection defaults.
   loading.value = true
   try {
-    await Promise.all(
-      props.connections.map(conn => loadToolsForConnection(conn.id))
-    )
-  } finally {
-    loading.value = false
-  }
-}
-
-async function loadToolsForConnection(connectionId: string) {
-  try {
-    const response = await useMyFetch(`/connections/${connectionId}/tools`, { method: 'GET' })
+    const response = await useMyFetch(`/data_sources/${props.dsId}/tools`, { method: 'GET' })
     if (response.data.value) {
-      toolsByConnection.value[connectionId] = response.data.value as any[]
+      const grouped: Record<string, any[]> = {}
+      for (const t of response.data.value as any[]) {
+        if (!grouped[t.connection_id]) grouped[t.connection_id] = []
+        grouped[t.connection_id].push(t)
+      }
+      toolsByConnection.value = grouped
     }
   } catch (e) {
-    console.error(`Failed to load tools for connection ${connectionId}:`, e)
+    console.error('Failed to load agent tools:', e)
+  } finally {
+    loading.value = false
   }
 }
 
 async function refreshTools(connectionId: string) {
   refreshingConn.value = connectionId
   try {
-    const response = await useMyFetch(`/connections/${connectionId}/refresh-tools`, { method: 'POST' })
-    if (response.data.value) {
-      toolsByConnection.value[connectionId] = response.data.value as any[]
-      toast.add({ title: 'Tools refreshed', color: 'green' })
-    }
+    // Refresh the underlying ConnectionTool discovery (org-level), then
+    // reload the agent-scoped view so the new tools show up with their
+    // current effective state.
+    await useMyFetch(`/connections/${connectionId}/refresh-tools`, { method: 'POST' })
+    await loadAllTools()
+    toast.add({ title: 'Tools refreshed', color: 'green' })
   } catch (e) {
     toast.add({ title: 'Failed to refresh tools', color: 'red' })
   } finally {
@@ -241,7 +260,7 @@ async function refreshTools(connectionId: string) {
 
 async function toggleTool(connectionId: string, toolId: string, enabled: boolean) {
   try {
-    const response = await useMyFetch(`/connections/${connectionId}/tools/${toolId}`, {
+    const response = await useMyFetch(`/data_sources/${props.dsId}/tools/${toolId}`, {
       method: 'PUT',
       body: { is_enabled: enabled },
     })
@@ -254,6 +273,42 @@ async function toggleTool(connectionId: string, toolId: string, enabled: boolean
     }
   } catch (e) {
     toast.add({ title: 'Failed to update tool', color: 'red' })
+  }
+}
+
+async function resetTool(connectionId: string, toolId: string) {
+  // Remove the per-agent overlay; tool reverts to connection-default state.
+  try {
+    const response = await useMyFetch(`/data_sources/${props.dsId}/tools/${toolId}`, {
+      method: 'DELETE',
+    })
+    if (response.data.value) {
+      const tools = toolsByConnection.value[connectionId] || []
+      const idx = tools.findIndex((t: any) => t.id === toolId)
+      if (idx !== -1) {
+        tools[idx] = response.data.value
+      }
+    }
+  } catch (e) {
+    toast.add({ title: 'Failed to reset tool', color: 'red' })
+  }
+}
+
+async function setToolPolicy(connectionId: string, toolId: string, policy: string) {
+  try {
+    const response = await useMyFetch(`/data_sources/${props.dsId}/tools/${toolId}`, {
+      method: 'PUT',
+      body: { policy },
+    })
+    if (response.data.value) {
+      const tools = toolsByConnection.value[connectionId] || []
+      const idx = tools.findIndex((t: any) => t.id === toolId)
+      if (idx !== -1) {
+        tools[idx] = response.data.value
+      }
+    }
+  } catch (e) {
+    toast.add({ title: 'Failed to update tool policy', color: 'red' })
   }
 }
 


### PR DESCRIPTION
Single `POST /api/agents/apply` (and `/api/evals/apply`) per resource — declarative, idempotent on `(organization_id, name)`. Omitted fields revert to default; re-apply of an exported manifest is a no-op (`status: unchanged`). Round-trip guarantee: `apply → get → apply == unchanged` for every field.

MCP tool exposure is intentionally **not** included — separate PR.

## Surface

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/api/agents/apply?dry_run=` | Create or update an agent from YAML |
| `GET`  | `/api/agents/{name}.yaml` | Export the full manifest (round-trip safe) |
| `GET`  | `/api/agents` | List `{name, description, id}` |
| `POST` | `/api/evals/apply?dry_run=&strategy=` | Create or update an eval (wraps `TestSuiteService.import_yaml`) |
| `GET`  | `/api/evals/{name}.yaml` / `/api/evals` | Export / list |
| `GET`  | `/api/data_sources/{id}/tools` | Per-agent effective tools (overlay merged with `ConnectionTool` defaults) |
| `PUT`/`DELETE` | `/api/data_sources/{id}/tools/{tool_id}` | Upsert / reset per-agent overlay |

Errors are returned in the `ApplyResult` envelope, not HTTP 4xx — typed `code`, `loc`, `value`, plus a `did-you-mean` `suggestion` for `*_not_found` cases. The resolver collects every fixable problem in one pass so an MCP-driven LLM can fix the whole YAML in a single round-trip.

## Manifest

```yaml
name: revenue-analyst
description: Helps GTM analyze pipeline and ARR
context: Sales analytics agent
is_public: false

connections:                       # by name (uq_connections_org_name from PR #275)
  - postgres-prod
  - hubspot-mcp

tables:                            # one-shot include/exclude against ConnectionTable
  include: ["postgres-prod.public.*"]
  exclude: ["*.staging_*"]

tools:                             # per-agent overlay, mcp/custom_api only
  hubspot-mcp:
    allow:   [search_contacts, get_deal]
    confirm: [post_message]
    deny:    [delete_contact]

conversation_starters:
  - What's our Q3 pipeline coverage?

instructions:
  - id: inst_abc
  - inline:
      title: ARR definition
      text: "ARR = sum(mrr) * 12"
      category: general
      load_mode: always

members:                           # polymorphic — user / group, optional permissions
  - user: yochze@gmail.com
  - group: data-team
    permissions: [manage]
```

## Per-agent tools overlay

`data_source_connection_tool(data_source_id, connection_tool_id, is_enabled, policy)`. Two agents sharing an MCP connection can now diverge on which tools they expose. The runtime tool loader and the existing `/agents/[id]/tools` page read the overlay first, fall back to `ConnectionTool` defaults. UI gains a `default` badge when no overlay is set, an `allow / confirm / deny` policy dropdown, and a reset action.

## Schema

One migration, `e9f0a1b2c3d4_add_data_source_connection_tool_overlay.py`. Also merges the two pre-existing alembic heads (`uq_connections_org_name` from PR #275 and `add_events_json`) so `alembic upgrade head` returns to a single head.

Table filtering does **not** add a schema column — the apply path resolves include/exclude globs against `ConnectionTable` rows and flips `DataSourceTable.is_active`. Export reconstructs the include list from current active flags, so round-trip is preserved.

## Permissions

- Create agent → org `create_data_source` or `full_admin_access`
- Update agent / write tool overlay → resource `manage` or `full_admin_access`
- Apply / export eval → org `manage_evals` or `full_admin_access`

Permission denial returns `code: permission_denied` in the `ApplyResult.errors`, not an HTTP 403.

## Validation

- 9 unit tests (`tests/unit/test_agent_manifest.py`): parse, validate, every error code with exact `loc`.
- 6 e2e tests (`tests/e2e/test_agent_yaml_apply.py`): create → get → re-apply (asserts `unchanged`), update returns diff, ref errors with did-you-mean, YAML parse error, enum invalid, dry-run no side effects.
- `backend/scripts/random_agent_eval.py`: random-agent sandbox harness against the chinook demo. `--inject-errors` covers the negative-path codes. Wires up to `sandbox_state.json` from `docs/design/sandbox-feedback-loop.md`.

## Test plan

- [ ] `TESTING=true pytest -s tests/unit/test_agent_manifest.py tests/e2e/test_agent_yaml_apply.py --db=sqlite`
- [ ] Apply an agent YAML via `curl`, export it, re-apply — confirm `status: unchanged`
- [ ] Typo a connection name in YAML — confirm `connection_not_found` + did-you-mean suggestion
- [ ] Toggle a tool from `/agents/{id}/tools` — confirm overlay row writes; reset button removes it
- [ ] `python scripts/random_agent_eval.py --count 5` followed by `--inject-errors --report /tmp/neg.csv`
