### PR TITLE
Clarify Tableau client API usage in system prompt

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -259,9 +259,10 @@ class Coder:
            - The function should return the main dataframe that will answer the user prompt.
 
         2. **Data Source Usage**:
-           - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
+           - Use `ds_clients["<client_key>"].execute_query(...)` to query non-Excel data sources.
              * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
-             * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
+             * IMPORTANT: `execute_query` is NOT the same for every client. Some clients are SQL-based and take a single SQL string (e.g. `execute_query("SELECT * FROM orders")`); others are NOT SQL-based and take structured keyword arguments (e.g. Tableau uses `execute_query(datasource_luid=..., fields=[...])`). ALWAYS follow the exact method signature, argument names, and call examples shown in that client's `description` under <connection_clients>. Do NOT pass a SQL string to a non-SQL client.
+             * SQL example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
            - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
            - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
            - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
@@ -492,9 +493,10 @@ class Coder:
                - The `http` parameter will be `None` if the organization disabled web fetch. Guard with `if http is None: raise RuntimeError("web fetch is disabled for this organization")` and return an empty DataFrame.
 
             2. **Data Source Usage**:
-               - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
+               - Use `ds_clients["<client_key>"].execute_query(...)` to query non-Excel data sources.
                  * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
-                 * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
+                 * IMPORTANT: `execute_query` is NOT the same for every client. Some clients are SQL-based and take a single SQL string (e.g. `execute_query("SELECT * FROM orders")`); others are NOT SQL-based and take structured keyword arguments (e.g. Tableau uses `execute_query(datasource_luid=..., fields=[...])`). ALWAYS follow the exact method signature, argument names, and call examples shown in that client's `description` under <connection_clients>. Do NOT pass a SQL string to a non-SQL client.
+                 * SQL example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
                - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
                - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
                - After each query or DataFrame creation, print its info using: print("df Info:", df.info())

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -259,10 +259,9 @@ class Coder:
            - The function should return the main dataframe that will answer the user prompt.
 
         2. **Data Source Usage**:
-           - Use `ds_clients["<client_key>"].execute_query(...)` to query non-Excel data sources.
+           - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
              * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
-             * IMPORTANT: `execute_query` is NOT the same for every client. Some clients are SQL-based and take a single SQL string (e.g. `execute_query("SELECT * FROM orders")`); others are NOT SQL-based and take structured keyword arguments (e.g. Tableau uses `execute_query(datasource_luid=..., fields=[...])`). ALWAYS follow the exact method signature, argument names, and call examples shown in that client's `description` under <connection_clients>. Do NOT pass a SQL string to a non-SQL client.
-             * SQL example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
+             * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
            - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
            - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
            - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
@@ -493,10 +492,9 @@ class Coder:
                - The `http` parameter will be `None` if the organization disabled web fetch. Guard with `if http is None: raise RuntimeError("web fetch is disabled for this organization")` and return an empty DataFrame.
 
             2. **Data Source Usage**:
-               - Use `ds_clients["<client_key>"].execute_query(...)` to query non-Excel data sources.
+               - Use `ds_clients["<client_key>"].execute_query("SOME QUERY")` to query non-Excel data sources.
                  * Use the exact `client_key` string from the <connection_clients> section — it is a literal string, not a variable.
-                 * IMPORTANT: `execute_query` is NOT the same for every client. Some clients are SQL-based and take a single SQL string (e.g. `execute_query("SELECT * FROM orders")`); others are NOT SQL-based and take structured keyword arguments (e.g. Tableau uses `execute_query(datasource_luid=..., fields=[...])`). ALWAYS follow the exact method signature, argument names, and call examples shown in that client's `description` under <connection_clients>. Do NOT pass a SQL string to a non-SQL client.
-                 * SQL example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
+                 * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
                - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
                - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
                - After each query or DataFrame creation, print its info using: print("df Info:", df.info())

--- a/backend/app/data_sources/clients/tableau_client.py
+++ b/backend/app/data_sources/clients/tableau_client.py
@@ -370,11 +370,22 @@ class TableauClient(DataSourceClient):
         text = """
 Executes VizQL queries against Tableau data sources to answer business questions from published data. This tool allows you to retrieve aggregated and filtered data with proper sorting and grouping.
 
+## IMPORTANT: This client is NOT SQL-based
+Tableau does NOT accept a SQL string. Do NOT call `execute_query("SELECT ...")` — that will fail.
+The `execute_query` method signature is:
+
+    execute_query(datasource_luid: str, fields: list[dict], filters: list[dict] = None, ...) -> pandas.DataFrame
+
+Both `datasource_luid` and `fields` are REQUIRED. `datasource_luid` is the version-4 UUID of the
+published data source (take it from the schema). `fields` is a list of field dicts (see examples below).
+Call it on the connection client using the exact client_key, e.g.
+`ds_clients["<client_key>"].execute_query(datasource_luid="...", fields=[...])`.
+
 ## Examples
 
 ```python
 # Quick profiling: record count
-df = client.execute_query(
+df = ds_clients["<client_key>"].execute_query(
   datasource_luid="version-4 UUID (take it from the schema)",
   fields=[{"fieldCaption": "Order ID", "function": "COUNT", "fieldAlias": "Total Records"}]
 )
@@ -382,7 +393,7 @@ df = client.execute_query(
 
 ```python
 # Top 10 customers by revenue (with current year filter)
-df = client.execute_query(
+df = ds_clients["<client_key>"].execute_query(
   datasource_luid="version-4 UUID (take it from the schema)",
   fields=[
     {"fieldCaption": "Customer Name"},
@@ -414,7 +425,7 @@ df = client.execute_query(
 
 ```python
 # Monthly sales trend (last 12 months)
-df = client.execute_query(
+df = ds_clients["<client_key>"].execute_query(
   datasource_luid="version-4 UUID (take it from the schema)",
   fields=[
     {


### PR DESCRIPTION
## Summary
Updated the Tableau client system prompt to provide clearer guidance on the correct API usage, emphasizing that this is a VizQL-based client (not SQL-based) and clarifying the required parameters and calling conventions.

## Key Changes
- Added prominent "IMPORTANT" section warning against SQL-style queries
- Documented the correct `execute_query()` method signature with required parameters (`datasource_luid` and `fields`)
- Clarified that `datasource_luid` is a version-4 UUID from the schema
- Updated all code examples to use the correct client reference pattern: `ds_clients["<client_key>"].execute_query(...)` instead of `client.execute_query(...)`
- Added explicit guidance on how to call the method on the connection client using the exact client_key

## Implementation Details
These changes improve the system prompt documentation to prevent common misuse patterns where users might attempt to pass SQL queries to a VizQL-based API. The updated examples now consistently demonstrate the proper way to access and call the Tableau client within the agent's execution context.

https://claude.ai/code/session_01NZZjKwLjxGRraPZVFLP5GZ