### PR TITLE
Implement enterprise license quotas for users and agents

### DIFF
--- a/backend/app/ee/__init__.py
+++ b/backend/app/ee/__init__.py
@@ -7,6 +7,8 @@ from app.ee.license import (
     get_license_info,
     require_enterprise,
     is_datasource_allowed,
+    get_max_users,
+    get_max_agents,
     LicenseInfo,
     ENTERPRISE_DATASOURCES,
 )
@@ -16,6 +18,8 @@ __all__ = [
     "get_license_info",
     "require_enterprise",
     "is_datasource_allowed",
+    "get_max_users",
+    "get_max_agents",
     "LicenseInfo",
     "ENTERPRISE_DATASOURCES",
 ]

--- a/backend/app/ee/license.py
+++ b/backend/app/ee/license.py
@@ -54,6 +54,11 @@ class LicenseInfo(BaseModel):
     expires_at: Optional[datetime] = None
     features: List[str] = []
     license_id: Optional[str] = None
+    # Per-organization quotas. -1 means "no limit" (the default when the license
+    # omits them or the instance is unlicensed/expired). A value >= 0 is a hard cap
+    # enforced on member invites and data source ("agent") creation.
+    max_users: int = -1
+    max_agents: int = -1
 
 
 # Cached license info (the license key's signature is verified and decoded once).
@@ -78,6 +83,21 @@ def _get_license_key() -> Optional[str]:
             return None
         return key
     return None
+
+
+def _coerce_limit(value) -> int:
+    """Normalize a quota claim from the JWT into an int limit.
+
+    Anything missing, non-numeric, or negative is treated as "no limit" (-1).
+    A value of 0 is preserved (a deliberate cap of zero), so only >= 0 caps bite.
+    """
+    if value is None:
+        return -1
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return -1
+    return limit if limit >= 0 else -1
 
 
 def _validate_license_key(key: str) -> LicenseInfo:
@@ -125,7 +145,10 @@ def _validate_license_key(key: str) -> LicenseInfo:
             org_name=payload.get("org_name"),
             expires_at=expires_at,
             features=payload.get("features", []),
-            license_id=payload.get("sub")
+            license_id=payload.get("sub"),
+            # Quotas only apply to an active license. Missing/negative → unlimited.
+            max_users=_coerce_limit(payload.get("max_users")),
+            max_agents=_coerce_limit(payload.get("max_agents")),
         )
 
     except jwt.InvalidTokenError as e:
@@ -241,6 +264,22 @@ def is_datasource_allowed(ds_type: str) -> bool:
 
     # Only enterprise tier gets access to enterprise data sources
     return license_info.tier == "enterprise"
+
+
+def get_max_users() -> int:
+    """Max members (active + pending invites) allowed per organization.
+
+    Returns -1 (unlimited) unless an *active* license sets an explicit cap.
+    """
+    return get_license_info().max_users
+
+
+def get_max_agents() -> int:
+    """Max data sources ("agents") allowed per organization.
+
+    Returns -1 (unlimited) unless an *active* license sets an explicit cap.
+    """
+    return get_license_info().max_agents
 
 
 def require_enterprise(feature: Optional[str] = None):

--- a/backend/app/ee/routes.py
+++ b/backend/app/ee/routes.py
@@ -2,11 +2,20 @@
 # Licensed under the Business Source License 1.1
 # See ENTERPRISE_LICENSE for details
 
-from fastapi import APIRouter
-from app.ee.license import get_license_info, LicenseInfo
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
+from app.ee.license import get_license_info, get_max_users, get_max_agents, LicenseInfo
 from app.ee.audit.routes import router as audit_router
 from app.ee.scim.routes import scim_admin_router
 from app.ee.ldap.routes import ldap_admin_router
+from app.dependencies import get_async_db, get_current_organization
+from app.core.auth import current_user
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.membership import Membership
+from app.models.data_source import DataSource
 
 router = APIRouter(tags=["enterprise"])
 
@@ -23,3 +32,45 @@ async def get_license_status():
     This endpoint is public and does not require authentication.
     """
     return get_license_info()
+
+
+class LicenseUsage(BaseModel):
+    """Current per-organization usage against the license quotas.
+
+    A max of -1 means unlimited. Counts reflect this organization only.
+    """
+    max_users: int = -1
+    current_users: int = 0
+    max_agents: int = -1
+    current_agents: int = 0
+
+
+@router.get("/license/usage", response_model=LicenseUsage)
+async def get_license_usage(
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+):
+    """
+    Current usage for the active organization against its license quotas.
+
+    Unlike /license, this is organization-scoped (requires auth + org context) so
+    the UI can render a "used / allowed" seat and agent readout. Members include
+    pending invites; agents are data sources.
+    """
+    users_result = await db.execute(
+        select(func.count(Membership.id)).where(
+            Membership.organization_id == organization.id
+        )
+    )
+    agents_result = await db.execute(
+        select(func.count(DataSource.id)).where(
+            DataSource.organization_id == organization.id
+        )
+    )
+    return LicenseUsage(
+        max_users=get_max_users(),
+        current_users=users_result.scalar() or 0,
+        max_agents=get_max_agents(),
+        current_agents=agents_result.scalar() or 0,
+    )

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -279,7 +279,27 @@ class DataSourceService:
 
         if data_source_dict['name'] == '':
             raise HTTPException(status_code=400, detail="Data source name is required")
-        
+
+        # Enforce per-organization agent (data source) cap from the enterprise license.
+        # No-op when unlicensed/unset (max_agents == -1 → unlimited).
+        from app.ee.license import get_max_agents
+        max_agents = get_max_agents()
+        if max_agents >= 0:
+            count_result = await db.execute(
+                select(func.count(DataSource.id)).filter(
+                    DataSource.organization_id == organization.id
+                )
+            )
+            current_agents = count_result.scalar() or 0
+            if current_agents >= max_agents:
+                raise HTTPException(
+                    status_code=402,
+                    detail=(
+                        f"Agent limit reached for your license ({max_agents}). "
+                        "Contact sales to increase your agent count."
+                    ),
+                )
+
         # Remove legacy generation flags (generation now deferred to llm_sync after table selection)
         data_source_dict.pop("generate_summary", None)
         data_source_dict.pop("generate_conversation_starters", None)

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -243,6 +243,39 @@ class OrganizationService:
         return result.scalar_one_or_none()
     
 
+    async def _count_org_memberships(self, db: AsyncSession, organization_id) -> int:
+        """Count all memberships in an org — active members and pending invites alike.
+
+        Pending invites (user_id is NULL) count too, so the license seat cap can't be
+        bypassed by leaving invites unaccepted.
+        """
+        from sqlalchemy import func
+        result = await db.execute(
+            select(func.count(Membership.id)).where(
+                Membership.organization_id == organization_id
+            )
+        )
+        return result.scalar() or 0
+
+    async def _enforce_user_limit(self, db: AsyncSession, organization_id, adding: int = 1) -> None:
+        """Raise 402 if adding `adding` member(s) would exceed the license seat cap.
+
+        No-op when unlicensed/unset (max_users == -1 → unlimited).
+        """
+        from app.ee.license import get_max_users
+        max_users = get_max_users()
+        if max_users < 0:
+            return
+        current = await self._count_org_memberships(db, organization_id)
+        if current + adding > max_users:
+            raise HTTPException(
+                status_code=402,
+                detail=(
+                    f"User limit reached for your license ({max_users}). "
+                    "Contact sales to increase your seat count."
+                ),
+            )
+
     async def add_member(self, db: AsyncSession, membership_data: MembershipCreate, current_user: User) -> MembershipSchema:
         #check if email is already a user
         # if it is, add user_id to membership and remove email
@@ -251,6 +284,11 @@ class OrganizationService:
         membership_exists = await self._is_email_already_in_organization(db, membership_data.email, membership_data.organization_id)
         if membership_exists:
             raise HTTPException(status_code=400, detail="Already a member with this email")
+
+        # Enforce per-organization seat cap from the enterprise license (if any).
+        # Checked after the duplicate guard so re-adding an existing email still
+        # 400s rather than being masked by a seat-limit 402.
+        await self._enforce_user_limit(db, membership_data.organization_id)
         
         user = await db.execute(select(User).where(User.email == membership_data.email))
         user = user.scalar_one_or_none()
@@ -609,6 +647,16 @@ class OrganizationService:
         report_rows: List[MembershipImportRow] = []
         summary = MembershipImportSummary()
 
+        # Enterprise license seat cap. We track a running projection of how many *new*
+        # members the import would create so the limit is reported up front — in the
+        # dry-run preview and the real run alike — instead of failing row-by-row only
+        # once writes start. -1 means unlimited. Existing members (updated/unchanged)
+        # don't consume a new seat, so only freshly-created rows count toward it.
+        from app.ee.license import get_max_users
+        max_users = get_max_users()
+        current_members = await self._count_org_memberships(db, organization.id) if max_users >= 0 else 0
+        projected_new = 0
+
         for idx, raw in enumerate(rows, start=2):  # data starts at row 2 (header is row 1)
             email = (raw.get("email") or "").strip()
             note = raw.get("note")
@@ -653,6 +701,20 @@ class OrganizationService:
                 continue
 
             # New email — invite as a new pending membership.
+            # Gate against the license seat cap using the running projection so the
+            # overflow is reported identically in dry-run and real runs.
+            if max_users >= 0 and current_members + projected_new >= max_users:
+                report_rows.append(MembershipImportRow(
+                    row=idx, email=email, note=note, status="error",
+                    error=(
+                        f"User limit reached for your license ({max_users}). "
+                        "Contact sales to increase your seat count."
+                    ),
+                ))
+                summary.errors += 1
+                continue
+            projected_new += 1
+
             if dry_run:
                 report_rows.append(MembershipImportRow(
                     row=idx, email=email, note=note, status="created",

--- a/backend/tests/e2e/test_license_limits.py
+++ b/backend/tests/e2e/test_license_limits.py
@@ -1,0 +1,243 @@
+"""e2e tests for enterprise license quotas: max_users (members/invites) and
+max_agents (data sources) per organization.
+
+The license signature path is exercised elsewhere; here we drive the *enforcement*
+by seeding the in-process license cache directly (no private signing key needed).
+A quota of -1 means unlimited, which is also the default when a license omits it.
+
+Covers:
+ - single invite blocked once the seat cap is reached (active members + pending invites)
+ - no cap when max_users is unset (-1)
+ - bulk CSV/xlsx import reports the seat overflow in both dry-run and real runs
+ - data source ("agent") creation blocked once the agent cap is reached
+ - no cap when max_agents is unset (-1)
+ - GET /license/usage reports current vs allowed for the active org
+"""
+import contextlib
+import io
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+import app.ee.license as license_mod
+from app.ee.license import LicenseInfo
+
+
+CHINOOK_DB = (Path(__file__).resolve().parent.parent / "config" / "chinook.sqlite").resolve()
+
+
+@contextlib.contextmanager
+def _license(*, max_users: int = -1, max_agents: int = -1):
+    """Temporarily seed an active enterprise license with the given quotas.
+
+    Writes the module-level cache so every caller — services and routes — reads the
+    same live LicenseInfo, regardless of how each module imported the helpers.
+    """
+    prev_cache = license_mod._cached_license
+    prev_init = license_mod._cache_initialized
+    license_mod._cached_license = LicenseInfo(
+        licensed=True,
+        tier="enterprise",
+        org_name="Test Org",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=365),
+        max_users=max_users,
+        max_agents=max_agents,
+    )
+    license_mod._cache_initialized = True
+    try:
+        yield
+    finally:
+        license_mod._cached_license = prev_cache
+        license_mod._cache_initialized = prev_init
+
+
+def _auth_headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": org_id}
+
+
+def _admin_setup(create_user, login_user, whoami):
+    admin = create_user()
+    token = login_user(admin["email"], admin["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    return admin, token, org_id
+
+
+def _invite(test_client, token, org_id, email, role="member"):
+    return test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": email, "role": role},
+        headers=_auth_headers(token, org_id),
+    )
+
+
+def _csv_bytes(emails):
+    out = io.StringIO()
+    out.write("email,note\n")
+    for email in emails:
+        out.write(f"{email},\n")
+    return out.getvalue().encode("utf-8")
+
+
+def _rand_email(prefix="u"):
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@test.com"
+
+
+# ---------------------------------------------------------------------------
+# max_users — single invites
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_user_limit_blocks_invite_when_cap_reached(test_client, create_user, login_user, whoami):
+    # Org starts with 1 membership (the admin). Cap at 2 → exactly one more invite.
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    with _license(max_users=2):
+        first = _invite(test_client, token, org_id, _rand_email())
+        assert first.status_code == 200, first.json()
+
+        second = _invite(test_client, token, org_id, _rand_email())
+        assert second.status_code == 402, second.json()
+        assert "limit" in second.json()["detail"].lower()
+
+
+@pytest.mark.e2e
+def test_pending_invites_count_toward_user_limit(test_client, create_user, login_user, whoami):
+    """Pending (unaccepted) invites consume seats too — the cap can't be bypassed."""
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    with _license(max_users=2):
+        # admin (1) + one pending invite (2) = full
+        assert _invite(test_client, token, org_id, _rand_email()).status_code == 200
+        # even though the invite is still pending, the next one is blocked
+        assert _invite(test_client, token, org_id, _rand_email()).status_code == 402
+
+
+@pytest.mark.e2e
+def test_user_limit_unlimited_when_unset(test_client, create_user, login_user, whoami):
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    with _license(max_users=-1):
+        for _ in range(5):
+            assert _invite(test_client, token, org_id, _rand_email()).status_code == 200
+
+
+@pytest.mark.e2e
+def test_no_license_means_no_user_cap(test_client, create_user, login_user, whoami):
+    """Without any license seeded (community mode), invites are unlimited."""
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    for _ in range(4):
+        assert _invite(test_client, token, org_id, _rand_email()).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# max_users — bulk import
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_import_respects_user_limit(test_client, create_user, login_user, whoami, dry_run):
+    # Org has the admin (1). Cap 2 → only ONE new member fits; the rest overflow.
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    emails = [_rand_email("imp") for _ in range(3)]
+    csv = _csv_bytes(emails)
+
+    with _license(max_users=2):
+        resp = test_client.post(
+            f"/api/organizations/{org_id}/members/import?dry_run={'true' if dry_run else 'false'}",
+            files={"file": ("members.csv", csv, "text/csv")},
+            headers=_auth_headers(token, org_id),
+        )
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["summary"]["created"] == 1
+    assert report["summary"]["errors"] == 2
+    overflow = [r for r in report["rows"] if r["status"] == "error"]
+    assert overflow and all("limit" in r["error"].lower() for r in overflow)
+
+
+# ---------------------------------------------------------------------------
+# max_agents — data sources
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_agent_limit_blocks_data_source(test_client, create_data_source, create_user, login_user, whoami):
+    if not CHINOOK_DB.exists():
+        pytest.skip(f"SQLite test database missing at {CHINOOK_DB}")
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    def _make(name):
+        return test_client.post(
+            "/api/data_sources",
+            json={
+                "name": name,
+                "type": "sqlite",
+                "config": {"database": str(CHINOOK_DB)},
+                "credentials": {},
+                "auth_policy": "system_only",
+                "generate_summary": False,
+                "generate_conversation_starters": False,
+                "generate_ai_rules": False,
+            },
+            headers=_auth_headers(token, org_id),
+        )
+
+    with _license(max_agents=1):
+        first = _make("agent-1")
+        assert first.status_code == 200, first.json()
+        second = _make("agent-2")
+        assert second.status_code == 402, second.json()
+        assert "limit" in second.json()["detail"].lower()
+
+
+@pytest.mark.e2e
+def test_agent_limit_unlimited_when_unset(test_client, create_data_source, create_user, login_user, whoami):
+    if not CHINOOK_DB.exists():
+        pytest.skip(f"SQLite test database missing at {CHINOOK_DB}")
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    with _license(max_agents=-1):
+        for i in range(3):
+            ds = create_data_source(
+                name=f"agent-{i}",
+                type="sqlite",
+                config={"database": str(CHINOOK_DB)},
+                credentials={},
+                user_token=token,
+                org_id=org_id,
+            )
+            assert ds["name"] == f"agent-{i}"
+
+
+# ---------------------------------------------------------------------------
+# usage endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_license_usage_endpoint(test_client, create_user, login_user, whoami):
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    # admin (1) + one invite = 2 members
+    assert _invite(test_client, token, org_id, _rand_email()).status_code == 200
+
+    with _license(max_users=10, max_agents=5):
+        resp = test_client.get("/api/license/usage", headers=_auth_headers(token, org_id))
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["max_users"] == 10
+    assert body["current_users"] == 2
+    assert body["max_agents"] == 5
+    assert body["current_agents"] == 0
+
+
+@pytest.mark.e2e
+def test_license_usage_reports_unlimited(test_client, create_user, login_user, whoami):
+    _, token, org_id = _admin_setup(create_user, login_user, whoami)
+    with _license(max_users=-1, max_agents=-1):
+        resp = test_client.get("/api/license/usage", headers=_auth_headers(token, org_id))
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["max_users"] == -1
+    assert body["max_agents"] == -1
+    assert body["current_users"] >= 1  # at least the admin

--- a/backend/tests/unit/test_license_limits.py
+++ b/backend/tests/unit/test_license_limits.py
@@ -1,0 +1,56 @@
+"""Unit tests for license quota parsing (max_users / max_agents).
+
+These cover the pure helpers without touching the DB or the signing key:
+ - _coerce_limit normalization rules
+ - LicenseInfo defaults to unlimited (-1)
+ - get_max_users / get_max_agents read the live cache
+"""
+import pytest
+
+import app.ee.license as license_mod
+from app.ee.license import LicenseInfo, _coerce_limit, get_max_users, get_max_agents
+
+
+@pytest.mark.parametrize("value,expected", [
+    (None, -1),       # missing → unlimited
+    (-1, -1),         # explicit unlimited
+    (-5, -1),         # any negative → unlimited
+    (0, 0),           # a deliberate cap of zero is preserved
+    (10, 10),         # normal cap
+    ("25", 25),       # numeric string coerced
+    ("nope", -1),     # non-numeric → unlimited
+    (3.0, 3),         # float coerced to int
+])
+def test_coerce_limit(value, expected):
+    assert _coerce_limit(value) == expected
+
+
+def test_license_info_defaults_to_unlimited():
+    info = LicenseInfo()
+    assert info.max_users == -1
+    assert info.max_agents == -1
+
+
+@pytest.fixture
+def restore_license_cache():
+    prev_cache = license_mod._cached_license
+    prev_init = license_mod._cache_initialized
+    yield
+    license_mod._cached_license = prev_cache
+    license_mod._cache_initialized = prev_init
+
+
+def test_getters_read_active_license(restore_license_cache):
+    license_mod._cached_license = LicenseInfo(
+        licensed=True, tier="enterprise", max_users=7, max_agents=3
+    )
+    license_mod._cache_initialized = True
+    assert get_max_users() == 7
+    assert get_max_agents() == 3
+
+
+def test_getters_unlimited_when_unlicensed(restore_license_cache):
+    license_mod._cached_license = LicenseInfo(licensed=False, tier="community")
+    license_mod._cache_initialized = True
+    assert get_max_users() == -1
+    assert get_max_agents() == -1


### PR DESCRIPTION
## Summary
Add enforcement of per-organization license quotas for maximum users (members + pending invites) and maximum agents (data sources). Quotas are defined in the enterprise license JWT and enforced at the API layer when creating members or data sources. A new `/api/license/usage` endpoint reports current usage against the license limits.

## Key Changes

- **License quota parsing** (`app/ee/license.py`):
  - Added `max_users` and `max_agents` fields to `LicenseInfo` (default to -1 for unlimited)
  - Implemented `_coerce_limit()` helper to normalize quota claims from JWT (missing/negative → -1, zero preserved)
  - Added `get_max_users()` and `get_max_agents()` getters that return -1 when unlicensed or quota unset

- **User/member quota enforcement** (`app/services/organization_service.py`):
  - Added `_count_org_memberships()` to count active members + pending invites
  - Added `_enforce_user_limit()` to check seat cap before adding members (raises 402 when exceeded)
  - Integrated enforcement into `add_member()` for single invites
  - Integrated enforcement into `import_members()` with running projection of new members so overflow is reported identically in dry-run and real runs

- **Agent/data source quota enforcement** (`app/services/data_source_service.py`):
  - Added agent count check in `create_data_source()` (raises 402 when limit reached)

- **License usage endpoint** (`app/ee/routes.py`):
  - New `GET /api/license/usage` returns current vs. allowed counts for users and agents in the active organization
  - Requires authentication and organization context

- **Test coverage**:
  - E2E tests (`backend/tests/e2e/test_license_limits.py`): Single invites, pending invites, bulk CSV/XLSX import, data source creation, usage endpoint
  - Unit tests (`backend/tests/unit/test_license_limits.py`): Quota parsing and getter behavior

## Implementation Details

- Quotas only apply to active enterprise licenses; unlicensed instances have no limits
- A quota of -1 means unlimited (the default when omitted from the license)
- Pending (unaccepted) invites count toward the user seat cap to prevent bypassing the limit
- Bulk member import reports overflow errors up front (in both dry-run and real runs) rather than failing row-by-row
- HTTP 402 (Payment Required) is used for quota limit violations
- The license cache is seeded directly in tests (no private signing key needed)

https://claude.ai/code/session_01GDk9foHNraGPycApeUNkfC