### PR TITLE
Add periodic schema auto-reload (scheduled reindex)

### DIFF
--- a/backend/alembic/versions/sf4a5b6c7d8e_add_connection_auto_reindex.py
+++ b/backend/alembic/versions/sf4a5b6c7d8e_add_connection_auto_reindex.py
@@ -1,0 +1,57 @@
+"""add per-connection scheduled auto-reindex columns
+
+Revision ID: sf4a5b6c7d8e
+Revises: se3f4a5b6c7d
+Create Date: 2026-06-12 10:00:00.000000
+
+Adds per-connection scheduling state for the background schema auto-reload
+sweeper (`app.services.scheduled_reindex.sweep_due_reindexes`):
+
+  - auto_reindex_enabled   : per-connection on/off toggle (default on)
+  - reindex_interval_hours : per-connection cadence override (NULL -> 12h default)
+  - next_retry_at          : failure/backoff gate so a failing source isn't
+                             re-kicked every sweep tick
+  - last_reindex_error     : last background reindex error (diagnostics)
+
+The feature is gated behind the enterprise `scheduled_reindex` license feature;
+the columns themselves are harmless on community installs (the sweeper no-ops
+without the license).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'sf4a5b6c7d8e'
+down_revision: Union[str, None] = 'se3f4a5b6c7d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # server_default so existing rows backfill to "enabled" without a data migration.
+    op.add_column(
+        'connections',
+        sa.Column('auto_reindex_enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        'connections',
+        sa.Column('reindex_interval_hours', sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        'connections',
+        sa.Column('next_retry_at', sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        'connections',
+        sa.Column('last_reindex_error', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('connections', 'last_reindex_error')
+    op.drop_column('connections', 'next_retry_at')
+    op.drop_column('connections', 'reindex_interval_hours')
+    op.drop_column('connections', 'auto_reindex_enabled')

--- a/backend/app/ee/license.py
+++ b/backend/app/ee/license.py
@@ -28,6 +28,7 @@ TIER_FEATURES = {
         "ldap",
         "domain_signup",
         "usage_limits",
+        "scheduled_reindex",
     ],
 }
 

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, JSON, DateTime, Text, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, String, Boolean, JSON, DateTime, Text, Integer, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
 from app.models.base import BaseSchema
 from cryptography.fernet import Fernet
@@ -31,7 +31,31 @@ class Connection(BaseSchema):
     # Authentication policy
     auth_policy = Column(String, nullable=False, default="system_only")  # system_only, user_required
     allowed_user_auth_modes = Column(JSON, nullable=True, default=None)
-    
+
+    # Scheduled schema auto-reload (enterprise feature `scheduled_reindex`).
+    # A background sweeper periodically re-indexes the shared catalog so tables
+    # stay fresh without a manual reindex. Per-connection so admins can tune
+    # cadence (or disable) per source. NULL interval falls back to the default.
+    auto_reindex_enabled = Column(Boolean, nullable=False, default=True)
+    reindex_interval_hours = Column(Integer, nullable=True, default=None)
+    # Failure backoff / "wait for next attempt" state for the sweeper. On a
+    # failed (or skipped) background reindex we set next_retry_at so we don't
+    # hammer the source every tick — user_required catalogs heal on user login
+    # in the meantime. Cleared on a successful index.
+    next_retry_at = Column(DateTime, nullable=True, default=None)
+    last_reindex_error = Column(Text, nullable=True, default=None)
+
+    # Default cadence when reindex_interval_hours is unset (every 12 hours).
+    DEFAULT_REINDEX_INTERVAL_HOURS = 12
+
+    @property
+    def effective_reindex_interval_hours(self) -> int:
+        """Resolved reindex cadence — the per-connection override or the default."""
+        val = self.reindex_interval_hours
+        if val is None or val <= 0:
+            return self.DEFAULT_REINDEX_INTERVAL_HOURS
+        return val
+
     # Organization ownership
     organization_id = Column(String(36), ForeignKey('organizations.id'), nullable=False)
     organization = relationship("Organization", back_populates="connections")

--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -322,6 +322,10 @@ async def get_connection(
         agent_count=len(connection.data_sources) if connection.data_sources else 0,
         agent_names=[ds.name for ds in connection.data_sources] if connection.data_sources else [],
         has_credentials=has_credentials,
+        auto_reindex_enabled=bool(connection.auto_reindex_enabled),
+        reindex_interval_hours=connection.reindex_interval_hours,
+        next_retry_at=connection.next_retry_at.isoformat() if connection.next_retry_at else None,
+        last_reindex_error=connection.last_reindex_error,
     )
 
 

--- a/backend/app/schemas/connection_schema.py
+++ b/backend/app/schemas/connection_schema.py
@@ -27,6 +27,9 @@ class ConnectionUpdate(BaseModel):
     is_active: Optional[bool] = None
     auth_policy: Optional[str] = None  # system_only, user_required
     allowed_user_auth_modes: Optional[list] = None
+    # Scheduled auto-reindex (enterprise `scheduled_reindex` feature).
+    auto_reindex_enabled: Optional[bool] = None
+    reindex_interval_hours: Optional[int] = None
 
 
 class ConnectionSchema(BaseModel):
@@ -71,6 +74,11 @@ class ConnectionDetailSchema(BaseModel):
     agent_count: int = 0
     agent_names: List[str] = []  # Names of linked agents (for delete confirmation)
     has_credentials: bool = False  # Whether system credentials are set
+    # Scheduled auto-reindex config (enterprise `scheduled_reindex` feature).
+    auto_reindex_enabled: bool = True
+    reindex_interval_hours: Optional[int] = None  # NULL -> default cadence
+    next_retry_at: Optional[str] = None
+    last_reindex_error: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -378,6 +378,15 @@ class ConnectionIndexingService:
                             fresh.error = str(exc)[:4000]
                             fresh.finished_at = datetime.utcnow()
                             await err_db.commit()
+                        # Record the failure on the connection for the scheduled
+                        # auto-reindex sweeper's diagnostics. next_retry_at was
+                        # already stamped by the sweeper before kicking, so the
+                        # connection won't be re-kicked until its interval elapses
+                        # (user_required catalogs heal on user login meanwhile).
+                        conn_row = await err_db.get(Connection, row.connection_id)
+                        if conn_row is not None:
+                            conn_row.last_reindex_error = str(exc)[:4000]
+                            await err_db.commit()
                     await _append_event("error", _state_snapshot()["phase"], f"Indexing failed: {exc}")
                     return
 

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -278,6 +278,25 @@ class ConnectionService:
                     detail="User authentication mode requires an enterprise license."
                 )
 
+        # Scheduled auto-reindex is an enterprise feature. Gate any attempt to
+        # customize the cadence / toggle so community installs can't configure a
+        # job the sweeper will never run for them (the sweeper itself also checks
+        # the license — this just rejects the write with a clear 402).
+        if ("auto_reindex_enabled" in updates) or ("reindex_interval_hours" in updates):
+            from app.ee.license import has_feature
+            if not has_feature("scheduled_reindex"):
+                raise HTTPException(
+                    status_code=402,
+                    detail="Scheduled schema reindexing requires an enterprise license.",
+                )
+            # Sanity-bound the interval (1 hour .. 7 days).
+            ivl = updates.get("reindex_interval_hours")
+            if ivl is not None and (ivl < 1 or ivl > 24 * 7):
+                raise HTTPException(
+                    status_code=400,
+                    detail="reindex_interval_hours must be between 1 and 168.",
+                )
+
         # Default allowed_user_auth_modes when switching to user_required (see create_connection)
         if new_auth_policy == "user_required" and not updates.get("allowed_user_auth_modes"):
             from app.services.connection_oauth_service import ENTRA_OBO_CONNECTION_TYPES
@@ -834,6 +853,10 @@ class ConnectionService:
             # NOTE: our SQLAlchemy DateTime columns are stored as TIMESTAMP WITHOUT TIME ZONE,
             # so we must write naive UTC datetimes (asyncpg will error on tz-aware datetimes).
             connection.last_synced_at = datetime.utcnow()
+            # A successful index clears any scheduled-reindex failure backoff so
+            # the staleness gate alone governs the next auto-reload.
+            connection.next_retry_at = None
+            connection.last_reindex_error = None
             logger.info(f"refresh_schema: Committing {created_count} new tables to database...")
             await db.commit()
             logger.info(f"refresh_schema: Commit successful")

--- a/backend/app/services/scheduled_reindex.py
+++ b/backend/app/services/scheduled_reindex.py
@@ -1,0 +1,163 @@
+"""Scheduled schema auto-reload sweeper.
+
+Periodically re-indexes connection schemas so tables stay fresh without a
+manual reindex — the schema-side counterpart to the QVD/PBIRS cache warmups.
+
+Design (see docs/design discussion in the PR):
+
+  * Decoupled tick vs. work. A frequent, cheap sweep selects only the
+    connections whose schema is *due* (stale past their per-connection
+    interval) and kicks a bounded batch of them. Steady-state load is
+    O(N / interval), not O(N) per tick, so it stays flat at hundreds of
+    connections.
+
+  * Bounded batch. At most `BOW_REINDEX_SWEEP_BATCH` connections are kicked
+    per tick (oldest-synced first), so a burst of newly-due connections can
+    never become a thundering herd against upstream sources.
+
+  * Idempotent + deduped. The sweep tick is claimed via `claim_scheduled_run`
+    (one worker/replica per fire) and each connection goes through
+    `ConnectionIndexingService.start`, which is itself idempotent (returns the
+    in-flight row if an index is already running).
+
+  * Failure backoff / heal-on-login. Before kicking, we stamp
+    `next_retry_at = now + interval`, so a connection that fails (or is skipped
+    because a user_required source has no system creds) is not re-kicked every
+    tick. user_required per-user catalogs heal on the next user login instead.
+    A successful index clears `next_retry_at` and advances `last_synced_at`
+    (both gate re-selection).
+
+  * Enterprise-gated. No-ops entirely unless the `scheduled_reindex` license
+    feature is active.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
+
+SWEEP_JOB_ID = "schema_reindex_sweep"
+
+# Max connections kicked per sweep tick. Caps concurrent upstream load; the
+# rest roll to the next tick. Generous default — steady-state due-count per
+# tick is N/(interval/sweep_period), far below this for typical deployments.
+_DEFAULT_BATCH = 10
+
+
+def _batch_size() -> int:
+    try:
+        return max(1, int(os.environ.get("BOW_REINDEX_SWEEP_BATCH", _DEFAULT_BATCH)))
+    except (TypeError, ValueError):
+        return _DEFAULT_BATCH
+
+
+def _is_due(connection, now: datetime) -> bool:
+    """True if this connection's shared catalog is stale past its interval.
+
+    NULL `last_synced_at` (never indexed) counts as due. The per-connection
+    interval (or the model default) governs cadence.
+    """
+    interval = timedelta(hours=connection.effective_reindex_interval_hours)
+    last = connection.last_synced_at
+    if last is None:
+        return True
+    return (now - last) >= interval
+
+
+async def sweep_due_reindexes() -> None:
+    """Scheduled entrypoint: re-index every connection whose schema is due.
+
+    Safe to register on a short APScheduler interval (e.g. every 10 minutes);
+    the staleness gate keeps actual reindex work proportional to N / interval.
+    """
+    from app.core.scheduler import claim_scheduled_run
+
+    # One worker/replica per fire.
+    if not await asyncio.to_thread(claim_scheduled_run, SWEEP_JOB_ID):
+        return
+
+    # Enterprise gate — community installs get manual refresh only.
+    from app.ee.license import has_feature
+    if not has_feature("scheduled_reindex"):
+        return
+
+    from app.dependencies import async_session_maker
+    from app.models.connection import Connection
+    from app.services.connection_indexing_service import ConnectionIndexingService
+    from app.services.connection_service import ConnectionService
+
+    now = datetime.utcnow()
+    batch = _batch_size()
+    t0 = time.perf_counter()
+
+    svc = ConnectionService()
+    indexing_service = ConnectionIndexingService()
+
+    async with async_session_maker() as db:
+        # Coarse SQL filter: enabled, live, and past any failure-backoff gate.
+        # The per-connection interval check happens in Python (interval varies
+        # per row). Oldest-synced first so the most stale get priority; we pull
+        # a bounded candidate window and never scan the whole table.
+        candidates = (
+            await db.execute(
+                select(Connection)
+                .where(
+                    Connection.is_active.is_(True),
+                    Connection.deleted_at.is_(None),
+                    Connection.auto_reindex_enabled.is_(True),
+                    (Connection.next_retry_at.is_(None))
+                    | (Connection.next_retry_at <= now),
+                )
+                .order_by(Connection.last_synced_at.asc().nullsfirst())
+                .limit(batch * 5)
+            )
+        ).scalars().all()
+
+        due = []
+        for conn in candidates:
+            # Per-user catalogs (OneDrive, personal Drive) have no admin-side
+            # catalog to re-index — they heal on each user's sign-in. Skip.
+            if svc._is_per_user_catalog(conn.type):
+                continue
+            if _is_due(conn, now):
+                due.append(conn)
+            if len(due) >= batch:
+                break
+
+        if not due:
+            logger.info("schema_reindex.sweep", extra={"due": 0, "candidates": len(candidates)})
+            return
+
+        # Stamp the backoff gate BEFORE kicking so a crash/failure mid-run can't
+        # leave the connection eligible to be re-kicked on the very next tick.
+        # A successful index clears this and advances last_synced_at.
+        for conn in due:
+            conn.next_retry_at = now + timedelta(hours=conn.effective_reindex_interval_hours)
+        await db.commit()
+
+        kicked = 0
+        for conn in due:
+            try:
+                await indexing_service.start(db=db, connection=conn)
+                kicked += 1
+            except Exception as exc:
+                logger.warning(
+                    "schema_reindex.kick_failed",
+                    extra={"connection_id": str(conn.id), "error": str(exc)},
+                )
+
+    logger.info(
+        "schema_reindex.sweep.done",
+        extra={
+            "due": len(due),
+            "kicked": kicked,
+            "batch": batch,
+            "elapsed_s": round(time.perf_counter() - t0, 3),
+        },
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from app.models.user import User
 from app.services.maintenance_service import purge_step_payloads_keep_latest_per_query
 from app.data_sources.clients.qvd_client import warm_all_qvd_caches
 from app.data_sources.clients.powerbi_report_server_client import warm_all_pbirs_caches
+from app.services.scheduled_reindex import sweep_due_reindexes
 from app.core.otel import setup_telemetry, instrument_app
 from app.ee.audit.tool_audit import start_tool_audit_worker, stop_tool_audit_worker
 
@@ -431,6 +432,26 @@ async def startup_event():
             logger.info("Scheduled job: pbirs_warmup every 1 hour")
         except Exception as e:
             logger.error(f"Failed to schedule PBIRS warmup job: {e}")
+
+    # Periodic schema auto-reload: re-index connection schemas whose tables are
+    # stale past their per-connection interval (enterprise `scheduled_reindex`).
+    # A frequent, cheap sweep + staleness gate keeps reindex work proportional
+    # to N/interval rather than O(N) per tick; the sweep no-ops without license.
+    if is_scheduler_leader:
+        try:
+            scheduler.add_job(
+                sweep_due_reindexes,
+                trigger="interval",
+                minutes=10,
+                id="schema_reindex_sweep",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+                misfire_grace_time=600,
+            )
+            logger.info("Scheduled job: schema_reindex_sweep every 10 minutes")
+        except Exception as e:
+            logger.error(f"Failed to schedule schema reindex sweep job: {e}")
 
     # Register LDAP group sync job if configured AND licensed (sync is enterprise-only)
     if is_scheduler_leader and settings.bow_config.ldap.enabled and has_feature("ldap"):

--- a/backend/tests/e2e/test_connection_auto_reindex.py
+++ b/backend/tests/e2e/test_connection_auto_reindex.py
@@ -1,0 +1,134 @@
+"""
+E2E tests for per-connection scheduled auto-reindex.
+
+Covers the enterprise `scheduled_reindex` feature:
+  - default schedule fields surfaced on the connection detail payload,
+  - PUT is enterprise-gated (402 without the license feature),
+  - PUT persists a custom interval / toggle when licensed,
+  - invalid intervals are rejected,
+  - the sweeper's staleness gate (`_is_due`) and due-selection behaviour.
+"""
+import pytest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+CONNECTION_TEST_DB_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "chinook.sqlite"
+).resolve()
+
+
+def _auth_headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+@pytest.mark.e2e
+def test_auto_reindex_detail_fields_and_ee_gate(
+    test_client,
+    create_connection,
+    get_connection,
+    create_user,
+    login_user,
+    whoami,
+    monkeypatch,
+):
+    """Detail exposes schedule defaults; PUT is enterprise-gated and validated."""
+    if not CONNECTION_TEST_DB_PATH.exists():
+        pytest.skip(f"SQLite test database missing at {CONNECTION_TEST_DB_PATH}")
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    conn = create_connection(
+        name="Auto Reindex Conn",
+        type="sqlite",
+        config={"database": str(CONNECTION_TEST_DB_PATH)},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    cid = conn["id"]
+
+    # Defaults: enabled, NULL interval (=> model default cadence).
+    detail = get_connection(connection_id=cid, user_token=token, org_id=org_id)
+    assert detail["auto_reindex_enabled"] is True
+    assert detail["reindex_interval_hours"] is None
+    assert detail["next_retry_at"] is None
+    assert detail["last_reindex_error"] is None
+
+    import app.ee.license as lic
+    headers = _auth_headers(token, org_id)
+
+    # Unlicensed: customizing the schedule is rejected with 402.
+    monkeypatch.setattr(lic, "has_feature", lambda feature: False)
+    resp = test_client.put(
+        f"/api/connections/{cid}",
+        json={"reindex_interval_hours": 24},
+        headers=headers,
+    )
+    assert resp.status_code == 402, resp.json()
+
+    # Licensed: persists a custom interval and the toggle.
+    monkeypatch.setattr(lic, "has_feature", lambda feature: True)
+    resp = test_client.put(
+        f"/api/connections/{cid}",
+        json={"reindex_interval_hours": 6, "auto_reindex_enabled": False},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    detail = get_connection(connection_id=cid, user_token=token, org_id=org_id)
+    assert detail["reindex_interval_hours"] == 6
+    assert detail["auto_reindex_enabled"] is False
+
+    # Licensed but invalid interval => 400.
+    resp = test_client.put(
+        f"/api/connections/{cid}",
+        json={"reindex_interval_hours": 999},
+        headers=headers,
+    )
+    assert resp.status_code == 400, resp.json()
+
+
+@pytest.mark.e2e
+def test_sweeper_staleness_gate():
+    """`_is_due` honours the per-connection interval; the model default applies
+    when no override is set."""
+    from app.models.connection import Connection
+    from app.services.scheduled_reindex import _is_due
+
+    now = datetime.utcnow()
+
+    # Never synced => always due.
+    c = Connection(name="x", type="sqlite", config={})
+    c.last_synced_at = None
+    assert _is_due(c, now) is True
+
+    # Synced just now with a 6h override => not due.
+    c.reindex_interval_hours = 6
+    c.last_synced_at = now - timedelta(hours=1)
+    assert _is_due(c, now) is False
+
+    # Past the 6h override => due.
+    c.last_synced_at = now - timedelta(hours=7)
+    assert _is_due(c, now) is True
+
+    # NULL interval falls back to the model default (12h).
+    c.reindex_interval_hours = None
+    c.last_synced_at = now - timedelta(hours=11)
+    assert _is_due(c, now) is False
+    c.last_synced_at = now - timedelta(hours=13)
+    assert _is_due(c, now) is True
+
+
+@pytest.mark.e2e
+def test_effective_interval_default():
+    """`effective_reindex_interval_hours` resolves override vs default."""
+    from app.models.connection import Connection
+
+    c = Connection(name="x", type="sqlite", config={})
+    assert c.effective_reindex_interval_hours == Connection.DEFAULT_REINDEX_INTERVAL_HOURS
+    c.reindex_interval_hours = 0  # non-positive => default
+    assert c.effective_reindex_interval_hours == Connection.DEFAULT_REINDEX_INTERVAL_HOURS
+    c.reindex_interval_hours = 8
+    assert c.effective_reindex_interval_hours == 8

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -76,6 +76,45 @@
         </div>
       </div>
 
+      <!-- Auto-reindex schedule (enterprise `scheduled_reindex`). Admin-only.
+           Periodically re-indexes the shared catalog so tables stay fresh
+           without a manual reindex. -->
+      <div v-if="canUpdateDataSource && !isToolProvider" class="py-3 border-t border-gray-100">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-1.5">
+            <span class="text-xs font-medium text-gray-700">{{ $t('data.autoReindex') }}</span>
+            <UIcon v-if="!autoReindexLicensed" name="heroicons-lock-closed" class="w-3 h-3 text-gray-400" />
+          </div>
+          <UToggle
+            :model-value="autoReindexEnabled"
+            :disabled="!autoReindexLicensed || savingAutoReindex"
+            size="sm"
+            @update:model-value="onToggleAutoReindex"
+          />
+        </div>
+        <p class="text-[11px] text-gray-400 mt-1">
+          {{ autoReindexLicensed ? $t('data.autoReindexHint') : $t('data.autoReindexEnterprise') }}
+        </p>
+
+        <!-- Interval picker — only when enabled & licensed. -->
+        <div v-if="autoReindexLicensed && autoReindexEnabled" class="mt-2 flex items-center justify-between">
+          <span class="text-xs text-gray-500">{{ $t('data.autoReindexEvery') }}</span>
+          <select
+            :value="autoReindexInterval"
+            :disabled="savingAutoReindex"
+            class="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-300 disabled:opacity-50"
+            @change="onChangeInterval(($event.target as HTMLSelectElement).value)"
+          >
+            <option v-for="opt in intervalOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </div>
+
+        <!-- Last background failure, if any. -->
+        <p v-if="autoReindexError" class="text-[11px] text-red-500 mt-1.5 truncate" :title="autoReindexError">
+          {{ $t('data.autoReindexLastError') }}: {{ autoReindexError }}
+        </p>
+      </div>
+
       <!-- Per-user summary — honest, user-scoped view for OBO viewers: what THEY
            can see, not the service-principal's "Discovered N tables" / logs. -->
       <div v-else-if="isPerUserViewer" class="py-3 border-t border-gray-100">
@@ -337,6 +376,7 @@ import ConnectionIndexingProgress from '~/components/ConnectionIndexingProgress.
 import AddMCPModal from '~/components/AddMCPModal.vue'
 import { useCan } from '~/composables/usePermissions'
 import { isIndexingActive, type ConnectionIndexing } from '~/composables/useConnectionStatus'
+import { useEnterprise } from '~/ee/composables/useEnterprise'
 
 const props = defineProps<{
   modelValue: boolean
@@ -533,6 +573,70 @@ function stopPolling() {
   }
 }
 
+// ── Auto-reindex schedule (enterprise `scheduled_reindex`) ──────────────────
+const { hasFeature } = useEnterprise()
+const autoReindexLicensed = computed(() => hasFeature('scheduled_reindex'))
+const autoReindexEnabled = ref(true)
+const autoReindexInterval = ref(12)
+const autoReindexError = ref<string | null>(null)
+const savingAutoReindex = ref(false)
+const intervalOptions = [
+  { value: 6, label: t('data.everyNHours', { n: 6 }) },
+  { value: 12, label: t('data.everyNHours', { n: 12 }) },
+  { value: 24, label: t('data.everyNHours', { n: 24 }) },
+  { value: 48, label: t('data.everyNHours', { n: 48 }) },
+]
+
+async function fetchAutoReindexConfig() {
+  // Only admins can read connection detail (config-bearing). The list payload
+  // doesn't carry the schedule fields, so fetch them here.
+  if (!props.connection?.id || !canUpdateDataSource.value || isToolProvider.value) return
+  try {
+    const { data } = await useMyFetch(`/connections/${props.connection.id}`, { method: 'GET' })
+    const d = (data as any).value
+    if (d) {
+      autoReindexEnabled.value = d.auto_reindex_enabled !== false
+      autoReindexInterval.value = d.reindex_interval_hours || 12
+      autoReindexError.value = d.last_reindex_error || null
+    }
+  } catch {
+    // Non-fatal — section just shows defaults.
+  }
+}
+
+async function saveAutoReindex() {
+  if (!props.connection?.id || savingAutoReindex.value) return
+  savingAutoReindex.value = true
+  try {
+    const { error } = await useMyFetch(`/connections/${props.connection.id}`, {
+      method: 'PUT',
+      body: {
+        auto_reindex_enabled: autoReindexEnabled.value,
+        reindex_interval_hours: autoReindexInterval.value,
+      },
+    })
+    if (error.value) {
+      toast.add({
+        title: t('data.autoReindexSaveFailed'),
+        description: (error.value as any)?.data?.detail || (error.value as any)?.message,
+        color: 'red',
+      })
+    }
+  } finally {
+    savingAutoReindex.value = false
+  }
+}
+
+function onToggleAutoReindex(val: boolean) {
+  autoReindexEnabled.value = val
+  saveAutoReindex()
+}
+
+function onChangeInterval(val: string) {
+  autoReindexInterval.value = parseInt(val, 10) || 12
+  saveAutoReindex()
+}
+
 async function reindex() {
   if (!props.connection?.id || reindexing.value) return
   reindexing.value = true
@@ -704,6 +808,7 @@ watch(isOpen, (val) => {
   pendingIdentity.value = null
   indexingState.value = (props.connection?.indexing as ConnectionIndexing) || null
   fetchIndexing().then(() => startPollingIfActive())
+  fetchAutoReindexConfig()
 })
 
 // If the parent swaps the connection prop while the modal is open, refresh.

--- a/locales/en.json
+++ b/locales/en.json
@@ -1346,7 +1346,14 @@
     "disconnecting": "Disconnecting…",
     "disconnect": "Disconnect",
     "serviceAccountNote": "Queries run with the connection's service account.",
-    "switchIdentityFailed": "Failed to switch query identity"
+    "switchIdentityFailed": "Failed to switch query identity",
+    "autoReindex": "Auto-reindex schema",
+    "autoReindexHint": "Periodically re-index this connection so tables stay fresh.",
+    "autoReindexEnterprise": "Scheduled reindexing is an enterprise feature.",
+    "autoReindexEvery": "Reindex every",
+    "everyNHours": "Every {n} hours",
+    "autoReindexLastError": "Last error",
+    "autoReindexSaveFailed": "Failed to save auto-reindex settings"
   },
   "share": {
     "shareDashboard": "Share Dashboard",


### PR DESCRIPTION
## Summary

Periodically re-indexes connection schemas so tables stay fresh without a manual reindex — the schema-side counterpart to the existing QVD/PBIRS cache warmups. Works for both system-credential and user-required-auth connections, runs every few hours (per-connection, default 12h), and is gated behind a new enterprise `scheduled_reindex` license feature.

## Design

- **Decoupled tick vs. work.** A frequent, cheap sweep (every 10 min, behind the scheduler leader lock) selects only connections whose schema is *stale past their per-connection interval* and kicks a **bounded batch** (`BOW_REINDEX_SWEEP_BATCH`, default 10), oldest-synced first. Steady-state load is **O(N / interval)**, not O(N) per tick — e.g. 500 connections @ 12h ≈ 7 due per tick.
- **Idempotent + deduped.** The tick is claimed via `claim_scheduled_run` (one worker/replica per fire); each connection goes through the idempotent `ConnectionIndexingService.start` (reusing domain-sync + cache warm).
- **Failure backoff / heal-on-login.** The sweep stamps `next_retry_at = now + interval` *before* kicking, so a failing source (e.g. a `user_required` connection with no system creds) isn't re-hammered every tick — it waits for the next interval, and per-user catalogs heal on the next user login. A successful index clears `next_retry_at`/`last_reindex_error` and advances `last_synced_at`.
- **Per-user catalogs are not swept** (OneDrive/personal Drive) — they refresh lazily on sign-in, which keeps the dangerous users×connections axis out of the background job.
- **Enterprise-gated.** Sweeper no-ops without the `scheduled_reindex` feature; the connection update route returns 402 when customizing the schedule unlicensed (plus 1–168h interval bounds).

## Changes

**Backend**
- New per-connection columns + migration: `auto_reindex_enabled`, `reindex_interval_hours` (NULL → 12h default), `next_retry_at`, `last_reindex_error`.
- `app/services/scheduled_reindex.py` — the sweeper; registered in `main.py` on a 10-min interval.
- `scheduled_reindex` added to the enterprise tier; EE gate + interval validation in `ConnectionService.update_connection`; schedule fields on the detail API; backoff clear/record wired into `refresh_schema` / the indexing runner.

**Frontend**
- EE-gated "Auto-reindex schema" section in the connection detail modal: enable toggle + cadence picker (default *Every 12 hours*), auto-saving; surfaces the last background failure when present.

**Tests**
- `tests/e2e/test_connection_auto_reindex.py`: detail fields, EE gate (402/200), interval validation, sweeper staleness gate, effective-interval resolution.

## Verification (sandbox)

- Migration applied; all 4 columns present.
- Sweeper: fresh connection not kicked; stale (>interval) kicked → re-indexed → backoff cleared; `next_retry_at` stamped synchronously before the kick.
- Failure path: forced `refresh_schema` to raise → `last_reindex_error` recorded, backoff retained.
- EE gate: 402 unlicensed / 200 licensed; invalid interval 400.
- UI dropdown change persisted to backend through the modal.
- Scheduler logs `Scheduled job: schema_reindex_sweep every 10 minutes`.
- Tests: 3 new e2e + 11 existing connection/indexing tests pass.

https://claude.ai/code/session_01B9eBgC4LkjzFX6CrF1hTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9eBgC4LkjzFX6CrF1hTML)_