### PR TITLE
Delete scheduled prompts when reports are archived

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -33,6 +33,7 @@ from app.ee.audit.service import audit_service
 from app.models.visualization import Visualization
 from app.models.query import Query
 from app.models.step import Step
+from app.models.scheduled_prompt import ScheduledPrompt
 from app.core.otel import get_tracer
 
 logger = getLogger(__name__)
@@ -677,6 +678,34 @@ class ReportService:
         logger.info(f"Completed scheduled report run for report_id: {report_id}")
         return report
 
+    async def _delete_scheduled_prompts_for_reports(self, db: AsyncSession, report_ids: list[str]) -> None:
+        """Soft-delete any active scheduled prompts attached to the given reports and
+        remove their APScheduler jobs. Used when reports are archived so that nested
+        scheduled tasks no longer fire."""
+        if not report_ids:
+            return
+
+        result = await db.execute(
+            select(ScheduledPrompt)
+            .filter(ScheduledPrompt.report_id.in_(report_ids))
+            .filter(ScheduledPrompt.deleted_at == None)
+        )
+        scheduled_prompts = result.scalars().all()
+        if not scheduled_prompts:
+            return
+
+        now = datetime.utcnow()
+        for sp in scheduled_prompts:
+            sp.deleted_at = now
+            try:
+                scheduler.remove_job(job_id=f"scheduled_prompt_{sp.id}")
+            except JobLookupError:
+                pass
+            except Exception:
+                logger.warning(f"Failed to remove scheduler job for scheduled prompt {sp.id}", exc_info=True)
+
+        logger.info(f"Deleted {len(scheduled_prompts)} scheduled prompt(s) for archived report(s): {report_ids}")
+
     async def archive_report(self, db: AsyncSession, report_id: str, current_user: User, organization: Organization) -> Report:
         result = await db.execute(select(Report).filter(Report.id == report_id).filter(Report.report_type == 'regular'))
         report = result.scalar_one_or_none()
@@ -684,6 +713,7 @@ class ReportService:
             raise HTTPException(status_code=404, detail="Report not found")
 
         report.status = 'archived'
+        await self._delete_scheduled_prompts_for_reports(db, [str(report.id)])
         await db.commit()
         await db.refresh(report)
 
@@ -1346,6 +1376,7 @@ class ReportService:
             count += 1
 
         if count:
+            await self._delete_scheduled_prompts_for_reports(db, archived_ids)
             await db.commit()
 
             # Audit log

--- a/backend/tests/e2e/test_scheduled_prompt.py
+++ b/backend/tests/e2e/test_scheduled_prompt.py
@@ -173,6 +173,50 @@ def test_delete_scheduled_prompt(
 
 
 @pytest.mark.e2e
+def test_archiving_report_deletes_scheduled_prompts(
+    create_scheduled_prompt,
+    list_scheduled_prompts,
+    delete_report,
+    create_report,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Archiving a report should soft-delete its nested scheduled prompts."""
+    user = create_user()
+    user_token = login_user(user["email"], user["password"])
+    org_id = whoami(user_token)["organizations"][0]["id"]
+
+    report = create_report(title="SP Archive Report", user_token=user_token, org_id=org_id)
+
+    create_scheduled_prompt(
+        report_id=report["id"],
+        prompt={"content": "Prompt A"},
+        cron_schedule="0 8 * * *",
+        user_token=user_token,
+        org_id=org_id,
+    )
+    create_scheduled_prompt(
+        report_id=report["id"],
+        prompt={"content": "Prompt B"},
+        cron_schedule="0 12 * * *",
+        user_token=user_token,
+        org_id=org_id,
+    )
+
+    # Sanity check: both prompts exist before archiving
+    prompts = list_scheduled_prompts(report_id=report["id"], user_token=user_token, org_id=org_id)
+    assert len(prompts) == 2
+
+    # Archiving is exposed via DELETE /reports/{id}
+    delete_report(report_id=report["id"], user_token=user_token, org_id=org_id)
+
+    # After archiving, the nested scheduled prompts should be gone
+    prompts = list_scheduled_prompts(report_id=report["id"], user_token=user_token, org_id=org_id)
+    assert len(prompts) == 0
+
+
+@pytest.mark.e2e
 def test_create_scheduled_prompt_with_subscribers(
     create_scheduled_prompt,
     create_report,


### PR DESCRIPTION
## Summary
When a report is archived, any scheduled prompts attached to that report are now soft-deleted and their APScheduler jobs are removed. This prevents scheduled tasks from continuing to execute after their parent report has been archived.

## Key Changes
- Added `_delete_scheduled_prompts_for_reports()` method to `ReportService` that:
  - Soft-deletes active scheduled prompts for given report IDs
  - Removes associated APScheduler jobs to prevent future execution
  - Handles missing jobs gracefully with error logging
  
- Updated `archive_report()` to call the new cleanup method when archiving a single report

- Updated `bulk_archive_reports()` to call the new cleanup method when bulk archiving reports

- Added comprehensive e2e test `test_archiving_report_deletes_scheduled_prompts()` that verifies:
  - Scheduled prompts are created for a report
  - Archiving the report removes the scheduled prompts from the list
  - The behavior works correctly through the DELETE /reports/{id} endpoint

## Implementation Details
- Uses soft-delete pattern (sets `deleted_at` timestamp) consistent with existing codebase patterns
- Gracefully handles `JobLookupError` when scheduler jobs don't exist
- Logs warnings for unexpected scheduler errors while continuing cleanup
- Supports both single and bulk report archival operations

https://claude.ai/code/session_01Ke9Gu2EJ9PDtnAfwn6zrGz