### PR TITLE
search_mcps: stop returning 0 tools on natural-language queries

### DIFF
--- a/backend/app/ai/tools/implementations/search_mcps.py
+++ b/backend/app/ai/tools/implementations/search_mcps.py
@@ -129,13 +129,30 @@ Use when:
         result = await db.execute(stmt)
         tools = result.scalars().all()
 
-        # Filter by query if provided
+        # Filter by query if provided.
+        #
+        # The query is a relevance hint, not a hard filter. A naive full-string
+        # substring match (`q in name or q in description`) returns ZERO tools
+        # for any natural-language or multi-word query (e.g. "contacts for a
+        # company", or an id), which silently defeats discovery — the agent
+        # gets no schemas and falls back to guessing argument shapes. Instead:
+        #   - tokenize the query and rank tools by how many tokens they match,
+        #   - keep only tools that match at least one token,
+        #   - but if nothing matches (over-specific/NL query), fall back to
+        #     returning all tools so discovery never yields an empty result
+        #     when tools actually exist.
         if data.query:
-            q = data.query.lower()
-            tools = [
-                t for t in tools
-                if q in (t.name or "").lower() or q in (t.description or "").lower()
-            ]
+            import re
+            tokens = [tok for tok in re.split(r"[^a-z0-9_]+", data.query.lower()) if len(tok) >= 3]
+            if tokens:
+                def _score(t) -> int:
+                    hay = f"{t.name or ''} {t.description or ''}".lower()
+                    return sum(1 for tok in tokens if tok in hay)
+                scored = sorted(((_score(t), t) for t in tools), key=lambda x: -x[0])
+                matched = [t for s, t in scored if s > 0]
+                # Fall back to all tools when no token matched — better to return
+                # every schema than none.
+                tools = matched or tools
 
         # Build output
         tool_previews = []


### PR DESCRIPTION
## Problem

`search_mcps` is the tool the agent calls to discover external MCP tools and their input schemas (the path we steer it toward so it stops guessing argument shapes). But its query filter was a full-string substring match:

```python
if data.query:
    q = data.query.lower()
    tools = [t for t in tools if q in (t.name or "").lower() or q in (t.description or "").lower()]
```

The entire query string had to appear verbatim in a single tool's name/description. So a natural-language query (e.g. `"contacts for a company"`), a multi-word phrase, or an id matched **nothing** → **"Found 0 tool(s)"**. Discovery silently returns empty, the agent gets no schema, and it falls back to guessing argument shapes — exactly the failing-call loop seen against the Intercom MCP.

(Confirmed in practice: `query="search"` → 9 tools, `query="search_contacts"` → 2, but a descriptive query → 0.)

## Fix

Treat the query as a **relevance hint, not a hard filter**:
- tokenize the query and rank tools by how many tokens appear in name/description,
- keep tools matching ≥1 token,
- **fall back to returning all tools when nothing matches**, so discovery never yields an empty result when tools actually exist.

```
query="search_contacts"            -> [search_contacts]
query="contacts for company"       -> [search, get_company, search_contacts]
query="find all contacts of a company" -> [get_company, list_companies, search, search_contacts]
query="2e7eabb8-1311-…" (a UUID)   -> all 13 tools (was: 0)
query="users"                      -> all 13 tools (was: 0)
query="search"                     -> [search, search_articles, search_contacts, search_conversations]
```

## Scope / what this does NOT fix

This addresses the discovery dead-end only. Two related issues are **capability/semantic gaps, not code bugs**, and are intentionally out of scope:
- Intercom's `search` needs a unified-search **query string**; knowing the arg name (`query`) isn't enough to express "contacts at company X".
- There is **no company→contacts operation** among the enabled Intercom tools, so that specific task can't be completed regardless of argument shape.

## Tests

MCP e2e suite: **29 passed**. The only 2 failures (`test_mcp_tools_list`, `test_mcp_rest_tools_endpoint`) are **pre-existing on `main` and unrelated** — verified by re-running them with this change stashed (identical `assert 12 == 11` failure). They assert a hardcoded count of the BoW MCP-server registry (now 12 tools), a code path that shares nothing with `search_mcps`.

https://claude.ai/code/session_01N9To7HXaFpNgA4AFAAm6WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9To7HXaFpNgA4AFAAm6WR)_