### PR TITLE
Make dropdown panels flexible width to accommodate long content

### DIFF
--- a/frontend/components/AgentFlyout.vue
+++ b/frontend/components/AgentFlyout.vue
@@ -16,7 +16,7 @@
         @mouseenter="$emit('mouseenter')"
         @mouseleave="$emit('mouseleave')"
       >
-        <div class="w-[400px] bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden">
+        <div class="w-max min-w-[400px] max-w-[520px] bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden">
           <!-- Header with connection info -->
           <div class="px-4 py-3 border-b border-gray-100">
             <!-- Title row -->

--- a/frontend/components/AgentSelector.vue
+++ b/frontend/components/AgentSelector.vue
@@ -68,7 +68,7 @@
       <template #panel>
         <div class="overflow-visible">
           <!-- Agent list -->
-          <div class="w-56 bg-white rounded-xl shadow-xl border border-gray-200 overflow-hidden">
+          <div class="w-max min-w-[14rem] max-w-[24rem] bg-white rounded-xl shadow-xl border border-gray-200 overflow-hidden">
             <div class="p-1.5">
               <div v-if="loading" class="flex items-center justify-center py-6">
                 <Spinner class="w-5 h-5 text-gray-400 animate-spin" />

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -232,7 +232,9 @@ const showFlyoutAtEvent = (evt: MouseEvent) => {
     const panelRect = panel?.getBoundingClientRect()
     const rect = el.getBoundingClientRect()
 
-    const flyoutWidth = 400
+    // Matches AgentFlyout's max width (it grows to fit long names) so a
+    // left-placed flyout reserves enough room and never overlaps the dropdown.
+    const flyoutWidth = 520
     const gap = 8
 
     // Position to the right of the dropdown panel

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -39,7 +39,7 @@
                 </button>
             </UTooltip>
             <template #panel>
-                <div class="p-2 text-xs max-h-64 overflow-y-auto w-[260px] rounded-xl">
+                <div class="p-2 text-xs max-h-64 overflow-y-auto w-max min-w-[260px] max-w-[420px] rounded-xl">
                     <div v-if="isLoading" class="flex items-center justify-center py-6 text-gray-500 space-x-2">
                         <Spinner class="w-4 h-4 text-gray-400 animate-spin" />
                         <span>Loading data sources…</span>


### PR DESCRIPTION
## Summary
Updated dropdown panels in DataSourceSelector, AgentFlyout, and AgentSelector components to use flexible widths that grow to fit content while maintaining maximum width constraints. This prevents text truncation and ensures consistent spacing between related UI elements.

## Key Changes
- **DataSourceSelector**: Changed panel from fixed `w-[260px]` to `w-max min-w-[260px] max-w-[420px]` to allow expansion for longer data source names
- **AgentFlyout**: Updated from fixed `w-[400px]` to `w-max min-w-[400px] max-w-[520px]` to accommodate longer agent names and descriptions
- **AgentSelector**: Changed from fixed `w-56` to `w-max min-w-[14rem] max-w-[24rem]` for flexible agent list width
- **DataSourceSelector flyout positioning**: Increased `flyoutWidth` constant from `400` to `520` to match AgentFlyout's maximum width, ensuring proper spacing and preventing overlap when the flyout is positioned to the left of the dropdown

## Implementation Details
The width adjustments use Tailwind's `w-max` with `min-w` and `max-w` constraints to create responsive containers that:
- Grow naturally to fit content (`w-max`)
- Maintain minimum widths for visual consistency
- Respect maximum widths to prevent excessive expansion
- Align flyout positioning logic with actual component dimensions to prevent overlapping UI elements

https://claude.ai/code/session_018CRakXLv87GXxw8r2gYQBF