### PR TITLE
Add usage tracking scopes and fix token counting for cached requests

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -346,6 +346,8 @@ class AgentV2:
             model=self.small_model,
             organization_settings=self.organization_settings,
             instruction_context_builder=self.context_hub.instruction_builder,
+            usage_session_maker=async_session_maker,
+            usage_context=self.usage_limit_context,
         )
 
         # Knowledge harness phase replaces the legacy SuggestInstructions post-loop generator.
@@ -578,7 +580,12 @@ class AgentV2:
             # sit inside the DB retry loop below — a locked-SQLite write should
             # only retry the write, never re-run the model.
             if self.organization_settings.get_config("enable_llm_judgement") and self.organization_settings.get_config("enable_llm_judgement").value and self.report_type == 'regular':
-                judge = Judge(model=self.model, organization_settings=self.organization_settings)
+                judge = Judge(
+                    model=self.model,
+                    organization_settings=self.organization_settings,
+                    usage_session_maker=async_session_maker,
+                    usage_context=self.usage_limit_context,
+                )
                 instructions_score, context_score = await judge.score_instructions_and_context_from_planner_input(planner_input)
             else:
                 instructions_score = 3
@@ -600,7 +607,12 @@ class AgentV2:
             # Score once, up-front — keep the Judge LLM call out of the DB retry
             # loop so a locked-SQLite write never triggers a redundant model call.
             if self.organization_settings.get_config("enable_llm_judgement") and self.organization_settings.get_config("enable_llm_judgement").value and self.report_type == 'regular':
-                judge = Judge(model=self.model, organization_settings=self.organization_settings)
+                judge = Judge(
+                    model=self.model,
+                    organization_settings=self.organization_settings,
+                    usage_session_maker=async_session_maker,
+                    usage_context=self.usage_limit_context,
+                )
                 original_prompt = self.head_completion.prompt.get("content", "") if getattr(self.head_completion, "prompt", None) else ""
                 response_score = await judge.score_response_quality(original_prompt, messages_context, observation_data=observation_data)
             else:

--- a/backend/app/ai/agents/answer/answer.py
+++ b/backend/app/ai/agents/answer/answer.py
@@ -3,12 +3,13 @@ from app.models.llm_model import LLMModel
 from app.schemas.organization_settings_schema import OrganizationSettingsConfig
 from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
 from app.ai.prompt_language import build_language_directive
+from app.dependencies import async_session_maker
 from datetime import datetime
 
 class Answer:
 
     def __init__(self, model: LLMModel, organization_settings: OrganizationSettingsConfig, instruction_context_builder: InstructionContextBuilder) -> None:
-        self.llm = LLM(model)
+        self.llm = LLM(model, usage_session_maker=async_session_maker)
         self.organization_settings = organization_settings
         self.code_reviewer = organization_settings.get_config("code_reviewer").value
         self.search_context = organization_settings.get_config("search_context").value
@@ -146,7 +147,7 @@ Now, provide your answer following these guidelines.
         chunk_buffer = ""
         chunk_count = 0
         
-        async for chunk in self.llm.inference_stream(prompt=text):
+        async for chunk in self.llm.inference_stream(prompt=text, usage_scope="answer"):
             if sigkill_event and sigkill_event.is_set():
                 break
             chunk_buffer += chunk

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -320,7 +320,9 @@ class Coder:
         Now produce ONLY the Python function code as described. Do not output anything else besides the function python code. No markdown, no comments, no triple backticks, no triple quotes, no triple anything, no text, no anything.
         """
 
-        result = await asyncio.to_thread(self.llm.inference, text)
+        result = await asyncio.to_thread(
+            self.llm.inference, text, usage_scope="create_data.code_gen"
+        )
 
         # Remove markdown code fence (with optional language tag) if present
         result = re.sub(r'^\s*```(?:[A-Za-z0-9_\-]+)?\s*\r?\n', '', result.strip(), flags=re.IGNORECASE)
@@ -550,6 +552,7 @@ class Coder:
                 span.set_attribute("coder.allow_llm_see_data", bool(self.enable_llm_see_data))
                 async for evt in self.llm.inference_stream_v2(
                     messages=[Message(role="user", content=text)],
+                    usage_scope="create_data.code_gen",
                 ):
                     if isinstance(evt, TextDeltaEvent):
                         chunks.append(evt.text)
@@ -678,6 +681,7 @@ class Coder:
         chunks: list[str] = []
         async for evt in self.llm.inference_stream_v2(
             messages=[Message(role="user", content=text)],
+            usage_scope="create_data.inspection",
         ):
             if isinstance(evt, TextDeltaEvent):
                 chunks.append(evt.text)

--- a/backend/app/ai/agents/data_source/data_source.py
+++ b/backend/app/ai/agents/data_source/data_source.py
@@ -5,6 +5,7 @@ from app.ai.llm import LLM
 import pandas as pd
 import json
 from app.models.llm_model import LLMModel
+from app.dependencies import async_session_maker
 
 """
 """
@@ -13,7 +14,7 @@ class DataSourceAgent:
 
     def __init__(self, data_source: DataSource, schema: str, model: LLMModel):
         self.data_source = data_source
-        self.llm = LLM(model)
+        self.llm = LLM(model, usage_session_maker=async_session_maker)
         self.schema = schema
 
     def generate_summary(self):
@@ -30,7 +31,7 @@ Rules:
 - Plain text only.
 - Max 30 words total.
 """
-        response = self.llm.inference(prompt)
+        response = self.llm.inference(prompt, usage_scope="data_source.summary")
         return response
 
     def generate_conversation_starters(self):
@@ -70,7 +71,7 @@ Important: Return only the JSON array with no additional text, formatting, or ex
 Do not add prefix ``` or markdown or anything. just the list of conversation starters.
 """
 
-        response = self.llm.inference(prompt)
+        response = self.llm.inference(prompt, usage_scope="data_source.conversation_starters")
         # Strip any potential whitespace or extra characters
         response = response.strip()
         json_response = json.loads(response)
@@ -119,7 +120,7 @@ Rules:
 Return JSON only:
 {{"title": "{title}", "text": "...", "category": "general", "load_mode": "always", "confidence": 0.95}}"""
 
-        response = self.llm.inference(prompt)
+        response = self.llm.inference(prompt, usage_scope="data_source.instruction")
         response = response.strip()
         # Strip markdown code fences if present
         if response.startswith("```"):
@@ -163,5 +164,5 @@ Examples:
 - "Google Analytics data that provides information about website traffic, user behavior, and marketing effectiveness."
 - "Jira data that provides information about engineering projects, tasks, and team performance."
 """
-        response = self.llm.inference(prompt)
+        response = self.llm.inference(prompt, usage_scope="data_source.description")
         return response

--- a/backend/app/ai/agents/excel/excel.py
+++ b/backend/app/ai/agents/excel/excel.py
@@ -5,6 +5,7 @@ from app.ai.llm import LLM
 import pandas as pd
 import json
 from app.models.llm_model import LLMModel
+from app.dependencies import async_session_maker
 
 """
 
@@ -17,7 +18,7 @@ class ExcelAgent:
 
     def __init__(self, excel_file: File, model: LLMModel):
         self.excel_file = excel_file
-        self.llm = LLM(model)
+        self.llm = LLM(model, usage_session_maker=async_session_maker)
 
     
 
@@ -65,7 +66,7 @@ class ExcelAgent:
         and no markdown formatting.
         """
 
-        schema = self.llm.inference(prompt)
+        schema = self.llm.inference(prompt, usage_scope="excel.schema_infer")
 
         schema = json.loads(schema)
 

--- a/backend/app/ai/agents/judge/judge.py
+++ b/backend/app/ai/agents/judge/judge.py
@@ -1,7 +1,10 @@
 from app.ai.llm import LLM
 from app.models.llm_model import LLMModel
 from app.schemas.organization_settings_schema import OrganizationSettingsConfig
-import tiktoken 
+from app.services.usage_policy_service import UsageLimitContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Callable, Optional
+import tiktoken
 import json
 from partialjson.json_parser import JSONParser
 from app.schemas.ai.planner import PlannerInput
@@ -9,8 +12,15 @@ import asyncio
 
 class Judge:
 
-    def __init__(self, model: LLMModel, organization_settings: OrganizationSettingsConfig, instruction_context_builder=None) -> None:
-        self.llm = LLM(model)
+    def __init__(
+        self,
+        model: LLMModel,
+        organization_settings: OrganizationSettingsConfig,
+        instruction_context_builder=None,
+        usage_session_maker: Optional[Callable[[], AsyncSession]] = None,
+        usage_context: Optional[UsageLimitContext] = None,
+    ) -> None:
+        self.llm = LLM(model, usage_session_maker=usage_session_maker, usage_context=usage_context)
         self.organization_settings = organization_settings
     
     async def judge_test_case(self, test_case_prompt: str, trace: any): 
@@ -35,7 +45,9 @@ class Judge:
         }}
         """
 
-        response = await asyncio.to_thread(self.llm.inference, judge_prompt)
+        response = await asyncio.to_thread(
+            self.llm.inference, judge_prompt, usage_scope="judge.test_case"
+        )
         try:
             result = json.loads(response)
             passed = result["passed"]
@@ -93,7 +105,9 @@ class Judge:
             """
 
             # Offload potentially blocking LLM call to a thread to avoid blocking the event loop
-            response = await asyncio.to_thread(self.llm.inference, scoring_prompt)
+            response = await asyncio.to_thread(
+                self.llm.inference, scoring_prompt, usage_scope="judge.instructions_context"
+            )
             try:
                 scores = json.loads(response)
                 instructions_score = max(1, min(5, int(scores.get("instructions_score", 3))))
@@ -165,8 +179,10 @@ class Judge:
             """
 
             # Offload potentially blocking LLM call to a thread to avoid blocking the event loop
-            response = await asyncio.to_thread(self.llm.inference, scoring_prompt)
-            
+            response = await asyncio.to_thread(
+                self.llm.inference, scoring_prompt, usage_scope="judge.response_quality"
+            )
+
             try:
                 score_data = json.loads(response)
                 response_score = max(1, min(5, int(score_data.get("response_score", 3))))

--- a/backend/app/ai/agents/reporter/reporter.py
+++ b/backend/app/ai/agents/reporter/reporter.py
@@ -51,4 +51,6 @@ class Reporter:
         # `run_blocking`. Called from a running event loop with no `loop`
         # wired on the usage context, that check raises immediately. Offload
         # to a worker thread so the sync check has no loop to collide with.
-        return await asyncio.to_thread(self.llm.inference, text)
+        return await asyncio.to_thread(
+            self.llm.inference, text, usage_scope="report.title"
+        )

--- a/backend/app/ai/llm/clients/openai_client.py
+++ b/backend/app/ai/llm/clients/openai_client.py
@@ -82,6 +82,11 @@ class OpenAi(LLMClient):
 
         if stream:
             params["stream"] = True
+            # Ask the API to emit a final usage chunk so we record provider-reported
+            # token counts instead of falling back to the char/4 estimate (which
+            # undercounts dense/structured content by ~25-30%). The usage chunk
+            # arrives after all content has streamed, so it adds no latency.
+            params["stream_options"] = {"include_usage": True}
 
         # Enable medium reasoning effort for reasoning-capable models.
         # Adjust this predicate as you add/change reasoning models.

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -37,6 +37,14 @@ tracer = get_tracer(__name__)
 # can still schedule usage recording via run_coroutine_threadsafe.
 _MAIN_LOOP: Optional[asyncio.AbstractEventLoop] = None
 
+# Strong references to in-flight usage-record tasks. asyncio only keeps a weak
+# reference to tasks created via loop.create_task(), so a fire-and-forget task
+# can be garbage-collected mid-execution before its DB commit lands — silently
+# dropping the usage record. Holding a reference here until the task completes
+# closes that gap. This adds no latency: the tasks still run in the background,
+# off the response path. The set is bounded by in-flight count and self-drains.
+_PENDING_RECORD_TASKS: set = set()
+
 
 class LLM:
     def __init__(
@@ -654,8 +662,19 @@ class LLM:
         cache_creation_tokens: int = 0,
         should_record: bool,
     ):
-        if not should_record or not scope or ((prompt_tokens or 0) == 0 and (completion_tokens or 0) == 0):
+        if not should_record or ((prompt_tokens or 0) == 0 and (completion_tokens or 0) == 0):
             return
+        # Safety net: a call that reaches here with tokens but no scope is a
+        # call site that forgot to label itself. Rather than silently dropping
+        # the record (the old behavior, which made tokens vanish from
+        # /monitoring), record it under "unscoped" and warn so it's visible.
+        if not scope:
+            logger.warning(
+                "LLM usage recorded without a usage_scope (provider=%s model=%s); "
+                "labeling as 'unscoped'. Add usage_scope at the call site.",
+                self.provider, self.model_id,
+            )
+            scope = "unscoped"
         session_maker = self._usage_session_maker
         if session_maker is None:
             return
@@ -697,7 +716,11 @@ class LLM:
                 logger.warning("Unable to schedule LLM usage recording (threadsafe): %s", exc)
             return
         try:
-            loop.create_task(_record_usage())
+            task = loop.create_task(_record_usage())
+            # Retain a strong reference until the task finishes so it can't be
+            # GC'd mid-flight (see _PENDING_RECORD_TASKS note above).
+            _PENDING_RECORD_TASKS.add(task)
+            task.add_done_callback(_PENDING_RECORD_TASKS.discard)
         except Exception as exc:
             logger.warning("Unable to schedule LLM usage recording: %s", exc)
 

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -984,6 +984,19 @@ class ConsoleService:
             completion_tokens = int(row.completion_tokens or 0)
             cache_read_tokens = int(row.cache_read_tokens or 0)
             cache_creation_tokens = int(row.cache_creation_tokens or 0)
+            # Token total must not double-count cache. Providers differ:
+            #   - Anthropic reports cache_read/cache_creation SEPARATELY from
+            #     prompt_tokens, so they must be added in.
+            #   - OpenAI/Azure already fold cached tokens INTO prompt_tokens
+            #     (and have no cache_creation concept), so adding cache_read
+            #     again would over-count. Mirror the cost model's split.
+            if (row.provider_type or "") == "anthropic":
+                row_total_tokens = (
+                    prompt_tokens + completion_tokens
+                    + cache_read_tokens + cache_creation_tokens
+                )
+            else:
+                row_total_tokens = prompt_tokens + completion_tokens
             total_calls += int(row.total_calls or 0)
             total_prompt_tokens += prompt_tokens
             total_completion_tokens += completion_tokens
@@ -1005,7 +1018,7 @@ class ConsoleService:
                     completion_tokens=completion_tokens,
                     cache_read_tokens=cache_read_tokens,
                     cache_creation_tokens=cache_creation_tokens,
-                    total_tokens=prompt_tokens + completion_tokens + cache_read_tokens + cache_creation_tokens,
+                    total_tokens=row_total_tokens,
                     input_cost_usd=input_cost,
                     output_cost_usd=output_cost,
                     total_cost_usd=total_cost,


### PR DESCRIPTION
## Summary
This PR enhances LLM usage tracking by introducing explicit `usage_scope` labels throughout the codebase and fixes token counting logic to properly handle cached tokens across different providers (Anthropic vs OpenAI/Azure).

## Key Changes

### Usage Tracking Improvements
- **Added `usage_scope` parameter** to all LLM inference calls across agents (Judge, Coder, Answer, DataSource, Excel, Reporter) to enable granular usage monitoring
- **Updated Judge class** to accept and pass through `usage_session_maker` and `usage_context` for proper usage tracking
- **Updated DataSourceAgent, ExcelAgent, and Answer classes** to initialize LLM with `async_session_maker` for usage recording
- **Updated agent_v2.py** to pass usage context when instantiating Judge instances in early and late scoring phases
- **Added safety net for unscoped calls**: LLM calls without a `usage_scope` are now recorded under "unscoped" with a warning log instead of silently dropping the record

### Task Lifecycle Management
- **Fixed task garbage collection issue** in LLM usage recording by maintaining strong references to in-flight usage-record tasks in `_PENDING_RECORD_TASKS` set
- Tasks are automatically removed from the set via `done_callback` once they complete, preventing premature GC mid-execution

### Token Counting Fix
- **Fixed double-counting of cached tokens** in `console_service.py`:
  - Anthropic reports cache tokens separately from prompt_tokens, so they must be added
  - OpenAI/Azure already fold cached tokens into prompt_tokens, so adding them again would over-count
  - Now correctly handles both provider types based on `provider_type` field

### OpenAI Streaming Enhancement
- **Added `stream_options` with `include_usage`** to OpenAI chat params when streaming is enabled
- This ensures provider-reported token counts are captured instead of falling back to character-based estimates (which undercount by ~25-30%)

## Notable Implementation Details
- All `usage_scope` labels follow a hierarchical naming convention (e.g., "judge.test_case", "data_source.summary", "create_data.code_gen")
- The task reference management adds no latency—tasks still run in the background off the response path
- The set is self-draining and bounded by in-flight request count

https://claude.ai/code/session_018U4VjMKwWDpUyLYAKRUmft