### PR TITLE
Add email attachment support to send_email tool

### DIFF
--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -342,6 +342,15 @@ def _digest_notification_tool(tool_execution) -> str:
         if rj.get('subject'):
             subj = str(rj.get('subject'))
             parts.append(f"subject: {subj[:80]}{'…' if len(subj) > 80 else ''}")
+        atts = rj.get('attachments') or []
+        if atts:
+            sent = [a for a in atts if a.get('success')]
+            failed = [a for a in atts if not a.get('success')]
+            names = ", ".join((a.get('filename') or a.get('ref_id') or '?') for a in sent[:5])
+            if names:
+                parts.append(f"attached: {names}")
+            if failed:
+                parts.append(f"attach_failed: {len(failed)}")
         if rj.get('error'):
             parts.append(f"error: {rj.get('error')}")
         return "; ".join(parts)

--- a/backend/app/ai/tools/implementations/send_email.py
+++ b/backend/app/ai/tools/implementations/send_email.py
@@ -4,15 +4,30 @@ The recipient is always the current user (resolved from runtime context), so the
 agent cannot email anyone else. Subject and body are free-form. This is the first
 of a planned family of notification tools (email today; Slack / WhatsApp / Teams
 in the future) — each channel gets its own tool so the UI status stays per-channel.
+
+Emails may carry up to 5 attachments. Each attachment is generated on the fly from
+something the assistant already produced in this report: a visualization/query
+result (CSV/XLSX), an artifact (PPTX for slides, PDF for page dashboards), or an
+uploaded file (attached as-is). All references are scoped to the current report /
+organization so the agent cannot exfiltrate arbitrary objects.
 """
 
-from typing import AsyncIterator, Dict, Any, Type
+from typing import AsyncIterator, Dict, Any, Type, List, Optional, Tuple
+from io import BytesIO
 from pydantic import BaseModel
+import os
+import re
+import tempfile
 import logging
 
 from app.ai.tools.base import Tool
 from app.ai.tools.metadata import ToolMetadata
-from app.ai.tools.schemas.send_email import SendEmailInput, SendEmailOutput
+from app.ai.tools.schemas.send_email import (
+    SendEmailInput,
+    SendEmailOutput,
+    EmailAttachmentSpec,
+    SendEmailAttachmentResult,
+)
 from app.ai.tools.schemas.events import (
     ToolEvent,
     ToolStartEvent,
@@ -24,8 +39,62 @@ from app.settings.config import settings
 logger = logging.getLogger(__name__)
 
 
+# Default export format per ref_type when the caller doesn't specify one.
+_DEFAULT_FORMAT = {
+    "visualization": "csv",
+    "query": "csv",
+    "artifact": None,  # resolved from artifact.mode (slides -> pptx, page -> pdf)
+    "file": None,      # original format
+}
+
+# MIME (maintype, subtype) per export format, in the fastapi-mail dict shape.
+_MIME = {
+    "csv": ("text", "csv"),
+    "xlsx": ("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    "pptx": ("application", "vnd.openxmlformats-officedocument.presentationml.presentation"),
+    "pdf": ("application", "pdf"),
+}
+
+
+def _slugify(name: str) -> str:
+    name = (name or "attachment").strip()
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-")
+    return name or "attachment"
+
+
+def _content_disposition(filename: str) -> str:
+    """Build a Content-Disposition value that displays ``filename`` reliably.
+
+    Plain ``filename="..."`` for ASCII names; RFC 2231 ``filename*`` for names
+    with non-ASCII characters so mail clients render them correctly.
+    """
+    try:
+        filename.encode("ascii")
+        safe = filename.replace('"', "")
+        return f'attachment; filename="{safe}"'
+    except UnicodeEncodeError:
+        from urllib.parse import quote
+        return f"attachment; filename*=UTF-8''{quote(filename)}"
+
+
+def _att_dict(path: str, filename: str, maintype: str, subtype: str) -> Dict[str, Any]:
+    """Build a fastapi-mail attachment dict that sets BOTH the MIME type and the
+    displayed filename.
+
+    This fastapi-mail version reads ``mime_type``/``mime_subtype`` for the part
+    type and otherwise derives the filename from the on-disk basename — so the
+    displayed name is controlled via an explicit Content-Disposition header.
+    """
+    return {
+        "file": path,
+        "mime_type": maintype,
+        "mime_subtype": subtype,
+        "headers": {"Content-Disposition": _content_disposition(filename)},
+    }
+
+
 class SendEmailTool(Tool):
-    """Send a free-form email to the current user's own inbox."""
+    """Send a free-form email (optionally with attachments) to the current user's own inbox."""
 
     @property
     def metadata(self) -> ToolMetadata:
@@ -48,14 +117,21 @@ class SendEmailTool(Tool):
                 "build heavy templated layouts, inline CSS styling, wrapper divs, banners, "
                 "or branded headers/footers.\n"
                 "- Write a clear, specific subject line. Put the real content in the body; "
-                "don't just restate the subject."
+                "don't just restate the subject.\n\n"
+                "Attachments (optional, up to 5): when the user asks to be emailed a result, "
+                "export, or dashboard, attach it via 'attachments'. Reference the object by "
+                "the id you can see in context — visualization_id or query_id (attached as a "
+                "CSV/XLSX of the underlying data), artifact_id (a slides deck as PPTX or a "
+                "page dashboard as PDF), or file_id (an uploaded file, as-is). Steps are not "
+                "directly attachable — attach the visualization instead. Mention in the body "
+                "what you've attached."
             ),
             category="action",
-            version="1.0.0",
+            version="1.1.0",
             input_schema=SendEmailInput.model_json_schema(),
             output_schema=SendEmailOutput.model_json_schema(),
             max_retries=1,
-            timeout_seconds=30,
+            timeout_seconds=60,
             idempotent=False,
             # Hidden from the catalog when SMTP isn't configured. Evaluated at
             # registry startup, where settings.email_client is already resolved.
@@ -72,11 +148,13 @@ class SendEmailTool(Tool):
                 },
                 {
                     "input": {
-                        "subject": "Weekly report",
-                        "body": "<h1>Weekly report</h1><p>All metrics nominal.</p>",
-                        "body_format": "html",
+                        "subject": "Top tracks export",
+                        "body": "Attached is the CSV of the top tracks you asked for.",
+                        "attachments": [
+                            {"ref_type": "visualization", "ref_id": "<visualization_id>", "format": "csv"}
+                        ],
                     },
-                    "description": "Send an HTML-formatted email to yourself.",
+                    "description": "Email a query result as a CSV attachment.",
                 },
             ],
         )
@@ -107,7 +185,11 @@ class SendEmailTool(Tool):
 
         yield ToolStartEvent(
             type="tool.start",
-            payload={"subject": data.subject, "recipient": recipient},
+            payload={
+                "subject": data.subject,
+                "recipient": recipient,
+                "attachment_count": len(data.attachments),
+            },
         )
 
         if not recipient:
@@ -128,43 +210,281 @@ class SendEmailTool(Tool):
             )
             return
 
+        # Resolve attachments (best-effort: failures are reported but don't block the send).
+        temp_paths: List[str] = []
+        attachment_dicts: List[Dict[str, Any]] = []
+        attachment_results: List[SendEmailAttachmentResult] = []
         try:
-            from app.services.notification_service import notification_service
+            for spec in data.attachments:
+                result, att_dict, temp_path = await self._resolve_attachment(spec, runtime_ctx)
+                attachment_results.append(result)
+                if att_dict:
+                    attachment_dicts.append(att_dict)
+                if temp_path:
+                    temp_paths.append(temp_path)
 
-            subtype = "html" if data.body_format == "html" else "plain"
-            result = await notification_service.send_custom_email(
-                recipients=[recipient],
-                subject=data.subject,
-                body=data.body,
-                subtype=subtype,
-            )
+            try:
+                from app.services.notification_service import notification_service
 
-            success = result.status == "sent"
-            summary = (
-                f"Email sent to {recipient}: {data.subject}"
-                if success
-                else f"Failed to send email: {result.error or 'unknown error'}"
-            )
+                subtype = "html" if data.body_format == "html" else "plain"
+                result = await notification_service.send_custom_email(
+                    recipients=[recipient],
+                    subject=data.subject,
+                    body=data.body,
+                    subtype=subtype,
+                    attachments=attachment_dicts or None,
+                )
 
-            yield ToolEndEvent(
-                type="tool.end",
-                payload={
-                    "output": SendEmailOutput(
-                        success=success,
-                        recipient=recipient,
-                        subject=data.subject,
-                        error=None if success else (result.error or "Failed to send email"),
-                    ).model_dump(),
-                    "observation": {
-                        "summary": summary,
-                        "success": success,
-                        "artifacts": [],
+                success = result.status == "sent"
+                sent_names = [r.filename for r in attachment_results if r.success and r.filename]
+                failed = [r for r in attachment_results if not r.success]
+                att_summary = ""
+                if attachment_results:
+                    att_summary = f" with {len(sent_names)} attachment(s)"
+                    if failed:
+                        att_summary += f" ({len(failed)} failed)"
+                summary = (
+                    f"Email sent to {recipient}: {data.subject}{att_summary}"
+                    if success
+                    else f"Failed to send email: {result.error or 'unknown error'}"
+                )
+
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload={
+                        "output": SendEmailOutput(
+                            success=success,
+                            recipient=recipient,
+                            subject=data.subject,
+                            attachments=attachment_results,
+                            error=None if success else (result.error or "Failed to send email"),
+                        ).model_dump(),
+                        "observation": {
+                            "summary": summary,
+                            "success": success,
+                            "artifacts": [],
+                        },
                     },
-                },
-            )
+                )
+            except Exception as e:
+                logger.exception("Failed to send email: %s", e)
+                yield ToolErrorEvent(
+                    type="tool.error",
+                    payload={"error": f"Failed to send email: {str(e)}", "code": "SEND_FAILED"},
+                )
+        finally:
+            # Only remove temp files we created; never touch persistent paths
+            # (uploaded files, generated artifact PDFs in uploads/).
+            for p in temp_paths:
+                try:
+                    os.unlink(p)
+                except Exception:
+                    pass
+
+    # ---- attachment resolution ----
+
+    async def _resolve_attachment(
+        self, spec: EmailAttachmentSpec, runtime_ctx: Dict[str, Any]
+    ) -> Tuple[SendEmailAttachmentResult, Optional[Dict[str, Any]], Optional[str]]:
+        """Resolve a single attachment spec to a fastapi-mail attachment dict.
+
+        Returns (result, attachment_dict_or_None, temp_path_to_cleanup_or_None).
+        On any failure, result.success is False with an error and the dict is None.
+        """
+        res = SendEmailAttachmentResult(ref_type=spec.ref_type, ref_id=spec.ref_id, success=False)
+        try:
+            if spec.ref_type in ("visualization", "query"):
+                return await self._resolve_tabular(spec, runtime_ctx, res)
+            if spec.ref_type == "artifact":
+                return await self._resolve_artifact(spec, runtime_ctx, res)
+            if spec.ref_type == "file":
+                return await self._resolve_file(spec, runtime_ctx, res)
+            res.error = f"Unknown ref_type '{spec.ref_type}'"
+            return res, None, None
         except Exception as e:
-            logger.exception("Failed to send email: %s", e)
-            yield ToolErrorEvent(
-                type="tool.error",
-                payload={"error": f"Failed to send email: {str(e)}", "code": "SEND_FAILED"},
-            )
+            logger.exception("Attachment resolution failed for %s %s", spec.ref_type, spec.ref_id)
+            res.error = str(e)
+            return res, None, None
+
+    @staticmethod
+    def _scope_ids(runtime_ctx: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+        report = runtime_ctx.get("report")
+        org = runtime_ctx.get("organization")
+        report_id = str(getattr(report, "id", "")) if report is not None else None
+        org_id = str(getattr(org, "id", "")) if org is not None else None
+        return report_id, org_id
+
+    async def _resolve_tabular(self, spec, runtime_ctx, res):
+        """visualization_id / query_id -> CSV or XLSX of the underlying step data."""
+        from sqlalchemy import select
+        from app.models.visualization import Visualization
+        from app.models.query import Query
+        from app.models.step import Step
+        from app.services.step_service import StepService
+
+        db = runtime_ctx.get("db")
+        report_id, org_id = self._scope_ids(runtime_ctx)
+
+        query: Optional[Query] = None
+        title = None
+        if spec.ref_type == "visualization":
+            viz = await db.get(Visualization, spec.ref_id)
+            if not viz:
+                res.error = "Visualization not found"
+                return res, None, None
+            if report_id and str(viz.report_id) != report_id:
+                res.error = "Visualization does not belong to this report"
+                return res, None, None
+            title = viz.title
+            query = await db.get(Query, viz.query_id) if viz.query_id else None
+        else:  # query
+            query = await db.get(Query, spec.ref_id)
+            if not query:
+                res.error = "Query not found"
+                return res, None, None
+            # Queries may be report-scoped or global-to-org; require one to match.
+            q_report = str(query.report_id) if query.report_id else None
+            q_org = str(query.organization_id) if query.organization_id else None
+            if report_id and q_report and q_report != report_id and (not org_id or q_org != org_id):
+                res.error = "Query does not belong to this report or organization"
+                return res, None, None
+            title = query.title
+
+        if not query:
+            res.error = "No query linked to this visualization"
+            return res, None, None
+
+        # Find the step that holds the result: default step, else latest.
+        step = None
+        if query.default_step_id:
+            step = await db.get(Step, query.default_step_id)
+        if not step:
+            step = (await db.execute(
+                select(Step).where(Step.query_id == query.id).order_by(Step.created_at.desc()).limit(1)
+            )).scalar_one_or_none()
+        if not step:
+            res.error = "No executed result available to export"
+            return res, None, None
+
+        df, _ = await StepService().export_step_to_csv(db, step.id)
+        if df is None or df.empty:
+            res.error = "Result is empty — nothing to export"
+            return res, None, None
+
+        fmt = spec.format if spec.format in ("csv", "xlsx") else _DEFAULT_FORMAT[spec.ref_type]
+        base = spec.filename or _slugify(title or step.title or "export")
+        base = re.sub(r"\.(csv|xlsx)$", "", base, flags=re.IGNORECASE)
+
+        if fmt == "xlsx":
+            buf = BytesIO()
+            try:
+                df.to_excel(buf, index=False)
+            except Exception as e:
+                res.error = f"XLSX export unavailable ({e}); try format='csv'"
+                return res, None, None
+            content = buf.getvalue()
+        else:
+            fmt = "csv"
+            content = df.to_csv(index=False).encode("utf-8")
+
+        filename = f"{base}.{fmt}"
+        temp_path = self._write_temp(content, suffix=f".{fmt}")
+        maintype, subtype = _MIME[fmt]
+        res.filename = filename
+        res.success = True
+        return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
+
+    async def _resolve_artifact(self, spec, runtime_ctx, res):
+        """artifact_id -> PPTX (slides) or PDF (page)."""
+        from app.models.artifact import Artifact
+
+        db = runtime_ctx.get("db")
+        report_id, _ = self._scope_ids(runtime_ctx)
+
+        artifact = await db.get(Artifact, spec.ref_id)
+        if not artifact or artifact.deleted_at is not None:
+            res.error = "Artifact not found"
+            return res, None, None
+        if report_id and str(artifact.report_id) != report_id:
+            res.error = "Artifact does not belong to this report"
+            return res, None, None
+
+        mode = (artifact.mode or "page").lower()
+        default_fmt = "pptx" if mode == "slides" else "pdf"
+        fmt = spec.format if spec.format in ("pptx", "pdf") else default_fmt
+        base = spec.filename or _slugify(artifact.title or "artifact")
+        base = re.sub(r"\.(pptx|pdf)$", "", base, flags=re.IGNORECASE)
+
+        if fmt == "pptx":
+            if mode != "slides":
+                res.error = "PPTX export is only available for slides artifacts"
+                return res, None, None
+            slides = (artifact.content or {}).get("slides") or []
+            if not slides:
+                res.error = "Artifact has no slides to export"
+                return res, None, None
+            from app.services.pptx_export_service import PptxExportService
+            buf = PptxExportService().generate_pptx(slides, title=artifact.title or "Presentation")
+            content = buf.getvalue()
+            filename = f"{base}.pptx"
+            temp_path = self._write_temp(content, suffix=".pptx")
+            maintype, subtype = _MIME["pptx"]
+            res.filename = filename
+            res.success = True
+            return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
+
+        # pdf
+        from app.services.report_pdf_service import ReportPdfService
+        pdf_path = await ReportPdfService().generate_for_artifact(str(artifact.id))
+        if not pdf_path or not os.path.isfile(pdf_path):
+            res.error = "PDF generation failed"
+            return res, None, None
+        filename = f"{base}.pdf"
+        maintype, subtype = _MIME["pdf"]
+        res.filename = filename
+        res.success = True
+        # pdf_path is a persistent file under uploads/ — do NOT schedule it for cleanup.
+        return res, _att_dict(pdf_path, filename, maintype, subtype), None
+
+    async def _resolve_file(self, spec, runtime_ctx, res):
+        """file_id -> attach the uploaded file as-is."""
+        from app.models.file import File
+
+        db = runtime_ctx.get("db")
+        _, org_id = self._scope_ids(runtime_ctx)
+
+        f = await db.get(File, spec.ref_id)
+        if not f:
+            res.error = "File not found"
+            return res, None, None
+        if org_id and str(f.organization_id) != org_id:
+            res.error = "File does not belong to this organization"
+            return res, None, None
+        if not f.path or not os.path.isfile(f.path):
+            res.error = "File is no longer available on disk"
+            return res, None, None
+
+        filename = spec.filename or f.filename or os.path.basename(f.path)
+        ctype = f.content_type or "application/octet-stream"
+        if "/" in ctype:
+            maintype, subtype = ctype.split("/", 1)
+        else:
+            maintype, subtype = "application", "octet-stream"
+        res.filename = filename
+        res.success = True
+        # f.path is the persistent upload — do NOT schedule it for cleanup.
+        return res, _att_dict(f.path, filename, maintype, subtype), None
+
+    @staticmethod
+    def _write_temp(content: bytes, suffix: str) -> str:
+        fd, path = tempfile.mkstemp(suffix=suffix, prefix="bow_email_attach_")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(content)
+        except Exception:
+            try:
+                os.unlink(path)
+            except Exception:
+                pass
+            raise
+        return path

--- a/backend/app/ai/tools/schemas/__init__.py
+++ b/backend/app/ai/tools/schemas/__init__.py
@@ -22,7 +22,12 @@ from .write_to_excel import WriteToExcelInput, WriteToExcelOutput
 from .write_officejs_code import WriteOfficeJsCodeInput, WriteOfficeJsCodeOutput
 from .read_excel_range import ReadExcelRangeInput, ReadExcelRangeOutput, ReadExcelRangeItem
 from .read_excel_as_csv import ReadExcelAsCsvInput, ReadExcelAsCsvOutput
-from .send_email import SendEmailInput, SendEmailOutput
+from .send_email import (
+    SendEmailInput,
+    SendEmailOutput,
+    EmailAttachmentSpec,
+    SendEmailAttachmentResult,
+)
 from .events import (
     ToolEvent,
     ToolStartEvent,
@@ -83,6 +88,8 @@ __all__ = [
     "ReadExcelAsCsvOutput",
     "SendEmailInput",
     "SendEmailOutput",
+    "EmailAttachmentSpec",
+    "SendEmailAttachmentResult",
     "ToolEvent",
     "ToolStartEvent",
     "ToolProgressEvent",

--- a/backend/app/ai/tools/schemas/send_email.py
+++ b/backend/app/ai/tools/schemas/send_email.py
@@ -1,5 +1,46 @@
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 from pydantic import BaseModel, Field
+
+
+class EmailAttachmentSpec(BaseModel):
+    """A single file to attach to an email.
+
+    The file is generated on the fly from something the assistant already
+    produced in this report — a visualization/query result (exported as a
+    spreadsheet), an artifact (exported as a slide deck or PDF), or an
+    uploaded file (attached as-is). Reference it by the id you can see in the
+    conversation context (visualization_id / query_id / artifact_id / file_id).
+    """
+
+    ref_type: Literal["visualization", "query", "artifact", "file"] = Field(
+        ...,
+        description=(
+            "What kind of object to attach: 'visualization' or 'query' (attaches the "
+            "underlying query result as a CSV/XLSX), 'artifact' (attaches a slides deck "
+            "as PPTX or a page dashboard as PDF), or 'file' (attaches an uploaded file "
+            "as-is). Note: steps are not directly attachable — use the visualization."
+        ),
+    )
+    ref_id: str = Field(
+        ...,
+        description=(
+            "The id of the object to attach, taken from the conversation context: a "
+            "visualization_id, query_id, artifact_id, or file_id."
+        ),
+    )
+    format: Optional[Literal["csv", "xlsx", "pptx", "pdf"]] = Field(
+        default=None,
+        description=(
+            "Optional output format. Defaults per ref_type: visualization/query -> 'csv' "
+            "(may also be 'xlsx'); artifact -> 'pptx' for slides, 'pdf' for page. Ignored "
+            "for 'file' (attached in its original format)."
+        ),
+    )
+    filename: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Optional filename override (extension is added automatically if missing).",
+    )
 
 
 class SendEmailInput(BaseModel):
@@ -36,6 +77,25 @@ class SendEmailInput(BaseModel):
             "genuinely helps readability."
         ),
     )
+    attachments: List[EmailAttachmentSpec] = Field(
+        default_factory=list,
+        max_length=5,
+        description=(
+            "Optional files to attach (max 5). Use this when the user asks you to email them "
+            "a result, dashboard, or export — reference the visualization_id / query_id / "
+            "artifact_id / file_id you can see in context. Leave empty for a plain message."
+        ),
+    )
+
+
+class SendEmailAttachmentResult(BaseModel):
+    """Per-attachment outcome reported back to the assistant."""
+
+    ref_type: str
+    ref_id: str
+    filename: Optional[str] = None
+    success: bool = False
+    error: Optional[str] = None
 
 
 class SendEmailOutput(BaseModel):
@@ -44,4 +104,8 @@ class SendEmailOutput(BaseModel):
     success: bool = Field(..., description="Whether the email was sent to the SMTP server successfully.")
     recipient: Optional[str] = Field(default=None, description="The email address the message was sent to.")
     subject: Optional[str] = Field(default=None, description="The subject line that was sent.")
+    attachments: List[SendEmailAttachmentResult] = Field(
+        default_factory=list,
+        description="Outcome for each requested attachment (which were included, which failed).",
+    )
     error: Optional[str] = Field(default=None, description="Error message if sending failed.")

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -181,12 +181,16 @@ class NotificationService:
         subject: str,
         body: str,
         subtype: str = "plain",
+        attachments: Optional[list] = None,
     ) -> ChannelResult:
         """Send a free-form email with arbitrary subject/body.
 
         Unlike ``dispatch`` (template-driven), this sends exactly the subject
         and body provided. The send is awaited so the returned status reflects
         actual delivery to the SMTP server, not just enqueueing.
+
+        ``attachments`` follows the fastapi-mail dict shape, e.g.
+        ``{"file": "/abs/path", "filename": "x.csv", "type": "text", "subtype": "csv"}``.
         """
         fm = settings.email_client
         if not fm:
@@ -200,12 +204,15 @@ class NotificationService:
         if subtype not in ("plain", "html"):
             subtype = "plain"
 
-        message = MessageSchema(
+        message_kwargs = dict(
             subject=subject,
             recipients=recipients,
             body=body,
             subtype=subtype,
         )
+        if attachments:
+            message_kwargs["attachments"] = attachments
+        message = MessageSchema(**message_kwargs)
 
         try:
             await fm.send_message(message)

--- a/backend/app/services/report_pdf_service.py
+++ b/backend/app/services/report_pdf_service.py
@@ -104,12 +104,7 @@ class ReportPdfService:
         try:
             from app.dependencies import async_session_maker
             from app.models.artifact import Artifact
-            from app.models.report import Report
-            from app.models.visualization import Visualization
-            from app.models.query import Query
-            from app.models.step import Step
             from sqlalchemy import select
-            from sqlalchemy.orm import selectinload
 
             async with async_session_maker() as db:
                 stmt = (
@@ -125,68 +120,104 @@ class ReportPdfService:
                     logger.warning(f"No artifact found for report {report_id}")
                     return None
 
-                report = await db.get(Report, report_id)
-                if not report:
-                    return None
-
-                # Get visualization data
-                viz_stmt = (
-                    select(Visualization)
-                    .options(selectinload(Visualization.query))
-                    .where(Visualization.report_id == report_id)
-                )
-                viz_result = await db.execute(viz_stmt)
-                visualizations = viz_result.scalars().all()
-
-                viz_data = []
-                for viz in visualizations:
-                    if not viz.query_id:
-                        continue
-                    query = await db.get(Query, viz.query_id)
-                    if not query:
-                        continue
-
-                    step = None
-                    if query.default_step_id:
-                        step = await db.get(Step, query.default_step_id)
-                    if not step:
-                        step_result = await db.execute(
-                            select(Step).where(Step.query_id == query.id).order_by(Step.created_at.desc()).limit(1)
-                        )
-                        step = step_result.scalar_one_or_none()
-
-                    viz_data.append({
-                        "id": str(viz.id),
-                        "title": viz.title or query.title or "Untitled",
-                        "view": viz.view or {},
-                        "rows": step.data.get("rows", []) if step and step.data else [],
-                        "columns": step.data.get("columns", []) if step and step.data else [],
-                        "dataModel": step.data_model or {} if step else {},
-                    })
-
-                artifact_code = artifact.content.get("code", "")
-                html_content = self._build_pdf_html(
-                    report_id=str(report.id),
-                    report_title=report.title,
-                    report_theme=report.theme_name,
-                    artifact_code=artifact_code,
-                    visualizations=viz_data,
-                    mode=artifact.mode or "page",
-                )
-
-                rel_path = await self.generate_pdf(
-                    artifact_id=str(artifact.id),
-                    html_content=html_content,
-                    mode=artifact.mode or "page",
-                )
-
-                if rel_path:
-                    return str(self.UPLOADS_DIR / f"{artifact.id}.pdf")
-                return None
+                return await self._render_artifact_pdf(db, artifact)
 
         except Exception as e:
             logger.exception(f"Failed to generate PDF for report {report_id}: {e}")
             return None
+
+    async def generate_for_artifact(self, artifact_id: str) -> Optional[str]:
+        """Generate a PDF for a specific artifact.
+
+        Returns:
+            Absolute filesystem path to the PDF, or None on failure.
+        """
+        try:
+            from app.dependencies import async_session_maker
+            from app.models.artifact import Artifact
+
+            async with async_session_maker() as db:
+                artifact = await db.get(Artifact, artifact_id)
+                if not artifact or artifact.deleted_at is not None or not artifact.content:
+                    logger.warning(f"No usable artifact found for id {artifact_id}")
+                    return None
+
+                return await self._render_artifact_pdf(db, artifact)
+
+        except Exception as e:
+            logger.exception(f"Failed to generate PDF for artifact {artifact_id}: {e}")
+            return None
+
+    async def _render_artifact_pdf(self, db, artifact) -> Optional[str]:
+        """Build the artifact HTML (with its report's visualization data) and render to PDF.
+
+        Returns the absolute filesystem path to the PDF, or None on failure.
+        """
+        from app.models.report import Report
+        from app.models.visualization import Visualization
+        from app.models.query import Query
+        from app.models.step import Step
+        from sqlalchemy import select
+        from sqlalchemy.orm import selectinload
+
+        report = await db.get(Report, artifact.report_id)
+        if not report:
+            return None
+
+        # Get visualization data for the artifact's report
+        viz_stmt = (
+            select(Visualization)
+            .options(selectinload(Visualization.query))
+            .where(Visualization.report_id == artifact.report_id)
+        )
+        viz_result = await db.execute(viz_stmt)
+        visualizations = viz_result.scalars().all()
+
+        viz_data = []
+        for viz in visualizations:
+            if not viz.query_id:
+                continue
+            query = await db.get(Query, viz.query_id)
+            if not query:
+                continue
+
+            step = None
+            if query.default_step_id:
+                step = await db.get(Step, query.default_step_id)
+            if not step:
+                step_result = await db.execute(
+                    select(Step).where(Step.query_id == query.id).order_by(Step.created_at.desc()).limit(1)
+                )
+                step = step_result.scalar_one_or_none()
+
+            viz_data.append({
+                "id": str(viz.id),
+                "title": viz.title or query.title or "Untitled",
+                "view": viz.view or {},
+                "rows": step.data.get("rows", []) if step and step.data else [],
+                "columns": step.data.get("columns", []) if step and step.data else [],
+                "dataModel": step.data_model or {} if step else {},
+            })
+
+        artifact_code = artifact.content.get("code", "")
+        html_content = self._build_pdf_html(
+            report_id=str(report.id),
+            report_title=report.title,
+            report_theme=report.theme_name,
+            artifact_code=artifact_code,
+            visualizations=viz_data,
+            mode=artifact.mode or "page",
+        )
+
+        rel_path = await self.generate_pdf(
+            artifact_id=str(artifact.id),
+            html_content=html_content,
+            mode=artifact.mode or "page",
+        )
+
+        if rel_path:
+            return str(self.UPLOADS_DIR / f"{artifact.id}.pdf")
+        return None
 
     def _build_pdf_html(
         self,


### PR DESCRIPTION
## Summary
Extended the `send_email` tool to support attaching up to 5 files generated from report objects (visualizations, queries, artifacts, and uploaded files). Attachments are resolved on-the-fly with proper scoping to prevent data exfiltration, and failures are reported per-attachment without blocking the email send.

## Key Changes

- **New attachment schema** (`EmailAttachmentSpec`, `SendEmailAttachmentResult`):
  - Allows specifying attachments by reference type and ID (visualization, query, artifact, or file)
  - Supports optional format override (CSV/XLSX for tabular data, PPTX/PDF for artifacts)
  - Custom filename override with automatic extension handling

- **Attachment resolution logic** in `SendEmailTool`:
  - `_resolve_tabular()`: Exports visualization/query results to CSV or XLSX via `StepService`
  - `_resolve_artifact()`: Generates PPTX for slides or PDF for page dashboards
  - `_resolve_file()`: Attaches uploaded files as-is with original content type
  - All references scoped to current report/organization to prevent unauthorized access
  - Temporary files cleaned up after send; persistent files (uploads, generated PDFs) left untouched

- **Helper utilities**:
  - `_slugify()`: Sanitizes filenames for safe attachment names
  - `_content_disposition()`: Builds RFC 2231-compliant Content-Disposition headers for non-ASCII filenames
  - `_att_dict()`: Constructs fastapi-mail attachment dicts with explicit MIME type and filename control
  - `_write_temp()`: Safely writes binary content to temporary files

- **Updated `ReportPdfService`**:
  - Extracted PDF rendering logic into `_render_artifact_pdf()` helper
  - New `generate_for_artifact()` method to generate PDF for a specific artifact (used by email attachments)
  - Reuses existing visualization data collection and HTML building

- **Enhanced output and context**:
  - `SendEmailOutput` now includes per-attachment results (filename, success, error)
  - Tool start event reports attachment count
  - Message context builder digests attachment outcomes in conversation history
  - Tool timeout increased from 30s to 60s to accommodate file generation

- **Updated tool metadata**:
  - Version bumped to 1.1.0
  - Enhanced description with attachment guidance
  - Example updated to show CSV attachment workflow

## Implementation Details

- Attachment resolution is best-effort: individual failures are reported but don't block the email send
- Temporary files (CSV/XLSX exports, PPTX slides) are cleaned up in a finally block; persistent files (uploaded files, generated PDFs in uploads/) are never deleted
- All database queries validate report/organization ownership to prevent cross-tenant access
- MIME types are explicitly set via fastapi-mail's `mime_type`/`mime_subtype` fields with Content-Disposition headers for reliable filename display across mail clients

https://claude.ai/code/session_01R6Pa9VLrUHaPQAyFt12x7m