### PR TITLE
Spark: lean connect form + rename title to "Spark"

### DIFF
--- a/backend/app/data_sources/clients/spark_connect_client.py
+++ b/backend/app/data_sources/clients/spark_connect_client.py
@@ -222,14 +222,18 @@ class SparkConnectClient(DataSourceClient):
     def _guard_enabled(self) -> bool:
         return bool(self.require_partition_filter or self.max_scan_bytes)
 
-    def explain_cost(self, sql: str, spark=None) -> str:
-        """Return the `EXPLAIN COST` plan text for a query (planning only, no scan).
+    def explain_cost(self, sql: str, spark=None, cost: bool = True) -> str:
+        """Return the EXPLAIN plan text for a query (planning only, no scan).
 
-        Uses `EXPLAIN COST <sql>` rather than DataFrame.explain() so the plan is
-        returned as a string over Spark Connect (explain() prints to stdout).
+        Uses a SQL `EXPLAIN` statement rather than DataFrame.explain() so the plan
+        is returned as a string over Spark Connect (explain() prints to stdout).
+        `cost=True` adds size statistics (needed only for a byte-size gate); the
+        partition-filter check needs just the physical plan, so it uses plain
+        `EXPLAIN`, which skips the stats work and is cheaper.
         """
+        stmt = "EXPLAIN COST" if cost else "EXPLAIN"
         def _do(s):
-            rows = s.sql(f"EXPLAIN COST {sql}").collect()
+            rows = s.sql(f"{stmt} {sql}").collect()
             return rows[0][0] if rows else ""
         if spark is not None:
             return _do(spark)
@@ -245,7 +249,9 @@ class SparkConnectClient(DataSourceClient):
         if not self._guard_enabled:
             return
         try:
-            plan = self.explain_cost(sql, spark=spark)
+            # COST stats only needed for the byte-size gate; partition-filter
+            # check works off the plain (cheaper) physical plan.
+            plan = self.explain_cost(sql, spark=spark, cost=bool(self.max_scan_bytes))
         except Exception:
             return  # can't explain -> don't block
 

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -506,7 +506,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
     ),
     "spark_connect": DataSourceRegistryEntry(
         type="spark_connect",
-        title="Spark Connect",
+        title="Spark",
         description="Run Spark SQL against a remote Spark cluster via Spark Connect (sc://). Compute runs on the cluster; BOW only sends SQL and receives results — no in-process engine on the BOW server.",
         config_schema=SparkConnectConfig,
         credentials_auth=AuthOptions(

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -657,26 +657,6 @@ class SparkConnectConfig(BaseModel):
         description="Reject queries that scan a partitioned table without filtering on a partition column (checked via EXPLAIN before the query runs).",
         json_schema_extra={"ui:type": "boolean"}
     )
-    max_scan_bytes: Optional[int] = Field(
-        None,
-        ge=0,
-        title="Max Scan Bytes",
-        description="Reject queries whose estimated scan size exceeds this many bytes (EXPLAIN-based pre-check, approximate; needs table stats). Keep blank to disable.",
-        json_schema_extra={"ui:type": "number"}
-    )
-    profile_partitions: bool = Field(
-        False,
-        title="Profile Partition Values",
-        description="Enrich partition columns with a bounded value summary (min/max/sample) from the metastore via SHOW PARTITIONS. Metadata only — no data scan. Skipped for tables with more partitions than the limit below.",
-        json_schema_extra={"ui:type": "boolean"}
-    )
-    partition_profile_limit: int = Field(
-        1000,
-        ge=1,
-        title="Partition Profile Limit",
-        description="Max partitions to read when profiling partition values. Tables above this are flagged as partitioned but not value-profiled (keeps high-cardinality tables cheap).",
-        json_schema_extra={"ui:type": "number"}
-    )
 
 
 # OAuth Delegated Credentials (empty — user provides nothing, OAuth flow populates tokens)

--- a/backend/tests/unit/test_spark_connect_client.py
+++ b/backend/tests/unit/test_spark_connect_client.py
@@ -346,7 +346,7 @@ def _install_plan_aware_spark(monkeypatch, plan_text):
 
     def _sql(q):
         res = MagicMock()
-        if q.strip().upper().startswith("EXPLAIN COST"):
+        if q.strip().upper().startswith("EXPLAIN"):
             res.collect.return_value = [(plan_text,)]
         else:
             res.toPandas.return_value = pd.DataFrame({"x": [1]})
@@ -397,7 +397,7 @@ class TestExplainGate:
         spark = MagicMock()
 
         def _sql(q):
-            if q.strip().upper().startswith("EXPLAIN COST"):
+            if q.strip().upper().startswith("EXPLAIN"):
                 raise RuntimeError("cannot explain")
             res = MagicMock()
             res.toPandas.return_value = pd.DataFrame({"x": [1]})


### PR DESCRIPTION
Follow-up to the merged Spark Connect connector (#368), refining the data source before it ships via #367.

**Changes**
- **Lean connect form** — drop `max_scan_bytes`, `profile_partitions`, and `partition_profile_limit` from `SparkConnectConfig`. Those are query-governance/tuning knobs, not connection settings, and cluttered the form. Only `require_partition_filter` stays. The client constructor kwargs + code paths for the removed options are retained, so they can resurface via a proper settings surface later without re-implementation.
- **Rename** the data source title **"Spark Connect" → "Spark"**. The internal `type` stays `spark_connect`, so the client resolver, icon (`spark_connect.png`), and registry wiring are unaffected.
- **Pre-flight speedup** — with no byte-size cap to compute, `require_partition_filter` now uses plain `EXPLAIN` instead of `EXPLAIN COST`, skipping the stats work (the partition-filter check only needs the physical plan's `PartitionFilters`).

The form is now **Host · Port · Auth · (use_ssl · catalog · database)** + the single `require_partition_filter` guardrail.

**Tests:** 33 unit tests passing (plan-aware fakes broadened to match plain `EXPLAIN`).

Note: this branch contains *only* the lean-form/rename commit — the e2e completion test commits on `claude/duckdb-low-resource-server-swdiot` are intentionally excluded.

https://claude.ai/code/session_01LnDCyj4ZqtxTd8MPLJH4LU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnDCyj4ZqtxTd8MPLJH4LU)_