### PR TITLE
Fix second admin overlay on shared-catalog user-required sources

### DIFF
--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3111,6 +3111,9 @@ class DataSourceService:
                         db, data_source, conn, max_auto_select=None
                     )
                 if not per_user_conns:
+                    user_scoped = await self._refresh_shared_user_overlay(db, data_source, current_user)
+                    if user_scoped is not None:
+                        return user_scoped
                     schemas = await data_source.get_schemas(db=db, include_inactive=True)
                     return schemas
 
@@ -3121,13 +3124,50 @@ class DataSourceService:
 
             # Mixed (shared + per-user) already refreshed the shared side above.
             if shared_conns:
+                user_scoped = await self._refresh_shared_user_overlay(db, data_source, current_user)
+                if user_scoped is not None:
+                    return user_scoped
                 schemas = await data_source.get_schemas(db=db, include_inactive=True)
                 return schemas
 
         # No connections at all: legacy direct fetch (nothing to link against).
         schemas = await self.save_or_update_tables(db=db, data_source=data_source, organization=organization, should_set_active=False, current_user=current_user)
         return schemas or []
-    
+
+    async def _refresh_shared_user_overlay(self, db: AsyncSession, data_source: DataSource, current_user: User):
+        """On an explicit reload of a SHARED-catalog, user_required (delegated/OBO,
+        e.g. Fabric/PowerBI) source, also refresh the CALLER's per-user overlay.
+
+        The shared-catalog refresh above only updates the canonical catalog
+        (ConnectionTable -> DataSourceTable). But the tables selector is
+        overlay-scoped for a caller running with their own delegated token
+        (effective_auth == "user"), so without this the caller sees ZERO tables
+        right after reloading and only sees them later, once an unrelated path
+        (sign-in, OAuth connect, credential upsert) lazily warms the overlay.
+
+        Returns the caller's user-scoped schema list when the overlay applies, or
+        None to signal the caller should get the full canonical catalog (admin via
+        service account, or a non-delegated source).
+        """
+        conns = getattr(data_source, "connections", None) or []
+        auth_policy = (conns[0].auth_policy if conns else "system_only") or "system_only"
+        if auth_policy != "user_required" or current_user is None:
+            return None
+        effective_auth = await self._resolve_effective_auth(db, data_source, current_user)
+        if effective_auth == "user":
+            # Caller runs with their own token: populate + return their overlay so
+            # the reload reflects exactly the tables they can query.
+            try:
+                schemas = await self.get_user_data_source_schema(db=db, data_source=data_source, user=current_user)
+                return schemas or []
+            except Exception:
+                return []
+        if effective_auth == "none":
+            # No proven access (disconnected/expired) → nothing to show.
+            return []
+        # effective_auth == "system": admin via service account → full catalog.
+        return None
+
     async def get_metadata_resources(self, db: AsyncSession, data_source_id: str, organization: Organization, current_user: User = None):
         result = await db.execute(select(DataSource).filter(DataSource.id == data_source_id, DataSource.organization_id == organization.id))
         data_source = result.scalar_one_or_none()

--- a/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
+++ b/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
@@ -1,6 +1,12 @@
 """
-Reproduction: second admin sees NO tables on a shared-catalog, user-required
-(Fabric / PowerBI / OBO) data source — and "Reload tables" does not fix it.
+Fix validation: second admin on a shared-catalog, user-required (Fabric /
+PowerBI / OBO) data source.
+
+Before the fix: the second admin saw NO tables, and "Reload tables" did not help
+(they only appeared later, once an unrelated path warmed the per-user overlay).
+After the fix: clicking "Reload tables" refreshes the caller's per-user overlay,
+so their tables appear immediately (see
+DataSourceService._refresh_shared_user_overlay).
 
 Scenario (mirrors the reported Entra ID / OBO bug):
   - Admin1 creates an ms_fabric connection (auth_policy=user_required,
@@ -225,33 +231,46 @@ async def _count_overlay(ids, user_id):
         return res.scalar() or 0
 
 
+class _FakeFabricClient:
+    """Stands in for the live Fabric client: returns the tables the caller can
+    see (HAS_PERMS-filtered upstream). Here admin2 can see both."""
+    async def aget_schemas(self):
+        return [
+            {"name": "sales", "columns": [{"name": "id", "dtype": "int"}],
+             "pks": [], "fks": [], "metadata_json": {"schema": "dbo"}},
+            {"name": "finance", "columns": [{"name": "id", "dtype": "int"}],
+             "pks": [], "fks": [], "metadata_json": {"schema": "dbo"}},
+        ]
+
+
 @pytest.mark.e2e
-def test_second_admin_sees_no_tables_and_reload_does_not_help(monkeypatch):
+def test_reload_populates_second_admin_overlay(monkeypatch):
+    """FIX validation: after the fix, clicking 'Reload tables' as the second
+    admin refreshes THEIR per-user overlay, so tables appear immediately."""
     ids = _run(_seed())
 
-    # CLAIM 1 — display scoping: admin1 sees both tables, admin2 sees none.
-    a1_total, a1_len = _run(_paginated_total(ids, ids["admin1_id"]))
-    a2_total, a2_len = _run(_paginated_total(ids, ids["admin2_id"]))
-    print(f"\n[display] admin1 sees total={a1_total} rows={a1_len}; "
-          f"admin2 sees total={a2_total} rows={a2_len}")
-
-    assert a1_total == 2 and a1_len == 2, "admin1 (with overlay) should see both tables"
-    assert a2_total == 0 and a2_len == 0, (
-        "BUG REPRODUCED: admin2 has a valid OBO token (can run queries) but an "
-        "empty overlay, so the tables selector shows ZERO tables"
-    )
-
-    # CLAIM 2 — reload doesn't populate admin2's overlay. Stub the connection
-    # schema refresh (canonical catalog already seeded) and confirm the shared
-    # catalog reload path never writes admin2's UserDataSourceTable rows.
+    # Initial display scoping: admin1 (has overlay) sees both; admin2 sees none
+    # (overlay empty — the paginated read is overlay-scoped). This part is the
+    # original symptom and is unchanged by the fix.
+    a1_total, _ = _run(_paginated_total(ids, ids["admin1_id"]))
+    a2_total, _ = _run(_paginated_total(ids, ids["admin2_id"]))
+    print(f"\n[before] admin1 sees total={a1_total}; admin2 sees total={a2_total}")
+    assert a1_total == 2
+    assert a2_total == 0
     assert _run(_count_overlay(ids, ids["admin2_id"])) == 0
 
+    # Stub the live seams: canonical refresh is a no-op (already seeded), and the
+    # per-user fetch returns admin2's visible tables via the fake client.
     from app.services.connection_service import ConnectionService
 
     async def _noop_refresh_schema(self, db, connection, current_user=None):
-        return []  # simulate a successful canonical refresh, no overlay writes
+        return []
+
+    async def _fake_construct_client(self, db, data_source, current_user):
+        return _FakeFabricClient()
 
     monkeypatch.setattr(ConnectionService, "refresh_schema", _noop_refresh_schema)
+    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
 
     async def _reload_as_admin2():
         svc = DataSourceService()
@@ -268,14 +287,16 @@ def test_second_admin_sees_no_tables_and_reload_does_not_help(monkeypatch):
     _run(_reload_as_admin2())
 
     overlay_after = _run(_count_overlay(ids, ids["admin2_id"]))
-    a2_total_after, _ = _run(_paginated_total(ids, ids["admin2_id"]))
-    print(f"[reload]  admin2 overlay rows after reload={overlay_after}; "
-          f"admin2 tables after reload={a2_total_after}")
+    a2_total_after, a2_len_after = _run(_paginated_total(ids, ids["admin2_id"]))
+    print(f"[after]  admin2 overlay rows={overlay_after}; "
+          f"admin2 tables={a2_total_after} rows={a2_len_after}")
 
-    assert overlay_after == 0, "reload must NOT have populated admin2's overlay"
-    assert a2_total_after == 0, (
-        "BUG REPRODUCED: after 'Reload tables', admin2 STILL sees zero tables — "
-        "the shared-catalog reload refreshes only the canonical catalog"
+    assert overlay_after == 2, (
+        "FIX: reload must populate the second admin's per-user overlay"
+    )
+    assert a2_total_after == 2 and a2_len_after == 2, (
+        "FIX: after 'Reload tables' the second admin now sees their tables "
+        "immediately (no need to leave and return)"
     )
 
 

--- a/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
+++ b/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
@@ -1,0 +1,290 @@
+"""
+Reproduction: second admin sees NO tables on a shared-catalog, user-required
+(Fabric / PowerBI / OBO) data source — and "Reload tables" does not fix it.
+
+Scenario (mirrors the reported Entra ID / OBO bug):
+  - Admin1 creates an ms_fabric connection (auth_policy=user_required,
+    allowed_user_auth_modes=["oauth"], catalog_ownership=shared).
+  - The canonical catalog (ConnectionTable -> DataSourceTable) is populated.
+  - Admin1's per-user overlay (UserDataSourceTable) is populated (this happens
+    for the creator via OBO auto-provision / first live fetch).
+  - Admin2 ALSO has a valid delegated OBO token (a UserConnectionCredentials
+    row, auth_mode="oauth"), so their effective_auth resolves to "user" and they
+    CAN run queries — exactly the case the user pointed out.
+  - Admin2 has NO per-user overlay rows yet.
+
+Hypothesis being validated:
+  1. The tables list (paginated endpoint) scopes a user_required source to the
+     caller's UserDataSourceTable overlay when effective_auth == "user". With an
+     empty overlay, Admin2 sees ZERO tables even though Admin1 sees all.
+  2. "Reload tables" -> refresh_data_source_schema for a SHARED catalog only
+     refreshes the canonical catalog (ConnectionTable/DataSourceTable) and never
+     writes Admin2's overlay, so Admin2 still sees zero after reloading.
+
+No live Azure/Fabric needed: the reload's connection-level schema fetch is
+stubbed (the canonical catalog is already seeded). The bug is purely in the
+app's overlay scoping + reload not populating the caller's overlay.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_fabric_second_admin_overlay_repro.py -v -s
+"""
+import uuid
+import asyncio
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.user_connection_credentials import UserConnectionCredentials
+from app.models.user_data_source_overlay import UserDataSourceTable
+from app.models.domain_connection import domain_connection
+from app.services.data_source_service import DataSourceService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed(populate_admin2_overlay: bool = False):
+    """Seed an ms_fabric (shared-catalog, user_required) data source with two
+    token-holding admins. Admin1 has an overlay; Admin2 does not."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"OBO Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        admin1 = User(
+            name="Admin One",
+            email=f"admin1-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        admin2 = User(
+            name="Admin Two",
+            email=f"admin2-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        db.add_all([admin1, admin2])
+        await db.flush()
+
+        # Fabric connection — delegated/OBO (user_required + oauth) => supports_user_token
+        conn = Connection(
+            organization_id=org.id,
+            name=f"Fabric {suffix}",
+            type="ms_fabric",
+            config={"server_hostname": "example.datawarehouse.fabric.microsoft.com", "database": "demo_db"},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+        )
+        conn.encrypt_credentials({
+            "tenant_id": "t", "client_id": "c", "client_secret": "s",
+        })
+        db.add(conn)
+        await db.flush()
+
+        ds = DataSource(
+            name=f"Fabric DS {suffix}",
+            organization_id=org.id,
+            is_active=True,
+            owner_user_id=admin1.id,
+        )
+        db.add(ds)
+        await db.flush()
+        # link DS <-> Connection (M:N)
+        await db.execute(domain_connection.insert().values(
+            data_source_id=ds.id, connection_id=conn.id,
+        ))
+
+        # Canonical catalog: two tables (sales, finance)
+        canonical_ds_table_ids = {}
+        for tname in ("sales", "finance"):
+            ct = ConnectionTable(
+                name=tname,
+                connection_id=conn.id,
+                columns=[{"name": "id", "dtype": "int"}],
+                pks=[], fks=[], no_rows=0,
+                metadata_json={"schema": "dbo"},
+            )
+            db.add(ct)
+            await db.flush()
+            dst = DataSourceTable(
+                name=tname,
+                datasource_id=ds.id,
+                connection_table_id=ct.id,
+                is_active=True,
+                metadata_json={"schema": "dbo"},
+                # legacy non-null-on-downgrade columns (kept for sqlite teardown)
+                columns=[{"name": "id", "dtype": "int"}],
+                pks=[], fks=[], no_rows=0,
+            )
+            db.add(dst)
+            await db.flush()
+            canonical_ds_table_ids[tname] = dst.id
+
+        # Both admins hold a valid delegated OBO token => effective_auth == "user"
+        for u in (admin1, admin2):
+            cred = UserConnectionCredentials(
+                connection_id=conn.id,
+                user_id=u.id,
+                organization_id=org.id,
+                auth_mode="oauth",
+                is_active=True,
+                is_primary=True,
+                last_used_at=datetime.utcnow(),
+                expires_at=datetime.utcnow() + timedelta(hours=1),
+            )
+            cred.encrypt_credentials({
+                "access_token": "tok", "refresh_token": "r",
+                "token_type": "Bearer",
+            })
+            db.add(cred)
+
+        # Admin1 overlay: both tables accessible. (Creator got this via OBO
+        # auto-provision / first live fetch.)
+        for tname, dst_id in canonical_ds_table_ids.items():
+            db.add(UserDataSourceTable(
+                data_source_id=ds.id,
+                user_id=admin1.id,
+                table_name=tname,
+                data_source_table_id=dst_id,
+                is_accessible=True,
+                status="accessible",
+            ))
+
+        # Admin2 overlay: optionally populate (used to show the fix's effect).
+        if populate_admin2_overlay:
+            for tname, dst_id in canonical_ds_table_ids.items():
+                db.add(UserDataSourceTable(
+                    data_source_id=ds.id,
+                    user_id=admin2.id,
+                    table_name=tname,
+                    data_source_table_id=dst_id,
+                    is_accessible=True,
+                    status="accessible",
+                ))
+
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "ds_id": ds.id,
+            "conn_id": conn.id,
+            "admin1_id": admin1.id,
+            "admin2_id": admin2.id,
+        }
+
+
+async def _get_user(db, user_id):
+    return await db.get(User, user_id)
+
+
+async def _get_org(db, org_id):
+    return await db.get(Organization, org_id)
+
+
+async def _paginated_total(ids, user_id):
+    """Return total tables the paginated tables-selector endpoint shows `user_id`."""
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        org = await _get_org(db, ids["org_id"])
+        user = await _get_user(db, user_id)
+        resp = await svc.get_data_source_schema_paginated(
+            db=db,
+            data_source_id=ids["ds_id"],
+            organization=org,
+            page=1,
+            page_size=100,
+            include_inactive=True,
+            current_user=user,
+        )
+        return resp.total_tables, len(resp.tables)
+
+
+async def _count_overlay(ids, user_id):
+    from sqlalchemy import select, func
+    async with async_session_maker() as db:
+        res = await db.execute(
+            select(func.count(UserDataSourceTable.id)).where(
+                UserDataSourceTable.data_source_id == ids["ds_id"],
+                UserDataSourceTable.user_id == user_id,
+            )
+        )
+        return res.scalar() or 0
+
+
+@pytest.mark.e2e
+def test_second_admin_sees_no_tables_and_reload_does_not_help(monkeypatch):
+    ids = _run(_seed())
+
+    # CLAIM 1 — display scoping: admin1 sees both tables, admin2 sees none.
+    a1_total, a1_len = _run(_paginated_total(ids, ids["admin1_id"]))
+    a2_total, a2_len = _run(_paginated_total(ids, ids["admin2_id"]))
+    print(f"\n[display] admin1 sees total={a1_total} rows={a1_len}; "
+          f"admin2 sees total={a2_total} rows={a2_len}")
+
+    assert a1_total == 2 and a1_len == 2, "admin1 (with overlay) should see both tables"
+    assert a2_total == 0 and a2_len == 0, (
+        "BUG REPRODUCED: admin2 has a valid OBO token (can run queries) but an "
+        "empty overlay, so the tables selector shows ZERO tables"
+    )
+
+    # CLAIM 2 — reload doesn't populate admin2's overlay. Stub the connection
+    # schema refresh (canonical catalog already seeded) and confirm the shared
+    # catalog reload path never writes admin2's UserDataSourceTable rows.
+    assert _run(_count_overlay(ids, ids["admin2_id"])) == 0
+
+    from app.services.connection_service import ConnectionService
+
+    async def _noop_refresh_schema(self, db, connection, current_user=None):
+        return []  # simulate a successful canonical refresh, no overlay writes
+
+    monkeypatch.setattr(ConnectionService, "refresh_schema", _noop_refresh_schema)
+
+    async def _reload_as_admin2():
+        svc = DataSourceService()
+        async with async_session_maker() as db:
+            org = await _get_org(db, ids["org_id"])
+            user = await _get_user(db, ids["admin2_id"])
+            return await svc.refresh_data_source_schema(
+                db=db,
+                data_source_id=ids["ds_id"],
+                organization=org,
+                current_user=user,
+            )
+
+    _run(_reload_as_admin2())
+
+    overlay_after = _run(_count_overlay(ids, ids["admin2_id"]))
+    a2_total_after, _ = _run(_paginated_total(ids, ids["admin2_id"]))
+    print(f"[reload]  admin2 overlay rows after reload={overlay_after}; "
+          f"admin2 tables after reload={a2_total_after}")
+
+    assert overlay_after == 0, "reload must NOT have populated admin2's overlay"
+    assert a2_total_after == 0, (
+        "BUG REPRODUCED: after 'Reload tables', admin2 STILL sees zero tables — "
+        "the shared-catalog reload refreshes only the canonical catalog"
+    )
+
+
+@pytest.mark.e2e
+def test_control_admin2_with_overlay_sees_tables():
+    """Control: if admin2 HAD an overlay (e.g. via OBO auto-provision), they'd
+    see the tables. Confirms the scoping — not some unrelated failure — is what
+    hides them in the bug case."""
+    ids = _run(_seed(populate_admin2_overlay=True))
+    a2_total, a2_len = _run(_paginated_total(ids, ids["admin2_id"]))
+    print(f"\n[control] admin2 WITH overlay sees total={a2_total} rows={a2_len}")
+    assert a2_total == 2 and a2_len == 2

--- a/sandbox-feedback-loop.md
+++ b/sandbox-feedback-loop.md
@@ -139,4 +139,25 @@ demo1; `exchange_obo_token` for Fabric/PowerBI.
   overlay** — so reload can't fix it. Bug confirmed and isolated to the overlay
   scoping + reload paths above.
 
-No fix is implemented (per request) — this is the validation harness only.
+## The fix
+
+`DataSourceService._refresh_shared_user_overlay` (`data_source_service.py`), wired
+into `refresh_data_source_schema`'s shared-catalog branch: after the canonical
+refresh, if the source is `user_required` and the caller resolves to
+`effective_auth == "user"`, refresh the **caller's** per-user overlay
+(`get_user_data_source_schema`) and return their user-scoped tables. Admins on the
+service account (`effective_auth == "system"`) still get the full canonical
+catalog; disconnected callers (`"none"`) get nothing (no canonical leak).
+
+Result (Loop A, after fix):
+
+```
+[before] admin1 sees total=2; admin2 sees total=0   # overlay-scoped, empty
+[after]  admin2 overlay rows=2; admin2 tables=2      # reload populated it now
+```
+
+> Regression note: some `tests/e2e/test_connection_oauth_flow.py` tests fail in
+> this sandbox with `create_user -> 404 Not Found` (the HTTP signup route isn't
+> available under this config). This is **pre-existing and unrelated** — it
+> reproduces with the fix stashed. The repro/fix test seeds users directly to
+> avoid that harness dependency.

--- a/sandbox-feedback-loop.md
+++ b/sandbox-feedback-loop.md
@@ -1,0 +1,142 @@
+# Sandbox Feedback Loop — Fabric / Entra OBO "second admin sees no tables"
+
+Reproduces and validates the reported bug: on a Microsoft **Fabric / PowerBI**
+connection in an **Entra ID / OBO** (`auth_policy=user_required`,
+`allowed_user_auth_modes=["oauth"]`) environment, the **creating admin sees all
+tables**, but a **second admin** — who *also* has a valid delegated token and can
+run queries — **sees no tables in the Tables Selector, and "Reload tables" does
+not fix it.**
+
+This doc is the runnable feedback loop used to confirm the root cause in a fresh
+cloud sandbox.
+
+---
+
+## Root cause (validated)
+
+Two independent app behaviors combine:
+
+1. **Display scoping.** `DataSourceService.get_data_source_schema_paginated`
+   (`backend/app/services/data_source_service.py:2058-2083`) — the endpoint the
+   "full schema" Tables Selector uses — scopes a `user_required` source to the
+   caller's **per-user overlay** (`UserDataSourceTable`) when
+   `effective_auth == "user"`. With an empty overlay, the canonical-table query
+   is scoped to `id IN ([])` → **zero rows**. Unlike the legacy
+   `get_data_source_schema` (`:1979`), the paginated path has **no live-fetch
+   fallback** to populate the overlay on a miss.
+
+2. **Reload gap.** `refresh_data_source_schema` (`:3057-3129`) for a
+   **shared-catalog** source (Fabric/PowerBI) refreshes only the **canonical**
+   catalog (`ConnectionTable` → `DataSourceTable` via
+   `sync_domain_tables_from_connection`) and **never writes the caller's
+   `UserDataSourceTable` overlay**. So clicking "Reload tables" cannot populate
+   the second admin's overlay.
+
+The creating admin's overlay was populated out-of-band (OBO auto-provision /
+first live fetch at connect time — `connection_oauth_service.auto_provision_connection_credentials`),
+which is why they see tables and the second admin doesn't.
+
+> Note: This is *not* the "Connect required / 403" path. The second admin has a
+> valid token (`effective_auth == "user"`), confirmed live below.
+
+---
+
+## Environment setup (fresh sandbox)
+
+The app targets **Python 3.12** (uses 3.12 f-string syntax). The sandbox default
+`python` may be 3.11 — use 3.12 explicitly.
+
+```bash
+cd backend
+python3.12 -m venv /tmp/venv312
+/tmp/venv312/bin/pip install -q --upgrade pip
+
+# Heavy/native packages aren't needed for the app-logic repro on SQLite.
+grep -ivE '^psycopg2|^pyspark|^thrift|^pyodbc|^grpcio-tools|^confluent-kafka|^snowflake|^cx[-_]Oracle|^oracledb|^pymssql|^sqlalchemy-bigquery|^google-cloud' \
+  requirements_versioned.txt > /tmp/reqs_lite.txt
+/tmp/venv312/bin/pip install -q -r /tmp/reqs_lite.txt
+
+# Required by bow-config.dev.yaml (database.url: ${BOW_DATABASE_URL})
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+mkdir -p db
+```
+
+Tests run on SQLite by default; the autouse `run_migrations` fixture builds the
+schema per test (`tests/conftest.py`).
+
+---
+
+## Loop A — App-logic reproduction (no live Azure needed)
+
+Self-contained: seeds an `ms_fabric` data source with two token-holding admins
+(admin1 with an overlay, admin2 without), then asserts the two claims. The
+reload's connection-level schema fetch is stubbed (the canonical catalog is
+already seeded), so no live Fabric/ODBC is required.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+/tmp/venv312/bin/python -m pytest \
+  tests/e2e/test_fabric_second_admin_overlay_repro.py -v -s
+```
+
+**Observed (PASS):**
+
+```
+[display] admin1 sees total=2 rows=2; admin2 sees total=0 rows=0   # Claim 1
+[reload]  admin2 overlay rows after reload=0; admin2 tables after reload=0  # Claim 2
+[control] admin2 WITH overlay sees total=2 rows=2                  # scoping is the cause
+2 passed
+```
+
+Iterate here: edit the candidate fix (e.g. populate-on-miss in the paginated
+path, or have the shared-catalog reload also refresh the caller's overlay) and
+re-run — `test_second_admin_...` should then show admin2 `total=2`.
+
+---
+
+## Loop B — Live OBO confirmation (real Entra tenant)
+
+Confirms the premise that **both** admins can obtain delegated tokens (so both
+are `effective_auth == "user"` / can run queries). Requires outbound network to
+`login.microsoftonline.com` and **ROPC enabled** on the app registration.
+
+Secrets are passed via **env vars only — never commit them**:
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+export BOW_ENTRA_TENANT_ID=...        # app registration tenant
+export BOW_ENTRA_CLIENT_ID=...
+export BOW_ENTRA_CLIENT_SECRET=...
+export BOW_OAUTH_TEST_DEMO1_EMAIL=...
+export BOW_OAUTH_TEST_DEMO1_PASSWORD=...
+export BOW_OAUTH_TEST_DEMO2_EMAIL=...
+export BOW_OAUTH_TEST_DEMO2_PASSWORD=...
+export BOW_FABRIC_SERVER=...          # <id>.datawarehouse.fabric.microsoft.com
+
+/tmp/venv312/bin/python -m pytest tests/integrations/test_oauth_delegated.py \
+  -k "TestClientCredentials or TestROPCLogin or TestOBOExchange or TestOBOServiceFunction" -v
+```
+
+**Observed (PASS, 10/10):** client_credentials (SP) for Graph/Fabric/PowerBI;
+demo1 & demo2 ROPC login; OBO exchange demo1 & demo2 → Fabric token; OBO PowerBI
+demo1; `exchange_obo_token` for Fabric/PowerBI.
+
+> The `TestFabricClientDelegated` SQL tests (demo1 sees all / demo2 sees only
+> sales) additionally need `pyodbc` + **ODBC Driver 18 for SQL Server**, which is
+> not installed in this sandbox — they `skip` here. They exercise upstream Fabric
+> ACLs, not the app overlay bug, so they're not required for this validation.
+
+---
+
+## What this proves
+
+- Live: a second admin **can** get a valid delegated token and run queries
+  (premise confirmed) — so the "no tables" symptom is **not** missing auth.
+- App: with a token but **no per-user overlay**, the paginated Tables Selector
+  shows **zero** tables, and the shared-catalog **reload never populates that
+  overlay** — so reload can't fix it. Bug confirmed and isolated to the overlay
+  scoping + reload paths above.
+
+No fix is implemented (per request) — this is the validation harness only.


### PR DESCRIPTION
## Summary

Fixes a bug where a second admin on a shared-catalog, user-required (Fabric/PowerBI/OBO) data source sees no tables in the Tables Selector, and clicking "Reload tables" does not help. The creating admin sees all tables because their per-user overlay was populated at connection time, but the second admin's overlay remains empty.

## Root Cause

Two independent behaviors combine to hide tables from the second admin:

1. **Display scoping**: `get_data_source_schema_paginated` scopes `user_required` sources to the caller's per-user overlay (`UserDataSourceTable`) when `effective_auth == "user"`. With an empty overlay, the query returns zero rows.

2. **Reload gap**: `refresh_data_source_schema` for shared-catalog sources (Fabric/PowerBI) only refreshes the canonical catalog (`ConnectionTable` → `DataSourceTable`) and never populates the caller's `UserDataSourceTable` overlay. So reloading cannot fix the empty overlay.

The creating admin's overlay was populated out-of-band during initial connection setup (OBO auto-provision), which is why they see tables while the second admin doesn't.

## Changes

- **Added `_refresh_shared_user_overlay` method** in `DataSourceService`: After a shared-catalog refresh, if the source is `user_required` and the caller has a valid delegated token (`effective_auth == "user"`), this method refreshes the caller's per-user overlay by fetching their user-scoped schema and returning it immediately.

- **Integrated overlay refresh into `refresh_data_source_schema`**: For both pure shared-catalog and mixed (shared + per-user) connection scenarios, call `_refresh_shared_user_overlay` after the canonical refresh. If it returns a user-scoped result, return that; otherwise fall back to the full canonical catalog (for service-account admins or non-delegated sources).

- **Added comprehensive test and documentation**: `test_fabric_second_admin_overlay_repro.py` reproduces the bug with stubbed live calls (no Azure/Fabric needed) and validates the fix. `sandbox-feedback-loop.md` documents the root cause analysis and validation loops.

## Implementation Details

- The overlay refresh only applies when `auth_policy == "user_required"` and the caller resolves to `effective_auth == "user"` (has a valid delegated token).
- Service-account admins (`effective_auth == "system"`) continue to see the full canonical catalog.
- Disconnected callers (`effective_auth == "none"`) see nothing (no canonical leak).
- The method gracefully handles exceptions during overlay fetch, returning an empty list rather than failing the reload.

https://claude.ai/code/session_015sC4ABAVJGqddcdtYSzs1Y