### PR TITLE
fix(azure): normalize endpoint root for Chat Completions (404 Resource not found)

### DIFF
--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -106,7 +106,12 @@ class LLM:
                     enable_web_search=enable_web_search,
                 )
             else:
-                self.client = AzureClient(api_key=self.api_key, endpoint_url=endpoint_url)
+                # Chat Completions needs the bare resource root — normalize in
+                # case the endpoint was saved as the /openai/v1 (Responses) URL.
+                self.client = AzureClient(
+                    api_key=self.api_key,
+                    endpoint_url=self._azure_resource_root(endpoint_url),
+                )
         elif self.provider == "custom":
             base_url = self.model.provider.additional_config.get("base_url") if self.model.provider.additional_config else None
             if not base_url:
@@ -139,6 +144,22 @@ class LLM:
             self.client = BedrockClient(**bedrock_kwargs)
         else:
             raise ValueError(f"Provider {self.provider} not supported")
+
+    @staticmethod
+    def _azure_resource_root(endpoint_url: str) -> str:
+        """Resource root for the AzureOpenAI (Chat Completions) client.
+
+        AzureOpenAI builds ``{root}/openai/deployments/{model}/chat/completions``
+        itself, so it needs the bare resource root. Admins may paste the
+        Responses-style ``https://<resource>.openai.azure.com/openai/v1`` URL —
+        strip any ``/openai...`` path so Chat Completions doesn't 404 with
+        "Resource not found". ("openai" in the hostname is unaffected: it appears
+        as ``.openai`` there, never ``/openai``.)
+        """
+        base = (endpoint_url or "").rstrip("/")
+        if "/openai" in base:
+            base = base.split("/openai")[0]
+        return base.rstrip("/")
 
     @staticmethod
     def _azure_v1_base_url(endpoint_url: str) -> str:


### PR DESCRIPTION
## Summary

Fixes `azure returned an error (404): Resource not found` on plain Azure (Chat Completions) when the provider's `endpoint_url` is saved as the Responses-style `https://<resource>.openai.azure.com/openai/v1` URL.

`AzureOpenAI` (Chat Completions) builds `{endpoint}/openai/deployments/{model}/chat/completions` itself, so given a `/openai/v1` endpoint it produces `.../openai/v1/openai/deployments/...` → 404 "Resource not found".

## Fix

Add `LLM._azure_resource_root()` which strips any `/openai...` path to the bare resource root, and use it when constructing the `AzureClient` (Chat Completions) path. The Responses path is unchanged (still uses `_azure_v1_base_url`). Now both paths work regardless of whether the admin pasted the resource root **or** the `/openai/v1` URL.

## Verification

Reproduced live against an Azure resource:
- root endpoint → Chat Completions works
- `/openai/v1` endpoint → 404 "Resource not found" (the reported bug)

After the fix, end-to-end in the app: provider with `endpoint_url=.../openai/v1`, no Responses/web search → completion succeeds (was 404). Normalization verified across all endpoint forms (root, trailing slash, `/openai`, `/openai/v1`, `/openai/v1/`).

Follow-up to #325.

https://claude.ai/code/session_01RUT2mtQ8JdzroCCk3Qa7ty

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUT2mtQ8JdzroCCk3Qa7ty)_