### PR TITLE
Allow org-level manage_connections to imply manage_data_sources

### DIFF
--- a/backend/app/core/permission_resolver.py
+++ b/backend/app/core/permission_resolver.py
@@ -25,10 +25,14 @@ FULL_ADMIN = "full_admin_access"
 # Org-level permissions that implicitly grant specific per-resource permissions.
 # E.g. holding `manage_instructions` at the org level means the user can
 # create/edit instructions on any data source, without needing per-DS grants.
+# Likewise, `manage_connections` (org-level connection admin) implies the
+# ability to create data sources/agents on any connection, so a connection
+# admin doesn't need a per-connection `manage_data_sources` grant.
 ORG_PERM_IMPLIES_RESOURCE: dict[str, dict[str, set[str]]] = {
     "manage_instructions": {"data_source": {"manage_instructions"}},
     "manage_entities":     {"data_source": {"create_entities"}},
     "manage_evals":        {"data_source": {"manage_evals"}},
+    "manage_connections":  {"connection": {"manage_data_sources"}},
 }
 
 

--- a/backend/tests/e2e/test_rbac_complex_roles.py
+++ b/backend/tests/e2e/test_rbac_complex_roles.py
@@ -971,6 +971,51 @@ def test_connection_manage_data_sources_granted(test_client, create_user, login_
     assert resp.status_code != 403, f"Should succeed with manage_data_sources grant: {resp.text}"
 
 
+@pytest.mark.e2e
+def test_connection_manage_connections_org_perm_can_create_ds(test_client, create_user, login_user, whoami, dynamic_sqlite_db, create_connection):
+    """User with org-level manage_connections can create a DS from any connection
+    without a per-connection manage_data_sources grant.
+
+    A connection admin (org-level manage_connections) should be able to build
+    data sources/agents on any connection. The org perm implies the
+    manage_data_sources resource permission on connections.
+    """
+    ctx = _setup_org_with_member(test_client, create_user, login_user, whoami)
+
+    if not _requires_enterprise(test_client, ctx["admin_token"], ctx["org_id"]):
+        pytest.skip("Enterprise license required for custom roles")
+
+    conn = create_connection(
+        name="rbac-test-conn-org-admin",
+        type="sqlite",
+        config={"database": dynamic_sqlite_db},
+        credentials={},
+        user_token=ctx["admin_token"],
+        org_id=ctx["org_id"],
+    )
+
+    # Give member create_data_source + manage_connections org-level perms, but
+    # NO per-connection resource grant.
+    role = _create_custom_role(test_client, ctx["admin_token"], ctx["org_id"], "DS Creator Conn Admin", [
+        "create_data_source", "manage_connections",
+    ])
+    _assign_role(test_client, ctx["admin_token"], ctx["org_id"], role["id"], "user", ctx["member_id"])
+
+    # Member creates a DS from the connection — should succeed via org perm
+    resp = test_client.post(
+        "/api/data_sources",
+        json={
+            "name": "Org Admin DS",
+            "type": "sqlite",
+            "connection_id": conn["id"],
+            "config": {},
+            "credentials": {},
+        },
+        headers=_headers(ctx["member_token"], ctx["org_id"]),
+    )
+    assert resp.status_code != 403, f"Should succeed with org-level manage_connections: {resp.text}"
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # 10. Resource-grant escalation prevention
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
This change allows users with org-level `manage_connections` permission to create data sources on any connection without requiring explicit per-connection `manage_data_sources` grants. This aligns the permission model so that connection admins have the expected ability to manage data sources across all connections.

## Key Changes
- **Permission resolver update**: Added `manage_connections` to the `ORG_PERM_IMPLIES_RESOURCE` mapping so that org-level connection admin permission implicitly grants `manage_data_sources` on all connections
- **Test coverage**: Added `test_connection_manage_connections_org_perm_can_create_ds` to verify that a user with org-level `manage_connections` and `create_data_source` permissions can successfully create a data source on any connection without per-connection resource grants

## Implementation Details
- The permission implication is configured in `permission_resolver.py` using the existing `ORG_PERM_IMPLIES_RESOURCE` dictionary pattern, which already handles similar cases for `manage_instructions`, `manage_entities`, and `manage_evals`
- The test validates the behavior by creating a custom role with org-level permissions, assigning it to a member, and confirming they can create a data source on a connection they have no explicit per-connection grants for
- Enterprise license check is included in the test since custom roles require enterprise features

https://claude.ai/code/session_014ohN2Pz6HGfcMmf2MBLk2L