### PR TITLE
web_fetch: put rich content in observation, compact on next turn

### DIFF
--- a/backend/app/ai/context/builders/observation_context_builder.py
+++ b/backend/app/ai/context/builders/observation_context_builder.py
@@ -71,6 +71,20 @@ class ObservationContextBuilder:
                     code_len = len(prev_observation["code"])
                     del prev_observation["code"]
                     prev_observation["code_compacted"] = f"{code_len} chars"
+            elif prev_obs["tool_name"] == "web_fetch":
+                if "content" in prev_observation:
+                    content_len = len(prev_observation["content"] or "")
+                    del prev_observation["content"]
+                    prev_observation["content_compacted"] = f"{content_len} chars"
+                if "json_ld" in prev_observation:
+                    del prev_observation["json_ld"]
+                    prev_observation["json_ld_compacted"] = True
+                if "metadata" in prev_observation:
+                    del prev_observation["metadata"]
+                    prev_observation["metadata_compacted"] = True
+                if "headings" in prev_observation:
+                    del prev_observation["headings"]
+                    prev_observation["headings_compacted"] = True
 
         tool_observation = {
             "execution_number": self.execution_count,

--- a/backend/app/ai/tools/implementations/web_fetch.py
+++ b/backend/app/ai/tools/implementations/web_fetch.py
@@ -600,7 +600,16 @@ Do not use when:
                             "observation": {
                                 "summary": summary,
                                 "success": True,
-                                "preview": (output.content or "")[:2000],
+                                "url": data.url,
+                                "final_url": final_url,
+                                "status_code": status,
+                                "title": output.title,
+                                "description": output.description,
+                                "content": output.content,
+                                "metadata": output.metadata,
+                                "json_ld": output.json_ld,
+                                "headings": output.headings,
+                                "truncated": output.truncated,
                             },
                         },
                     )


### PR DESCRIPTION
## Summary

The planner LLM only sees a tool's `observation` payload, never its `output`. `web_fetch` was emitting only `{summary, success, preview[:2000]}` — so even though the tool extracts title, description, metadata, JSON-LD, and headings, **the agent never saw any of them**, just a 2000-char body preview.

On pages where the leading body text is noisy (nav menus, framework strings, JSP debug paths), that preview drowns out the actual signal — even when structured data like `og:price:amount` or a Product JSON-LD block sits right there in `output`, ready to use.

This PR mirrors the `read_artifact` pattern: dump the heavy payload in `observation` for the turn the tool ran, then compact it on the next tool call.

## Changes

**`web_fetch.py`** — success-path observation now carries:
- Identity: `url`, `final_url`, `status_code`, `title`, `description`, `truncated`
- Content: `content`, `metadata`, `json_ld`, `headings`

(replaces the previous `preview` field, which was a strict subset)

**`observation_context_builder.py`** — `add_tool_observation` gets a `web_fetch` branch in its compactor:
- Strips `content` → `content_compacted: "N chars"`
- Strips `json_ld`, `metadata`, `headings` → `*_compacted: True`
- Keeps `summary`, `success`, identity fields

Same lifecycle `read_artifact` already uses for `code` (see `read_artifact.py:268`).

## Net effect

| Turn | What agent sees for a prior `web_fetch` |
|---|---|
| Turn it ran | Full content + metadata + json_ld + headings + identity |
| Next turn (after any tool call) | summary + identity + `content_compacted: "N chars"` |

Context cost matches `read_artifact`. If the agent needs the page again, it re-fetches — `web_fetch` is already `idempotent=True` (`web_fetch.py:255`).

## Test plan

- [ ] Existing `tests/unit/test_web_fetch_tool.py` still passes (no test asserts on the observation shape — all checks are on `output`)
- [ ] Manual: fetch an IL retail product URL (e.g. super-pharm) and confirm planner reasoning now references `og:price:amount`/`json_ld` price instead of complaining about a JSP-shell page
- [ ] Manual: confirm `<past_observations>` shows `content_compacted` on the turn after a `web_fetch` call, not the full body

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmzpGnh3r3EmG9Pg7DhU4D)_