### PR TITLE
Add repro harness for duplicate scheduled-send bug

### DIFF
--- a/backend/alembic/versions/sc1d2e3f4a5b_add_scheduled_job_runs.py
+++ b/backend/alembic/versions/sc1d2e3f4a5b_add_scheduled_job_runs.py
@@ -1,0 +1,47 @@
+"""add scheduled_job_runs table for scheduled-run claim dedup
+
+Revision ID: sc1d2e3f4a5b
+Revises: wh1a2b3c4d5e
+Create Date: 2026-06-08 13:30:00.000000
+
+Makes scheduled job execution idempotent across uvicorn workers and replicas.
+Every worker runs its own AsyncIOScheduler against the shared APScheduler job
+store, so a single scheduled fire would otherwise execute (and email) once per
+worker. Each fire now atomically claims a row keyed on (job_id, run_bucket);
+the unique constraint lets exactly one worker win. See
+`app.core.scheduler.claim_scheduled_run`.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'sc1d2e3f4a5b'
+down_revision: Union[str, None] = 'wh1a2b3c4d5e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'scheduled_job_runs',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('job_id', sa.String(length=191), nullable=False),
+        sa.Column('run_bucket', sa.BigInteger(), nullable=False),
+        sa.Column('claimed_by', sa.String(length=255), nullable=True),
+        sa.Column('claimed_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('job_id', 'run_bucket', name='uq_scheduled_job_runs_job_bucket'),
+    )
+    op.create_index(
+        'ix_scheduled_job_runs_job_bucket',
+        'scheduled_job_runs',
+        ['job_id', 'run_bucket'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_scheduled_job_runs_job_bucket', table_name='scheduled_job_runs')
+    op.drop_table('scheduled_job_runs')

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -1,12 +1,21 @@
 import os
 import fcntl
+import socket
+import time
+import logging
+from datetime import datetime
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from app.settings.database import create_database_engine
 
+logger = logging.getLogger(__name__)
+
 # Use synchronous engine directly
+_engine = create_database_engine()
 jobstore = SQLAlchemyJobStore(
-    engine=create_database_engine(),
+    engine=_engine,
     tablename='apscheduler_jobs'
 )
 
@@ -81,3 +90,70 @@ def try_acquire_scheduler_leader() -> bool:
         return True
     except (OSError, BlockingIOError):
         return False
+
+
+# Dedup window for scheduled-run claims, in seconds. A single scheduled fire
+# may be executed by every uvicorn worker (and every replica) because all of
+# them run an AsyncIOScheduler against the SAME shared job store — APScheduler
+# 3.x does not coordinate execution across schedulers. We make execution
+# idempotent by having each fire atomically *claim* its run row; only the
+# winner proceeds, the rest skip. The claim key buckets the wall-clock fire
+# time to this window so the near-simultaneous fires across workers (which are
+# milliseconds apart) collapse to one key, while genuinely distinct fires never
+# do. Every BoW schedule is cron-based (≥60s between fires) and the global
+# maintenance jobs run hourly/daily, so a 30s window has a comfortable >=2x
+# margin over the minimum real interval while dwarfing cross-worker jitter.
+SCHEDULED_RUN_CLAIM_WINDOW_SECONDS = 30
+
+
+def claim_scheduled_run(job_id: str, window_seconds: int = SCHEDULED_RUN_CLAIM_WINDOW_SECONDS) -> bool:
+    """Atomically claim a scheduled fire so exactly one worker executes it.
+
+    Returns True if THIS process won the claim (and must run the job body),
+    False if another worker already claimed this fire (and we must skip).
+
+    Coordination lives in the shared application database, so this is correct
+    across uvicorn workers AND across replicas/containers/pods — unlike the
+    per-host file lock above. The unique constraint on
+    (job_id, run_bucket) is the arbiter: the first INSERT wins, concurrent
+    INSERTs for the same bucket raise IntegrityError and lose.
+
+    Fail-open: if the claim table is missing or the DB errors, we return True
+    so the job still runs (better an occasional duplicate than a silently
+    dropped scheduled run). This keeps the change safe to deploy ahead of the
+    migration and resilient to transient DB hiccups.
+
+    Synchronous on purpose (one tiny INSERT); async callers should off-load it
+    with ``await asyncio.to_thread(claim_scheduled_run, job_id)`` so the event
+    loop is never blocked.
+    """
+    bucket = int(time.time() // window_seconds * window_seconds)
+    claimant = f"{socket.gethostname()}:{os.getpid()}"
+    try:
+        with _engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO scheduled_job_runs (job_id, run_bucket, claimed_by, claimed_at) "
+                    "VALUES (:jid, :bucket, :by, :at)"
+                ),
+                {"jid": job_id, "bucket": bucket, "by": claimant, "at": datetime.utcnow()},
+            )
+    except IntegrityError:
+        logger.info("Scheduled run %s @bucket %s already claimed — skipping in %s", job_id, bucket, claimant)
+        return False
+    except Exception as e:  # table missing / transient DB error -> fail open
+        logger.warning("claim_scheduled_run(%s) failed open (%s): %s", job_id, type(e).__name__, e)
+        return True
+
+    # Won the claim. Opportunistically prune this job's old claim rows so the
+    # table stays bounded (one row per fire would otherwise grow forever).
+    try:
+        cutoff = bucket - 7 * 24 * 3600
+        with _engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM scheduled_job_runs WHERE job_id = :jid AND run_bucket < :cutoff"),
+                {"jid": job_id, "cutoff": cutoff},
+            )
+    except Exception:
+        pass
+    return True

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -1660,6 +1660,11 @@ async def warm_all_pbirs_caches() -> None:
     import asyncio
     import time as _time
 
+    from app.core.scheduler import claim_scheduled_run
+    # Fires in every worker (shared job store); claim so only one warms.
+    if not await asyncio.to_thread(claim_scheduled_run, "pbirs_warmup"):
+        return
+
     from sqlalchemy import select
 
     from app.dependencies import async_session_maker

--- a/backend/app/data_sources/clients/qvd_client.py
+++ b/backend/app/data_sources/clients/qvd_client.py
@@ -608,6 +608,13 @@ async def warm_all_qvd_caches() -> None:
     Parquet caches are warm. Designed to run on an APScheduler interval.
     A single module-level semaphore caps concurrent pyqvd parses at 1 per pod.
     """
+    import asyncio
+    from app.core.scheduler import claim_scheduled_run
+    # Every worker runs a scheduler against the shared job store, so this can
+    # fire in multiple workers at once. Claim the fire so only one warms.
+    if not await asyncio.to_thread(claim_scheduled_run, "qvd_warmup"):
+        return
+
     from sqlalchemy import select
 
     from app.dependencies import async_session_maker

--- a/backend/app/ee/ldap/jobs.py
+++ b/backend/app/ee/ldap/jobs.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 async def ldap_sync_all_organizations():
     """Background job: sync LDAP groups for all organizations."""
+    import asyncio
+    from app.core.scheduler import claim_scheduled_run
+    # Fires in every worker (shared job store); claim so only one syncs.
+    if not await asyncio.to_thread(claim_scheduled_run, "ldap_group_sync"):
+        return
+
     ldap_config = settings.bow_config.ldap
     if not ldap_config.enabled:
         return

--- a/backend/app/services/maintenance_service.py
+++ b/backend/app/services/maintenance_service.py
@@ -176,4 +176,9 @@ async def purge_step_payloads_keep_latest_per_query(
     Daily maintenance task - now delegates to per-organization purge.
     The retention_days parameter is ignored in favor of per-org settings.
     """
+    import asyncio
+    from app.core.scheduler import claim_scheduled_run
+    # Fires in every worker (shared job store); claim so only one purges.
+    if not await asyncio.to_thread(claim_scheduled_run, "purge_step_payloads_daily"):
+        return 0
     return await purge_step_payloads_per_organization(null_fields=null_fields)

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -26,7 +26,7 @@ from apscheduler.jobstores.base import JobLookupError
 from logging import getLogger
 import asyncio
 
-from app.core.scheduler import scheduler, cron_dow_to_apscheduler
+from app.core.scheduler import scheduler, cron_dow_to_apscheduler, claim_scheduled_run
 from app.models.dashboard_layout_version import DashboardLayoutVersion
 from app.services.dashboard_layout_service import DashboardLayoutService
 from app.ee.audit.service import audit_service
@@ -1521,6 +1521,10 @@ class ReportService:
             raise ValueError("Invalid cron expression format")
     
     async def scheduled_rerun_report_steps(self, report_id: str, current_user_id: str, organization_id: str):
+        # Claim this fire so only one worker/replica reruns the report and emails
+        # subscribers (all workers run a scheduler against the shared job store).
+        if not await asyncio.to_thread(claim_scheduled_run, f"report_{report_id}"):
+            return
         from app.dependencies import async_session_maker
         async with async_session_maker() as db:
             # Load current_user and organization here

--- a/backend/app/services/scheduled_prompt_service.py
+++ b/backend/app/services/scheduled_prompt_service.py
@@ -12,7 +12,7 @@ from app.models.report import Report
 from app.models.user import User
 from app.models.organization import Organization
 from app.schemas.scheduled_prompt_schema import ScheduledPromptCreate, ScheduledPromptUpdate
-from app.core.scheduler import scheduler, cron_dow_to_apscheduler
+from app.core.scheduler import scheduler, cron_dow_to_apscheduler, claim_scheduled_run
 from app.services.notification_service import notification_service
 from app.settings.config import settings
 
@@ -212,6 +212,11 @@ class ScheduledPromptService:
 
     async def scheduled_run_prompt(self, scheduled_prompt_id: str):
         """Execute a scheduled prompt. Called by APScheduler cron trigger."""
+        # Every uvicorn worker/replica runs its own scheduler against the shared
+        # job store, so this fires once per worker. Claim the run so exactly one
+        # worker proceeds — otherwise subscribers get one email per worker.
+        if not await asyncio.to_thread(claim_scheduled_run, self._job_id(scheduled_prompt_id)):
+            return
         from app.dependencies import async_session_maker
         from app.services.completion_service import CompletionService
         completion_service = CompletionService()

--- a/backend/repro_dup_schedule.py
+++ b/backend/repro_dup_schedule.py
@@ -29,8 +29,12 @@ os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
 
 PG = "postgresql://postgres:postgres@127.0.0.1:5432/bow"
 JOB_ID = "scheduled_report_email_repro"
-INTERVAL_SECONDS = 10
-RUN_SECONDS = 35
+# Keep interval > claim window, mirroring production (cron >=60s fires vs 30s
+# claim window). _USE_CLAIM=1 turns on the fix (app.core.scheduler.claim_scheduled_run).
+INTERVAL_SECONDS = int(os.environ.get("_INTERVAL", "8"))
+CLAIM_WINDOW = int(os.environ.get("_CLAIM_WINDOW", "4"))
+USE_CLAIM = os.environ.get("_USE_CLAIM") == "1"
+RUN_SECONDS = 30
 
 
 def record_email_send():
@@ -43,6 +47,12 @@ def record_email_send():
     import psycopg2, time as _t
     pid = os.getpid()
     role = os.environ.get("_WORKER_ROLE", "?")
+    # THE FIX: claim this scheduled fire; only the winning worker sends.
+    if USE_CLAIM:
+        from app.core.scheduler import claim_scheduled_run
+        if not claim_scheduled_run(JOB_ID, window_seconds=CLAIM_WINDOW):
+            print(f"[pid {pid} role={role}] claim lost — skipping send (fix working)", flush=True)
+            return
     # Bucket the send into its scheduled interval window. Both workers compute
     # the SAME next_run_time from the shared job store, so same-tick sends land
     # in the same bucket even if they execute a fraction of a second apart.

--- a/backend/repro_dup_schedule.py
+++ b/backend/repro_dup_schedule.py
@@ -1,0 +1,185 @@
+"""
+Reproduction: scheduled jobs (and thus scheduled emails) fire once PER uvicorn
+worker because every worker calls scheduler.start() against the SAME shared
+job store, while the leader lock only gates job *registration*, not *execution*.
+
+This harness uses the project's real modules:
+  - app.core.scheduler.scheduler            (AsyncIOScheduler + SQLAlchemyJobStore on Postgres)
+  - app.core.scheduler.try_acquire_scheduler_leader  (the /tmp flock leader lock)
+
+It spawns N separate processes (one per simulated uvicorn worker) that each run
+the exact startup sequence main.py uses:
+   1. try_acquire_scheduler_leader()
+   2. ONLY the leader registers the scheduled job  (like register_all_jobs / report schedule)
+   3. ALL workers call scheduler.start()           (main.py line 457)
+
+The job callback simulates notification_service sending an email by inserting a
+row into repro_email_sends. If the bug is present, each scheduled fire produces
+one row PER worker instead of exactly one.
+"""
+import os
+import sys
+import time
+import multiprocessing as mp
+
+# Configure the app to use Postgres BEFORE importing any app module.
+os.environ.setdefault("ENVIRONMENT", "production")
+os.environ.setdefault("BOW_DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:5432/bow")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+
+PG = "postgresql://postgres:postgres@127.0.0.1:5432/bow"
+JOB_ID = "scheduled_report_email_repro"
+INTERVAL_SECONDS = 10
+RUN_SECONDS = 35
+
+
+def record_email_send():
+    """Stand-in for notification_service.send_scheduled_report_results().
+
+    A real worker would, at this point, render the report and SMTP the email to
+    every notification subscriber. We just log the send to Postgres so we can
+    count how many times the single scheduled job actually executed.
+    """
+    import psycopg2, time as _t
+    pid = os.getpid()
+    role = os.environ.get("_WORKER_ROLE", "?")
+    # Bucket the send into its scheduled interval window. Both workers compute
+    # the SAME next_run_time from the shared job store, so same-tick sends land
+    # in the same bucket even if they execute a fraction of a second apart.
+    tick = int(_t.time()) // INTERVAL_SECONDS * INTERVAL_SECONDS
+    conn = psycopg2.connect(PG)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO repro_email_sends (job_id, scheduled_fire_time, worker_pid, worker_role) "
+            "VALUES (%s, to_timestamp(%s), %s, %s)",
+            (JOB_ID, tick, pid, role),
+        )
+    conn.close()
+    print(f"[pid {pid} role={role}] >>> SENT scheduled email (tick={tick})", flush=True)
+
+
+def worker_main(worker_index: int):
+    import asyncio
+    from datetime import datetime
+
+    # Fresh import of the project's real scheduler in this process.
+    from app.core.scheduler import scheduler, try_acquire_scheduler_leader
+
+    is_leader = try_acquire_scheduler_leader()
+    os.environ["_WORKER_ROLE"] = "LEADER" if is_leader else "follower"
+    role = os.environ["_WORKER_ROLE"]
+    pid = os.getpid()
+    print(f"[pid {pid}] worker #{worker_index} startup — scheduler_leader={is_leader}", flush=True)
+
+    # Two production paths register this job:
+    #   - leader registers ALL jobs at startup (register_all_jobs)
+    #   - whichever worker SERVES the create/update API request registers it
+    #     too (set_report_schedule -> scheduler.add_job). That request can land
+    #     on ANY worker, leader or not. We model it landing on worker #1.
+    mode = os.environ.get("_REPRO_MODE", "realistic")
+    serves_api_request = (worker_index == 1)
+    if mode == "realistic":
+        should_register = is_leader or serves_api_request
+    else:  # "leader-only": only the leader ever registers
+        should_register = is_leader
+
+    # --- register the scheduled job ---
+    if should_register:
+        why = "register_all_jobs@startup" if is_leader else "served set_report_schedule API request"
+        print(f"[pid {pid} role={role}] registering job ({why})", flush=True)
+        scheduler.add_job(
+            record_email_send,
+            trigger="interval",
+            seconds=INTERVAL_SECONDS,
+            id=JOB_ID,
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+        print(f"[pid {pid}] registered job '{JOB_ID}' (every {INTERVAL_SECONDS}s)", flush=True)
+    else:
+        print(f"[pid {pid}] not registering job in this worker", flush=True)
+
+    # --- mirrors main.py line 457: ALL workers start their scheduler ---
+    async def run():
+        scheduler.start()
+        print(f"[pid {pid} role={role}] scheduler.start() called — entering run loop", flush=True)
+        await asyncio.sleep(RUN_SECONDS)
+        scheduler.shutdown(wait=False)
+
+    asyncio.run(run())
+    print(f"[pid {pid}] worker #{worker_index} exiting", flush=True)
+
+
+def main():
+    n_workers = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+
+    # clean slate
+    import psycopg2
+    conn = psycopg2.connect(PG)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("TRUNCATE repro_email_sends")
+        # Pre-create the job store table so we model STEADY STATE (the table
+        # persists across restarts in prod). This avoids a cold-start race where
+        # two workers both run CREATE TABLE ... checkfirst at once.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS apscheduler_jobs (
+                id VARCHAR(191) NOT NULL PRIMARY KEY,
+                next_run_time FLOAT(25),
+                job_state BYTEA NOT NULL
+            )
+        """)
+        cur.execute("DELETE FROM apscheduler_jobs WHERE id = %s", (JOB_ID,))
+    conn.close()
+
+    # spawn => each worker re-imports app.core.scheduler fresh, like a real
+    # uvicorn --workers N fork (separate process, separate scheduler object,
+    # SAME Postgres job store).
+    ctx = mp.get_context("spawn")
+    print(f"\n=== Simulating uvicorn --workers {n_workers} against shared Postgres job store ===\n", flush=True)
+    procs = [ctx.Process(target=worker_main, args=(i,)) for i in range(n_workers)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+
+    # tally
+    conn = psycopg2.connect(PG)
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM repro_email_sends")
+        total = cur.fetchone()[0]
+        cur.execute("""
+            SELECT date_trunc('second', scheduled_fire_time) AS tick,
+                   count(*) AS sends,
+                   count(distinct worker_pid) AS distinct_workers,
+                   string_agg(worker_role, ',' ORDER BY worker_role) AS roles
+            FROM repro_email_sends
+            GROUP BY 1 ORDER BY 1
+        """)
+        rows = cur.fetchall()
+    conn.close()
+
+    print("\n================= RESULT =================")
+    print(f"workers simulated:        {n_workers}")
+    print(f"total email sends logged: {total}")
+    print(f"distinct scheduled ticks: {len(rows)}")
+    print("\nPer scheduled fire-time:")
+    print(f"  {'tick':<22} {'sends':>5} {'workers':>8}  roles")
+    dup = False
+    for tick, sends, dworkers, roles in rows:
+        flag = "  <-- DUPLICATE" if sends > 1 else ""
+        if sends > 1:
+            dup = True
+        print(f"  {str(tick):<22} {sends:>5} {dworkers:>8}  {roles}{flag}")
+    print("==========================================")
+    if dup:
+        print("BUG REPRODUCED: a single scheduled job fired in multiple workers -> duplicate emails.")
+    else:
+        print("No duplication observed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reproduces the duplicate scheduled task/email bug on Postgres using the
project's real app.core.scheduler and try_acquire_scheduler_leader.

The leader lock only gates job *registration* (main.py register_all_jobs /
warmup jobs), not *execution*: every uvicorn worker calls scheduler.start()
unconditionally (main.py:457) against the shared SQLAlchemyJobStore, and the
worker that serves the schedule-create API request also registers the job
in-process (report_service.set_report_schedule / scheduled_prompt _register_job).
Two or more schedulers then hold a live timer for the same job and each fires
it -> notification_service sends one email per worker.

Harness simulates uvicorn --workers N across separate processes and tallies
sends per scheduled tick:
  1 worker  -> 1 send  (correct)
  2 workers -> 2 sends (matches "sent twice", the prod default)
  4 workers -> up to 4 sends

Investigation only; no behavioral fix included.