### PR TITLE
Improve MCP tool error handling and visibility

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -58,6 +58,42 @@ def _detect_thinking_trigger(prompt_text: Optional[str]) -> bool:
     return any(kw in p for kw in THINKING_TRIGGERS)
 
 
+def _observation_failed(observation) -> bool:
+    """True when a tool observation signals failure.
+
+    Tools report failure in two ways: a truthy ``error`` payload, or an explicit
+    ``success: False`` with no ``error`` key (e.g. execute_mcp on a tool-level
+    MCP error). Checking only ``error`` mislabels the latter as success, which is
+    why failed MCP calls used to show a green ✓ in the trace. Treat either as a
+    failure.
+    """
+    if not observation:
+        return False
+    if observation.get("error"):
+        return True
+    if observation.get("success") is False:
+        return True
+    return False
+
+
+def _observation_error_message(observation) -> Optional[str]:
+    """Best-effort human-readable error string from a failed observation.
+
+    Handles both the structured ``error: {message: ...}`` shape and the flatter
+    ``success: False`` + ``summary`` shape that execute_mcp and friends emit.
+    """
+    if not observation:
+        return None
+    err = observation.get("error")
+    if isinstance(err, dict):
+        return err.get("message") or None
+    if isinstance(err, str) and err.strip():
+        return err
+    if observation.get("success") is False:
+        return observation.get("error_message") or observation.get("summary") or None
+    return None
+
+
 def _resolve_reasoning_effort(
     *,
     per_completion: Optional[str],
@@ -985,8 +1021,8 @@ class AgentV2:
                         tool_execution=tool_execution,
                         result_model=tool_output,
                         summary=observation.get("summary", "") if observation else "",
-                        error_message=observation.get("error", {}).get("message") if observation and observation.get("error") else None,
-                        success=bool(observation and not observation.get("error") and not _is_stopped),
+                        error_message=_observation_error_message(observation),
+                        success=bool(observation and not _observation_failed(observation) and not _is_stopped),
                     )
                 except Exception as _fin_err:
                     logger.warning(f"Knowledge harness: finish_tool_execution failed: {_fin_err!r}")
@@ -1019,7 +1055,7 @@ class AgentV2:
 
                 try:
                     _is_stopped = bool(observation and observation.get("stopped"))
-                    _tool_status = "stopped" if _is_stopped else ("success" if observation and not observation.get("error") else "error")
+                    _tool_status = "stopped" if _is_stopped else ("error" if _observation_failed(observation) else "success")
                     seq_fin = await self.project_manager.next_seq(self.db, self.current_execution)
                     safe_result_json = None
                     if tool_output is not None:
@@ -2776,7 +2812,7 @@ class AgentV2:
                             await self._handle_tool_output(tool_name, tool_input, observation, tool_output)
 
                             # Circuit breaker: track repeated tool failures
-                            if observation and observation.get("error"):
+                            if _observation_failed(observation):
                                 failed_tool_count[tool_name] = failed_tool_count.get(tool_name, 0) + 1
                                 if failed_tool_count[tool_name] >= max_tool_failures:
                                     analysis_done = True
@@ -2913,13 +2949,10 @@ class AgentV2:
                             # DB writes and the block.upsert SSE.
                             _success_flag = bool(
                                 observation
-                                and not observation.get("error")
+                                and not _observation_failed(observation)
                                 and not (observation and observation.get("stopped"))
                             )
-                            _error_msg = (
-                                observation.get("error", {}).get("message")
-                                if observation and observation.get("error") else None
-                            )
+                            _error_msg = _observation_error_message(observation)
                             _summary = observation.get("summary", "") if observation else ""
 
                             # Mutate the in-memory tool_execution synchronously so
@@ -2990,7 +3023,7 @@ class AgentV2:
                                     {
                                         "agent_execution_id": str(self.current_execution.id),
                                         "tool_name": tool_name,
-                                        "status": "success" if observation and not observation.get("error") else "error",
+                                        "status": "error" if _observation_failed(observation) else "success",
                                         "duration_ms": getattr(tool_execution, "duration_ms", None),
                                     },
                                     user_id=str(getattr(self.head_completion, 'user_id', None)) if hasattr(self.head_completion, 'user_id') and self.head_completion.user_id else None,
@@ -3107,7 +3140,7 @@ class AgentV2:
 
                             # Emit tool.finished with result
                             _is_stopped = bool(observation and observation.get("stopped"))
-                            _tool_status = "stopped" if _is_stopped else ("success" if observation and not observation.get("error") else "error")
+                            _tool_status = "stopped" if _is_stopped else ("error" if _observation_failed(observation) else "success")
                             seq_fin = await self.project_manager.next_seq(self.db, self.current_execution)
                             safe_result_json = None
                             if tool_output is not None:
@@ -4129,7 +4162,7 @@ class AgentV2:
         same agent run then died. By scoping this whole block to a fresh
         session, a transport death here can't poison the rest of the run.
         """
-        if not observation or observation.get("error"):
+        if not observation or _observation_failed(observation):
             return  # Don't process failed tool executions
 
         # All ORM references that come into this method (self.current_step,

--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -194,6 +194,61 @@ def _digest_web_search(tool_execution) -> str:
     return "web search " + " — ".join(parts) if parts else ""
 
 
+def _digest_execute_mcp(tool_execution) -> str:
+    """Digest for execute_mcp so the planner sees WHAT it called, not just the result.
+
+    Without the input (which MCP tool + arguments) the planner can't tell which
+    calls it already tried and loops through variants — and a tool-level failure
+    used to surface only as "Tool returned error: None". Include the called tool
+    name, a compact argument echo, and the real error message on failure so the
+    next turn can correct course instead of guessing. Returns "" for other tools.
+    """
+    if getattr(tool_execution, 'tool_name', None) != 'execute_mcp':
+        return ""
+    rj = tool_execution.result_json or {}
+    obs = rj.get('observation') or rj
+    args = getattr(tool_execution, 'arguments_json', None) or {}
+    if not isinstance(args, dict):
+        args = {}
+    digest_parts = []
+
+    # Echo the call: which underlying MCP tool, with what arguments.
+    called = args.get('tool_name')
+    if called:
+        call_str = f"called: {called}"
+        tool_args = args.get('arguments')
+        if tool_args is not None:
+            try:
+                args_str = json.dumps(tool_args, default=str)
+            except Exception:
+                args_str = str(tool_args)
+            if len(args_str) > 300:
+                args_str = args_str[:300] + '…'
+            call_str += f"({args_str})"
+        digest_parts.append(call_str)
+
+    # Failure: surface the real error and mark it clearly so the planner adapts.
+    failed = obs.get('success') is False or rj.get('success') is False
+    if failed:
+        err = obs.get('error_message') or rj.get('error_message') or obs.get('summary') or 'unknown error'
+        digest_parts.append(f"FAILED: {str(err)[:300]}")
+        return "; ".join(digest_parts)
+
+    summary = obs.get('summary') or ''
+    if summary:
+        digest_parts.append(summary)
+    ct = obs.get('content_type') or rj.get('content_type')
+    if ct:
+        digest_parts.append(f"type: {ct}")
+    fid = obs.get('file_id') or rj.get('file_id')
+    if fid:
+        digest_parts.append(f"file_id: {fid}")
+    rc = obs.get('row_count') or rj.get('row_count')
+    if rc:
+        digest_parts.append(f"{rc} rows")
+    return "; ".join(digest_parts)
+
+
 def _digest_excel_tool(tool_execution) -> str:
     """Digest for Excel bridge tools.
 
@@ -771,23 +826,9 @@ class MessageContextBuilder:
                                     if digest_parts:
                                         tool_info += " - " + "; ".join(digest_parts)
                                 elif tool_execution.tool_name == 'execute_mcp' and tool_execution.result_json:
-                                    rj = tool_execution.result_json or {}
-                                    obs = rj.get('observation') or rj
-                                    digest_parts = []
-                                    summary = obs.get('summary') or ''
-                                    if summary:
-                                        digest_parts.append(summary)
-                                    ct = obs.get('content_type') or rj.get('content_type')
-                                    if ct:
-                                        digest_parts.append(f"type: {ct}")
-                                    fid = obs.get('file_id') or rj.get('file_id')
-                                    if fid:
-                                        digest_parts.append(f"file_id: {fid}")
-                                    rc = obs.get('row_count') or rj.get('row_count')
-                                    if rc:
-                                        digest_parts.append(f"{rc} rows")
-                                    if digest_parts:
-                                        tool_info += " - " + "; ".join(digest_parts)
+                                    digest = _digest_execute_mcp(tool_execution)
+                                    if digest:
+                                        tool_info += " - " + digest
                                 elif tool_execution.tool_name in ('search_instructions', 'create_instruction', 'edit_instruction') and tool_execution.result_json:
                                     digest = _digest_knowledge_tool(tool_execution)
                                     if digest:
@@ -1381,23 +1422,9 @@ class MessageContextBuilder:
                                 if digest_parts:
                                     tool_info += " - " + "; ".join(digest_parts)
                             elif tool_execution.tool_name == 'execute_mcp' and tool_execution.result_json:
-                                rj = tool_execution.result_json or {}
-                                obs = rj.get('observation') or rj
-                                digest_parts = []
-                                summary = obs.get('summary') or ''
-                                if summary:
-                                    digest_parts.append(summary)
-                                ct = obs.get('content_type') or rj.get('content_type')
-                                if ct:
-                                    digest_parts.append(f"type: {ct}")
-                                fid = obs.get('file_id') or rj.get('file_id')
-                                if fid:
-                                    digest_parts.append(f"file_id: {fid}")
-                                rc = obs.get('row_count') or rj.get('row_count')
-                                if rc:
-                                    digest_parts.append(f"{rc} rows")
-                                if digest_parts:
-                                    tool_info += " - " + "; ".join(digest_parts)
+                                digest = _digest_execute_mcp(tool_execution)
+                                if digest:
+                                    tool_info += " - " + digest
                             elif tool_execution.tool_name in ('search_instructions', 'create_instruction', 'edit_instruction') and tool_execution.result_json:
                                 digest = _digest_knowledge_tool(tool_execution)
                                 if digest:

--- a/backend/app/data_sources/clients/mcp_client.py
+++ b/backend/app/data_sources/clients/mcp_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import List, Dict, Any, Optional
 from app.data_sources.clients.tool_provider_base import ToolProviderClient
@@ -95,11 +96,18 @@ class McpClient(ToolProviderClient):
                 data = self._extract_result_data(result)
                 content_type = self._detect_content_type(data)
 
+                is_error = bool(getattr(result, "isError", False))
+                # On a tool-level error (isError=True) the MCP spec puts the
+                # explanation in the content blocks, not in a transport
+                # exception. Surface it in `error` so callers don't see a
+                # useless "None" — otherwise the agent retries blindly.
+                error_msg = self._extract_error_message(data) if is_error else None
+
                 return {
-                    "success": not getattr(result, "isError", False),
+                    "success": not is_error,
                     "data": data,
                     "content_type": content_type,
-                    "error": None,
+                    "error": error_msg,
                 }
         except BaseException as e:
             msg = self._unwrap_exception(e)
@@ -139,6 +147,43 @@ class McpClient(ToolProviderClient):
             elif hasattr(content, "data"):
                 parts.append(content.data)
         return parts
+
+    @staticmethod
+    def _extract_error_message(data: Any) -> str:
+        """Pull a human-readable error string out of an isError tool result.
+
+        MCP servers signal tool-level failures with isError=True and the reason
+        carried in the content blocks (already parsed into `data` by
+        _extract_result_data). The shape varies — a dict like
+        {"error": "..."} / {"message": "..."}, a list of such dicts, or a
+        plain string. Fall back to a stringified form so the caller always gets
+        something more useful than None.
+        """
+        def _from_dict(d: dict) -> str | None:
+            for key in ("error", "message", "detail", "error_message"):
+                val = d.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val
+                if isinstance(val, dict):
+                    nested = _from_dict(val)
+                    if nested:
+                        return nested
+            return None
+
+        if isinstance(data, dict):
+            return _from_dict(data) or json.dumps(data, default=str)
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    msg = _from_dict(item)
+                    if msg:
+                        return msg
+                elif isinstance(item, str) and item.strip():
+                    return item
+            return json.dumps(data, default=str) if data else "Tool reported an error"
+        if isinstance(data, str) and data.strip():
+            return data
+        return "Tool reported an error"
 
     @staticmethod
     def _unwrap_exception(e: BaseException) -> str:

--- a/frontend/components/tools/MCPTool.vue
+++ b/frontend/components/tools/MCPTool.vue
@@ -25,6 +25,23 @@
     <!-- Expandable content -->
     <Transition name="slide">
       <div v-if="isExpanded && status !== 'running'" class="mt-2 space-y-1.5">
+        <!-- Command (input) -->
+        <div v-if="command" class="group">
+          <div
+            class="flex items-center text-[11px] text-gray-500 cursor-pointer hover:text-gray-600 mb-0.5"
+            @click="showCommand = !showCommand"
+          >
+            <Icon
+              :name="showCommand ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+              class="w-2.5 h-2.5 me-1 text-gray-400 rtl-flip"
+            />
+            <span>{{ $t('tools.common.input') }}</span>
+          </div>
+          <div v-if="showCommand" class="max-h-28 overflow-auto rounded bg-gray-50 border border-gray-100">
+            <pre class="text-[10px] leading-tight text-gray-600 p-2 m-0 whitespace-pre-wrap break-words font-mono">{{ command }}</pre>
+          </div>
+        </div>
+
         <!-- Result preview -->
         <div v-if="preview" class="group">
           <div
@@ -72,6 +89,7 @@ const props = defineProps<{
 
 const isExpanded = ref(false)
 const showPreview = ref(true)
+const showCommand = ref(true)
 
 const status = computed(() => props.toolExecution?.status || '')
 const toolName = computed(() => props.toolExecution?.tool_name || '')
@@ -112,6 +130,29 @@ const doneLabel = computed(() => {
     return rows ? t('tools.common.rows', { n: rows }) : 'CSV'
   }
   return 'MCP tool'
+})
+
+// The actual call being made — surfaced so users can see WHAT was invoked,
+// not just the result. execute_mcp: the underlying tool + its arguments.
+// search_mcps / write_csv: the relevant query/code input.
+const command = computed(() => {
+  const a = args.value || {}
+  if (toolName.value === 'execute_mcp') {
+    const called = a.tool_name
+    if (!called) return ''
+    const toolArgs = a.arguments
+    if (toolArgs && Object.keys(toolArgs).length) {
+      return `${called}(${JSON.stringify(toolArgs, null, 2)})`
+    }
+    return `${called}()`
+  }
+  if (toolName.value === 'search_mcps') {
+    return a.query ? `query: ${a.query}` : ''
+  }
+  if (toolName.value === 'write_csv') {
+    return a.code || ''
+  }
+  return ''
 })
 
 const preview = computed(() => {


### PR DESCRIPTION
## Summary
This PR enhances error reporting and visibility for MCP (Model Context Protocol) tool executions across the agent, backend context builder, and frontend UI. It fixes issues where tool-level MCP failures were not properly surfaced to the planner and adds comprehensive input/output display in the UI.

## Key Changes

### Backend - Agent Error Detection (`agent_v2.py`)
- Added `_observation_failed()` helper to properly detect tool failures by checking both `error` payload and explicit `success: False` status (fixes issue where MCP tool-level errors were mislabeled as success)
- Added `_observation_error_message()` helper to extract human-readable error strings from both structured error shapes and flatter `success: False` + `summary` formats
- Updated all tool status determination logic to use these helpers instead of only checking for `error` key
- Ensures failed MCP calls now correctly show as "error" status in traces and trigger proper failure handling

### Backend - MCP Client (`mcp_client.py`)
- Enhanced `_acall_tool()` to surface tool-level MCP errors (when `isError=True`) in the response
- Added `_extract_error_message()` static method to parse human-readable error messages from MCP error responses
- Handles multiple error message shapes: dict with `error`/`message`/`detail` keys, lists of dicts, or plain strings
- Falls back to JSON stringification when no standard error format is found

### Backend - Context Builder (`message_context_builder.py`)
- Extracted MCP tool digestion logic into dedicated `_digest_execute_mcp()` function
- Enhanced digest to include:
  - The actual MCP tool called and its arguments (so planner knows what was attempted)
  - Clear "FAILED:" prefix with error message on tool-level failures
  - Summary, content type, file ID, and row count metadata
- Refactored two duplicate code blocks in `build_context()` and `build()` methods to use the new function
- Improves planner's ability to avoid retry loops by showing exactly what was called and why it failed

### Frontend - MCP Tool Display (`MCPTool.vue`)
- Added expandable "Input" section showing the actual command/arguments being executed
- For `execute_mcp`: displays the underlying tool name and arguments in readable format
- For `search_mcps`: shows the search query
- For `write_csv`: shows the code being executed
- Input section defaults to expanded for better visibility of what was attempted
- Provides users with full context of tool invocation alongside results

## Implementation Details
- Error detection now handles both transport-level errors and MCP spec tool-level errors (isError flag)
- Error message extraction is defensive with multiple fallback strategies
- Digest truncation at 300 characters prevents context bloat while preserving essential information
- All changes maintain backward compatibility with existing tool execution formats

https://claude.ai/code/session_01N9To7HXaFpNgA4AFAAm6WR