### PR TITLE
Add per-agent channel availability (Slack/Teams/WhatsApp/Email/MCP)

### DIFF
--- a/backend/alembic/versions/c4a1d2e3f4b5_add_channel_availability_to_data_sources.py
+++ b/backend/alembic/versions/c4a1d2e3f4b5_add_channel_availability_to_data_sources.py
@@ -1,0 +1,39 @@
+"""add channel_availability to data sources
+
+Revision ID: c4a1d2e3f4b5
+Revises: e7f0a1b2c3d4, g2h3i4j5k6l7
+Create Date: 2026-06-15 09:00:00.000000
+
+Adds the ``channel_availability`` JSON column to ``data_sources`` so an agent
+can be configured to be available (queryable) only in a subset of the
+organization's connected channels (Slack, Teams, WhatsApp, email, MCP).
+
+Stored as a JSON map of ``{channel_type: bool}``. ``NULL`` (the backfill value
+for existing rows) means "available in every connected channel", so this
+migration is behaviour-preserving.
+
+This revision also merges the two open migration heads
+(``e7f0a1b2c3d4`` and ``g2h3i4j5k6l7``) into a single head.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c4a1d2e3f4b5'
+down_revision: Union[str, Sequence[str], None] = ('e7f0a1b2c3d4', 'g2h3i4j5k6l7')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('data_sources') as batch_op:
+        batch_op.add_column(
+            sa.Column('channel_availability', sa.JSON(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('data_sources') as batch_op:
+        batch_op.drop_column('channel_availability')

--- a/backend/app/ai/tools/mcp/create_report.py
+++ b/backend/app/ai/tools/mcp/create_report.py
@@ -67,7 +67,7 @@ class CreateReportTool(MCPTool):
         # all visibility filtering and attaches every org data source —
         # including private ones the user isn't a member of.
         data_sources = await ds_service.get_active_data_sources(
-            db, organization, current_user=user
+            db, organization, current_user=user, channel="mcp"
         )
         
         # Create the report with MCP platform

--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -38,6 +38,18 @@ class DataSource(BaseSchema):
     # admins) can see them. Sharing org-wide is an opt-in (set is_public=True).
     is_public = Column(Boolean, nullable=False, default=False)
 
+    # Per-agent channel availability: which connected channels (Slack, Teams,
+    # WhatsApp, email, MCP) may query this agent. A JSON map of
+    # ``{channel_type: bool}`` — e.g. ``{"slack": true, "teams": false}``.
+    #   NULL / missing key  → available in every connected channel (default,
+    #                         preserves pre-existing behaviour, no regression).
+    #   explicit ``false``  → this agent is hidden from that channel.
+    # Channel availability is gating *in addition* to is_public / publish_status
+    # / membership; it never widens access, only narrows which channels can use
+    # an otherwise-accessible agent. The in-app/web experience is never gated by
+    # this map (only external channels pass a ``channel`` to the selectors).
+    channel_availability = Column(JSON, nullable=True)
+
     # When true, the system may run LLM onboarding synchronously (onboarding flow only)
     owner_user_id = Column(String(36), ForeignKey('users.id'), nullable=True)
     context = Column(Text, nullable=True)
@@ -365,6 +377,21 @@ class DataSource(BaseSchema):
         # Build context for just this data source
         return await context_builder.build([self])
     
+    def is_available_in(self, channel: str | None) -> bool:
+        """Whether this agent may be queried from the given channel.
+
+        ``channel`` is an external channel type (e.g. ``"slack"``, ``"teams"``,
+        ``"mcp"``). ``None`` means an internal/web context that is never gated by
+        channel availability. Defaults to available unless the agent's
+        ``channel_availability`` map explicitly turns that channel off.
+        """
+        if not channel:
+            return True
+        mapping = self.channel_availability
+        if not isinstance(mapping, dict):
+            return True
+        return mapping.get(channel, True) is not False
+
     def has_membership(self, user_id: str) -> bool:
         """
         Check if a user has explicit membership to this data source.

--- a/backend/app/routes/data_source.py
+++ b/backend/app/routes/data_source.py
@@ -50,6 +50,17 @@ async def get_active_data_sources(
 ):
     return await data_source_service.get_active_data_sources(db, organization, current_user, include_unconnected=include_unconnected)
 
+@router.get("/data_sources/connected_channels", response_model=list[dict])
+async def get_connected_channels(
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization)
+):
+    """List the org's channels (Slack/Teams/WhatsApp/email/MCP) annotated with
+    whether each is connected. Drives the per-agent channel-availability toggles
+    in the new-agent and agent-settings UI."""
+    return await data_source_service.get_connected_channels(db, organization)
+
 @router.get("/data_sources/{data_source_id}", response_model=DataSourceSchema)
 @requires_resource_permission('data_source', 'view')
 async def get_data_source(

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -153,6 +153,9 @@ class DataSourceSchema(DataSourceBase):
     # Distinct from is_active (connection health).
     publish_status: str = "published"
     use_llm_sync: bool = False
+    # Per-channel availability map ({channel_type: bool}). None = available in
+    # every connected channel.
+    channel_availability: Optional[Dict[str, bool]] = None
     owner_user_id: Optional[str] = None
     git_repository: Optional[GitRepositorySchema] = None
     memberships: Optional[List[DataSourceMembershipSchema]] = []
@@ -239,6 +242,9 @@ class DataSourceCreate(DataSourceBase):
     generate_ai_rules: bool = False
     is_public: bool = False
     use_llm_sync: bool = False
+    # Per-channel availability map ({channel_type: bool}). None = available in
+    # every connected channel.
+    channel_availability: Optional[Dict[str, bool]] = None
     member_user_ids: Optional[List[str]] = []  # User IDs to grant access to
 
     @validator('credentials')
@@ -289,6 +295,8 @@ class DataSourceUpdate(DataSourceBase):
     conversation_starters: Optional[list] = None
     is_public: Optional[bool] = None
     use_llm_sync: Optional[bool] = None
+    # Per-channel availability map ({channel_type: bool}). None = leave unchanged.
+    channel_availability: Optional[Dict[str, bool]] = None
     # Manager-set publishing lifecycle. Guarded by the 'manage' resource
     # permission on the data source (see routes/data_source.py).
     publish_status: Optional[str] = None

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -310,6 +310,7 @@ class DataSourceService:
         config = data_source_dict.pop("config", None)
         is_public = data_source_dict.pop("is_public", False)
         use_llm_sync = data_source_dict.pop("use_llm_sync", False)
+        channel_availability = data_source_dict.pop("channel_availability", None)
         member_user_ids = data_source_dict.pop("member_user_ids", [])
         auth_policy = data_source_dict.get("auth_policy", "system_only")
         
@@ -439,6 +440,7 @@ class DataSourceService:
             "organization_id": organization.id,
             "is_public": is_public,
             "use_llm_sync": use_llm_sync,
+            "channel_availability": channel_availability,
             "owner_user_id": current_user.id
         }
         
@@ -600,6 +602,7 @@ class DataSourceService:
             is_public=final_data_source.is_public,
             publish_status=getattr(final_data_source, "publish_status", "published") or "published",
             use_llm_sync=final_data_source.use_llm_sync,
+            channel_availability=getattr(final_data_source, "channel_availability", None),
             owner_user_id=str(final_data_source.owner_user_id) if final_data_source.owner_user_id else None,
             git_repository=final_data_source.git_repository,
             memberships=final_data_source.data_source_memberships,
@@ -889,6 +892,7 @@ class DataSourceService:
             is_public=data_source.is_public,
             publish_status=getattr(data_source, "publish_status", "published") or "published",
             use_llm_sync=data_source.use_llm_sync,
+            channel_availability=getattr(data_source, "channel_availability", None),
             owner_user_id=data_source.owner_user_id,
             git_repository=data_source.git_repository,
             memberships=data_source.data_source_memberships,
@@ -1029,8 +1033,14 @@ class DataSourceService:
             schemas.append(s)
         return schemas
 
-    async def get_active_data_sources(self, db: AsyncSession, organization: Organization, current_user: User = None, include_unconnected: bool = False) -> List[DataSourceListItemSchema]:
-        """Get all active data sources for an organization that the user has access to, compact list shape"""
+    async def get_active_data_sources(self, db: AsyncSession, organization: Organization, current_user: User = None, include_unconnected: bool = False, channel: str | None = None) -> List[DataSourceListItemSchema]:
+        """Get all active data sources for an organization that the user has access to, compact list shape.
+
+        When ``channel`` is provided (an external channel type such as ``"slack"``,
+        ``"teams"`` or ``"mcp"``), agents that have been configured as unavailable
+        in that channel are excluded. ``None`` (internal/web) applies no channel
+        gating.
+        """
         # See get_data_sources above for the lazyload("*") rationale — same
         # cascade applies here. The list schema doesn't expose
         # data_source_memberships, so we don't eager-load it.
@@ -1100,6 +1110,9 @@ class DataSourceService:
                 continue
             if publish_status == "draft" and not (is_gov or str(d.id) in manage_ids):
                 continue
+            # Channel availability gating (external channels only).
+            if not d.is_available_in(channel):
+                continue
             # Build connections list
             connections_list = await self._build_connections_list(
                 db=db,
@@ -1140,11 +1153,14 @@ class DataSourceService:
             items.append(s)
         return items
 
-    async def get_public_data_sources(self, db: AsyncSession, organization: Organization) -> List[DataSourceListItemSchema]:
+    async def get_public_data_sources(self, db: AsyncSession, organization: Organization, channel: str | None = None) -> List[DataSourceListItemSchema]:
         """
         Get only public active data sources with system_only auth for an organization.
         Used for Slack channel mentions where we can't rely on individual user credentials.
         Only includes data sources that use system-level credentials (auth_policy="system_only").
+
+        When ``channel`` is provided, agents configured as unavailable in that
+        channel are excluded.
         """
         stmt = (
             select(DataSource)
@@ -1167,6 +1183,9 @@ class DataSourceService:
 
         items: list[DataSourceListItemSchema] = []
         for d in data_sources:
+            # Channel availability gating (external channels only).
+            if not d.is_available_in(channel):
+                continue
             conn = d.connections[0] if d.connections else None
             # Only include data sources with system_only auth policy
             # Skip user_required data sources since channel mentions can't use individual user credentials
@@ -1196,6 +1215,49 @@ class DataSourceService:
             )
             items.append(s)
         return items
+
+    # Channels an agent can be made available in. Keeping this catalog here (vs.
+    # hard-coded in the route/UI) keeps the backend the single source of truth.
+    CHANNEL_CATALOG = [
+        {"key": "slack", "name": "Slack"},
+        {"key": "teams", "name": "Microsoft Teams"},
+        {"key": "whatsapp", "name": "WhatsApp"},
+        {"key": "email", "name": "Email"},
+        {"key": "mcp", "name": "MCP"},
+    ]
+
+    async def get_connected_channels(self, db: AsyncSession, organization: Organization) -> List[dict]:
+        """Return the channel catalog annotated with whether each channel is
+        connected for this organization.
+
+        A platform channel (Slack/Teams/WhatsApp/email) is "connected" when an
+        active ``ExternalPlatform`` row exists; MCP is "connected" when the
+        ``mcp_enabled`` org setting is on. The new-agent UI uses this to render a
+        channel-availability toggle for each connected channel.
+        """
+        from app.models.external_platform import ExternalPlatform
+
+        result = await db.execute(
+            select(ExternalPlatform.platform_type).where(
+                ExternalPlatform.organization_id == organization.id,
+                ExternalPlatform.is_active == True,
+            )
+        )
+        active_types = {row for row in result.scalars().all()}
+
+        mcp_enabled = False
+        try:
+            if organization.settings:
+                cfg = organization.settings.get_config("mcp_enabled")
+                mcp_enabled = bool(cfg and getattr(cfg, "value", False))
+        except Exception:
+            mcp_enabled = False
+
+        channels = []
+        for c in self.CHANNEL_CATALOG:
+            connected = (c["key"] == "mcp" and mcp_enabled) or (c["key"] in active_types)
+            channels.append({**c, "connected": connected})
+        return channels
 
     async def get_data_source_fields(self, db: AsyncSession, data_source_type: str, organization: Organization, current_user: User, auth_type: str | None = None, auth_policy: str | None = None):
         try:

--- a/backend/app/services/external_platform_manager.py
+++ b/backend/app/services/external_platform_manager.py
@@ -338,11 +338,12 @@ class ExternalPlatformManager:
         # If no recent report, create a new one
         # For channel mentions, only use public data sources (visible to everyone in the channel)
         # For DMs, use all data sources the user has access to (public + private with membership)
+        platform_type = user_mapping.platform_type
         if channel_type == "channel":
-            data_sources = await self.data_source_service.get_public_data_sources(db, organization)
+            data_sources = await self.data_source_service.get_public_data_sources(db, organization, channel=platform_type)
         else:
             # DM: user gets public + private data sources they have access to
-            data_sources = await self.data_source_service.get_active_data_sources(db, organization, user)
+            data_sources = await self.data_source_service.get_active_data_sources(db, organization, user, channel=platform_type)
 
         data_source_ids = [data_source.id for data_source in data_sources]
         report_create_data = ReportCreate(
@@ -509,9 +510,9 @@ class ExternalPlatformManager:
         if platform_type == "teams" and report is not None and not created:
             from app.services.report_service import ReportService
             if channel_type == "channel":
-                fresh = await self.data_source_service.get_public_data_sources(db, organization)
+                fresh = await self.data_source_service.get_public_data_sources(db, organization, channel=platform_type)
             else:
-                fresh = await self.data_source_service.get_active_data_sources(db, organization, user)
+                fresh = await self.data_source_service.get_active_data_sources(db, organization, user, channel=platform_type)
             fresh_ids = [str(ds.id) for ds in fresh]
             await ReportService().set_data_sources_for_report(
                 db, report, fresh_ids, user, organization

--- a/backend/tests/e2e/test_channel_availability.py
+++ b/backend/tests/e2e/test_channel_availability.py
@@ -1,0 +1,137 @@
+"""
+Per-agent channel availability gating.
+
+An agent (data source) can be configured to be available only in a subset of the
+org's connected channels via ``DataSource.channel_availability`` (a JSON map of
+``{channel_type: bool}``). This validates:
+
+  - default (NULL map)        -> available in every channel (no regression)
+  - ``{"slack": false}``      -> excluded from Slack, still in Teams / MCP / web
+  - the ``channel`` argument threaded into the two selector methods
+    (``get_public_data_sources`` for channel mentions, ``get_active_data_sources``
+    for DMs / MCP) actually filters.
+
+No external services needed — pure DB + service logic on SQLite.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_channel_availability.py -v -s
+"""
+import uuid
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.domain_connection import domain_connection
+from app.services.data_source_service import DataSourceService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed(channel_availability):
+    """Seed one public, published, system_only agent with the given
+    channel_availability map. Returns (org_id, ds_id, admin_id)."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"Chan Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        admin = User(
+            name="Admin",
+            email=f"admin-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        db.add(admin)
+        await db.flush()
+
+        conn = Connection(
+            organization_id=org.id,
+            name=f"PG {suffix}",
+            type="postgresql",
+            config={"host": "localhost", "database": "demo"},
+            auth_policy="system_only",
+        )
+        conn.encrypt_credentials({"user": "u", "password": "p"})
+        db.add(conn)
+        await db.flush()
+
+        ds = DataSource(
+            name=f"Sales {suffix}",
+            organization_id=org.id,
+            is_active=True,
+            is_public=True,
+            publish_status="published",
+            channel_availability=channel_availability,
+            owner_user_id=admin.id,
+        )
+        db.add(ds)
+        await db.flush()
+        await db.execute(domain_connection.insert().values(
+            data_source_id=ds.id, connection_id=conn.id,
+        ))
+        await db.commit()
+        return str(org.id), str(ds.id), str(admin.id)
+
+
+async def _names_for_channel(org_id, channel, public=True, user_id=None):
+    """Return the set of agent ids the selector exposes for `channel`."""
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        from sqlalchemy import select
+        org = (await db.execute(select(Organization).where(Organization.id == org_id))).scalar_one()
+        if public:
+            items = await svc.get_public_data_sources(db, org, channel=channel)
+        else:
+            user = (await db.execute(select(User).where(User.id == user_id))).scalar_one()
+            items = await svc.get_active_data_sources(db, org, user, channel=channel)
+        return {it.id for it in items}
+
+
+def test_model_is_available_in_defaults_to_available():
+    ds = DataSource(name="x")
+    # NULL map -> available everywhere
+    assert ds.is_available_in("slack") is True
+    assert ds.is_available_in(None) is True
+    # explicit false only blocks that channel
+    ds.channel_availability = {"slack": False}
+    assert ds.is_available_in("slack") is False
+    assert ds.is_available_in("teams") is True
+    assert ds.is_available_in("mcp") is True
+    # internal/web context is never gated
+    assert ds.is_available_in(None) is True
+
+
+def test_default_agent_available_in_all_channels():
+    org_id, ds_id, admin_id = _run(_seed(channel_availability=None))
+    for ch in ("slack", "teams", "mcp"):
+        assert ds_id in _run(_names_for_channel(org_id, ch)), f"public/{ch}"
+    # DM / MCP path
+    assert ds_id in _run(_names_for_channel(org_id, "mcp", public=False, user_id=admin_id))
+    print("[default] agent visible in slack/teams/mcp (public + active) ✓")
+
+
+def test_disabled_channel_is_filtered_out():
+    org_id, ds_id, admin_id = _run(_seed(channel_availability={"slack": False}))
+
+    # Channel-mention selector (public): excluded from Slack, present elsewhere.
+    assert ds_id not in _run(_names_for_channel(org_id, "slack"))
+    assert ds_id in _run(_names_for_channel(org_id, "teams"))
+
+    # DM / MCP selector (active): excluded from Slack, present in MCP + web (None).
+    assert ds_id not in _run(_names_for_channel(org_id, "slack", public=False, user_id=admin_id))
+    assert ds_id in _run(_names_for_channel(org_id, "mcp", public=False, user_id=admin_id))
+    assert ds_id in _run(_names_for_channel(org_id, None, public=False, user_id=admin_id))
+    print("[gated] agent hidden from slack, still visible in teams/mcp/web ✓")

--- a/frontend/components/AgentSettingsPanel.vue
+++ b/frontend/components/AgentSettingsPanel.vue
@@ -40,6 +40,27 @@
                 </div>
             </div>
 
+            <!-- Channels -->
+            <div v-if="connectedChannels.length > 0" class="border-b border-gray-100 pb-5 mb-5">
+                <div class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 mb-2">Channels</div>
+                <p class="text-[11px] text-gray-400 mb-3">Choose which connected channels can query this agent. Disabled channels won't see it.</p>
+                <div class="space-y-2">
+                    <div v-for="ch in connectedChannels" :key="ch.key" class="flex items-center gap-3">
+                        <UToggle
+                            :model-value="channelAvailability[ch.key] !== false"
+                            :disabled="!canManageDs || savingChannels"
+                            @update:model-value="onToggleChannel(ch.key, $event)"
+                        />
+                        <span class="inline-flex items-center gap-1.5 text-[11px] text-gray-600">
+                            <img v-if="channelIcon(ch.key).img" :src="channelIcon(ch.key).img" :alt="ch.name" class="w-3.5 h-3.5" />
+                            <McpIcon v-else-if="channelIcon(ch.key).mcp" class="w-3.5 h-3.5 text-gray-600" />
+                            <UIcon v-else :name="channelIcon(ch.key).uicon" class="w-3.5 h-3.5 text-gray-400" />
+                            {{ ch.name }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
             <!-- Members (only shown when not public) -->
             <div v-if="!form.isPublic" class="border-b border-gray-100 pb-5 mb-5">
                 <div class="flex items-center justify-between mb-2">
@@ -245,6 +266,7 @@
 import { useCan } from '~/composables/usePermissions'
 import { useEnterprise } from '~/ee/composables/useEnterprise'
 import Spinner from '~/components/Spinner.vue'
+import McpIcon from '~/components/icons/McpIcon.vue'
 
 const props = defineProps<{ agentId: string }>()
 const emit = defineEmits(['updated', 'deleted'])
@@ -267,6 +289,50 @@ const original = reactive({
 })
 
 const saving = reactive({ name: false, public: false })
+
+// ── Channel availability ─────────────────────────────────────────────────
+interface ChannelInfo { key: string; name: string; connected: boolean }
+const connectedChannels = ref<ChannelInfo[]>([])
+const channelAvailability = ref<Record<string, boolean>>({})
+const savingChannels = ref(false)
+
+function channelIcon(key: string): { img?: string; mcp?: boolean; uicon?: string } {
+    switch (key) {
+        case 'slack': return { img: '/icons/slack.png' }
+        case 'teams': return { img: '/icons/teams.png' }
+        case 'whatsapp': return { img: '/icons/whatsapp.png' }
+        case 'email': return { uicon: 'i-heroicons-envelope' }
+        case 'mcp': return { mcp: true }
+        default: return { uicon: 'i-heroicons-chat-bubble-left-right' }
+    }
+}
+
+async function loadChannels() {
+    try {
+        const { data } = await useMyFetch('/data_sources/connected_channels', { method: 'GET' })
+        connectedChannels.value = ((data.value as ChannelInfo[]) || []).filter(c => c.connected)
+    } catch {
+        connectedChannels.value = []
+    }
+}
+
+async function onToggleChannel(key: string, enabled: boolean) {
+    if (!ready.value || savingChannels.value) return
+    savingChannels.value = true
+    // Build the full map across connected channels so the saved value is
+    // self-contained (default true for any channel not explicitly set).
+    const map: Record<string, boolean> = {}
+    for (const c of connectedChannels.value) {
+        map[c.key] = c.key === key ? enabled : (channelAvailability.value[c.key] !== false)
+    }
+    const ok = await updateDataSource({ channel_availability: map })
+    if (ok) {
+        channelAvailability.value = map
+        if (integration.value) integration.value.channel_availability = map
+        emit('updated')
+    }
+    savingChannels.value = false
+}
 const deleting = ref(false)
 const ready = computed(() => !loading.value && !!integration.value)
 const showDelete = ref(false)
@@ -338,6 +404,9 @@ watch(integration, (ds) => {
         form.isPublic = ds?.is_public ?? false
         original.name = form.name
         original.isPublic = form.isPublic
+        channelAvailability.value = (ds?.channel_availability && typeof ds.channel_availability === 'object')
+            ? { ...ds.channel_availability }
+            : {}
     }
 }, { immediate: true })
 
@@ -351,6 +420,7 @@ watch(() => props.agentId, async () => {
         loadGroups(),
         loadRoles(),
         loadDsPermOptions(),
+        loadChannels(),
     ])
 }, { immediate: true })
 

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -107,6 +107,23 @@
               <span class="text-xs text-gray-700">Use LLM to learn agent</span>
             </div>
 
+            <!-- Channel availability -->
+            <div v-if="connectedChannels.length > 0" class="mb-4">
+              <label class="block text-xs font-medium text-gray-700 mb-1">Available in channels</label>
+              <p class="text-[11px] text-gray-400 mb-2">Choose which connected channels can query this agent. Disabled channels won't see it.</p>
+              <div class="space-y-2">
+                <div v-for="ch in connectedChannels" :key="ch.key" class="flex items-center gap-2">
+                  <UToggle v-model="channelAvailability[ch.key]" :disabled="creatingFromConnection" size="xs" color="blue" />
+                  <span class="inline-flex items-center gap-1.5 text-xs text-gray-700">
+                    <img v-if="channelIcon(ch.key).img" :src="channelIcon(ch.key).img" :alt="ch.name" class="w-3.5 h-3.5" />
+                    <McpIcon v-else-if="channelIcon(ch.key).mcp" class="w-3.5 h-3.5 text-gray-600" />
+                    <UIcon v-else :name="channelIcon(ch.key).uicon" class="w-3.5 h-3.5 text-gray-500" />
+                    {{ ch.name }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
             <div v-if="errorMessage" class="p-3 bg-red-50 text-red-700 rounded-lg text-sm mb-4">
               {{ errorMessage }}
             </div>
@@ -272,6 +289,7 @@ import AddConnectionModal from '~/components/AddConnectionModal.vue'
 import GitRepoModalComponent from '@/components/GitRepoModalComponent.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import GitBranchIcon from '~/components/icons/GitBranchIcon.vue'
+import McpIcon from '~/components/icons/McpIcon.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits<{
@@ -317,7 +335,10 @@ watch(isOpen, (val) => {
     instructionText.value = ''
     draftInstructionId.value = null
     integration.value = null
+    connectedChannels.value = []
+    channelAvailability.value = {}
     loadConnections()
+    loadChannels()
   }
 })
 
@@ -338,6 +359,36 @@ const useLlmSync = ref(true)
 const creatingFromConnection = ref(false)
 const errorMessage = ref('')
 const showAddConnectionModal = ref(false)
+
+// ── Channel availability ──────────────────────────────────────────────────────
+interface ChannelInfo { key: string; name: string; connected: boolean }
+const connectedChannels = ref<ChannelInfo[]>([])
+const channelAvailability = ref<Record<string, boolean>>({})
+
+function channelIcon(key: string): { img?: string; mcp?: boolean; uicon?: string } {
+  switch (key) {
+    case 'slack': return { img: '/icons/slack.png' }
+    case 'teams': return { img: '/icons/teams.png' }
+    case 'whatsapp': return { img: '/icons/whatsapp.png' }
+    case 'email': return { uicon: 'i-heroicons-envelope' }
+    case 'mcp': return { mcp: true }
+    default: return { uicon: 'i-heroicons-chat-bubble-left-right' }
+  }
+}
+
+async function loadChannels() {
+  try {
+    const response = await useMyFetch('/data_sources/connected_channels', { method: 'GET' })
+    const all = (response.data.value || []) as ChannelInfo[]
+    connectedChannels.value = all.filter(c => c.connected)
+    // Default every connected channel to available.
+    const avail: Record<string, boolean> = {}
+    for (const c of connectedChannels.value) avail[c.key] = true
+    channelAvailability.value = avail
+  } catch (err) {
+    connectedChannels.value = []
+  }
+}
 
 const canSubmitExisting = computed(() =>
   selectedConnections.value.length > 0 &&
@@ -376,7 +427,7 @@ async function createAgentFromExistingConnection() {
   creatingFromConnection.value = true
   errorMessage.value = ''
   try {
-    const payload = {
+    const payload: Record<string, any> = {
       name: agentName.value.trim(),
       connection_ids: selectedConnections.value.map(c => c.id),
       use_llm_sync: useLlmSync.value,
@@ -384,6 +435,18 @@ async function createAgentFromExistingConnection() {
       generate_summary: false,
       generate_conversation_starters: false,
       generate_ai_rules: false,
+    }
+    // Only send channel_availability when channels exist and at least one is
+    // turned off — a null map means "available everywhere" (the default).
+    if (connectedChannels.value.length > 0) {
+      const map: Record<string, boolean> = {}
+      let anyOff = false
+      for (const c of connectedChannels.value) {
+        const enabled = channelAvailability.value[c.key] !== false
+        map[c.key] = enabled
+        if (!enabled) anyOff = true
+      }
+      if (anyOff) payload.channel_availability = map
     }
     const response = await useMyFetch('/data_sources', { method: 'POST', body: payload })
     if (response.error.value) {


### PR DESCRIPTION
## Summary
Lets an agent (data source) be configured as available only in a subset of the organization's **connected channels** — Slack, Teams, WhatsApp, Email, MCP. Builds on top of #390.

Stored as a JSON map on `data_sources` (`channel_availability`, `{channel_type: bool}`). `NULL` / missing key means "available in every connected channel", so existing agents are unchanged (no regression). Channel availability only *narrows* which channels can query an otherwise-accessible agent — it never widens access (still gated by `is_public` / `publish_status` / membership).

## Backend
- `data_sources.channel_availability` column + migration `c4a1d2e3f4b5`. The migration also **merges the two open migration heads** (`e7f0a1b2c3d4` and `g2h3i4j5k6l7`) into a single head.
- `DataSource.is_available_in(channel)` helper.
- Threaded a `channel` arg through `get_public_data_sources` (channel mentions) and `get_active_data_sources` (DMs / MCP) and gated at every external-channel call site: `external_platform_manager` (Slack/Teams mentions + DMs + the Teams 5-day re-sync) and MCP `create_report` (`channel="mcp"`). The in-app/web path passes no channel, so it is never gated.
- Persist + serialize the field in create / update / detail schemas.
- New `GET /data_sources/connected_channels` so the UI renders toggles only for channels the org has actually connected.
- `tests/e2e/test_channel_availability.py` covering the model helper and both selectors.

## Frontend
- "Available in channels" toggles in the **New Agent wizard** (`NewAgentWizardModal.vue`).
- "Channels" section in the agent **Settings panel** (`AgentSettingsPanel.vue`), saved via `PUT /data_sources/{id}`.

## Verification
- Backend e2e tests pass (3/3).
- Migration applies cleanly to a single head on SQLite; column present.
- Ran the full app (backend + Nuxt): created an agent through the wizard and edited it in Settings; toggling Slack off persisted `{"slack": false, ...}` to the DB.

## Notes
The migration merges the two heads present on this branch. If those branches get reconciled elsewhere, re-check the head chain at merge time.

https://claude.ai/code/session_01A39rDkCdz2vo61jxtRt6td

---
_Generated by [Claude Code](https://claude.ai/code/session_01A39rDkCdz2vo61jxtRt6td)_