### PR TITLE
Add ⌘K command palette (reports, agents, instructions)

### DIFF
--- a/frontend/components/CommandPalette.vue
+++ b/frontend/components/CommandPalette.vue
@@ -1,0 +1,260 @@
+<template>
+  <UModal
+    v-model="isOpen"
+    :ui="{ width: 'sm:max-w-2xl', container: 'items-start', margin: 'sm:mt-[12vh]' }"
+  >
+    <UCommandPalette
+      ref="paletteRef"
+      :groups="groups"
+      :placeholder="t('commandPalette.placeholder')"
+      :empty-state="{ icon: 'i-heroicons-magnifying-glass', label: t('commandPalette.emptyLabel'), queryLabel: t('commandPalette.emptyQueryLabel') }"
+      icon="i-heroicons-magnifying-glass"
+      :loading="loading"
+      class="!h-auto"
+      @update:model-value="onSelect"
+      @close="close"
+    />
+
+    <!-- Footer keyboard hints -->
+    <div class="flex items-center gap-4 px-4 py-2 border-t border-gray-100 text-[11px] text-gray-400 bg-gray-50/60 rounded-b-lg">
+      <span><kbd class="font-sans">↑↓</kbd> navigate</span>
+      <span><kbd class="font-sans">↵</kbd> open</span>
+      <span><kbd class="font-sans">esc</kbd> close</span>
+    </div>
+  </UModal>
+
+  <!-- Instruction create / view — reused for "New instruction" action and opening a result.
+       The modal itself decides global-create vs. suggestion based on permission. -->
+  <InstructionModalComponent
+    v-if="showInstructionModal"
+    v-model="showInstructionModal"
+    :instruction="instructionModalInstruction"
+    :initial-text="instructionInitialText"
+    @instructionSaved="onInstructionSaved"
+  />
+</template>
+
+<script setup lang="ts">
+import InstructionModalComponent from '~/components/InstructionModalComponent.vue'
+import { useCan, useCanAny } from '~/composables/usePermissions'
+
+const { t } = useI18n()
+const router = useRouter()
+const { isOpen, close } = useCommandPalette()
+
+// Global ⌘K / Ctrl+K. usingInput:true so it also fires while a text field is focused.
+defineShortcuts({
+  meta_k: {
+    usingInput: true,
+    handler: () => { isOpen.value = !isOpen.value },
+  },
+})
+
+// --- live query (owned by UCommandPalette, mirrored here for echo + filtering) ---
+const paletteRef = ref<any>(null)
+const queryStr = ref('')
+watch(() => paletteRef.value?.query, (q: string) => { queryStr.value = q ?? '' })
+
+// --- data ---
+const loading = ref(false)
+const reportItems = ref<any[]>([])
+const agentItemsRaw = ref<any[]>([])
+const instructionItems = ref<any[]>([])
+
+async function fetchReports(q: string) {
+  try {
+    const qs = `/reports?filter=my&limit=6${q ? `&search=${encodeURIComponent(q)}` : ''}`
+    const res: any = await useMyFetch(qs, { method: 'GET' })
+    reportItems.value = res?.data?.value?.reports ?? []
+  } catch { reportItems.value = [] }
+}
+
+async function fetchInstructions(q: string) {
+  try {
+    const qs = `/instructions?limit=6&include_drafts=true${q ? `&search=${encodeURIComponent(q)}` : ''}`
+    const res: any = await useMyFetch(qs, { method: 'GET' })
+    instructionItems.value = res?.data?.value?.items ?? []
+  } catch { instructionItems.value = [] }
+}
+
+async function fetchAgents() {
+  try {
+    const res: any = await useMyFetch('/data_sources', { method: 'GET' })
+    const list = res?.data?.value ?? []
+    // newest first for the "recent" default view
+    agentItemsRaw.value = [...list].sort((a: any, b: any) =>
+      new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
+  } catch { agentItemsRaw.value = [] }
+}
+
+// Debounced server-side search for reports + instructions; agents filter client-side.
+let debounceT: any = null
+watch(queryStr, (q) => {
+  clearTimeout(debounceT)
+  loading.value = true
+  debounceT = setTimeout(async () => {
+    await Promise.all([fetchReports(q), fetchInstructions(q)])
+    loading.value = false
+  }, 200)
+})
+
+// On open: clear stale query and load recents.
+watch(isOpen, async (open) => {
+  if (!open) return
+  await nextTick()
+  paletteRef.value?.updateQuery?.('')
+  queryStr.value = ''
+  loading.value = true
+  await Promise.all([fetchReports(''), fetchInstructions(''), fetchAgents()])
+  loading.value = false
+})
+
+// --- helpers ---
+function relTime(iso?: string): string {
+  if (!iso) return ''
+  const d = new Date(iso).getTime()
+  if (Number.isNaN(d)) return ''
+  const s = Math.floor((Date.now() - d) / 1000)
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`
+  const days = Math.floor(h / 24); if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+function truncate(s?: string, n = 60): string {
+  if (!s) return ''
+  return s.length > n ? s.slice(0, n).trimEnd() + '…' : s
+}
+
+const canCreateInstructions = computed(() => useCanAny('manage_instructions', 'data_source'))
+
+// --- groups (all static: we search server-side ourselves) ---
+const actionsGroup = computed(() => {
+  const q = queryStr.value.trim()
+  const commands: any[] = [
+    {
+      id: 'action-new-report',
+      label: q ? t('commandPalette.newReportWithQuery', { query: q }) : t('commandPalette.newReport'),
+      icon: 'i-heroicons-plus-circle',
+      shortcuts: ['↵'],
+      click: () => createReport(q),
+    },
+    {
+      id: 'action-new-instruction',
+      label: canCreateInstructions.value
+        ? (q ? t('commandPalette.newInstructionWithQuery', { query: q }) : t('commandPalette.newInstruction'))
+        : (q ? t('commandPalette.suggestInstructionWithQuery', { query: q }) : t('commandPalette.suggestInstruction')),
+      icon: 'i-heroicons-pencil-square',
+      suffix: canCreateInstructions.value ? undefined : t('commandPalette.suggestionHint'),
+      click: () => openNewInstruction(q),
+    },
+  ]
+  return { key: 'actions', label: t('commandPalette.actions'), static: true, commands }
+})
+
+const reportsGroup = computed(() => ({
+  key: 'reports',
+  label: t('commandPalette.reports'),
+  static: true,
+  commands: reportItems.value.map((r: any) => ({
+    id: `report-${r.id}`,
+    label: r.title || 'Untitled report',
+    icon: 'i-heroicons-document-text',
+    suffix: relTime(r.created_at),
+    to: `/reports/${r.id}`,
+  })),
+}))
+
+const agentsGroup = computed(() => {
+  const q = queryStr.value.trim().toLowerCase()
+  const filtered = (q
+    ? agentItemsRaw.value.filter((a: any) => (a.name || '').toLowerCase().includes(q))
+    : agentItemsRaw.value
+  ).slice(0, 6)
+  return {
+    key: 'agents',
+    label: t('commandPalette.agents'),
+    static: true,
+    commands: filtered.map((a: any) => ({
+      id: `agent-${a.id}`,
+      label: a.name,
+      icon: 'i-heroicons-circle-stack',
+      suffix: a.status === 'active' ? 'active' : 'inactive',
+      to: `/agents/${a.id}`,
+    })),
+  }
+})
+
+const instructionsGroup = computed(() => ({
+  key: 'instructions',
+  label: t('commandPalette.instructions'),
+  static: true,
+  commands: instructionItems.value.map((i: any) => ({
+    id: `instruction-${i.id}`,
+    label: i.title || truncate(i.text),
+    icon: 'i-heroicons-chat-bubble-bottom-center-text',
+    suffix: i.category || undefined,
+    instruction: i,
+  })),
+}))
+
+const groups = computed(() => {
+  const g: any[] = [actionsGroup.value]
+  if (reportsGroup.value.commands.length) g.push(reportsGroup.value)
+  if (agentsGroup.value.commands.length) g.push(agentsGroup.value)
+  if (instructionsGroup.value.commands.length) g.push(instructionsGroup.value)
+  return g
+})
+
+// --- selection handling ---
+function onSelect(option: any) {
+  if (!option) return
+  if (option.click) { close(); option.click(); return }
+  if (option.instruction) { openInstruction(option.instruction); return }
+  if (option.to) { close(); router.push(option.to) }
+}
+
+// --- actions ---
+const { initAgent, selectedAgentObjects } = useAgent()
+const creatingReport = ref(false)
+async function createReport(initialPrompt: string) {
+  if (creatingReport.value) return
+  creatingReport.value = true
+  try {
+    const dataSourceIds = selectedAgentObjects.value.map((a: any) => a.id)
+    const res: any = await useMyFetch('/reports', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'untitled report', files: [], data_sources: dataSourceIds }),
+    })
+    const data: any = res?.data?.value
+    if (data?.id) {
+      router.push({ path: `/reports/${data.id}`, query: initialPrompt ? { prompt: initialPrompt } : undefined })
+    }
+  } finally {
+    creatingReport.value = false
+  }
+}
+
+// --- instruction modal ---
+const showInstructionModal = ref(false)
+const instructionModalInstruction = ref<any>(null)
+const instructionInitialText = ref('')
+
+function openNewInstruction(initialText: string) {
+  close()
+  instructionModalInstruction.value = null
+  instructionInitialText.value = initialText
+  nextTick(() => { showInstructionModal.value = true })
+}
+function openInstruction(instruction: any) {
+  close()
+  instructionInitialText.value = ''
+  instructionModalInstruction.value = instruction
+  nextTick(() => { showInstructionModal.value = true })
+}
+function onInstructionSaved() {
+  showInstructionModal.value = false
+}
+
+onMounted(() => { initAgent() })
+</script>

--- a/frontend/components/InstructionGlobalCreateComponent.vue
+++ b/frontend/components/InstructionGlobalCreateComponent.vue
@@ -855,6 +855,7 @@ const props = withDefaults(defineProps<{
     initialVersionNumber?: number  // If set (and initialVersionId not), preselect by version_number after the version list loads
     agentId?: string  // When opened from an agent panel, seed the data source scope
     initialTitle?: string  // Seed the title field when creating a new instruction
+    initialText?: string  // Seed the text/body when creating a new instruction (e.g. command palette)
     uppercaseTitle?: boolean  // When false, do not force the title to uppercase (input & display)
     startInEditMode?: boolean  // When true (and an instruction is provided), open directly in edit mode instead of view mode
 }>(), {
@@ -1572,7 +1573,7 @@ const buildInstructionPayload = () => {
 const resetForm = () => {
     const seedTitle = props.initialTitle || ''
     instructionForm.value = {
-        text: '',
+        text: props.initialText || '',
         title: props.uppercaseTitle ? seedTitle.toUpperCase() : seedTitle,
         status: props.defaultStatus || 'draft',
         category: 'general',

--- a/frontend/components/InstructionModalComponent.vue
+++ b/frontend/components/InstructionModalComponent.vue
@@ -36,6 +36,7 @@
                                 :instruction="instruction"
                                 :analyzing="isAnalyzing"
                                 :shared-form="sharedForm"
+                                :initial-text="initialText"
                                 :selected-data-sources="selectedDataSources"
                                 :is-git-sourced="isGitSourced"
                                 :is-git-synced="isGitSynced"
@@ -228,6 +229,7 @@ const props = defineProps<{
     initialType?: 'global' | 'private'
     isSuggestion?: boolean
     targetBuildId?: string | null  // If set, update instruction within this existing build
+    initialText?: string  // Seed the text field when creating (e.g. from the command palette)
 }>()
 
 const emit = defineEmits(['update:modelValue', 'instructionSaved'])
@@ -592,6 +594,12 @@ watch(() => props.instruction, (newInstruction) => {
     } else {
         // If the instruction prop is cleared, reset the form for a clean 'create' state.
         resetForm()
+        // Seed the text when opening straight into create mode (e.g. command palette).
+        // Runs here (immediate watcher) because the modal often mounts with
+        // modelValue already true, so the open watcher below never transitions.
+        if (props.initialText) {
+            sharedForm.value.text = props.initialText
+        }
     }
 }, { immediate: true })
 

--- a/frontend/composables/useCommandPalette.ts
+++ b/frontend/composables/useCommandPalette.ts
@@ -1,0 +1,12 @@
+// Shared open-state for the global ⌘K / Ctrl+K command palette.
+// The palette itself is mounted once in layouts/default.vue (see CommandPalette.vue);
+// this composable lets any component open/close/toggle it.
+export const useCommandPalette = () => {
+  const isOpen = useState<boolean>('command-palette-open', () => false)
+
+  const open = () => { isOpen.value = true }
+  const close = () => { isOpen.value = false }
+  const toggle = () => { isOpen.value = !isOpen.value }
+
+  return { isOpen, open, close, toggle }
+}

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -222,6 +222,9 @@
   </div>
 
   <McpModal v-if="showMcpModal" v-model="showMcpModal" />
+
+  <!-- Global ⌘K / Ctrl+K command palette -->
+  <CommandPalette />
   </div>
 </template>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,20 @@
 {
+  "commandPalette": {
+    "placeholder": "Search reports, agents, instructions…",
+    "actions": "Actions",
+    "newReport": "New report",
+    "newReportWithQuery": "New report “{query}”",
+    "newInstruction": "New instruction",
+    "newInstructionWithQuery": "New instruction “{query}”",
+    "suggestInstruction": "Suggest instruction",
+    "suggestInstructionWithQuery": "Suggest instruction “{query}”",
+    "suggestionHint": "sent for review",
+    "reports": "Recent reports",
+    "agents": "Agents",
+    "instructions": "Instructions",
+    "emptyLabel": "Start typing to search",
+    "emptyQueryLabel": "No results found"
+  },
   "smoke": {
     "hello": "Hello",
     "subtitle": "i18n plumbing is live"


### PR DESCRIPTION
## Summary

Adds a global **⌘K / Ctrl+K command palette** for quick navigation and creation, built on `@nuxt/ui`'s `UCommandPalette` + `defineShortcuts`. Opens from anywhere in the app.

## Behavior

- **Search-all** across **Recent reports**, **Agents**, and **Instructions** in one input — server-side `search` for reports & instructions, client-side filtering for agents. Recents are shown by default on open.
- **Pinned actions that echo the typed query:**
  - `New report "<query>"` → creates a report and navigates to it.
  - Permission-aware instruction action: `New instruction "<query>"` for users who can create, or `Suggest instruction "<query>"` (tagged *sent for review*) for those who can't. It drives the existing `InstructionModalComponent`, which already branches global-create vs. suggestion via `useCanAny('manage_instructions', 'data_source')`.
- A no-match query still surfaces the pinned create actions (standard Raycast/Linear pattern).
- `New instruction` opens the modal **pre-filled** with the typed query via a new `initialText` prop threaded into `InstructionGlobalCreateComponent`.

## Changes

**New**
- `frontend/components/CommandPalette.vue` — the palette, mounted once in the default layout.
- `frontend/composables/useCommandPalette.ts` — shared open/close/toggle state.

**Modified**
- `frontend/layouts/default.vue` — mounts `<CommandPalette />`.
- `frontend/components/InstructionModalComponent.vue` + `InstructionGlobalCreateComponent.vue` — `initialText` prop for pre-filled create.
- `locales/en.json` — `commandPalette.*` strings.

## Verification

Ran backend + frontend locally (per `docs/design/sandbox-feedback-loop.md`), seeded reports/agents/instructions, and confirmed via Playwright with a logged-in session:

- ⌘K / Ctrl+K opens the palette; recents + trailing metadata (time / status / category) render.
- Query echoes into both create actions; server-side search filters reports & instructions; empty groups hide.
- No-results shows only the pinned actions.
- **New report** → creates and navigates to `/reports/<id>`.
- A report row → navigates to the report.
- **New instruction** → opens the global-create modal pre-filled with the query.

## Notes

- Backend untouched — reports & instructions already support `search`; agents filter client-side (small list).
- Mounted only in `layouts/default.vue`; adding it to the `excel`/`data` layouts is a one-line change each if desired.

https://claude.ai/code/session_0115zHaHZDG88ZCDc1Kbxwna

---
_Generated by [Claude Code](https://claude.ai/code/session_0115zHaHZDG88ZCDc1Kbxwna)_