### PR TITLE
Native web search (OpenAI + Azure OpenAI) as a first-class agent tool

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -3683,7 +3683,8 @@ class AgentV2:
                 return False
             ptype = getattr(provider, "provider_type", None)
             if ptype == "azure":
-                return True
+                # Web search needs the Responses API, which the admin opts into.
+                return bool(add.get("use_responses_api"))
             if ptype == "openai":
                 return not bool(add.get("base_url"))
             return False

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -94,18 +94,16 @@ class LLM:
             endpoint_url = additional_config.get("endpoint_url")
             if not endpoint_url:
                 raise ValueError("Azure provider requires endpoint_url in additional_config")
-            if enable_web_search:
-                # Native web search is a Responses-API tool that does NOT exist on
-                # Azure Chat Completions. Azure serves the Responses API (with the
-                # web_search tool, backed by Grounding-with-Bing) on its /openai/v1
-                # surface, which is reachable with the plain OpenAI client + base_url.
-                # This is opt-in per provider and assumes an Azure *OpenAI* (GPT)
-                # deployment — Claude-on-Azure uses a different (Messages) surface
-                # and keeps the AzureClient path.
+            # Default to Chat Completions (AzureClient) — works in every region.
+            # Admins opt into the Responses API explicitly (use_responses_api),
+            # which is required for native web search and only available in some
+            # Azure regions. Web search is honored only on the Responses path.
+            use_responses_api = bool(additional_config.get("use_responses_api", False))
+            if use_responses_api:
                 self.client = OpenAIResponsesClient(
                     api_key=self.api_key,
                     base_url=self._azure_v1_base_url(endpoint_url),
-                    enable_web_search=True,
+                    enable_web_search=enable_web_search,
                 )
             else:
                 self.client = AzureClient(api_key=self.api_key, endpoint_url=endpoint_url)

--- a/backend/app/schemas/llm_schema.py
+++ b/backend/app/schemas/llm_schema.py
@@ -97,9 +97,12 @@ class GoogleConfig(BaseModel):
 class AzureCredentials(BaseModel):
     api_key: str
     endpoint_url: str
-    # Per-provider opt-in for native web search. When set, the Azure provider is
-    # routed to the Responses API (/openai/v1) so the web_search tool is
-    # available. Persisted to additional_config, not encrypted.
+    # Opt-in to Azure OpenAI's Responses API (/openai/v1) instead of Chat
+    # Completions. Off by default — only some Azure regions serve Responses.
+    # Persisted to additional_config, not encrypted.
+    use_responses_api: Optional[bool] = None
+    # Per-provider opt-in for native web search. Only effective when
+    # use_responses_api is on (web search is a Responses-API tool).
     enable_web_search: Optional[bool] = None
 
 class AzureConfig(BaseModel):

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -574,6 +574,15 @@ class LLMService:
                     "enable_web_search": bool(credentials.get("enable_web_search")),
                 }
 
+        # Azure: opt-in to the Responses API (off → Chat Completions, works in
+        # every region). Gates web search.
+        if provider.provider_type == "azure":
+            if "use_responses_api" in credentials:
+                existing_additional_config = {
+                    **existing_additional_config,
+                    "use_responses_api": bool(credentials.get("use_responses_api")),
+                }
+
         # Custom (OpenAI-compatible): base_url (required), verify_ssl (optional)
         if provider.provider_type == "custom":
             base_url = credentials.get("base_url")

--- a/frontend/components/LLMProviderModalComponent.vue
+++ b/frontend/components/LLMProviderModalComponent.vue
@@ -130,15 +130,35 @@
                                 />
                             </div>
                         </div>
-                        <div class="" v-if="selectedProvider?.provider_type === 'openai' || selectedProvider?.type === 'openai' || selectedProvider?.provider_type === 'azure' || selectedProvider?.type === 'azure'">
+                        <!-- Azure: Responses API opt-in (gates web search) -->
+                        <div class="" v-if="selectedProvider?.provider_type === 'azure' || selectedProvider?.type === 'azure'">
+                            <div class="flex items-center gap-2">
+                                <UCheckbox v-model="selectedProvider.credentials.use_responses_api" />
+                                <label class="text-sm font-medium text-gray-700">Use Responses API</label>
+                            </div>
+                            <p class="text-xs text-gray-500 mt-1">
+                                Use Azure OpenAI's Responses API instead of Chat Completions. Required for web search, and only available in regions that support the Responses API.
+                            </p>
+                            <div v-if="selectedProvider.credentials.use_responses_api" class="mt-3 ms-1">
+                                <div class="flex items-center gap-2">
+                                    <UCheckbox v-model="selectedProvider.credentials.enable_web_search" />
+                                    <label class="text-sm font-medium text-gray-700">Enable web search</label>
+                                </div>
+                                <p class="text-xs text-gray-500 mt-1">
+                                    Native, provider-executed web search for facts not in your connected data. Requires the org-level Web Fetch setting to also be on.
+                                </p>
+                            </div>
+                        </div>
+                        <!-- OpenAI: Responses API is the default, so web search needs no extra toggle -->
+                        <div class="" v-if="selectedProvider?.provider_type === 'openai' || selectedProvider?.type === 'openai'">
                             <div class="flex items-center gap-2">
                                 <UCheckbox v-model="selectedProvider.credentials.enable_web_search" />
                                 <label class="text-sm font-medium text-gray-700">Enable web search</label>
                             </div>
                             <p class="text-xs text-gray-500 mt-1">
-                                Lets the agent run native, provider-executed web searches (via the Responses API) for facts not in your connected data. Requires the org-level Web Fetch setting to also be on.
+                                Lets the agent run native, provider-executed web searches for facts not in your connected data. Requires the org-level Web Fetch setting to also be on.
                             </p>
-                            <p v-if="(selectedProvider?.provider_type === 'openai' || selectedProvider?.type === 'openai') && selectedProvider.credentials.base_url" class="text-xs text-gray-500 mt-1">
+                            <p v-if="selectedProvider.credentials.base_url" class="text-xs text-gray-500 mt-1">
                                 Note: a custom base URL uses the Chat Completions API, which does not support web search. Clear it to use web search.
                             </p>
                         </div>
@@ -303,7 +323,22 @@
                                         class="border border-gray-300 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
                                 </div>
                             </div>
-                            <div v-if="providerForm.provider_type === 'openai' || providerForm.provider_type === 'azure'" class="mt-3">
+                            <!-- Azure: Responses API opt-in gates web search -->
+                            <div v-if="providerForm.provider_type === 'azure'" class="mt-3">
+                                <div class="flex items-center gap-2">
+                                    <UCheckbox v-model="providerForm.credentials.use_responses_api" />
+                                    <label class="text-sm text-gray-700">Use Responses API</label>
+                                </div>
+                                <p class="text-xs text-gray-500 mt-1">Use Azure OpenAI's Responses API instead of Chat Completions. Required for web search, and only available in regions that support it.</p>
+                                <div v-if="providerForm.credentials.use_responses_api" class="mt-3 ms-1">
+                                    <div class="flex items-center gap-2">
+                                        <UCheckbox v-model="providerForm.credentials.enable_web_search" />
+                                        <label class="text-sm text-gray-700">Enable web search</label>
+                                    </div>
+                                    <p class="text-xs text-gray-500 mt-1">Native, provider-executed web search for external facts. Requires the org-level Web Fetch setting to also be on.</p>
+                                </div>
+                            </div>
+                            <div v-if="providerForm.provider_type === 'openai'" class="mt-3">
                                 <div class="flex items-center gap-2">
                                     <UCheckbox v-model="providerForm.credentials.enable_web_search" />
                                     <label class="text-sm text-gray-700">Enable web search</label>
@@ -509,7 +544,7 @@ const credentialFieldsForNewProvider = computed<CredentialField[]>(() => {
     const providerType = providerForm.value.provider_type;
     const all = fieldsForProvider(providerType);
     // Exclude fields that have dedicated UI controls
-    let filtered = all.filter(f => f.key !== 'verify_ssl' && f.key !== 'enable_web_search');
+    let filtered = all.filter(f => f.key !== 'verify_ssl' && f.key !== 'enable_web_search' && f.key !== 'use_responses_api');
     if (providerType === 'openai') {
         filtered = filtered.filter(f => f.key !== 'base_url');
     }
@@ -886,6 +921,10 @@ watch(selectedProvider, (newValue) => {
         // Hydrate the native web-search opt-in from additional_config (OpenAI/Azure)
         if ((newValue.provider_type === 'openai' || newValue.type === 'openai' || newValue.provider_type === 'azure' || newValue.type === 'azure')) {
             (newValue.credentials as any).enable_web_search = !!(newValue as any)?.additional_config?.enable_web_search;
+        }
+        // Hydrate the Azure Responses-API opt-in from additional_config
+        if ((newValue.provider_type === 'azure' || newValue.type === 'azure')) {
+            (newValue.credentials as any).use_responses_api = !!(newValue as any)?.additional_config?.use_responses_api;
         }
         // Ensure base_url and verify_ssl fields exist for Custom so users can view/update them
         if ((newValue.provider_type === 'custom' || newValue.type === 'custom')) {


### PR DESCRIPTION
## Summary

Adds **native, provider-executed web search** to the agent for **OpenAI** and **Azure OpenAI** (via the Responses API `web_search` tool). It's opt-in per provider, gated by the org-level Web Fetch setting, surfaced in the UI as a real tool card with the query + cited sources, and recorded as a proper `ToolExecution` so it shows up in agent execution history and conversation context.

Native web search is a *server-side* tool the provider runs inside `inference_stream_v2` — results (search calls + URL-citation annotations) stream back inline and bypass the registry/ToolRunner.

## What's included

**Backend — LLM layer**
- `OpenAIResponsesClient`: accepts `base_url` (so it also targets Azure's `/openai/v1` Responses surface) and `enable_web_search`; injects the `{"type":"web_search", search_context_size:"high"}` tool; translates `web_search_call` items (search / `open_page` / find) and `url_citation` annotations into new stream events.
- New stream events: `WebSearchStartEvent` / `WebSearchCompleteEvent` / `WebSearchResultEvent`.
- `LLM.inference_stream_v2`: per-call `web_search` + `web_search_domains`, forwarded only to the Responses client.
- `filters.allowed_domains` derived from URLs in the user's turn → the tool opens/reads those pages (`open_page`) instead of snippet search.

**Backend — agent / planner / gating**
- Gating: org `enable_web_fetch` master switch **AND** per-provider `enable_web_search`, plus a capability guard (OpenAI Responses path only).
- Planner emits `PlannerWebSearchEvent`; `agent_v2` records each search as a `ToolExecution` (`tool_name=web_search`, query in `arguments_json`) + a standalone block, ordered just before the answer, with the turn's citations backfilled as `result.sources` (or "No results found"). Non-`completed` provider status is recorded as an error.
- Scoped planner directive (only when enabled); web-search digest added to `message_context_builder` for cross-turn continuity.

**Backend — Azure regions**
- New per-provider **`use_responses_api`** opt-in (default off). Azure defaults to Chat Completions (works in every region); the Responses client — and therefore web search — is only used when this is checked. Fixes "Azure OpenAI Responses API is not enabled in this region" bricking every completion when web search was enabled.

**Frontend**
- `WebSearchTool.vue`: expandable card showing the query, extra queries, and cited sources (with favicons), or "No results found"; registered in the chat tool dispatch.
- Provider modal: **"Use Responses API"** checkbox for Azure (default off) with **"Enable web search"** nested under it; OpenAI keeps its web-search toggle (Responses is its default). Egress note kept concise.

**Docs / housekeeping**
- `docs/design/sandbox-feedback-loop.md`: authenticated Playwright UI-inspection recipe.
- VERSION → `0.0.395`; CHANGELOG entry (merged cleanly with main's 0.0.393/0.0.394).

## Verification
Tested live against Azure OpenAI (`gpt-5.4-mini`): web search records with query + sources, ordered before the answer, expandable card with favicons; gating truth table (org × provider × `use_responses_api` × `enable_web_search`); and the Azure fix — without "Use Responses API" the provider runs Chat Completions (no 404, no web search), with it web search is active.

## Notes / limits
- Quality ceiling on Azure is Bing-grounding (snippets), which is flaky/lossy for JS SPAs behind bot walls (e.g. Super-Pharm); OpenAI-direct uses OpenAI's own search/browse and is cleaner.
- Anthropic native web search (`web_search_20250305`, incl. Claude-on-Azure via `/anthropic`) was scoped but intentionally deferred.

https://claude.ai/code/session_01RUT2mtQ8JdzroCCk3Qa7ty

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUT2mtQ8JdzroCCk3Qa7ty)_