### PR TITLE
Rename settings Integrations tab to Channels

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "سجلات التدقيق",
     "integrations": {
-      "title": "التكاملات",
+      "title": "القنوات",
       "subtitle": "اضبط منصات خارجية مثل Slack وMicrosoft Teams لمؤسستك.",
       "connected": "متصل",
       "notConnected": "غير متصل",

--- a/locales/de.json
+++ b/locales/de.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Audit-Protokolle",
     "integrations": {
-      "title": "Integrationen",
+      "title": "Kanäle",
       "subtitle": "Konfigurieren Sie externe Plattformen wie Slack und Microsoft Teams für Ihre Organisation.",
       "connected": "Verbunden",
       "notConnected": "Nicht verbunden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1023,7 +1023,7 @@
     },
     "auditLogs": "Audit Logs",
     "integrations": {
-      "title": "Integrations",
+      "title": "Channels",
       "subtitle": "Configure external platforms like Slack and Microsoft Teams for your organization.",
       "connected": "Connected",
       "notConnected": "Not connected",

--- a/locales/es.json
+++ b/locales/es.json
@@ -958,7 +958,7 @@
     },
     "auditLogs": "Registros de auditoría",
     "integrations": {
-      "title": "Integraciones",
+      "title": "Canales",
       "subtitle": "Configura plataformas externas como Slack y Microsoft Teams para tu organización.",
       "connected": "Conectado",
       "notConnected": "No conectado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Journaux d'audit",
     "integrations": {
-      "title": "Intégrations",
+      "title": "Canaux",
       "subtitle": "Configurez des plateformes externes comme Slack et Microsoft Teams pour votre organisation.",
       "connected": "Connecté",
       "notConnected": "Non connecté",

--- a/locales/he.json
+++ b/locales/he.json
@@ -958,7 +958,7 @@
     },
     "auditLogs": "יומני ביקורת",
     "integrations": {
-      "title": "אינטגרציות",
+      "title": "ערוצים",
       "subtitle": "הגדר פלטפורמות חיצוניות כמו Slack ו-Microsoft Teams עבור הארגון שלך.",
       "connected": "מחובר",
       "notConnected": "לא מחובר",

--- a/locales/it.json
+++ b/locales/it.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Registri di audit",
     "integrations": {
-      "title": "Integrazioni",
+      "title": "Canali",
       "subtitle": "Configura piattaforme esterne come Slack e Microsoft Teams per la tua organizzazione.",
       "connected": "Connesso",
       "notConnected": "Non connesso",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Logs de auditoria",
     "integrations": {
-      "title": "Integrações",
+      "title": "Canais",
       "subtitle": "Configure plataformas externas como Slack e Microsoft Teams para sua organização.",
       "connected": "Conectado",
       "notConnected": "Não conectado",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Журналы аудита",
     "integrations": {
-      "title": "Интеграции",
+      "title": "Каналы",
       "subtitle": "Настройте внешние платформы, такие как Slack и Microsoft Teams, для вашей организации.",
       "connected": "Подключено",
       "notConnected": "Не подключено",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -882,7 +882,7 @@
     },
     "auditLogs": "Granskningsloggar",
     "integrations": {
-      "title": "Integrationer",
+      "title": "Kanaler",
       "subtitle": "Konfigurera externa plattformar som Slack och Microsoft Teams för din organisation.",
       "connected": "Ansluten",
       "notConnected": "Ej ansluten",


### PR DESCRIPTION
Updates the settings.integrations.title translation key across all
locales so the settings tab and page heading read 'Channels'.