### PR TITLE
Add report research tools: search_reports and read_report

### DIFF
--- a/backend/app/ai/tools/implementations/read_report.py
+++ b/backend/app/ai/tools/implementations/read_report.py
@@ -1,0 +1,250 @@
+"""Read Report Tool — read a single report owned by the current user.
+
+Returns the report's metadata, attached data sources, artifact summary, and
+(optionally) the conversation. Use ``search_reports`` first to obtain a
+``report_id``.
+
+Scoping: the report MUST be owned by the calling user
+(``Report.user_id == user.id``) within the current organization. Any other
+report — including ones merely shared with the user — returns a not-found
+error. For deep artifact/query content the agent should use ``read_artifact``
+/ ``read_query`` within that report's own session.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type, Optional
+import logging
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+from app.ai.tools.schemas.read_report import (
+    ReadReportInput,
+    ReadReportOutput,
+    ReadReportMessage,
+    ReadReportArtifact,
+)
+from app.models.report import Report
+
+logger = logging.getLogger(__name__)
+
+# Cap conversation size so a long report doesn't blow up the observation.
+_MAX_MESSAGES = 40
+_MAX_CONTENT_CHARS = 2000
+
+
+def _extract_content(value: Any) -> str:
+    """Pull human-readable text out of a completion's prompt/completion JSON."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return value.get("content") or value.get("text") or ""
+    return str(value)
+
+
+class ReadReportTool(Tool):
+    """Read a single report (metadata, conversation, artifacts) owned by the user."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="read_report",
+            description=(
+                "RESEARCH: Read one of the current user's OWN reports by id — its "
+                "metadata, attached data sources, artifact summary, and conversation "
+                "(prompts and AI answers). Use search_reports first to find the "
+                "report_id. Only the user's own reports can be read; any other report "
+                "returns not found. Use this to recall what was asked or built in a "
+                "previous report before continuing related work."
+            ),
+            category="research",
+            version="1.0.0",
+            input_schema=ReadReportInput.model_json_schema(),
+            output_schema=ReadReportOutput.model_json_schema(),
+            max_retries=0,
+            timeout_seconds=20,
+            idempotent=True,
+            is_active=True,
+            required_permissions=[],
+            tags=["report", "read"],
+            observation_policy="on_trigger",
+            allowed_modes=["chat", "deep"],
+            examples=[
+                {
+                    "input": {"report_id": "<report-uuid>"},
+                    "description": "Read a prior report's conversation and artifacts",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return ReadReportInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return ReadReportOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = ReadReportInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {e}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(type="tool.start", payload={"report_id": data.report_id})
+
+        context_hub = runtime_ctx.get("context_hub")
+        db = context_hub.db if context_hub else runtime_ctx.get("db")
+        organization = context_hub.organization if context_hub else runtime_ctx.get("organization")
+        user = runtime_ctx.get("user")
+
+        if not all([db, organization, user]):
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": "Missing required runtime context (db, organization, user)",
+                    "code": "MISSING_CONTEXT",
+                },
+            )
+            return
+
+        try:
+            stmt = (
+                select(Report)
+                .where(Report.id == str(data.report_id))
+                .where(Report.organization_id == str(organization.id))
+                .where(Report.user_id == str(user.id))
+                .options(
+                    selectinload(Report.artifacts),
+                    selectinload(Report.data_sources),
+                    selectinload(Report.completions),
+                )
+            )
+            report: Optional[Report] = (await db.execute(stmt)).scalars().first()
+        except Exception as e:
+            logger.exception(f"read_report query failed: {e}")
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Read failed: {e}", "code": "READ_FAILED"},
+            )
+            return
+
+        if not report:
+            # Indistinguishable from "not yours" — by design, no leak.
+            output = ReadReportOutput(
+                success=False,
+                report_id=str(data.report_id),
+                error="not_found",
+                message=f"No report owned by you with id {data.report_id}",
+            )
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": output.model_dump(),
+                    "observation": {
+                        "summary": f"Report not found or not owned by you: {data.report_id}",
+                        "error": {"type": "not_found", "message": output.message},
+                    },
+                },
+            )
+            return
+
+        # Artifacts summary (most recent first)
+        artifacts = sorted(
+            report.artifacts or [],
+            key=lambda a: a.created_at.timestamp() if a.created_at else 0,
+            reverse=True,
+        )
+        artifact_items = [
+            ReadReportArtifact(
+                id=str(a.id),
+                title=a.title,
+                mode=a.mode,
+                version=a.version,
+            )
+            for a in artifacts
+        ]
+
+        data_source_names = [ds.name for ds in (report.data_sources or []) if ds.name]
+
+        # Conversation (oldest first), capped.
+        conversation = []
+        if data.include_conversation:
+            completions = sorted(
+                report.completions or [],
+                key=lambda c: (c.turn_index or 0, c.created_at.timestamp() if c.created_at else 0),
+            )
+            for c in completions:
+                # Hide internal webhook trigger rows.
+                if getattr(c, "webhook_id", None) and c.role == "user":
+                    continue
+                raw = c.prompt if c.role == "user" else c.completion
+                content = _extract_content(raw)
+                if not content or not str(content).strip():
+                    continue
+                content = str(content)[:_MAX_CONTENT_CHARS]
+                conversation.append(
+                    ReadReportMessage(
+                        role=c.role,
+                        content=content,
+                        created_at=str(c.created_at) if c.created_at else None,
+                    )
+                )
+            if len(conversation) > _MAX_MESSAGES:
+                # Keep the most recent messages.
+                conversation = conversation[-_MAX_MESSAGES:]
+
+        output = ReadReportOutput(
+            success=True,
+            report_id=str(report.id),
+            title=report.title,
+            slug=report.slug,
+            status=report.status,
+            mode=report.mode,
+            created_at=str(report.created_at) if report.created_at else None,
+            updated_at=str(report.updated_at) if report.updated_at else None,
+            data_sources=data_source_names,
+            artifacts=artifact_items,
+            conversation=conversation,
+            message=(
+                f"Read report '{report.title or 'Untitled'}' "
+                f"({len(artifact_items)} artifact(s), {len(conversation)} message(s))"
+            ),
+        )
+
+        summary = (
+            f"Read report '{report.title or 'Untitled'}' ({report.mode}) — "
+            f"{len(artifact_items)} artifact(s), {len(conversation)} message(s)"
+        )
+        yield ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": output.model_dump(),
+                "observation": {
+                    "summary": summary,
+                    "report_id": str(report.id),
+                    "title": report.title,
+                    "status": report.status,
+                    "mode": report.mode,
+                    "data_sources": data_source_names,
+                    "artifacts": [a.model_dump() for a in artifact_items],
+                    "conversation": [m.model_dump() for m in conversation],
+                },
+            },
+        )

--- a/backend/app/ai/tools/implementations/search_reports.py
+++ b/backend/app/ai/tools/implementations/search_reports.py
@@ -1,0 +1,187 @@
+"""Search Reports Tool — list/find the current user's own reports.
+
+A read-only research tool that lets the agent discover the user's prior
+reports by title before referencing or reading one with ``read_report``.
+
+Scoping: results are ALWAYS restricted to reports owned by the calling user
+(``Report.user_id == user.id``) within the current organization. Reports
+owned by other users — even shared ones — are never returned.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+import logging
+
+from pydantic import BaseModel
+from sqlalchemy import select
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+from app.ai.tools.schemas.search_reports import (
+    SearchReportsInput,
+    SearchReportsOutput,
+    SearchReportsItem,
+)
+from app.models.report import Report
+
+logger = logging.getLogger(__name__)
+
+
+class SearchReportsTool(Tool):
+    """List or substring-search the current user's own reports."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="search_reports",
+            description=(
+                "RESEARCH: List or substring-search the current user's OWN reports "
+                "by title (case-insensitive). Use this to find a previous report the "
+                "user is referring to before reading it with read_report. Only the "
+                "user's own reports are returned — never another user's. Returns "
+                "report id, title, status, mode, and whether it has artifacts. "
+                "Leave query empty to list the user's most recent reports."
+            ),
+            category="research",
+            version="1.0.0",
+            input_schema=SearchReportsInput.model_json_schema(),
+            output_schema=SearchReportsOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=15,
+            idempotent=True,
+            is_active=True,
+            required_permissions=[],
+            tags=["report", "search", "read"],
+            observation_policy="on_trigger",
+            allowed_modes=["chat", "deep"],
+            examples=[
+                {
+                    "input": {"query": "revenue", "limit": 10},
+                    "description": "Find the user's reports whose title mentions 'revenue'",
+                },
+                {
+                    "input": {"status": "published", "limit": 20},
+                    "description": "List the user's published reports",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return SearchReportsInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return SearchReportsOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = SearchReportsInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {e}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={"query": data.query, "status": data.status, "limit": data.limit},
+        )
+
+        context_hub = runtime_ctx.get("context_hub")
+        db = context_hub.db if context_hub else runtime_ctx.get("db")
+        organization = context_hub.organization if context_hub else runtime_ctx.get("organization")
+        user = runtime_ctx.get("user")
+
+        if not all([db, organization, user]):
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": "Missing required runtime context (db, organization, user)",
+                    "code": "MISSING_CONTEXT",
+                },
+            )
+            return
+
+        try:
+            # User-scoped: only the caller's own reports in this organization.
+            stmt = (
+                select(Report)
+                .where(Report.organization_id == str(organization.id))
+                .where(Report.user_id == str(user.id))
+                .where(Report.status != "archived")
+                .where(Report.report_type == "regular")
+            )
+
+            if data.status != "all":
+                stmt = stmt.where(Report.status == data.status)
+
+            if data.mode:
+                stmt = stmt.where(Report.mode == data.mode)
+
+            if data.query and data.query.strip():
+                like = f"%{data.query.strip()}%"
+                stmt = stmt.where(Report.title.ilike(like))
+
+            stmt = stmt.order_by(Report.created_at.desc()).limit(data.limit)
+            reports = (await db.execute(stmt)).scalars().all()
+
+            items = [
+                SearchReportsItem(
+                    id=str(r.id),
+                    title=r.title or "Untitled",
+                    slug=r.slug,
+                    status=r.status,
+                    mode=r.mode,
+                    has_artifacts=bool(r.artifacts),
+                    created_at=str(r.created_at) if r.created_at else None,
+                    updated_at=str(r.updated_at) if r.updated_at else None,
+                )
+                for r in reports
+            ]
+
+            output = SearchReportsOutput(
+                success=True,
+                reports=items,
+                total=len(items),
+                search_query=data.query,
+                message=f"Found {len(items)} report(s)",
+            )
+
+            summary = (
+                f"Found {len(items)} report(s) "
+                f"for query='{data.query or ''}' status='{data.status}'"
+            )
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": output.model_dump(),
+                    "observation": {
+                        "summary": summary,
+                        "artifacts": [
+                            {
+                                "type": "report_search_result",
+                                "count": len(items),
+                                "items": [
+                                    {"id": i.id, "title": i.title, "status": i.status, "mode": i.mode}
+                                    for i in items
+                                ],
+                            }
+                        ],
+                    },
+                },
+            )
+        except Exception as e:
+            logger.exception(f"search_reports failed: {e}")
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Search failed: {e}", "code": "SEARCH_FAILED"},
+            )

--- a/backend/app/ai/tools/schemas/__init__.py
+++ b/backend/app/ai/tools/schemas/__init__.py
@@ -13,6 +13,13 @@ from .edit_instruction import EditInstructionInput, EditInstructionOutput
 from .create_artifact import CreateArtifactInput, CreateArtifactOutput
 from .read_artifact import ReadArtifactInput, ReadArtifactOutput
 from .read_query import ReadQueryInput, ReadQueryOutput, ReadQueryResult
+from .search_reports import SearchReportsInput, SearchReportsOutput, SearchReportsItem
+from .read_report import (
+    ReadReportInput,
+    ReadReportOutput,
+    ReadReportMessage,
+    ReadReportArtifact,
+)
 from .edit_artifact import EditArtifactInput, EditArtifactOutput
 from .search_mcps import SearchMCPsInput, SearchMCPsOutput
 from .execute_mcp import ExecuteMCPInput, ExecuteMCPOutput
@@ -67,6 +74,13 @@ __all__ = [
     "ReadQueryInput",
     "ReadQueryOutput",
     "ReadQueryResult",
+    "SearchReportsInput",
+    "SearchReportsOutput",
+    "SearchReportsItem",
+    "ReadReportInput",
+    "ReadReportOutput",
+    "ReadReportMessage",
+    "ReadReportArtifact",
     "EditArtifactInput",
     "EditArtifactOutput",
     "SearchMCPsInput",

--- a/backend/app/ai/tools/schemas/read_report.py
+++ b/backend/app/ai/tools/schemas/read_report.py
@@ -1,0 +1,50 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class ReadReportInput(BaseModel):
+    """Input schema for the ``read_report`` tool.
+
+    Reads the metadata, conversation, and artifact/data-source summary of a
+    single report owned by the current user. Use ``search_reports`` first to
+    find the ``report_id``. Access is restricted to the caller's own reports.
+    """
+
+    report_id: str = Field(
+        ...,
+        description="The id of the report to read (from search_reports results).",
+    )
+
+    include_conversation: bool = Field(
+        True,
+        description="Include the report's conversation messages (prompts and AI answers).",
+    )
+
+
+class ReadReportMessage(BaseModel):
+    role: str
+    content: str
+    created_at: Optional[str] = None
+
+
+class ReadReportArtifact(BaseModel):
+    id: str
+    title: Optional[str] = None
+    mode: Optional[str] = None
+    version: Optional[int] = None
+
+
+class ReadReportOutput(BaseModel):
+    success: bool
+    report_id: str
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    status: Optional[str] = None
+    mode: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    data_sources: List[str] = Field(default_factory=list)
+    artifacts: List[ReadReportArtifact] = Field(default_factory=list)
+    conversation: List[ReadReportMessage] = Field(default_factory=list)
+    message: Optional[str] = None
+    error: Optional[str] = None

--- a/backend/app/ai/tools/schemas/search_reports.py
+++ b/backend/app/ai/tools/schemas/search_reports.py
@@ -1,0 +1,57 @@
+from typing import List, Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class SearchReportsInput(BaseModel):
+    """Input schema for the ``search_reports`` tool.
+
+    Lists/searches reports owned by the current user. Use this to find a
+    prior report — by title — before referencing or reading it with
+    ``read_report``. Results are always scoped to the calling user's own
+    reports; reports owned by other users are never returned.
+    """
+
+    query: Optional[str] = Field(
+        None,
+        description=(
+            "Substring to match (case-insensitive) against the report title. "
+            "Leave empty to list the user's most recent reports."
+        ),
+        max_length=400,
+    )
+
+    status: Literal["draft", "published", "all"] = Field(
+        "all",
+        description="Filter by report status. ``all`` includes drafts and published reports.",
+    )
+
+    mode: Optional[Literal["chat", "deep", "training"]] = Field(
+        None,
+        description="Optionally restrict to reports created in a specific mode.",
+    )
+
+    limit: int = Field(
+        10,
+        ge=1,
+        le=50,
+        description="Maximum number of reports to return (1-50).",
+    )
+
+
+class SearchReportsItem(BaseModel):
+    id: str
+    title: str
+    slug: Optional[str] = None
+    status: str
+    mode: Optional[str] = None
+    has_artifacts: bool = False
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class SearchReportsOutput(BaseModel):
+    success: bool
+    reports: List[SearchReportsItem] = Field(default_factory=list)
+    total: int = 0
+    search_query: Optional[str] = None
+    message: Optional[str] = None

--- a/backend/tests/e2e/test_report_research_tools.py
+++ b/backend/tests/e2e/test_report_research_tools.py
@@ -1,0 +1,129 @@
+"""E2E tests for the report research tools: search_reports and read_report.
+
+These planner tools let the agent discover and read the CURRENT USER's own
+reports. The key contract is user-scoping: a user can only ever see/read their
+own reports, never another user's — even within the same organization.
+
+We exercise the tools directly via run_stream against the real test DB,
+using a SimpleNamespace for the {user, organization} runtime context (the
+tools only read `.id` off them).
+"""
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+
+def _setup_two_users(create_user, login_user, whoami, test_client):
+    """Two users in the same org. Returns (token1, uid1, token2, uid2, org_id)."""
+    email1 = f"rt_owner_{uuid.uuid4().hex[:6]}@test.com"
+    create_user(email=email1, password="test123")
+    token1 = login_user(email=email1, password="test123")
+    me1 = whoami(token1)
+    org_id = me1["organizations"][0]["id"]
+    uid1 = me1["id"]
+
+    email2 = f"rt_member_{uuid.uuid4().hex[:6]}@test.com"
+    test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": email2, "role": "member"},
+        headers={"Authorization": f"Bearer {token1}", "X-Organization-Id": org_id},
+    )
+    create_user(email=email2, password="test123")
+    token2 = login_user(email=email2, password="test123")
+    me2 = whoami(token2)
+    uid2 = me2["id"]
+
+    return token1, uid1, token2, uid2, org_id
+
+
+async def _run(tool, tool_input, *, user_id, org_id):
+    from app.dependencies import async_session_maker
+
+    async with async_session_maker() as db:
+        ctx = {
+            "db": db,
+            "user": SimpleNamespace(id=user_id),
+            "organization": SimpleNamespace(id=org_id),
+        }
+        end = None
+        async for evt in tool.run_stream(tool_input, ctx):
+            if evt.type == "tool.end":
+                end = evt
+        assert end is not None, "expected a tool.end event"
+        return end.payload["output"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_search_reports_is_user_scoped(
+    create_user, login_user, whoami, test_client, create_report,
+):
+    from app.ai.tools.implementations.search_reports import SearchReportsTool
+
+    token1, uid1, token2, uid2, org_id = _setup_two_users(
+        create_user, login_user, whoami, test_client
+    )
+
+    # u1 owns two reports; u2 owns one with an overlapping keyword.
+    create_report(title="Revenue dashboard", user_token=token1, org_id=org_id, data_sources=[])
+    create_report(title="Churn study", user_token=token1, org_id=org_id, data_sources=[])
+    create_report(title="Revenue secret (u2)", user_token=token2, org_id=org_id, data_sources=[])
+
+    tool = SearchReportsTool()
+
+    # List all -> only u1's two reports, never u2's.
+    out = await _run(tool, {}, user_id=uid1, org_id=org_id)
+    assert out["success"] is True
+    titles = sorted(r["title"] for r in out["reports"])
+    assert titles == ["Churn study", "Revenue dashboard"], titles
+
+    # Search "revenue" -> u1 sees only their own revenue report.
+    out = await _run(tool, {"query": "revenue"}, user_id=uid1, org_id=org_id)
+    titles = [r["title"] for r in out["reports"]]
+    assert titles == ["Revenue dashboard"], titles
+
+    # u2 searching "revenue" sees only their own.
+    out = await _run(tool, {"query": "revenue"}, user_id=uid2, org_id=org_id)
+    titles = [r["title"] for r in out["reports"]]
+    assert titles == ["Revenue secret (u2)"], titles
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_read_report_user_scoping(
+    create_user, login_user, whoami, test_client, create_report,
+):
+    from app.ai.tools.implementations.read_report import ReadReportTool
+
+    token1, uid1, token2, uid2, org_id = _setup_two_users(
+        create_user, login_user, whoami, test_client
+    )
+
+    r1 = create_report(title="My report", user_token=token1, org_id=org_id, data_sources=[])
+    r2 = create_report(title="Their report", user_token=token2, org_id=org_id, data_sources=[])
+
+    tool = ReadReportTool()
+
+    # Owner can read their report.
+    out = await _run(tool, {"report_id": r1["id"]}, user_id=uid1, org_id=org_id)
+    assert out["success"] is True
+    assert out["title"] == "My report"
+    assert isinstance(out["artifacts"], list)
+    assert isinstance(out["conversation"], list)
+
+    # u1 cannot read u2's report — indistinguishable not_found, no leak.
+    out = await _run(tool, {"report_id": r2["id"]}, user_id=uid1, org_id=org_id)
+    assert out["success"] is False
+    assert out["error"] == "not_found"
+    assert out["title"] is None
+
+    # u2 can read their own.
+    out = await _run(tool, {"report_id": r2["id"]}, user_id=uid2, org_id=org_id)
+    assert out["success"] is True
+    assert out["title"] == "Their report"
+
+    # Unknown id -> not_found.
+    out = await _run(tool, {"report_id": str(uuid.uuid4())}, user_id=uid1, org_id=org_id)
+    assert out["success"] is False
+    assert out["error"] == "not_found"

--- a/frontend/components/tools/ReadReportTool.vue
+++ b/frontend/components/tools/ReadReportTool.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="mb-2">
+    <!-- Main Header -->
+    <div class="flex items-center text-xs text-gray-500 cursor-pointer hover:text-gray-700" @click="toggleCollapsed">
+      <Icon :name="isCollapsed ? 'heroicons-chevron-right' : 'heroicons-chevron-down'" class="w-3 h-3 me-1.5 text-gray-400 rtl-flip" />
+      <Spinner v-if="status === 'running'" class="w-3 h-3 me-1.5 text-gray-400" />
+      <Icon v-else-if="status === 'success'" name="heroicons-document-text" class="w-3 h-3 me-1.5 text-blue-500" />
+      <Icon v-else-if="status === 'error'" name="heroicons-exclamation-circle" class="w-3 h-3 me-1.5 text-amber-500" />
+
+      <span v-if="status === 'running'" class="tool-shimmer">Reading report…</span>
+      <span v-else-if="status === 'success' && found" class="text-gray-700">{{ successLabel }}</span>
+      <span v-else-if="status === 'success' && !found" class="text-gray-700 italic">Report not found</span>
+      <span v-else-if="status === 'error'" class="text-gray-700">Failed to read report</span>
+      <span v-else class="text-gray-700">Read report</span>
+
+      <span v-if="reportMode && reportMode !== 'chat' && status === 'success' && found" class="ms-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 text-gray-600">
+        {{ reportMode }}
+      </span>
+    </div>
+
+    <!-- Collapsible content -->
+    <Transition name="fade">
+      <div v-if="!isCollapsed && status === 'success' && found" class="mt-2 ms-4 space-y-2 text-xs text-gray-600">
+        <!-- Meta -->
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
+          <span v-if="reportStatus" class="px-1 py-0.5 rounded" :class="reportStatus === 'published' ? 'bg-green-50 text-green-600' : 'bg-gray-100 text-gray-500'">{{ reportStatus }}</span>
+          <span v-if="dataSources.length">Data: {{ dataSources.join(', ') }}</span>
+          <span v-if="artifacts.length">{{ artifacts.length }} artifact{{ artifacts.length === 1 ? '' : 's' }}</span>
+          <span v-if="conversation.length">{{ conversation.length }} message{{ conversation.length === 1 ? '' : 's' }}</span>
+        </div>
+
+        <!-- Artifacts -->
+        <div v-if="artifacts.length">
+          <div class="text-[11px] font-medium text-gray-500 mb-0.5">Artifacts</div>
+          <ul class="space-y-0.5">
+            <li v-for="a in artifacts" :key="a.id" class="flex items-center">
+              <Icon name="heroicons-chart-bar-square" class="w-3 h-3 me-1 text-gray-400" />
+              <span class="truncate text-gray-700">{{ a.title || 'Untitled' }}</span>
+              <span v-if="a.mode" class="ms-1 text-[9px] text-gray-400">{{ a.mode }}<template v-if="a.version"> v{{ a.version }}</template></span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Conversation -->
+        <div v-if="conversation.length">
+          <div class="text-[11px] font-medium text-gray-500 mb-0.5">Conversation</div>
+          <ul class="space-y-1">
+            <li v-for="(m, i) in conversation" :key="i" class="leading-snug">
+              <span class="text-[9px] uppercase tracking-wide me-1" :class="m.role === 'user' ? 'text-blue-500' : 'text-gray-400'">{{ m.role }}</span>
+              <span class="text-gray-700">{{ truncate(m.content) }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Error / not-found message -->
+    <div v-if="(status === 'error' || (status === 'success' && !found)) && message" class="mt-1 ms-4 text-xs text-gray-500">
+      {{ message }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import Spinner from '~/components/Spinner.vue'
+
+interface Props {
+  toolExecution: {
+    id: string
+    tool_name: string
+    tool_action?: string
+    arguments_json?: { report_id?: string }
+    result_json?: any
+    status: string
+    result_summary?: string
+  }
+  readonly?: boolean
+}
+
+const props = defineProps<Props>()
+const isCollapsed = ref(true)
+
+const status = computed(() => props.toolExecution.status)
+const rj = computed<any>(() => props.toolExecution.result_json || {})
+
+const found = computed<boolean>(() => rj.value?.success === true)
+const reportTitle = computed<string>(() => rj.value?.title || 'Untitled')
+const reportMode = computed<string>(() => rj.value?.mode || '')
+const reportStatus = computed<string>(() => rj.value?.status || '')
+const dataSources = computed<string[]>(() => Array.isArray(rj.value?.data_sources) ? rj.value.data_sources : [])
+const artifacts = computed<any[]>(() => Array.isArray(rj.value?.artifacts) ? rj.value.artifacts : [])
+const conversation = computed<any[]>(() => Array.isArray(rj.value?.conversation) ? rj.value.conversation : [])
+const message = computed<string>(() => rj.value?.message || rj.value?.error || '')
+
+const successLabel = computed(() => `Read "${reportTitle.value}"`)
+
+function toggleCollapsed() {
+  isCollapsed.value = !isCollapsed.value
+}
+
+function truncate(text: string): string {
+  const t = String(text || '')
+  return t.length > 200 ? t.slice(0, 197) + '…' : t
+}
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active { transition: opacity 0.25s ease; }
+.fade-enter-from,
+.fade-leave-to { opacity: 0; }
+
+@keyframes shimmer { 0% { background-position: -100% 0; } 100% { background-position: 100% 0; } }
+.tool-shimmer {
+  background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: shimmer 2s linear infinite;
+  font-weight: 400;
+  opacity: 1;
+}
+</style>

--- a/frontend/components/tools/SearchReportsTool.vue
+++ b/frontend/components/tools/SearchReportsTool.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="mt-1">
+    <!-- Status header -->
+    <div class="mb-2 flex items-center text-xs text-gray-500">
+      <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+        <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
+        <span>Searching reports{{ queryLabel ? ` for ${queryLabel}` : '' }}…</span>
+      </span>
+      <span v-else class="text-gray-700 flex items-center">
+        <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
+        <span class="align-middle">Searched reports{{ queryLabel ? ` for ${queryLabel}` : '' }}</span>
+        <span v-if="total > 0" class="ms-1.5 text-[10px] text-gray-400">· {{ total }} {{ total === 1 ? 'match' : 'matches' }}</span>
+      </span>
+    </div>
+
+    <!-- Results list -->
+    <div v-if="reports.length" class="text-xs text-gray-600">
+      <ul class="ms-1 space-y-0.5 leading-snug">
+        <li v-for="(item, idx) in reports" :key="item.id || idx">
+          <div class="flex items-center py-1 px-1 rounded">
+            <Icon name="heroicons-document-text" class="w-3 h-3 me-1.5 text-blue-400 flex-shrink-0" />
+            <div class="font-medium text-gray-700 truncate">{{ item.title || 'Untitled' }}</div>
+            <span
+              v-if="item.status"
+              class="ms-1.5 text-[9px] px-1 py-0.5 rounded flex-shrink-0"
+              :class="item.status === 'published' ? 'bg-green-50 text-green-600' : 'bg-gray-100 text-gray-500'"
+            >
+              {{ item.status }}
+            </span>
+            <span v-if="item.mode && item.mode !== 'chat'" class="ms-1 text-[9px] px-1 py-0.5 rounded bg-gray-100 text-gray-500 flex-shrink-0">{{ item.mode }}</span>
+            <Icon v-if="item.has_artifacts" name="heroicons-chart-bar-square" class="ms-1 w-3 h-3 text-gray-400 flex-shrink-0" title="Has artifacts" />
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Empty state -->
+    <div v-if="status !== 'running' && !reports.length" class="text-xs text-gray-400 ms-1">
+      No reports found.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  tool_action?: string
+  status: string
+  result_summary?: string
+  result_json?: any
+  arguments_json?: any
+}
+
+interface Props {
+  toolExecution: ToolExecution
+}
+
+const props = defineProps<Props>()
+
+const status = computed<string>(() => props.toolExecution?.status || '')
+
+const queryLabel = computed<string>(() => {
+  const rj = props.toolExecution?.result_json || {}
+  let q: any = rj.search_query
+  if (q == null) q = (props.toolExecution as any)?.arguments_json?.query
+  if (typeof q === 'string' && q.trim()) return `"${q.trim()}"`
+  return ''
+})
+
+const reports = computed<any[]>(() => {
+  const rj: any = props.toolExecution?.result_json || {}
+  return Array.isArray(rj.reports) ? rj.reports : []
+})
+
+const total = computed<number>(() => {
+  const rj: any = props.toolExecution?.result_json || {}
+  return typeof rj.total === 'number' ? rj.total : reports.value.length
+})
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+
+@keyframes shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: 100% 0; }
+}
+</style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -729,6 +729,8 @@ import CreateDashboardTool from '~/components/tools/CreateDashboardTool.vue'
 import CreateArtifactTool from '~/components/tools/CreateArtifactTool.vue'
 import ReadArtifactTool from '~/components/tools/ReadArtifactTool.vue'
 import ReadQueryTool from '~/components/tools/ReadQueryTool.vue'
+import SearchReportsTool from '~/components/tools/SearchReportsTool.vue'
+import ReadReportTool from '~/components/tools/ReadReportTool.vue'
 import EditArtifactTool from '~/components/tools/EditArtifactTool.vue'
 import DescribeTablesTool from '~/components/tools/DescribeTablesTool.vue'
 import DescribeEntityTool from '~/components/tools/DescribeEntityTool.vue'
@@ -1502,6 +1504,10 @@ function getToolComponent(toolName: string) {
 			return ReadArtifactTool
 		case 'read_query':
 			return ReadQueryTool
+		case 'search_reports':
+			return SearchReportsTool
+		case 'read_report':
+			return ReadReportTool
 		case 'edit_artifact':
 			return EditArtifactTool
 		case 'read_resources':


### PR DESCRIPTION
## Summary
Adds two new AI agent tools for researching and accessing user reports: `search_reports` (discover reports by title) and `read_report` (retrieve full report metadata, conversation, and artifacts). These tools enable agents to recall and reference prior work within the current user's own reports.

## Key Changes

### Backend Tools
- **`SearchReportsTool`** (`backend/app/ai/tools/implementations/search_reports.py`)
  - Lists or substring-searches the current user's own reports by title (case-insensitive)
  - Filters by status (draft/published/all) and mode (chat/deep/training)
  - Returns report id, title, slug, status, mode, artifact count, and timestamps
  - Strictly user-scoped: only returns reports owned by the calling user, never shared reports

- **`ReadReportTool`** (`backend/app/ai/tools/implementations/read_report.py`)
  - Reads a single report's full metadata, attached data sources, artifact summary, and conversation
  - Returns report title, slug, status, mode, creation/update timestamps, and up to 40 conversation messages (capped at 2000 chars each)
  - Strictly user-scoped: only accessible if the report is owned by the calling user; returns indistinguishable not-found error for other users' reports (no information leak)
  - Includes helper function `_extract_content()` to safely pull text from completion JSON structures

### Schemas
- **`SearchReportsInput/Output`** (`backend/app/ai/tools/schemas/search_reports.py`)
  - Input: query (optional substring), status filter, mode filter, limit (1-50)
  - Output: list of SearchReportsItem with id, title, status, mode, has_artifacts flag, timestamps

- **`ReadReportInput/Output`** (`backend/app/ai/tools/schemas/read_report.py`)
  - Input: report_id, include_conversation flag
  - Output: success flag, report metadata, data_sources list, artifacts list, conversation messages, error details

### Frontend Components
- **`SearchReportsTool.vue`** (`frontend/components/tools/SearchReportsTool.vue`)
  - Displays search results with report title, status badge, mode tag, and artifact indicator
  - Shows running/completed state with shimmer animation during execution
  - Lists total match count

- **`ReadReportTool.vue`** (`frontend/components/tools/ReadReportTool.vue`)
  - Collapsible display of report metadata (status, data sources, artifact/message counts)
  - Shows artifact list with title, mode, and version
  - Shows conversation excerpt with role labels and truncated content (200 char limit)
  - Displays success/error states with appropriate icons and messages

### Tests
- **`test_report_research_tools.py`** (`backend/tests/e2e/test_report_research_tools.py`)
  - E2E tests verifying user-scoping contract for both tools
  - Tests that users can only see/search their own reports, never other users' reports (even within same organization)
  - Tests read access control and not-found error handling
  - Uses real test database with SimpleNamespace runtime context

### Integration
- Updated `backend/app/ai/tools/schemas/__init__.py` to export new schema classes
- Updated `frontend/pages/reports/[id]/index.vue` to import and register new tool components

## Notable Implementation Details
- **User Scoping**: Both tools enforce strict user ownership checks at the database query level (`Report.user_id == user.id`), preventing any access to other users' reports
- **Security**: Read failures for non-owned reports return indistinguishable "not found" errors to prevent information leakage
- **Conversation Capping**: Conversation is limited to 40 most recent messages and 2000 chars per message to prevent bloating agent observations
- **Content Extraction**: Handles multiple JSON formats (string, dict with "content"/"text" keys) for completion data
- **Idempotent**: Both tools marked as idempotent with 0 retries (search) and 0 retries (read

https://claude.ai/code/session_01VUfXpbKTwB2gfvU4GWVk1a