### PR TITLE
Add query() alias for execute_query on data source clients

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -517,6 +517,16 @@ class QueryCapturingClientWrapper:
             "sql": query[:500] if isinstance(query, str) else None,
         }
 
+    def query(self, query: str, *args, **kwargs):
+        """Alias for execute_query.
+
+        Model-generated code often calls `.query(...)` instead of
+        `.execute_query(...)`. Route it through our own `execute_query` so the
+        call is still captured, timed, and metered — delegating via __getattr__
+        would hit the raw client and bypass all of that instrumentation.
+        """
+        return self.execute_query(query, *args, **kwargs)
+
     def __getattr__(self, name):
         """Delegate all other attributes to the original client."""
         return getattr(self._original, name)

--- a/backend/app/data_sources/clients/base.py
+++ b/backend/app/data_sources/clients/base.py
@@ -78,6 +78,16 @@ class DataSourceClient(ABC):
     def execute_query(self, **kwargs):
         pass
 
+    def query(self, *args, **kwargs):
+        """Alias for execute_query.
+
+        Model-generated code frequently reaches for the shorter, more natural
+        `.query(...)` instead of `.execute_query(...)`. Aliasing here avoids a
+        whole class of `AttributeError: '<Client>' object has no attribute
+        'query'` failures across every connector.
+        """
+        return self.execute_query(*args, **kwargs)
+
     # Async wrappers — offload blocking I/O to a thread so the event loop stays free.
 
     async def atest_connection(self):
@@ -103,6 +113,10 @@ class DataSourceClient(ABC):
 
     async def aexecute_query(self, *args, **kwargs):
         return await asyncio.to_thread(self.execute_query, *args, **kwargs)
+
+    async def aquery(self, *args, **kwargs):
+        """Async alias for aexecute_query (mirrors the sync `query` alias)."""
+        return await self.aexecute_query(*args, **kwargs)
 
     async def awarm_all(self) -> list:
         """Pre-warm any local caches needed before queries. No-op for most clients."""

--- a/backend/tests/unit/test_query_timeout.py
+++ b/backend/tests/unit/test_query_timeout.py
@@ -142,6 +142,28 @@ def test_wrapper_remains_usable_after_a_timeout():
     assert "error" not in timings[1]
 
 
+def test_query_alias_routes_through_instrumented_execute_query():
+    """`.query(...)` is an alias the model often reaches for instead of
+    `.execute_query(...)`. It must go through the wrapper's own execute_query so
+    the call is still captured and timed — not delegated to the raw client."""
+    client = _StubClient(sleep_seconds=0.0)
+    wrapper = _make_wrapper(client, timeout=2)
+    df = wrapper.query("select 1")
+    assert isinstance(df, pd.DataFrame)
+    assert client.calls == 1
+    # Captured + timed exactly as if execute_query had been called directly.
+    assert wrapper._captured_queries == ["select 1"]
+    assert len(wrapper._captured_timings) == 1
+
+
+def test_query_alias_honours_timeout():
+    """The alias inherits the per-query timeout enforcement."""
+    client = _StubClient(sleep_seconds=2.0)
+    wrapper = _make_wrapper(client, timeout=1)
+    with pytest.raises(QueryTimeoutError):
+        wrapper.query("select pg_sleep(2)")
+
+
 def test_non_timeout_exception_does_not_get_timeout_marker():
     client = _StubClient(raise_exc=RuntimeError("syntax error at or near 'FOO'"))
     wrapper = _make_wrapper(client, timeout=2)


### PR DESCRIPTION
## Problem

Model-generated analysis code frequently calls `.query(...)` instead of the documented `.execute_query(...)`, producing repeated runtime failures like:

```
Execution error: 'MSSQLClient' object has no attribute 'query'
```

Because **no** client defined a `query` method, the `QueryCapturingClientWrapper`'s `__getattr__` delegated the attribute lookup to the raw client, which raised `AttributeError`. This affected *every* connector — MSSQL is just where it happened to surface.

## Fix

Add `query` as an alias for `execute_query`:

- **`DataSourceClient` base** — adds `query` / `aquery` aliases so every connector inherits them, forwarding to `execute_query` / `aexecute_query`.
- **`QueryCapturingClientWrapper`** — adds a `query` method that routes through the wrapper's **own** instrumented `execute_query`. This matters: relying only on the base alias would let `.query()` fall through `__getattr__` to the raw client and bypass query capture, the per-query timeout, and usage metering.

## Tests

- Added two unit tests in `test_query_timeout.py` confirming `.query()` is captured/timed identically to `.execute_query()` and honors the timeout.
- Full `test_query_timeout.py` suite passes (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBjGP6oi2HYdxK6u7HQoUZ)_