### PR TITLE
Fix OAuth token binding to wrong org on multi-org deployments

### DIFF
--- a/backend/app/ai/tools/implementations/send_email.py
+++ b/backend/app/ai/tools/implementations/send_email.py
@@ -10,14 +10,13 @@ something the assistant already produced in this report: a visualization/query
 result (CSV/XLSX), an artifact (PPTX for slides, PDF for page dashboards), or an
 uploaded file (attached as-is). All references are scoped to the current report /
 organization so the agent cannot exfiltrate arbitrary objects.
+
+The attachment resolution + send is delegated to ``EmailSendService`` so the same
+logic backs the external MCP send_email tool.
 """
 
-from typing import AsyncIterator, Dict, Any, Type, List, Optional, Tuple
-from io import BytesIO
+from typing import AsyncIterator, Dict, Any, Type
 from pydantic import BaseModel
-import os
-import re
-import tempfile
 import logging
 
 from app.ai.tools.base import Tool
@@ -25,8 +24,6 @@ from app.ai.tools.metadata import ToolMetadata
 from app.ai.tools.schemas.send_email import (
     SendEmailInput,
     SendEmailOutput,
-    EmailAttachmentSpec,
-    SendEmailAttachmentResult,
 )
 from app.ai.tools.schemas.events import (
     ToolEvent,
@@ -34,63 +31,10 @@ from app.ai.tools.schemas.events import (
     ToolEndEvent,
     ToolErrorEvent,
 )
+from app.services.email_send_service import EmailSendService
 from app.settings.config import settings
 
 logger = logging.getLogger(__name__)
-
-
-# Default export format per ref_type when the caller doesn't specify one.
-_DEFAULT_FORMAT = {
-    "visualization": "csv",
-    "query": "csv",
-    "artifact": None,  # resolved from artifact.mode (slides -> pptx, page -> pdf)
-    "file": None,      # original format
-}
-
-# MIME (maintype, subtype) per export format, in the fastapi-mail dict shape.
-_MIME = {
-    "csv": ("text", "csv"),
-    "xlsx": ("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
-    "pptx": ("application", "vnd.openxmlformats-officedocument.presentationml.presentation"),
-    "pdf": ("application", "pdf"),
-}
-
-
-def _slugify(name: str) -> str:
-    name = (name or "attachment").strip()
-    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-")
-    return name or "attachment"
-
-
-def _content_disposition(filename: str) -> str:
-    """Build a Content-Disposition value that displays ``filename`` reliably.
-
-    Plain ``filename="..."`` for ASCII names; RFC 2231 ``filename*`` for names
-    with non-ASCII characters so mail clients render them correctly.
-    """
-    try:
-        filename.encode("ascii")
-        safe = filename.replace('"', "")
-        return f'attachment; filename="{safe}"'
-    except UnicodeEncodeError:
-        from urllib.parse import quote
-        return f"attachment; filename*=UTF-8''{quote(filename)}"
-
-
-def _att_dict(path: str, filename: str, maintype: str, subtype: str) -> Dict[str, Any]:
-    """Build a fastapi-mail attachment dict that sets BOTH the MIME type and the
-    displayed filename.
-
-    This fastapi-mail version reads ``mime_type``/``mime_subtype`` for the part
-    type and otherwise derives the filename from the on-disk basename — so the
-    displayed name is controlled via an explicit Content-Disposition header.
-    """
-    return {
-        "file": path,
-        "mime_type": maintype,
-        "mime_subtype": subtype,
-        "headers": {"Content-Disposition": _content_disposition(filename)},
-    }
 
 
 class SendEmailTool(Tool):
@@ -210,281 +154,46 @@ class SendEmailTool(Tool):
             )
             return
 
-        # Resolve attachments (best-effort: failures are reported but don't block the send).
-        temp_paths: List[str] = []
-        attachment_dicts: List[Dict[str, Any]] = []
-        attachment_results: List[SendEmailAttachmentResult] = []
         try:
-            for spec in data.attachments:
-                result, att_dict, temp_path = await self._resolve_attachment(spec, runtime_ctx)
-                attachment_results.append(result)
-                if att_dict:
-                    attachment_dicts.append(att_dict)
-                if temp_path:
-                    temp_paths.append(temp_path)
-
-            try:
-                from app.services.notification_service import notification_service
-
-                subtype = "html" if data.body_format == "html" else "plain"
-                result = await notification_service.send_custom_email(
-                    recipients=[recipient],
-                    subject=data.subject,
-                    body=data.body,
-                    subtype=subtype,
-                    attachments=attachment_dicts or None,
-                )
-
-                success = result.status == "sent"
-                sent_names = [r.filename for r in attachment_results if r.success and r.filename]
-                failed = [r for r in attachment_results if not r.success]
-                att_summary = ""
-                if attachment_results:
-                    att_summary = f" with {len(sent_names)} attachment(s)"
-                    if failed:
-                        att_summary += f" ({len(failed)} failed)"
-                summary = (
-                    f"Email sent to {recipient}: {data.subject}{att_summary}"
-                    if success
-                    else f"Failed to send email: {result.error or 'unknown error'}"
-                )
-
-                yield ToolEndEvent(
-                    type="tool.end",
-                    payload={
-                        "output": SendEmailOutput(
-                            success=success,
-                            recipient=recipient,
-                            subject=data.subject,
-                            attachments=attachment_results,
-                            error=None if success else (result.error or "Failed to send email"),
-                        ).model_dump(),
-                        "observation": {
-                            "summary": summary,
-                            "success": success,
-                            "artifacts": [],
-                        },
-                    },
-                )
-            except Exception as e:
-                logger.exception("Failed to send email: %s", e)
-                yield ToolErrorEvent(
-                    type="tool.error",
-                    payload={"error": f"Failed to send email: {str(e)}", "code": "SEND_FAILED"},
-                )
-        finally:
-            # Only remove temp files we created; never touch persistent paths
-            # (uploaded files, generated artifact PDFs in uploads/).
-            for p in temp_paths:
-                try:
-                    os.unlink(p)
-                except Exception:
-                    pass
-
-    # ---- attachment resolution ----
-
-    async def _resolve_attachment(
-        self, spec: EmailAttachmentSpec, runtime_ctx: Dict[str, Any]
-    ) -> Tuple[SendEmailAttachmentResult, Optional[Dict[str, Any]], Optional[str]]:
-        """Resolve a single attachment spec to a fastapi-mail attachment dict.
-
-        Returns (result, attachment_dict_or_None, temp_path_to_cleanup_or_None).
-        On any failure, result.success is False with an error and the dict is None.
-        """
-        res = SendEmailAttachmentResult(ref_type=spec.ref_type, ref_id=spec.ref_id, success=False)
-        try:
-            if spec.ref_type in ("visualization", "query"):
-                return await self._resolve_tabular(spec, runtime_ctx, res)
-            if spec.ref_type == "artifact":
-                return await self._resolve_artifact(spec, runtime_ctx, res)
-            if spec.ref_type == "file":
-                return await self._resolve_file(spec, runtime_ctx, res)
-            res.error = f"Unknown ref_type '{spec.ref_type}'"
-            return res, None, None
+            output = await EmailSendService().send(
+                runtime_ctx.get("db"),
+                recipient=recipient,
+                subject=data.subject,
+                body=data.body,
+                body_format=data.body_format,
+                attachment_specs=data.attachments,
+                report=runtime_ctx.get("report"),
+                organization=runtime_ctx.get("organization"),
+            )
         except Exception as e:
-            logger.exception("Attachment resolution failed for %s %s", spec.ref_type, spec.ref_id)
-            res.error = str(e)
-            return res, None, None
+            logger.exception("Failed to send email: %s", e)
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Failed to send email: {str(e)}", "code": "SEND_FAILED"},
+            )
+            return
 
-    @staticmethod
-    def _scope_ids(runtime_ctx: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
-        report = runtime_ctx.get("report")
-        org = runtime_ctx.get("organization")
-        report_id = str(getattr(report, "id", "")) if report is not None else None
-        org_id = str(getattr(org, "id", "")) if org is not None else None
-        return report_id, org_id
+        sent_names = [r.filename for r in output.attachments if r.success and r.filename]
+        failed = [r for r in output.attachments if not r.success]
+        att_summary = ""
+        if output.attachments:
+            att_summary = f" with {len(sent_names)} attachment(s)"
+            if failed:
+                att_summary += f" ({len(failed)} failed)"
+        summary = (
+            f"Email sent to {recipient}: {data.subject}{att_summary}"
+            if output.success
+            else f"Failed to send email: {output.error or 'unknown error'}"
+        )
 
-    async def _resolve_tabular(self, spec, runtime_ctx, res):
-        """visualization_id / query_id -> CSV or XLSX of the underlying step data."""
-        from sqlalchemy import select
-        from app.models.visualization import Visualization
-        from app.models.query import Query
-        from app.models.step import Step
-        from app.services.step_service import StepService
-
-        db = runtime_ctx.get("db")
-        report_id, org_id = self._scope_ids(runtime_ctx)
-
-        query: Optional[Query] = None
-        title = None
-        if spec.ref_type == "visualization":
-            viz = await db.get(Visualization, spec.ref_id)
-            if not viz:
-                res.error = "Visualization not found"
-                return res, None, None
-            if report_id and str(viz.report_id) != report_id:
-                res.error = "Visualization does not belong to this report"
-                return res, None, None
-            title = viz.title
-            query = await db.get(Query, viz.query_id) if viz.query_id else None
-        else:  # query
-            query = await db.get(Query, spec.ref_id)
-            if not query:
-                res.error = "Query not found"
-                return res, None, None
-            # Queries may be report-scoped or global-to-org; require one to match.
-            q_report = str(query.report_id) if query.report_id else None
-            q_org = str(query.organization_id) if query.organization_id else None
-            if report_id and q_report and q_report != report_id and (not org_id or q_org != org_id):
-                res.error = "Query does not belong to this report or organization"
-                return res, None, None
-            title = query.title
-
-        if not query:
-            res.error = "No query linked to this visualization"
-            return res, None, None
-
-        # Find the step that holds the result: default step, else latest.
-        step = None
-        if query.default_step_id:
-            step = await db.get(Step, query.default_step_id)
-        if not step:
-            step = (await db.execute(
-                select(Step).where(Step.query_id == query.id).order_by(Step.created_at.desc()).limit(1)
-            )).scalar_one_or_none()
-        if not step:
-            res.error = "No executed result available to export"
-            return res, None, None
-
-        df, _ = await StepService().export_step_to_csv(db, step.id)
-        if df is None or df.empty:
-            res.error = "Result is empty — nothing to export"
-            return res, None, None
-
-        fmt = spec.format if spec.format in ("csv", "xlsx") else _DEFAULT_FORMAT[spec.ref_type]
-        base = spec.filename or _slugify(title or step.title or "export")
-        base = re.sub(r"\.(csv|xlsx)$", "", base, flags=re.IGNORECASE)
-
-        if fmt == "xlsx":
-            buf = BytesIO()
-            try:
-                df.to_excel(buf, index=False)
-            except Exception as e:
-                res.error = f"XLSX export unavailable ({e}); try format='csv'"
-                return res, None, None
-            content = buf.getvalue()
-        else:
-            fmt = "csv"
-            content = df.to_csv(index=False).encode("utf-8")
-
-        filename = f"{base}.{fmt}"
-        temp_path = self._write_temp(content, suffix=f".{fmt}")
-        maintype, subtype = _MIME[fmt]
-        res.filename = filename
-        res.success = True
-        return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
-
-    async def _resolve_artifact(self, spec, runtime_ctx, res):
-        """artifact_id -> PPTX (slides) or PDF (page)."""
-        from app.models.artifact import Artifact
-
-        db = runtime_ctx.get("db")
-        report_id, _ = self._scope_ids(runtime_ctx)
-
-        artifact = await db.get(Artifact, spec.ref_id)
-        if not artifact or artifact.deleted_at is not None:
-            res.error = "Artifact not found"
-            return res, None, None
-        if report_id and str(artifact.report_id) != report_id:
-            res.error = "Artifact does not belong to this report"
-            return res, None, None
-
-        mode = (artifact.mode or "page").lower()
-        default_fmt = "pptx" if mode == "slides" else "pdf"
-        fmt = spec.format if spec.format in ("pptx", "pdf") else default_fmt
-        base = spec.filename or _slugify(artifact.title or "artifact")
-        base = re.sub(r"\.(pptx|pdf)$", "", base, flags=re.IGNORECASE)
-
-        if fmt == "pptx":
-            if mode != "slides":
-                res.error = "PPTX export is only available for slides artifacts"
-                return res, None, None
-            slides = (artifact.content or {}).get("slides") or []
-            if not slides:
-                res.error = "Artifact has no slides to export"
-                return res, None, None
-            from app.services.pptx_export_service import PptxExportService
-            buf = PptxExportService().generate_pptx(slides, title=artifact.title or "Presentation")
-            content = buf.getvalue()
-            filename = f"{base}.pptx"
-            temp_path = self._write_temp(content, suffix=".pptx")
-            maintype, subtype = _MIME["pptx"]
-            res.filename = filename
-            res.success = True
-            return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
-
-        # pdf
-        from app.services.report_pdf_service import ReportPdfService
-        pdf_path = await ReportPdfService().generate_for_artifact(str(artifact.id))
-        if not pdf_path or not os.path.isfile(pdf_path):
-            res.error = "PDF generation failed"
-            return res, None, None
-        filename = f"{base}.pdf"
-        maintype, subtype = _MIME["pdf"]
-        res.filename = filename
-        res.success = True
-        # pdf_path is a persistent file under uploads/ — do NOT schedule it for cleanup.
-        return res, _att_dict(pdf_path, filename, maintype, subtype), None
-
-    async def _resolve_file(self, spec, runtime_ctx, res):
-        """file_id -> attach the uploaded file as-is."""
-        from app.models.file import File
-
-        db = runtime_ctx.get("db")
-        _, org_id = self._scope_ids(runtime_ctx)
-
-        f = await db.get(File, spec.ref_id)
-        if not f:
-            res.error = "File not found"
-            return res, None, None
-        if org_id and str(f.organization_id) != org_id:
-            res.error = "File does not belong to this organization"
-            return res, None, None
-        if not f.path or not os.path.isfile(f.path):
-            res.error = "File is no longer available on disk"
-            return res, None, None
-
-        filename = spec.filename or f.filename or os.path.basename(f.path)
-        ctype = f.content_type or "application/octet-stream"
-        if "/" in ctype:
-            maintype, subtype = ctype.split("/", 1)
-        else:
-            maintype, subtype = "application", "octet-stream"
-        res.filename = filename
-        res.success = True
-        # f.path is the persistent upload — do NOT schedule it for cleanup.
-        return res, _att_dict(f.path, filename, maintype, subtype), None
-
-    @staticmethod
-    def _write_temp(content: bytes, suffix: str) -> str:
-        fd, path = tempfile.mkstemp(suffix=suffix, prefix="bow_email_attach_")
-        try:
-            with os.fdopen(fd, "wb") as fh:
-                fh.write(content)
-        except Exception:
-            try:
-                os.unlink(path)
-            except Exception:
-                pass
-            raise
-        return path
+        yield ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": output.model_dump(),
+                "observation": {
+                    "summary": summary,
+                    "success": output.success,
+                    "artifacts": [],
+                },
+            },
+        )

--- a/backend/app/ai/tools/mcp/__init__.py
+++ b/backend/app/ai/tools/mcp/__init__.py
@@ -10,6 +10,7 @@ from .inspect_data import InspectDataMCPTool
 from .create_data import CreateDataMCPTool
 from .create_artifact import CreateArtifactMCPTool
 from .edit_artifact import EditArtifactMCPTool
+from .send_email import SendEmailMCPTool
 from .instructions import (
     ListInstructionsMCPTool,
     CreateInstructionMCPTool,
@@ -24,6 +25,7 @@ MCP_TOOLS = {
     "create_data": CreateDataMCPTool,
     "create_artifact": CreateArtifactMCPTool,
     "edit_artifact": EditArtifactMCPTool,
+    "send_email": SendEmailMCPTool,
     # Instruction management tools
     "list_instructions": ListInstructionsMCPTool,
     "create_instruction": CreateInstructionMCPTool,
@@ -49,6 +51,8 @@ def list_mcp_tools(include_app_only: bool = True):
     tools = []
     for tool_cls in MCP_TOOLS.values():
         tool = tool_cls()
+        if not tool.is_available:
+            continue
         if not include_app_only and "model" not in tool.visibility:
             continue
         tools.append(tool.to_schema())

--- a/backend/app/ai/tools/mcp/base.py
+++ b/backend/app/ai/tools/mcp/base.py
@@ -67,6 +67,16 @@ class MCPTool(ABC):
         return ["model", "app"]
 
     @property
+    def is_available(self) -> bool:
+        """Whether this tool is usable in the current deployment.
+
+        Tools whose backing capability isn't configured (e.g. send_email when
+        SMTP is absent) override this to False so they're excluded from
+        ``tools/list`` rather than advertised and always failing.
+        """
+        return True
+
+    @property
     @abstractmethod
     def input_schema(self) -> Dict[str, Any]:
         """JSON Schema for tool input arguments."""

--- a/backend/app/ai/tools/mcp/create_report.py
+++ b/backend/app/ai/tools/mcp/create_report.py
@@ -62,8 +62,13 @@ class CreateReportTool(MCPTool):
         # Ensure user mapping exists for Members page visibility
         await self._ensure_mcp_user_mapping(db, user, organization, platform)
         
-        # Get all active data sources for the organization
-        data_sources = await ds_service.get_active_data_sources(db, organization)
+        # Get active data sources the calling user is allowed to see. Passing
+        # current_user is essential: without it, get_active_data_sources skips
+        # all visibility filtering and attaches every org data source —
+        # including private ones the user isn't a member of.
+        data_sources = await ds_service.get_active_data_sources(
+            db, organization, current_user=user
+        )
         
         # Create the report with MCP platform
         report = await report_service.create_report(

--- a/backend/app/ai/tools/mcp/get_context.py
+++ b/backend/app/ai/tools/mcp/get_context.py
@@ -54,10 +54,17 @@ class GetContextTool(MCPTool):
 
         # Load report as ORM model (preserves Connection.get_credentials())
         report = await self._load_report(db, input_data.report_id)
-        # Exclude user_required data sources this user can't query (no creds, no
-        # system fallback) so the agent doesn't advertise sources that 403.
         from app.services.data_source_service import DataSourceService
-        data_sources, _skipped = await DataSourceService().filter_user_usable_data_sources(db, report.data_sources, user)
+        ds_service = DataSourceService()
+        # First, restrict to data sources THIS user is allowed to see — the
+        # report's attachments are not re-checked elsewhere, so without this a
+        # private source on a shared report would leak its schema to a non-member.
+        visible = await ds_service.filter_user_visible_data_sources(
+            db, report.data_sources, user, organization
+        )
+        # Then exclude user_required data sources this user can't query (no creds,
+        # no system fallback) so the agent doesn't advertise sources that 403.
+        data_sources, _skipped = await ds_service.filter_user_usable_data_sources(db, visible, user)
         
         # Update report with external_platform_id if not set (direct DB update)
         if not report.external_platform:

--- a/backend/app/ai/tools/mcp/send_email.py
+++ b/backend/app/ai/tools/mcp/send_email.py
@@ -1,0 +1,124 @@
+"""MCP Tool: send_email - email the requesting user a summary or export.
+
+The recipient is ALWAYS the authenticated token user — there is no recipient
+argument — so an external MCP client can only ever email that user their own
+data, never a third party. Attachments are scoped to a report the user's org
+owns (verified here before resolution), mirroring the internal send_email tool.
+
+Hidden from ``tools/list`` when SMTP isn't configured (``is_available``), so we
+never advertise a tool that can only fail.
+"""
+
+import logging
+from typing import Dict, Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.tools.mcp.base import MCPTool
+from app.models.user import User
+from app.models.organization import Organization
+from app.schemas.mcp import MCPSendEmailInput, MCPSendEmailOutput
+from app.services.email_send_service import EmailSendService
+from app.settings.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SendEmailMCPTool(MCPTool):
+    """Send a free-form email (optionally with report-scoped attachments) to the
+    authenticated user's own inbox."""
+
+    name = "send_email"
+    description = (
+        "Send an email to the current user (yourself). The recipient is ALWAYS the "
+        "authenticated user — you cannot send to anyone else, so there is no recipient "
+        "argument. Use it when the user asks to be emailed something (a summary, a result, "
+        "an export). Keep the body short and natural; default to plain text. "
+        "Attachments (optional, up to 5) are generated from objects in a report — reference "
+        "a visualization_id / query_id (CSV/XLSX), artifact_id (PPTX/PDF), or file_id, and "
+        "pass the owning report_id."
+    )
+
+    @property
+    def is_available(self) -> bool:
+        """Only expose the tool when an SMTP/email client is configured."""
+        return settings.email_client is not None
+
+    @property
+    def input_schema(self) -> Dict[str, Any]:
+        return MCPSendEmailInput.model_json_schema()
+
+    async def execute(
+        self,
+        args: Dict[str, Any],
+        db: AsyncSession,
+        user: User,
+        organization: Organization,
+    ) -> Dict[str, Any]:
+        try:
+            input_data = MCPSendEmailInput(**args)
+        except Exception as e:
+            return MCPSendEmailOutput(success=False, error=f"Invalid input: {e}").model_dump()
+
+        if not self.is_available:
+            return MCPSendEmailOutput(
+                success=False, subject=input_data.subject,
+                error="Email is not configured on this server.",
+            ).model_dump()
+
+        # Recipient is always the authenticated user — never caller-controllable.
+        recipient = getattr(user, "email", None)
+        if not recipient:
+            return MCPSendEmailOutput(
+                success=False, subject=input_data.subject,
+                error="Could not resolve your email address.",
+            ).model_dump()
+
+        # Attachments are scoped to a report. Require report_id and verify the
+        # report belongs to the caller's org before trusting it for scoping —
+        # _load_report alone does not check ownership.
+        report = None
+        if input_data.attachments:
+            if not input_data.report_id:
+                return MCPSendEmailOutput(
+                    success=False, subject=input_data.subject,
+                    error="report_id is required when sending attachments.",
+                ).model_dump()
+            try:
+                report = await self._load_report(db, input_data.report_id)
+            except Exception:
+                return MCPSendEmailOutput(
+                    success=False, subject=input_data.subject,
+                    error="Report not found.",
+                ).model_dump()
+            if str(report.organization_id) != str(organization.id):
+                return MCPSendEmailOutput(
+                    success=False, subject=input_data.subject,
+                    error="Report not found.",
+                ).model_dump()
+
+        try:
+            output = await EmailSendService().send(
+                db,
+                recipient=recipient,
+                subject=input_data.subject,
+                body=input_data.body,
+                body_format=input_data.body_format,
+                attachment_specs=input_data.attachments,
+                report=report,
+                organization=organization,
+            )
+        except Exception as e:
+            logger.exception("MCP send_email failed")
+            return MCPSendEmailOutput(
+                success=False, recipient=recipient, subject=input_data.subject,
+                error=f"Failed to send email: {e}",
+            ).model_dump()
+
+        return MCPSendEmailOutput(
+            success=output.success,
+            recipient=output.recipient,
+            subject=output.subject,
+            attachments=output.attachments,
+            error=output.error,
+        ).model_dump()

--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -124,7 +124,6 @@ async def authorize_redirect(
 async def authorize_approve(
     request: Request,
     user: User = Depends(current_user),
-    organization: Organization = Depends(get_current_organization),
     db: AsyncSession = Depends(get_async_db),
 ):
     """Called by frontend after user approves the consent.
@@ -157,6 +156,18 @@ async def authorize_approve(
     if not service.validate_redirect_uri(client, redirect_uri):
         raise HTTPException(status_code=400, detail="Invalid redirect_uri")
 
+    # The token's org is the CLIENT's org — never the caller's active-org header.
+    # On multi-org deployments a user can be active in org A while approving a
+    # client registered under org B; binding to the header would issue a token
+    # scoped to the wrong tenant. Gate on membership so a user can only approve
+    # clients belonging to an org they're actually in.
+    organization_id = client.organization_id
+    if not await service.user_is_member_of_org(db, user.id, organization_id):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of this application's organization",
+        )
+
     # Validate requested scope: must be a non-empty subset of both the server's
     # SUPPORTED_SCOPES and the client's registered scopes.
     scope_source = raw_scope if isinstance(raw_scope, str) and raw_scope.strip() else DEFAULT_SCOPE
@@ -174,7 +185,7 @@ async def authorize_approve(
         db=db,
         client_id=client_id,
         user_id=user.id,
-        organization_id=organization.id,
+        organization_id=organization_id,
         redirect_uri=redirect_uri,
         scope=scope,
         code_challenge=code_challenge,

--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -312,13 +312,7 @@ async def create_client(
             raise HTTPException(status_code=400, detail=f"Unsupported scope: {s}")
     scopes = " ".join(requested)
 
-    redirect_uris = body.get("redirect_uris")
-    if redirect_uris is not None:
-        if not isinstance(redirect_uris, list) or not redirect_uris:
-            raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
-        for uri in redirect_uris:
-            if not isinstance(uri, str) or not uri.strip():
-                raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
+    redirect_uris = _validate_redirect_uris(body.get("redirect_uris"))
 
     service = OAuthServerService()
     return await service.create_client(
@@ -328,6 +322,55 @@ async def create_client(
         scopes=scopes,
         redirect_uris=redirect_uris,
     )
+
+
+def _validate_redirect_uris(redirect_uris):
+    """Validate an optional redirect_uris payload. Returns the list unchanged,
+    or None when absent (caller decides the fallback)."""
+    if redirect_uris is None:
+        return None
+    if not isinstance(redirect_uris, list) or not redirect_uris:
+        raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
+    for uri in redirect_uris:
+        if not isinstance(uri, str) or not uri.strip():
+            raise HTTPException(status_code=400, detail="redirect_uris must be a non-empty list of strings")
+    return redirect_uris
+
+
+@router.patch("/clients/{client_db_id}")
+@requires_permission("manage_settings")
+async def update_client(
+    client_db_id: str,
+    request: Request,
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Update an OAuth client's name and/or redirect URIs."""
+    body = await request.json()
+
+    name = None
+    if "name" in body:
+        name = (body.get("name") or "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="name must not be empty")
+
+    redirect_uris = _validate_redirect_uris(body.get("redirect_uris"))
+
+    if name is None and redirect_uris is None:
+        raise HTTPException(status_code=400, detail="Nothing to update")
+
+    service = OAuthServerService()
+    updated = await service.update_client(
+        db=db,
+        client_db_id=client_db_id,
+        organization_id=organization.id,
+        name=name,
+        redirect_uris=redirect_uris,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return updated
 
 
 @router.get("/clients/{client_id}/info")

--- a/backend/app/schemas/mcp.py
+++ b/backend/app/schemas/mcp.py
@@ -238,3 +238,40 @@ class MCPEditArtifactOutput(BaseModel):
     diff_applied: Optional[bool] = Field(default=None, description="True if surgical diff was applied, False if fell back to full rewrite.")
     error_message: Optional[str] = None
     url: Optional[str] = Field(default=None, description="Link to view the edited artifact. Always share this with the user.")
+
+
+# ── send_email ─────────────────────────────────────────────────────
+
+# Reuse the attachment spec / result shapes from the internal tool so the MCP
+# surface and the agent tool stay in lockstep.
+from app.ai.tools.schemas.send_email import (  # noqa: E402
+    EmailAttachmentSpec,
+    SendEmailAttachmentResult,
+)
+
+
+class MCPSendEmailInput(BaseModel):
+    """Input for the send_email MCP tool.
+
+    Sends a free-form email to the requesting user themselves. The recipient is
+    ALWAYS the authenticated user — it is not selectable, so the tool can never
+    email anyone else.
+    """
+    subject: str = Field(..., min_length=1, max_length=300, description="A clear, specific subject line.")
+    body: str = Field(..., min_length=1, description="The email body. Plain text by default; keep it short and natural.")
+    body_format: str = Field(default="text", description="'text' (default) or 'html'. Use 'html' only when light structure genuinely helps.")
+    report_id: Optional[str] = Field(default=None, description="Report ID that owns any attachments. Required when 'attachments' is non-empty; attachments are scoped to this report.")
+    attachments: List[EmailAttachmentSpec] = Field(
+        default_factory=list,
+        max_length=5,
+        description="Optional files to attach (max 5), referenced by visualization_id / query_id / artifact_id / file_id from the report. Requires report_id.",
+    )
+
+
+class MCPSendEmailOutput(BaseModel):
+    """Output for the send_email MCP tool."""
+    success: bool
+    recipient: Optional[str] = None
+    subject: Optional[str] = None
+    attachments: List[SendEmailAttachmentResult] = Field(default_factory=list)
+    error: Optional[str] = None

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1513,6 +1513,47 @@ class DataSourceService:
             allowed = params
         return ClientClass(**allowed)
 
+    async def filter_user_visible_data_sources(
+        self,
+        db: AsyncSession,
+        data_sources: list,
+        current_user: User | None,
+        organization: Organization,
+    ) -> list:
+        """Keep only data sources the user is allowed to SEE.
+
+        Visibility (public OR explicit member/grant OR org-wide DS governance)
+        is distinct from usability (credentials, handled by
+        filter_user_usable_data_sources). A report's attached data sources are
+        trusted input from whoever created it, so when a *different* user reads
+        that report's context over MCP we must re-filter by their visibility —
+        otherwise a private data source's schema leaks to a non-member.
+
+        With no current_user (system/scheduled contexts) nothing is filtered.
+        """
+        if current_user is None:
+            return list(data_sources or [])
+
+        from app.core.permission_resolver import (
+            get_member_data_source_ids,
+            can_view_all_data_sources,
+        )
+
+        if await can_view_all_data_sources(
+            db, str(current_user.id), str(organization.id)
+        ):
+            return list(data_sources or [])
+
+        member_ids = set(
+            await get_member_data_source_ids(
+                db, str(current_user.id), str(organization.id)
+            )
+        )
+        return [
+            ds for ds in (data_sources or [])
+            if getattr(ds, "is_public", False) or str(ds.id) in member_ids
+        ]
+
     async def filter_user_usable_data_sources(
         self,
         db: AsyncSession,

--- a/backend/app/services/email_send_service.py
+++ b/backend/app/services/email_send_service.py
@@ -1,0 +1,350 @@
+"""Shared service for sending free-form emails with report-scoped attachments.
+
+Both the internal agent tool (``app.ai.tools.implementations.send_email``) and
+the external MCP tool (``app.ai.tools.mcp.send_email``) delegate here so the
+security-sensitive attachment-scoping logic lives in exactly one place.
+
+Attachments are generated on the fly from objects the assistant already
+produced — a visualization/query result (CSV/XLSX), an artifact (PPTX for
+slides, PDF for pages), or an uploaded file (as-is). Every reference is checked
+against the supplied report / organization, so a caller can only attach objects
+belonging to that scope; it can never exfiltrate arbitrary objects.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+from io import BytesIO
+import os
+import re
+import tempfile
+import logging
+
+from app.ai.tools.schemas.send_email import (
+    EmailAttachmentSpec,
+    SendEmailAttachmentResult,
+    SendEmailOutput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Default export format per ref_type when the caller doesn't specify one.
+_DEFAULT_FORMAT = {
+    "visualization": "csv",
+    "query": "csv",
+    "artifact": None,  # resolved from artifact.mode (slides -> pptx, page -> pdf)
+    "file": None,      # original format
+}
+
+# MIME (maintype, subtype) per export format, in the fastapi-mail dict shape.
+_MIME = {
+    "csv": ("text", "csv"),
+    "xlsx": ("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    "pptx": ("application", "vnd.openxmlformats-officedocument.presentationml.presentation"),
+    "pdf": ("application", "pdf"),
+}
+
+
+def _slugify(name: str) -> str:
+    name = (name or "attachment").strip()
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-")
+    return name or "attachment"
+
+
+def _content_disposition(filename: str) -> str:
+    """Build a Content-Disposition value that displays ``filename`` reliably.
+
+    Plain ``filename="..."`` for ASCII names; RFC 2231 ``filename*`` for names
+    with non-ASCII characters so mail clients render them correctly.
+    """
+    try:
+        filename.encode("ascii")
+        safe = filename.replace('"', "")
+        return f'attachment; filename="{safe}"'
+    except UnicodeEncodeError:
+        from urllib.parse import quote
+        return f"attachment; filename*=UTF-8''{quote(filename)}"
+
+
+def _att_dict(path: str, filename: str, maintype: str, subtype: str) -> Dict[str, Any]:
+    """Build a fastapi-mail attachment dict that sets BOTH the MIME type and the
+    displayed filename.
+
+    This fastapi-mail version reads ``mime_type``/``mime_subtype`` for the part
+    type and otherwise derives the filename from the on-disk basename — so the
+    displayed name is controlled via an explicit Content-Disposition header.
+    """
+    return {
+        "file": path,
+        "mime_type": maintype,
+        "mime_subtype": subtype,
+        "headers": {"Content-Disposition": _content_disposition(filename)},
+    }
+
+
+def _write_temp(content: bytes, suffix: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=suffix, prefix="bow_email_attach_")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(content)
+    except Exception:
+        try:
+            os.unlink(path)
+        except Exception:
+            pass
+        raise
+    return path
+
+
+class EmailSendService:
+    """Resolve report-scoped attachments and send a free-form email."""
+
+    async def send(
+        self,
+        db,
+        *,
+        recipient: str,
+        subject: str,
+        body: str,
+        body_format: str = "text",
+        attachment_specs: Optional[List[EmailAttachmentSpec]] = None,
+        report: Any = None,
+        organization: Any = None,
+    ) -> SendEmailOutput:
+        """Send an email to ``recipient`` with the given attachments.
+
+        Attachments are resolved against ``report`` / ``organization`` for
+        scoping. Attachment failures are reported per-item but never block the
+        send. Returns a :class:`SendEmailOutput`.
+        """
+        attachment_specs = attachment_specs or []
+
+        temp_paths: List[str] = []
+        attachment_dicts: List[Dict[str, Any]] = []
+        attachment_results: List[SendEmailAttachmentResult] = []
+        try:
+            for spec in attachment_specs:
+                result, att_dict, temp_path = await self.resolve_attachment(
+                    spec, db, report, organization
+                )
+                attachment_results.append(result)
+                if att_dict:
+                    attachment_dicts.append(att_dict)
+                if temp_path:
+                    temp_paths.append(temp_path)
+
+            from app.services.notification_service import notification_service
+
+            subtype = "html" if body_format == "html" else "plain"
+            send_result = await notification_service.send_custom_email(
+                recipients=[recipient],
+                subject=subject,
+                body=body,
+                subtype=subtype,
+                attachments=attachment_dicts or None,
+            )
+
+            success = send_result.status == "sent"
+            return SendEmailOutput(
+                success=success,
+                recipient=recipient,
+                subject=subject,
+                attachments=attachment_results,
+                error=None if success else (send_result.error or "Failed to send email"),
+            )
+        finally:
+            # Only remove temp files we created; never touch persistent paths
+            # (uploaded files, generated artifact PDFs in uploads/).
+            for p in temp_paths:
+                try:
+                    os.unlink(p)
+                except Exception:
+                    pass
+
+    # ---- attachment resolution ----
+
+    async def resolve_attachment(
+        self, spec: EmailAttachmentSpec, db, report: Any, organization: Any
+    ) -> Tuple[SendEmailAttachmentResult, Optional[Dict[str, Any]], Optional[str]]:
+        """Resolve a single attachment spec to a fastapi-mail attachment dict.
+
+        Returns (result, attachment_dict_or_None, temp_path_to_cleanup_or_None).
+        On any failure, result.success is False with an error and the dict is None.
+        """
+        res = SendEmailAttachmentResult(ref_type=spec.ref_type, ref_id=spec.ref_id, success=False)
+        try:
+            if spec.ref_type in ("visualization", "query"):
+                return await self._resolve_tabular(spec, db, report, organization, res)
+            if spec.ref_type == "artifact":
+                return await self._resolve_artifact(spec, db, report, res)
+            if spec.ref_type == "file":
+                return await self._resolve_file(spec, db, organization, res)
+            res.error = f"Unknown ref_type '{spec.ref_type}'"
+            return res, None, None
+        except Exception as e:
+            logger.exception("Attachment resolution failed for %s %s", spec.ref_type, spec.ref_id)
+            res.error = str(e)
+            return res, None, None
+
+    @staticmethod
+    def _scope_ids(report: Any, organization: Any) -> Tuple[Optional[str], Optional[str]]:
+        report_id = str(getattr(report, "id", "")) if report is not None else None
+        org_id = str(getattr(organization, "id", "")) if organization is not None else None
+        return report_id, org_id
+
+    async def _resolve_tabular(self, spec, db, report, organization, res):
+        """visualization_id / query_id -> CSV or XLSX of the underlying step data."""
+        from sqlalchemy import select
+        from app.models.visualization import Visualization
+        from app.models.query import Query
+        from app.models.step import Step
+        from app.services.step_service import StepService
+
+        report_id, org_id = self._scope_ids(report, organization)
+
+        query: Optional[Query] = None
+        title = None
+        if spec.ref_type == "visualization":
+            viz = await db.get(Visualization, spec.ref_id)
+            if not viz:
+                res.error = "Visualization not found"
+                return res, None, None
+            if report_id and str(viz.report_id) != report_id:
+                res.error = "Visualization does not belong to this report"
+                return res, None, None
+            title = viz.title
+            query = await db.get(Query, viz.query_id) if viz.query_id else None
+        else:  # query
+            query = await db.get(Query, spec.ref_id)
+            if not query:
+                res.error = "Query not found"
+                return res, None, None
+            # Queries may be report-scoped or global-to-org; require one to match.
+            q_report = str(query.report_id) if query.report_id else None
+            q_org = str(query.organization_id) if query.organization_id else None
+            if report_id and q_report and q_report != report_id and (not org_id or q_org != org_id):
+                res.error = "Query does not belong to this report or organization"
+                return res, None, None
+            title = query.title
+
+        if not query:
+            res.error = "No query linked to this visualization"
+            return res, None, None
+
+        # Find the step that holds the result: default step, else latest.
+        step = None
+        if query.default_step_id:
+            step = await db.get(Step, query.default_step_id)
+        if not step:
+            step = (await db.execute(
+                select(Step).where(Step.query_id == query.id).order_by(Step.created_at.desc()).limit(1)
+            )).scalar_one_or_none()
+        if not step:
+            res.error = "No executed result available to export"
+            return res, None, None
+
+        df, _ = await StepService().export_step_to_csv(db, step.id)
+        if df is None or df.empty:
+            res.error = "Result is empty — nothing to export"
+            return res, None, None
+
+        fmt = spec.format if spec.format in ("csv", "xlsx") else _DEFAULT_FORMAT[spec.ref_type]
+        base = spec.filename or _slugify(title or step.title or "export")
+        base = re.sub(r"\.(csv|xlsx)$", "", base, flags=re.IGNORECASE)
+
+        if fmt == "xlsx":
+            buf = BytesIO()
+            try:
+                df.to_excel(buf, index=False)
+            except Exception as e:
+                res.error = f"XLSX export unavailable ({e}); try format='csv'"
+                return res, None, None
+            content = buf.getvalue()
+        else:
+            fmt = "csv"
+            content = df.to_csv(index=False).encode("utf-8")
+
+        filename = f"{base}.{fmt}"
+        temp_path = _write_temp(content, suffix=f".{fmt}")
+        maintype, subtype = _MIME[fmt]
+        res.filename = filename
+        res.success = True
+        return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
+
+    async def _resolve_artifact(self, spec, db, report, res):
+        """artifact_id -> PPTX (slides) or PDF (page)."""
+        from app.models.artifact import Artifact
+
+        report_id, _ = self._scope_ids(report, None)
+
+        artifact = await db.get(Artifact, spec.ref_id)
+        if not artifact or artifact.deleted_at is not None:
+            res.error = "Artifact not found"
+            return res, None, None
+        if report_id and str(artifact.report_id) != report_id:
+            res.error = "Artifact does not belong to this report"
+            return res, None, None
+
+        mode = (artifact.mode or "page").lower()
+        default_fmt = "pptx" if mode == "slides" else "pdf"
+        fmt = spec.format if spec.format in ("pptx", "pdf") else default_fmt
+        base = spec.filename or _slugify(artifact.title or "artifact")
+        base = re.sub(r"\.(pptx|pdf)$", "", base, flags=re.IGNORECASE)
+
+        if fmt == "pptx":
+            if mode != "slides":
+                res.error = "PPTX export is only available for slides artifacts"
+                return res, None, None
+            slides = (artifact.content or {}).get("slides") or []
+            if not slides:
+                res.error = "Artifact has no slides to export"
+                return res, None, None
+            from app.services.pptx_export_service import PptxExportService
+            buf = PptxExportService().generate_pptx(slides, title=artifact.title or "Presentation")
+            content = buf.getvalue()
+            filename = f"{base}.pptx"
+            temp_path = _write_temp(content, suffix=".pptx")
+            maintype, subtype = _MIME["pptx"]
+            res.filename = filename
+            res.success = True
+            return res, _att_dict(temp_path, filename, maintype, subtype), temp_path
+
+        # pdf
+        from app.services.report_pdf_service import ReportPdfService
+        pdf_path = await ReportPdfService().generate_for_artifact(str(artifact.id))
+        if not pdf_path or not os.path.isfile(pdf_path):
+            res.error = "PDF generation failed"
+            return res, None, None
+        filename = f"{base}.pdf"
+        maintype, subtype = _MIME["pdf"]
+        res.filename = filename
+        res.success = True
+        # pdf_path is a persistent file under uploads/ — do NOT schedule it for cleanup.
+        return res, _att_dict(pdf_path, filename, maintype, subtype), None
+
+    async def _resolve_file(self, spec, db, organization, res):
+        """file_id -> attach the uploaded file as-is."""
+        from app.models.file import File
+
+        _, org_id = self._scope_ids(None, organization)
+
+        f = await db.get(File, spec.ref_id)
+        if not f:
+            res.error = "File not found"
+            return res, None, None
+        if org_id and str(f.organization_id) != org_id:
+            res.error = "File does not belong to this organization"
+            return res, None, None
+        if not f.path or not os.path.isfile(f.path):
+            res.error = "File is no longer available on disk"
+            return res, None, None
+
+        filename = spec.filename or f.filename or os.path.basename(f.path)
+        ctype = f.content_type or "application/octet-stream"
+        if "/" in ctype:
+            maintype, subtype = ctype.split("/", 1)
+        else:
+            maintype, subtype = "application", "octet-stream"
+        res.filename = filename
+        res.success = True
+        # f.path is the persistent upload — do NOT schedule it for cleanup.
+        return res, _att_dict(f.path, filename, maintype, subtype), None

--- a/backend/app/services/oauth_server_service.py
+++ b/backend/app/services/oauth_server_service.py
@@ -105,6 +105,44 @@ class OAuthServerService:
             "created_at": client.created_at.isoformat() if client.created_at else None,
         }
 
+    async def update_client(
+        self,
+        db: AsyncSession,
+        client_db_id: str,
+        organization_id: str,
+        name: Optional[str] = None,
+        redirect_uris: Optional[list[str]] = None,
+    ) -> Optional[dict]:
+        """Update an existing client's name and/or redirect URIs.
+
+        Only fields passed (non-None) are changed. Returns the updated client
+        (no secret) or None if not found in this org.
+        """
+        result = await db.execute(
+            select(OAuthClient)
+            .where(OAuthClient.id == client_db_id)
+            .where(OAuthClient.organization_id == organization_id)
+            .where(OAuthClient.deleted_at.is_(None))
+        )
+        client = result.scalar_one_or_none()
+        if not client:
+            return None
+
+        if name is not None:
+            client.name = name
+        if redirect_uris is not None:
+            client.redirect_uris = json.dumps(redirect_uris)
+        await db.commit()
+        await db.refresh(client)
+
+        return {
+            "id": client.id,
+            "client_id": client.client_id,
+            "name": client.name,
+            "redirect_uris": json.loads(client.redirect_uris),
+            "created_at": client.created_at.isoformat() if client.created_at else None,
+        }
+
     async def list_clients(
         self,
         db: AsyncSession,

--- a/backend/app/services/oauth_server_service.py
+++ b/backend/app/services/oauth_server_service.py
@@ -219,6 +219,27 @@ class OAuthServerService:
         allowed = json.loads(client.redirect_uris)
         return redirect_uri in allowed
 
+    async def user_is_member_of_org(
+        self,
+        db: AsyncSession,
+        user_id: str,
+        organization_id: str,
+    ) -> bool:
+        """True if the user belongs to the organization.
+
+        Used at consent time to ensure a user can only mint tokens for an org
+        they actually belong to — the token's org is the client's org, so this
+        is the membership gate that backs that binding.
+        """
+        from app.models.membership import Membership
+
+        result = await db.execute(
+            select(Membership)
+            .where(Membership.user_id == str(user_id))
+            .where(Membership.organization_id == str(organization_id))
+        )
+        return result.scalar_one_or_none() is not None
+
     # ── Authorization code ─────────────────────────────────────────
 
     async def create_authorization_code(

--- a/backend/tests/e2e/rbac/test_mcp_analysis.py
+++ b/backend/tests/e2e/rbac/test_mcp_analysis.py
@@ -255,3 +255,78 @@ def test_tools_list_gated_by_permission(
     assert "create_instruction" not in member_tools, (
         f"member saw privileged tools: {member_tools - admin_tools | (member_tools & {'create_instruction'})}"
     )
+
+
+# ── send_email ─────────────────────────────────────────────────────────
+
+from unittest.mock import AsyncMock, patch
+from app.schemas.notification_schema import ChannelResult
+
+
+def _tool_names(test_client, key):
+    r = _mcp(test_client, method="tools/list", api_key=key)
+    assert r.status_code == 200, r.text
+    return {t["name"] for t in r.json()["result"]["tools"]}
+
+
+@pytest.mark.e2e
+def test_send_email_hidden_when_smtp_unconfigured(mcp_org, create_api_key, test_client):
+    """With no email client configured, send_email is not advertised."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    with patch("app.settings.config.settings.email_client", None):
+        assert "send_email" not in _tool_names(test_client, key)
+
+
+@pytest.mark.e2e
+def test_send_email_listed_when_smtp_configured(mcp_org, create_api_key, test_client):
+    """When an email client is configured, send_email shows up in tools/list."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    with patch("app.settings.config.settings.email_client", object()):
+        assert "send_email" in _tool_names(test_client, key)
+
+
+@pytest.mark.e2e
+def test_send_email_sends_to_self(mcp_org, create_api_key, test_client):
+    """A plain message is sent, and the recipient is always the token user."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+
+    sent = ChannelResult(channel="email", status="sent", recipients=[admin["email"]])
+    mock_send = AsyncMock(return_value=sent)
+    with patch("app.settings.config.settings.email_client", object()), \
+         patch("app.services.notification_service.notification_service.send_custom_email", mock_send):
+        out = _tool_call(
+            test_client, name="send_email",
+            arguments={"subject": "Hi", "body": "Your summary"}, api_key=key,
+        )
+
+    assert out["success"] is True
+    assert out["recipient"] == admin["email"]
+    # Recipient is never caller-controllable — it's the token user's address.
+    assert mock_send.await_args.kwargs["recipients"] == [admin["email"]]
+
+
+@pytest.mark.e2e
+def test_send_email_attachments_require_report_id(mcp_org, create_api_key, test_client):
+    """Attachments are report-scoped: without report_id the send is refused and
+    no email goes out."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+
+    mock_send = AsyncMock(return_value=ChannelResult(channel="email", status="sent"))
+    with patch("app.settings.config.settings.email_client", object()), \
+         patch("app.services.notification_service.notification_service.send_custom_email", mock_send):
+        out = _tool_call(
+            test_client, name="send_email",
+            arguments={
+                "subject": "Hi", "body": "x",
+                "attachments": [{"ref_type": "visualization", "ref_id": "whatever"}],
+            },
+            api_key=key,
+        )
+
+    assert out["success"] is False
+    assert "report_id" in (out["error"] or "")
+    mock_send.assert_not_awaited()

--- a/backend/tests/e2e/rbac/test_mcp_analysis.py
+++ b/backend/tests/e2e/rbac/test_mcp_analysis.py
@@ -1,0 +1,257 @@
+"""Full MCP integration analysis.
+
+Exercises the MCP endpoint across the dimensions that matter for tenancy and
+access control:
+
+  * private vs public data sources surfaced by create_report / get_context
+  * API-key auth vs OAuth-token auth parity
+  * permission-gated tool visibility in tools/list
+  * tool execution (tools/call) scoping
+
+Reuses the rbac/ fixtures (bootstrap_admin, sqlite_data_source, invite_user_to_org,
+grant_resource, ...) plus the global oauth/api-key/mcp fixtures.
+"""
+
+import hashlib
+import base64
+import json
+import secrets
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+def _pkce_pair():
+    verifier = secrets.token_urlsafe(32)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _oauth_access_token(test_client, *, consent_token, client):
+    """Run consent + token exchange, return a bow_oauth_ access token."""
+    verifier, challenge = _pkce_pair()
+    redirect_uri = "https://claude.ai/api/mcp/auth_callback"
+    auth = test_client.post(
+        "/api/oauth/authorize",
+        json={
+            "client_id": client["client_id"],
+            "redirect_uri": redirect_uri,
+            "state": "s",
+            "scope": "mcp",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={"Authorization": f"Bearer {consent_token}"},
+    )
+    assert auth.status_code == 200, auth.json()
+    code = parse_qs(urlparse(auth.json()["redirect_url"]).query)["code"][0]
+    tok = test_client.post(
+        "/api/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client["client_id"],
+            "client_secret": client["client_secret"],
+            "code_verifier": verifier,
+        },
+    )
+    assert tok.status_code == 200, tok.json()
+    return tok.json()["access_token"]
+
+
+def _mcp(test_client, *, method, params=None, api_key=None, bearer=None):
+    headers = {}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    resp = test_client.post(
+        "/api/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
+        headers=headers,
+    )
+    return resp
+
+
+def _tool_call(test_client, *, name, arguments, **auth):
+    resp = _mcp(test_client, method="tools/call",
+                params={"name": name, "arguments": arguments}, **auth)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "result" in body, body
+    # tools/call wraps the tool result as text content
+    text = body["result"]["content"][0]["text"]
+    return json.loads(text)
+
+
+# ── fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mcp_org(bootstrap_admin, sqlite_data_source, invite_user_to_org):
+    """An org with a public DS, a private DS, an admin, and a plain member who
+    has NOT been granted the private DS."""
+    admin = bootstrap_admin("mcpadmin")
+    public_ds = sqlite_data_source(
+        name="Public DS", user_token=admin["token"], org_id=admin["org_id"],
+        is_public=True,
+    )
+    private_ds = sqlite_data_source(
+        name="Private DS", user_token=admin["token"], org_id=admin["org_id"],
+        is_public=False,
+    )
+    member = invite_user_to_org(
+        org_id=admin["org_id"], admin_token=admin["token"], role="member",
+    )
+    return {
+        "admin": admin,
+        "member": member,
+        "org_id": admin["org_id"],
+        "public_ds": public_ds,
+        "private_ds": private_ds,
+    }
+
+
+# ── private vs public ──────────────────────────────────────────────────
+
+@pytest.mark.e2e
+def test_create_report_hides_private_ds_from_member_via_api_key(
+    mcp_org, create_api_key, test_client,
+):
+    """A member without access to the private DS must NOT get it attached to a
+    report created over MCP (API-key auth)."""
+    member = mcp_org["member"]
+    key = create_api_key(user_token=member["token"], org_id=mcp_org["org_id"])["key"]
+
+    result = _tool_call(
+        test_client, name="create_report",
+        arguments={"title": "member session"},
+        api_key=key,
+    )
+    names = {ds["name"] for ds in result["data_sources"]}
+    assert "Public DS" in names
+    assert "Private DS" not in names, (
+        f"Private DS leaked to a non-member over MCP create_report: {names}"
+    )
+
+
+@pytest.mark.e2e
+def test_create_report_hides_private_ds_from_member_via_oauth(
+    mcp_org, create_oauth_client, test_client,
+):
+    """Same as above but over OAuth-token auth — must behave identically."""
+    admin = mcp_org["admin"]
+    member = mcp_org["member"]
+    client = create_oauth_client(
+        user_token=admin["token"], org_id=mcp_org["org_id"], name="Claude Web",
+    )
+    access = _oauth_access_token(test_client, consent_token=member["token"], client=client)
+
+    result = _tool_call(
+        test_client, name="create_report",
+        arguments={"title": "member session"},
+        bearer=access,
+    )
+    names = {ds["name"] for ds in result["data_sources"]}
+    assert "Public DS" in names
+    assert "Private DS" not in names, (
+        f"Private DS leaked to a non-member over MCP create_report (OAuth): {names}"
+    )
+
+
+@pytest.mark.e2e
+def test_get_context_refilters_shared_report_by_visibility(
+    mcp_org, create_api_key, test_client,
+):
+    """Defense-in-depth: even if a report already has a private DS attached
+    (e.g. created by the admin), a member reading that report's context must not
+    see the private DS schema."""
+    admin = mcp_org["admin"]
+    member = mcp_org["member"]
+    admin_key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    member_key = create_api_key(user_token=member["token"], org_id=mcp_org["org_id"])["key"]
+
+    # Admin creates a report — it gets both Public and Private DS attached.
+    rep = _tool_call(test_client, name="create_report",
+                     arguments={"title": "shared"}, api_key=admin_key)
+    assert {"Public DS", "Private DS"} <= {d["name"] for d in rep["data_sources"]}
+
+    # Member opens the same report's context.
+    ctx = _tool_call(test_client, name="get_context",
+                     arguments={"report_id": rep["report_id"]}, api_key=member_key)
+    names = {d["name"] for d in ctx["data_sources"]}
+    assert "Private DS" not in names, f"private DS schema leaked via shared report: {names}"
+
+
+@pytest.mark.e2e
+def test_admin_sees_private_ds(mcp_org, create_api_key, test_client):
+    """The admin (full access) should see both data sources — sanity check that
+    the hiding above is about permissions, not a broken fixture."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    result = _tool_call(
+        test_client, name="create_report",
+        arguments={"title": "admin session"}, api_key=key,
+    )
+    names = {ds["name"] for ds in result["data_sources"]}
+    assert {"Public DS", "Private DS"} <= names, names
+
+
+# ── API key vs OAuth parity ────────────────────────────────────────────
+
+@pytest.mark.e2e
+def test_api_key_and_oauth_resolve_same_context(
+    mcp_org, create_api_key, create_oauth_client, test_client,
+):
+    """For the same user, API-key and OAuth auth must surface the same data
+    sources in get_context."""
+    admin = mcp_org["admin"]
+    key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    client = create_oauth_client(
+        user_token=admin["token"], org_id=mcp_org["org_id"], name="Claude Web",
+    )
+    access = _oauth_access_token(test_client, consent_token=admin["token"], client=client)
+
+    rep_key = _tool_call(test_client, name="create_report",
+                         arguments={"title": "k"}, api_key=key)
+    ctx_key = _tool_call(test_client, name="get_context",
+                         arguments={"report_id": rep_key["report_id"]}, api_key=key)
+
+    rep_oauth = _tool_call(test_client, name="create_report",
+                           arguments={"title": "o"}, bearer=access)
+    ctx_oauth = _tool_call(test_client, name="get_context",
+                           arguments={"report_id": rep_oauth["report_id"]}, bearer=access)
+
+    assert {d["name"] for d in ctx_key["data_sources"]} == \
+           {d["name"] for d in ctx_oauth["data_sources"]}
+
+
+# ── permission-gated tool visibility ───────────────────────────────────
+
+@pytest.mark.e2e
+def test_tools_list_gated_by_permission(
+    mcp_org, create_api_key, test_client,
+):
+    """create_instruction/delete_instruction require manage_instructions, so a
+    plain member should not see them while the admin should."""
+    admin = mcp_org["admin"]
+    member = mcp_org["member"]
+    admin_key = create_api_key(user_token=admin["token"], org_id=mcp_org["org_id"])["key"]
+    member_key = create_api_key(user_token=member["token"], org_id=mcp_org["org_id"])["key"]
+
+    def tool_names(key):
+        r = _mcp(test_client, method="tools/list", api_key=key)
+        assert r.status_code == 200, r.text
+        return {t["name"] for t in r.json()["result"]["tools"]}
+
+    admin_tools = tool_names(admin_key)
+    member_tools = tool_names(member_key)
+
+    assert "create_instruction" in admin_tools
+    assert "create_instruction" not in member_tools, (
+        f"member saw privileged tools: {member_tools - admin_tools | (member_tools & {'create_instruction'})}"
+    )

--- a/backend/tests/e2e/test_oauth_mcp.py
+++ b/backend/tests/e2e/test_oauth_mcp.py
@@ -82,6 +82,57 @@ def test_create_oauth_client(
 
 
 @pytest.mark.e2e
+def test_create_oauth_client_with_custom_redirect_uris(
+    create_oauth_client,
+    list_oauth_clients,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Custom redirect_uris are stored verbatim (no defaults appended) and
+    returned on both create and list."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    custom = [
+        "https://my-app.example.com/oauth/callback",
+        "https://my-app.example.com/oauth/callback/debug",
+    ]
+    client = create_oauth_client(
+        user_token=token, org_id=org_id, name="My App", redirect_uris=custom,
+    )
+    assert client["redirect_uris"] == custom
+
+    listed = list_oauth_clients(user_token=token, org_id=org_id)
+    match = next(c for c in listed if c["client_id"] == client["client_id"])
+    assert match["redirect_uris"] == custom
+
+
+@pytest.mark.e2e
+def test_create_oauth_client_rejects_empty_redirect_uris(
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """An explicitly-provided redirect_uris list must be non-empty and contain
+    only non-blank strings."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+    for bad in ([], ["  "], [123]):
+        resp = test_client.post(
+            "/api/oauth/clients",
+            json={"name": "Bad", "redirect_uris": bad},
+            headers=headers,
+        )
+        assert resp.status_code == 400, (bad, resp.json())
+
+
+@pytest.mark.e2e
 def test_list_oauth_clients(
     create_oauth_client,
     list_oauth_clients,

--- a/backend/tests/e2e/test_oauth_mcp.py
+++ b/backend/tests/e2e/test_oauth_mcp.py
@@ -110,6 +110,76 @@ def test_create_oauth_client_with_custom_redirect_uris(
 
 
 @pytest.mark.e2e
+def test_update_oauth_client_redirect_uris(
+    create_oauth_client,
+    list_oauth_clients,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """PATCH replaces a client's redirect URIs and persists them."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    client = create_oauth_client(user_token=token, org_id=org_id, name="My App")
+    new_uris = ["https://new.example.com/oauth/callback"]
+
+    resp = test_client.patch(
+        f"/api/oauth/clients/{client['id']}",
+        json={"redirect_uris": new_uris},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["redirect_uris"] == new_uris
+
+    listed = list_oauth_clients(user_token=token, org_id=org_id)
+    match = next(c for c in listed if c["client_id"] == client["client_id"])
+    assert match["redirect_uris"] == new_uris
+
+
+@pytest.mark.e2e
+def test_update_oauth_client_validations(
+    create_oauth_client,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """PATCH rejects empty payloads / bad URIs, and 404s on unknown clients."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    client = create_oauth_client(user_token=token, org_id=org_id)
+
+    # Nothing to update
+    resp = test_client.patch(
+        f"/api/oauth/clients/{client['id']}", json={}, headers=headers,
+    )
+    assert resp.status_code == 400, resp.json()
+
+    # Bad redirect_uris
+    resp = test_client.patch(
+        f"/api/oauth/clients/{client['id']}",
+        json={"redirect_uris": []},
+        headers=headers,
+    )
+    assert resp.status_code == 400, resp.json()
+
+    # Unknown client
+    resp = test_client.patch(
+        "/api/oauth/clients/does-not-exist",
+        json={"redirect_uris": ["https://x.example.com/cb"]},
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.json()
+
+
+@pytest.mark.e2e
 def test_create_oauth_client_rejects_empty_redirect_uris(
     test_client,
     create_user,

--- a/backend/tests/e2e/test_oauth_mcp_multiorg.py
+++ b/backend/tests/e2e/test_oauth_mcp_multiorg.py
@@ -1,0 +1,171 @@
+"""Regression: OAuth token must bind to the CLIENT's org, not the browser's
+active org (X-Organization-Id) at consent time.
+
+Scenario (rare but possible): one user belongs to two orgs on the same
+deployment. They register an OAuth client under org B. But when they approve
+the consent screen, their browser's active org is A, so the consent POST
+carries X-Organization-Id: A. Before the fix, the authorization code — and
+therefore the access token — was bound to org A, even though the client
+belongs to org B, so the MCP client operated against the wrong tenant.
+"""
+
+import hashlib
+import base64
+import secrets
+
+import pytest
+
+from app.settings.config import settings as bow_settings
+
+
+@pytest.fixture
+def _allow_multiple_orgs():
+    """Allow a user to belong to more than one org, and allow extra signups —
+    needed to construct the rare multi-org / multi-user scenarios."""
+    flags = bow_settings.bow_config.features
+    saved = (flags.allow_multiple_organizations, flags.allow_uninvited_signups)
+    flags.allow_multiple_organizations = True
+    flags.allow_uninvited_signups = True
+    try:
+        yield
+    finally:
+        flags.allow_multiple_organizations, flags.allow_uninvited_signups = saved
+
+
+def _pkce_pair():
+    verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _resolve_token_org(access_token):
+    """Return the organization_id an OAuth access token resolves to."""
+    import asyncio
+    from app.settings.database import create_async_session_factory
+    from app.services.oauth_server_service import OAuthServerService
+
+    async def _run():
+        session_factory = create_async_session_factory()
+        async with session_factory() as db:
+            result = await OAuthServerService().validate_access_token(db, access_token)
+            assert result is not None, "token did not validate"
+            _, org = result
+            return str(org.id)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+def _run_flow(test_client, client, redirect_uri, consent_org_id):
+    """Consent + token exchange. Returns the access token."""
+    code_verifier, code_challenge = _pkce_pair()
+    authorize_response = test_client.post(
+        "/api/oauth/authorize",
+        json={
+            "client_id": client["client_id"],
+            "redirect_uri": redirect_uri,
+            "state": "s",
+            "scope": "mcp",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={
+            "Authorization": f"Bearer {consent_org_id['token']}",
+            "X-Organization-Id": str(consent_org_id["org_id"]),
+        },
+    )
+    assert authorize_response.status_code == 200, authorize_response.json()
+    from urllib.parse import urlparse, parse_qs
+    auth_code = parse_qs(urlparse(authorize_response.json()["redirect_url"]).query)["code"][0]
+
+    token_response = test_client.post(
+        "/api/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "redirect_uri": redirect_uri,
+            "client_id": client["client_id"],
+            "client_secret": client["client_secret"],
+            "code_verifier": code_verifier,
+        },
+    )
+    assert token_response.status_code == 200, token_response.json()
+    return token_response.json()["access_token"]
+
+
+@pytest.mark.e2e
+def test_oauth_token_binds_to_client_org_not_active_org(
+    _allow_multiple_orgs,
+    create_oauth_client,
+    create_organization,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """A token minted via org B's client must be scoped to org B, even when the
+    consent request's active org (X-Organization-Id) points at org A."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+
+    # Org A is auto-created on registration; org B is created explicitly.
+    org_a = whoami(token)["organizations"][0]["id"]
+    org_b = create_organization(name="Org B", user_token=token)
+
+    # The client is registered under org B.
+    client = create_oauth_client(user_token=token, org_id=org_b, name="MCP for B")
+    redirect_uri = "https://claude.ai/api/mcp/auth_callback"
+
+    # The user approves consent while their browser's active org is A.
+    access_token = _run_flow(
+        test_client, client, redirect_uri,
+        consent_org_id={"token": token, "org_id": org_a},
+    )
+
+    # The token was minted via org B's client, so it must be scoped to org B.
+    bound_org_id = _resolve_token_org(access_token)
+    assert bound_org_id == str(org_b), (
+        f"OAuth token minted via org B's client ({org_b}) was bound to org "
+        f"{bound_org_id}. A token's org must come from the client's org, not "
+        f"the active-org header (org_a={org_a}) sent at consent."
+    )
+
+
+@pytest.mark.e2e
+def test_oauth_consent_rejected_for_non_member(
+    _allow_multiple_orgs,
+    create_oauth_client,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """A user who is not a member of the client's org cannot mint a token for it."""
+    # Owner of org B registers the client.
+    owner = create_user(email="owner_b@test.com")
+    owner_token = login_user(owner["email"], owner["password"])
+    org_b = whoami(owner_token)["organizations"][0]["id"]
+    client = create_oauth_client(user_token=owner_token, org_id=org_b, name="MCP for B")
+
+    # An outsider (member of their own org A only) approves consent for org B's client.
+    outsider = create_user(email="outsider_a@test.com")
+    outsider_token = login_user(outsider["email"], outsider["password"])
+
+    _, code_challenge = _pkce_pair()
+    resp = test_client.post(
+        "/api/oauth/authorize",
+        json={
+            "client_id": client["client_id"],
+            "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+            "state": "s",
+            "scope": "mcp",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={"Authorization": f"Bearer {outsider_token}"},
+    )
+    assert resp.status_code == 403, resp.json()

--- a/backend/tests/fixtures/oauth_server.py
+++ b/backend/tests/fixtures/oauth_server.py
@@ -6,10 +6,13 @@ import pytest
 @pytest.fixture
 def create_oauth_client(test_client):
     """Create an OAuth MCP client for an organization."""
-    def _create_oauth_client(user_token, org_id, name="Test Claude Web"):
+    def _create_oauth_client(user_token, org_id, name="Test Claude Web", redirect_uris=None):
+        body = {"name": name}
+        if redirect_uris is not None:
+            body["redirect_uris"] = redirect_uris
         response = test_client.post(
             "/api/oauth/clients",
-            json={"name": name},
+            json=body,
             headers={
                 "Authorization": f"Bearer {user_token}",
                 "X-Organization-Id": str(org_id),

--- a/frontend/components/OAuthClientsModal.vue
+++ b/frontend/components/OAuthClientsModal.vue
@@ -81,6 +81,22 @@
               </UButton>
             </div>
           </div>
+
+          <!-- Registered redirect URIs -->
+          <div v-if="client.redirect_uris?.length" class="mt-1">
+            <details class="text-[11px] text-gray-500">
+              <summary class="cursor-pointer hover:text-gray-700">
+                {{ client.redirect_uris.length }} redirect URI{{ client.redirect_uris.length === 1 ? '' : 's' }}
+              </summary>
+              <ul class="mt-1 space-y-0.5">
+                <li
+                  v-for="uri in client.redirect_uris"
+                  :key="uri"
+                  class="font-mono break-all text-gray-600"
+                >{{ uri }}</li>
+              </ul>
+            </details>
+          </div>
         </div>
       </div>
 
@@ -108,6 +124,23 @@
             </UButton>
           </div>
         </div>
+
+        <details class="text-sm">
+          <summary class="cursor-pointer text-gray-500 hover:text-gray-700">
+            Custom redirect URIs (optional)
+          </summary>
+          <div class="mt-2">
+            <textarea
+              v-model="newRedirectUris"
+              rows="3"
+              class="w-full border rounded px-2 py-1 text-sm font-mono"
+              placeholder="https://your-app.example.com/oauth/callback"
+            />
+            <p class="text-[11px] text-gray-400 mt-1">
+              One URI per line. Leave empty to use the defaults (Claude Web and local MCP inspector).
+            </p>
+          </div>
+        </details>
       </form>
 
       <!-- Claude Web setup instructions -->
@@ -160,6 +193,7 @@ const clients = ref<OAuthClient[]>([])
 const creating = ref(false)
 const rotatingId = ref<string | null>(null)
 const newName = ref('')
+const newRedirectUris = ref('')
 const baseUrl = ref('')
 
 // Map of client_id → freshly revealed secret (shown until modal closes or user dismisses)
@@ -208,11 +242,17 @@ async function loadClients() {
 async function submit() {
   const name = newName.value.trim()
   if (!name) return
+  const redirectUris = newRedirectUris.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
   creating.value = true
   try {
+    const body: { name: string; redirect_uris?: string[] } = { name }
+    if (redirectUris.length) body.redirect_uris = redirectUris
     const res = await useMyFetch('/api/oauth/clients', {
       method: 'POST',
-      body: { name }
+      body
     })
     if (res.data.value) {
       const created = res.data.value as OAuthClient
@@ -221,6 +261,7 @@ async function submit() {
         freshSecretByClientId.value[created.client_id] = created.client_secret
       }
       newName.value = ''
+      newRedirectUris.value = ''
       toast.add({ title: 'OAuth client created', icon: 'i-heroicons-check-circle', color: 'green' })
       emit('updated')
     }

--- a/frontend/components/OAuthClientsModal.vue
+++ b/frontend/components/OAuthClientsModal.vue
@@ -48,6 +48,15 @@
                 size="xs"
                 color="gray"
                 variant="ghost"
+                @click="startEdit(client)"
+                title="Edit redirect URIs"
+              >
+                <UIcon name="heroicons-pencil-square" class="w-4 h-4" />
+              </UButton>
+              <UButton
+                size="xs"
+                color="gray"
+                variant="ghost"
                 @click="rotate(client)"
                 :loading="rotatingId === client.id"
                 title="Rotate secret"
@@ -82,8 +91,30 @@
             </div>
           </div>
 
+          <!-- Inline edit form for redirect URIs -->
+          <div v-if="editingId === client.id" class="mt-2 bg-gray-50 border border-gray-200 rounded p-2">
+            <label class="block text-[11px] text-gray-500 uppercase tracking-wide mb-1">Redirect URIs</label>
+            <textarea
+              v-model="editRedirectUris"
+              rows="3"
+              class="w-full border rounded px-2 py-1 text-sm font-mono"
+              placeholder="https://your-app.example.com/oauth/callback"
+            />
+            <p class="text-[11px] text-gray-400 mt-1">One URI per line.</p>
+            <div class="flex justify-end gap-2 mt-2">
+              <UButton size="xs" color="gray" variant="ghost" @click="cancelEdit">Cancel</UButton>
+              <UButton
+                size="xs"
+                color="blue"
+                :loading="savingId === client.id"
+                :disabled="!editRedirectUrisList.length"
+                @click="saveEdit(client)"
+              >Save</UButton>
+            </div>
+          </div>
+
           <!-- Registered redirect URIs -->
-          <div v-if="client.redirect_uris?.length" class="mt-1">
+          <div v-else-if="client.redirect_uris?.length" class="mt-1">
             <details class="text-[11px] text-gray-500">
               <summary class="cursor-pointer hover:text-gray-700">
                 {{ client.redirect_uris.length }} redirect URI{{ client.redirect_uris.length === 1 ? '' : 's' }}
@@ -192,9 +223,16 @@ const loading = ref(true)
 const clients = ref<OAuthClient[]>([])
 const creating = ref(false)
 const rotatingId = ref<string | null>(null)
+const editingId = ref<string | null>(null)
+const editRedirectUris = ref('')
+const savingId = ref<string | null>(null)
 const newName = ref('')
 const newRedirectUris = ref('')
 const baseUrl = ref('')
+
+const editRedirectUrisList = computed(() =>
+  editRedirectUris.value.split('\n').map(s => s.trim()).filter(Boolean)
+)
 
 // Map of client_id → freshly revealed secret (shown until modal closes or user dismisses)
 const freshSecretByClientId = ref<Record<string, string>>({})
@@ -269,6 +307,40 @@ async function submit() {
     toast.add({ title: 'Failed to create client', icon: 'i-heroicons-x-circle', color: 'red' })
   } finally {
     creating.value = false
+  }
+}
+
+function startEdit(client: OAuthClient) {
+  editingId.value = client.id
+  editRedirectUris.value = (client.redirect_uris || []).join('\n')
+}
+
+function cancelEdit() {
+  editingId.value = null
+  editRedirectUris.value = ''
+}
+
+async function saveEdit(client: OAuthClient) {
+  const uris = editRedirectUrisList.value
+  if (!uris.length) return
+  savingId.value = client.id
+  try {
+    const res = await useMyFetch(`/api/oauth/clients/${client.id}`, {
+      method: 'PATCH',
+      body: { redirect_uris: uris }
+    })
+    if (res.data.value) {
+      const updated = res.data.value as OAuthClient
+      const idx = clients.value.findIndex(c => c.id === client.id)
+      if (idx !== -1) clients.value[idx].redirect_uris = updated.redirect_uris
+      cancelEdit()
+      toast.add({ title: 'Redirect URIs updated', icon: 'i-heroicons-check-circle', color: 'green' })
+      emit('updated')
+    }
+  } catch (e) {
+    toast.add({ title: 'Failed to update redirect URIs', icon: 'i-heroicons-x-circle', color: 'red' })
+  } finally {
+    savingId.value = null
   }
 }
 


### PR DESCRIPTION
The consent endpoint bound the authorization code (and resulting access
token) to the caller's active-org header (X-Organization-Id) instead of
the OAuth client's own organization. On multi-org deployments a user
active in org A could approve a client registered under org B and receive
a token scoped to org A, so the MCP client operated against the wrong
tenant.

Bind the token to the client's organization_id and require the consenting
user to be a member of that org (403 otherwise). Adds e2e regression
coverage for both the binding and the membership gate.

https://claude.ai/code/session_01WMvKNPxgrrDmmDak4zEd6S