### PR TITLE
Enable Test Connection for existing LLM providers

### DIFF
--- a/backend/app/routes/llm.py
+++ b/backend/app/routes/llm.py
@@ -12,6 +12,7 @@ from app.schemas.llm_schema import (
     LLMProviderSchema,
     LLMProviderCreate,
     LLMProviderUpdate,
+    LLMProviderTestConnection,
     LLMModelSchema,
     LLMModelCreate,
     LLMModelUpdate,
@@ -45,7 +46,7 @@ async def get_available_models(
 @router.post("/llm/test_connection", response_model=dict)
 @requires_permission('manage_llm')
 async def test_connection(
-    provider: LLMProviderCreate,
+    provider: LLMProviderTestConnection,
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization)

--- a/backend/app/schemas/llm_schema.py
+++ b/backend/app/schemas/llm_schema.py
@@ -55,6 +55,39 @@ class LLMProviderCreate(LLMProviderBase):
         
         return schema(**v).dict()
 
+class LLMProviderTestConnection(LLMProviderBase):
+    # When set, the test targets an already-saved provider. Blank credential
+    # fields then fall back to the stored (encrypted) values.
+    provider_id: Optional[str] = None
+    credentials: dict = {}
+    models: list[dict] = []
+
+    @validator('credentials')
+    def validate_credentials(cls, v, values):
+        if 'provider_type' not in values:
+            raise ValueError('Provider type must be specified')
+
+        credential_schemas = {
+            'anthropic': AnthropicCredentials,
+            'openai': OpenAICredentials,
+            'google': GoogleCredentials,
+            'azure': AzureCredentials,
+            'custom': CustomCredentials,
+            'bedrock': BedrockCredentials,
+        }
+
+        schema = credential_schemas.get(values['provider_type'])
+        if not schema:
+            raise ValueError(f'Unknown provider type: {values["provider_type"]}')
+
+        # For an existing provider, the payload may omit/blank required secrets
+        # (they fall back to stored values), so skip strict schema validation
+        # and pass the raw partial credentials through.
+        if values.get('provider_id'):
+            return v
+
+        return schema(**v).dict()
+
 class LLMProviderUpdate(BaseModel):
     name: Optional[str] = None
     config: Optional[Dict[str, Any]] = None

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -10,7 +10,7 @@ from app.models.user import User
 from app.settings.config import settings
 from app.models.llm_provider import LLM_PROVIDER_DETAILS
 from app.models.llm_model import LLM_MODEL_DETAILS
-from app.schemas.llm_schema import AnthropicCredentials, OpenAICredentials, GoogleCredentials, LLMModelSchema, LLMProviderCreate
+from app.schemas.llm_schema import AnthropicCredentials, OpenAICredentials, GoogleCredentials, LLMModelSchema, LLMProviderCreate, LLMProviderTestConnection
 from app.ai.llm.llm import LLM
 from app.dependencies import async_session_maker
 from datetime import datetime
@@ -996,9 +996,23 @@ class LLMService:
         db: AsyncSession,
         organization: Organization,
         current_user: User,
-        provider: LLMProviderCreate
+        provider: LLMProviderTestConnection
     ):
-        logger.info("Testing LLM connection: provider_type=%s, name=%s, org_id=%s, user_id=%s", provider.provider_type, provider.name, organization.id, current_user.id)
+        logger.info("Testing LLM connection: provider_type=%s, name=%s, provider_id=%s, org_id=%s, user_id=%s", provider.provider_type, provider.name, getattr(provider, 'provider_id', None), organization.id, current_user.id)
+
+        # When testing an already-saved provider, load it so blank credential
+        # fields fall back to the stored (encrypted) values.
+        stored_provider = None
+        if getattr(provider, 'provider_id', None):
+            result = await db.execute(
+                select(LLMProvider)
+                .filter(LLMProvider.id == provider.provider_id)
+                .filter(LLMProvider.organization_id == organization.id)
+                .filter(LLMProvider.deleted_at == None)
+            )
+            stored_provider = result.unique().scalar_one_or_none()
+            if stored_provider is None:
+                raise HTTPException(status_code=404, detail="Provider not found")
 
         # Build an in-memory provider based on the payload (no DB writes)
         provider_obj = LLMProvider(
@@ -1011,8 +1025,15 @@ class LLMService:
             additional_config=None
         )
 
+        # Seed encrypted credentials + config from the saved provider; any
+        # credentials supplied in the payload override these below.
+        if stored_provider is not None:
+            provider_obj.api_key = stored_provider.api_key
+            provider_obj.api_secret = stored_provider.api_secret
+            provider_obj.additional_config = dict(stored_provider.additional_config or {})
+
         # Set credentials and merge provider-specific additional_config
-        self._set_provider_credentials(provider_obj, provider.credentials)
+        self._set_provider_credentials(provider_obj, provider.credentials or {})
 
         # Choose a model to test from user-provided list, preferring default or custom
         selected_model = None

--- a/backend/tests/unit/test_llm_test_connection_schema.py
+++ b/backend/tests/unit/test_llm_test_connection_schema.py
@@ -1,0 +1,59 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.llm_schema import LLMProviderCreate, LLMProviderTestConnection
+
+
+def test_new_provider_requires_api_key():
+    """Without a provider_id (new provider), missing required secrets fail."""
+    with pytest.raises(ValidationError):
+        LLMProviderTestConnection(
+            name="openai temp",
+            provider_type="openai",
+            credentials={},  # missing api_key
+        )
+
+
+def test_existing_provider_allows_blank_credentials():
+    """With a provider_id (existing provider), blank credentials are allowed
+    because they fall back to the stored values."""
+    payload = LLMProviderTestConnection(
+        provider_id="prov-123",
+        name="openai",
+        provider_type="openai",
+        credentials={"api_key": None},
+    )
+    assert payload.provider_id == "prov-123"
+    # Raw credentials passed through untouched for existing providers
+    assert payload.credentials == {"api_key": None}
+
+
+def test_existing_provider_overrides_with_new_key():
+    """A supplied key on an existing provider is preserved in the payload."""
+    payload = LLMProviderTestConnection(
+        provider_id="prov-123",
+        name="openai",
+        provider_type="openai",
+        credentials={"api_key": "sk-new"},
+    )
+    assert payload.credentials["api_key"] == "sk-new"
+
+
+def test_unknown_provider_type_rejected():
+    with pytest.raises(ValidationError):
+        LLMProviderTestConnection(
+            provider_id="prov-123",
+            name="weird",
+            provider_type="not_a_provider",
+            credentials={},
+        )
+
+
+def test_create_schema_still_strict():
+    """The create schema is unchanged: api_key remains required."""
+    with pytest.raises(ValidationError):
+        LLMProviderCreate(
+            name="openai",
+            provider_type="openai",
+            credentials={},
+        )

--- a/frontend/components/LLMProviderModalComponent.vue
+++ b/frontend/components/LLMProviderModalComponent.vue
@@ -403,7 +403,7 @@
                         </div>
 
                 <div class="flex items-center pt-4">
-                    <div v-if="isNewProviderSelected && providerForm.provider_type">
+                    <div v-if="showTestConnection">
                         <UTooltip text="Regular charges may occur">
                             <UButton 
                                 variant="soft" 
@@ -589,6 +589,15 @@ function getFieldPlaceholder(field: CredentialField): string {
 
 const isNewProviderSelected = computed(() => {
     return selectedProvider.value?.type === 'new_provider';
+});
+
+const showTestConnection = computed(() => {
+    // New provider: show once a provider type has been picked
+    if (isNewProviderSelected.value) {
+        return !!providerForm.value.provider_type;
+    }
+    // Existing provider: show whenever a provider is selected for editing
+    return !!selectedProvider.value && selectedProvider.value.type !== 'new_provider';
 });
 
 // fieldsForProvider moved above to include required keys
@@ -1060,6 +1069,7 @@ async function testConnection() {
             }));
 
             payload = {
+                provider_id: selectedProvider.value.id,
                 name: selectedProvider.value.name,
                 provider_type: selectedProvider.value.provider_type || selectedProvider.value.type,
                 credentials: selectedProvider.value.credentials || {},


### PR DESCRIPTION
## Summary

The "Test Connection" button was only available when creating a **new** LLM provider. This change exposes it when editing an **existing** provider as well, and makes the backend fall back to the stored (encrypted) credentials when fields are left blank.

### Why it didn't work for existing providers before
- The button's `v-if` was `isNewProviderSelected && providerForm.provider_type`, so it never rendered for existing providers.
- The stored API key is never sent to the browser (the edit form starts the key blank with "Keep blank to use stored key").
- The strict credentials validator would reject `api_key: null` with a 422.

## Changes

**Frontend** (`LLMProviderModalComponent.vue`)
- New `showTestConnection` computed: shows the button for a new provider once a type is picked, and whenever an existing provider is opened for editing.
- The existing-provider test payload now includes `provider_id`.

**Backend**
- `llm_schema.py`: new `LLMProviderTestConnection` schema with an optional `provider_id` and a lenient credentials validator — when `provider_id` is present, blank/partial credentials pass through (they fall back to stored values); new providers stay strict.
- `llm_service.py`: when `provider_id` is set, `test_connection` loads the saved provider (scoped to the org), seeds the in-memory test provider with its encrypted credentials + `additional_config`, then applies any payload credentials on top. A blank key reuses the stored key; an entered key overrides it. Still no DB writes.
- `llm.py`: route uses the new schema.

**Tests**
- Added `test_llm_test_connection_schema.py` covering existing-provider leniency, new-provider strictness, and unknown-type rejection.

## Notes
- Behavior depends on the actual model call, so for an existing **custom** provider, clearing a required field like `base_url` surfaces as a "Connection failed" toast rather than a validation error — the expected graceful outcome.

https://claude.ai/code/session_019ViEitfBieafkRdLHUxYkF

---
_Generated by [Claude Code](https://claude.ai/code/session_019ViEitfBieafkRdLHUxYkF)_