### PR TITLE
Fix OAuth credential storage failure on PostgreSQL (naive expires_at)

### DIFF
--- a/backend/app/routes/connection_oauth.py
+++ b/backend/app/routes/connection_oauth.py
@@ -28,6 +28,7 @@ from app.services.connection_oauth_service import (
     generate_pkce_pair,
     get_oauth_params,
     exchange_code_for_tokens,
+    parse_expires_at,
 )
 
 logger = get_logger(__name__)
@@ -292,7 +293,7 @@ async def oauth_callback(
     if existing:
         existing.auth_mode = "oauth"
         existing.encrypt_credentials(tokens)
-        existing.expires_at = datetime.fromisoformat(tokens["expires_at"]) if tokens.get("expires_at") else None
+        existing.expires_at = parse_expires_at(tokens.get("expires_at"))
         db.add(existing)
     else:
         row = UserConnectionCredentials(
@@ -302,7 +303,7 @@ async def oauth_callback(
             auth_mode="oauth",
             is_active=True,
             is_primary=True,
-            expires_at=datetime.fromisoformat(tokens["expires_at"]) if tokens.get("expires_at") else None,
+            expires_at=parse_expires_at(tokens.get("expires_at")),
         )
         row.encrypt_credentials(tokens)
         db.add(row)

--- a/backend/app/services/connection_oauth_service.py
+++ b/backend/app/services/connection_oauth_service.py
@@ -23,6 +23,25 @@ from app.settings.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+def parse_expires_at(value: Optional[str]) -> Optional[datetime]:
+    """Parse an OAuth ``expires_at`` ISO string into a naive UTC datetime.
+
+    Token responses encode ``expires_at`` as an RFC3339 string with a UTC
+    offset (e.g. ``2026-06-02T10:09:32+00:00``), which ``datetime.fromisoformat``
+    turns into a timezone-aware datetime. The ``user_connection_credentials``
+    columns are ``TIMESTAMP WITHOUT TIME ZONE`` (matching ``created_at`` /
+    ``updated_at``, which use naive UTC), and asyncpg rejects aware datetimes
+    for those columns. Normalize to naive UTC so the value is consistent with
+    the rest of the schema and storable on PostgreSQL.
+    """
+    if not value:
+        return None
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
 # ---------------------------------------------------------------------------
 # PKCE helpers (extracted from auth_providers.py for reuse)
 # ---------------------------------------------------------------------------
@@ -402,7 +421,7 @@ async def auto_provision_connection_credentials(
         # Upsert credentials
         if existing:
             existing.encrypt_credentials(tokens)
-            existing.expires_at = datetime.fromisoformat(tokens["expires_at"]) if tokens.get("expires_at") else None
+            existing.expires_at = parse_expires_at(tokens.get("expires_at"))
             db.add(existing)
         else:
             row = UserConnectionCredentials(
@@ -412,7 +431,7 @@ async def auto_provision_connection_credentials(
                 auth_mode="oauth",
                 is_active=True,
                 is_primary=True,
-                expires_at=datetime.fromisoformat(tokens["expires_at"]) if tokens.get("expires_at") else None,
+                expires_at=parse_expires_at(tokens.get("expires_at")),
             )
             row.encrypt_credentials(tokens)
             db.add(row)
@@ -481,7 +500,7 @@ async def maybe_refresh_oauth_credentials(
         new_tokens = await refresh_access_token(oauth_params, refresh_token)
         # Update stored credentials
         cred_row.encrypt_credentials(new_tokens)
-        cred_row.expires_at = datetime.fromisoformat(new_tokens["expires_at"])
+        cred_row.expires_at = parse_expires_at(new_tokens.get("expires_at"))
         db.add(cred_row)
         await db.commit()
         await db.refresh(cred_row)

--- a/backend/tests/unit/test_connection_oauth.py
+++ b/backend/tests/unit/test_connection_oauth.py
@@ -19,6 +19,7 @@ from app.services.connection_oauth_service import (
     exchange_code_for_tokens,
     refresh_access_token,
     exchange_obo_token,
+    parse_expires_at,
     ENTRA_OBO_CONNECTION_TYPES,
 )
 
@@ -434,3 +435,42 @@ class TestIsEntraProvider:
         from app.services.auth_providers import _is_entra_provider
         with patch("app.services.auth_providers._get_oidc_config", return_value=None):
             assert _is_entra_provider("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_expires_at Tests
+# ---------------------------------------------------------------------------
+
+class TestParseExpiresAt:
+    """parse_expires_at must return naive UTC so the value is storable on
+    PostgreSQL TIMESTAMP WITHOUT TIME ZONE columns (regression: asyncpg
+    DataError 'can't subtract offset-naive and offset-aware datetimes')."""
+
+    def test_aware_iso_string_becomes_naive_utc(self):
+        # The shape produced by exchange_*_token(): RFC3339 with +00:00 offset.
+        result = parse_expires_at("2026-06-02T10:09:32.274348+00:00")
+        assert result.tzinfo is None
+        assert result == datetime(2026, 6, 2, 10, 9, 32, 274348)
+
+    def test_offset_is_converted_to_utc_then_stripped(self):
+        # A +02:00 wall-clock time must be shifted to 08:00 UTC, then made naive.
+        result = parse_expires_at("2026-06-02T10:00:00+02:00")
+        assert result.tzinfo is None
+        assert result == datetime(2026, 6, 2, 8, 0, 0)
+
+    def test_naive_iso_string_passthrough(self):
+        result = parse_expires_at("2026-06-02T10:00:00")
+        assert result.tzinfo is None
+        assert result == datetime(2026, 6, 2, 10, 0, 0)
+
+    def test_none_returns_none(self):
+        assert parse_expires_at(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_expires_at("") is None
+
+    def test_real_token_expires_at_is_naive(self):
+        # End-to-end with the exact producer expression.
+        expires_at = datetime.fromtimestamp(time.time() + 3600, tz=timezone.utc).isoformat()
+        result = parse_expires_at(expires_at)
+        assert result.tzinfo is None


### PR DESCRIPTION
OAuth token responses encode expires_at as an RFC3339 string with a UTC
offset, so datetime.fromisoformat() produced a timezone-aware datetime.
The user_connection_credentials.expires_at column is TIMESTAMP WITHOUT
TIME ZONE (like created_at/updated_at, which use naive UTC), and asyncpg
rejects aware datetimes for those columns with:

  asyncpg.exceptions.DataError: invalid input for query argument $9 ...
  (can't subtract offset-naive and offset-aware datetimes)

This surfaced only on PostgreSQL deployments using the per-user OAuth
connector flow; SQLite silently accepts the aware value, which is why it
went unnoticed in SQLite-backed setups.

Add a parse_expires_at() helper that normalizes the value to naive UTC
and route all expires_at column writes through it (oauth_callback,
auto_provision_connection_credentials, maybe_refresh_oauth_credentials).
Add unit coverage for the helper.