### PR TITLE
Fix: demo install must grant creator RBAC manage, not just membership

### DIFF
--- a/backend/app/services/demo_data_source_service.py
+++ b/backend/app/services/demo_data_source_service.py
@@ -10,7 +10,6 @@ from sqlalchemy.future import select
 from sqlalchemy import and_
 
 from app.models.data_source import DataSource
-from app.models.data_source_membership import DataSourceMembership, PRINCIPAL_TYPE_USER
 from app.models.user import User
 from app.models.organization import Organization
 from app.schemas.demo_data_source_schema import (
@@ -212,14 +211,17 @@ class DemoDataSourceService:
             f"for org={organization.id}"
         )
 
-        # Add the creator as a member
-        membership = DataSourceMembership(
-            data_source_id=data_source.id,
-            principal_type=PRINCIPAL_TYPE_USER,
-            principal_id=current_user.id,
+        # Add the creator as a member with full manage rights. Mirror the
+        # real create paths (DataSourceService.create_data_source) via the
+        # shared helper so the creator gets BOTH the legacy membership and
+        # the RBAC `manage` grant. Hand-rolling only the legacy membership
+        # (as this did before) left a non-admin installer able to see the
+        # demo in their list yet failing every `manage` resource check on
+        # it. _create_memberships commits internally.
+        from app.services.data_source_service import DataSourceService
+        await DataSourceService()._create_memberships(
+            db, data_source, [current_user.id], permissions=["manage"]
         )
-        db.add(membership)
-        await db.commit()
 
         # Load and save tables from the data source
         await self._load_tables(db, data_source, organization, current_user)

--- a/backend/tests/e2e/rbac/test_rbac_data_sources.py
+++ b/backend/tests/e2e/rbac/test_rbac_data_sources.py
@@ -373,3 +373,70 @@ def test_outsider_cannot_see_other_orgs_data_source(test_client, ds_world):
         d["id"] not in (ds_world["ds_a"]["id"], ds_world["ds_b"]["id"])
         for d in list_resp.json()
     )
+
+
+# ────────────────────────────────────────────────────────────────────
+# Demo install: creator gets the RBAC manage grant, not just membership
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_demo_installer_gets_manage_grant(
+    test_client,
+    bootstrap_admin,
+    invite_user_to_org,
+    create_role,
+    assign_role,
+    install_demo_data_source,
+):
+    """A non-admin who installs a demo data source must receive the RBAC
+    `manage` grant — not just the legacy DataSourceMembership — so they can
+    actually manage the data source they created.
+
+    Regression: the demo-install path used to hand-roll only the membership
+    row, leaving a non-admin installer able to see the demo in their list
+    yet failing every `manage`-gated action on it (e.g. PUT). Admins never
+    hit this because full_admin_access bypasses resource checks, so we test
+    with a plain member holding only create_data_source.
+    """
+    admin = bootstrap_admin()
+    org_id = admin["org_id"]
+
+    # A member who may create data sources but is NOT an org admin.
+    role_resp = create_role(
+        name="ds-creator",
+        permissions=["create_data_source"],
+        user_token=admin["token"],
+        org_id=org_id,
+    )
+    assert role_resp.status_code == 200, role_resp.json()
+    role_id = role_resp.json()["id"]
+
+    member = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    assign_resp = assign_role(
+        role_id=role_id,
+        principal_type="user",
+        principal_id=member["user_id"],
+        user_token=admin["token"],
+        org_id=org_id,
+    )
+    assert assign_resp.status_code in (200, 201), assign_resp.json()
+
+    # Member installs the demo (gated by create_data_source).
+    result = install_demo_data_source(
+        demo_id="chinook", user_token=member["token"], org_id=org_id
+    )
+    assert result["success"] is True, result
+    ds_id = result["data_source_id"]
+
+    # The installer must be able to perform a `manage`-gated update on it.
+    # Without the manage grant this returns 403.
+    put_resp = test_client.put(
+        f"/api/data_sources/{ds_id}",
+        json={"description": "updated by installer"},
+        headers=_hdr(member["token"], org_id),
+    )
+    assert put_resp.status_code == 200, (
+        f"installer should hold manage on the demo they created; got "
+        f"{put_resp.status_code}: {put_resp.text}"
+    )


### PR DESCRIPTION
## Problem

When a user installs a demo data source (e.g. Chinook / Stocks), the install path hand-rolled **only** a legacy `DataSourceMembership` row for the creator:

```python
# demo_data_source_service.py (before)
membership = DataSourceMembership(
    data_source_id=data_source.id,
    principal_type=PRINCIPAL_TYPE_USER,
    principal_id=current_user.id,
)
db.add(membership)
```

This skips the RBAC `ResourceGrant` with `["manage"]` that the real create paths add via `_create_memberships(..., permissions=["manage"])` (see `DataSourceService.create_data_source`).

### Impact
- A **non-admin** with `create_data_source` who installs a demo would **see it in their list** (via the legacy membership) but **fail every** `@requires_resource_permission('data_source', 'manage')` check on it — they could not edit, configure, or delete the data source they just created.
- **Full admins** never hit this because `full_admin_access` bypasses resource checks, which is why it went unnoticed.

Verified against the live DB — admin-installed demos showed `membership: YES | resource_grant: NONE`.

## Fix

Route the demo creator through the shared `_create_memberships(..., permissions=["manage"])` helper, so they get **both** the legacy membership **and** the RBAC `manage` grant — consistent with every other create path. Removes the now-unused `DataSourceMembership` import.

After the fix, the same check shows `membership: YES | resource_grant: ["manage"]`.

## Test

Adds `test_demo_installer_gets_manage_grant`: a non-admin member (holding only `create_data_source`) installs the Chinook demo, then performs a `manage`-gated `PUT` on it and expects `200`. Confirmed it **fails without the fix** (403) and **passes with it**. Full `tests/e2e/rbac/test_rbac_data_sources.py` + `test_demo_data_source.py` suite passes (15 passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ji8BwxTviyDQDK1dwXABXH)_