### PR TITLE
Fix Athena connector: support boto3 default auth and optional S3 output location

### DIFF
--- a/backend/app/data_sources/clients/aws_athena_client.py
+++ b/backend/app/data_sources/clients/aws_athena_client.py
@@ -88,7 +88,7 @@ class AwsAthenaClient(DataSourceClient):
         self,
         region: str,
         database: str,
-        s3_output_location: str,
+        s3_output_location: str = None,
         access_key: str = None,
         secret_key: str = None,
         role_arn: str = None,
@@ -164,10 +164,11 @@ class AwsAthenaClient(DataSourceClient):
                 'sql': sql,
                 'database': self.database,
                 'ctas_approach': False,
-                's3_output': self.s3_output_location,
                 'workgroup': self.workgroup,
                 'data_source': self.data_source,
             }
+            if self.s3_output_location:
+                wrangler_params['s3_output'] = self.s3_output_location
             
             # Add optional parameters
             if self.encryption_option:
@@ -222,9 +223,10 @@ class AwsAthenaClient(DataSourceClient):
             }
         except Exception as e:
             if "AccessDenied" in str(e) and "S3" in str(e):
+                location = self.s3_output_location or "workgroup output location"
                 return {
                     "success": False,
-                    "message": f"Connected to Glue catalog but S3 access denied. Check S3 permissions for: {self.s3_output_location}"
+                    "message": f"Connected to Glue catalog but S3 access denied. Check S3 permissions for: {location}"
                 }
             elif "INVALID_INPUT" in str(e) and "database" in str(e).lower():
                 return {

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -90,6 +90,7 @@ from app.schemas.data_sources.configs import (
     GCPCredentials,
     AWSCostCredentials,
     AWSAthenaCredentials,
+    AWSAthenaDefaultCredentials,
     VerticaCredentials,
     AwsRedshiftUserPassCredentials,
     AwsRedshiftIAMCredentials,
@@ -307,8 +308,9 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         title="AWS Athena",
         description="AWS Athena is a serverless query service that makes it easy to analyze data in Amazon S3 using standard SQL.",
         config_schema=AWSAthenaConfig,
-        credentials_auth=AuthOptions(default="key", by_auth={
-            "key": AuthVariant(title="AWS Keys", schema=AWSAthenaCredentials, scopes=["system", "user"])  # system
+        credentials_auth=AuthOptions(default="default", by_auth={
+            "default": AuthVariant(title="AWS Default (IAM Role / Instance Profile)", schema=AWSAthenaDefaultCredentials, scopes=["system", "user"]),
+            "key": AuthVariant(title="AWS Access Keys", schema=AWSAthenaCredentials, scopes=["system", "user"]),
         }),
         client_path=None,
         version="beta",

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -316,11 +316,17 @@ class AWSAthenaCredentials(BaseModel):
     role_arn: str = Field(..., title="Role ARN", description="", json_schema_extra={"ui:type": "string"})
 
 
+class AWSAthenaDefaultCredentials(BaseModel):
+    """No credentials required — boto3 resolves via its default chain (env vars, instance profile, IRSA, etc.)."""
+    class Config:
+        extra = 'allow'
+
+
 class AWSAthenaConfig(BaseModel):
     region: str = Field(..., title="Region", description="", json_schema_extra={"ui:type": "string"})
     database: str = Field(..., title="Database", description="", json_schema_extra={"ui:type": "string"})
     workgroup: str = Field("primary", title="Workgroup", description="", json_schema_extra={"ui:type": "string"})
-    s3_output_location: str = Field(..., title="S3 Output Location", description="", json_schema_extra={"ui:type": "string"})
+    s3_output_location: Optional[str] = Field(None, title="S3 Output Location", description="Leave blank if your workgroup has a default output location", json_schema_extra={"ui:type": "string"})
     data_source: str = Field("AwsDataCatalog", title="Data Source", description="", json_schema_extra={"ui:type": "string"})
 
 
@@ -1219,6 +1225,7 @@ __all__ = [
     "GCPCredentials",
     "AWSCostCredentials",
     "AWSAthenaCredentials",
+    "AWSAthenaDefaultCredentials",
     "VerticaCredentials",
     "AwsRedshiftCredentials",
     "TableauCredentials",

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -461,7 +461,7 @@ class ConnectionService:
                 }
 
             table_count = schema_status.get("table_count", 0)
-            message = _connected_message(connection.type, table_count)
+            message = _connected_message(data_source_type, table_count)
             return {
                 "success": True,
                 "message": message,


### PR DESCRIPTION
## Summary

- **Add boto3 default auth variant** — users relying on the AWS SDK's default credential chain (env vars, instance profiles, EKS pod identity / IRSA, EC2 instance roles) can now connect to Athena without providing explicit access keys or a role ARN. The new auth option is called *AWS Default (IAM Role / Instance Profile)* and is now the default selection.
- **Make `s3_output_location` optional** — workgroups that already have a default output location configured no longer need to supply it during datasource setup.
- **Fix `NameError` in `test_connection_params`** — `connection.type` was incorrectly referenced instead of `data_source_type`, causing every new connection test to raise `name 'connection' is not defined`.

## Changes

| File | Change |
|------|--------|
| `configs.py` | Add `AWSAthenaDefaultCredentials` (empty model); make `s3_output_location` optional |
| `data_source_registry.py` | Add `"default"` auth variant; set it as the default |
| `aws_athena_client.py` | Make `s3_output_location` optional; omit `s3_output` from wrangler when unset |
| `connection_service.py` | Fix `connection.type` → `data_source_type` in `test_connection_params` |

## Test Plan

- [ ] Add Athena datasource using "AWS Default" auth (no keys) — should connect successfully when running with an IAM role/instance profile
- [ ] Add Athena datasource using "AWS Access Keys" auth — existing behaviour unchanged
- [ ] Add Athena datasource without filling in S3 Output Location when workgroup has a default — should not raise a validation error
- [ ] Verify the `NameError` is gone by observing a successful connection test message

🤖 Generated with [Claude Code](https://claude.com/claude-code)