### PR TITLE
Add send_email tool for agents to notify users via email

### DIFF
--- a/backend/app/ai/tools/implementations/send_email.py
+++ b/backend/app/ai/tools/implementations/send_email.py
@@ -1,0 +1,158 @@
+"""Send Email Tool - sends a free-form email to the requesting user.
+
+The recipient is always the current user (resolved from runtime context), so the
+agent cannot email anyone else. Subject and body are free-form. This is the first
+of a planned family of notification tools (email today; Slack / WhatsApp / Teams
+in the future) — each channel gets its own tool so the UI status stays per-channel.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.send_email import SendEmailInput, SendEmailOutput
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+from app.settings.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SendEmailTool(Tool):
+    """Send a free-form email to the current user's own inbox."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="send_email",
+            description=(
+                "ACTION: Send a free-form email to the current user (yourself). "
+                "The recipient is always the requesting user — you cannot email "
+                "anyone else. Use this to deliver a summary, result, or reminder "
+                "to the user's inbox. Provide a subject and body; set "
+                "body_format='html' to send formatted HTML."
+            ),
+            category="action",
+            version="1.0.0",
+            input_schema=SendEmailInput.model_json_schema(),
+            output_schema=SendEmailOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=30,
+            idempotent=False,
+            # Hidden from the catalog when SMTP isn't configured. Evaluated at
+            # registry startup, where settings.email_client is already resolved.
+            is_active=settings.email_client is not None,
+            required_permissions=[],
+            tags=["notification", "email", "action"],
+            examples=[
+                {
+                    "input": {
+                        "subject": "Your revenue summary",
+                        "body": "Q2 revenue was $1.2M, up 14% QoQ.",
+                    },
+                    "description": "Send a plain-text summary to yourself.",
+                },
+                {
+                    "input": {
+                        "subject": "Weekly report",
+                        "body": "<h1>Weekly report</h1><p>All metrics nominal.</p>",
+                        "body_format": "html",
+                    },
+                    "description": "Send an HTML-formatted email to yourself.",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return SendEmailInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return SendEmailOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = SendEmailInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {str(e)}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        # Recipient is always the requesting user — never caller-controllable.
+        user = runtime_ctx.get("user")
+        recipient = getattr(user, "email", None) if user else None
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={"subject": data.subject, "recipient": recipient},
+        )
+
+        if not recipient:
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": SendEmailOutput(
+                        success=False,
+                        subject=data.subject,
+                        error="Could not resolve your email address.",
+                    ).model_dump(),
+                    "observation": {
+                        "summary": "Email not sent: no recipient address available for the current user.",
+                        "success": False,
+                        "artifacts": [],
+                    },
+                },
+            )
+            return
+
+        try:
+            from app.services.notification_service import notification_service
+
+            subtype = "html" if data.body_format == "html" else "plain"
+            result = await notification_service.send_custom_email(
+                recipients=[recipient],
+                subject=data.subject,
+                body=data.body,
+                subtype=subtype,
+            )
+
+            success = result.status == "sent"
+            summary = (
+                f"Email sent to {recipient}: {data.subject}"
+                if success
+                else f"Failed to send email: {result.error or 'unknown error'}"
+            )
+
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": SendEmailOutput(
+                        success=success,
+                        recipient=recipient,
+                        subject=data.subject,
+                        error=None if success else (result.error or "Failed to send email"),
+                    ).model_dump(),
+                    "observation": {
+                        "summary": summary,
+                        "success": success,
+                        "artifacts": [],
+                    },
+                },
+            )
+        except Exception as e:
+            logger.exception("Failed to send email: %s", e)
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Failed to send email: {str(e)}", "code": "SEND_FAILED"},
+            )

--- a/backend/app/ai/tools/implementations/send_email.py
+++ b/backend/app/ai/tools/implementations/send_email.py
@@ -32,11 +32,23 @@ class SendEmailTool(Tool):
         return ToolMetadata(
             name="send_email",
             description=(
-                "ACTION: Send a free-form email to the current user (yourself). "
-                "The recipient is always the requesting user — you cannot email "
-                "anyone else. Use this to deliver a summary, result, or reminder "
-                "to the user's inbox. Provide a subject and body; set "
-                "body_format='html' to send formatted HTML."
+                "ACTION: Send an email to the current user (yourself). The recipient is "
+                "ALWAYS the requesting user — you cannot send to anyone else, so there is "
+                "no recipient argument.\n\n"
+                "When to use: the user explicitly asks to be emailed something (a summary, "
+                "a result, a reminder, a list of findings), or asks to 'send me' / 'email me' "
+                "the answer. Do NOT use it to deliver every response — only when the user "
+                "wants the content in their inbox.\n\n"
+                "Writing the email — write like a person, not a marketing system:\n"
+                "- Default to plain text (body_format='text'). Keep it short, natural, and "
+                "to the point, the way a colleague would write a quick email.\n"
+                "- Use body_format='html' ONLY when light structure genuinely helps (a few "
+                "bullet points or a small table). Even then, keep the HTML simple and "
+                "human-looking — basic tags like <p>, <ul>/<li>, <strong>, <table>. Do NOT "
+                "build heavy templated layouts, inline CSS styling, wrapper divs, banners, "
+                "or branded headers/footers.\n"
+                "- Write a clear, specific subject line. Put the real content in the body; "
+                "don't just restate the subject."
             ),
             category="action",
             version="1.0.0",

--- a/backend/app/ai/tools/schemas/__init__.py
+++ b/backend/app/ai/tools/schemas/__init__.py
@@ -22,6 +22,7 @@ from .write_to_excel import WriteToExcelInput, WriteToExcelOutput
 from .write_officejs_code import WriteOfficeJsCodeInput, WriteOfficeJsCodeOutput
 from .read_excel_range import ReadExcelRangeInput, ReadExcelRangeOutput, ReadExcelRangeItem
 from .read_excel_as_csv import ReadExcelAsCsvInput, ReadExcelAsCsvOutput
+from .send_email import SendEmailInput, SendEmailOutput
 from .events import (
     ToolEvent,
     ToolStartEvent,
@@ -80,6 +81,8 @@ __all__ = [
     "ReadExcelRangeItem",
     "ReadExcelAsCsvInput",
     "ReadExcelAsCsvOutput",
+    "SendEmailInput",
+    "SendEmailOutput",
     "ToolEvent",
     "ToolStartEvent",
     "ToolProgressEvent",

--- a/backend/app/ai/tools/schemas/send_email.py
+++ b/backend/app/ai/tools/schemas/send_email.py
@@ -15,16 +15,26 @@ class SendEmailInput(BaseModel):
         ...,
         min_length=1,
         max_length=300,
-        description="The email subject line.",
+        description="A clear, specific subject line. Don't just restate it in the body.",
     )
     body: str = Field(
         ...,
         min_length=1,
-        description="The email body. Plain text by default; set body_format='html' to send HTML.",
+        description=(
+            "The email body. Write it like a person would — short, natural, and direct. "
+            "Plain text by default. If you set body_format='html', keep the HTML simple and "
+            "human-looking (basic tags like <p>, <ul>/<li>, <strong>, small <table>); avoid "
+            "heavy templated layouts, inline CSS, wrapper divs, banners, or branded "
+            "headers/footers."
+        ),
     )
     body_format: Literal["text", "html"] = Field(
         default="text",
-        description="Format of the body: 'text' for plain text (default) or 'html' for HTML content.",
+        description=(
+            "Body format: 'text' for plain text (default, preferred) or 'html' for simple "
+            "HTML. Only choose 'html' when light structure (a few bullets or a small table) "
+            "genuinely helps readability."
+        ),
     )
 
 

--- a/backend/app/ai/tools/schemas/send_email.py
+++ b/backend/app/ai/tools/schemas/send_email.py
@@ -1,0 +1,37 @@
+from typing import Optional, Literal
+from pydantic import BaseModel, Field
+
+
+class SendEmailInput(BaseModel):
+    """Input schema for the send_email tool.
+
+    Sends a free-form email to the requesting user themselves. The recipient is
+    always the current user — it is not selectable here, so the agent cannot
+    email anyone else. Use this to deliver a summary, reminder, or result to the
+    user's inbox.
+    """
+
+    subject: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        description="The email subject line.",
+    )
+    body: str = Field(
+        ...,
+        min_length=1,
+        description="The email body. Plain text by default; set body_format='html' to send HTML.",
+    )
+    body_format: Literal["text", "html"] = Field(
+        default="text",
+        description="Format of the body: 'text' for plain text (default) or 'html' for HTML content.",
+    )
+
+
+class SendEmailOutput(BaseModel):
+    """Output schema for the send_email tool."""
+
+    success: bool = Field(..., description="Whether the email was sent to the SMTP server successfully.")
+    recipient: Optional[str] = Field(default=None, description="The email address the message was sent to.")
+    subject: Optional[str] = Field(default=None, description="The subject line that was sent.")
+    error: Optional[str] = Field(default=None, description="Error message if sending failed.")

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -173,6 +173,57 @@ class NotificationService:
             recipients=recipients,
         )
 
+    # ---- free-form email ----
+
+    async def send_custom_email(
+        self,
+        recipients: List[str],
+        subject: str,
+        body: str,
+        subtype: str = "plain",
+    ) -> ChannelResult:
+        """Send a free-form email with arbitrary subject/body.
+
+        Unlike ``dispatch`` (template-driven), this sends exactly the subject
+        and body provided. The send is awaited so the returned status reflects
+        actual delivery to the SMTP server, not just enqueueing.
+        """
+        fm = settings.email_client
+        if not fm:
+            return ChannelResult(
+                channel="email",
+                status="failed",
+                recipients=recipients,
+                error="SMTP is not configured",
+            )
+
+        if subtype not in ("plain", "html"):
+            subtype = "plain"
+
+        message = MessageSchema(
+            subject=subject,
+            recipients=recipients,
+            body=body,
+            subtype=subtype,
+        )
+
+        try:
+            await fm.send_message(message)
+            logger.info("Custom email sent to %s", recipients)
+            return ChannelResult(
+                channel="email",
+                status="sent",
+                recipients=recipients,
+            )
+        except Exception as e:
+            logger.error("Failed to send custom email: %s", e)
+            return ChannelResult(
+                channel="email",
+                status="failed",
+                recipients=recipients,
+                error=str(e),
+            )
+
     # ---- scheduled report results ----
 
     async def send_scheduled_report_results(

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -440,6 +440,7 @@ import CreateDataTool from '../tools/CreateDataTool.vue'
 import InspectDataTool from '../tools/InspectDataTool.vue'
 import CreateInstructionTool from '../tools/CreateInstructionTool.vue'
 import EditInstructionTool from '../tools/EditInstructionTool.vue'
+import SendEmailTool from '../tools/SendEmailTool.vue'
 import ListAgentExecutionsTool from '../tools/ListAgentExecutionsTool.vue'
 import DataSourceIcon from '../DataSourceIcon.vue'
 import Spinner from '../Spinner.vue'
@@ -892,6 +893,8 @@ function getToolComponent(toolName: string) {
             return CreateInstructionTool
         case 'edit_instruction':
             return EditInstructionTool
+        case 'send_email':
+            return SendEmailTool
         case 'list_agent_executions':
             return ListAgentExecutionsTool
         default:

--- a/frontend/components/tools/SendEmailTool.vue
+++ b/frontend/components/tools/SendEmailTool.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="mt-1">
+    <!-- Status header -->
+    <Transition name="fade" appear>
+      <div
+        class="flex items-center text-xs text-gray-500 cursor-pointer hover:text-gray-700"
+        @click="toggleExpanded"
+      >
+        <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+          <Icon name="heroicons-envelope" class="w-3 h-3 me-1.5 text-gray-400" />
+          {{ $t('tools.sendEmail.sending') }}
+        </span>
+        <span v-else-if="isSuccess" class="text-gray-600 flex items-center">
+          <Icon name="heroicons-envelope" class="w-3 h-3 me-1.5 text-blue-500" />
+          <span dir="auto" class="truncate max-w-[300px]">{{ $t('tools.sendEmail.sentPrefix', { subject: truncatedSubject }) }}</span>
+          <Icon
+            :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+            class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip"
+          />
+        </span>
+        <span v-else class="text-gray-600 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
+          <span>{{ $t('tools.sendEmail.failed') }}</span>
+          <Icon
+            :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+            class="w-3 h-3 ms-1 text-gray-400 rtl-flip"
+          />
+        </span>
+      </div>
+    </Transition>
+
+    <!-- Expandable content -->
+    <Transition name="slide">
+      <div v-if="isExpanded && status !== 'running'" class="mt-2 space-y-2">
+        <div class="border border-gray-150 rounded-md overflow-hidden">
+          <div class="px-3 py-1.5 bg-gray-50 border-b border-gray-150 flex items-center gap-2">
+            <span class="text-[10px] text-gray-600 font-medium">{{ $t('tools.sendEmail.subject') }}</span>
+            <span dir="auto" class="text-[11px] text-gray-800 truncate">{{ subject }}</span>
+          </div>
+          <div v-if="recipient" class="px-3 py-1 bg-white border-b border-gray-100 flex items-center gap-2">
+            <span class="text-[10px] text-gray-500">{{ $t('tools.sendEmail.to') }}</span>
+            <span dir="auto" class="text-[11px] text-gray-700">{{ recipient }}</span>
+          </div>
+          <div v-if="body" class="px-3 py-2 bg-white">
+            <pre dir="auto" class="text-[11px] text-gray-700 whitespace-pre-wrap font-sans m-0">{{ truncatedBody }}</pre>
+          </div>
+        </div>
+
+        <!-- Error message -->
+        <div v-if="errorMessage" class="text-[10px] text-red-500 bg-red-50/50 rounded px-2 py-1">
+          {{ errorMessage }}
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  tool_action?: string
+  status: string
+  result_summary?: string
+  result_json?: any
+  arguments_json?: any
+  duration_ms?: number
+}
+
+interface Props {
+  toolExecution: ToolExecution
+}
+
+const props = defineProps<Props>()
+
+const isExpanded = ref(false)
+
+const status = computed<string>(() => props.toolExecution?.status || '')
+
+const isSuccess = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  return status.value === 'success' && rj.success === true
+})
+
+// Prefer the input arguments for subject/body (always present), fall back to output.
+const subject = computed(() => {
+  const args = props.toolExecution?.arguments_json || {}
+  const rj = props.toolExecution?.result_json || {}
+  return args.subject || rj.subject || ''
+})
+
+const body = computed(() => {
+  const args = props.toolExecution?.arguments_json || {}
+  return args.body || ''
+})
+
+const recipient = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  return rj.recipient || ''
+})
+
+const truncatedSubject = computed(() => {
+  const s = subject.value
+  if (!s) return ''
+  return s.length > 60 ? s.substring(0, 57) + '...' : s
+})
+
+const truncatedBody = computed(() => {
+  const b = body.value
+  if (!b) return ''
+  return b.length > 1000 ? b.substring(0, 1000) + '…' : b
+})
+
+const errorMessage = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  if (status.value === 'error') {
+    return rj.error || rj.message || ''
+  }
+  if (status.value === 'success' && rj.success === false) {
+    return rj.error || ''
+  }
+  return ''
+})
+
+function toggleExpanded() {
+  if (status.value !== 'running') {
+    isExpanded.value = !isExpanded.value
+  }
+}
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+
+@keyframes shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: 100% 0; }
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+
+.slide-enter-active, .slide-leave-active {
+  transition: all 0.15s ease;
+  overflow: hidden;
+}
+.slide-enter-from, .slide-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+.slide-enter-to, .slide-leave-from {
+  opacity: 1;
+  max-height: 500px;
+}
+</style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -725,6 +725,7 @@ import ReadFileTool from '~/components/tools/ReadFileTool.vue'
 import InstructionSuggestions from '@/components/InstructionSuggestions.vue'
 import CreateInstructionTool from '~/components/tools/CreateInstructionTool.vue'
 import EditInstructionTool from '~/components/tools/EditInstructionTool.vue'
+import SendEmailTool from '~/components/tools/SendEmailTool.vue'
 import ListAgentExecutionsTool from '~/components/tools/ListAgentExecutionsTool.vue'
 import WebFetchTool from '~/components/tools/WebFetchTool.vue'
 import ClarifyTool from '~/components/tools/ClarifyTool.vue'
@@ -1467,6 +1468,8 @@ function getToolComponent(toolName: string) {
 			return CreateInstructionTool
 		case 'edit_instruction':
 			return EditInstructionTool
+		case 'send_email':
+			return SendEmailTool
 		case 'list_agent_executions':
 			return ListAgentExecutionsTool
 		case 'search_instructions':

--- a/locales/en.json
+++ b/locales/en.json
@@ -576,6 +576,13 @@
       "toastFailedDelete": "Failed to delete instruction",
       "toastSaved": "Instruction saved"
     },
+    "sendEmail": {
+      "sending": "Sending email...",
+      "sentPrefix": "Sent: {subject}",
+      "failed": "Failed to send email",
+      "subject": "Subject",
+      "to": "To"
+    },
     "inspectData": {
       "inspecting": "Inspecting",
       "inspected": "Inspected",


### PR DESCRIPTION
## Summary
Adds a new `send_email` tool that allows AI agents to send free-form emails to the requesting user. This is the first in a planned family of notification tools (email, Slack, WhatsApp, Teams), with each channel getting its own tool for independent UI status tracking.

## Key Changes

- **Backend Tool Implementation** (`backend/app/ai/tools/implementations/send_email.py`)
  - New `SendEmailTool` class that sends emails to the current user only (recipient is not caller-controllable)
  - Supports both plain text and HTML email formats via `body_format` parameter
  - Includes proper error handling and validation
  - Tool is only active when SMTP is configured

- **Email Service Enhancement** (`backend/app/services/notification_service.py`)
  - Added `send_custom_email()` method to send free-form emails with arbitrary subject/body
  - Unlike template-driven dispatch, this sends exactly what the agent specifies
  - Awaits the send operation so returned status reflects actual SMTP delivery

- **Input/Output Schemas** (`backend/app/ai/tools/schemas/send_email.py`)
  - `SendEmailInput`: subject, body, and optional body_format (text/html)
  - `SendEmailOutput`: success status, recipient, subject, and error message

- **Frontend UI Component** (`frontend/components/tools/SendEmailTool.vue`)
  - New Vue component to display email tool execution status
  - Shows "Sending email..." with shimmer animation while in progress
  - Displays success state with truncated subject line
  - Expandable details showing full subject, recipient, body, and error messages
  - Smooth fade and slide transitions

- **Localization** (`locales/en.json`)
  - Added English translations for email tool UI strings

- **Integration**
  - Registered `SendEmailTool` in tool schemas exports
  - Integrated `SendEmailTool` component into `TraceModal.vue` and reports page

## Notable Implementation Details

- The recipient is always resolved from the runtime context (current user) and cannot be overridden by the agent, ensuring security
- Tool is conditionally active based on SMTP configuration (`settings.email_client`)
- Email body supports both plain text and HTML formats
- UI truncates long subjects (60 chars) and bodies (1000 chars) for readability while preserving full content in expandable view
- Tool execution status is non-blocking during send (shows shimmer animation)

https://claude.ai/code/session_01AtF2ggVbHTZSeKy62hkkwT