### PR TITLE
fix(e2e): settings tab renamed Members -> Access

### DIFF
--- a/frontend/tests/settings/view-settings.spec.ts
+++ b/frontend/tests/settings/view-settings.spec.ts
@@ -9,7 +9,8 @@ test('can view settings page', async ({ page }) => {
     .toBeVisible({ timeout: 15000 });
 
   // Verify settings tabs are present (redirects to /settings/members)
-  await expect(page.getByRole('link', { name: 'Members' }))
+  // Note: the members tab is labelled "Access" in the UI (settings.membersTab).
+  await expect(page.getByRole('link', { name: 'Access' }))
     .toBeVisible({ timeout: 10000 });
   await expect(page.getByRole('link', { name: 'LLM' }))
     .toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
The settings tab label was renamed from 'Members' to 'Access'
(settings.membersTab in locales/en.json, commit e488459), but
view-settings.spec.ts still asserted a 'Members' link, failing all
retries deterministically. Update the assertion to match the UI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D1caH79MNidbGqXko14iCx