### PR TITLE
Fix DataSourceSelector tap and mobile dashboard full-screen

### DIFF
--- a/backend/app/routes/data_source.py
+++ b/backend/app/routes/data_source.py
@@ -42,11 +42,12 @@ async def get_data_sources(
 
 @router.get("/data_sources/active", response_model=list[DataSourceListItemSchema])
 async def get_active_data_sources(
+    include_unconnected: bool = Query(False, description="Include user_required data sources the user hasn't connected yet (returned with user_status so the client can offer a Connect action)"),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization)
 ):
-    return await data_source_service.get_active_data_sources(db, organization, current_user)
+    return await data_source_service.get_active_data_sources(db, organization, current_user, include_unconnected=include_unconnected)
 
 @router.get("/data_sources/{data_source_id}", response_model=DataSourceSchema)
 @requires_resource_permission('data_source', 'view')

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -886,7 +886,7 @@ class DataSourceService:
             schemas.append(s)
         return schemas
 
-    async def get_active_data_sources(self, db: AsyncSession, organization: Organization, current_user: User = None) -> List[DataSourceListItemSchema]:
+    async def get_active_data_sources(self, db: AsyncSession, organization: Organization, current_user: User = None, include_unconnected: bool = False) -> List[DataSourceListItemSchema]:
         """Get all active data sources for an organization that the user has access to, compact list shape"""
         # See get_data_sources above for the lazyload("*") rationale — same
         # cascade applies here. The list schema doesn't expose
@@ -961,13 +961,15 @@ class DataSourceService:
 
             # Exclude user_required data sources lacking user credentials,
             # unless the user has permission to update data sources (admin/editor)
+            # or the caller explicitly opted in via include_unconnected (so the
+            # client can surface a "Connect" action for them).
             auth_policy = conn.auth_policy if conn else "system_only"
             if auth_policy == "user_required" and current_user:
                 try:
                     has_user_creds = getattr(s.user_status, "has_user_credentials", False)
                 except Exception:
                     has_user_creds = False
-                if not has_user_creds and not has_update_perm:
+                if not has_user_creds and not has_update_perm and not include_unconnected:
                     continue
             items.append(s)
         return items

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -116,6 +116,17 @@ const hoveredDataSourceId = ref<string | null>(null)
 const flyout = reactive({ visible: false, bottom: 0, left: 0 })
 let flyoutHideTimer: ReturnType<typeof setTimeout> | null = null
 
+// On touch/coarse-pointer devices there is no hover. Tapping a row would
+// otherwise fire `mouseenter` and pop the fixed flyout overlay on top of the
+// list, swallowing the tap so the selection never registers. Detect touch and
+// skip the flyout entirely so rows stay tappable on mobile.
+const isTouchDevice = ref(false)
+onMounted(() => {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+        isTouchDevice.value = window.matchMedia('(pointer: coarse)').matches
+    }
+})
+
 const showFlyoutAtEvent = (evt: MouseEvent) => {
     const el = evt.currentTarget as HTMLElement | null
     if (!el) return
@@ -149,6 +160,8 @@ const showFlyoutAtEvent = (evt: MouseEvent) => {
 }
 
 const onDataSourceHover = (dataSourceId: string, evt: MouseEvent) => {
+    // No hover flyout on touch devices — keep rows tappable.
+    if (isTouchDevice.value) return
     if (flyoutHideTimer) {
         clearTimeout(flyoutHideTimer)
         flyoutHideTimer = null

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -45,35 +45,63 @@
                         <span>Loading data sources…</span>
                     </div>
                     <template v-else>
-                        <div v-if="visibleDataSources.length === 0" class="text-center text-gray-500 py-4">
+                        <div v-if="visibleDataSources.length === 0 && connectableDataSources.length === 0" class="text-center text-gray-500 py-4">
                             No data sources found
                         </div>
                         <template v-else>
-                            <div
-                                class="px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer flex items-center justify-between"
-                                @click="toggleAutoMode"
-                            >
-                                <div class="flex items-center">
-                                    <Icon name="heroicons-bolt" class="h-4 w-4 text-gray-500 me-2" />
-                                    <span class="text-[13px]">Auto</span>
+                            <template v-if="visibleDataSources.length > 0">
+                                <div
+                                    class="px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer flex items-center justify-between"
+                                    @click="toggleAutoMode"
+                                >
+                                    <div class="flex items-center">
+                                        <Icon name="heroicons-bolt" class="h-4 w-4 text-gray-500 me-2" />
+                                        <span class="text-[13px]">Auto</span>
+                                    </div>
+                                    <Icon v-if="isAutoMode" name="heroicons-check" class="w-4 h-4 text-blue-500" />
                                 </div>
-                                <Icon v-if="isAutoMode" name="heroicons-check" class="w-4 h-4 text-blue-500" />
-                            </div>
-                            <div class="my-1 border-t border-gray-100" />
-                            <div
-                                v-for="ds in visibleDataSources"
-                                :key="ds.id"
-                                class="px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer flex items-center justify-between"
-                                @click="() => { toggleDataSource(ds); }"
-                                @mouseenter="onDataSourceHover(ds.id, $event)"
-                                @mouseleave="onDataSourceHoverLeave()"
-                            >
-                                <div class="flex items-center">
-                                    <DataSourceIcon :type="ds.type" class="h-4" />
-                                    <span class="ms-2 text-[13px]">{{ ds.name }}</span>
+                                <div class="my-1 border-t border-gray-100" />
+                                <div
+                                    v-for="ds in visibleDataSources"
+                                    :key="ds.id"
+                                    class="px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer flex items-center justify-between"
+                                    @click="() => { toggleDataSource(ds); }"
+                                    @mouseenter="onDataSourceHover(ds.id, $event)"
+                                    @mouseleave="onDataSourceHoverLeave()"
+                                >
+                                    <div class="flex items-center">
+                                        <DataSourceIcon :type="ds.type" class="h-4" />
+                                        <span class="ms-2 text-[13px]">{{ ds.name }}</span>
+                                    </div>
+                                    <Icon v-if="!isAutoMode && isSelected(ds)" name="heroicons-check" class="w-4 h-4 text-blue-500" />
                                 </div>
-                                <Icon v-if="!isAutoMode && isSelected(ds)" name="heroicons-check" class="w-4 h-4 text-blue-500" />
-                            </div>
+                            </template>
+
+                            <!-- Not-yet-connected (user_required) data sources: grayed out
+                                 with a Connect action. These are NOT selectable and are
+                                 never persisted to the report until connected. -->
+                            <template v-if="connectableDataSources.length > 0">
+                                <div v-if="visibleDataSources.length > 0" class="my-1 border-t border-gray-100" />
+                                <div
+                                    v-for="ds in connectableDataSources"
+                                    :key="ds.id"
+                                    class="px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer flex items-center justify-between gap-2"
+                                    @click="openCredentialsModal(ds)"
+                                >
+                                    <div class="flex items-center min-w-0 opacity-50">
+                                        <DataSourceIcon :type="ds.type" class="h-4 flex-shrink-0" />
+                                        <span class="ms-2 text-[13px] truncate">{{ ds.name }}</span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        class="flex-shrink-0 inline-flex items-center gap-1 px-2 py-0.5 text-[11px] text-blue-600 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+                                        @click.stop="openCredentialsModal(ds)"
+                                    >
+                                        <Icon name="heroicons-key" class="w-3 h-3" />
+                                        {{ $t('data.connect') }}
+                                    </button>
+                                </div>
+                            </template>
                         </template>
                     </template>
                 </div>
@@ -88,6 +116,13 @@
             @mouseenter="onFlyoutEnter"
             @mouseleave="onFlyoutLeave"
         />
+
+        <!-- User credentials / OAuth modal for connecting user_required sources -->
+        <UserDataSourceCredentialsModal
+            v-model="showCredsModal"
+            :data-source="selectedConnectDs"
+            @saved="onCredentialsSaved"
+        />
     </div>
 
 </template>
@@ -96,11 +131,16 @@
 import Spinner from '@/components/Spinner.vue'
 import AgentFlyout from '~/components/AgentFlyout.vue'
 import AgentIcon from '~/components/icons/AgentIcon.vue'
+import UserDataSourceCredentialsModal from '~/components/UserDataSourceCredentialsModal.vue'
 import { usePermissions, usePermissionsLoaded, useResourcePermissions } from '~/composables/usePermissions'
 
-type DataSource = { id: string; name: string; type?: string; auth_policy?: string; user_status?: { effective_auth?: string; has_user_credentials?: boolean; uses_fallback?: boolean } }
+type DataSource = { id: string; name: string; type?: string; auth_policy?: string; connections?: any[]; user_status?: { effective_auth?: string; has_user_credentials?: boolean; uses_fallback?: boolean } }
 const internalSelectedDataSources = ref<DataSource[]>([])
 const dataSources = ref<DataSource[]>([])
+// user_required data sources the user hasn't connected yet — shown grayed out
+// with a Connect action. Kept separate so they never enter selection/auto-mode
+// and are never persisted to the report.
+const connectableDataSources = ref<DataSource[]>([])
 const isLoading = ref(true)
 const isOpen = ref(false)
 const containerRef = ref<HTMLElement | null>(null)
@@ -126,6 +166,21 @@ onMounted(() => {
         isTouchDevice.value = window.matchMedia('(pointer: coarse)').matches
     }
 })
+
+// Connect (user credentials / OAuth) modal state
+const showCredsModal = ref(false)
+const selectedConnectDs = ref<DataSource | null>(null)
+
+function openCredentialsModal(ds: DataSource) {
+    selectedConnectDs.value = ds
+    showCredsModal.value = true
+}
+
+async function onCredentialsSaved() {
+    showCredsModal.value = false
+    // Re-fetch so a freshly-connected source moves into the selectable list.
+    await getDataSources()
+}
 
 const showFlyoutAtEvent = (evt: MouseEvent) => {
     const el = evt.currentTarget as HTMLElement | null
@@ -233,17 +288,20 @@ async function getDataSources() {
     try {
         const response = await useMyFetch('/data_sources/active', {
             method: 'GET',
+            query: { include_unconnected: true },
         })
         const allSources = (response.data.value as any[]) || []
-        // Exclude data sources that require user credentials the user hasn't provided
-        dataSources.value = allSources.filter((ds: any) => {
-            if (ds.auth_policy === 'user_required') {
-                const status = ds.user_status
-                if (status?.has_user_credentials) return true
-                return status?.effective_auth === 'system' && !status?.uses_fallback
-            }
-            return true
-        })
+        // A source is usable (selectable) when it doesn't require per-user
+        // credentials, or the user already has them / falls back to system auth.
+        const isUsable = (ds: any) => {
+            if (ds.auth_policy !== 'user_required') return true
+            const status = ds.user_status
+            if (status?.has_user_credentials) return true
+            return status?.effective_auth === 'system' && !status?.uses_fallback
+        }
+        dataSources.value = allSources.filter(isUsable)
+        // Everything else returned is a user_required source the user can connect.
+        connectableDataSources.value = allSources.filter((ds: any) => !isUsable(ds))
         // Initialize selection from prop if provided, otherwise leave empty for parent to decide
         if ((props.selectedDataSources as any[])?.length) {
             // Align to the objects from the current dataSources list by id

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -14,7 +14,7 @@
 	</div>
 
 	<SplitScreenLayout v-else
-		:isSplitScreen="isSplitScreen" 
+		:isSplitScreen="isSplitScreen && !isMobile"
 		:leftPanelWidth="leftPanelWidth"
 		:isResizing="isResizing"
 		@startResize="startResize"
@@ -519,7 +519,7 @@
 					:compact="isExcel"
 					@submitCompletion="onSubmitCompletion"
 					@stopGeneration="abortStream"
-					@viewDashboard="() => { if (!isSplitScreen) toggleSplitScreen(); rightPanelView = 'artifact'; }"
+					@viewDashboard="() => { if (isMobile) { mobileView = 'dashboard'; } else { if (!isSplitScreen) toggleSplitScreen(); rightPanelView = 'artifact'; } }"
 					@scrollToMessage="scrollToMessage"
 					@editScheduledPrompt="editScheduledPrompt"
 					@editTrainingInstruction="editTrainingInstruction"
@@ -2865,6 +2865,12 @@ async function checkHasArtifacts(): Promise<boolean> {
 const { collapse: collapseSidebar } = useSidebar()
 
 function toggleSplitScreen() {
+	// On mobile there is no split layout — surface the dashboard as a
+	// full-screen tab instead of opening the side panel.
+	if (isMobile.value) {
+		mobileView.value = mobileView.value === 'dashboard' ? 'chat' : 'dashboard'
+		return
+	}
 	nextTick(() => {
 		isSplitScreen.value = !isSplitScreen.value
 		if (isSplitScreen.value) {


### PR DESCRIPTION
- DataSourceSelector: skip the hover flyout on touch/coarse-pointer devices so tapping a data-source row registers the selection instead of being swallowed by the fixed flyout overlay.
- reports/[id]: never split the layout on mobile; route dashboard (and other tabs) to full-screen mobile views via mobileView so the split panel does not collide with the narrow viewport.