### PR TITLE
Fix permission resolution race condition and Settings link visibility

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -239,6 +239,24 @@
     external?: boolean
     activePath?: string
   }
+  // Settings tabs and the permission each requires — must mirror the tab list
+  // in layouts/settings.vue. The sidebar Settings link uses this to (a) hide
+  // itself when no tab is reachable and (b) deep-link to the first reachable
+  // tab, so clicking it never lands on a page the user gets redirected out of.
+  const settingsTabPermissions: { name: string; permission: string }[] = [
+    { name: 'members', permission: 'view_members' },
+    { name: 'models', permission: 'manage_llm' },
+    { name: 'ai_settings', permission: 'manage_settings' },
+    { name: 'general', permission: 'manage_settings' },
+    { name: 'integrations', permission: 'manage_settings' },
+    { name: 'audit', permission: 'view_audit_logs' },
+    { name: 'identity-provider', permission: 'manage_identity_providers' },
+    { name: 'license', permission: 'manage_settings' },
+  ]
+  const firstAccessibleSettingsTab = computed(() =>
+    settingsTabPermissions.find(tab => useCan(tab.permission)) || null
+  )
+
   const mainNavItems: NavItem[] = [
     { href: '/reports', icon: 'heroicons-chat-bubble-left-right', label: 'nav.reports' },
     { href: '/dashboards', icon: 'heroicons-chart-bar-square', label: 'nav.dashboards' },
@@ -250,11 +268,22 @@
     { href: '/evals', icon: 'heroicons-check-circle', label: 'nav.evals', permission: 'manage_evals' },
   ]
 
-  const bottomNavItems: NavItem[] = [
-    { href: '/agents', component: AgentIcon, label: 'nav.dataAgents' },
-    { href: '/settings/members', activePath: '/settings', icon: 'heroicons-cog-6-tooth', label: 'nav.settings' },
-    { href: 'https://docs.bagofwords.com', icon: 'heroicons-book-open', label: 'nav.documentation', external: true },
-  ]
+  const bottomNavItems = computed<NavItem[]>(() => {
+    const items: NavItem[] = [
+      { href: '/agents', component: AgentIcon, label: 'nav.dataAgents' },
+    ]
+    // The Settings entry was always shown but hard-linked to /settings/members,
+    // which requires `view_members`. A user on a custom role without that perm
+    // would click it and get silently bounced to '/' by permissions.global.ts —
+    // i.e. "the Settings button does nothing". Only surface it when the user can
+    // actually reach a settings tab, and point it at the first one they can open.
+    const tab = firstAccessibleSettingsTab.value
+    if (tab) {
+      items.push({ href: `/settings/${tab.name}`, activePath: '/settings', icon: 'heroicons-cog-6-tooth', label: 'nav.settings' })
+    }
+    items.push({ href: 'https://docs.bagofwords.com', icon: 'heroicons-book-open', label: 'nav.documentation', external: true })
+    return items
+  })
   
   // Agent management - use selectedAgentObjects for new report creation
   const { initAgent, selectedAgentObjects, agents, hasAgents } = useAgent()

--- a/frontend/plugins/fetchPermissions.client.ts
+++ b/frontend/plugins/fetchPermissions.client.ts
@@ -1,46 +1,54 @@
 import { usePermissions, usePermissionsLoaded, useResourcePermissions } from '~/composables/usePermissions'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
-  const { getSession } = useAuth()
+  const { getSession, data: sessionData } = useAuth()
   const { organization, ensureOrganization } = useOrganization()
   const permissions = usePermissions()
   const permissionsLoaded = usePermissionsLoaded()
   const resourcePermissions = useResourcePermissions()
 
-  // Extract the permission loading logic into a reusable function
+  // Resolve the active org's permissions from an already-fetched session.
+  // Pure (no network): safe to call from a reactive watcher without looping.
+  // Returns true once the active org was matched and its permissions applied.
+  const resolveFromSession = (session: any): boolean => {
+    if (!session?.organizations?.length) return false
+
+    const org = session.organizations.find(
+      (o: any) => o.id === organization.value.id
+    )
+
+    // The active org may not be matchable yet (id not set, or the session
+    // predates the current selection). Don't fall back to member-only perms —
+    // that would strip an admin's `full_admin_access` and hide admin-gated
+    // items. Leave the existing set in place; the watcher re-resolves once the
+    // session or org settles.
+    if (!org) return false
+
+    if (org.permissions?.length) {
+      // New path: server-supplied resolved permissions
+      permissions.value = org.permissions
+      resourcePermissions.value = org.resource_permissions || {}
+    } else {
+      // Fallback: old path for backward compat during migration
+      permissions.value = getPermissionsForRole(org.role)
+      resourcePermissions.value = {}
+    }
+    permissionsLoaded.value = true
+    return true
+  }
+
+  // Initial load: fetch the session (and ensure an org is selected) once.
   const loadPermissions = async () => {
     try {
       const session = await getSession()
       await ensureOrganization()
-
-      if (!session) {
-        console.warn('Session data is undefined. Ensure the user is authenticated.')
-        permissionsLoaded.value = true
-        return
-      }
-
-      if (session.organizations && session.organizations.length > 0) {
-        const org = session.organizations.find(
-          (o: any) => o.id === organization.value.id
-        )
-
-        if (org?.permissions?.length) {
-          // New path: server-supplied resolved permissions
-          permissions.value = org.permissions
-          resourcePermissions.value = org.resource_permissions || {}
-        } else {
-          // Fallback: old path for backward compat during migration
-          const rolePermissions = getPermissionsForRole(org?.role)
-          permissions.value = rolePermissions
-          resourcePermissions.value = {}
-        }
-        permissionsLoaded.value = true
-      } else {
-        console.warn('No organizations found in session data.')
-        permissionsLoaded.value = true
-      }
+      resolveFromSession(session)
     } catch (error) {
       console.error('Error fetching session data:', error)
+    } finally {
+      // Always unblock the app even if the org couldn't be matched yet — gated
+      // items stay hidden until the watcher resolves real permissions, but the
+      // rest of the UI (which keys off `permissionsLoaded`) can render.
       permissionsLoaded.value = true
     }
   }
@@ -50,6 +58,20 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   // permission-gated sidebar links while Nuxt is also patching the page.
   // Under fast navigation this can trip Vue's Suspense DOM moves.
   await loadPermissions()
+
+  // Self-heal stale/partial permissions. The initial load can race: if the
+  // first whoami resolves before `organization.value.id` is set, the org
+  // lookup misses and an admin is left without `full_admin_access` — silently
+  // hiding admin-gated sidebar items (Monitoring, Evals) until a full reload.
+  // The session refreshes on window focus (`enableRefreshOnWindowFocus`) and
+  // the active org can change, so re-resolve from the latest session whenever
+  // either settles. Resolving is pure (no fetch), so watching `sessionData`
+  // can't loop, and we only ever set `permissionsLoaded` true (never back to
+  // false), so the permission set updates in place without flickering links.
+  watch(
+    [sessionData, () => organization.value?.id],
+    () => { resolveFromSession(sessionData.value) },
+  )
 })
 
 // Fallback: minimal MVP perms used only if the server didn't return resolved


### PR DESCRIPTION
## Summary
This PR fixes a race condition in permission resolution that could leave admins without proper permissions after initial load, and improves the Settings navigation link to only appear when the user can actually access at least one settings tab.

## Key Changes

- **Permission resolution refactoring** (`fetchPermissions.client.ts`):
  - Extracted permission resolution logic into a pure `resolveFromSession()` function that can be safely called from reactive watchers without network requests
  - Added a reactive watcher on `sessionData` and `organization.value.id` to re-resolve permissions when either changes, fixing the race condition where the initial session fetch completes before the organization ID is set
  - Improved error handling with a `finally` block to always set `permissionsLoaded = true`, preventing the app from blocking indefinitely
  - Added detailed comments explaining the race condition and why permissions aren't reset on failed matches

- **Settings navigation improvements** (`layouts/default.vue`):
  - Created `settingsTabPermissions` mapping that mirrors the actual settings tabs and their required permissions
  - Added `firstAccessibleSettingsTab` computed property to find the first settings tab the user can access
  - Changed `bottomNavItems` from a static array to a computed property that:
    - Only includes the Settings link when the user has permission to access at least one settings tab
    - Deep-links to the first accessible tab instead of always pointing to `/settings/members`
    - Prevents users from clicking a Settings button that would silently redirect them away

## Implementation Details

The permission resolution now follows a two-phase approach:
1. **Initial load**: Fetch session and ensure organization is selected
2. **Self-healing watcher**: Re-resolve permissions whenever the session refreshes (on window focus) or the active organization changes, without requiring additional network requests

This ensures that even if the initial load races and misses the organization match, permissions will be corrected once the organization ID settles, without flickering or silent redirects.

https://claude.ai/code/session_01SEHY74E1ZhRZY1hopQHpbD