### PR TITLE
fix: prevent 'Cannot use import statement outside a module' in artifact iframe

### DIFF
--- a/backend/app/ai/tools/implementations/_sandbox_context.py
+++ b/backend/app/ai/tools/implementations/_sandbox_context.py
@@ -18,7 +18,12 @@ SANDBOX RUNTIME ENVIRONMENT (pre-loaded globally — do NOT import or redefine)
 
 The generated code runs inside a sandboxed iframe. The following libraries and
 helpers are **already loaded globally** — do NOT import, redefine, or remove
-references to any of them:
+references to any of them.
+
+⚠️  NEVER write `import` statements of any kind. They cause an immediate
+    SyntaxError: "Cannot use import statement outside a module" that breaks
+    the entire dashboard. All globals below are already available — use them
+    directly with no imports.
 
 • **React 18** — `React`, `ReactDOM` available globally
   - Hooks are also global: `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback` — use directly without `React.` prefix

--- a/frontend/public/libs/artifact-globals.js
+++ b/frontend/public/libs/artifact-globals.js
@@ -971,4 +971,38 @@
     } catch (e) { /* non-fatal */ }
   })();
 
+  // ─── Babel sandbox patches ──────────────────────────────────────────────────
+  //
+  // 1. Force Babel to use classic JSX runtime so JSX compiles to React.createElement()
+  //    instead of _jsx() calls (which require react/jsx-runtime, not available here).
+  //
+  // 2. Intercept Node.prototype.appendChild to strip any residual LLM-written
+  //    `import` declarations from the script Babel injects into the DOM — Babel
+  //    transforms JSX but leaves `import` keywords unchanged, causing the browser
+  //    to throw "Cannot use import statement outside a module".
+  (function patchBabel() {
+    // Patch 1: classic JSX runtime
+    if (window.Babel && window.Babel.availablePresets && window.Babel.availablePresets.react) {
+      var _origReact = window.Babel.availablePresets.react;
+      window.Babel.availablePresets.react = function(api, opts, dir) {
+        return _origReact(api, Object.assign({}, opts, { runtime: 'classic' }), dir);
+      };
+    }
+
+    // Patch 2: strip LLM-written imports from Babel's injected script output
+    function stripImports(code) {
+      var s = code.replace(/import\s*\{[^}]*\}\s*from\s*['"][^'"]+['"]\s*;?/g, '');
+      return s.replace(/^[ \t]*import\b(?!\s*\().*$/gm, '');
+    }
+    var _origAppendChild = Node.prototype.appendChild;
+    Node.prototype.appendChild = function(node) {
+      if (node && node.nodeType === 1 && node.tagName === 'SCRIPT' &&
+          !node.getAttribute('src') && !node.getAttribute('type') &&
+          node.textContent && /\bimport\b/.test(node.textContent)) {
+        node.textContent = stripImports(node.textContent);
+      }
+      return _origAppendChild.call(this, node);
+    };
+  })();
+
 })();


### PR DESCRIPTION
## Summary

- **Root cause:** LLM-generated artifact code sometimes includes ES6 `import` statements (e.g. `import React from 'react'`, compact `import{useState}from'react'`) inside `<script type="text/babel">`. Babel transforms JSX but leaves `import` unchanged, then appends the result as a plain `<script>` — the browser throws "Cannot use import statement outside a module". With Babel's automatic JSX runtime the error compounds: Babel also emits `import { jsx as _jsx } from 'react/jsx-runtime'` which has no resolver in the sandbox, causing a follow-up "_jsx is not defined" error.
- **Regression window:** ~Jun 11–13 2026, when the InfoPopover/data-bow feature was added. The new prompt complexity causes the LLM to generate TypeScript-style imports more frequently.

## Changes

**`frontend/public/libs/artifact-globals.js`** — two patches applied inside the sandbox iframe:
1. Patch `Babel.availablePresets.react` to force `runtime: 'classic'` so JSX compiles to `React.createElement()` (globally available) instead of `_jsx()` calls that require `react/jsx-runtime`.
2. Patch `Node.prototype.appendChild` to strip any residual LLM-written `import` declarations from the script Babel injects into the DOM — the last line of defense.

**`backend/app/ai/tools/implementations/_sandbox_context.py`** — adds a prominent `⚠️ NEVER write import statements` warning to the LLM prompt so the model is less likely to generate them.

## Why these two approaches

- `window.Babel.transform` patching does **not** work — Babel standalone's auto-processing uses an internal function reference, not the public API.
- `Babel.availablePresets.react` **is** consulted during auto-processing and can be patched.
- `Node.prototype.appendChild` is the unavoidable DOM call (`sve` in Babel's stack) — patching it catches any imports that slip through.

## Test plan

- [ ] Create a new dashboard — verify it renders without console errors
- [ ] Open an existing dashboard that previously showed the error — verify it now renders
- [ ] Confirm no regression in dashboards that were already working

🤖 Generated with [Claude Code](https://claude.com/claude-code)