### PR TITLE
feat(mcp): let the agent read MCP server resources (list_mcp_resources + read_mcp_resource)

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -191,6 +191,7 @@ PLAN TYPE GUIDANCE
 - You must review user message, the chat's previous messages and activity, inspect schemas or gather context first.
 - If the user's message is a greeting/thanks/farewell, do not call any tool; respond briefly.
 - Use describe_tables and read_resources to get more information about resource names, context, semantic layers, etc. before the next step.
+- When MCP connections are attached, their servers may expose business rules/definitions/schemas as MCP resources (URIs like 'pulse://rules'). Use list_mcp_resources to discover them, then read_mcp_resource to fetch a resource's content BEFORE querying. (read_resources only covers indexed dbt/LookML/docs, not MCP resource URIs.)
 - Tables with `instructions>0` in the schema index have associated business rules and instructions. Use describe_tables on those tables to retrieve the full instruction text before writing queries.
 - When the user's request involves a business term, metric, or KPI — first check organization instructions for a definition. If found, use it. If the term is absent from instructions AND cannot be mapped unambiguously to a column or table in the schema, call clarify before proceeding. Never invent a definition.
 - Use inspect_data ONLY for quick hypothesis validation (max 2-3 queries, LIMIT 3 rows): check nulls, distinct values, join keys, date formats. It's a peek, not analysis.

--- a/backend/app/ai/tools/implementations/_mcp_resource_helpers.py
+++ b/backend/app/ai/tools/implementations/_mcp_resource_helpers.py
@@ -1,0 +1,64 @@
+"""Dependency-free helpers for the MCP resource tools.
+
+Kept import-light (no app/SQLAlchemy imports) so the pure logic — content
+formatting, truncation, connection selection — is unit-testable without
+importing the full implementations package. Mirrors _search_mcps_query.py.
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+# Cap inline content so a large resource can't blow up the agent's context.
+# The Pulse rulebook is ~20 KB, so this returns typical docs whole.
+MAX_RESOURCE_CHARS = 50_000
+
+
+def format_resource_contents(
+    contents: List[Dict[str, Any]],
+    max_chars: int = MAX_RESOURCE_CHARS,
+) -> Tuple[str, Optional[str], bool]:
+    """Join text blocks; render binary blocks as a placeholder.
+
+    `contents` blocks are shaped by McpClient.aread_resource:
+    text  -> {"type": "text", "text", "mime_type", "uri"}
+    binary-> {"type": "binary", "byte_size", "mime_type", "uri"}
+
+    Returns (content, mime_type, truncated).
+    """
+    parts: List[str] = []
+    mime_type: Optional[str] = None
+    for c in contents:
+        if mime_type is None:
+            mime_type = c.get("mime_type")
+        if c.get("type") == "binary":
+            mt = c.get("mime_type") or "application/octet-stream"
+            parts.append(f"[binary resource: {mt}, {c.get('byte_size', 0)} bytes]")
+        else:
+            parts.append(c.get("text") or "")
+    content = "\n".join(parts)
+    truncated = False
+    if len(content) > max_chars:
+        content = content[:max_chars] + (
+            f"\n… [truncated, {len(content)} total chars — read a more specific resource/URI]"
+        )
+        truncated = True
+    return content, mime_type, truncated
+
+
+def select_mcp_connection(connections: List[Any], connection_id: Optional[str]):
+    """Pick the target MCP connection from those attached to a report.
+
+    Returns the matching connection object, or an actionable error *string*
+    when the choice is ambiguous or no match is found. Connection objects only
+    need `.id` and `.name` attributes.
+    """
+    if connection_id:
+        wanted = str(connection_id)
+        match = next((c for c in connections if str(c.id) == wanted or c.name == wanted), None)
+        if not match:
+            return f"MCP connection '{connection_id}' not found on this report's data sources."
+        return match
+    if not connections:
+        return "No MCP connections found on linked data sources."
+    if len(connections) == 1:
+        return connections[0]
+    names = ", ".join(f"{c.name} ({c.id})" for c in connections)
+    return f"Multiple MCP connections attached — specify connection_id. Options: {names}"

--- a/backend/app/ai/tools/implementations/list_mcp_resources.py
+++ b/backend/app/ai/tools/implementations/list_mcp_resources.py
@@ -1,0 +1,193 @@
+import logging
+from typing import AsyncIterator, Dict, Any, Type, List
+
+from pydantic import BaseModel
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.list_mcp_resources import ListMcpResourcesInput, ListMcpResourcesOutput
+from app.ai.tools.schemas import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolProgressEvent,
+    ToolEndEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cap the combined list so a server with thousands of resources can't blow up
+# the agent's context. Mirrors the Go bridge's maxResourcesListed.
+MAX_RESOURCES_LISTED = 200
+
+
+class ListMcpResourcesTool(Tool):
+    """Discover MCP *resources* (data the server reads on demand) and URI templates."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="list_mcp_resources",
+            description="""
+            Purpose:
+List data resources exposed by connected MCP servers (documents, rulebooks, schemas, records, etc.).
+Returns resource URIs with names and descriptions, including parameterized URI templates.
+
+MCP *resources* are different from MCP *tools* (use search_mcps for tools) and from indexed
+metadata (use read_resources for dbt/LookML/docs). Call this first to discover what resources
+exist, then read_mcp_resource to fetch a resource's content by URI.
+
+Use when:
+    - An MCP server may expose business rules, definitions, glossaries, or schema docs as resources.
+    - You have a URI like 'pulse://rules' and want to confirm it exists / find related resources.
+            """,
+            category="research",
+            version="1.0.0",
+            input_schema=ListMcpResourcesInput.model_json_schema(),
+            output_schema=ListMcpResourcesOutput.model_json_schema(),
+            tags=["mcp", "resources", "discovery", "research"],
+            timeout_seconds=30,
+            idempotent=True,
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return ListMcpResourcesInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return ListMcpResourcesOutput
+
+    async def run_stream(self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]) -> AsyncIterator[ToolEvent]:
+        data = ListMcpResourcesInput(**tool_input)
+        organization_settings = runtime_ctx.get("settings")
+
+        # Feature gate — same flag that governs search_mcps/execute_mcp.
+        if organization_settings:
+            enable_mcp = organization_settings.get_config("enable_mcp_tools")
+            if enable_mcp and not enable_mcp.value:
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload={
+                        "output": {"resources": [], "total_count": 0, "truncated": False, "errors": []},
+                        "observation": {"summary": "MCP tools are disabled for this organization.", "success": False},
+                    },
+                )
+                return
+
+        yield ToolStartEvent(type="tool.start", payload={"title": "Listing MCP resources"})
+
+        db = runtime_ctx.get("db")
+        report = runtime_ctx.get("report")
+        current_user = runtime_ctx.get("user") or runtime_ctx.get("current_user")
+
+        if not db or not report:
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": {"resources": [], "total_count": 0, "truncated": False, "errors": []},
+                    "observation": {"summary": "No database session or report available.", "success": False},
+                },
+            )
+            return
+
+        # Resolve MCP connections linked to this report's data sources via an
+        # explicit join — lazy-loading report.data_sources → ds.connections
+        # silently returns empty in async context (see search_mcps). Resources
+        # are an MCP-only concept, so we filter to type == "mcp".
+        from sqlalchemy import select
+        from app.models.connection import Connection
+        from app.models.domain_connection import domain_connection
+        from app.models.report_data_source_association import report_data_source_association
+
+        conn_result = await db.execute(
+            select(Connection)
+            .join(domain_connection, domain_connection.c.connection_id == Connection.id)
+            .join(
+                report_data_source_association,
+                report_data_source_association.c.data_source_id == domain_connection.c.data_source_id,
+            )
+            .where(
+                report_data_source_association.c.report_id == str(report.id),
+                Connection.type == "mcp",
+            )
+        )
+        connections = list({str(c.id): c for c in conn_result.scalars().all()}.values())
+
+        if data.connection_id:
+            wanted = str(data.connection_id)
+            connections = [c for c in connections if str(c.id) == wanted or c.name == wanted]
+
+        if not connections:
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": {"resources": [], "total_count": 0, "truncated": False, "errors": []},
+                    "observation": {"summary": "No MCP connections found on linked data sources.", "success": False},
+                },
+            )
+            return
+
+        from app.services.connection_service import ConnectionService
+        service = ConnectionService()
+
+        items: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        truncated = False
+
+        for conn in connections:
+            if len(items) >= MAX_RESOURCES_LISTED:
+                truncated = True
+                break
+            yield ToolProgressEvent(type="tool.progress", payload={"stage": "listing", "connection_name": conn.name})
+            try:
+                client = await service.construct_client(db, conn, current_user)
+            except Exception as e:
+                errors.append(f"{conn.name}: failed to connect: {e}")
+                continue
+
+            # Concrete resources and URI templates come from two separate calls;
+            # templates are optional, so a failure there is non-fatal.
+            try:
+                resources = await client.alist_resources()
+            except Exception as e:
+                errors.append(f"{conn.name}: list resources failed: {e}")
+                resources = []
+            try:
+                templates = await client.alist_resource_templates()
+            except Exception:
+                # Many servers don't implement templates/list — treat as none.
+                templates = []
+
+            for r in (resources or []) + (templates or []):
+                if len(items) >= MAX_RESOURCES_LISTED:
+                    truncated = True
+                    break
+                item = dict(r)
+                item.setdefault("is_template", False)
+                item["connection_id"] = str(conn.id)
+                item["connection_name"] = conn.name
+                items.append(item)
+
+        summary = f"Found {len(items)} resource(s)/template(s) across {len(connections)} MCP connection(s)."
+        if truncated:
+            summary += f" (capped at {MAX_RESOURCES_LISTED} — narrow with connection_id)"
+        if errors:
+            summary += f" {len(errors)} connection error(s)."
+
+        yield ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": {
+                    "resources": items,
+                    "total_count": len(items),
+                    "truncated": truncated,
+                    "errors": errors,
+                },
+                "observation": {
+                    "summary": summary,
+                    "resources": items,
+                    "errors": errors,
+                    "success": True,
+                },
+            },
+        )

--- a/backend/app/ai/tools/implementations/read_mcp_resource.py
+++ b/backend/app/ai/tools/implementations/read_mcp_resource.py
@@ -1,0 +1,174 @@
+import logging
+from typing import AsyncIterator, Dict, Any, Type
+
+from pydantic import BaseModel
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.read_mcp_resource import ReadMcpResourceInput, ReadMcpResourceOutput
+from app.ai.tools.schemas import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolProgressEvent,
+    ToolEndEvent,
+)
+from app.ai.tools.implementations._mcp_resource_helpers import (
+    format_resource_contents,
+    select_mcp_connection,
+)
+from app.ee.audit.tool_audit import log_tool_audit
+
+logger = logging.getLogger(__name__)
+
+
+class ReadMcpResourceTool(Tool):
+    """Read the content of an MCP *resource* by URI."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="read_mcp_resource",
+            description="""
+            Purpose:
+Read the content of a resource exposed by a connected MCP server, by its URI
+(e.g. 'pulse://rules'). Use list_mcp_resources first to discover URIs, or build one from a
+URI template. Returns the resource content (text; binary is summarized, not inlined).
+
+MCP resources often hold business rules, definitions, and schema docs — if a relevant
+resource exists, read it BEFORE querying so you apply the right definitions.
+
+Do not use for:
+    - MCP tools (use execute_mcp) or indexed dbt/LookML/docs metadata (use read_resources).
+            """,
+            category="research",
+            version="1.0.0",
+            input_schema=ReadMcpResourceInput.model_json_schema(),
+            output_schema=ReadMcpResourceOutput.model_json_schema(),
+            tags=["mcp", "resources", "read", "research"],
+            timeout_seconds=30,
+            idempotent=True,
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return ReadMcpResourceInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return ReadMcpResourceOutput
+
+    async def run_stream(self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]) -> AsyncIterator[ToolEvent]:
+        data = ReadMcpResourceInput(**tool_input)
+        organization_settings = runtime_ctx.get("settings")
+
+        # Feature gate — same flag that governs search_mcps/execute_mcp.
+        if organization_settings:
+            enable_mcp = organization_settings.get_config("enable_mcp_tools")
+            if enable_mcp and not enable_mcp.value:
+                yield self._end(False, error="MCP tools are disabled for this organization.")
+                return
+
+        yield ToolStartEvent(type="tool.start", payload={"title": f"Reading {data.uri}", "uri": data.uri})
+
+        db = runtime_ctx.get("db")
+        report = runtime_ctx.get("report")
+        organization = runtime_ctx.get("organization")
+        current_user = runtime_ctx.get("user") or runtime_ctx.get("current_user")
+
+        if not db or not report or not organization:
+            yield self._end(False, uri=data.uri, error="Missing database session, report, or organization context.")
+            return
+
+        # Resolve MCP connections linked to this report (explicit join — see
+        # search_mcps for why lazy-loading is unreliable in async context).
+        yield ToolProgressEvent(type="tool.progress", payload={"stage": "resolving_connection"})
+        from sqlalchemy import select
+        from app.models.connection import Connection
+        from app.models.domain_connection import domain_connection
+        from app.models.report_data_source_association import report_data_source_association
+
+        conn_result = await db.execute(
+            select(Connection)
+            .join(domain_connection, domain_connection.c.connection_id == Connection.id)
+            .join(
+                report_data_source_association,
+                report_data_source_association.c.data_source_id == domain_connection.c.data_source_id,
+            )
+            .where(
+                report_data_source_association.c.report_id == str(report.id),
+                Connection.organization_id == str(organization.id),
+                Connection.type == "mcp",
+            )
+        )
+        mcp_connections = list({str(c.id): c for c in conn_result.scalars().all()}.values())
+
+        connection = select_mcp_connection(mcp_connections, data.connection_id)
+        if isinstance(connection, str):
+            # select_mcp_connection returns an error message string when ambiguous/not found.
+            yield self._end(False, uri=data.uri, error=connection)
+            return
+
+        yield ToolProgressEvent(type="tool.progress", payload={"stage": "reading", "connection_name": connection.name})
+
+        from app.services.connection_service import ConnectionService
+        try:
+            client = await ConnectionService().construct_client(db, connection, current_user)
+            result = await client.aread_resource(data.uri)
+        except NotImplementedError:
+            yield self._end(False, uri=data.uri, connection_name=connection.name,
+                            error=f"Connection '{connection.name}' does not support resources.")
+            return
+        except BaseException as e:
+            logger.error(f"read_mcp_resource: read failed for {data.uri}: {e}")
+            yield self._end(False, uri=data.uri, connection_name=connection.name, error=str(e))
+            return
+
+        if not result.get("success"):
+            # Bad/unknown URI etc. — surface as a tool error, not a crash.
+            yield self._end(False, uri=data.uri, connection_name=connection.name,
+                            error=result.get("error") or "Failed to read resource.")
+            return
+
+        content, mime_type, truncated = format_resource_contents(result.get("contents") or [])
+
+        # Audit — record metadata only; NEVER the content (it can carry sensitive data).
+        await log_tool_audit(
+            runtime_ctx,
+            action="tool.mcp_resource_read",
+            resource_type="report",
+            resource_id=str(report.id) if report else None,
+            details={
+                "tool": "read_mcp_resource",
+                "connection_id": str(connection.id),
+                "uri": data.uri,
+                "content_length": len(content),
+                "truncated": truncated,
+            },
+        )
+
+        yield self._end(
+            True, uri=data.uri, connection_name=connection.name,
+            content=content, mime_type=mime_type, truncated=truncated,
+        )
+
+    @staticmethod
+    def _end(success: bool, *, uri=None, connection_name=None, content=None, mime_type=None,
+             truncated=False, error=None) -> ToolEndEvent:
+        output = {
+            "success": success,
+            "content": content,
+            "mime_type": mime_type,
+            "uri": uri,
+            "connection_name": connection_name,
+            "truncated": truncated,
+            "error_message": error,
+        }
+        if success:
+            summary = f"Read resource {uri}"
+            if connection_name:
+                summary += f" from {connection_name}"
+            summary += f" ({len(content or '')} chars{', truncated' if truncated else ''})."
+            observation = {"summary": summary, "content": content, "uri": uri, "success": True}
+        else:
+            observation = {"summary": f"Failed to read resource {uri or ''}: {error}", "success": False}
+        return ToolEndEvent(type="tool.end", payload={"output": output, "observation": observation})

--- a/backend/app/ai/tools/implementations/read_resources.py
+++ b/backend/app/ai/tools/implementations/read_resources.py
@@ -31,9 +31,12 @@ class ReadResourcesTool(Tool):
         return ToolMetadata(
             name="read_resources",
             description=(
-                "RESEARCH: Read metadata resources (dbt/LookML/docs). "
+                "RESEARCH: Search INDEXED metadata resources (dbt/LookML/docs) stored in this "
+                "workspace. Matches by resource name/path. "
                 "CRITICAL: Metadata often contains business rules, definitions, and guidelines. "
-                "If metadata resources exist, read them FIRST - they can contain rules you need."
+                "If metadata resources exist, read them FIRST - they can contain rules you need. "
+                "NOTE: This does NOT read MCP server resources by URI (e.g. 'pulse://rules') - "
+                "use list_mcp_resources / read_mcp_resource for those."
             ),
             category="research",
             version="1.0.0",

--- a/backend/app/ai/tools/schemas/__init__.py
+++ b/backend/app/ai/tools/schemas/__init__.py
@@ -23,6 +23,8 @@ from .read_report import (
 from .edit_artifact import EditArtifactInput, EditArtifactOutput
 from .search_mcps import SearchMCPsInput, SearchMCPsOutput
 from .execute_mcp import ExecuteMCPInput, ExecuteMCPOutput
+from .list_mcp_resources import ListMcpResourcesInput, ListMcpResourcesOutput
+from .read_mcp_resource import ReadMcpResourceInput, ReadMcpResourceOutput
 from .web_fetch import WebFetchInput, WebFetchOutput
 from .write_csv import WriteCsvInput, WriteCsvOutput
 from .write_to_excel import WriteToExcelInput, WriteToExcelOutput
@@ -87,6 +89,10 @@ __all__ = [
     "SearchMCPsOutput",
     "ExecuteMCPInput",
     "ExecuteMCPOutput",
+    "ListMcpResourcesInput",
+    "ListMcpResourcesOutput",
+    "ReadMcpResourceInput",
+    "ReadMcpResourceOutput",
     "WebFetchInput",
     "WebFetchOutput",
     "WriteCsvInput",

--- a/backend/app/ai/tools/schemas/list_mcp_resources.py
+++ b/backend/app/ai/tools/schemas/list_mcp_resources.py
@@ -1,0 +1,25 @@
+from typing import Optional, List, Dict, Any
+from pydantic import BaseModel, Field
+
+
+class ListMcpResourcesInput(BaseModel):
+    connection_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional ID (or name) of a specific MCP connection to list resources from. "
+            "Omit to list resources across all MCP connections attached to the current data sources."
+        ),
+    )
+
+
+class ListMcpResourcesOutput(BaseModel):
+    resources: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Resources and URI templates. Each item has: uri (or uri_template), name, "
+            "description, mime_type, is_template, connection_id, connection_name."
+        ),
+    )
+    total_count: int = Field(default=0, description="Number of resources/templates returned.")
+    truncated: bool = Field(default=False, description="True if the result was capped.")
+    errors: List[str] = Field(default_factory=list, description="Per-connection errors, if any.")

--- a/backend/app/ai/tools/schemas/read_mcp_resource.py
+++ b/backend/app/ai/tools/schemas/read_mcp_resource.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class ReadMcpResourceInput(BaseModel):
+    uri: str = Field(
+        ...,
+        description=(
+            "The URI of the resource to read (e.g. 'pulse://rules'), taken from list_mcp_resources "
+            "or built by filling in a URI template."
+        ),
+    )
+    connection_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "ID (or name) of the MCP connection that exposes this resource. "
+            "Optional when exactly one MCP connection is attached; required when there are several."
+        ),
+    )
+
+
+class ReadMcpResourceOutput(BaseModel):
+    success: bool = Field(..., description="Whether the resource was read successfully.")
+    content: Optional[str] = Field(default=None, description="The resource content (text; binary rendered as a placeholder).")
+    mime_type: Optional[str] = Field(default=None, description="MIME type of the resource, if reported.")
+    uri: Optional[str] = Field(default=None, description="The URI that was read.")
+    connection_name: Optional[str] = Field(default=None, description="Name of the connection the resource was read from.")
+    truncated: bool = Field(default=False, description="True if the content was truncated to fit.")
+    error_message: Optional[str] = Field(default=None, description="Error message if the read failed.")

--- a/backend/app/data_sources/clients/mcp_client.py
+++ b/backend/app/data_sources/clients/mcp_client.py
@@ -84,6 +84,125 @@ class McpClient(ToolProviderClient):
             self._acall_tool(tool_name, arguments)
         )
 
+    # ------------------------------------------------------------------
+    # Resources
+    #
+    # MCP servers can expose *resources* (data the server reads on demand)
+    # alongside tools. The protocol surfaces three calls: resources/list,
+    # resources/templates/list, and resources/read. The agent bridges these via
+    # the list_mcp_resources / read_mcp_resource tools — the LLM has no native
+    # notion of resources, so we hand it list + read so it can pull resource
+    # context just-in-time.
+    # ------------------------------------------------------------------
+
+    # Cap pagination so a misbehaving server can't make us walk forever.
+    _MAX_RESOURCES = 500
+
+    async def alist_resources(self) -> List[Dict[str, Any]]:
+        """List concrete resources exposed by the MCP server.
+
+        Returns a list of {uri, name, description, mime_type}. Follows
+        nextCursor pagination up to a safety cap.
+        """
+        try:
+            resources: List[Dict[str, Any]] = []
+            async with self._connect() as session:
+                cursor = None
+                while True:
+                    result = await session.list_resources(cursor=cursor)
+                    for r in (result.resources or []):
+                        resources.append({
+                            "uri": str(getattr(r, "uri", "")),
+                            "name": getattr(r, "name", None),
+                            "description": getattr(r, "description", None),
+                            "mime_type": getattr(r, "mimeType", None),
+                        })
+                        if len(resources) >= self._MAX_RESOURCES:
+                            return resources
+                    cursor = getattr(result, "nextCursor", None)
+                    if not cursor:
+                        break
+            return resources
+        except BaseException as e:
+            raise RuntimeError(self._unwrap_exception(e)) from None
+
+    async def alist_resource_templates(self) -> List[Dict[str, Any]]:
+        """List parameterized URI templates exposed by the MCP server.
+
+        Returns a list of {uri_template, name, description, mime_type,
+        is_template}. Templates are optional; servers that don't implement
+        resources/templates/list raise, which the caller treats as "none".
+        """
+        try:
+            templates: List[Dict[str, Any]] = []
+            async with self._connect() as session:
+                cursor = None
+                while True:
+                    result = await session.list_resource_templates(cursor=cursor)
+                    for t in (result.resourceTemplates or []):
+                        templates.append({
+                            "uri_template": getattr(t, "uriTemplate", None),
+                            "name": getattr(t, "name", None),
+                            "description": getattr(t, "description", None),
+                            "mime_type": getattr(t, "mimeType", None),
+                            "is_template": True,
+                        })
+                        if len(templates) >= self._MAX_RESOURCES:
+                            return templates
+                    cursor = getattr(result, "nextCursor", None)
+                    if not cursor:
+                        break
+            return templates
+        except BaseException as e:
+            raise RuntimeError(self._unwrap_exception(e)) from None
+
+    async def aread_resource(self, uri: str) -> Dict[str, Any]:
+        """Read a resource by URI.
+
+        Returns {success, contents, error} where contents is a list of blocks:
+        text blocks {type: "text", text, mime_type, uri} and binary blocks
+        {type: "binary", byte_size, mime_type, uri}. A failure here is usually a
+        bad/unknown URI, so it's reported as success=False rather than raised —
+        mirroring acall_tool's contract.
+        """
+        from pydantic import AnyUrl
+
+        try:
+            async with self._connect() as session:
+                result = await session.read_resource(AnyUrl(uri))
+                contents: List[Dict[str, Any]] = []
+                for c in (getattr(result, "contents", None) or []):
+                    mime_type = getattr(c, "mimeType", None)
+                    c_uri = str(getattr(c, "uri", uri))
+                    # The wire format distinguishes blob from text by the
+                    # presence of the blob field, not by text being empty.
+                    blob = getattr(c, "blob", None)
+                    if blob is not None:
+                        # blob is base64; report decoded size, not encoded length.
+                        import base64
+                        try:
+                            byte_size = len(base64.b64decode(blob, validate=False))
+                        except Exception:
+                            byte_size = len(blob)
+                        contents.append({
+                            "type": "binary",
+                            "byte_size": byte_size,
+                            "mime_type": mime_type or "application/octet-stream",
+                            "uri": c_uri,
+                        })
+                    else:
+                        contents.append({
+                            "type": "text",
+                            "text": getattr(c, "text", "") or "",
+                            "mime_type": mime_type,
+                            "uri": c_uri,
+                        })
+                return {"success": True, "contents": contents, "error": None}
+        except BaseException as e:
+            msg = self._unwrap_exception(e)
+            logger.error(f"MCP read_resource failed: {uri}: {msg}")
+            return {"success": False, "contents": [], "error": msg}
+
     async def _acall_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Async implementation of call_tool using the MCP SDK."""
         from mcp import ClientSession

--- a/backend/app/data_sources/clients/tool_provider_base.py
+++ b/backend/app/data_sources/clients/tool_provider_base.py
@@ -66,3 +66,16 @@ class ToolProviderClient(ABC):
 
     async def atest_connection(self) -> Dict[str, Any]:
         return await asyncio.to_thread(self.test_connection)
+
+    # Resources — optional capability. Only MCP servers expose resources;
+    # providers that don't (e.g. custom API) inherit these defaults so callers
+    # get a clear NotImplementedError instead of an AttributeError.
+
+    async def alist_resources(self) -> List[Dict[str, Any]]:
+        raise NotImplementedError("This provider does not support resources")
+
+    async def alist_resource_templates(self) -> List[Dict[str, Any]]:
+        raise NotImplementedError("This provider does not support resources")
+
+    async def aread_resource(self, uri: str) -> Dict[str, Any]:
+        raise NotImplementedError("This provider does not support resources")

--- a/backend/tests/mocks/mock_mcp_server.py
+++ b/backend/tests/mocks/mock_mcp_server.py
@@ -56,14 +56,36 @@ DEFAULT_MOCK_TOOLS = [
 ]
 
 
+# Default resources for the mock server (mirrors a Pulse-like server).
+DEFAULT_MOCK_RESOURCES = [
+    {"uri": "mock://overview", "name": "overview", "description": "Product overview doc.", "mime_type": "text/markdown"},
+    {"uri": "mock://rules", "name": "rules", "description": "Business rules to read first.", "mime_type": "text/markdown"},
+]
+
+DEFAULT_MOCK_RESOURCE_TEMPLATES = [
+    {"uri_template": "mock://tables/{name}", "name": "table_schema", "description": "Schema for one table.", "mime_type": "text/markdown", "is_template": True},
+]
+
+# Resource bodies keyed by URI, returned by aread_resource.
+DEFAULT_MOCK_RESOURCE_BODIES = {
+    "mock://overview": "# Overview\nMock product overview.",
+    "mock://rules": "# Rules\n1. Always dedupe.\n2. Disclose assumptions.",
+}
+
+
 class MockToolProviderClient(ToolProviderClient):
     """
     In-process mock that replaces the real MCP/API client for testing.
     No network calls, no subprocess — pure Python.
     """
 
-    def __init__(self, tools: List[Dict[str, Any]] = None, **kwargs):
+    def __init__(self, tools: List[Dict[str, Any]] = None,
+                 resources: List[Dict[str, Any]] = None,
+                 resource_templates: List[Dict[str, Any]] = None,
+                 **kwargs):
         self._tools = tools or DEFAULT_MOCK_TOOLS
+        self._resources = resources if resources is not None else DEFAULT_MOCK_RESOURCES
+        self._resource_templates = resource_templates if resource_templates is not None else DEFAULT_MOCK_RESOURCE_TEMPLATES
         self._call_log: List[Dict[str, Any]] = []
 
     def list_tools(self) -> List[Dict[str, Any]]:
@@ -121,6 +143,25 @@ class MockToolProviderClient(ToolProviderClient):
         return {
             "success": True,
             "message": f"Mock MCP server connected. {len(self._tools)} tool(s) available.",
+        }
+
+    # --- Resources (MCP-only capability) ---
+
+    async def alist_resources(self) -> List[Dict[str, Any]]:
+        return list(self._resources)
+
+    async def alist_resource_templates(self) -> List[Dict[str, Any]]:
+        return list(self._resource_templates)
+
+    async def aread_resource(self, uri: str) -> Dict[str, Any]:
+        self._call_log.append({"read_resource": uri})
+        body = DEFAULT_MOCK_RESOURCE_BODIES.get(uri)
+        if body is None:
+            return {"success": False, "contents": [], "error": "Resource not found"}
+        return {
+            "success": True,
+            "contents": [{"type": "text", "text": body, "mime_type": "text/markdown", "uri": uri}],
+            "error": None,
         }
 
     def set_tools(self, tools: List[Dict[str, Any]]):

--- a/backend/tests/unit/test_mcp_resource_helpers.py
+++ b/backend/tests/unit/test_mcp_resource_helpers.py
@@ -1,0 +1,103 @@
+"""Unit tests for the MCP resource helpers (format + connection selection).
+
+The helpers are intentionally dependency-free, so we load them directly by file
+path — keeping the test fast and runnable without importing the full app (the
+implementations package auto-imports every tool on import).
+"""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+_HELPER = (
+    Path(__file__).resolve().parents[2]
+    / "app" / "ai" / "tools" / "implementations" / "_mcp_resource_helpers.py"
+)
+_spec = importlib.util.spec_from_file_location("_mcp_resource_helpers", _HELPER)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+format_resource_contents = _mod.format_resource_contents
+select_mcp_connection = _mod.select_mcp_connection
+
+
+def _conn(id, name):
+    return SimpleNamespace(id=id, name=name)
+
+
+# ---------- format_resource_contents ----------
+
+def test_format_joins_text_blocks():
+    content, mime, truncated = format_resource_contents([
+        {"type": "text", "text": "line one", "mime_type": "text/markdown"},
+        {"type": "text", "text": "line two", "mime_type": "text/plain"},
+    ])
+    assert content == "line one\nline two"
+    assert mime == "text/markdown"  # first block's mime wins
+    assert truncated is False
+
+
+def test_format_binary_is_placeholder_not_inlined():
+    content, mime, truncated = format_resource_contents([
+        {"type": "binary", "byte_size": 2048, "mime_type": "image/png"},
+    ])
+    assert content == "[binary resource: image/png, 2048 bytes]"
+    assert mime == "image/png"
+    assert truncated is False
+
+
+def test_format_binary_defaults_mime():
+    content, _, _ = format_resource_contents([{"type": "binary", "byte_size": 0}])
+    assert content == "[binary resource: application/octet-stream, 0 bytes]"
+
+
+def test_format_truncates_over_cap():
+    big = "x" * 100
+    content, _, truncated = format_resource_contents(
+        [{"type": "text", "text": big}], max_chars=10
+    )
+    assert truncated is True
+    assert content.startswith("x" * 10)
+    assert "truncated, 100 total chars" in content
+
+
+def test_format_empty():
+    content, mime, truncated = format_resource_contents([])
+    assert content == ""
+    assert mime is None
+    assert truncated is False
+
+
+# ---------- select_mcp_connection ----------
+
+def test_select_single_connection_auto():
+    c = _conn("id-1", "Pulse")
+    assert select_mcp_connection([c], None) is c
+
+
+def test_select_none_attached_returns_error():
+    result = select_mcp_connection([], None)
+    assert isinstance(result, str)
+    assert "No MCP connections" in result
+
+
+def test_select_ambiguous_requires_id():
+    result = select_mcp_connection([_conn("a", "One"), _conn("b", "Two")], None)
+    assert isinstance(result, str)
+    assert "specify connection_id" in result
+    assert "One (a)" in result and "Two (b)" in result
+
+
+def test_select_by_id():
+    a, b = _conn("a", "One"), _conn("b", "Two")
+    assert select_mcp_connection([a, b], "b") is b
+
+
+def test_select_by_name():
+    a, b = _conn("a", "One"), _conn("b", "Two")
+    assert select_mcp_connection([a, b], "One") is a
+
+
+def test_select_unknown_id_returns_error():
+    result = select_mcp_connection([_conn("a", "One")], "nope")
+    assert isinstance(result, str)
+    assert "not found" in result


### PR DESCRIPTION
## Problem

BoW integrates MCP servers as **tool providers only**. The MCP protocol's *resources* capability (`resources/list`, `resources/templates/list`, `resources/read`) is never consumed anywhere in the backend — `McpClient` implements only `list_tools` / `call_tool` / `test_connection`.

The agent's existing `read_resources` tool is unrelated: it searches the local `MetadataResource` table (dbt/LookML/docs indexed from repos). So when the agent passed MCP resource URIs (e.g. `pulse://overview`, `pulse://rules`) to it, it returned **"Described 0 resources across 0 data sources."**

Fixes #399.

## What this adds

Two **research** tools that bridge MCP resources to the agent (auto-registered by the existing registry; no new feature flag — reuse the `enable_mcp_tools` gate and the `search_mcps`/`execute_mcp` connection-resolution pattern):

- **`list_mcp_resources`** — discover resources *and* URI templates across the report's attached MCP connections (or one, via `connection_id`). Tolerant of partial failure (templates are optional), capped at 200 with a truncation note.
- **`read_mcp_resource`** — read a resource by `uri`. `connection_id` is optional (auto-resolved when exactly one MCP connection is attached; required when several). Text is returned inline (capped at 50k chars with a truncation note); binary is rendered as `[binary resource: <mime>, <n> bytes]`. Bad-URI/read failures are surfaced as tool errors, never crashes. **Content is never logged** (it can carry sensitive data).

Supporting changes:
- `McpClient` gains `alist_resources` / `alist_resource_templates` / `aread_resource` (reusing existing `_connect`/`_build_headers`/`_unwrap_exception`).
- `ToolProviderClient` base raises `NotImplementedError` for these so non-MCP providers (custom API) fail clearly rather than with `AttributeError`.
- `read_resources` description tightened to state it covers indexed dbt/LookML/docs only — not MCP resource URIs — so the agent stops routing URIs there.
- One-line planner hint; mock MCP server extended with resource support for tests.

This mirrors a proven Go implementation of the same bridge (list + read, including URI templates) used in another service.

## Design notes

- **Two tools, not one.** The agent can't read URIs it can't discover, so a discovery companion (`list_mcp_resources`) ships alongside the read tool.
- **MCP-only.** Both tools filter attached connections to `type == "mcp"` (resources are not a `custom_api` concept).
- **No file materialization** (unlike `execute_mcp`): resources are context-to-read, not tabular data. Revisit if a use case needs binary bytes downstream.

## Verification

- **Unit:** `tests/unit/test_mcp_resource_helpers.py` — content formatting (text join, binary placeholder, truncation) and connection selection (auto/ambiguous/by-id/by-name/not-found). The risky pure logic is extracted into a dependency-free helper (`_mcp_resource_helpers.py`), mirroring `_search_mcps_query.py`. **20 passed** in the full pytest harness (sqlite, alembic up).
- **Registry:** confirmed `list_mcp_resources` and `read_mcp_resource` register as `category=research`.
- **Live client (read-only):** exercised the real `McpClient` against a `streamable_http` MCP server — `alist_resources()` returned 4 resources, `alist_resource_templates()` returned 1 template, `aread_resource("pulse://rules")` returned ~20 KB markdown, and an unknown URI degraded to `{success: False, error: "Resource not found"}`.
- SDK: `mcp==1.26.0`.