### PR TITLE
scope data source list to explicit members, not full_admin_access

### DIFF
--- a/backend/app/core/permission_resolver.py
+++ b/backend/app/core/permission_resolver.py
@@ -233,17 +233,46 @@ async def get_accessible_data_source_ids(
     - accessible_ds_ids is a list of data_source ids the user can see via:
       legacy DataSourceMembership (user) OR ResourceGrant (user/group/role).
       Public data sources are NOT included here — callers must OR them in.
+
+    Use this for capability checks ("can this user access DS X if they
+    navigate to it?"). For default list views, prefer
+    ``get_member_data_source_ids`` so admins only see DSs they are
+    explicitly members of.
     """
-    from app.models.data_source_membership import DataSourceMembership, PRINCIPAL_TYPE_USER
     resolved = await resolve_permissions(db, str(user_id), str(org_id))
     is_admin = FULL_ADMIN in resolved.org_permissions
     if is_admin:
         return True, []
+    return False, await _resolved_member_ds_ids(db, user_id, resolved)
+
+
+async def get_member_data_source_ids(
+    db: AsyncSession, user_id: str, org_id: str,
+) -> list[str]:
+    """Return data_source IDs where the user holds an explicit grant or
+    legacy membership (direct, via group, or via role).
+
+    Unlike ``get_accessible_data_source_ids``, this does NOT short-circuit
+    on ``full_admin_access``. Admins get the same explicit-only view as any
+    other user — they only see DSs they actually joined or created. They
+    can still navigate directly to any DS via their admin bypass at the
+    capability layer (``get_accessible_data_source_ids``,
+    ``user_can_access_data_source``).
+
+    Public data sources are NOT included; callers must OR them in.
+    """
+    resolved = await resolve_permissions(db, str(user_id), str(org_id))
+    return await _resolved_member_ds_ids(db, user_id, resolved)
+
+
+async def _resolved_member_ds_ids(
+    db: AsyncSession, user_id: str, resolved: ResolvedPermissions,
+) -> list[str]:
+    from app.models.data_source_membership import DataSourceMembership, PRINCIPAL_TYPE_USER
     ds_ids = {
         rid for (rtype, rid) in resolved.resource_permissions.keys()
         if rtype == "data_source"
     }
-    # Union legacy memberships
     mem_result = await db.execute(
         select(DataSourceMembership.data_source_id).where(
             DataSourceMembership.principal_type == PRINCIPAL_TYPE_USER,
@@ -252,7 +281,7 @@ async def get_accessible_data_source_ids(
     )
     for (ds_id,) in mem_result.all():
         ds_ids.add(ds_id)
-    return False, list(ds_ids)
+    return list(ds_ids)
 
 
 async def get_ds_ids_with_permission(

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -832,8 +832,11 @@ class DataSourceService:
         # NOTE: Do NOT use selectinload(DataSource.tables) here - it loads ALL tables into memory
         # For data sources with 25K+ tables, this causes severe performance issues
         # Table count is fetched separately via COUNT query in _build_connections_list
-        from app.core.permission_resolver import get_accessible_data_source_ids
-        is_admin, accessible_ids = await get_accessible_data_source_ids(
+        # NOTE: scope this to *explicit* memberships even for admins so the
+        # default list isn't flooded with every DS in the org. Admins keep
+        # capability bypass and can still open any DS via direct URL.
+        from app.core.permission_resolver import get_member_data_source_ids
+        member_ids = await get_member_data_source_ids(
             db, str(current_user.id), str(organization.id)
         )
 
@@ -851,11 +854,10 @@ class DataSourceService:
             )
             .filter(DataSource.organization_id == organization.id)
         )
-        if not is_admin:
-            clauses = [DataSource.is_public == True]
-            if accessible_ids:
-                clauses.append(DataSource.id.in_(accessible_ids))
-            query = query.filter(or_(*clauses))
+        clauses = [DataSource.is_public == True]
+        if member_ids:
+            clauses.append(DataSource.id.in_(member_ids))
+        query = query.filter(or_(*clauses))
         result = await db.execute(query)
         data_sources = result.scalars().all()
         # Build list with connection info (no live test for list to keep it fast)
@@ -905,15 +907,14 @@ class DataSourceService:
         
         # Apply access control if user is provided (same logic as get_data_sources)
         if current_user:
-            from app.core.permission_resolver import get_accessible_data_source_ids
-            is_admin, accessible_ids = await get_accessible_data_source_ids(
+            from app.core.permission_resolver import get_member_data_source_ids
+            member_ids = await get_member_data_source_ids(
                 db, str(current_user.id), str(organization.id)
             )
-            if not is_admin:
-                clauses = [DataSource.is_public == True]
-                if accessible_ids:
-                    clauses.append(DataSource.id.in_(accessible_ids))
-                stmt = stmt.filter(or_(*clauses))
+            clauses = [DataSource.is_public == True]
+            if member_ids:
+                clauses.append(DataSource.id.in_(member_ids))
+            stmt = stmt.filter(or_(*clauses))
             
         result = await db.execute(stmt)
         data_sources = result.scalars().all()

--- a/backend/tests/e2e/rbac/test_rbac_data_sources.py
+++ b/backend/tests/e2e/rbac/test_rbac_data_sources.py
@@ -139,7 +139,11 @@ def test_data_source_list_basic_filter_and_invariant(test_client, ds_world):
     """List filtering + forward list/detail invariant.
 
     Specifically:
-      - admin bypasses filtering (full_admin_access) and sees both DSes
+      - admin sees both DSes because they CREATED them (creator-as-member
+        rule). The list endpoint does NOT bypass for full_admin_access —
+        admins only see DSes they explicitly belong to. See
+        ``test_admin_does_not_auto_see_other_admins_data_source`` for the
+        non-creator admin case.
       - member_no_grants sees nothing
       - every DS that a principal does see in the list must open via GET /{id}
 
@@ -160,7 +164,7 @@ def test_data_source_list_basic_filter_and_invariant(test_client, ds_world):
         got_ids = {d["id"] for d in list_resp.json()}
 
         if name == "admin":
-            # Admin auto-gets DataSourceMembership rows on create, so should see both.
+            # Admin created both DSes → creator-as-member auto-write → visible.
             for ds_id in (ds_a_id, ds_b_id):
                 if ds_id not in got_ids:
                     failures.append(f"admin list missing: {ds_id}")
@@ -222,6 +226,42 @@ def test_data_source_grant_appears_in_list(test_client, ds_world):
             failures.append(f"{name}: list leaked {leaked}")
 
     assert not failures, "\n".join(failures)
+
+
+@pytest.mark.e2e
+def test_admin_does_not_auto_see_other_admins_data_source(
+    test_client, bootstrap_admin, invite_user_to_org, sqlite_data_source
+):
+    """A second admin who didn't create the DS and wasn't added to it
+    should NOT see it in the default list — only the creator does. This
+    is the noise-reduction guarantee: full_admin_access grants capability
+    (direct GET still works), not list membership.
+    """
+    creator = bootstrap_admin("creator")
+    org_id = creator["org_id"]
+
+    ds = sqlite_data_source(name="creator_ds", user_token=creator["token"], org_id=org_id)
+    ds_id = ds["id"]
+
+    second_admin = invite_user_to_org(
+        org_id=org_id, admin_token=creator["token"], role="admin"
+    )
+
+    # The default list MUST NOT include a DS the admin neither created
+    # nor was added to.
+    list_resp = test_client.get(
+        "/api/data_sources", headers=_hdr(second_admin["token"], org_id)
+    )
+    assert list_resp.status_code == 200, list_resp.json()
+    assert ds_id not in {d["id"] for d in list_resp.json()}, (
+        f"second admin should not auto-see {ds_id}; got {list_resp.json()}"
+    )
+
+    # Capability bypass is preserved: direct GET still succeeds for admins.
+    detail = test_client.get(
+        f"/api/data_sources/{ds_id}", headers=_hdr(second_admin["token"], org_id)
+    )
+    assert detail.status_code == 200, detail.json()
 
 
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The /data_sources and /data_sources/active list endpoints previously
short-circuited filtering for any user holding full_admin_access — admins
saw every DS in the org by default, even ones they were never added to.
This made the agents/DS list noisy in orgs with many admins, since
admins appeared to "join" everything implicitly.

Now both list endpoints filter by explicit membership (legacy
DataSourceMembership + ResourceGrant unioned with public DSes), same as
any other user. Admins still get capability bypass via
get_accessible_data_source_ids / user_can_access_data_source, so direct
GET /data_sources/{id} (and the @requires_resource_permission decorators
behind it) keep working — admins can manage any DS by URL, they just
don't see every DS unprompted.

Creator-as-member is unchanged (data_source_service.py:445), so a DS
created by an admin still shows up in that admin's list.