### PR TITLE
Show all loaded instructions including system category ones

### DIFF
--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1160,7 +1160,9 @@ async function editTrainingInstruction(inst: { instructionId: string }) {
 }
 
 function visibleInstructions(m: ChatMessage) {
-	return (m._loaded_instructions || []).filter((ins: any) => ins.category !== 'system')
+	// Show every loaded instruction (including system-category ones) so the
+	// count and popover match the agent trace modal, which lists all of them.
+	return m._loaded_instructions || []
 }
 
 function isScheduledSystemExpanded(msg: ChatMessage): boolean {


### PR DESCRIPTION
## Summary
Updated the `visibleInstructions` function to display all loaded instructions instead of filtering out system-category instructions. This ensures consistency between the instruction count/popover display and the agent trace modal.

## Changes
- Removed the filter that excluded instructions with `category === 'system'`
- Now returns all loaded instructions (`m._loaded_instructions || []`)
- Added clarifying comment explaining the rationale: to match the behavior of the agent trace modal which lists all instructions

## Details
Previously, the function filtered out system-category instructions from the visible set, which caused a mismatch between what was displayed in the instruction count/popover and what appeared in the agent trace modal. This change aligns the two views by showing the complete set of loaded instructions.

https://claude.ai/code/session_016zzpRQtAoHuyaZxctCGESA