### PR TITLE
Discover Postgres materialized views; add sandbox dev-env hook

### DIFF
--- a/backend/app/data_sources/clients/postgresql_client.py
+++ b/backend/app/data_sources/clients/postgresql_client.py
@@ -136,7 +136,85 @@ class PostgresqlClient(DataSourceClient):
                     dtype=data_type,
                     description=col_comment
                 ))
+
+            # Materialized views are not exposed via information_schema, so fetch
+            # them separately from pg_catalog and merge into the result.
+            self._append_materialized_views(conn, tables, with_comments=True)
             return list(tables.values())
+
+    def _append_materialized_views(self, conn, tables: dict, with_comments: bool) -> None:
+        """Append materialized view columns (and optional comments) to `tables`.
+
+        Materialized views (pg_class.relkind = 'm') are a Postgres-specific
+        object and are not present in information_schema, so the standard table
+        queries miss them. This reads them directly from pg_catalog.
+        """
+        params = {}
+        where_clauses = [
+            "c.relkind = 'm'",
+            "n.nspname NOT IN ('information_schema', 'pg_catalog')",
+        ]
+        if self._schemas:
+            in_keys = []
+            for idx, sch in enumerate(self._schemas):
+                key = f"mv_s{idx}"
+                params[key] = sch
+                in_keys.append(f":{key}")
+            where_clauses.append(f"n.nspname IN ({', '.join(in_keys)})")
+        where_sql = " WHERE " + " AND ".join(where_clauses)
+
+        if with_comments:
+            select_extra = (
+                ",\n                col_desc.description AS column_comment,"
+                "\n                tbl_desc.description AS table_comment"
+            )
+            join_extra = """
+            LEFT JOIN pg_catalog.pg_description col_desc
+                ON col_desc.objoid = c.oid AND col_desc.objsubid = a.attnum
+            LEFT JOIN pg_catalog.pg_description tbl_desc
+                ON tbl_desc.objoid = c.oid AND tbl_desc.objsubid = 0"""
+        else:
+            select_extra = ""
+            join_extra = ""
+
+        sql = text(f"""
+            SELECT
+                n.nspname AS table_schema,
+                c.relname AS table_name,
+                a.attname AS column_name,
+                format_type(a.atttypid, a.atttypmod) AS data_type{select_extra}
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n
+                ON n.oid = c.relnamespace
+            JOIN pg_catalog.pg_attribute a
+                ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped{join_extra}
+            {where_sql}
+            ORDER BY n.nspname, c.relname, a.attnum
+        """)
+        result = conn.execute(sql, params).fetchall()
+
+        for row in result:
+            if with_comments:
+                table_schema, table_name, column_name, data_type, col_comment, tbl_comment = row
+            else:
+                table_schema, table_name, column_name, data_type = row
+                col_comment = tbl_comment = None
+            key = (table_schema, table_name)
+            fqn = f"{table_schema}.{table_name}"
+            if key not in tables:
+                tables[key] = Table(
+                    name=fqn,
+                    description=tbl_comment,
+                    columns=[],
+                    pks=[],
+                    fks=[],
+                    metadata_json={"schema": table_schema, "is_materialized_view": True}
+                )
+            tables[key].columns.append(TableColumn(
+                name=column_name,
+                dtype=data_type,
+                description=col_comment
+            ))
 
     def _get_tables_basic(self) -> List[Table]:
         """Get tables without comments (original query - always works)."""
@@ -174,6 +252,9 @@ class PostgresqlClient(DataSourceClient):
                             name=fqn, columns=[], pks=[], fks=[], metadata_json={"schema": table_schema}
                         )
                     tables[key].columns.append(TableColumn(name=column_name, dtype=data_type))
+
+                # Materialized views are absent from information_schema; merge them in.
+                self._append_materialized_views(conn, tables, with_comments=False)
                 return list(tables.values())
         except Exception as e:
             print(f"Error retrieving tables: {e}")

--- a/backend/tests/integrations/ds_clients.py
+++ b/backend/tests/integrations/ds_clients.py
@@ -53,6 +53,11 @@ try:
         "seed_sql": [
             "CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(100), email VARCHAR(100))",
             "CREATE TABLE orders (id SERIAL PRIMARY KEY, user_id INT REFERENCES users(id), total DECIMAL(10,2))",
+            # Materialized view: not exposed via information_schema, must be
+            # discovered via pg_catalog (see PostgresqlClient).
+            "CREATE MATERIALIZED VIEW user_order_totals AS "
+            "SELECT u.id, u.name, SUM(o.total) AS total "
+            "FROM users u LEFT JOIN orders o ON o.user_id = u.id GROUP BY u.id, u.name",
         ],
     }
 except ImportError:


### PR DESCRIPTION
PostgresqlClient.get_tables() sourced columns from information_schema,
which does not expose materialized views (pg_class.relkind = 'm'). Add
_append_materialized_views() to read matview columns (and table/column
comments) from pg_catalog and merge them into both the enriched and
basic-fallback code paths. Matviews are tagged
metadata_json.is_materialized_view and honor the schema filter.

Add a testcontainers-backed integration test proving matviews surface
with comments, in the basic fallback, under schema filtering, and are
queryable; seed a matview in the shared ds_clients fixture too.

Also add a SessionStart hook + docs/sandbox-feedback-loop.md to set up
the backend Python env (py3.12 venv, libpq-dev, requirements) for remote
sandbox sessions.