### PR TITLE
feat(agents): allow setting an existing instruction as primary

### DIFF
--- a/frontend/components/instructions/PrimaryInstructionMenu.vue
+++ b/frontend/components/instructions/PrimaryInstructionMenu.vue
@@ -1,0 +1,186 @@
+<template>
+    <div class="relative inline-block" ref="rootRef">
+        <!-- Trigger: three-dots (kebab) -->
+        <button
+            type="button"
+            @click.stop="toggle"
+            class="flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+            :class="{ 'bg-gray-100 text-gray-700': open }"
+            aria-label="Primary instruction actions"
+        >
+            <UIcon name="heroicons-ellipsis-horizontal" class="w-4 h-4" />
+        </button>
+
+        <!-- Panel -->
+        <div
+            v-if="open"
+            class="absolute z-30 mt-1 end-0 w-72 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
+        >
+            <!-- Default action list -->
+            <div v-if="view === 'menu'" class="py-1">
+                <button type="button" @click.stop="onEdit" class="menu-item">
+                    <UIcon name="heroicons-pencil-square" class="w-4 h-4 text-gray-400" />
+                    <span>Edit instruction</span>
+                </button>
+                <button type="button" @click.stop="openReplace" class="menu-item">
+                    <UIcon name="heroicons-arrow-path-rounded-square" class="w-4 h-4 text-gray-400" />
+                    <span>Replace with existing…</span>
+                </button>
+
+                <template v-if="canTrain">
+                    <div class="my-1 border-t border-gray-100"></div>
+                    <button type="button" @click.stop="onStartTraining" class="menu-item">
+                        <UIcon name="heroicons-academic-cap" class="w-4 h-4 text-sky-500" />
+                        <span>Start a training session</span>
+                    </button>
+                    <div class="px-3 pb-1.5 pt-0.5 text-[10px] leading-tight text-gray-400">
+                        Opens a new report in training mode to refine this agent's instructions.
+                    </div>
+                </template>
+            </div>
+
+            <!-- Replace view: searchable existing instructions -->
+            <div v-else-if="view === 'replace'">
+                <div class="flex items-center gap-1.5 p-2 border-b border-gray-100">
+                    <button type="button" @click.stop="view = 'menu'" class="p-0.5 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-700">
+                        <UIcon name="heroicons-chevron-left" class="w-4 h-4" />
+                    </button>
+                    <div class="relative flex-1">
+                        <UIcon name="heroicons-magnifying-glass" class="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+                        <input
+                            ref="searchRef"
+                            v-model="search"
+                            type="text"
+                            placeholder="Search instructions…"
+                            class="w-full h-8 ps-7 pe-2 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            @input="onSearchInput"
+                            @click.stop
+                        />
+                    </div>
+                </div>
+
+                <div class="max-h-64 overflow-y-auto py-1">
+                    <div v-if="loading" class="px-3 py-4 text-center text-xs text-gray-400">Loading…</div>
+                    <div v-else-if="items.length === 0" class="px-3 py-4 text-center text-xs text-gray-400">No instructions found</div>
+                    <button
+                        v-for="inst in items"
+                        :key="inst.id"
+                        type="button"
+                        :disabled="inst.id === currentInstructionId"
+                        @click.stop="select(inst)"
+                        class="w-full text-start px-3 py-2 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        :class="inst.id === currentInstructionId ? 'bg-blue-50/50' : ''"
+                    >
+                        <div class="flex items-center gap-1.5">
+                            <span class="text-xs font-medium text-gray-800 truncate">{{ inst.title || 'Untitled instruction' }}</span>
+                            <span v-if="inst.id === currentInstructionId" class="text-[9px] px-1 py-0.5 bg-blue-100 text-blue-700 rounded shrink-0">Current</span>
+                        </div>
+                        <div class="text-[11px] text-gray-500 line-clamp-2 mt-0.5">{{ inst.text }}</div>
+                    </button>
+                </div>
+
+                <div class="px-3 py-2 border-t border-gray-100 text-[10px] text-gray-400">
+                    The previous primary stays in your library — it's only unlinked.
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+
+const props = withDefaults(defineProps<{
+    agentId: string
+    currentInstructionId?: string | null
+    canTrain?: boolean
+}>(), {
+    currentInstructionId: null,
+    canTrain: false,
+})
+
+const emit = defineEmits<{
+    (e: 'edit'): void
+    (e: 'select', instruction: any): void
+    (e: 'start-training'): void
+}>()
+
+const rootRef = ref<HTMLElement | null>(null)
+const searchRef = ref<HTMLInputElement | null>(null)
+const open = ref(false)
+const view = ref<'menu' | 'replace'>('menu')
+const loading = ref(false)
+const items = ref<any[]>([])
+const search = ref('')
+
+function toggle() {
+    open.value = !open.value
+    if (open.value) view.value = 'menu'
+}
+
+function close() {
+    open.value = false
+}
+
+function onEdit() {
+    close()
+    emit('edit')
+}
+
+function onStartTraining() {
+    close()
+    emit('start-training')
+}
+
+async function openReplace() {
+    view.value = 'replace'
+    await fetchInstructions()
+    await nextTick()
+    searchRef.value?.focus()
+}
+
+async function fetchInstructions() {
+    loading.value = true
+    try {
+        const query: Record<string, any> = {
+            skip: 0,
+            limit: 50,
+            status: 'published',
+            data_source_ids: props.agentId,
+            include_global: true,
+        }
+        if (search.value.trim()) query.search = search.value.trim()
+        const { data, error } = await useMyFetch<any>('/instructions', { method: 'GET', query })
+        if (error?.value) throw new Error(String(error.value))
+        items.value = (data.value as any)?.items || []
+    } catch (e) {
+        items.value = []
+    } finally {
+        loading.value = false
+    }
+}
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+function onSearchInput() {
+    if (searchTimeout) clearTimeout(searchTimeout)
+    searchTimeout = setTimeout(fetchInstructions, 250)
+}
+
+function select(inst: any) {
+    if (inst.id === props.currentInstructionId) return
+    close()
+    emit('select', inst)
+}
+
+function onOutsideClick(e: MouseEvent) {
+    if (rootRef.value && !rootRef.value.contains(e.target as Node)) close()
+}
+onMounted(() => document.addEventListener('click', onOutsideClick))
+onUnmounted(() => document.removeEventListener('click', onOutsideClick))
+</script>
+
+<style scoped>
+.menu-item {
+    @apply w-full flex items-center gap-2.5 px-3 py-2 text-xs text-gray-700 hover:bg-gray-50 transition-colors text-start;
+}
+</style>

--- a/frontend/components/instructions/PrimaryInstructionPicker.vue
+++ b/frontend/components/instructions/PrimaryInstructionPicker.vue
@@ -1,0 +1,143 @@
+<template>
+    <div class="relative inline-block" ref="rootRef">
+        <button
+            type="button"
+            @click.stop="toggle"
+            class="text-[10px] text-blue-600 hover:underline"
+        >
+            {{ label }}
+        </button>
+
+        <!-- Dropdown panel -->
+        <div
+            v-if="open"
+            class="absolute z-30 mt-1 start-0 w-80 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
+        >
+            <!-- Search -->
+            <div class="p-2 border-b border-gray-100">
+                <div class="relative">
+                    <UIcon name="heroicons-magnifying-glass" class="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+                    <input
+                        ref="searchRef"
+                        v-model="search"
+                        type="text"
+                        placeholder="Search instructions…"
+                        class="w-full h-8 ps-7 pe-2 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-200"
+                        @input="onSearchInput"
+                        @click.stop
+                    />
+                </div>
+            </div>
+
+            <!-- List -->
+            <div class="max-h-72 overflow-y-auto py-1">
+                <div v-if="loading" class="px-3 py-4 text-center text-xs text-gray-400">
+                    Loading…
+                </div>
+                <div v-else-if="items.length === 0" class="px-3 py-4 text-center text-xs text-gray-400">
+                    No instructions found
+                </div>
+                <button
+                    v-for="inst in items"
+                    :key="inst.id"
+                    type="button"
+                    :disabled="inst.id === currentInstructionId"
+                    @click.stop="select(inst)"
+                    class="w-full text-start px-3 py-2 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    :class="inst.id === currentInstructionId ? 'bg-blue-50/50' : ''"
+                >
+                    <div class="flex items-center gap-1.5">
+                        <span class="text-xs font-medium text-gray-800 truncate">
+                            {{ inst.title || 'Untitled instruction' }}
+                        </span>
+                        <span v-if="inst.id === currentInstructionId" class="text-[9px] px-1 py-0.5 bg-blue-100 text-blue-700 rounded shrink-0">
+                            Current
+                        </span>
+                    </div>
+                    <div class="text-[11px] text-gray-500 line-clamp-2 mt-0.5">
+                        {{ inst.text }}
+                    </div>
+                </button>
+            </div>
+
+            <!-- Footer hint -->
+            <div class="px-3 py-2 border-t border-gray-100 text-[10px] text-gray-400">
+                The previous primary stays in your library — it's only unlinked.
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+
+const props = withDefaults(defineProps<{
+    agentId: string
+    currentInstructionId?: string | null
+    label?: string
+}>(), {
+    label: 'Replace',
+    currentInstructionId: null,
+})
+
+const emit = defineEmits<{
+    (e: 'select', instruction: any): void
+}>()
+
+const rootRef = ref<HTMLElement | null>(null)
+const searchRef = ref<HTMLInputElement | null>(null)
+const open = ref(false)
+const loading = ref(false)
+const items = ref<any[]>([])
+const search = ref('')
+
+async function fetchInstructions() {
+    loading.value = true
+    try {
+        const query: Record<string, any> = {
+            skip: 0,
+            limit: 50,
+            status: 'published',
+            data_source_ids: props.agentId,
+            include_global: true,
+        }
+        if (search.value.trim()) query.search = search.value.trim()
+        const { data, error } = await useMyFetch<any>('/instructions', { method: 'GET', query })
+        if (error?.value) throw new Error(String(error.value))
+        items.value = (data.value as any)?.items || []
+    } catch (e) {
+        items.value = []
+    } finally {
+        loading.value = false
+    }
+}
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+function onSearchInput() {
+    if (searchTimeout) clearTimeout(searchTimeout)
+    searchTimeout = setTimeout(fetchInstructions, 250)
+}
+
+async function toggle() {
+    open.value = !open.value
+    if (open.value) {
+        await fetchInstructions()
+        await nextTick()
+        searchRef.value?.focus()
+    }
+}
+
+function select(inst: any) {
+    if (inst.id === props.currentInstructionId) return
+    open.value = false
+    emit('select', inst)
+}
+
+function onOutsideClick(e: MouseEvent) {
+    if (rootRef.value && !rootRef.value.contains(e.target as Node)) {
+        open.value = false
+    }
+}
+onMounted(() => document.addEventListener('click', onOutsideClick))
+onUnmounted(() => document.removeEventListener('click', onOutsideClick))
+</script>

--- a/frontend/pages/agents/[id]/index.vue
+++ b/frontend/pages/agents/[id]/index.vue
@@ -67,18 +67,17 @@
 
                     <!-- Existing instruction: simple read-only view -->
                     <template v-else-if="dataSource?.primary_instruction">
-                        <div class="flex items-center gap-2 mb-2">
+                        <div class="flex items-center justify-between gap-2 mb-2">
                             <span class="text-sm font-medium text-gray-800">{{ dataSource.primary_instruction.title || 'Primary instruction' }}</span>
-                            <div v-if="useCan('update_data_source')" class="flex items-center gap-2">
-                                <button @click="editingInstruction = true" class="text-[10px] text-blue-600 hover:underline">Edit</button>
-                                <span class="text-gray-300 text-[10px]">·</span>
-                                <PrimaryInstructionPicker
-                                    :agent-id="(route.params.id as string)"
-                                    :current-instruction-id="dataSource.primary_instruction.id"
-                                    label="Replace"
-                                    @select="onSelectExistingInstruction"
-                                />
-                            </div>
+                            <PrimaryInstructionMenu
+                                v-if="useCan('update_data_source')"
+                                :agent-id="(route.params.id as string)"
+                                :current-instruction-id="dataSource.primary_instruction.id"
+                                :can-train="canStartTraining"
+                                @edit="editingInstruction = true"
+                                @select="onSelectExistingInstruction"
+                                @start-training="startTrainingSession"
+                            />
                         </div>
                         <InstructionText
                             :text="dataSource.primary_instruction.text"
@@ -111,6 +110,12 @@
                                 label="select existing"
                                 @select="onSelectExistingInstruction"
                             />
+                        </div>
+                        <div v-if="useCan('update_data_source') && canStartTraining" class="mt-3">
+                            <button @click="startTrainingSession" class="text-xs text-sky-600 hover:underline inline-flex items-center gap-1">
+                                <UIcon name="heroicons-academic-cap" class="w-3.5 h-3.5" />
+                                Start a training session
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -179,13 +184,20 @@ import { isIndexingActive, indexingSummary } from '~/composables/useConnectionSt
 import InstructionGlobalCreateComponent from '~/components/InstructionGlobalCreateComponent.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
 import PrimaryInstructionPicker from '~/components/instructions/PrimaryInstructionPicker.vue'
+import PrimaryInstructionMenu from '~/components/instructions/PrimaryInstructionMenu.vue'
+import { useOrgSettings } from '~/composables/useOrgSettings'
 import type { Ref } from 'vue'
 
 definePageMeta({ auth: true, layout: 'data' })
 
 const { t } = useI18n()
 const route = useRoute()
+const router = useRouter()
 const toast = useToast?.()
+
+// Training mode is gated by org setting + permission (mirrors the prompt box).
+const { isTrainingModeEnabled } = useOrgSettings()
+const canStartTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
 
 // Inject integration data from layout (avoid duplicate API calls)
 const injectedIntegration = inject<Ref<any>>('integration', ref(null))
@@ -232,6 +244,31 @@ async function onPrimaryInstructionCreated(saved: any) {
 async function onPrimaryInstructionSaved(_saved: any) {
     editingInstruction.value = false
     await injectedFetchIntegration()
+}
+
+async function startTrainingSession() {
+    const agentId = route.params.id as string
+    // Partial prompt the admin completes — pre-filled, not auto-submitted.
+    const prompt = 'I need to update the instruction for this agent with '
+    try {
+        // 1. New report scoped to this agent.
+        const { data, error } = await useMyFetch<any>('/reports', {
+            method: 'POST',
+            body: { title: 'Training session', data_sources: [agentId] },
+        })
+        const reportId = (data?.value as any)?.id
+        if (error?.value || !reportId) throw new Error(error?.value ? String(error.value) : 'Failed to create report')
+        // 2. Put it in training mode.
+        const { error: modeErr } = await useMyFetch(`/reports/${reportId}`, {
+            method: 'PUT',
+            body: { mode: 'training' },
+        })
+        if (modeErr?.value) throw new Error(String(modeErr.value))
+        // 3. Land on the report with the prompt pre-filled (non-submitting).
+        router.push({ path: `/reports/${reportId}`, query: { prompt } })
+    } catch (e: any) {
+        toast?.add?.({ title: 'Error', description: String(e?.message || e), color: 'red' })
+    }
 }
 
 async function onSelectExistingInstruction(instruction: any) {

--- a/frontend/pages/agents/[id]/index.vue
+++ b/frontend/pages/agents/[id]/index.vue
@@ -69,7 +69,16 @@
                     <template v-else-if="dataSource?.primary_instruction">
                         <div class="flex items-center gap-2 mb-2">
                             <span class="text-sm font-medium text-gray-800">{{ dataSource.primary_instruction.title || 'Primary instruction' }}</span>
-                            <button v-if="useCan('update_data_source')" @click="editingInstruction = true" class="text-[10px] text-blue-600 hover:underline">Edit</button>
+                            <div v-if="useCan('update_data_source')" class="flex items-center gap-2">
+                                <button @click="editingInstruction = true" class="text-[10px] text-blue-600 hover:underline">Edit</button>
+                                <span class="text-gray-300 text-[10px]">·</span>
+                                <PrimaryInstructionPicker
+                                    :agent-id="(route.params.id as string)"
+                                    :current-instruction-id="dataSource.primary_instruction.id"
+                                    label="Replace"
+                                    @select="onSelectExistingInstruction"
+                                />
+                            </div>
                         </div>
                         <InstructionText
                             :text="dataSource.primary_instruction.text"
@@ -88,14 +97,21 @@
                         <div class="text-xs text-gray-500 mt-1 max-w-md mx-auto">
                             Give this agent a guiding instruction it applies to every report — context about the data, conventions to follow, or rules to enforce.
                         </div>
-                        <button
-                            v-if="useCan('update_data_source')"
-                            @click="creatingInstruction = true"
-                            class="mt-4 inline-flex items-center gap-1.5 text-xs px-3 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-                        >
-                            <UIcon name="heroicons-plus" class="w-3.5 h-3.5" />
-                            Add Primary Instruction
-                        </button>
+                        <div v-if="useCan('update_data_source')" class="mt-4 flex items-center justify-center gap-3">
+                            <button
+                                @click="creatingInstruction = true"
+                                class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                            >
+                                <UIcon name="heroicons-plus" class="w-3.5 h-3.5" />
+                                Add Primary Instruction
+                            </button>
+                            <span class="text-xs text-gray-400">or</span>
+                            <PrimaryInstructionPicker
+                                :agent-id="(route.params.id as string)"
+                                label="select existing"
+                                @select="onSelectExistingInstruction"
+                            />
+                        </div>
                     </div>
                 </div>
 
@@ -162,6 +178,7 @@ import { useCan } from '~/composables/usePermissions'
 import { isIndexingActive, indexingSummary } from '~/composables/useConnectionStatus'
 import InstructionGlobalCreateComponent from '~/components/InstructionGlobalCreateComponent.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
+import PrimaryInstructionPicker from '~/components/instructions/PrimaryInstructionPicker.vue'
 import type { Ref } from 'vue'
 
 definePageMeta({ auth: true, layout: 'data' })
@@ -215,6 +232,25 @@ async function onPrimaryInstructionCreated(saved: any) {
 async function onPrimaryInstructionSaved(_saved: any) {
     editingInstruction.value = false
     await injectedFetchIntegration()
+}
+
+async function onSelectExistingInstruction(instruction: any) {
+    const id = route.params.id as string
+    const newId = instruction?.id
+    if (!newId) return
+    try {
+        const { error } = await useMyFetch(`/data_sources/${id}`, {
+            method: 'PUT',
+            body: { primary_instruction_id: newId },
+        })
+        if (error?.value) throw new Error(String(error.value))
+        editingInstruction.value = false
+        creatingInstruction.value = false
+        await injectedFetchIntegration()
+        toast?.add?.({ title: 'Saved', description: 'Primary instruction updated.' })
+    } catch (e: any) {
+        toast?.add?.({ title: 'Error', description: String(e?.message || e), color: 'red' })
+    }
 }
 
 const indexingConnections = computed(() =>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -523,6 +523,7 @@
 					:report_id="report_id"
 					:initialSelectedDataSources="report?.data_sources || []"
 					:initialMode="report?.mode || 'chat'"
+					:textareaContent="prefillText"
 					:latestInProgressCompletion="isCompletionInProgress ? {} : undefined"
 					:isStopping="false"
 					:queryList="queryList"
@@ -1383,6 +1384,8 @@ const initialPanelWidth = ref(0)
 
 // Live prompt mode (mirrors PromptBoxV2 selection; initialised from report once loaded)
 const currentPromptMode = ref<'chat' | 'deep' | 'training'>('chat')
+// Draft text pushed into the prompt box without auto-submitting (e.g. training session).
+const prefillText = ref('')
 watch(() => report.value?.mode, (m) => { if (m) currentPromptMode.value = m as any }, { immediate: true })
 
 // Right panel view mode
@@ -3556,6 +3559,9 @@ onMounted(async () => {
 		const mode = typeof route.query.mode === 'string' ? route.query.mode : 'chat'
 		const model_id = typeof route.query.model_id === 'string' ? route.query.model_id : null
 		onSubmitCompletion({ text: route.query.new_message as string, mentions, mode, model_id: model_id || undefined })
+	} else if (route.query.prompt && messages.value.length == 0) {
+		// Pre-fill the prompt box without submitting (e.g. a training session draft).
+		prefillText.value = route.query.prompt as string
 	}
 
 	// If a system message is still in progress (after refresh), begin polling until it finishes


### PR DESCRIPTION
Add a searchable PrimaryInstructionPicker so an agent's primary
instruction can be swapped to an existing one from the library,
instead of only creating a new instruction or editing the current
one in place.

- New component reuses GET /instructions (scoped to the agent +
  globals, published) with debounced search; the current primary is
  marked and disabled.
- Wired into the agent overview in two spots: a 'Replace' action next
  to 'Edit' on the read-only view, and an 'or select existing' entry
  beside 'Add Primary Instruction' in the empty state.
- Selection reuses the existing PUT /data_sources/{id}
  { primary_instruction_id } — no backend changes. Swapping only
  unlinks the previous primary; it stays in the library.