### PR TITLE
Remove unused autoevals dep to clear GPL-2.0 (Levenshtein) license High

### DIFF
--- a/backend/requirements_versioned.txt
+++ b/backend/requirements_versioned.txt
@@ -13,7 +13,6 @@ asn1crypto==1.5.1
 asttokens==2.4.1
 asyncpg==0.29.0
 attrs==24.2.0
-autoevals==0.0.109
 awswrangler==3.11.0
 azure-kusto-data==4.6.2
 azure-identity==1.19.0
@@ -25,7 +24,6 @@ cachetools==5.5.0
 certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==3.4.0
-chevron==0.14.0
 click==8.1.7
 clickhouse-connect==0.8.7
 contourpy==1.3.2
@@ -81,7 +79,6 @@ jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 ldap3==2.9.1
-Levenshtein==0.26.1
 lkml==1.3.7
 lxml==6.1.0
 lz4==4.3.3


### PR DESCRIPTION
## What
Removes the unused `autoevals==0.0.109` dependency and its exclusively-used transitive pins (`Levenshtein==0.26.1`, `chevron==0.14.0`) from `backend/requirements_versioned.txt`.

## Why
Snyk flagged a **High license-compliance** issue: `Levenshtein==0.26.1` is licensed **GPLv2+**. It's pulled in transitively by `autoevals`, which is an **orphan dependency**:
- Not imported anywhere — app code, tests, or evals (`grep` for `autoevals`/`braintrust` returns nothing).
- Nothing else in the tree requires it (it's a direct pin, `requested: true`).
- Its transitives `Levenshtein`, `chevron`, and `braintrust` are required **only** by `autoevals` (verified against the resolved dependency graph).

Removing the direct `Levenshtein` pin is necessary too — leaving it would keep the GPL package installed even after dropping `autoevals`. `braintrust_core` was an unpinned floater and drops automatically.

## Effect
- **Eliminates the GPL-2.0 High** license finding.
- No functional change — nothing imports the removed packages.

## Validation
- Full requirements set re-resolves cleanly via `pip install --dry-run`: **248 packages, no conflicts**, and `Levenshtein`/`autoevals`/`chevron` confirmed absent from the resolved set.

## Context (rest of the customer's latest report)
- **0 Criticals.** The other 2 Highs (Path Traversal CWE-23, Hardcoded Key CWE-321) are **already fixed** in `main` (PR #300) — `snyk code test` on current main returns **0 high issues**; the report is showing a stale Snyk Code re-test that will clear on the next analysis.
- The remaining Mediums are weak-copyleft (LGPL `psycopg2`/`ldap3`, MPL `certifi`/`pathspec`) and Ubuntu base-image CVEs — standard hygiene, no action here.

https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5qm3EPFX3sX8xET6GB31C)_