### PR TITLE
Fix metric breakdown collapsing to single line in charts

### DIFF
--- a/REPRO-viz-breakdown.md
+++ b/REPRO-viz-breakdown.md
@@ -1,0 +1,185 @@
+# Repro & feedback loop — "metric broken down by a dimension renders as a single line"
+
+Sandbox-ready reproduction harness for the bug reported in `#bow-joom`:
+
+> When we ask BoW to build a metric in dynamics broken down by any dimension
+> (e.g. *gmv by categories*), it ignores the breakdown and builds just **one
+> line for the total**. At the same time, on the SQL level we see grouping by
+> category.
+
+This doc gives you a two-tier feedback loop to reproduce, diagnose, and (later)
+verify a fix — entirely inside the sandbox, no Docker required.
+
+---
+
+## Root cause (one paragraph)
+
+The breakdown is lost in `create_data`'s post-execution **visualization
+inference**, not in SQL generation. The viz-inference LLM is prompted to emit
+`group_by` as a **string** (`backend/app/ai/tools/implementations/create_data.py`
+— every example and the OUTPUT FORMAT use `"group_by": "column_name_or_null"`).
+That candidate is fed into `DataModel(**candidate_json)`, but
+`DataModel.group_by` is typed `Optional[List[str]]`
+(`backend/app/ai/tools/schemas/create_data_model.py:158`). Pydantic v2 does
+**not** coerce a bare `str` into `List[str]` — it raises — and the surrounding
+`except` resets the whole candidate to `{"type": "table", "series": []}`,
+discarding `group_by` **and** the series. Downstream, `build_view_from_data_model`
+gets no series, returns `None`, and the view falls back to a bare
+`{"type": "line_chart"}` — which the frontend renders as a single total line.
+
+There's also a type disagreement across the stack worth noting when fixing:
+
+| Layer | File | Treats `group_by` as |
+|---|---|---|
+| Inference prompt | `implementations/create_data.py` | string |
+| `DataModel` schema | `schemas/create_data_model.py:158` | `List[str]` |
+| View schema `groupBy` | `schemas/view_schema.py:140` | `str` |
+| Chart codegen | `services/artifact_codegen.py:45,77,86` | string |
+
+---
+
+## One-time environment setup
+
+The codebase needs **Python 3.12+** (3.11 trips an f-string-with-backslash
+`SyntaxError` in `app/ai/agents/planner/planner.py`). `psycopg2` won't build
+without `libpq`, but tests default to **sqlite**, so we use `psycopg2-binary`.
+
+```bash
+cd backend
+python3.12 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+
+# Install everything except the source psycopg2, then the prebuilt binary.
+grep -iv '^psycopg2==' requirements_versioned.txt > /tmp/reqs_nopsy.txt
+pip install -r /tmp/reqs_nopsy.txt
+pip install psycopg2-binary
+```
+
+### Required environment variables
+
+Run the e2e test exactly like CI does (`ENVIRONMENT=production TESTING=true`,
+which loads `bow-config.yaml` with `auth.mode: hybrid` so local password
+registration works):
+
+```bash
+export ENVIRONMENT=production
+export TESTING=true
+# Any valid Fernet key — used to encrypt the stored provider credential.
+export BOW_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
+# Your Anthropic key. NEVER commit this.
+export ANTHROPIC_API_KEY_TEST="sk-ant-..."
+```
+
+> The test installs an Anthropic provider with **Haiku**
+> (`claude-haiku-4-5-20251001`) as the org default — the bug is
+> model-independent (it's a schema/validation mismatch, not a planning
+> failure), so Haiku keeps the loop cheap and fast (~40s/run). Override with
+> `BOW_REPRO_MODEL=<model_id>`.
+
+---
+
+## The feedback loop
+
+### Inner loop — fast, deterministic, no API key (~30s)
+
+`backend/tests/unit/test_repro_group_by_dropped.py` pins the exact mechanism
+with no LLM and no network: a string `group_by` (what the planner emits) is
+rejected by `DataModel`, collapsing the candidate to a bare table.
+
+```bash
+cd backend && source venv/bin/activate
+export BOW_DATABASE_URL="sqlite:///db/app.db"   # any string; harness overrides the real DB
+python -m pytest tests/unit/test_repro_group_by_dropped.py -v
+```
+
+Expected on current `main` (bug present):
+
+```
+test_datamodel_rejects_string_group_by ............... PASSED
+test_create_data_construction_drops_the_breakdown ... PASSED
+test_planner_string_group_by_survives ............... XFAIL   <-- desired behavior, currently failing
+====== 2 passed, 1 xfailed ======
+```
+
+`test_planner_string_group_by_survives` is the canary: it's `xfail(strict=True)`,
+so **once the bug is fixed it flips to XPASS and the suite fails**, prompting you
+to delete the marker. Use this loop while iterating on the fix.
+
+### Outer loop — end-to-end against Chinook + real model (~40s)
+
+`backend/tests/e2e/test_repro_viz_breakdown.py` drives the **real agent**
+through the HTTP API against the committed `demo-datasources/chinook.sqlite`,
+then inspects the chart that was actually persisted on the widget
+(`last_step.data_model` + `last_step.view`).
+
+```bash
+cd backend && source venv/bin/activate
+# (env vars from the setup section above must be exported)
+python -m pytest tests/e2e/test_repro_viz_breakdown.py -s -m e2e
+```
+
+The prompt mirrors the customer's "metric broken down by category":
+
+> *Plot total sales over time broken down by music genre, as a LINE chart with
+> one line per genre … Join Invoice → InvoiceLine → Track → Genre …*
+
+---
+
+## Reproduced output (current `main`, Haiku)
+
+```
+========== REPRO DIAGNOSTIC: viz breakdown ==========
+widgets produced: 1
+{
+  "title": "Sales by Genre Over Time (Monthly)",
+  "type": "line_chart",
+  "columns": ["Month", "GenreName", "TotalSales"],   <-- SQL DID group by genre
+  "total_rows": 351,                                  <-- tall: many rows per month
+  "x_key": null,
+  "value_keys": [],
+  "series_count": 0,                                  <-- series dropped
+  "group_by": null,                                   <-- THE BUG: breakdown lost
+  "view_group_by": null,
+  "breakdown_dim_present": true,
+  "breakdown_applied": false
+}
+=====================================================
+
+AssertionError: Metric breakdown was lost on the chart — the data is granular
+along a category dimension, but the chart applies no group_by / multi-series,
+so it renders a single total line.
+
+WARNING app.project_manager update_visualization_view failed: 2 validation
+errors for ViewSchema
+  view.line_chart.x  Field required ... input_value={'type': 'line_chart'}
+  view.line_chart.y  Field required ...
+```
+
+The trailing `ViewSchema` warning is the tail of the same chain: with series
+dropped, the view degrades to a bare `{"type": "line_chart"}` (no `x`/`y`),
+and the frontend auto-renders a single line.
+
+---
+
+## What "fixed" looks like
+
+After the fix (normalize `group_by` so the planner's choice survives into the
+data model and the view), re-run both loops:
+
+- **Inner:** `test_planner_string_group_by_survives` goes from `xfail` →
+  `xpass`; remove the `@pytest.mark.xfail` marker so it's a plain green
+  regression guard.
+- **Outer:** the e2e diagnostic shows `group_by` (or `view_group_by`) set to
+  the category column, `breakdown_applied: true`, and the test passes —
+  i.e. the chart renders one line per genre.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `backend/tests/unit/test_repro_group_by_dropped.py` | Fast, key-free root-cause check (inner loop) |
+| `backend/tests/e2e/test_repro_viz_breakdown.py` | End-to-end Chinook + real-model repro (outer loop) |
+| `REPRO-viz-breakdown.md` | This guide |

--- a/REPRO-viz-breakdown.md
+++ b/REPRO-viz-breakdown.md
@@ -1,91 +1,106 @@
-# Repro & feedback loop — "metric broken down by a dimension renders as a single line"
+# Fix & feedback loop — "metric broken down by a dimension renders as a single line"
 
-Sandbox-ready reproduction harness for the bug reported in `#bow-joom`:
+Reproduction + fix for the bug reported in `#bow-joom`:
 
 > When we ask BoW to build a metric in dynamics broken down by any dimension
 > (e.g. *gmv by categories*), it ignores the breakdown and builds just **one
 > line for the total**. At the same time, on the SQL level we see grouping by
 > category.
 
-This doc gives you a two-tier feedback loop to reproduce, diagnose, and (later)
-verify a fix — entirely inside the sandbox, no Docker required.
+Status: **fixed**. Both feedback loops below are green.
 
 ---
 
-## Root cause (one paragraph)
+## Root cause
 
-The breakdown is lost in `create_data`'s post-execution **visualization
-inference**, not in SQL generation. The viz-inference LLM is prompted to emit
-`group_by` as a **string** (`backend/app/ai/tools/implementations/create_data.py`
-— every example and the OUTPUT FORMAT use `"group_by": "column_name_or_null"`).
-That candidate is fed into `DataModel(**candidate_json)`, but
-`DataModel.group_by` is typed `Optional[List[str]]`
-(`backend/app/ai/tools/schemas/create_data_model.py:158`). Pydantic v2 does
-**not** coerce a bare `str` into `List[str]` — it raises — and the surrounding
-`except` resets the whole candidate to `{"type": "table", "series": []}`,
-discarding `group_by` **and** the series. Downstream, `build_view_from_data_model`
-gets no series, returns `None`, and the view falls back to a bare
-`{"type": "line_chart"}` — which the frontend renders as a single total line.
+The breakdown was lost in `create_data`'s post-execution **visualization
+inference** (`backend/app/ai/tools/implementations/create_data.py`), not in SQL
+generation. The SQL was always correct (the result is granular: many rows per
+x-axis value, one per category). Two layered defects threw the breakdown away:
 
-There's also a type disagreement across the stack worth noting when fixing:
+1. **Brittle JSON parse (the one that actually bit in practice).** The
+   inference asks the model for "only valid JSON", but models routinely wrap it
+   in ```` ```json ```` fences and append a prose *Rationale*. The code did a
+   bare `json.loads(raw)`, which throws on that, and the `except` set
+   `candidate_json = None` → the candidate fell back to
+   `{"type": "table", "series": []}`. Observed verbatim with Haiku: a perfect
+   `{"type":"line_chart","series":[…],"group_by":"GenreName"}` payload, discarded
+   because of the surrounding fence + rationale.
 
-| Layer | File | Treats `group_by` as |
-|---|---|---|
-| Inference prompt | `implementations/create_data.py` | string |
-| `DataModel` schema | `schemas/create_data_model.py:158` | `List[str]` |
-| View schema `groupBy` | `schemas/view_schema.py:140` | `str` |
-| Chart codegen | `services/artifact_codegen.py:45,77,86` | string |
+2. **Schema type drop (latent, behind #1).** Even with clean JSON, the inference
+   prompt emits `group_by` as a **string**, but `DataModel.group_by` was typed
+   `Optional[List[str]]`. Pydantic v2 rejects a bare `str`, and the same
+   `except` collapsed the candidate to a table — dropping `group_by` and the
+   series.
+
+With series + `group_by` gone, `build_view_from_data_model` returned `None`, the
+view degraded to a bare `{"type": "line_chart"}` (no `x`/`y`/`groupBy`), and the
+frontend rendered a single total line.
+
+There was also a stack-wide disagreement on `group_by`'s shape (the inference
+prompt and the ECharts codegen treat it as a single string; `DataModel` and
+`create_widget` use a list; `view.groupBy` is a single string).
+
+## The fix
+
+`backend/app/ai/tools/implementations/create_data.py`
+- `_extract_json_object()` — tolerant extraction: direct parse → strip code
+  fences → scan for the first balanced `{…}` object (drops trailing prose).
+  Used in place of `json.loads(raw)` in the viz-inference pass.
+- `build_view_from_data_model()` — normalize `group_by` to a single column name
+  before constructing the view.
+
+`backend/app/ai/tools/schemas/create_data_model.py`
+- `group_by` is now `Optional[Union[str, List[str]]]` so the planner's string
+  validates instead of nuking the candidate.
+- `normalize_group_by()` — shared helper that flattens str/list/empty → a single
+  column name (charts render one breakdown dimension).
+
+`backend/app/services/artifact_codegen.py`
+- Normalize `group_by` before embedding it as a JS key, so a list can never
+  reach `_js_str` (it would have crashed).
 
 ---
 
-## One-time environment setup
+## Environment setup (sandbox)
 
-The codebase needs **Python 3.12+** (3.11 trips an f-string-with-backslash
-`SyntaxError` in `app/ai/agents/planner/planner.py`). `psycopg2` won't build
-without `libpq`, but tests default to **sqlite**, so we use `psycopg2-binary`.
+Needs **Python 3.12+** (3.11 trips an f-string `SyntaxError` in
+`planner.py`). `psycopg2` won't build without `libpq`, but tests default to
+**sqlite**, so use `psycopg2-binary`.
 
 ```bash
 cd backend
 python3.12 -m venv venv
 source venv/bin/activate
 pip install --upgrade pip
-
-# Install everything except the source psycopg2, then the prebuilt binary.
 grep -iv '^psycopg2==' requirements_versioned.txt > /tmp/reqs_nopsy.txt
 pip install -r /tmp/reqs_nopsy.txt
 pip install psycopg2-binary
 ```
 
-### Required environment variables
-
-Run the e2e test exactly like CI does (`ENVIRONMENT=production TESTING=true`,
-which loads `bow-config.yaml` with `auth.mode: hybrid` so local password
-registration works):
+Env vars (the e2e test mirrors CI: `ENVIRONMENT=production TESTING=true` loads
+`bow-config.yaml` with `auth.mode: hybrid` so password registration works):
 
 ```bash
 export ENVIRONMENT=production
 export TESTING=true
-# Any valid Fernet key — used to encrypt the stored provider credential.
 export BOW_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
-# Your Anthropic key. NEVER commit this.
-export ANTHROPIC_API_KEY_TEST="sk-ant-..."
+export ANTHROPIC_API_KEY_TEST="sk-ant-..."   # NEVER commit this
 ```
 
-> The test installs an Anthropic provider with **Haiku**
-> (`claude-haiku-4-5-20251001`) as the org default — the bug is
-> model-independent (it's a schema/validation mismatch, not a planning
-> failure), so Haiku keeps the loop cheap and fast (~40s/run). Override with
-> `BOW_REPRO_MODEL=<model_id>`.
+The e2e test installs an Anthropic provider with **Haiku**
+(`claude-haiku-4-5-20251001`) as the org default — the bug was
+model-independent. Override with `BOW_REPRO_MODEL=<model_id>`.
 
 ---
 
 ## The feedback loop
 
-### Inner loop — fast, deterministic, no API key (~30s)
+### Inner loop — fast, deterministic, no API key
 
-`backend/tests/unit/test_repro_group_by_dropped.py` pins the exact mechanism
-with no LLM and no network: a string `group_by` (what the planner emits) is
-rejected by `DataModel`, collapsing the candidate to a bare table.
+`backend/tests/unit/test_repro_group_by_dropped.py` pins both mechanisms with no
+LLM and no network: tolerant JSON extraction (fences + prose), the schema
+accepting a string `group_by`, and `normalize_group_by`.
 
 ```bash
 cd backend && source venv/bin/activate
@@ -93,25 +108,13 @@ export BOW_DATABASE_URL="sqlite:///db/app.db"   # any string; harness overrides 
 python -m pytest tests/unit/test_repro_group_by_dropped.py -v
 ```
 
-Expected on current `main` (bug present):
+### Outer loop — end-to-end against Chinook + real model
 
-```
-test_datamodel_rejects_string_group_by ............... PASSED
-test_create_data_construction_drops_the_breakdown ... PASSED
-test_planner_string_group_by_survives ............... XFAIL   <-- desired behavior, currently failing
-====== 2 passed, 1 xfailed ======
-```
-
-`test_planner_string_group_by_survives` is the canary: it's `xfail(strict=True)`,
-so **once the bug is fixed it flips to XPASS and the suite fails**, prompting you
-to delete the marker. Use this loop while iterating on the fix.
-
-### Outer loop — end-to-end against Chinook + real model (~40s)
-
-`backend/tests/e2e/test_repro_viz_breakdown.py` drives the **real agent**
-through the HTTP API against the committed `demo-datasources/chinook.sqlite`,
-then inspects the chart that was actually persisted on the widget
-(`last_step.data_model` + `last_step.view`).
+`backend/tests/e2e/test_repro_viz_breakdown.py` drives the **real agent** through
+the HTTP API against the committed `demo-datasources/chinook.sqlite`, with the
+prompt "total sales over time broken down by music genre, one line per genre",
+then asserts the breakdown survived to **both** the persisted `data_model` and
+the rendered `Visualization.view` (the layer the customer sees).
 
 ```bash
 cd backend && source venv/bin/activate
@@ -119,60 +122,30 @@ cd backend && source venv/bin/activate
 python -m pytest tests/e2e/test_repro_viz_breakdown.py -s -m e2e
 ```
 
-The prompt mirrors the customer's "metric broken down by category":
-
-> *Plot total sales over time broken down by music genre, as a LINE chart with
-> one line per genre … Join Invoice → InvoiceLine → Track → Genre …*
-
 ---
 
-## Reproduced output (current `main`, Haiku)
+## Before / after (Chinook, Haiku)
+
+**Before** — SQL grouped by genre (`351 rows`), but the chart dropped it:
 
 ```
-========== REPRO DIAGNOSTIC: viz breakdown ==========
-widgets produced: 1
-{
-  "title": "Sales by Genre Over Time (Monthly)",
-  "type": "line_chart",
-  "columns": ["Month", "GenreName", "TotalSales"],   <-- SQL DID group by genre
-  "total_rows": 351,                                  <-- tall: many rows per month
-  "x_key": null,
-  "value_keys": [],
-  "series_count": 0,                                  <-- series dropped
-  "group_by": null,                                   <-- THE BUG: breakdown lost
-  "view_group_by": null,
-  "breakdown_dim_present": true,
-  "breakdown_applied": false
-}
-=====================================================
-
-AssertionError: Metric breakdown was lost on the chart — the data is granular
-along a category dimension, but the chart applies no group_by / multi-series,
-so it renders a single total line.
-
-WARNING app.project_manager update_visualization_view failed: 2 validation
-errors for ViewSchema
-  view.line_chart.x  Field required ... input_value={'type': 'line_chart'}
-  view.line_chart.y  Field required ...
+"columns": ["Month", "GenreName", "TotalSales"], "total_rows": 351
+"series_count": 0, "group_by": null, "breakdown_applied": false
+WARNING update_visualization_view failed: view.line_chart.x/y Field required
 ```
 
-The trailing `ViewSchema` warning is the tail of the same chain: with series
-dropped, the view degrades to a bare `{"type": "line_chart"}` (no `x`/`y`),
-and the frontend auto-renders a single line.
+**After** — the breakdown reaches the rendered visualization view:
 
----
+```
+"series_count": 1, "group_by": "GenreName", "x_key": "Month", "breakdown_applied": true
 
-## What "fixed" looks like
+VIZ VIEWS: [{"version":"v2","view":{"type":"line_chart","x":"YearMonth",
+  "y":"TotalSales","groupBy":"GenreName","legend":{"show":true,...},
+  "seriesStyles":[{"key":"TotalSales","label":"Total Sales","aggregation":"sum"}]}}]
+```
 
-After the fix (normalize `group_by` so the planner's choice survives into the
-data model and the view), re-run both loops:
-
-- **Inner:** `test_planner_string_group_by_survives` goes from `xfail` →
-  `xpass`; remove the `@pytest.mark.xfail` marker so it's a plain green
-  regression guard.
-- **Outer:** the e2e diagnostic shows `group_by` (or `view_group_by`) set to
-  the category column, `breakdown_applied: true`, and the test passes —
-  i.e. the chart renders one line per genre.
+`groupBy: "GenreName"` → one line per genre. The `update_visualization_view`
+warning is gone.
 
 ---
 
@@ -180,6 +153,9 @@ data model and the view), re-run both loops:
 
 | File | Role |
 |---|---|
-| `backend/tests/unit/test_repro_group_by_dropped.py` | Fast, key-free root-cause check (inner loop) |
-| `backend/tests/e2e/test_repro_viz_breakdown.py` | End-to-end Chinook + real-model repro (outer loop) |
+| `backend/app/ai/tools/implementations/create_data.py` | Fix: tolerant JSON parse + group_by normalization in the view builder |
+| `backend/app/ai/tools/schemas/create_data_model.py` | Fix: `group_by` accepts str-or-list + `normalize_group_by` helper |
+| `backend/app/services/artifact_codegen.py` | Fix: normalize `group_by` before JS embedding |
+| `backend/tests/unit/test_repro_group_by_dropped.py` | Inner-loop regression guard (no key) |
+| `backend/tests/e2e/test_repro_viz_breakdown.py` | Outer-loop end-to-end repro (Chinook + real model) |
 | `REPRO-viz-breakdown.md` | This guide |

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 import logging
+import re
 import time as _time
 from typing import AsyncIterator, Dict, Any, Type, Optional, List, Union
 from pydantic import BaseModel
@@ -28,6 +29,7 @@ from app.ai.llm.types import Message, TextDeltaEvent
 from app.dependencies import async_session_maker
 from app.services.usage_policy_service import UsageLimitContext
 from app.ai.tools.schemas import DataModel
+from app.ai.tools.schemas.create_data_model import normalize_group_by
 from app.ai.schemas.codegen import CodeGenContext, CodeGenRequest
 from app.ai.prompt_formatters import build_codegen_context
 from app.schemas.view_schema import (
@@ -53,6 +55,65 @@ ALLOWED_VIZ_TYPES = {
     "table","bar_chart","line_chart","pie_chart","area_chart","count","metric_card",
     "heatmap","map","candlestick","treemap","radar_chart","scatter_plot",
 }
+
+
+def _extract_json_object(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Best-effort extraction of a single JSON object from an LLM response.
+
+    The visualization-inference prompt asks for "only valid JSON", but models
+    routinely wrap it in ```json fences and/or append a prose rationale. A bare
+    ``json.loads`` then throws, and the caller's ``except`` discards the whole
+    candidate — dropping the series and the breakdown ``group_by``. This tries,
+    in order: a direct parse, a parse after stripping markdown code fences, and
+    finally the first balanced ``{...}`` object found in the text.
+    """
+    if not text:
+        return None
+
+    def _as_dict(s: str) -> Optional[Dict[str, Any]]:
+        try:
+            obj = json.loads(s)
+        except Exception:
+            return None
+        return obj if isinstance(obj, dict) else None
+
+    # 1) Direct parse.
+    obj = _as_dict(text)
+    if obj is not None:
+        return obj
+
+    # 2) Strip a leading ```json / ``` fence and any closing fence, then retry.
+    stripped = re.sub(r'^\s*```(?:[A-Za-z0-9_\-]+)?\s*\r?\n', '', text.strip())
+    stripped = re.sub(r'(?m)^\s*```\s*$', '', stripped)
+    obj = _as_dict(stripped)
+    if obj is not None:
+        return obj
+
+    # 3) Scan for the first balanced top-level object (drops trailing prose).
+    start = stripped.find('{')
+    if start == -1:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(stripped)):
+        c = stripped[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == '\\':
+                esc = True
+            elif c == '"':
+                in_str = False
+        elif c == '"':
+            in_str = True
+        elif c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                return _as_dict(stripped[start:i + 1])
+    return None
 
 
 def _infer_palette_theme(runtime_ctx: Dict[str, Any]) -> Optional[str]:
@@ -153,8 +214,11 @@ def build_view_from_data_model(
         # Use list when multiple measures exist
         y_value: Union[str, List[str]] = value_cols[0] if len(value_cols) == 1 else value_cols
         series_styles = _build_series_styles(series)
+        # group_by may arrive as a string (planner) or a list (other tools);
+        # the view expects a single column name.
+        group_by = normalize_group_by(data_model.get("group_by"))
         # Show legend if multiple series or groupBy is used
-        has_multiple_series = len(series) > 1 or data_model.get("group_by")
+        has_multiple_series = len(series) > 1 or bool(group_by)
         view_cls = {
             "bar_chart": BarChartView,
             "line_chart": LineChartView,
@@ -164,7 +228,7 @@ def build_view_from_data_model(
             title=title,
             x=str(x_key),
             y=y_value,
-            groupBy=data_model.get("group_by"),
+            groupBy=group_by,
             palette=palette,
             seriesStyles=series_styles,
             legend=LegendOptions(show=bool(has_multiple_series)),
@@ -588,10 +652,11 @@ Do not use generic placeholders like "value" unless that is the actual column na
         candidate = {"type": "table", "series": []}
         view_options: Dict[str, Any] | None = None
         if raw:
-            try:
-                candidate_json = json.loads(raw)
-            except Exception:
-                candidate_json = None
+            # Models routinely wrap the JSON in ```json fences and append a prose
+            # "Rationale" section despite the "return only JSON" instruction, so a
+            # bare json.loads(raw) throws and the breakdown is silently lost.
+            # Extract the first balanced JSON object instead.
+            candidate_json = _extract_json_object(raw)
             if isinstance(candidate_json, dict):
                 try:
                     dm = DataModel(**{k: v for k, v in candidate_json.items() if k in {"type", "series", "group_by", "sort", "limit", "filters"}})

--- a/backend/app/ai/tools/schemas/create_data_model.py
+++ b/backend/app/ai/tools/schemas/create_data_model.py
@@ -126,6 +126,25 @@ SeriesItem = Union[
 ]
 
 
+def normalize_group_by(value: Any) -> Optional[str]:
+    """Normalize a ``group_by`` value to a single column name (or None).
+
+    Charts render exactly one breakdown dimension, and every consumer
+    (``view.groupBy`` is ``Optional[str]``, the ECharts codegen embeds it as a
+    string) expects a single column. The planner emits a string; other tools
+    emit a list. Accept both and return the first usable column.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if isinstance(item, str) and item:
+                return item
+    return None
+
+
 class SortSpec(BaseModel):
     field: str
     direction: Literal["asc", "desc"] = "asc"
@@ -155,7 +174,13 @@ class DataModel(BaseModel):
             "Used when raw data is granular and should open in a filtered state."
         ),
     )
-    group_by: Optional[List[str]] = Field(default=None, description="Group-by fields")
+    # Accept both the planner's single-column string (what the create_data
+    # visualization-inference prompt emits, e.g. "category") and a list. A
+    # bare List[str] here used to reject the string and — because the caller
+    # swallows the ValidationError — silently drop the breakdown (and series)
+    # entirely, collapsing "metric by category" into a single total line.
+    # Charts render a single breakdown dimension; see ``normalize_group_by``.
+    group_by: Optional[Union[str, List[str]]] = Field(default=None, description="Group-by field(s)")
     #sort: Optional[List[SortSpec]] = Field(default=None, description="Sorting specifications")
     #limit: Optional[int] = Field(default=100, description="Row limit")
     series: Optional[List[SeriesItem]] = Field(default=None, description="Chart series configuration if applicable")

--- a/backend/app/services/artifact_codegen.py
+++ b/backend/app/services/artifact_codegen.py
@@ -8,6 +8,8 @@ that the LLM would produce, but instantly.
 import re
 from typing import List, Optional
 
+from app.ai.tools.schemas.create_data_model import normalize_group_by
+
 
 # ---------------------------------------------------------------------------
 # Chart-type → ECharts option JS builders
@@ -42,7 +44,9 @@ def _build_cartesian(data_model: dict, viz_index: int) -> str:
     if not category_key:
         return "{}"
 
-    group_by = data_model.get("group_by") or ""
+    # group_by may be a string (planner) or a list (other tools); the codegen
+    # embeds it as a single JS string key, so normalize to one column name.
+    group_by = normalize_group_by(data_model.get("group_by")) or ""
     is_horizontal = data_model.get("horizontal", False)
     chart_type = "line" if dm_type in ("line_chart", "area_chart") else "bar"
     is_area = dm_type == "area_chart"

--- a/backend/tests/e2e/test_repro_viz_breakdown.py
+++ b/backend/tests/e2e/test_repro_viz_breakdown.py
@@ -1,0 +1,250 @@
+"""End-to-end reproduction of the "metric broken down by a dimension renders
+as a single line" bug, against the committed Chinook demo and a real
+Anthropic model.
+
+Symptom (from the field): asking for a metric in dynamics broken down by a
+dimension (e.g. "GMV by category") produces SQL that correctly GROUPs BY the
+dimension, but the chart shows a single total line instead of one line per
+category.
+
+This test drives the *real* agent through the HTTP surface — same path the
+product uses — then inspects the chart that was actually persisted on the
+widget (``last_step.data_model`` + ``last_step.view``) and asserts the
+breakdown dimension survived into the visualization config.
+
+Gating
+------
+Requires ``ANTHROPIC_API_KEY_TEST`` (skipped otherwise) and the committed
+``demo-datasources/chinook.sqlite``. Runs against the default sqlite test DB,
+so no Docker/Postgres is needed in the sandbox.
+
+Run it:
+    cd backend
+    ANTHROPIC_API_KEY_TEST=sk-ant-... \
+      python -m pytest tests/e2e/test_repro_viz_breakdown.py -s -m e2e
+
+See ``REPRO-viz-breakdown.md`` for the full feedback loop.
+"""
+
+import json
+import os
+
+import pytest
+
+# Mirror the customer's "metric broken down by category" ask, using a Chinook
+# dimension (genre) that requires the agent to GROUP BY a categorical column.
+# The prompt is deliberately prescriptive so the SQL reliably returns granular,
+# tall (month x genre) rows — which is exactly the shape that triggers the bug.
+REPRO_PROMPT = (
+    "Plot total sales over time broken down by music genre, as a LINE chart "
+    "with one line per genre. Aggregate sales by month. "
+    "Join Invoice -> InvoiceLine -> Track -> Genre and use the sum of "
+    "InvoiceLine.UnitPrice * InvoiceLine.Quantity as the sales metric. "
+    "I want to compare genres against each other over time, not a single total line."
+)
+
+CARTESIAN_TYPES = {"line_chart", "bar_chart", "area_chart"}
+
+# Model used for the repro. Override with BOW_REPRO_MODEL. Defaults to Haiku
+# (cheap + fast) — the bug is model-independent (it's a schema/validation
+# mismatch in create_data's viz inference, not a planning failure).
+REPRO_MODEL_ID = os.getenv("BOW_REPRO_MODEL", "claude-haiku-4-5-20251001")
+
+
+def _install_anthropic_haiku(test_client, *, user_token: str, org_id: str) -> None:
+    """Install an Anthropic provider with the repro model as the org default.
+
+    Uses ``ANTHROPIC_API_KEY_TEST``. Sets the chosen model as both default and
+    small-default so the planner, viz-inference pass, and judge all run on it.
+    """
+    api_key = os.getenv("ANTHROPIC_API_KEY_TEST", "")
+    assert api_key, "ANTHROPIC_API_KEY_TEST is not set"
+    resp = test_client.post(
+        "/api/llm/providers",
+        json={
+            "name": "anthropic provider",
+            "provider_type": "anthropic",
+            "credentials": {"api_key": str(api_key)},
+            "models": [
+                {
+                    "model_id": REPRO_MODEL_ID,
+                    "name": REPRO_MODEL_ID,
+                    "is_custom": False,
+                    "is_default": True,
+                }
+            ],
+        },
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "X-Organization-Id": str(org_id),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _looks_numeric(values) -> bool:
+    seen = False
+    for v in values:
+        if v is None:
+            continue
+        seen = True
+        if isinstance(v, bool):
+            return False
+        if not isinstance(v, (int, float)):
+            return False
+    return seen
+
+
+def _analyze_chart(step: dict) -> dict:
+    """Pull the breakdown-relevant fields out of a persisted step."""
+    dm = step.get("data_model") or {}
+    view = step.get("view") or {}
+    inner_view = view.get("view") if isinstance(view.get("view"), dict) else view
+    data = step.get("data") or {}
+
+    columns = []
+    for c in data.get("columns") or []:
+        if isinstance(c, dict):
+            f = c.get("field") or c.get("headerName")
+            if f:
+                columns.append(f)
+        elif isinstance(c, str):
+            columns.append(c)
+
+    rows = data.get("rows") or []
+    info = data.get("info") or {}
+    total_rows = info.get("total_rows")
+    if not isinstance(total_rows, int):
+        total_rows = len(rows)
+
+    series = dm.get("series") or []
+    x_key = series[0].get("key") if series and isinstance(series[0], dict) else None
+    value_keys = {
+        s.get("value") for s in series if isinstance(s, dict) and s.get("value")
+    }
+
+    group_by = dm.get("group_by")
+    view_group_by = inner_view.get("groupBy") if isinstance(inner_view, dict) else None
+    y = inner_view.get("y") if isinstance(inner_view, dict) else None
+    multi_measure = isinstance(y, list) and len(y) > 1
+
+    # A candidate breakdown column = a non-x, non-measure column. For a tall
+    # (month, genre, total) result that's the 'genre' column.
+    dim_cols = [c for c in columns if c != x_key and c not in value_keys]
+    # Trim obvious measure columns from the sample to reduce false positives.
+    if rows:
+        dim_cols = [
+            c
+            for c in dim_cols
+            if not _looks_numeric([r.get(c) for r in rows[:25] if isinstance(r, dict)])
+        ]
+
+    distinct_x = None
+    if x_key and rows:
+        distinct_x = len({r.get(x_key) for r in rows if isinstance(r, dict)})
+
+    breakdown_dim_present = bool(dim_cols) or (
+        distinct_x is not None and total_rows > distinct_x
+    )
+    breakdown_applied = bool(group_by) or bool(view_group_by) or len(series) > 1 or multi_measure
+
+    return {
+        "title": step.get("title"),
+        "type": dm.get("type"),
+        "columns": columns,
+        "total_rows": total_rows,
+        "x_key": x_key,
+        "value_keys": sorted(v for v in value_keys if v),
+        "series_count": len(series),
+        "group_by": group_by,
+        "view_group_by": view_group_by,
+        "view_y": y,
+        "dim_cols": dim_cols,
+        "distinct_x": distinct_x,
+        "breakdown_dim_present": breakdown_dim_present,
+        "breakdown_applied": breakdown_applied,
+    }
+
+
+@pytest.mark.e2e
+def test_metric_breakdown_survives_to_chart(
+    create_user,
+    login_user,
+    whoami,
+    install_demo_data_source,
+    create_report,
+    create_completion,
+    test_client,
+):
+    if not os.getenv("ANTHROPIC_API_KEY_TEST"):
+        pytest.skip("ANTHROPIC_API_KEY_TEST is not set")
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    _install_anthropic_haiku(test_client, user_token=token, org_id=org_id)
+    print(f"[repro] using model: {REPRO_MODEL_ID}", flush=True)
+    ds = install_demo_data_source(demo_id="chinook", user_token=token, org_id=org_id)
+    ds_id = ds["data_source_id"]
+
+    report = create_report(
+        title="Repro: metric breakdown by category",
+        user_token=token,
+        org_id=org_id,
+        data_sources=[ds_id],
+    )
+
+    # Drive the real agent (synchronous foreground run).
+    create_completion(
+        report_id=report["id"],
+        prompt=REPRO_PROMPT,
+        user_token=token,
+        org_id=org_id,
+        background=False,
+    )
+
+    # Inspect what got persisted on the report's widgets.
+    resp = test_client.get(f"/api/reports/{report['id']}/widgets", headers=headers)
+    assert resp.status_code == 200, resp.text
+    widgets = resp.json()
+
+    analyses = []
+    for w in widgets:
+        step = w.get("last_step")
+        if isinstance(step, dict):
+            analyses.append(_analyze_chart(step))
+
+    print("\n========== REPRO DIAGNOSTIC: viz breakdown ==========", flush=True)
+    print(f"prompt: {REPRO_PROMPT}", flush=True)
+    print(f"widgets produced: {len(widgets)}", flush=True)
+    for a in analyses:
+        print(json.dumps(a, indent=2, default=str), flush=True)
+    print("=====================================================\n", flush=True)
+
+    charts = [a for a in analyses if a["type"] in CARTESIAN_TYPES]
+    assert charts, (
+        "Agent did not produce a line/bar/area chart widget; cannot evaluate the "
+        f"breakdown. Produced types: {[a['type'] for a in analyses]}"
+    )
+
+    # The bug: a chart whose underlying data carries a breakdown dimension, but
+    # whose visualization config applies no grouping (single line).
+    broken = [
+        a
+        for a in charts
+        if a["breakdown_dim_present"] and not a["breakdown_applied"]
+    ]
+    assert not broken, (
+        "Metric breakdown was lost on the chart — the data is granular along a "
+        "category dimension, but the chart applies no group_by / multi-series, so "
+        "it renders a single total line. Offending chart(s):\n"
+        + json.dumps(broken, indent=2, default=str)
+    )
+
+    # Positive confirmation that at least one chart actually applied the breakdown.
+    assert any(a["breakdown_applied"] for a in charts), (
+        "No chart applied a breakdown (group_by / multi-series). Charts:\n"
+        + json.dumps(charts, indent=2, default=str)
+    )

--- a/backend/tests/e2e/test_repro_viz_breakdown.py
+++ b/backend/tests/e2e/test_repro_viz_breakdown.py
@@ -248,3 +248,45 @@ def test_metric_breakdown_survives_to_chart(
         "No chart applied a breakdown (group_by / multi-series). Charts:\n"
         + json.dumps(charts, indent=2, default=str)
     )
+
+    # The frontend renders from the Visualization.view (not Step.view), so
+    # assert the breakdown actually reached the rendered view: a valid
+    # CartesianView with x/y and a groupBy. This is the layer the customer sees.
+    import asyncio as _asyncio
+    from sqlalchemy import select as _select
+    from app.dependencies import async_session_maker as _sm
+    from app.models.visualization import Visualization as _Viz
+
+    async def _viz_views():
+        async with _sm() as s:
+            rows = (await s.execute(
+                _select(_Viz.view).where(_Viz.report_id == str(report["id"]))
+            )).all()
+            return [r[0] for r in rows if isinstance(r[0], dict)]
+
+    viz_views = _asyncio.run(_viz_views())
+    print("VIZ VIEWS:", json.dumps(viz_views, default=str), flush=True)
+
+    def _view_group_by(v: dict):
+        inner = v.get("view") if isinstance(v.get("view"), dict) else v
+        if not isinstance(inner, dict):
+            return None
+        gb = inner.get("groupBy")
+        if gb:
+            return gb
+        enc = inner.get("encoding") if isinstance(inner.get("encoding"), dict) else None
+        if enc and (enc.get("groupBy") or enc.get("series")):
+            return enc.get("groupBy") or "multi-series"
+        return None
+
+    cartesian_views = [
+        v for v in viz_views
+        if isinstance((v.get("view") or v), dict)
+        and ((v.get("view") or v).get("type") in CARTESIAN_TYPES)
+    ]
+    assert cartesian_views, f"No cartesian visualization view persisted: {viz_views}"
+    assert any(_view_group_by(v) for v in cartesian_views), (
+        "Rendered visualization view has no breakdown (groupBy/multi-series); "
+        "the chart would draw a single line. Views:\n"
+        + json.dumps(viz_views, indent=2, default=str)
+    )

--- a/backend/tests/unit/test_repro_group_by_dropped.py
+++ b/backend/tests/unit/test_repro_group_by_dropped.py
@@ -1,36 +1,80 @@
-"""Fast, key-free root-cause check for the "metric breakdown collapses to a
-single line" bug.
+"""Regression guard for the "metric breakdown collapses to a single line" bug.
 
-Context
+History
 -------
-When a user asks for a metric *broken down by a dimension* (e.g. "GMV by
-category", "sales by genre"), ``create_data`` generates SQL that correctly
-GROUPs BY the dimension, so the result is granular: many rows per x-axis
-value (one per category). The chart, however, renders a single total line.
+When a user asked for a metric *broken down by a dimension* (e.g. "GMV by
+category", "sales by genre"), ``create_data`` generated SQL that correctly
+GROUPed BY the dimension — so the result was granular, with many rows per
+x-axis value — yet the chart rendered a single total line.
 
-The breakdown is lost inside ``create_data``'s post-execution visualization
+The breakdown was lost in ``create_data``'s post-execution visualization
 inference. The inference LLM is prompted to emit ``group_by`` as a **string**
 (see ``implementations/create_data.py`` — the prompt examples and OUTPUT
-FORMAT all use ``"group_by": "column_name_or_null"``). That candidate is then
-fed straight into ``DataModel(**candidate_json)``, but ``DataModel.group_by``
-is typed ``Optional[List[str]]``. Pydantic v2 does not coerce a bare ``str``
-into ``List[str]`` — it raises — and the surrounding ``except`` resets the
-whole candidate to ``{"type": "table", "series": []}``, throwing away
-``group_by`` (and the series) entirely.
+FORMAT all use ``"group_by": "column_name_or_null"``). That candidate was fed
+into ``DataModel(**candidate_json)``, but ``DataModel.group_by`` was typed
+``Optional[List[str]]``. Pydantic v2 does not coerce a bare ``str`` into
+``List[str]`` — it raised — and the surrounding ``except`` reset the whole
+candidate to ``{"type": "table", "series": []}``, discarding ``group_by`` (and
+the series) entirely.
 
-This module pins that mechanism deterministically, with no LLM and no
-network. It is the *inner* loop of the feedback cycle documented in
-``REPRO-viz-breakdown.md``; the *outer* loop is the end-to-end agent repro in
+Fix
+---
+``DataModel.group_by`` now accepts ``Optional[Union[str, List[str]]]`` so the
+planner's string validates, and ``normalize_group_by`` flattens whatever shape
+to the single column name every renderer expects.
+
+This module pins that fixed behavior deterministically — no LLM, no network.
+It is the *inner* loop of the feedback cycle in ``REPRO-viz-breakdown.md``; the
+*outer* loop is the end-to-end agent repro in
 ``tests/e2e/test_repro_viz_breakdown.py``.
-
-When the fix lands, ``test_planner_string_group_by_survives`` flips from
-xfail to pass (strict=True will then flag the stale marker for removal).
 """
 
 import pytest
-from pydantic import ValidationError
 
-from app.ai.tools.schemas.create_data_model import DataModel
+from app.ai.tools.schemas.create_data_model import DataModel, normalize_group_by
+from app.ai.tools.implementations.create_data import _extract_json_object
+
+
+# The literal shape Haiku returned in the end-to-end repro: fenced JSON with a
+# trailing prose "Rationale" block. A bare json.loads() throws on this, which is
+# what dropped the series + group_by before the schema was ever reached.
+LLM_FENCED_WITH_PROSE = (
+    "```json\n"
+    '{\n  "type": "line_chart",\n'
+    '  "series": [{"name": "Total Sales", "key": "InvoiceMonth", "value": "TotalSales"}],\n'
+    '  "group_by": "GenreName"\n}\n'
+    "```\n\n"
+    "**Rationale:**\n\n1. Line chart is correct because the user asked for trends.\n"
+    "2. group_by GenreName yields one line per genre."
+)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"type": "line_chart", "series": [], "group_by": "GenreName"}',  # plain
+        '```json\n{"type": "line_chart", "group_by": "GenreName"}\n```',   # fenced
+        '```\n{"type": "bar_chart"}\n```',                                  # bare fence
+        LLM_FENCED_WITH_PROSE,                                              # fence + prose
+        'Here you go:\n{"type": "pie_chart", "series": []}\nHope that helps!',  # prose around
+    ],
+)
+def test_extract_json_object_handles_fences_and_prose(raw):
+    obj = _extract_json_object(raw)
+    assert isinstance(obj, dict) and obj.get("type")
+
+
+def test_extract_json_object_recovers_breakdown():
+    obj = _extract_json_object(LLM_FENCED_WITH_PROSE)
+    assert obj["type"] == "line_chart"
+    assert obj["series"] and obj["series"][0]["value"] == "TotalSales"
+    assert obj["group_by"] == "GenreName"
+
+
+def test_extract_json_object_returns_none_on_garbage():
+    assert _extract_json_object("no json here") is None
+    assert _extract_json_object("") is None
+    assert _extract_json_object(None) is None
 
 
 # A representative candidate exactly as the viz-inference LLM is prompted to
@@ -58,21 +102,22 @@ def _build_candidate_like_create_data(candidate_json: dict) -> dict:
     try:
         return DataModel(**keep).model_dump()
     except Exception:
-        # The production code swallows the ValidationError and falls back to a
-        # bare table — dropping series AND group_by.
+        # Pre-fix fallback: a ValidationError here dropped series AND group_by.
         return {"type": "table", "series": []}
 
 
-def test_datamodel_rejects_string_group_by():
-    """Schema-level proof: a string group_by (what the planner emits) is
-    rejected by the List[str] field."""
-    with pytest.raises(ValidationError):
-        DataModel(
-            type="line_chart",
-            series=[{"name": "Sales", "key": "month", "value": "total"}],
-            group_by="genre",
-        )
-    # A list, by contrast, validates fine.
+def test_datamodel_accepts_planner_group_by_string():
+    """The planner's single-column string must validate (it used to raise)."""
+    dm = DataModel(
+        type="line_chart",
+        series=[{"name": "Sales", "key": "month", "value": "total"}],
+        group_by="genre",
+    )
+    assert dm.group_by == "genre"
+
+
+def test_datamodel_accepts_group_by_list():
+    """A list (as other tools emit) still validates."""
     dm = DataModel(
         type="line_chart",
         series=[{"name": "Sales", "key": "month", "value": "total"}],
@@ -81,31 +126,28 @@ def test_datamodel_rejects_string_group_by():
     assert dm.group_by == ["genre"]
 
 
-def test_create_data_construction_drops_the_breakdown():
-    """End-to-end of the inline snippet: the planner's string group_by causes
-    the entire candidate to collapse to a table, so the breakdown is lost."""
-    built = _build_candidate_like_create_data(PLANNER_CANDIDATE)
-    # Bug signature: type downgraded to table, series + group_by gone.
-    assert built.get("group_by") in (None, [], "")
-    assert not built.get("series")
-    assert built.get("type") == "table"
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="BUG: planner emits group_by as a string, which DataModel "
-    "(List[str]) rejects; the breakdown is dropped. Remove this marker when "
-    "create_data normalizes group_by before/while building the DataModel.",
-)
-def test_planner_string_group_by_survives():
-    """Desired behavior (currently failing): the dimension the planner chose
-    must survive into the final data model so the chart can render one line
-    per category."""
+def test_create_data_construction_preserves_breakdown():
+    """The construction the tool performs must keep the chart type, the
+    series, and the breakdown dimension — i.e. one line per category."""
     built = _build_candidate_like_create_data(PLANNER_CANDIDATE)
     assert built.get("type") == "line_chart"
-    assert built.get("series"), "series should be preserved"
+    assert built.get("series"), "series must be preserved"
     gb = built.get("group_by")
     assert gb, "group_by must survive"
-    # Normalized to the column name regardless of str/list representation.
-    flat = gb[0] if isinstance(gb, list) else gb
-    assert flat == "genre"
+    assert normalize_group_by(gb) == "genre"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("genre", "genre"),
+        (["genre"], "genre"),
+        (["genre", "country"], "genre"),  # charts render a single dimension
+        ([], None),
+        ("", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_normalize_group_by(value, expected):
+    assert normalize_group_by(value) == expected

--- a/backend/tests/unit/test_repro_group_by_dropped.py
+++ b/backend/tests/unit/test_repro_group_by_dropped.py
@@ -1,0 +1,111 @@
+"""Fast, key-free root-cause check for the "metric breakdown collapses to a
+single line" bug.
+
+Context
+-------
+When a user asks for a metric *broken down by a dimension* (e.g. "GMV by
+category", "sales by genre"), ``create_data`` generates SQL that correctly
+GROUPs BY the dimension, so the result is granular: many rows per x-axis
+value (one per category). The chart, however, renders a single total line.
+
+The breakdown is lost inside ``create_data``'s post-execution visualization
+inference. The inference LLM is prompted to emit ``group_by`` as a **string**
+(see ``implementations/create_data.py`` — the prompt examples and OUTPUT
+FORMAT all use ``"group_by": "column_name_or_null"``). That candidate is then
+fed straight into ``DataModel(**candidate_json)``, but ``DataModel.group_by``
+is typed ``Optional[List[str]]``. Pydantic v2 does not coerce a bare ``str``
+into ``List[str]`` — it raises — and the surrounding ``except`` resets the
+whole candidate to ``{"type": "table", "series": []}``, throwing away
+``group_by`` (and the series) entirely.
+
+This module pins that mechanism deterministically, with no LLM and no
+network. It is the *inner* loop of the feedback cycle documented in
+``REPRO-viz-breakdown.md``; the *outer* loop is the end-to-end agent repro in
+``tests/e2e/test_repro_viz_breakdown.py``.
+
+When the fix lands, ``test_planner_string_group_by_survives`` flips from
+xfail to pass (strict=True will then flag the stale marker for removal).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.tools.schemas.create_data_model import DataModel
+
+
+# A representative candidate exactly as the viz-inference LLM is prompted to
+# emit it: a granular line chart with the breakdown dimension as a *string*.
+PLANNER_CANDIDATE = {
+    "type": "line_chart",
+    "series": [{"name": "Sales", "key": "month", "value": "total", "aggregation": "sum"}],
+    "group_by": "genre",  # <-- string, per the inference prompt's OUTPUT FORMAT
+}
+
+
+def _build_candidate_like_create_data(candidate_json: dict) -> dict:
+    """Mirror the exact construction in
+    ``CreateDataTool._infer_visualization_model_traced``.
+
+    Keeping this in lock-step with the implementation is the whole point: if
+    the production snippet changes shape, update this helper so the test keeps
+    describing real behavior.
+    """
+    keep = {
+        k: v
+        for k, v in candidate_json.items()
+        if k in {"type", "series", "group_by", "sort", "limit", "filters"}
+    }
+    try:
+        return DataModel(**keep).model_dump()
+    except Exception:
+        # The production code swallows the ValidationError and falls back to a
+        # bare table — dropping series AND group_by.
+        return {"type": "table", "series": []}
+
+
+def test_datamodel_rejects_string_group_by():
+    """Schema-level proof: a string group_by (what the planner emits) is
+    rejected by the List[str] field."""
+    with pytest.raises(ValidationError):
+        DataModel(
+            type="line_chart",
+            series=[{"name": "Sales", "key": "month", "value": "total"}],
+            group_by="genre",
+        )
+    # A list, by contrast, validates fine.
+    dm = DataModel(
+        type="line_chart",
+        series=[{"name": "Sales", "key": "month", "value": "total"}],
+        group_by=["genre"],
+    )
+    assert dm.group_by == ["genre"]
+
+
+def test_create_data_construction_drops_the_breakdown():
+    """End-to-end of the inline snippet: the planner's string group_by causes
+    the entire candidate to collapse to a table, so the breakdown is lost."""
+    built = _build_candidate_like_create_data(PLANNER_CANDIDATE)
+    # Bug signature: type downgraded to table, series + group_by gone.
+    assert built.get("group_by") in (None, [], "")
+    assert not built.get("series")
+    assert built.get("type") == "table"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BUG: planner emits group_by as a string, which DataModel "
+    "(List[str]) rejects; the breakdown is dropped. Remove this marker when "
+    "create_data normalizes group_by before/while building the DataModel.",
+)
+def test_planner_string_group_by_survives():
+    """Desired behavior (currently failing): the dimension the planner chose
+    must survive into the final data model so the chart can render one line
+    per category."""
+    built = _build_candidate_like_create_data(PLANNER_CANDIDATE)
+    assert built.get("type") == "line_chart"
+    assert built.get("series"), "series should be preserved"
+    gb = built.get("group_by")
+    assert gb, "group_by must survive"
+    # Normalized to the column name regardless of str/list representation.
+    flat = gb[0] if isinstance(gb, list) else gb
+    assert flat == "genre"


### PR DESCRIPTION
## Summary

Fixes a bug where metrics broken down by a dimension (e.g., "sales by genre") would render as a single total line instead of multiple lines, one per category. The breakdown dimension was being silently dropped during visualization inference in `create_data`.

## Root Cause

Two layered defects in the visualization inference pass:

1. **Brittle JSON parsing**: The inference LLM wraps JSON in markdown code fences and appends prose explanations despite instructions to return only JSON. A bare `json.loads()` would throw, and the exception handler would reset the candidate to `{"type": "table", "series": []}`, discarding the `group_by` field.

2. **Schema type mismatch**: The inference prompt emits `group_by` as a **string** (e.g., `"group_by": "GenreName"`), but `DataModel.group_by` was typed as `Optional[List[str]]`. Pydantic v2 rejects the string-to-list coercion, triggering the same exception handler and losing the breakdown.

## Changes

### `backend/app/ai/tools/implementations/create_data.py`
- Added `_extract_json_object()`: Tolerant JSON extraction that handles markdown fences and trailing prose by attempting direct parse → fence stripping → scanning for first balanced `{...}` object
- Updated `_infer_visualization_model_traced()` to use `_extract_json_object()` instead of bare `json.loads()`
- Modified `build_view_from_data_model()` to normalize `group_by` to a single column name before constructing the view

### `backend/app/ai/tools/schemas/create_data_model.py`
- Changed `DataModel.group_by` type from `Optional[List[str]]` to `Optional[Union[str, List[str]]]` to accept both the planner's string and list formats
- Added `normalize_group_by()` helper function that flattens string/list/empty values to a single column name (charts render one breakdown dimension)

### `backend/app/services/artifact_codegen.py`
- Added normalization of `group_by` before embedding in JavaScript to prevent list values from reaching string formatting

## Testing

- **Unit tests** (`backend/tests/unit/test_repro_group_by_dropped.py`): Deterministic regression guard covering JSON extraction with fences/prose, schema validation of string `group_by`, and normalization logic
- **E2E tests** (`backend/tests/e2e/test_repro_viz_breakdown.py`): Full agent reproduction against Chinook demo dataset with real Anthropic model, verifying breakdown survives to both persisted `data_model` and rendered `Visualization.view`

## Documentation

Added `REPRO-viz-breakdown.md` with complete feedback loop documentation, environment setup, and before/after examples.

https://claude.ai/code/session_011GaBFq7QVounDuz3nNGaeo