### PR TITLE
Add publish_status (publishing lifecycle) to data sources/agents

### DIFF
--- a/backend/alembic/versions/d6d9a78b7b4a_add_publish_status_to_data_sources.py
+++ b/backend/alembic/versions/d6d9a78b7b4a_add_publish_status_to_data_sources.py
@@ -1,0 +1,44 @@
+"""add publish_status to data_sources
+
+Revision ID: d6d9a78b7b4a
+Revises: sf4a5b6c7d8e
+Create Date: 2026-06-14 00:00:00.000000
+
+Adds the manager-set publishing lifecycle column to data sources.
+
+``publish_status`` is distinct from ``is_active`` (connection health,
+system-managed). Values:
+  - published — visible to everyone with access (default)
+  - draft     — visible only to users who can ``manage`` the agent
+  - disabled  — off; hidden everywhere
+
+Stored as a plain string (not a DB enum) for clean SQLite/Postgres parity.
+Existing rows are backfilled to ``published`` via the server default.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd6d9a78b7b4a'
+down_revision: Union[str, None] = 'sf4a5b6c7d8e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('data_sources') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'publish_status',
+                sa.String(),
+                nullable=False,
+                server_default='published',
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('data_sources') as batch_op:
+        batch_op.drop_column('publish_status')

--- a/backend/app/ai/context/builders/code_context_builder.py
+++ b/backend/app/ai/context/builders/code_context_builder.py
@@ -420,6 +420,8 @@ class CodeContextBuilder:
         stmt = select(DataSource.id).where(
             DataSource.organization_id == self.organization.id,
             DataSource.is_active == True,
+            # Disabled agents are off — never feed their schema into AI context.
+            DataSource.publish_status != "disabled",
         )
         if not is_admin:
             clauses = [DataSource.is_public == True]

--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -21,7 +21,19 @@ class DataSource(BaseSchema):
     # Connection-related fields have been moved to the Connection model
     # type, config, credentials, auth_policy, allowed_user_auth_modes are now on Connection
     last_synced_at = Column(DateTime, nullable=True)
+    # Connection health: system-managed, auto-toggled by connection test results.
+    # "Can we physically reach and query this data source right now?" — NOT a
+    # human-set flag. Do not overload it with publishing intent.
     is_active = Column(Boolean, nullable=False, default=True)
+    # Publishing lifecycle: manager-set, intentional. "Has a human decided this
+    # agent is ready for consumers?" Orthogonal to is_active (health).
+    #   published — visible to everyone with access (the selector, AI context)
+    #   draft     — visible only to users who can `manage` this agent (builders)
+    #   disabled  — off; hidden everywhere, excluded from AI context
+    # Stored as a plain string (not a DB enum) for clean SQLite/Postgres parity.
+    publish_status = Column(
+        String, nullable=False, default="published", server_default="published"
+    )
     # Data sources are private by default: only explicitly added members (plus
     # admins) can see them. Sharing org-wide is an opt-in (set is_public=True).
     is_public = Column(Boolean, nullable=False, default=False)

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -149,6 +149,9 @@ class DataSourceSchema(DataSourceBase):
     conversation_starters: Optional[list] = None
     is_active: bool
     is_public: bool = False
+    # Manager-set publishing lifecycle: "published" | "draft" | "disabled".
+    # Distinct from is_active (connection health).
+    publish_status: str = "published"
     use_llm_sync: bool = False
     owner_user_id: Optional[str] = None
     git_repository: Optional[GitRepositorySchema] = None
@@ -187,7 +190,10 @@ class DataSourceListItemSchema(BaseModel):
     description: Optional[str]
     conversation_starters: Optional[list] = None
     created_at: UTCDatetime
-    status: str  # "active" | "inactive"
+    # Connection-health derived state, kept for backward compatibility.
+    status: str  # "active" | "inactive" (mirrors is_active)
+    # Manager-set publishing lifecycle: "published" | "draft" | "disabled".
+    publish_status: str = "published"
 
     # Connection info (multi-connection support)
     connections: List[ConnectionEmbedded] = []
@@ -282,8 +288,21 @@ class DataSourceUpdate(DataSourceBase):
     conversation_starters: Optional[list] = None
     is_public: Optional[bool] = None
     use_llm_sync: Optional[bool] = None
+    # Manager-set publishing lifecycle. Guarded by the 'manage' resource
+    # permission on the data source (see routes/data_source.py).
+    publish_status: Optional[str] = None
     member_user_ids: Optional[List[str]] = None  # User IDs to grant access to
     primary_instruction_id: Optional[Union[str, None]] = None  # None = clear, str = set
+
+    @field_validator('publish_status')
+    @classmethod
+    def _validate_publish_status(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        allowed = {"published", "draft", "disabled"}
+        if v not in allowed:
+            raise ValueError(f"publish_status must be one of {sorted(allowed)}")
+        return v
 
     # Connection-related fields (will be delegated to Connection update)
     config: Optional[dict] = None

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -598,6 +598,7 @@ class DataSourceService:
             conversation_starters=final_data_source.conversation_starters,
             is_active=final_data_source.is_active,
             is_public=final_data_source.is_public,
+            publish_status=getattr(final_data_source, "publish_status", "published") or "published",
             use_llm_sync=final_data_source.use_llm_sync,
             owner_user_id=str(final_data_source.owner_user_id) if final_data_source.owner_user_id else None,
             git_repository=final_data_source.git_repository,
@@ -886,6 +887,7 @@ class DataSourceService:
             conversation_starters=data_source.conversation_starters,
             is_active=data_source.is_active,
             is_public=data_source.is_public,
+            publish_status=getattr(data_source, "publish_status", "published") or "published",
             use_llm_sync=data_source.use_llm_sync,
             owner_user_id=data_source.owner_user_id,
             git_repository=data_source.git_repository,
@@ -906,7 +908,35 @@ class DataSourceService:
 
     async def get_available_data_sources(self, db: AsyncSession, organization: Organization):
         return list_available_data_sources()
-    
+
+    async def _publish_visibility(self, db: AsyncSession, current_user: User, organization: Organization):
+        """Returns (is_governance, manageable_ds_ids).
+
+        Used to decide whether a non-published agent (draft/disabled) is visible
+        to the caller. Managers — org-wide governance (full_admin_access /
+        manage_connections) or a per-DS ``manage`` grant — can see their drafts;
+        everyone else only sees ``published`` agents.
+        """
+        if current_user is None:
+            return False, set()
+        try:
+            from app.core.permission_resolver import resolve_permissions, FULL_ADMIN
+            resolved = await resolve_permissions(
+                db, str(current_user.id), str(organization.id)
+            )
+            is_gov = (
+                FULL_ADMIN in resolved.org_permissions
+                or resolved.has_org_permission("manage_connections")
+            )
+            manage_ids = {
+                str(rid)
+                for (rtype, rid), perms in resolved.resource_permissions.items()
+                if rtype == "data_source" and "manage" in perms
+            }
+            return is_gov, manage_ids
+        except Exception:
+            return False, set()
+
     async def get_data_sources(self, db: AsyncSession, current_user: User, organization: Organization, show_all: bool = False) -> List[DataSourceListItemSchema]:
         # Query for data sources the user has access to
         # NOTE: Do NOT use selectinload(DataSource.tables) here - it loads ALL tables into memory
@@ -957,9 +987,14 @@ class DataSourceService:
             query = query.filter(or_(*clauses))
         result = await db.execute(query)
         data_sources = result.scalars().all()
+        # Non-published agents (draft/disabled) are only visible to managers.
+        is_gov, manage_ids = await self._publish_visibility(db, current_user, organization)
         # Build list with connection info (no live test for list to keep it fast)
         schemas: list[DataSourceListItemSchema] = []
         for d in data_sources:
+            publish_status = getattr(d, "publish_status", "published") or "published"
+            if publish_status != "published" and not (is_gov or str(d.id) in manage_ids):
+                continue
             # Build connections list
             connections_list = await self._build_connections_list(
                 db=db,
@@ -976,6 +1011,7 @@ class DataSourceService:
                 description=getattr(d, "description", None),
                 created_at=d.created_at,
                 status=("active" if bool(d.is_active) else "inactive"),
+                publish_status=publish_status,
                 connections=connections_list,
                 # Legacy fields from first connection for backward compatibility
                 type=conn.type if conn else None,
@@ -1026,6 +1062,8 @@ class DataSourceService:
         # Compute once whether the current user has admin-level access to data sources
         # (full_admin_access or org-level create_data_source).
         has_update_perm = False
+        is_gov = False
+        manage_ids: set = set()
         if current_user:
             try:
                 from app.core.permission_resolver import resolve_permissions, FULL_ADMIN
@@ -1036,11 +1074,31 @@ class DataSourceService:
                     FULL_ADMIN in resolved.org_permissions
                     or resolved.has_org_permission("create_data_source")
                 )
+                # Managers (governance or per-DS `manage`) may also see/use their
+                # own draft agents in the selector; everyone else gets published.
+                is_gov = (
+                    FULL_ADMIN in resolved.org_permissions
+                    or resolved.has_org_permission("manage_connections")
+                )
+                manage_ids = {
+                    str(rid)
+                    for (rtype, rid), perms in resolved.resource_permissions.items()
+                    if rtype == "data_source" and "manage" in perms
+                }
             except Exception:
                 has_update_perm = False
-        
+
         items: list[DataSourceListItemSchema] = []
         for d in data_sources:
+            # Publishing-lifecycle visibility:
+            #   disabled → never usable, hidden from everyone
+            #   draft    → only managers (governance / per-DS manage)
+            #   published → everyone with access
+            publish_status = getattr(d, "publish_status", "published") or "published"
+            if publish_status == "disabled":
+                continue
+            if publish_status == "draft" and not (is_gov or str(d.id) in manage_ids):
+                continue
             # Build connections list
             connections_list = await self._build_connections_list(
                 db=db,
@@ -1057,6 +1115,7 @@ class DataSourceService:
                 description=getattr(d, "description", None),
                 created_at=d.created_at,
                 status=("active" if bool(d.is_active) else "inactive"),
+                publish_status=publish_status,
                 connections=connections_list,
                 # Legacy fields from first connection for backward compatibility
                 type=conn.type if conn else None,
@@ -1094,7 +1153,10 @@ class DataSourceService:
             .where(
                 DataSource.organization_id == organization.id,
                 DataSource.is_active == True,
-                DataSource.is_public == True  # Only public data sources
+                DataSource.is_public == True,  # Only public data sources
+                # Slack channel mentions have no manager context — only ever
+                # expose published agents (never draft/disabled).
+                DataSource.publish_status == "published",
             )
         )
 
@@ -1124,6 +1186,7 @@ class DataSourceService:
                 description=getattr(d, "description", None),
                 created_at=d.created_at,
                 status=("active" if bool(d.is_active) else "inactive"),
+                publish_status=getattr(d, "publish_status", "published") or "published",
                 connections=connections_list,
                 type=conn.type if conn else None,
                 auth_policy=auth_policy,

--- a/backend/tests/e2e/rbac/test_rbac_data_sources.py
+++ b/backend/tests/e2e/rbac/test_rbac_data_sources.py
@@ -440,3 +440,106 @@ def test_demo_installer_gets_manage_grant(
         f"installer should hold manage on the demo they created; got "
         f"{put_resp.status_code}: {put_resp.text}"
     )
+
+
+# ────────────────────────────────────────────────────────────────────
+# publish_status (publishing lifecycle) — visibility + validation
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_publish_status_visibility_and_validation(
+    test_client,
+    bootstrap_admin,
+    invite_user_to_org,
+    sqlite_data_source,
+    grant_resource,
+):
+    """publish_status gates who sees an agent, independent of access grants.
+
+    - published → visible to every principal with access (default)
+    - draft     → visible only to managers (full_admin / per-DS manage)
+    - disabled  → never appears in the selector (/data_sources/active)
+    """
+    admin = bootstrap_admin("admin")
+    org_id = admin["org_id"]
+
+    # Public so a plain member would otherwise see it — isolates the
+    # publish_status filter from the access/membership filter.
+    ds = sqlite_data_source(
+        name="published_agent", user_token=admin["token"], org_id=org_id, is_public=True
+    )
+    ds_id = ds["id"]
+
+    member = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    manager = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    grant = grant_resource(
+        resource_type="data_source",
+        resource_id=ds_id,
+        principal_type="user",
+        principal_id=manager["user_id"],
+        permissions=["manage"],
+        user_token=admin["token"],
+        org_id=org_id,
+    )
+    assert grant.status_code == 200, grant.json()
+
+    def active_ids(token):
+        r = test_client.get(
+            "/api/data_sources/active?include_unconnected=true",
+            headers=_hdr(token, org_id),
+        )
+        assert r.status_code == 200, r.text
+        return {d["id"] for d in r.json()}
+
+    def detail(token):
+        return test_client.get(f"/api/data_sources/{ds_id}", headers=_hdr(token, org_id))
+
+    # Default is published, exposed on the read schema.
+    assert detail(admin["token"]).json()["publish_status"] == "published"
+
+    # published → everyone with access sees it.
+    assert ds_id in active_ids(admin["token"])
+    assert ds_id in active_ids(manager["token"])
+    assert ds_id in active_ids(member["token"])
+
+    # Flip to draft (manage-gated). Member can't; admin can.
+    assert (
+        test_client.put(
+            f"/api/data_sources/{ds_id}",
+            json={"publish_status": "draft"},
+            headers=_hdr(member["token"], org_id),
+        ).status_code == 403
+    )
+    put = test_client.put(
+        f"/api/data_sources/{ds_id}",
+        json={"publish_status": "draft"},
+        headers=_hdr(admin["token"], org_id),
+    )
+    assert put.status_code == 200, put.text
+    assert put.json()["publish_status"] == "draft"
+
+    # draft → only managers (admin + per-DS manage) see it; member does not.
+    assert ds_id in active_ids(admin["token"])
+    assert ds_id in active_ids(manager["token"])
+    assert ds_id not in active_ids(member["token"])
+
+    # disabled → nobody sees it in the selector, not even admin.
+    assert (
+        test_client.put(
+            f"/api/data_sources/{ds_id}",
+            json={"publish_status": "disabled"},
+            headers=_hdr(admin["token"], org_id),
+        ).status_code == 200
+    )
+    assert ds_id not in active_ids(admin["token"])
+    assert ds_id not in active_ids(manager["token"])
+    assert ds_id not in active_ids(member["token"])
+
+    # Invalid value is rejected by the schema validator.
+    bad = test_client.put(
+        f"/api/data_sources/{ds_id}",
+        json={"publish_status": "bogus"},
+        headers=_hdr(admin["token"], org_id),
+    )
+    assert bad.status_code == 422, bad.text

--- a/frontend/components/datasources/PublishStatusControl.vue
+++ b/frontend/components/datasources/PublishStatusControl.vue
@@ -1,0 +1,99 @@
+<template>
+    <!-- Manager: interactive dropdown to change the publishing lifecycle -->
+    <UDropdown
+        v-if="canManage"
+        :items="items"
+        :popper="{ placement: 'bottom-end' }"
+    >
+        <button
+            type="button"
+            :disabled="saving"
+            :class="[
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
+                publishStatusBadgeClass(status),
+                saving ? 'opacity-60 cursor-wait' : 'hover:brightness-95',
+            ]"
+        >
+            <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', publishStatusDotClass(status)]" />
+            {{ publishStatusLabel(status) }}
+            <UIcon name="heroicons-chevron-down" class="w-3 h-3 opacity-60" />
+        </button>
+
+        <template #item="{ item }">
+            <div class="flex items-start gap-2 w-full text-left">
+                <span :class="['mt-1 w-1.5 h-1.5 rounded-full flex-shrink-0', publishStatusDotClass(item.value)]" />
+                <div class="min-w-0">
+                    <div class="flex items-center gap-1.5">
+                        <span class="text-sm text-gray-900">{{ item.label }}</span>
+                        <UIcon
+                            v-if="item.value === status"
+                            name="heroicons-check"
+                            class="w-3.5 h-3.5 text-blue-600"
+                        />
+                    </div>
+                    <div class="text-[11px] text-gray-500 whitespace-normal">{{ item.description }}</div>
+                </div>
+            </div>
+        </template>
+    </UDropdown>
+
+    <!-- Non-manager: read-only badge, only meaningful when not the default published -->
+    <span
+        v-else-if="status && status !== 'published'"
+        :class="['inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium', publishStatusBadgeClass(status)]"
+    >
+        <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', publishStatusDotClass(status)]" />
+        {{ publishStatusLabel(status) }}
+    </span>
+</template>
+
+<script setup lang="ts">
+import { useCan } from '~/composables/usePermissions'
+import {
+    publishStatusBadgeClass,
+    publishStatusDotClass,
+    publishStatusLabel,
+    publishStatusOptions,
+    type PublishStatus,
+} from '~/composables/useDataSourcePublishStatus'
+
+const props = defineProps<{
+    dataSourceId: string
+    status: string
+}>()
+
+const emit = defineEmits<{ (e: 'updated', value: PublishStatus): void }>()
+
+const toast = useToast?.()
+const saving = ref(false)
+
+const canManage = computed(() =>
+    useCan('manage', { type: 'data_source', id: props.dataSourceId })
+)
+
+// UDropdown expects an array of groups (array of arrays).
+const items = computed(() => [
+    publishStatusOptions().map((opt) => ({
+        label: opt.label,
+        description: opt.description,
+        value: opt.value,
+        click: () => select(opt.value),
+    })),
+])
+
+async function select(value: PublishStatus) {
+    if (saving.value || value === props.status) return
+    saving.value = true
+    const { error } = await useMyFetch(`/data_sources/${props.dataSourceId}`, {
+        method: 'PUT',
+        body: { publish_status: value },
+    })
+    saving.value = false
+    if (error?.value) {
+        toast?.add?.({ title: 'Failed to update status', color: 'red' })
+        return
+    }
+    toast?.add?.({ title: `Agent set to ${publishStatusLabel(value)}` })
+    emit('updated', value)
+}
+</script>

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -72,6 +72,12 @@
                                     <div class="flex items-center min-w-0">
                                         <DataSourceIcon :type="ds.type" class="h-4 flex-shrink-0" />
                                         <span class="ms-2 text-[13px] truncate">{{ ds.name }}</span>
+                                        <!-- Non-published agents only reach here for managers; flag
+                                             them so it's clear they aren't live for consumers yet. -->
+                                        <span
+                                            v-if="ds.publish_status && ds.publish_status !== 'published'"
+                                            :class="['ms-2 flex-shrink-0 text-[10px] rounded border px-1 py-0.5', publishStatusBadgeClass(ds.publish_status)]"
+                                        >{{ publishStatusLabel(ds.publish_status) }}</span>
                                         <!-- Running via the connection's system (service principal) creds -->
                                         <span
                                             v-if="isServiceAccount(ds)"
@@ -141,8 +147,9 @@ import AgentFlyout from '~/components/AgentFlyout.vue'
 import AgentIcon from '~/components/icons/AgentIcon.vue'
 import UserDataSourceCredentialsModal from '~/components/UserDataSourceCredentialsModal.vue'
 import { usePermissions, usePermissionsLoaded, useResourcePermissions } from '~/composables/usePermissions'
+import { publishStatusBadgeClass, publishStatusLabel } from '~/composables/useDataSourcePublishStatus'
 
-type DataSource = { id: string; name: string; type?: string; auth_policy?: string; connections?: any[]; user_status?: { effective_auth?: string; has_user_credentials?: boolean; uses_fallback?: boolean } }
+type DataSource = { id: string; name: string; type?: string; auth_policy?: string; publish_status?: string; connections?: any[]; user_status?: { effective_auth?: string; has_user_credentials?: boolean; uses_fallback?: boolean } }
 const internalSelectedDataSources = ref<DataSource[]>([])
 const dataSources = ref<DataSource[]>([])
 // user_required data sources the user hasn't connected yet — shown grayed out

--- a/frontend/composables/useDataSourcePublishStatus.ts
+++ b/frontend/composables/useDataSourcePublishStatus.ts
@@ -1,0 +1,77 @@
+/**
+ * Manager-set publishing lifecycle for an agent (data source).
+ *
+ * Distinct from connection health (see useConnectionStatus.ts). This is the
+ * intentional, human-set state that decides who can see/use the agent:
+ *   - published — visible to everyone with access
+ *   - draft     — visible only to users who can `manage` the agent (builders)
+ *   - disabled  — off; hidden everywhere, excluded from AI context
+ *
+ * Keeps badge/label/option rendering in one place so the agent page, the
+ * agents list, and the data source selector stay consistent.
+ */
+
+export type PublishStatus = 'published' | 'draft' | 'disabled'
+
+export const PUBLISH_STATUSES: PublishStatus[] = ['published', 'draft', 'disabled']
+
+export function publishStatusLabel(status?: string | null): string {
+  switch (status) {
+    case 'published':
+      return 'Published'
+    case 'draft':
+      return 'Draft'
+    case 'disabled':
+      return 'Disabled'
+    default:
+      return 'Published'
+  }
+}
+
+export function publishStatusBadgeClass(status?: string | null): string {
+  switch (status) {
+    case 'published':
+      return 'bg-green-50 text-green-700 border-green-200'
+    case 'draft':
+      return 'bg-amber-50 text-amber-700 border-amber-200'
+    case 'disabled':
+      return 'bg-gray-100 text-gray-600 border-gray-200'
+    default:
+      return 'bg-green-50 text-green-700 border-green-200'
+  }
+}
+
+export function publishStatusDotClass(status?: string | null): string {
+  switch (status) {
+    case 'published':
+      return 'bg-green-500'
+    case 'draft':
+      return 'bg-amber-500'
+    case 'disabled':
+      return 'bg-gray-400'
+    default:
+      return 'bg-green-500'
+  }
+}
+
+export function publishStatusDescription(status?: string | null): string {
+  switch (status) {
+    case 'published':
+      return 'Visible to everyone with access'
+    case 'draft':
+      return 'Visible only to people who can manage this agent'
+    case 'disabled':
+      return 'Turned off — hidden everywhere'
+    default:
+      return 'Visible to everyone with access'
+  }
+}
+
+/** Options for a select/dropdown control, in lifecycle order. */
+export function publishStatusOptions(): Array<{ value: PublishStatus; label: string; description: string }> {
+  return PUBLISH_STATUSES.map((value) => ({
+    value,
+    label: publishStatusLabel(value),
+    description: publishStatusDescription(value),
+  }))
+}

--- a/frontend/layouts/data.vue
+++ b/frontend/layouts/data.vue
@@ -94,8 +94,13 @@
                         </template>
                     </div>
 
-                    <!-- New Report CTA -->
-                    <div v-if="!isLoading && !fetchError && integration" class="shrink-0 mt-1">
+                    <!-- Publish status + New Report CTA -->
+                    <div v-if="!isLoading && !fetchError && integration" class="shrink-0 mt-1 flex items-center gap-3">
+                        <PublishStatusControl
+                            :data-source-id="id"
+                            :status="integration.publish_status || 'published'"
+                            @updated="onPublishStatusUpdated"
+                        />
                         <UButton
                             color="blue"
                             size="sm"
@@ -166,6 +171,7 @@
 
 <script setup lang="ts">
 import Spinner from '~/components/Spinner.vue'
+import PublishStatusControl from '~/components/datasources/PublishStatusControl.vue'
 import {
     getEffectiveStatus,
     hasAnyActiveIndexing,
@@ -285,6 +291,12 @@ async function saveDesc() {
         toast?.add?.({ title: 'Description updated' })
         await fetchIntegration()
     }
+}
+
+function onPublishStatusUpdated(value: string) {
+    // Optimistic local update; refetch keeps derived views in sync.
+    if (integration.value) integration.value.publish_status = value
+    fetchIntegration()
 }
 
 async function startChat() {

--- a/frontend/pages/agents/index.vue
+++ b/frontend/pages/agents/index.vue
@@ -93,6 +93,10 @@
                                     <UTooltip v-if="ds.admin_only" :text="$t('data.adminOnlyHint')">
                                         <span class="text-[9px] font-medium uppercase tracking-wide text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded">{{ $t('data.adminOnlyTag') }}</span>
                                     </UTooltip>
+                                    <!-- Publishing lifecycle badge (only when not the default published) -->
+                                    <UTooltip v-if="ds.publish_status && ds.publish_status !== 'published'" :text="publishStatusDescription(ds.publish_status)">
+                                        <span :class="['text-[9px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded border', publishStatusBadgeClass(ds.publish_status)]">{{ publishStatusLabel(ds.publish_status) }}</span>
+                                    </UTooltip>
                                 </div>
 
                                 <!-- Metadata -->
@@ -216,6 +220,11 @@ import AddConnectionModal from '~/components/AddConnectionModal.vue'
 import DataSourceGrid from '~/components/datasources/DataSourceGrid.vue'
 import Spinner from '~/components/Spinner.vue'
 import { useCan } from '~/composables/usePermissions'
+import {
+    publishStatusBadgeClass,
+    publishStatusLabel,
+    publishStatusDescription,
+} from '~/composables/useDataSourcePublishStatus'
 import { resolveComponent } from 'vue'
 
 const NuxtLink = resolveComponent('NuxtLink')


### PR DESCRIPTION
## Summary

Adds a manager-set **publishing lifecycle** for agents (data sources), deliberately kept separate from the system-managed `is_active` connection-health flag (these were two distinct concerns being conflated).

New column `publish_status` (string, default `published`):

| Value | Visibility |
|-------|-----------|
| `published` (default) | Everyone with access |
| `draft` | Only users who can `manage` the agent (builders) |
| `disabled` | Off — hidden from the selector everywhere, excluded from AI context |

`is_active` is untouched and keeps its meaning ("can we reach/query the connection right now?", auto-toggled by health checks).

## Backend
- New `publish_status` column + Alembic migration (`d6d9a78b7b4a`, batch mode, backfills existing rows to `published`; plain string for SQLite/Postgres parity).
- `DataSourceUpdate` accepts `publish_status` with value validation (invalid → 422); update route stays gated by the existing `manage` resource permission — no new permission.
- Viewer-aware filtering in `get_data_sources` / `get_active_data_sources`: consumers see only `published`; managers (`full_admin_access` / `manage_connections` / per-DS `manage`) also see `draft`; `disabled` is hidden from the selector for everyone.
- Public (Slack) listing restricted to `published`; AI context builder skips `disabled` agents.
- New e2e test `test_publish_status_visibility_and_validation` covering visibility per principal + validation.

## Frontend
- `useDataSourcePublishStatus` composable (labels / badges / options).
- `PublishStatusControl` in the agent page top bar — dropdown for managers, read-only badge otherwise.
- Status badges on the agents list and in the `DataSourceSelector`.

## Testing
- Existing data-source / RBAC e2e suite: **8 passed**.
- New `publish_status` e2e test: **passed**.
- Verified end-to-end via live API and Playwright screenshots (top-bar pill → dropdown → draft toast → list badge → selector badge in both published and draft states).

https://claude.ai/code/session_01RPCQ8LF7qaYNvwSrYCMVec

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPCQ8LF7qaYNvwSrYCMVec)_