### PR TITLE
fix: index credential-less user_required sources (SQLite/DuckDB/QVD)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,10 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # The sqlite matrix leg runs a full alembic up/down per test on a file DB
+    # and the suite has grown past the old 60-minute cap (it was being
+    # cancelled mid-run). 90 gives headroom while still bounding runaway hangs.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -888,6 +888,19 @@ def config_schema_for(ds_type: str) -> Type[BaseModel]:
     return get_entry(ds_type).config_schema
 
 
+def requires_no_credentials(ds_type: str) -> bool:
+    """True for sources whose catalog is indexed from `config` alone, with no
+    credentials involved — i.e. the default auth variant is "none" (SQLite,
+    DuckDB, QVD). These are credential-less but still indexable: the DB path /
+    file location lives in `config`, so schema discovery needs no creds even
+    under a `user_required` auth policy. Unknown types default to False (treat
+    as credentialed)."""
+    try:
+        return get_entry(ds_type).credentials_auth.default == "none"
+    except ValueError:
+        return False
+
+
 def default_credentials_schema_for(ds_type: str) -> Type[BaseModel]:
     entry = get_entry(ds_type)
     default = entry.credentials_auth.default

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -667,7 +667,7 @@ class ConnectionService:
             # not a filtered subset of an admin universe. Admin-time indexing
             # is meaningless; the user's catalog gets fetched on their first
             # sign-in via get_user_data_source_schema. Skip cleanly.
-            from app.schemas.data_source_registry import get_entry
+            from app.schemas.data_source_registry import get_entry, requires_no_credentials
             try:
                 entry = get_entry(connection.type)
                 if entry.catalog_ownership == "per_user":
@@ -693,7 +693,14 @@ class ConnectionService:
             # Only skip when neither is available (e.g. a delegated-only OBO setup
             # where the admin stored no creds and no user has signed in yet), so we
             # don't 403 out of resolve_credentials.
-            if connection.auth_policy == "user_required":
+            #
+            # Credential-less sources (SQLite/DuckDB/QVD — registry default auth
+            # "none") are exempt: their catalog is indexed from `config` (the DB
+            # path / file location), so they need no creds even under
+            # user_required. Without this exemption an owner/admin refresh of a
+            # user_required SQLite domain would skip indexing and return zero
+            # tables, since both `credentials` and per-user creds are empty.
+            if connection.auth_policy == "user_required" and not requires_no_credentials(connection.type):
                 from app.models.user_connection_credentials import UserConnectionCredentials
                 from sqlalchemy import select as _select
 

--- a/backend/tests/e2e/test_domains.py
+++ b/backend/tests/e2e/test_domains.py
@@ -848,7 +848,11 @@ def test_domain_user_required_owner_can_access(
     assert isinstance(tables, list)
     assert len(tables) > 0, "Owner should be able to refresh schema and see tables"
 
-    # Owner should be able to get schema
+    # Owner should be able to get schema. Note: a fresh refresh leaves tables
+    # INACTIVE (ONBOARDING_MAX_TABLES=0 — users select tables explicitly), and
+    # the /schema endpoint is active-only, so it may legitimately be empty here.
+    # Owner visibility was already proven above via refresh_schema (which
+    # includes inactive tables). This mirrors test_domain_inherits_connection_tables.
     schema = get_schema(
         data_source_id=domain["id"],
         user_token=owner_token,
@@ -856,7 +860,6 @@ def test_domain_user_required_owner_can_access(
     )
 
     assert isinstance(schema, list)
-    assert len(schema) > 0
 
     # Owner should be able to test connection
     connection_result = test_connection(


### PR DESCRIPTION
The user_required credential guard in ConnectionService.refresh_schema
skipped schema indexing whenever neither per-user nor system credentials
were present. Credential-less sources (SQLite/DuckDB/QVD, registry default
auth "none") index their catalog from config alone, so an owner/admin
refresh of a user_required SQLite domain returned zero tables.

Exempt these sources via a new requires_no_credentials() registry helper.
Also relax the owner e2e assertion that checked the active-only /schema
endpoint right after a fresh refresh: tables start inactive by design
(ONBOARDING_MAX_TABLES=0), matching test_domain_inherits_connection_tables.