### PR TITLE
Hide Intercom launcher on mobile viewports

### DIFF
--- a/frontend/composables/useMobile.ts
+++ b/frontend/composables/useMobile.ts
@@ -1,0 +1,29 @@
+import { ref, readonly, onMounted, onBeforeUnmount } from 'vue'
+
+const MOBILE_BREAKPOINT_PX = 768
+
+const globalIsMobile = ref(false)
+let listenerInstalled = false
+
+function update() {
+  if (typeof window === 'undefined') return
+  globalIsMobile.value = window.innerWidth < MOBILE_BREAKPOINT_PX
+}
+
+function ensureListener() {
+  if (typeof window === 'undefined') return
+  if (listenerInstalled) return
+  listenerInstalled = true
+  update()
+  window.addEventListener('resize', update)
+}
+
+export const useMobile = () => {
+  onMounted(ensureListener)
+  // Also try synchronously so the first read on the client is correct.
+  ensureListener()
+
+  return {
+    isMobile: readonly(globalIsMobile)
+  }
+}

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -295,6 +295,7 @@
   })
 
   const { isExcel } = useExcel()
+  const { isMobile } = useMobile()
   const router = useRouter()
   const { $intercom } = useNuxtApp()
 
@@ -390,8 +391,9 @@
   const isAdmin = computed<boolean>(() => useCan('full_admin_access'))
  
   if (environment === 'production' && intercom) {
+    const hideLauncher = computed<boolean>(() => isExcel.value || isMobile.value)
     $intercom.boot({
-      hide_default_launcher: isExcel.value,
+      hide_default_launcher: hideLauncher.value,
       alignment: intercomAlignment.value
     })
     watch([currentUser, organization], ([user, org]) => {
@@ -403,7 +405,7 @@
           version: version,
           environment: environment,
           app_url: app_url,
-          hide_default_launcher: isExcel.value,
+          hide_default_launcher: hideLauncher.value,
           alignment: intercomAlignment.value,
           company: {
             company_id: org.id,
@@ -414,6 +416,9 @@
     }, { immediate: true })
     watch(intercomAlignment, (alignment) => {
       $intercom.update({ alignment })
+    })
+    watch(hideLauncher, (hide) => {
+      $intercom.update({ hide_default_launcher: hide })
     })
   }
 

--- a/frontend/layouts/users.vue
+++ b/frontend/layouts/users.vue
@@ -9,6 +9,7 @@
 const { signIn, signOut, token, data: currentUser, status, lastRefreshedAt, getSession } = useAuth()
 const { $intercom } = useNuxtApp()
 const { environment, intercom } = useRuntimeConfig().public
+const { isMobile } = useMobile()
 const route = useRoute()
 const { locale: i18nLocale } = useI18n({ useScope: 'global' })
 const RTL_LOCALES = new Set(['he', 'ar', 'fa', 'ur'])
@@ -17,9 +18,15 @@ const intercomAlignment = computed<'left' | 'right'>(() =>
 )
 
 if (environment === 'production' && intercom) {
-  $intercom.boot({ alignment: intercomAlignment.value })
+  $intercom.boot({
+    hide_default_launcher: isMobile.value,
+    alignment: intercomAlignment.value
+  })
   watch(intercomAlignment, (alignment) => {
     $intercom.update({ alignment })
+  })
+  watch(isMobile, (hide) => {
+    $intercom.update({ hide_default_launcher: hide })
   })
 }
 


### PR DESCRIPTION
Mirror the existing Excel-mode behavior so the launcher also gets out of
the way on narrow screens (< 768 px). Add a shared useMobile composable
and apply hide_default_launcher in both the default and users layouts,
reactively updating it on resize.