### PR TITLE
Support multi-word reference mentions with spaces and special chars

### DIFF
--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -89,22 +89,71 @@ interface Segment {
   raw?: string
 }
 
+// Reference display names sorted longest-first, so multi-word mentions like
+// "Microsoft Fabric / dbo.sales" win over the bare leading word ("Microsoft").
+const refMatchers = computed(() =>
+  normalizedRefs.value
+    .filter(r => r.name)
+    .map(r => ({ name: r.name as string, ref: r }))
+    .sort((a, b) => b.name.length - a.name.length)
+)
+
 const segments = computed((): Segment[] => {
+  const text = props.text || ''
   const result: Segment[] = []
-  const parts = props.text.split(/(@[A-Za-z_][A-Za-z0-9_]*)/)
-  for (const part of parts) {
-    if (part.startsWith('@')) {
-      const word = part.slice(1)
-      const ref = refByName.value.get(word.toLowerCase())
-      if (ref) {
-        result.push({ ref, raw: word })
-      } else {
-        result.push({ mention: word })
-      }
-    } else {
-      result.push({ text: part })
+  let buffer = ''
+  const flush = () => {
+    if (buffer) {
+      result.push({ text: buffer })
+      buffer = ''
     }
   }
+
+  let i = 0
+  while (i < text.length) {
+    if (text[i] === '@') {
+      const rest = text.slice(i + 1)
+
+      // 1. Quoted mention: @"some label with spaces"
+      if (rest[0] === '"') {
+        const end = rest.indexOf('"', 1)
+        if (end !== -1) {
+          const label = rest.slice(1, end)
+          flush()
+          const ref = refByName.value.get(label.toLowerCase())
+          result.push(ref ? { ref, raw: label } : { mention: label })
+          i += 1 + end + 1
+          continue
+        }
+      }
+
+      // 2. Longest matching reference display name (handles spaces, slashes,
+      //    dots — e.g. data-source tables like "Microsoft Fabric / dbo.sales").
+      const match = refMatchers.value.find(m => rest.startsWith(m.name))
+      if (match) {
+        flush()
+        result.push({ ref: match.ref, raw: match.name })
+        i += 1 + match.name.length
+        continue
+      }
+
+      // 3. Fallback: a plain identifier word (optionally dotted/dashed).
+      const word = rest.match(/^[A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*/)
+      if (word) {
+        flush()
+        const w = word[0]
+        const ref = refByName.value.get(w.toLowerCase())
+        result.push(ref ? { ref, raw: w } : { mention: w })
+        i += 1 + w.length
+        continue
+      }
+    }
+
+    buffer += text[i]
+    i++
+  }
+
+  flush()
   return result
 })
 

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1702,10 +1702,18 @@ function promptMentionsToRefs(mentions?: Array<{ name: string; items: any[] }>) 
 	for (const group of mentions) {
 		const type = GROUP_TYPE_MAP[(group.name || '').toUpperCase()] || 'entity'
 		for (const item of group.items || []) {
+			let name = item.name || item.title || item.filename || ''
+			// Data-source tables are serialized into the prompt text with their
+			// source prefix (e.g. "@Microsoft Fabric / dbo.sales"), so the ref
+			// name must include it to match and render as a single mention chip.
+			if (type === 'datasource_table') {
+				const prefix = item.connection_name || item.data_source_name
+				if (prefix) name = `${prefix} / ${name}`
+			}
 			refs.push({
 				id: item.id,
 				type,
-				name: item.name || item.title || item.filename || '',
+				name,
 				data_source_type: item.connection_type || item.data_source_type || undefined,
 			})
 		}


### PR DESCRIPTION
## Summary
Enhanced the mention parsing logic to support reference display names containing spaces, slashes, dots, and dashes (e.g., "Microsoft Fabric / dbo.sales"). Previously, only simple identifier-style mentions were recognized.

## Key Changes

- **InstructionText.vue**: Rewrote the segment parsing algorithm to handle three mention formats in priority order:
  1. Quoted mentions: `@"label with spaces"`
  2. Longest-matching reference display names (handles multi-word names with special characters)
  3. Fallback to simple identifier words with optional dots/dashes
  
  Added `refMatchers` computed property that sorts references by name length (longest-first) to ensure multi-word mentions take precedence over partial matches.

- **reports/[id]/index.vue**: Updated `promptMentionsToRefs()` to construct datasource table reference names with their connection/source prefix (e.g., `"Microsoft Fabric / dbo.sales"`), ensuring they match the serialized format in prompt text and render as single mention chips.

## Implementation Details

- The new parsing uses a character-by-character iteration approach with a buffer, replacing the previous regex-based split that only handled simple `@word` patterns
- Reference matching prioritizes exact display name matches over partial identifier matches
- Datasource table names are now prefixed with their source name to maintain consistency between serialization and parsing

https://claude.ai/code/session_01SA6EwXiwRDoxyKxJY1Kahv