### PR TITLE
Surface MCP tool input schemas so the agent stops guessing arguments

### DIFF
--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -232,6 +232,16 @@ def _digest_execute_mcp(tool_execution) -> str:
     if failed:
         err = obs.get('error_message') or rj.get('error_message') or obs.get('summary') or 'unknown error'
         digest_parts.append(f"FAILED: {str(err)[:300]}")
+        # Surface the tool's valid argument names so a later turn corrects the
+        # call instead of re-guessing (execute_mcp attaches input_schema on
+        # failure).
+        schema = obs.get('input_schema') or rj.get('input_schema')
+        if isinstance(schema, dict):
+            props = schema.get('properties') or {}
+            if props:
+                required = set(schema.get('required') or [])
+                arg_list = ", ".join(f"{n}*" if n in required else n for n in props.keys())
+                digest_parts.append(f"valid args: {{{arg_list}}}")
         return "; ".join(digest_parts)
 
     summary = obs.get('summary') or ''

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -165,6 +165,14 @@ class TablesSchemaContext(ContextSection):
                 if conn_id != 'default':
                     conn_attrs["id"] = conn_id
                 conn_parts.append(xml_tag("connection", "\n".join(tool_xmls), conn_attrs))
+            # Only tool names + descriptions are listed above — not argument
+            # schemas. Tell the agent to fetch the exact schema before calling,
+            # so it doesn't guess argument names and burn turns on failed calls.
+            conn_parts.append(
+                "<note>Only tool names and descriptions are shown above, not their argument schemas. "
+                "Call search_mcps to get a tool's full input schema (exact argument names and types) "
+                "before calling execute_mcp — do not guess arguments.</note>"
+            )
             return xml_tag("mcp_tools", "\n".join(conn_parts))
 
         def render(self) -> str:

--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -150,6 +150,11 @@ Do not use when:
             )
         )
         tool_record = tool_result.scalar_one_or_none()
+        # Capture the tool's declared input schema up front so that, on any
+        # downstream failure, we can hand the agent the *correct* argument shape
+        # in the observation. Without this the agent only learns what was wrong
+        # (e.g. "invalid search field") and keeps re-guessing argument names.
+        tool_input_schema = getattr(tool_record, "input_schema", None) if tool_record else None
         if tool_record and not tool_record.is_enabled:
             yield ToolEndEvent(
                 type="tool.end",
@@ -180,20 +185,14 @@ Do not use when:
             logger.error(f"execute_mcp: Tool call failed: {e}", exc_info=True)
             yield ToolEndEvent(
                 type="tool.end",
-                payload={
-                    "output": {"success": False, "error_message": str(e)},
-                    "observation": {"summary": f"Tool call failed: {e}", "success": False},
-                },
+                payload=self._failure_payload(data.tool_name, str(e), tool_input_schema),
             )
             return
 
         if not result.get("success"):
             yield ToolEndEvent(
                 type="tool.end",
-                payload={
-                    "output": {"success": False, "error_message": result.get("error", "Unknown error")},
-                    "observation": {"summary": f"Tool returned error: {result.get('error')}", "success": False},
-                },
+                payload=self._failure_payload(data.tool_name, result.get("error", "Unknown error"), tool_input_schema),
             )
             return
 
@@ -293,6 +292,33 @@ Do not use when:
                 },
             },
         )
+
+    @staticmethod
+    def _failure_payload(tool_name: str, error: str, input_schema: Any) -> Dict[str, Any]:
+        """Build a tool.end payload for a failed MCP call that includes the
+        tool's declared input schema.
+
+        The schema is carried as a structured field on both the output and the
+        observation (so it survives planner past-observation compaction) and is
+        summarized in prose so the agent sees, in one round-trip, exactly which
+        arguments the tool accepts instead of re-guessing.
+        """
+        err = error or "Unknown error"
+        summary = f"Tool '{tool_name}' failed: {err}"
+        if input_schema:
+            props = (input_schema.get("properties") or {}) if isinstance(input_schema, dict) else {}
+            required = input_schema.get("required") or [] if isinstance(input_schema, dict) else []
+            if props:
+                def _fmt(name: str) -> str:
+                    spec = props.get(name) or {}
+                    typ = spec.get("type") or "any"
+                    return f"{name}*:{typ}" if name in required else f"{name}:{typ}"
+                arg_list = ", ".join(_fmt(n) for n in props.keys())
+                summary += f". Valid arguments for '{tool_name}': {{{arg_list}}} (* = required). Retry with these argument names."
+        return {
+            "output": {"success": False, "error_message": err, "input_schema": input_schema},
+            "observation": {"summary": summary, "success": False, "input_schema": input_schema},
+        }
 
     async def _materialize_to_csv(self, data: list, tool_name: str, runtime_ctx: dict):
         """Save tabular data as a CSV file, create a File record, and link to report."""

--- a/backend/app/ai/tools/implementations/search_mcps.py
+++ b/backend/app/ai/tools/implementations/search_mcps.py
@@ -19,9 +19,14 @@ class SearchMCPsTool(Tool):
 Search for available MCP and custom API tools connected to the current data sources.
 Returns full tool descriptions and input schemas so you can understand how to call them.
 
+IMPORTANT: Call this BEFORE execute_mcp to get a tool's exact input schema (the precise
+argument names and types). The <mcp_tools> context lists only tool names and descriptions,
+not their argument schemas — do not guess argument names. Calling a tool with the wrong
+argument shape wastes a turn; fetch the schema here first.
+
 Use when:
     - You need to discover what external tools are available (Notion, Jira, Datadog, etc.)
-    - You need the full input schema for a tool before calling execute_mcp
+    - You need the full input schema for a tool before calling execute_mcp (do this first)
     - You want to understand what capabilities are available beyond SQL queries
             """,
             category="research",


### PR DESCRIPTION
## Problem

When the agent uses external MCP tools (e.g. Intercom), it would loop on failing calls — retrying `search_contacts`, `search`, `get_company` with slightly different **guessed** argument shapes (`custom_attributes.company_id` flat key, `object_type`, `company_id`, `per_page`…) and never converge. It looked like it "wasn't learning" from the errors.

Root cause: the agent never had the tools' **argument schemas**. The `<mcp_tools>` context block lists only tool *name + description*, and the agent rarely calls `search_mcps` (0 calls in repro). The error feedback told it *what was wrong* ("invalid search field") but not the *valid schema*, so it re-guessed and looped. The schemas were already discovered and stored on `ConnectionTool.input_schema` (and returned by `search_mcps`) — they just never reached the planner.

## Changes

1. **`execute_mcp` — schema-on-failure (the deterministic fix).** On any tool failure, attach the tool's `input_schema` to both the `output` and the `observation`, and summarize valid args in prose:
   > Tool 'search_contacts' failed: …. **Valid arguments for 'search_contacts': {name:string, email:string, custom_attributes:object, per_page\*:integer}** (\* = required). Retry with these argument names.

   The agent gets the correct shape in one round-trip instead of re-guessing. Structured field survives planner `past_observations` compaction. (`_failure_payload` helper dedupes the two failure branches.)
2. **`search_mcps` description** — now tells the planner to call it **before** `execute_mcp` to fetch exact argument names, and notes that `<mcp_tools>` lists only names/descriptions.
3. **`<mcp_tools>` context `<note>`** — instructs the agent to call `search_mcps` for a tool's full schema before calling it.
4. **Cross-turn digest** (`message_context_builder`) — surfaces the valid args on failed `execute_mcp` so later turns carry the schema too.

## Verification (live: Intercom MCP + Haiku)

- **Before:** 0 `search_mcps` calls; blind flat-key guesses → loop.
- **After:** the agent calls `search_mcps` to discover schemas, then issues **well-formed** calls — `get_company{id}`, `search_contacts{custom_attributes:{…}}` (correct nested object, not the old flat key), `search{query}`. Failed observations now carry `input_schema` + the "Valid arguments" summary (confirmed in DB and in the live planner prompt).
- Remaining errors in the manual test are pure data (the test company id is a BoW org UUID, genuinely not an Intercom entity) — the calls themselves are now correctly shaped.
- **MCP e2e suite: 31 passed.**

Builds on the already-merged error-reporting/status/reflection/UI fixes (`362c53f`).

https://claude.ai/code/session_01N9To7HXaFpNgA4AFAAm6WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9To7HXaFpNgA4AFAAm6WR)_