### PR TITLE
Remove unused Cursor rules configuration file

### DIFF
--- a/.cursor/rules/hi.mdc
+++ b/.cursor/rules/hi.mdc
@@ -1,5 +1,0 @@
----
-description:
-globs:
-alwaysApply: false
----


### PR DESCRIPTION
## Summary
Removed the unused `.cursor/rules/hi.mdc` configuration file that contained an empty rule definition.

## Changes
- Deleted `.cursor/rules/hi.mdc` - an empty Cursor IDE rules file with no meaningful configuration

## Details
This file appeared to be a placeholder or test file with no actual rule content (only empty metadata fields for description, globs, and alwaysApply). Removing it cleans up the repository by eliminating unused configuration files.

https://claude.ai/code/session_01MDwhAmzQMju5kYxWaiiXDU