### PR TITLE
Fix RTL placeholder alignment in prompt input

### DIFF
--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -3,7 +3,7 @@
     <div
       ref="inputRef"
       contenteditable="true"
-      dir="auto"
+      :dir="inputDir"
       :class="[
         'w-full outline-none resize-none bg-transparent text-gray-900 placeholder-gray-400 text-start',
         props.compact ? 'text-sm leading-[20px]' : 'text-sm min-h-[40px]'
@@ -258,6 +258,16 @@ const allCategories = ref<MentionCategory[]>([])
 const isLoadingMentions = ref(false)
 const orgPermsState = usePermissions()
 const resourcePermsState = useResourcePermissions()
+
+// While the field is empty, `dir="auto"` has no strong character to scan and
+// falls back to LTR — which left-aligns an RTL placeholder (e.g. Hebrew). Fall
+// back to the UI locale direction when empty; once the user types, switch to
+// `auto` so the direction follows the typed text.
+const RTL_LOCALES = new Set(['he', 'ar', 'fa', 'ur'])
+const inputDir = computed(() => {
+  if (textContent.value.trim().length > 0) return 'auto'
+  return RTL_LOCALES.has(String(i18nLocale.value)) ? 'rtl' : 'ltr'
+})
 
 const lineHeightPx = computed(() => props.compact ? 18 : 24)
 const minHeight = computed(() => `${Math.max(1, props.rows) * lineHeightPx.value}px`)


### PR DESCRIPTION
## Summary
Fixes the prompt input placeholder being left-aligned under RTL locales (e.g. Hebrew) in `PromptBoxV2`.

The placeholder is rendered by the inner `MentionInput.vue` contenteditable, which used a hardcoded `dir="auto"`. Per the HTML spec, `dir="auto"` resolves direction from the first strong character in the element's content — but while the field is empty there is nothing to scan, so it falls back to LTR. That left-anchored the Hebrew placeholder.

## Fix
Make the `dir` attribute reactive in `MentionInput.vue`:
- **Empty** → fall back to the UI locale direction (`rtl` for `he`/`ar`/`fa`/`ur`), so the placeholder aligns to the correct edge.
- **Has content** → use `auto`, so typed text still picks its own direction (Latin stays LTR, Hebrew goes RTL), preserving mixed-language behavior.

https://claude.ai/code/session_01JPHZRqPD5Uj3T6EZsaqnfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPHZRqPD5Uj3T6EZsaqnfD)_