### PR TITLE
Bump PyJWT 2.12.0 → 2.13.0 (fix Improper Authentication, CWE-287)

### DIFF
--- a/backend/requirements_versioned.txt
+++ b/backend/requirements_versioned.txt
@@ -122,7 +122,7 @@ pydantic==2.11.10
 pydantic-settings==2.7.0
 pydantic_core==2.33.2
 Pygments==2.20.0
-PyJWT==2.12.0
+PyJWT==2.13.0
 PyMySQL==1.1.1
 pyOpenSSL==26.0.0
 pyparsing==3.2.0


### PR DESCRIPTION
## What
`PyJWT 2.12.0 → 2.13.0` in `backend/requirements_versioned.txt`.

## Why
Snyk flagged **5 issues** in `pyjwt@2.12.0`, **newly disclosed after the previous dependency sweep**, led by:

| Sev | Issue | CWE | CVSS |
|---|---|---|---|
| **High** | Improper Authentication | CWE-287 | 8.8 |
| Medium | Allocation of Resources Without Limits | CWE-770 | 6.9 |
| Medium | Improper Verification of Cryptographic Signature | CWE-347 | 5.3 |

All are fixed in **2.13.0**. PyJWT is used directly by `app/ee/license.py` (`jwt.decode`) and the auth stack, so this is relevant, not just transitive noise.

## Validation
- Full requirements set resolves with **no conflicts** (`pip install --dry-run`).
- Satisfies `fastapi-users 15.0.5` constraint `pyjwt[crypto]<3.0.0,>=2.12.0`.
- `pyjwt 2.13.0` requires Python ≥3.9; runtime is 3.12. ✓

## Note
The `shell-quote` (Critical) and `devalue` (High) entries still showing in the Snyk UI are **already fixed** in `main`'s `yarn.lock` (`shell-quote@1.8.4`, `devalue@5.8.1`) via PR #300 — that view is a stale pre-merge scan and will clear on the next Snyk re-test. This PR is the only outstanding real fix.

https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C)_