### PR TITLE
Feed agent publishing status into the planner prompt

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -198,6 +198,7 @@ PLAN TYPE GUIDANCE
 - After inspect_data, move to create_data to generate the actual tracked insight.
 - If schemas are empty/insufficient OR the request is ambiguous, call the clarify tool.
 - When schemas show tables under different `<connection>` tags, those are separate databases. Queries CANNOT join across connections.
+- Each `<data_source>` may carry a `<status>` block describing its state — connection health (active/inactive) and publishing lifecycle (published/draft/disabled), each with a short explanation. Factor this in: if a source you need is inactive, warn the user its connection is currently unreachable and queries may fail; if it's a draft, note it's still being configured rather than finalized. Don't silently rely on a source whose status signals it may be unavailable.
 - If you have enough information, go ahead and execute — prefer create_data for generating insights.
 - If the user attached a screenshot or an image — describe it briefly in message text — don't use inspect_data for images.
 - When working with data files (excel, csv, etc), ALWAYS use inspect_data to verify the file content and structure before creating data widgets.

--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -198,7 +198,7 @@ PLAN TYPE GUIDANCE
 - After inspect_data, move to create_data to generate the actual tracked insight.
 - If schemas are empty/insufficient OR the request is ambiguous, call the clarify tool.
 - When schemas show tables under different `<connection>` tags, those are separate databases. Queries CANNOT join across connections.
-- Each `<data_source>` may carry a `<status>` block describing its state — connection health (active/inactive) and publishing lifecycle (published/draft/disabled), each with a short explanation. Factor this in: if a source you need is inactive, warn the user its connection is currently unreachable and queries may fail; if it's a draft, note it's still being configured rather than finalized. Don't silently rely on a source whose status signals it may be unavailable.
+- Each `<data_source>` may carry a `<status>` block describing its publishing status (published/draft/disabled), with a short explanation. Factor this in: if a source is a draft, note it's still being configured rather than finalized; if it's disabled, don't rely on it. Treat published sources as ready for normal use.
 - If you have enough information, go ahead and execute — prefer create_data for generating insights.
 - If the user attached a screenshot or an image — describe it briefly in message text — don't use inspect_data for images.
 - When working with data files (excel, csv, etc), ALWAYS use inspect_data to verify the file content and structure before creating data widgets.

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -384,6 +384,13 @@ class SchemaContextBuilder:
                         type=getattr(ds, 'type', None) or (ds.connections[0].type if getattr(ds, 'connections', None) else None),
                         # Prefer the richer human-written description when available; fallback to context
                         context=(getattr(ds, 'description', None) or getattr(ds, 'context', None)),
+                        # Connection health → "active"/"inactive". Some Pydantic
+                        # list schemas already expose a `status` health string;
+                        # prefer it, else derive from the ORM `is_active` flag
+                        # (which defaults to True, so a missing attr means active).
+                        status=(getattr(ds, 'status', None) or ("active" if getattr(ds, 'is_active', True) else "inactive")),
+                        # Manager-set publishing lifecycle (published/draft/disabled).
+                        publish_status=getattr(ds, 'publish_status', None),
                     ),
                     tables=tables,
                     mcp_tools=mcp_tools,

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -384,11 +384,6 @@ class SchemaContextBuilder:
                         type=getattr(ds, 'type', None) or (ds.connections[0].type if getattr(ds, 'connections', None) else None),
                         # Prefer the richer human-written description when available; fallback to context
                         context=(getattr(ds, 'description', None) or getattr(ds, 'context', None)),
-                        # Connection health → "active"/"inactive". Some Pydantic
-                        # list schemas already expose a `status` health string;
-                        # prefer it, else derive from the ORM `is_active` flag
-                        # (which defaults to True, so a missing attr means active).
-                        status=(getattr(ds, 'status', None) or ("active" if getattr(ds, 'is_active', True) else "inactive")),
                         # Manager-set publishing lifecycle (published/draft/disabled).
                         publish_status=getattr(ds, 'publish_status', None),
                     ),

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -47,6 +47,40 @@ class TablesSchemaContext(ContextSection):
         tables: List[PromptTable] = []
         mcp_tools: List[MCPToolItem] = []
 
+        # Short, human-readable explanations of each agent (data source) status
+        # value so the planner understands what the status MEANS, not just the
+        # bare token. Kept terse — these go into every schema block.
+        _STATUS_DESCRIPTIONS: ClassVar[dict] = {
+            "active": "connection is healthy and reachable; tables can be queried right now",
+            "inactive": "connection is currently unreachable; queries against it may fail until it recovers",
+        }
+        _PUBLISH_STATUS_DESCRIPTIONS: ClassVar[dict] = {
+            "published": "live and available to everyone with access",
+            "draft": "still being configured by builders; not yet released to consumers",
+            "disabled": "turned off and excluded from normal use",
+        }
+
+        def _render_status_xml(self) -> str:
+            """Render an agent status block describing the data source's state.
+
+            Surfaces both the connection-health status (active/inactive) and the
+            publishing lifecycle (published/draft/disabled), each paired with a
+            short explanation so the planner knows what the status means and can
+            caveat its answers (e.g. warn when a source is inactive/draft).
+            """
+            parts: List[str] = []
+            status = (getattr(self.info, 'status', None) or '').strip().lower()
+            if status:
+                desc = self._STATUS_DESCRIPTIONS.get(status, "")
+                parts.append(xml_tag("connection_health", xml_escape(desc), {"value": status}))
+            publish = (getattr(self.info, 'publish_status', None) or '').strip().lower()
+            if publish:
+                desc = self._PUBLISH_STATUS_DESCRIPTIONS.get(publish, "")
+                parts.append(xml_tag("publishing", xml_escape(desc), {"value": publish}))
+            if not parts:
+                return ""
+            return xml_tag("status", "\n".join(parts))
+
         def _group_tables_by_connection(self) -> dict:
             """Group tables by connection_id. Tables without connection_id go under 'default'."""
             from collections import defaultdict
@@ -180,6 +214,9 @@ class TablesSchemaContext(ContextSection):
             conn_groups = self._group_tables_by_connection()
 
             content_parts = []
+            status_xml = self._render_status_xml()
+            if status_xml:
+                content_parts.append(status_xml)
             if self.info.context:
                 content_parts.append(xml_tag("context", xml_escape(self.info.context)))
 
@@ -445,6 +482,9 @@ class TablesSchemaContext(ContextSection):
             has_multi_connection = '<connection ' in sample_xml if sample_xml else False
 
             inner_parts: List[str] = []
+            status_xml = ds._render_status_xml()
+            if status_xml:
+                inner_parts.append(status_xml)
             if getattr(ds.info, 'context', None):
                 inner_parts.append(xml_tag("description", xml_escape(ds.info.context)))
             if sample_xml:

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -47,13 +47,9 @@ class TablesSchemaContext(ContextSection):
         tables: List[PromptTable] = []
         mcp_tools: List[MCPToolItem] = []
 
-        # Short, human-readable explanations of each agent (data source) status
-        # value so the planner understands what the status MEANS, not just the
-        # bare token. Kept terse — these go into every schema block.
-        _STATUS_DESCRIPTIONS: ClassVar[dict] = {
-            "active": "connection is healthy and reachable; tables can be queried right now",
-            "inactive": "connection is currently unreachable; queries against it may fail until it recovers",
-        }
+        # Short, human-readable explanations of each agent (data source)
+        # publishing-status value so the planner understands what the status
+        # MEANS, not just the bare token. Kept terse — goes into every block.
         _PUBLISH_STATUS_DESCRIPTIONS: ClassVar[dict] = {
             "published": "live and available to everyone with access",
             "draft": "still being configured by builders; not yet released to consumers",
@@ -61,25 +57,19 @@ class TablesSchemaContext(ContextSection):
         }
 
         def _render_status_xml(self) -> str:
-            """Render an agent status block describing the data source's state.
+            """Render the agent's publishing-status block.
 
-            Surfaces both the connection-health status (active/inactive) and the
-            publishing lifecycle (published/draft/disabled), each paired with a
-            short explanation so the planner knows what the status means and can
-            caveat its answers (e.g. warn when a source is inactive/draft).
+            Surfaces the manager-set publishing lifecycle (published/draft/
+            disabled) paired with a short explanation so the planner knows what
+            the status means and can caveat its answers (e.g. note when a source
+            is still a draft rather than finalized).
             """
-            parts: List[str] = []
-            status = (getattr(self.info, 'status', None) or '').strip().lower()
-            if status:
-                desc = self._STATUS_DESCRIPTIONS.get(status, "")
-                parts.append(xml_tag("connection_health", xml_escape(desc), {"value": status}))
             publish = (getattr(self.info, 'publish_status', None) or '').strip().lower()
-            if publish:
-                desc = self._PUBLISH_STATUS_DESCRIPTIONS.get(publish, "")
-                parts.append(xml_tag("publishing", xml_escape(desc), {"value": publish}))
-            if not parts:
+            if not publish:
                 return ""
-            return xml_tag("status", "\n".join(parts))
+            desc = self._PUBLISH_STATUS_DESCRIPTIONS.get(publish, "")
+            inner = xml_tag("publishing", xml_escape(desc), {"value": publish})
+            return xml_tag("status", inner)
 
         def _group_tables_by_connection(self) -> dict:
             """Group tables by connection_id. Tables without connection_id go under 'default'."""

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -8,6 +8,10 @@ class DataSourceSummarySchema(BaseModel):
     name: str
     type: Optional[str] = None  # Computed from connection
     context: Optional[str] = None
+    # Connection-health derived state ("active" | "inactive"); mirrors is_active.
+    status: Optional[str] = None
+    # Manager-set publishing lifecycle: "published" | "draft" | "disabled".
+    publish_status: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -8,8 +8,6 @@ class DataSourceSummarySchema(BaseModel):
     name: str
     type: Optional[str] = None  # Computed from connection
     context: Optional[str] = None
-    # Connection-health derived state ("active" | "inactive"); mirrors is_active.
-    status: Optional[str] = None
     # Manager-set publishing lifecycle: "published" | "draft" | "disabled".
     publish_status: Optional[str] = None
 

--- a/backend/tests/unit/test_schema_section_agent_status.py
+++ b/backend/tests/unit/test_schema_section_agent_status.py
@@ -1,10 +1,9 @@
-"""Unit tests for the agent (data source) status block in the schema context.
+"""Unit tests for the agent (data source) publishing-status block.
 
-The data source's status — connection health (active/inactive) and the
-manager-set publishing lifecycle (published/draft/disabled) — is surfaced into
-the schema context that PromptBuilderV3 feeds to the planner, each value paired
-with a short human-readable explanation so the model understands what the status
-MEANS, not just the bare token.
+The data source's manager-set publishing lifecycle (published/draft/disabled)
+is surfaced into the schema context that PromptBuilderV3 feeds to the planner,
+paired with a short human-readable explanation so the model understands what
+the status MEANS, not just the bare token.
 """
 from app.ai.context.sections.tables_schema_section import TablesSchemaContext
 from app.schemas.data_source_schema import DataSourceSummarySchema
@@ -16,37 +15,33 @@ def _ds(**info_kwargs):
     base.update(info_kwargs)
     return TablesSchemaContext.DataSource(
         info=DataSourceSummarySchema(**base),
-        tables=[Table(name="orders", columns=[TableColumn(name="id", dtype="int")], is_active=True)],
+        tables=[Table(name="orders", columns=[TableColumn(name="id", dtype="int")], pks=[], fks=[], is_active=True)],
     )
 
 
 def test_status_block_includes_value_and_description_in_full_render():
-    ctx = TablesSchemaContext(data_sources=[_ds(status="inactive", publish_status="draft")])
+    ctx = TablesSchemaContext(data_sources=[_ds(publish_status="draft")])
     out = ctx.render("full")
     assert "<status>" in out
-    assert '<connection_health value="inactive">' in out
-    assert "currently unreachable" in out
     assert '<publishing value="draft">' in out
     assert "still being configured" in out
 
 
 def test_status_block_in_combined_render():
-    ctx = TablesSchemaContext(data_sources=[_ds(status="active", publish_status="published")])
+    ctx = TablesSchemaContext(data_sources=[_ds(publish_status="published")])
     out = ctx.render_combined(top_k_per_ds=10, index_limit=200)
     assert "<status>" in out
-    assert '<connection_health value="active">' in out
-    assert "healthy" in out
     assert '<publishing value="published">' in out
     assert "available to everyone" in out
 
 
-def test_status_block_omitted_when_no_status():
+def test_status_block_omitted_when_no_publish_status():
     ctx = TablesSchemaContext(data_sources=[_ds()])
     out = ctx.render("full")
     assert "<status>" not in out
 
 
-def test_unknown_status_value_renders_without_description():
-    ctx = TablesSchemaContext(data_sources=[_ds(status="mystery")])
+def test_unknown_publish_status_renders_without_description():
+    ctx = TablesSchemaContext(data_sources=[_ds(publish_status="mystery")])
     out = ctx.render("full")
-    assert '<connection_health value="mystery">' in out
+    assert '<publishing value="mystery">' in out

--- a/backend/tests/unit/test_schema_section_agent_status.py
+++ b/backend/tests/unit/test_schema_section_agent_status.py
@@ -1,0 +1,52 @@
+"""Unit tests for the agent (data source) status block in the schema context.
+
+The data source's status — connection health (active/inactive) and the
+manager-set publishing lifecycle (published/draft/disabled) — is surfaced into
+the schema context that PromptBuilderV3 feeds to the planner, each value paired
+with a short human-readable explanation so the model understands what the status
+MEANS, not just the bare token.
+"""
+from app.ai.context.sections.tables_schema_section import TablesSchemaContext
+from app.schemas.data_source_schema import DataSourceSummarySchema
+from app.ai.prompt_formatters import Table, TableColumn
+
+
+def _ds(**info_kwargs):
+    base = dict(id="1", name="Revenue", type="postgres")
+    base.update(info_kwargs)
+    return TablesSchemaContext.DataSource(
+        info=DataSourceSummarySchema(**base),
+        tables=[Table(name="orders", columns=[TableColumn(name="id", dtype="int")], is_active=True)],
+    )
+
+
+def test_status_block_includes_value_and_description_in_full_render():
+    ctx = TablesSchemaContext(data_sources=[_ds(status="inactive", publish_status="draft")])
+    out = ctx.render("full")
+    assert "<status>" in out
+    assert '<connection_health value="inactive">' in out
+    assert "currently unreachable" in out
+    assert '<publishing value="draft">' in out
+    assert "still being configured" in out
+
+
+def test_status_block_in_combined_render():
+    ctx = TablesSchemaContext(data_sources=[_ds(status="active", publish_status="published")])
+    out = ctx.render_combined(top_k_per_ds=10, index_limit=200)
+    assert "<status>" in out
+    assert '<connection_health value="active">' in out
+    assert "healthy" in out
+    assert '<publishing value="published">' in out
+    assert "available to everyone" in out
+
+
+def test_status_block_omitted_when_no_status():
+    ctx = TablesSchemaContext(data_sources=[_ds()])
+    out = ctx.render("full")
+    assert "<status>" not in out
+
+
+def test_unknown_status_value_renders_without_description():
+    ctx = TablesSchemaContext(data_sources=[_ds(status="mystery")])
+    out = ctx.render("full")
+    assert '<connection_health value="mystery">' in out


### PR DESCRIPTION
## Summary
Surfaces each agent's (data source's) **publishing status** into the schema context that `PromptBuilderV3` feeds to the planner — paired with a short human-readable explanation so the model understands what the status *means*, not just the bare token.

Each `<data_source>` block now carries:

```xml
<status>
<publishing value="draft">
still being configured by builders; not yet released to consumers
</publishing>
</status>
```

Descriptions:
- `published` → "live and available to everyone with access"
- `draft` → "still being configured by builders; not yet released to consumers"
- `disabled` → "turned off and excluded from normal use"

## Changes
- **`schemas/data_source_schema.py`** — added `publish_status` to `DataSourceSummarySchema`.
- **`context/builders/schema_context_builder.py`** — populates `publish_status` from the data source.
- **`context/sections/tables_schema_section.py`** — `_render_status_xml()` emits the `<status>` block in both `render()` (full) and `render_combined()` (the `schemas_combined` path). Omitted when no publish status; unknown values render the value with an empty description.
- **`agents/planner/prompt_builder_v3.py`** — guidance telling the model to factor publishing status in (note drafts as not finalized, don't rely on disabled sources).
- **`tests/unit/test_schema_section_agent_status.py`** — new tests.

Based on #390.

https://claude.ai/code/session_01BLypyxhovWDJkGMkwhTN45

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLypyxhovWDJkGMkwhTN45)_