### PR TITLE
Pin Snyk's Python version to 3.12 via backend/.snyk

### DIFF
--- a/backend/.snyk
+++ b/backend/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file.
+#
+# Pin the Python version Snyk uses when resolving this project's
+# requirements_versioned.txt during SCM/Git scans.
+#
+# Without this, Snyk defaults to Python 3.7 and resolves version-gated
+# packages down to their newest 3.7-compatible release (e.g. pillow ->
+# 9.5.0, pyarrow -> 12.0.1), producing false-positive vulnerabilities for
+# versions this project does not ship. The deployed image runs on Ubuntu
+# 24.04 (Python 3.12), where the pinned versions (pillow 12.2.0,
+# pyarrow 16.1.0) are current and unaffected.
+language-settings:
+  python: '3.12'


### PR DESCRIPTION
## What

Adds `backend/.snyk` pinning the Python version Snyk uses for SCM dependency resolution to **3.12**:

```yaml
language-settings:
  python: '3.12'
```

## Why

Snyk's Git/SCM scanner **defaults to Python 3.7** when no version is configured (it does *not* read `pyproject.toml` `requires-python`, `.python-version`, `runtime.txt`, or `setup.py` `python_requires`). Under that assumption it treats our modern, version-gated pins as "incompatible" and silently resolves them **down** to their newest 3.7-compatible release, then reports CVEs against those old versions:

| Pinned in `requirements_versioned.txt` | Needs Python | Snyk (py3.7) resolves to | False-positive CVE |
|---|---|---|---|
| `pillow==12.2.0` | ≥3.10 | **9.5.0** | CVE-2023-4863 (+7 more) |
| `pyarrow==16.1.0` | ≥3.8 | **12.0.1** | CVE-2023-47248 |

These do **not** apply to what we actually ship. The Docker image builds on **Ubuntu 24.04 (Python 3.12)**, where `pillow 12.2.0` and `pyarrow 16.1.0` are current and unaffected.

## Verification

- `pillow 9.5.0` is the newest Pillow supporting Python 3.7; `pyarrow 12.0.1` is the newest pyarrow supporting 3.7 and is `< 14.0.1` (the CVE-2023-47248 fix) — exactly matching the Snyk report.
- Ran Snyk CLI against the real `pillow==12.2.0` in a Python venv → *"no vulnerable paths found."* Snyk's own DB agrees the actual version is clean.
- Independent scanners (Trivy, pip-audit) report **no** Pillow/pyarrow CVE-2023-x findings against the real pins.

## Effect

After this lands and the Snyk project is re-tested, the phantom pillow/pyarrow criticals clear, and likely several other findings that were the same py3.7 downgrade artifact. (Alternatively/additionally, the Org-level Python setting can be set to 3.12 in the Snyk UI.)

This does **not** touch genuinely-real dependency findings (e.g. duckdb 1.4.1 → 1.4.2), which are tracked separately.

https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C)_