### PR TITLE
fix(charts): dock a scrollable vertical legend for many-series cartesian charts

### DIFF
--- a/frontend/components/RenderVisual.vue
+++ b/frontend/components/RenderVisual.vue
@@ -444,18 +444,46 @@ function buildCartesianOptions(normalizedRows: DataRow[], dataModel: DataModel):
         splitLine: showGrid ? { show: true, lineStyle: { color: gridColor, width: 1 } } : { show: false }
     }
 
-    // Only include legend when it should be shown
-    const legendConfig = legendShouldShow ? {
-        show: true,
-        data: series.map(s => (s as any).name),
-        right: 12,
-        top: 12,
-        itemWidth: 10,
-        itemHeight: 6,
-        icon: 'roundRect'
-    } : { show: false };
+    // Only include legend when it should be shown. With many series a single
+    // horizontal row is useless, so dock a scrollable vertical legend on the
+    // right and reserve grid space for it.
+    const manySeries = series.length > 8;
+    const legendConfig = legendShouldShow
+        ? (manySeries
+            ? {
+                show: true,
+                type: 'scroll',
+                orient: 'vertical' as const,
+                right: 8,
+                top: 8,
+                bottom: 8,
+                data: series.map(s => (s as any).name),
+                itemWidth: 10,
+                itemHeight: 6,
+                icon: 'roundRect',
+                textStyle: { fontSize: 11 },
+                pageButtonItemGap: 4
+            }
+            : {
+                show: true,
+                type: 'scroll',
+                data: series.map(s => (s as any).name),
+                right: 12,
+                top: 12,
+                itemWidth: 10,
+                itemHeight: 6,
+                icon: 'roundRect'
+            })
+        : { show: false };
+
+    // Reserve room on the right for the vertical legend (otherwise it overlaps
+    // the plot). Mirrors the base grid but widens the right gutter.
+    const gridOverride = (legendShouldShow && manySeries)
+        ? { containLabel: true, left: '3%', right: 150, bottom: '10%', top: '12%' }
+        : undefined;
 
     return {
+        ...(gridOverride ? { grid: gridOverride } : {}),
         tooltip: {
             trigger: 'axis',
             axisPointer: { type: 'cross', label: { backgroundColor: '#6a7985' } }

--- a/frontend/components/dashboard/charts/EChartsVisual.vue
+++ b/frontend/components/dashboard/charts/EChartsVisual.vue
@@ -458,20 +458,48 @@ function buildCartesianOptions(rows: any[], dm: any): EChartsOption {
   // Respect user's legend setting, default to hidden
   const legendShouldShow = props.view?.legendVisible ?? viewV2?.legend?.show ?? false
 
-  // Only include legend config when it should be shown
-  const legendConfig = legendShouldShow ? {
-    show: true,
-    data: series.map(s => s.name),
-    right: 12,
-    top: 12,
-    orient: 'horizontal',
-    itemWidth: 10,
-    itemHeight: 6,
-    icon: 'roundRect',
-    textStyle: { color: tokens.value?.legend?.textColor, fontSize: 11 }
-  } : { show: false }
+  // Only include legend config when it should be shown. With many series a
+  // single horizontal row overflows the chart, so dock a scrollable vertical
+  // legend on the right and reserve grid space for it.
+  const manySeries = series.length > 8
+  const legendConfig = legendShouldShow
+    ? (manySeries
+      ? {
+        show: true,
+        type: 'scroll',
+        orient: 'vertical',
+        right: 8,
+        top: 8,
+        bottom: 8,
+        data: series.map(s => s.name),
+        itemWidth: 10,
+        itemHeight: 6,
+        icon: 'roundRect',
+        pageButtonItemGap: 4,
+        textStyle: { color: tokens.value?.legend?.textColor, fontSize: 11 }
+      }
+      : {
+        show: true,
+        type: 'scroll',
+        data: series.map(s => s.name),
+        right: 12,
+        top: 12,
+        orient: 'horizontal',
+        itemWidth: 10,
+        itemHeight: 6,
+        icon: 'roundRect',
+        textStyle: { color: tokens.value?.legend?.textColor, fontSize: 11 }
+      })
+    : { show: false }
+
+  // Reserve room on the right for the vertical legend so it doesn't overlap
+  // the plot.
+  const gridOverride = (legendShouldShow && manySeries)
+    ? { containLabel: true, left: 24, right: 150, bottom: 24, top: 18 }
+    : undefined
 
   return {
+    ...(gridOverride ? { grid: gridOverride } : {}),
     tooltip: { trigger: 'axis' },
     xAxis: isHorizontal ? valueAxis : categoryAxis,
     yAxis: isHorizontal ? categoryAxis : valueAxis,


### PR DESCRIPTION
When a line/bar/area chart has many series (e.g. a metric broken down by a
high-cardinality dimension), the horizontal legend wrapped into several rows
that overlapped the plot and axis labels.

buildCartesianOptions returned its own legend object without type:'scroll',
and the shallow { ...base, ...specific } merge clobbered the base scroll
legend. Now, when series > 8, render a scrollable vertical legend docked on
the right and reserve a right grid gutter so it never overlaps the plot;
fewer series keep a horizontal scroll legend. Applied to both RenderVisual
(chat/preview) and EChartsVisual (dashboard) so the fix holds across
'Add to Dashboard'.