### PR TITLE
UI: rename "Webhooks" to "Triggers"

### DIFF
--- a/frontend/components/report/ChatSummary.vue
+++ b/frontend/components/report/ChatSummary.vue
@@ -108,7 +108,7 @@
 
       <!-- Webhooks -->
       <section v-if="webhooks.length > 0">
-        <h3 class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">Webhooks</h3>
+        <h3 class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">Triggers</h3>
         <ul class="space-y-1.5">
           <li
             v-for="w in webhooks"
@@ -139,7 +139,7 @@
         class="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs text-gray-400 hover:text-gray-600 rounded-lg border border-dashed border-gray-200 hover:border-gray-300 transition-colors"
       >
         <Icon name="heroicons-plus" class="w-3.5 h-3.5" />
-        Configure webhook
+        Configure trigger
       </button>
     </div>
 

--- a/frontend/components/report/WebhookConfigModal.vue
+++ b/frontend/components/report/WebhookConfigModal.vue
@@ -4,7 +4,7 @@
 			<template #header>
 				<div class="flex items-start justify-between">
 					<div>
-						<h3 class="text-base font-semibold text-gray-900">Webhooks</h3>
+						<h3 class="text-base font-semibold text-gray-900">Triggers</h3>
 						<p class="text-sm text-gray-400 mt-0.5">Send external events into this report.</p>
 					</div>
 					<UButton color="gray" variant="ghost" icon="i-heroicons-x-mark-20-solid" size="xs" @click="isOpen = false" />
@@ -54,7 +54,7 @@
 
 			<!-- New webhook -->
 			<section>
-				<h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-3">New webhook</h4>
+				<h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-3">New trigger</h4>
 
 				<div class="space-y-4">
 					<div>
@@ -100,7 +100,7 @@
 							@click="create"
 						>
 							<Spinner v-if="creating" class="w-4 h-4" />
-							Create webhook
+							Create trigger
 						</button>
 					</div>
 				</div>
@@ -131,7 +131,7 @@ const creating = ref(false)
 const reveal = ref<any>(null)
 
 // Token header is the default auth mode (simplest for most senders).
-const defaultForm = () => ({ name: 'Webhook', source: 'github', auth_mode: 'token', classify_enabled: true, classifier_prompt: '' })
+const defaultForm = () => ({ name: 'Trigger', source: 'github', auth_mode: 'token', classify_enabled: true, classifier_prompt: '' })
 const form = ref(defaultForm())
 
 function sourceIcon(s: string): string {


### PR DESCRIPTION
Renames the user-facing **"Webhooks"** label to **"Triggers"** in the report UI, as requested.

### Scope
- **Summary panel** (`ChatSummary.vue`): section header `Webhooks` → `Triggers`; button `Configure webhook` → `Configure trigger`.
- **Config modal** (`WebhookConfigModal.vue`): title `Webhooks` → `Triggers`; section `New webhook` → `New trigger`; default name `Webhook` → `Trigger`; button `Create webhook` → `Create trigger`.

### Not changed
- Backend routes, models, schemas, and API remain `webhook` — this is a label-only change.
- Reports-list metric still reads "N webhooks" (out of the requested scope; can rename in a follow-up for full consistency if desired).

### Note
This PR targets the webhook feature branch (`claude/lucid-keller-uzRtU`) rather than `main`, because the labels being renamed only exist on that branch. That keeps this PR's diff limited to just the rename. It should be merged after (or together with) the webhook feature.

https://claude.ai/code/session_012C9BHojscDsdv2ttEwmHby

---
_Generated by [Claude Code](https://claude.ai/code/session_012C9BHojscDsdv2ttEwmHby)_