### PR TITLE
Private data sources by default + delayed member-added emails

### DIFF
--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -22,7 +22,9 @@ class DataSource(BaseSchema):
     # type, config, credentials, auth_policy, allowed_user_auth_modes are now on Connection
     last_synced_at = Column(DateTime, nullable=True)
     is_active = Column(Boolean, nullable=False, default=True)
-    is_public = Column(Boolean, nullable=False, default=True)
+    # Data sources are private by default: only explicitly added members (plus
+    # admins) can see them. Sharing org-wide is an opt-in (set is_public=True).
+    is_public = Column(Boolean, nullable=False, default=False)
 
     # When true, the system may run LLM onboarding synchronously (onboarding flow only)
     owner_user_id = Column(String(36), ForeignKey('users.id'), nullable=True)

--- a/backend/app/services/data_source_member_email.py
+++ b/backend/app/services/data_source_member_email.py
@@ -1,0 +1,163 @@
+"""Delayed "you've been added to a data source" member notifications.
+
+When a user is added as a member of a data source (an "agent" in product
+terms), we email them — but only if SMTP is configured, and only after a short
+delay. The delay is the whole point: if the add was a mistake and the
+membership is removed within the window, the email is never sent. Send time
+re-checks that the membership still exists before mailing.
+
+The job is scheduled on the shared APScheduler (``date`` trigger), so it
+survives a process restart and runs even if the request worker is gone. Every
+worker runs its own scheduler against the shared job store, so the send path
+claims the run to guarantee exactly one email.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+# How long to wait before a member-added email actually goes out. Short enough
+# to feel timely, long enough that an accidental add can be undone first.
+MEMBER_ADDED_EMAIL_DELAY_MINUTES = 5
+
+
+def _job_id(data_source_id: str, user_id: str) -> str:
+    return f"ds_member_email:{data_source_id}:{user_id}"
+
+
+def schedule_member_added_email(
+    data_source_id: str,
+    user_id: str,
+    added_by_user_id: str,
+    organization_id: str,
+) -> None:
+    """Schedule a delayed member-added email.
+
+    No-ops (silently) when SMTP isn't configured, when there's no recipient, or
+    when the actor added themselves. Never raises into the caller — a member is
+    added regardless of whether the notification can be scheduled.
+    """
+    from app.settings.config import settings
+
+    # "if smtp is configured, an email is sent" — otherwise don't even schedule.
+    if settings.email_client is None:
+        return
+    if not user_id:
+        return
+    # Don't notify someone for adding themselves (e.g. the creator/owner).
+    if added_by_user_id and str(user_id) == str(added_by_user_id):
+        return
+
+    try:
+        from app.core.scheduler import scheduler
+
+        run_date = datetime.utcnow() + timedelta(minutes=MEMBER_ADDED_EMAIL_DELAY_MINUTES)
+        # Unique id per (data source, user, schedule time) so re-adding after a
+        # remove schedules a fresh email instead of being silently dropped.
+        job_id = f"{_job_id(data_source_id, user_id)}:{int(datetime.utcnow().timestamp())}"
+        scheduler.add_job(
+            func="app.services.data_source_member_email:send_member_added_email",
+            trigger="date",
+            run_date=run_date,
+            args=[str(data_source_id), str(user_id), str(added_by_user_id or ""), str(organization_id)],
+            id=job_id,
+            replace_existing=True,
+            misfire_grace_time=3600,
+        )
+        logger.info(
+            "Scheduled member-added email for user=%s data_source=%s at %s",
+            user_id, data_source_id, run_date.isoformat(),
+        )
+    except Exception as e:
+        # Scheduling is best-effort; never block the membership write.
+        logger.warning("Failed to schedule member-added email: %s", e)
+
+
+async def send_member_added_email(
+    data_source_id: str,
+    user_id: str,
+    added_by_user_id: str,
+    organization_id: str,
+) -> None:
+    """APScheduler job body: re-validate, then send the member-added email.
+
+    Skips silently if: another worker already claimed this fire, SMTP is no
+    longer configured, the membership was removed (the mistake-undo path), or
+    the user/data source no longer exists.
+    """
+    import asyncio
+
+    from app.core.scheduler import claim_scheduled_run
+
+    # Every worker fires this once; only the claim winner proceeds.
+    if not await asyncio.to_thread(claim_scheduled_run, _job_id(data_source_id, user_id)):
+        return
+
+    from app.settings.config import settings
+
+    fm = settings.email_client
+    if fm is None:
+        return
+
+    from sqlalchemy import select
+
+    from app.dependencies import async_session_maker
+    from app.models.data_source import DataSource
+    from app.models.data_source_membership import DataSourceMembership, PRINCIPAL_TYPE_USER
+    from app.models.user import User
+
+    async with async_session_maker() as db:
+        # Undo safety: only mail if the membership still exists. If the add was a
+        # mistake and was removed within the delay window, the row is gone.
+        membership = await db.execute(
+            select(DataSourceMembership).where(
+                DataSourceMembership.data_source_id == data_source_id,
+                DataSourceMembership.principal_type == PRINCIPAL_TYPE_USER,
+                DataSourceMembership.principal_id == user_id,
+            )
+        )
+        if membership.scalar_one_or_none() is None:
+            logger.info(
+                "Membership user=%s data_source=%s no longer exists; skipping email",
+                user_id, data_source_id,
+            )
+            return
+
+        data_source = await db.get(DataSource, data_source_id)
+        if data_source is None or data_source.deleted_at is not None:
+            return
+
+        user = await db.get(User, user_id)
+        if user is None or not getattr(user, "email", None):
+            return
+        recipient = user.email
+        ds_name = data_source.name
+
+        added_by = await db.get(User, added_by_user_id) if added_by_user_id else None
+        added_by_name = getattr(added_by, "name", None) if added_by else None
+
+    from fastapi_mail import MessageSchema
+
+    base_url = getattr(settings.bow_config, "base_url", None) or "http://localhost:3000"
+    agent_url = f"{base_url.rstrip('/')}/agents/{data_source_id}"
+
+    by_clause = f" by {added_by_name}" if added_by_name else ""
+    subject = f"You've been given access to {ds_name} on Bag of words"
+    body = (
+        f"You've been added{by_clause} to the data source "
+        f"<strong>{ds_name}</strong> on Bag of words.<br /><br />"
+        f"You can now use it here: <a href=\"{agent_url}\">{agent_url}</a>"
+    )
+
+    message = MessageSchema(
+        subject=subject,
+        recipients=[recipient],
+        body=body,
+        subtype="html",
+    )
+    try:
+        await fm.send_message(message)
+        logger.info("Member-added email sent to %s for data_source=%s", recipient, data_source_id)
+    except Exception as e:
+        logger.error("Failed to send member-added email to %s: %s", recipient, e)

--- a/backend/app/services/data_source_member_email.py
+++ b/backend/app/services/data_source_member_email.py
@@ -132,6 +132,7 @@ async def send_member_added_email(
         if user is None or not getattr(user, "email", None):
             return
         recipient = user.email
+        recipient_name = getattr(user, "name", None)
         ds_name = data_source.name
 
         added_by = await db.get(User, added_by_user_id) if added_by_user_id else None
@@ -142,12 +143,20 @@ async def send_member_added_email(
     base_url = getattr(settings.bow_config, "base_url", None) or "http://localhost:3000"
     agent_url = f"{base_url.rstrip('/')}/agents/{data_source_id}"
 
-    by_clause = f" by {added_by_name}" if added_by_name else ""
-    subject = f"You've been given access to {ds_name} on Bag of words"
+    greeting = f"Hi {recipient_name},<br /><br />" if recipient_name else ""
+    if added_by_name:
+        intro = f"{added_by_name} added you to <strong>{ds_name}</strong> on BOW."
+    else:
+        intro = f"You've been added to <strong>{ds_name}</strong> on BOW."
+
+    subject = f"You've been given access to {ds_name}"
     body = (
-        f"You've been added{by_clause} to the data source "
-        f"<strong>{ds_name}</strong> on Bag of words.<br /><br />"
-        f"You can now use it here: <a href=\"{agent_url}\">{agent_url}</a>"
+        f"{greeting}"
+        f"{intro}<br /><br />"
+        f"You can now chat with this agent and explore its data.<br /><br />"
+        f"<a href=\"{agent_url}\" "
+        f"style=\"display:inline-block;padding:10px 18px;background:#111827;color:#ffffff;"
+        f"text-decoration:none;border-radius:6px;font-weight:600;\">Open {ds_name}</a>"
     )
 
     message = MessageSchema(

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -491,6 +491,18 @@ class DataSourceService:
             additional_user_ids = [uid for uid in member_user_ids if uid != current_user.id]
             if additional_user_ids:
                 await self._create_memberships(db, new_data_source, additional_user_ids)
+                # Notify each newly added member (delayed; only if SMTP configured).
+                try:
+                    from app.services.data_source_member_email import schedule_member_added_email
+                    for uid in additional_user_ids:
+                        schedule_member_added_email(
+                            data_source_id=str(new_data_source.id),
+                            user_id=str(uid),
+                            added_by_user_id=str(current_user.id),
+                            organization_id=str(organization.id),
+                        )
+                except Exception as e:
+                    logger.warning("Could not schedule member-added emails on create: %s", e)
 
         # Save tables (validation already passed above)
         # Note: Description, conversation starters, and instructions are generated
@@ -1745,9 +1757,24 @@ class DataSourceService:
         connection_changed = bool(connection_updates)
         
         # Handle membership updates
+        newly_added_member_ids: List[str] = []
         if 'member_user_ids' in update_data:
             member_user_ids = update_data.pop('member_user_ids')
             if member_user_ids is not None:
+                # Capture the current member set first so we can tell which of the
+                # incoming ids are genuinely *new* (this path replaces the whole
+                # membership list, so we must not re-notify existing members).
+                existing_result = await db.execute(
+                    select(DataSourceMembership.principal_id).where(
+                        DataSourceMembership.data_source_id == data_source_id,
+                        DataSourceMembership.principal_type == PRINCIPAL_TYPE_USER,
+                    )
+                )
+                existing_member_ids = {str(r) for r in existing_result.scalars().all()}
+                newly_added_member_ids = [
+                    str(uid) for uid in member_user_ids
+                    if str(uid) not in existing_member_ids and str(uid) != str(current_user.id)
+                ]
                 # Delete existing data_source_memberships
                 await db.execute(
                     delete(DataSourceMembership).where(
@@ -1783,7 +1810,21 @@ class DataSourceService:
         
         try:
             await db.commit()
-            
+
+            # Notify users newly added to this data source (delayed; SMTP-gated).
+            if newly_added_member_ids:
+                try:
+                    from app.services.data_source_member_email import schedule_member_added_email
+                    for uid in newly_added_member_ids:
+                        schedule_member_added_email(
+                            data_source_id=str(data_source_id),
+                            user_id=str(uid),
+                            added_by_user_id=str(current_user.id),
+                            organization_id=str(organization.id),
+                        )
+                except Exception as e:
+                    logger.warning("Could not schedule member-added emails on update: %s", e)
+
             # Refresh tables if connection fields changed
             if connection_changed and data_source_db.connections:
                 conn = data_source_db.connections[0]
@@ -3200,6 +3241,20 @@ class DataSourceService:
 
         await db.commit()
         await db.refresh(membership)
+
+        # Notify the newly added user (delayed; only if SMTP is configured).
+        if member.principal_type == PRINCIPAL_TYPE_USER:
+            try:
+                from app.services.data_source_member_email import schedule_member_added_email
+                schedule_member_added_email(
+                    data_source_id=str(data_source_id),
+                    user_id=str(member.principal_id),
+                    added_by_user_id=str(current_user.id),
+                    organization_id=str(organization.id),
+                )
+            except Exception as e:
+                logger.warning("Could not schedule member-added email: %s", e)
+
         return DataSourceMembershipSchema.from_orm(membership)
 
     async def remove_data_source_member(self, db: AsyncSession, data_source_id: str, user_id: str, organization: Organization, current_user: User):
@@ -3420,7 +3475,19 @@ class DataSourceService:
             additional_user_ids = [uid for uid in member_user_ids if uid != current_user.id]
             if additional_user_ids:
                 await self._create_memberships(db, new_data_source, additional_user_ids)
-        
+                # Notify each newly added member (delayed; only if SMTP configured).
+                try:
+                    from app.services.data_source_member_email import schedule_member_added_email
+                    for uid in additional_user_ids:
+                        schedule_member_added_email(
+                            data_source_id=str(new_data_source.id),
+                            user_id=str(uid),
+                            added_by_user_id=str(current_user.id),
+                            organization_id=str(organization.id),
+                        )
+                except Exception as e:
+                    logger.warning("Could not schedule member-added emails on create: %s", e)
+
         # Sync domain tables from connection tables (onboarding: auto-select up to 20)
         await self.sync_domain_tables_from_connection(
             db, new_data_source, connection, 

--- a/backend/tests/e2e/rbac/test_data_source_member_email.py
+++ b/backend/tests/e2e/rbac/test_data_source_member_email.py
@@ -1,0 +1,151 @@
+"""E2E coverage for: data sources are private by default, and adding a member
+schedules a delayed "you've been added" email only when SMTP is configured.
+
+Exercises the real HTTP routes end to end. The delayed-email send itself is not
+driven here (it fires minutes later via APScheduler); we assert the scheduling
+decision, which is where the "only if SMTP configured" rule lives.
+"""
+
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import app.core.scheduler as scheduler_mod
+from app.settings.config import settings as bow_settings
+
+
+pytestmark = pytest.mark.e2e
+
+CHINOOK_PATH = (Path(__file__).resolve().parents[2] / "config" / "chinook.sqlite").resolve()
+
+
+def _headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _add_member(test_client, admin, ds, member):
+    return test_client.post(
+        f"/api/data_sources/{ds['id']}/members",
+        json={"principal_type": "user", "principal_id": member["user_id"]},
+        headers=_headers(admin["token"], admin["org_id"]),
+    )
+
+
+@pytest.fixture
+def restore_email_client():
+    """Snapshot/restore the global email client so SMTP tweaks don't leak."""
+    saved = bow_settings.email_client
+    try:
+        yield
+    finally:
+        bow_settings.email_client = saved
+
+
+def test_data_source_is_private_by_default(bootstrap_admin, create_data_source):
+    """Creating a data source without is_public yields a private one."""
+    if not CHINOOK_PATH.exists():
+        pytest.skip(f"Missing SQLite fixture at {CHINOOK_PATH}")
+
+    admin = bootstrap_admin("priv_default")
+    ds = create_data_source(
+        name=f"ds_{uuid.uuid4().hex[:8]}",
+        type="sqlite",
+        config={"database": str(CHINOOK_PATH)},
+        credentials={},
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+    )
+    assert ds["is_public"] is False, ds
+
+
+def test_member_add_schedules_delayed_email_when_smtp_configured(
+    monkeypatch, restore_email_client, test_client, bootstrap_admin,
+    invite_user_to_org, sqlite_data_source,
+):
+    admin = bootstrap_admin("ds_email")
+    member = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
+    ds = sqlite_data_source(
+        name=f"ds_{uuid.uuid4().hex[:8]}",
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+        is_public=False,
+    )
+
+    # Spy on the scheduler the email helper uses, and pretend SMTP is configured.
+    add_job = MagicMock()
+    monkeypatch.setattr(scheduler_mod.scheduler, "add_job", add_job)
+    bow_settings.email_client = MagicMock()  # truthy => "SMTP configured"
+
+    resp = _add_member(test_client, admin, ds, member)
+    assert resp.status_code == 200, resp.json()
+
+    add_job.assert_called_once()
+    kwargs = add_job.call_args.kwargs
+    assert kwargs["trigger"] == "date"  # delayed, not immediate
+    assert kwargs["args"][0] == ds["id"]
+    assert kwargs["args"][1] == member["user_id"]
+
+
+def test_update_members_emails_only_newly_added(
+    monkeypatch, restore_email_client, test_client, bootstrap_admin,
+    invite_user_to_org, sqlite_data_source,
+):
+    """The Members UI saves the full list via PUT; only genuinely new members
+    should be notified, never the ones already on the data source."""
+    admin = bootstrap_admin("ds_update")
+    m1 = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
+    m2 = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
+    ds = sqlite_data_source(
+        name=f"ds_{uuid.uuid4().hex[:8]}",
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+        is_public=False,
+    )
+
+    add_job = MagicMock()
+    monkeypatch.setattr(scheduler_mod.scheduler, "add_job", add_job)
+    bow_settings.email_client = MagicMock()
+
+    def _put_members(ids):
+        return test_client.put(
+            f"/api/data_sources/{ds['id']}",
+            json={"member_user_ids": ids},
+            headers=_headers(admin["token"], admin["org_id"]),
+        )
+
+    # First save adds m1 -> exactly one email, for m1.
+    r1 = _put_members([m1["user_id"]])
+    assert r1.status_code == 200, r1.json()
+    add_job.assert_called_once()
+    assert add_job.call_args.kwargs["args"][1] == m1["user_id"]
+
+    # Re-saving with m1 + m2 must notify only m2 (m1 already a member).
+    add_job.reset_mock()
+    r2 = _put_members([m1["user_id"], m2["user_id"]])
+    assert r2.status_code == 200, r2.json()
+    add_job.assert_called_once()
+    assert add_job.call_args.kwargs["args"][1] == m2["user_id"]
+
+
+def test_member_add_does_not_schedule_email_without_smtp(
+    monkeypatch, restore_email_client, test_client, bootstrap_admin,
+    invite_user_to_org, sqlite_data_source,
+):
+    admin = bootstrap_admin("ds_nosmtp")
+    member = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
+    ds = sqlite_data_source(
+        name=f"ds_{uuid.uuid4().hex[:8]}",
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+        is_public=False,
+    )
+
+    add_job = MagicMock()
+    monkeypatch.setattr(scheduler_mod.scheduler, "add_job", add_job)
+    bow_settings.email_client = None  # SMTP not configured
+
+    resp = _add_member(test_client, admin, ds, member)
+    assert resp.status_code == 200, resp.json()
+    add_job.assert_not_called()

--- a/backend/tests/unit/test_data_source_member_email.py
+++ b/backend/tests/unit/test_data_source_member_email.py
@@ -1,0 +1,146 @@
+"""Unit tests for delayed member-added data source email notifications.
+
+Covers the two requirements:
+  1. Email is only sent when SMTP is configured.
+  2. The send is delayed and re-validates membership, so an accidental add that
+     is undone within the window never results in an email.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import data_source_member_email as mod
+
+
+class _AsyncCM:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _session_maker(db):
+    maker = MagicMock()
+    maker.return_value = _AsyncCM(db)
+    return maker
+
+
+# --------------------------------------------------------------------------
+# schedule_member_added_email
+# --------------------------------------------------------------------------
+
+class TestScheduleMemberAddedEmail:
+    def test_noop_when_smtp_not_configured(self):
+        with patch("app.settings.config.settings") as settings, \
+             patch("app.core.scheduler.scheduler") as scheduler:
+            settings.email_client = None
+            mod.schedule_member_added_email("ds1", "user1", "admin1", "org1")
+            scheduler.add_job.assert_not_called()
+
+    def test_schedules_job_when_smtp_configured(self):
+        with patch("app.settings.config.settings") as settings, \
+             patch("app.core.scheduler.scheduler") as scheduler:
+            settings.email_client = MagicMock()
+            mod.schedule_member_added_email("ds1", "user1", "admin1", "org1")
+            scheduler.add_job.assert_called_once()
+            kwargs = scheduler.add_job.call_args.kwargs
+            assert kwargs["trigger"] == "date"
+            assert kwargs["args"][0] == "ds1"
+            assert kwargs["args"][1] == "user1"
+
+    def test_noop_when_adding_self(self):
+        with patch("app.settings.config.settings") as settings, \
+             patch("app.core.scheduler.scheduler") as scheduler:
+            settings.email_client = MagicMock()
+            # Actor adds themselves (e.g. creator/owner) — no email.
+            mod.schedule_member_added_email("ds1", "user1", "user1", "org1")
+            scheduler.add_job.assert_not_called()
+
+    def test_noop_without_recipient(self):
+        with patch("app.settings.config.settings") as settings, \
+             patch("app.core.scheduler.scheduler") as scheduler:
+            settings.email_client = MagicMock()
+            mod.schedule_member_added_email("ds1", "", "admin1", "org1")
+            scheduler.add_job.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# send_member_added_email
+# --------------------------------------------------------------------------
+
+def _make_db(membership, data_source, user, added_by):
+    db = MagicMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = membership
+    db.execute = AsyncMock(return_value=exec_result)
+    db.get = AsyncMock(side_effect=[data_source, user, added_by])
+    return db
+
+
+def _ds(name="Sales DB"):
+    ds = MagicMock()
+    ds.name = name
+    ds.deleted_at = None
+    return ds
+
+
+def _user(email="member@example.com", name="Member"):
+    u = MagicMock()
+    u.email = email
+    u.name = name
+    return u
+
+
+class TestSendMemberAddedEmail:
+    def test_sends_when_membership_present(self):
+        fm = MagicMock()
+        fm.send_message = AsyncMock()
+        db = _make_db(membership=object(), data_source=_ds(), user=_user(),
+                      added_by=_user("admin@example.com", "Admin"))
+
+        with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
+             patch("app.settings.config.settings") as settings, \
+             patch("app.dependencies.async_session_maker", _session_maker(db)):
+            settings.email_client = fm
+            settings.bow_config = MagicMock(base_url="http://localhost:3000")
+            asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
+
+        fm.send_message.assert_awaited_once()
+        message = fm.send_message.call_args.args[0]
+        assert message.recipients == ["member@example.com"]
+
+    def test_skips_when_membership_removed(self):
+        """The mistake-undo path: membership gone before the delay elapsed."""
+        fm = MagicMock()
+        fm.send_message = AsyncMock()
+        db = _make_db(membership=None, data_source=_ds(), user=_user(),
+                      added_by=_user("admin@example.com", "Admin"))
+
+        with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
+             patch("app.settings.config.settings") as settings, \
+             patch("app.dependencies.async_session_maker", _session_maker(db)):
+            settings.email_client = fm
+            settings.bow_config = MagicMock(base_url="http://localhost:3000")
+            asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
+
+        fm.send_message.assert_not_called()
+
+    def test_skips_when_smtp_unconfigured_at_send_time(self):
+        with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
+             patch("app.settings.config.settings") as settings, \
+             patch("app.dependencies.async_session_maker") as maker:
+            settings.email_client = None
+            asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
+            maker.assert_not_called()
+
+    def test_skips_when_not_claim_winner(self):
+        with patch("app.core.scheduler.claim_scheduled_run", return_value=False), \
+             patch("app.dependencies.async_session_maker") as maker:
+            asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
+            maker.assert_not_called()

--- a/frontend/components/IntegrationConnectionForm.vue
+++ b/frontend/components/IntegrationConnectionForm.vue
@@ -293,7 +293,7 @@ async function handleSubmit() {
             name: (agentName.value || props.integrationTitle || form.name).trim(),
             type: props.integrationType,
             connection_ids: [connection.id],
-            is_public: true,
+            is_public: false,
             auth_policy: 'user_required',
             allowed_user_auth_modes: ['oauth'],
           },

--- a/frontend/components/datasources/ConnectForm.vue
+++ b/frontend/components/datasources/ConnectForm.vue
@@ -225,7 +225,7 @@ function initKeyValueFields() {
   }
 }
 const selectedAuth = ref<string | undefined>(undefined)
-const is_public = ref(true)
+const is_public = ref(false)
 const require_user_auth = ref(Boolean(props.initialRequireUserAuth))
 const use_llm_onboarding = ref(true)
 const submitting = ref(false)

--- a/frontend/pages/agents/[id]/settings.vue
+++ b/frontend/pages/agents/[id]/settings.vue
@@ -349,7 +349,7 @@ const groupMembers = ref<Record<string, { user_id: string; user_name: string; us
 watch(injectedIntegration, (ds) => {
     if (ds) {
         form.name = ds?.name || ''
-        form.isPublic = ds?.is_public ?? true
+        form.isPublic = ds?.is_public ?? false
         original.name = form.name
         original.isPublic = form.isPublic
     }

--- a/frontend/pages/agents/new/index.vue
+++ b/frontend/pages/agents/new/index.vue
@@ -189,7 +189,7 @@ async function createAgentFromExistingConnection() {
       name: agentName.value.trim(),
       connection_ids: selectedConnections.value.map(c => c.id),
       use_llm_sync: useLlmSync.value,
-      is_public: true,
+      is_public: false,
       generate_summary: false,
       generate_conversation_starters: false,
       generate_ai_rules: false,


### PR DESCRIPTION
Default visibility:
- DataSource.is_public now defaults to False (private). Only explicitly
  added members (plus admins) see a data source unless it's opted public.
- Frontend create flows (ConnectForm, new-agent, integration connect) and
  the settings edit fallback now default is_public to false.

Member-added notifications (agents in product = data sources in backend):
- New app.services.data_source_member_email schedules a "you've been added"
  email when a user is added to a data source, but only if SMTP is
  configured.
- The send is delayed a few minutes via APScheduler and re-validates the
  membership at send time, so an accidental add that's undone within the
  window never results in an email. The send path claims the run so exactly
  one worker mails.
- Wired into every add path: the members endpoint, both create flows, and
  the update/Members-UI replace flow (diffing so existing members aren't
  re-notified). The creator/self is never emailed.

Tests: unit coverage for the scheduling + send/undo logic, and e2e coverage
for private-by-default and SMTP-gated, new-member-only scheduling.