### PR TITLE
Knowledge Explorer: primary instruction management, training session & agent modal editor

### DIFF
--- a/backend/app/services/demo_data_source_service.py
+++ b/backend/app/services/demo_data_source_service.py
@@ -296,21 +296,31 @@ class DemoDataSourceService:
             
             created_count = 0
             for instruction_text in demo.instructions:
+                # Scope each demo instruction to THIS newly created data source.
+                # (Do NOT pass force_global — these must stay associated with the
+                # demo agent, not leak in as global/all-agent instructions.)
                 instruction_data = InstructionCreate(
                     text=instruction_text,
                     data_source_ids=[data_source.id],
                     category="general",
                 )
-                
-                await instruction_service.create_instruction(
+
+                created = await instruction_service.create_instruction(
                     db=db,
                     instruction_data=instruction_data,
                     current_user=current_user,
                     organization=organization,
-                    force_global=True,  # Make them global/approved so they're active immediately
                     build=demo_build,  # Use shared build
                     auto_finalize=False,  # Don't finalize yet
                 )
+
+                # Safety net: guarantee the association exists even if a future
+                # build/version flow change ever drops it.
+                try:
+                    if created is not None and not any(str(ds.id) == str(data_source.id) for ds in (created.data_sources or [])):
+                        await instruction_service._associate_data_sources(db, created, [data_source.id])
+                except Exception as assoc_error:
+                    logger.warning(f"Failed to ensure demo instruction association: {assoc_error}")
                 created_count += 1
             
             # === Finalize Build ===

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -276,9 +276,9 @@
               </div>
             </div>
             <template v-else-if="agentDetail?.primary_instruction">
-              <div class="flex items-center justify-between gap-2 mb-1.5">
-                <span class="text-sm font-medium text-gray-800">{{ agentDetail.primary_instruction.title || 'Primary instruction' }}</span>
-                <button v-if="agentCanUpdate" class="text-[11px] text-blue-600 hover:underline" @click="startEditPrimary">Edit</button>
+              <div v-if="agentCanUpdate" class="flex items-center justify-end gap-3 mb-1.5">
+                <PrimaryInstructionPicker :agent-id="agentView.agentId" :current-instruction-id="agentDetail.primary_instruction.id" label="Change" @select="onSelectExistingPrimary" />
+                <button class="text-[11px] text-blue-600 hover:underline" @click="startEditPrimary">Edit</button>
               </div>
               <InstructionText :text="agentDetail.primary_instruction.text" :references="agentDetail.primary_instruction.references || []" :prose="true" :markdown="true" />
             </template>
@@ -292,6 +292,9 @@
                 <button class="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg bg-blue-600 text-white text-xs font-medium hover:bg-blue-700 transition-colors" @click="startCreatePrimary"><UIcon name="i-heroicons-plus" class="w-3.5 h-3.5" />Add primary instruction</button>
                 <span class="text-xs text-gray-400">or</span>
                 <PrimaryInstructionPicker :agent-id="agentView.agentId" label="select existing" @select="onSelectExistingPrimary" />
+              </div>
+              <div v-if="agentCanStartTraining" class="mt-3">
+                <button class="text-xs text-sky-600 hover:underline inline-flex items-center gap-1" @click="startTrainingSessionForAgent(agentView.agentId)"><UIcon name="i-heroicons-academic-cap" class="w-3.5 h-3.5" />Start a training session</button>
               </div>
             </div>
 
@@ -567,6 +570,9 @@
                     <span v-if="(detail.data_sources || []).length === 0" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 text-gray-600 text-[11px]"><UIcon name="i-heroicons-globe-alt" class="w-3 h-3 text-gray-400" />All agents</span>
                     <span v-for="ds in detail.data_sources" :key="ds.id" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 text-gray-600 text-[11px]"><DataSourceIcon :type="ds.type" class="w-3 h-3" />{{ ds.name }}</span>
                   </template>
+                  <!-- Primary: only when scoped to a single agent -->
+                  <KSelect v-if="metaEditable && singleAgentId && !creating" v-model="primarySelectValue" :options="primaryOpts" icon="i-heroicons-star" />
+                  <span v-else-if="!metaEditable && (detail?.primary_for || []).length" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-amber-50 text-amber-700 text-[11px] font-medium"><UIcon name="i-heroicons-star" class="w-3 h-3" />Primary</span>
                   <!-- References -->
                   <span v-for="(r, i) in draft.references" :key="'ref'+i" class="inline-flex items-center gap-1 pl-2 h-7 rounded-md bg-gray-100 text-gray-600 text-[11px] font-mono" :class="metaEditable ? 'pr-1' : 'pr-2'">
                     <UIcon :name="h.getRefIcon(r.object_type)" class="w-3 h-3 text-gray-400" />{{ r.display_text || r.object_id }}
@@ -753,9 +759,13 @@ import DiffMatchPatch from 'diff-match-patch'
 import { useCan, useCanAny } from '~/composables/usePermissions'
 import { useConnectionSignIn } from '~/composables/useConnectionSignIn'
 import { useInstructionHelpers, type Instruction } from '~/composables/useInstructionHelpers'
+import { useOrgSettings } from '~/composables/useOrgSettings'
 
 const h = useInstructionHelpers()
 const toast = useToast()
+// Training mode is gated by org setting + permission (mirrors the legacy agents page).
+const { isTrainingModeEnabled } = useOrgSettings()
+const agentCanStartTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
 
 // ── State ───────────────────────────────────────────────
 const allInstructions = ref<Instruction[]>([])
@@ -832,6 +842,41 @@ const loadOpts = [{ value: 'always', label: 'Always' }, { value: 'intelligent', 
 const sourceOpts = [{ value: 'user', label: 'User' }, { value: 'ai', label: 'AI' }, { value: 'git', label: 'Git' }]
 const categoryOpts = computed(() => categories.value.filter(c => c !== 'dashboard').map(c => ({ value: c, label: h.formatCategory(c) })))
 const agentOpts = computed(() => agents.value.map(a => ({ value: a.id, label: a.name, type: a.type })))
+
+// Primary instruction toggle — only meaningful when the instruction is scoped to
+// exactly one agent. `primary_for` (from the API) lists data sources whose
+// primary_instruction_id points at this instruction.
+const singleAgentId = computed(() => draft.data_source_ids.length === 1 ? draft.data_source_ids[0] : null)
+const primaryOpts = [{ value: 'primary', label: 'Primary' }, { value: 'standard', label: 'Not primary' }]
+const settingPrimary = ref(false)
+const primarySelectValue = computed<string>({
+  get: () => {
+    const aid = singleAgentId.value
+    if (!aid) return 'standard'
+    return ((detail.value as any)?.primary_for || []).some((d: any) => String(d.id) === String(aid)) ? 'primary' : 'standard'
+  },
+  set: (val) => { setPrimaryForSingleAgent(val === 'primary') },
+})
+const setPrimaryForSingleAgent = async (makePrimary: boolean) => {
+  const aid = singleAgentId.value
+  const iid = detail.value?.id
+  if (!aid || !iid || settingPrimary.value) return
+  settingPrimary.value = true
+  try {
+    await useMyFetch(`/data_sources/${aid}`, { method: 'PUT', body: { primary_instruction_id: makePrimary ? iid : null } })
+    const d = detail.value as any
+    if (makePrimary) {
+      if (!(d.primary_for || []).some((x: any) => String(x.id) === String(aid))) {
+        d.primary_for = [...(d.primary_for || []), { id: aid, name: agents.value.find(a => a.id === aid)?.name || '' }]
+      }
+    } else {
+      d.primary_for = (d.primary_for || []).filter((x: any) => String(x.id) !== String(aid))
+    }
+    // Keep the agent panel in sync if it's open for this agent.
+    if (agentView.value?.agentId === aid) await refreshAgentDetail()
+    toast.add({ title: 'Saved', color: 'green' })
+  } catch (e: any) { toast.add({ title: 'Error', description: e?.message, color: 'red' }) } finally { settingPrimary.value = false }
+}
 
 // right-pane panel for Tables/Tools/Evals/Settings
 const panelView = ref<null | { kind: 'tables' | 'tools' | 'evals' | 'settings'; agentId: string }>(null)
@@ -925,6 +970,21 @@ const createReportForAgent = async (id: string) => {
     const rid = (data.value as any)?.id
     if (error.value || !rid) throw new Error('Failed to create report')
     navigateTo(`/reports/${rid}`)
+  } catch (e: any) { toast.add({ title: 'Error', description: e?.message, color: 'red' }) }
+}
+// Start a training session for an agent: a new report scoped to ONLY this
+// agent/data source, switched to training mode, with a pre-filled (non-submitting)
+// prompt — mirrors the legacy agents page.
+const startTrainingSessionForAgent = async (agentId: string) => {
+  if (!agentId) return
+  const prompt = 'I need to update the instruction for this agent with '
+  try {
+    const { data, error } = await useMyFetch<any>('/reports', { method: 'POST', body: { title: 'Training session', data_sources: [agentId] } })
+    const rid = (data.value as any)?.id
+    if (error.value || !rid) throw new Error('Failed to create report')
+    const { error: modeErr } = await useMyFetch(`/reports/${rid}`, { method: 'PUT', body: { mode: 'training' } })
+    if (modeErr.value) throw new Error(String(modeErr.value))
+    await navigateTo({ path: `/reports/${rid}`, query: { prompt } })
   } catch (e: any) { toast.add({ title: 'Error', description: e?.message, color: 'red' }) }
 }
 // description inline edit

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -107,23 +107,6 @@
               <span class="text-xs text-gray-700">Use LLM to learn agent</span>
             </div>
 
-            <!-- Channel availability -->
-            <div v-if="connectedChannels.length > 0" class="mb-4">
-              <label class="block text-xs font-medium text-gray-700 mb-1">Available in channels</label>
-              <p class="text-[11px] text-gray-400 mb-2">Choose which connected channels can query this agent. Disabled channels won't see it.</p>
-              <div class="space-y-2">
-                <div v-for="ch in connectedChannels" :key="ch.key" class="flex items-center gap-2">
-                  <UToggle v-model="channelAvailability[ch.key]" :disabled="creatingFromConnection" size="xs" color="blue" />
-                  <span class="inline-flex items-center gap-1.5 text-xs text-gray-700">
-                    <img v-if="channelIcon(ch.key).img" :src="channelIcon(ch.key).img" :alt="ch.name" class="w-3.5 h-3.5" />
-                    <McpIcon v-else-if="channelIcon(ch.key).mcp" class="w-3.5 h-3.5 text-gray-600" />
-                    <UIcon v-else :name="channelIcon(ch.key).uicon" class="w-3.5 h-3.5 text-gray-500" />
-                    {{ ch.name }}
-                  </span>
-                </div>
-              </div>
-            </div>
-
             <div v-if="errorMessage" class="p-3 bg-red-50 text-red-700 rounded-lg text-sm mb-4">
               {{ errorMessage }}
             </div>
@@ -181,80 +164,21 @@
             <h3 class="text-base font-semibold text-gray-900 mb-1">Add custom AI rules and instructions</h3>
             <p class="text-sm text-gray-500 mb-3">Business-specific context, glossary, and useful code guidelines.</p>
 
-            <!-- outer wrapper is relative so dropdown can overflow the border box -->
-            <div class="relative">
-              <div class="border border-gray-200 focus-within:ring-2 focus-within:ring-blue-100 focus-within:border-blue-400">
-                <!-- Loading overlay -->
-                <div v-if="loadingDraft" class="flex items-center justify-center gap-2 py-10 text-xs text-gray-400">
-                  <Spinner class="w-4 h-4" />
-                  <span>Generating overview instruction…</span>
-                </div>
-
-                <div v-else class="mention-container">
-                  <!-- Highlight backdrop -->
-                  <div ref="backdropRef" class="mention-backdrop" aria-hidden="true" v-html="highlightedText" />
-
-                  <!-- Textarea -->
-                  <textarea
-                    ref="textareaRef"
-                    v-model="instructionText"
-                    placeholder="Describe business rules, metric definitions, or query guidelines…"
-                    class="mention-textarea"
-                    @input="handleTextareaInput"
-                    @keydown="handleTextareaKeydown"
-                    @blur="handleTextareaBlur"
-                    @scroll="syncScroll"
-                  />
-                </div>
+            <div class="border border-gray-200 rounded-md px-3 py-2 focus-within:ring-2 focus-within:ring-blue-100 focus-within:border-blue-400">
+              <!-- Loading overlay -->
+              <div v-if="loadingDraft" class="flex items-center justify-center gap-2 py-10 text-xs text-gray-400">
+                <Spinner class="w-4 h-4" />
+                <span>Generating overview instruction…</span>
               </div>
 
-              <!-- @ Mention dropdown — outside overflow container so it can spill out -->
-              <div
-                v-if="mentionState.active && (filteredMentionItems.length > 0 || mentionState.query.length < 5)"
-                ref="mentionDropdownRef"
-                class="absolute z-50 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto w-80"
-                :style="mentionDropdownStyle"
-              >
-                <div v-if="filteredMentionItems.length === 0" class="px-3 py-2 text-xs text-gray-500">
-                  Type to search…
-                </div>
-                <button
-                  v-for="(item, index) in filteredMentionItems"
-                  :key="item.id"
-                  type="button"
-                  :data-mention-idx="index"
-                  class="w-full text-start px-3 py-2 text-xs hover:bg-gray-50 flex items-start gap-2 border-b border-gray-100 last:border-0"
-                  :class="{ 'bg-blue-50': index === mentionState.selectedIndex }"
-                  @mousedown.prevent="selectMention(item)"
-                >
-                  <template v-if="item.type === 'instruction'">
-                    <Icon name="heroicons:cube" class="w-3.5 h-3.5 mt-0.5 shrink-0 text-indigo-500" />
-                  </template>
-                  <template v-else-if="item.type === 'connection_tool'">
-                    <span class="relative inline-flex shrink-0 mt-0.5">
-                      <DataSourceIcon v-if="item.dataSourceType" :type="item.dataSourceType" class="h-3.5" />
-                      <Icon v-else name="heroicons:table-cells" class="w-3.5 h-3.5 text-blue-500" />
-                      <Icon name="heroicons:wrench-screwdriver" class="absolute -bottom-0.5 -right-1 w-2 h-2 text-indigo-400" />
-                    </span>
-                  </template>
-                  <template v-else>
-                    <Icon name="heroicons:table-cells" class="w-3.5 h-3.5 mt-0.5 shrink-0 text-blue-500" />
-                  </template>
-                  <div class="flex-1 min-w-0">
-                    <template v-if="item.type === 'instruction'">
-                      <span v-if="item.name" class="font-mono font-medium text-gray-900 block">{{ item.name }}</span>
-                      <span v-else class="text-gray-700 truncate block">"{{ item.textPreview?.slice(0, 30) }}..."</span>
-                    </template>
-                    <template v-else>
-                      <span class="font-mono font-medium text-gray-900 block">{{ item.name }}</span>
-                      <div class="flex items-center gap-1 mt-0.5">
-                        <DataSourceIcon v-if="item.dataSourceType && item.type !== 'connection_tool'" :type="item.dataSourceType" class="h-2.5" />
-                        <span class="text-[10px] text-gray-500">{{ item.dataSourceName }}</span>
-                      </div>
-                    </template>
-                  </div>
-                </button>
-              </div>
+              <InstructionEditor
+                v-else
+                v-model="instructionText"
+                mode="wysiwyg"
+                :editable="true"
+                :data-source-ids="dsId ? [dsId] : []"
+                placeholder="Describe business rules, metric definitions, or query guidelines… (type @ to mention a table or instruction)"
+              />
             </div>
           </div>
 
@@ -289,7 +213,7 @@ import AddConnectionModal from '~/components/AddConnectionModal.vue'
 import GitRepoModalComponent from '@/components/GitRepoModalComponent.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import GitBranchIcon from '~/components/icons/GitBranchIcon.vue'
-import McpIcon from '~/components/icons/McpIcon.vue'
+import InstructionEditor from '~/components/instructions/InstructionEditor.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits<{
@@ -335,10 +259,7 @@ watch(isOpen, (val) => {
     instructionText.value = ''
     draftInstructionId.value = null
     integration.value = null
-    connectedChannels.value = []
-    channelAvailability.value = {}
     loadConnections()
-    loadChannels()
   }
 })
 
@@ -359,36 +280,6 @@ const useLlmSync = ref(true)
 const creatingFromConnection = ref(false)
 const errorMessage = ref('')
 const showAddConnectionModal = ref(false)
-
-// ── Channel availability ──────────────────────────────────────────────────────
-interface ChannelInfo { key: string; name: string; connected: boolean }
-const connectedChannels = ref<ChannelInfo[]>([])
-const channelAvailability = ref<Record<string, boolean>>({})
-
-function channelIcon(key: string): { img?: string; mcp?: boolean; uicon?: string } {
-  switch (key) {
-    case 'slack': return { img: '/icons/slack.png' }
-    case 'teams': return { img: '/icons/teams.png' }
-    case 'whatsapp': return { img: '/icons/whatsapp.png' }
-    case 'email': return { uicon: 'i-heroicons-envelope' }
-    case 'mcp': return { mcp: true }
-    default: return { uicon: 'i-heroicons-chat-bubble-left-right' }
-  }
-}
-
-async function loadChannels() {
-  try {
-    const response = await useMyFetch('/data_sources/connected_channels', { method: 'GET' })
-    const all = (response.data.value || []) as ChannelInfo[]
-    connectedChannels.value = all.filter(c => c.connected)
-    // Default every connected channel to available.
-    const avail: Record<string, boolean> = {}
-    for (const c of connectedChannels.value) avail[c.key] = true
-    channelAvailability.value = avail
-  } catch (err) {
-    connectedChannels.value = []
-  }
-}
 
 const canSubmitExisting = computed(() =>
   selectedConnections.value.length > 0 &&
@@ -436,18 +327,6 @@ async function createAgentFromExistingConnection() {
       generate_conversation_starters: false,
       generate_ai_rules: false,
     }
-    // Only send channel_availability when channels exist and at least one is
-    // turned off — a null map means "available everywhere" (the default).
-    if (connectedChannels.value.length > 0) {
-      const map: Record<string, boolean> = {}
-      let anyOff = false
-      for (const c of connectedChannels.value) {
-        const enabled = channelAvailability.value[c.key] !== false
-        map[c.key] = enabled
-        if (!enabled) anyOff = true
-      }
-      if (anyOff) payload.channel_availability = map
-    }
     const response = await useMyFetch('/data_sources', { method: 'POST', body: payload })
     if (response.error.value) {
       const errData = (response.error.value as any).data as any
@@ -481,8 +360,6 @@ watch(step, (s) => {
   if (s === 'context') {
     fetchIntegration()
     loadDraftInstruction()
-    fetchAllMentionItems()
-    fetchMentionItems()
   }
 })
 
@@ -510,195 +387,6 @@ async function loadDraftInstruction() {
   } catch {} finally {
     loadingDraft.value = false
   }
-}
-
-// ── @ Mention ───────────────────────────────────────────────────────────────
-interface MentionItem {
-  id: string
-  type: 'instruction' | 'metadata_resource' | 'datasource_table' | 'connection_tool'
-  name: string | null
-  textPreview: string | null
-  dataSourceId: string | null
-  dataSourceName: string | null
-  dataSourceType: string | null
-}
-
-const textareaRef = ref<HTMLTextAreaElement | null>(null)
-const backdropRef = ref<HTMLDivElement | null>(null)
-const mentionDropdownRef = ref<HTMLDivElement | null>(null)
-
-const allMentionItems = ref<MentionItem[]>([])
-const mentionSearchResults = ref<MentionItem[]>([])
-const isFetchingMentions = ref(false)
-
-const mentionState = ref({
-  active: false,
-  query: '',
-  startPos: 0,
-  selectedIndex: 0,
-  top: 0,
-  left: 0,
-})
-
-const filteredMentionItems = computed(() => {
-  const instructions = mentionSearchResults.value.filter(i => i.type === 'instruction').slice(0, 3)
-  const tables = mentionSearchResults.value.filter(i => i.type === 'datasource_table' || i.type === 'metadata_resource').slice(0, 3)
-  const tools = mentionSearchResults.value.filter(i => i.type === 'connection_tool').slice(0, 3)
-  return [...instructions, ...tables, ...tools]
-})
-
-const mentionDropdownStyle = computed(() => ({
-  top: `${mentionState.value.top}px`,
-  left: `${mentionState.value.left}px`,
-}))
-
-const fetchAllMentionItems = async () => {
-  try {
-    const params = new URLSearchParams()
-    params.set('types', 'instruction,datasource_table,metadata_resource,connection_tool')
-    params.set('data_source_filter', dsId.value)
-    const { data, error } = await useMyFetch<any[]>(`/instructions/available-references?${params}`, { method: 'GET' })
-    if (!error.value && data.value) {
-      allMentionItems.value = data.value.map(item => ({
-        id: item.id, type: item.type, name: item.name, textPreview: item.text_preview || null,
-        dataSourceId: item.data_source_id, dataSourceName: item.data_source_name, dataSourceType: item.data_source_type
-      }))
-    }
-  } catch {}
-}
-
-const fetchMentionItems = async (query?: string) => {
-  isFetchingMentions.value = true
-  try {
-    const params = new URLSearchParams()
-    if (query) params.set('q', query)
-    params.set('types', 'instruction,datasource_table,metadata_resource,connection_tool')
-    params.set('data_source_filter', dsId.value)
-    const { data, error } = await useMyFetch<any[]>(`/instructions/available-references?${params}`, { method: 'GET' })
-    if (!error.value && data.value) {
-      mentionSearchResults.value = data.value.map(item => ({
-        id: item.id, type: item.type, name: item.name, textPreview: item.text_preview || null,
-        dataSourceId: item.data_source_id, dataSourceName: item.data_source_name, dataSourceType: item.data_source_type
-      }))
-    }
-  } catch {} finally {
-    isFetchingMentions.value = false
-  }
-}
-
-let mentionFetchTimeout: ReturnType<typeof setTimeout> | null = null
-watch(() => mentionState.value.query, (q) => {
-  if (mentionFetchTimeout) clearTimeout(mentionFetchTimeout)
-  mentionFetchTimeout = setTimeout(() => fetchMentionItems(q), 150)
-})
-
-const isKnownMention = (text: string) => {
-  const lower = text.toLowerCase()
-  return allMentionItems.value.some(item => {
-    if (item.name?.toLowerCase() === lower) return true
-    if (item.type === 'instruction' && item.textPreview) {
-      if ((item.textPreview.slice(0, 30) + '...').toLowerCase() === lower) return true
-    }
-    return false
-  })
-}
-
-const highlightedText = computed(() => {
-  const text = instructionText.value
-  if (!text) return ''
-  let html = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  html = html.replace(/@([A-Za-z_][A-Za-z0-9_]*|"[^"]+")/g, (match, captured) => {
-    let name = captured
-    if (name.startsWith('"') && name.endsWith('"')) name = name.slice(1, -1)
-    if (isKnownMention(name)) {
-      return `<mark style="background-color: rgba(99,102,241,0.12); color: transparent; border-radius: 3px; padding: 0;">${match}</mark>`
-    }
-    return match
-  })
-  return html + '\n'
-})
-
-const syncScroll = (e: Event) => {
-  const ta = e.target as HTMLTextAreaElement
-  if (backdropRef.value) backdropRef.value.scrollTop = ta.scrollTop
-}
-
-const handleTextareaInput = (e: Event) => {
-  const ta = e.target as HTMLTextAreaElement
-  const text = ta.value
-  const cursorPos = ta.selectionStart
-  const textBeforeCursor = text.slice(0, cursorPos)
-  const atIndex = textBeforeCursor.lastIndexOf('@')
-
-  if (atIndex !== -1) {
-    const textAfterAt = textBeforeCursor.slice(atIndex + 1)
-    if (!textAfterAt.includes('\n') && !textAfterAt.includes('  ') && textAfterAt.length <= 50) {
-      const lines = textBeforeCursor.split('\n')
-      const lineIndex = lines.length - 1
-      mentionState.value = {
-        active: true, query: textAfterAt, startPos: atIndex, selectedIndex: 0,
-        top: (lineIndex + 1) * 18 + 16,
-        left: Math.min((lines[lineIndex].length - textAfterAt.length) * 7 + 16, 200),
-      }
-      return
-    }
-  }
-  if (mentionState.value.active) mentionState.value.active = false
-}
-
-const scrollMentionIntoView = () => {
-  if (!mentionDropdownRef.value) return
-  const container = mentionDropdownRef.value
-  const el = container.querySelector(`[data-mention-idx="${mentionState.value.selectedIndex}"]`) as HTMLElement | null
-  if (!el) return
-  const top = container.scrollTop, bottom = top + container.clientHeight
-  if (el.offsetTop < top) container.scrollTop = el.offsetTop
-  else if (el.offsetTop + el.offsetHeight > bottom) container.scrollTop = el.offsetTop + el.offsetHeight - container.clientHeight
-}
-
-const handleTextareaKeydown = (e: KeyboardEvent) => {
-  if (!mentionState.value.active) return
-  const items = filteredMentionItems.value
-  if (e.key === 'ArrowDown') {
-    e.preventDefault()
-    mentionState.value.selectedIndex = Math.min(mentionState.value.selectedIndex + 1, items.length - 1)
-    nextTick(scrollMentionIntoView)
-  } else if (e.key === 'ArrowUp') {
-    e.preventDefault()
-    mentionState.value.selectedIndex = Math.max(mentionState.value.selectedIndex - 1, 0)
-    nextTick(scrollMentionIntoView)
-  } else if (e.key === 'Enter' || e.key === 'Tab') {
-    if (items.length > 0) { e.preventDefault(); selectMention(items[mentionState.value.selectedIndex]) }
-  } else if (e.key === 'Escape') {
-    e.preventDefault(); mentionState.value.active = false
-  }
-}
-
-const handleTextareaBlur = () => setTimeout(() => { mentionState.value.active = false }, 150)
-
-const needsQuotes = (name: string | null) => name && /[\s\-.]/.test(name)
-
-const selectMention = (item: MentionItem) => {
-  const ta = textareaRef.value
-  if (!ta) return
-  const { startPos, query } = mentionState.value
-  let mentionText: string
-  if (!item.name) {
-    mentionText = `@"${item.textPreview?.slice(0, 30)}..."`
-  } else if (needsQuotes(item.name)) {
-    mentionText = `@"${item.name}"`
-  } else {
-    mentionText = `@${item.name}`
-  }
-  const before = instructionText.value.slice(0, startPos)
-  const after = instructionText.value.slice(startPos + 1 + query.length)
-  instructionText.value = before + mentionText + ' ' + after
-  mentionState.value.active = false
-  nextTick(() => {
-    ta.focus()
-    const pos = startPos + mentionText.length + 1
-    ta.setSelectionRange(pos, pos)
-  })
 }
 
 // ── Save (final step) ───────────────────────────────────────────────────────
@@ -752,53 +440,7 @@ async function handleSave() {
 </script>
 
 <style scoped>
-.mention-container {
-  position: relative;
-}
-
-.mention-backdrop,
-.mention-textarea {
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  font-size: 12px;
-  line-height: 1.625;
-  padding: 16px;
-  margin: 0;
-  border: 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  letter-spacing: normal;
-  word-spacing: normal;
-}
-
-.mention-backdrop {
-  position: absolute;
-  inset: 0;
-  color: transparent;
-  pointer-events: none;
-  overflow: hidden;
-  background: transparent;
-}
-
-.mention-textarea {
-  position: relative;
-  z-index: 1;
-  width: 100%;
+.instruction-wysiwyg {
   min-height: 280px;
-  resize: vertical;
-  background: transparent;
-  caret-color: #111827;
-  outline: none;
-}
-
-.mention-textarea::placeholder {
-  color: #9ca3af;
-}
-
-.mention-backdrop :deep(mark) {
-  color: transparent;
-  border-radius: 3px;
-  padding: 2px 0;
-  box-decoration-break: clone;
 }
 </style>


### PR DESCRIPTION
Follow-up to #390 (already merged). Builds on the Knowledge Explorer.

## Changes

### Create Data Agent modal (`NewAgentWizardModal.vue`)
- Replace the custom textarea/@-mention editor with the shared `InstructionEditor` (WYSIWYG) used in `/agents`.
- Remove the "Available in channels" section from the new-agent flow.

### Knowledge Explorer (`KnowledgeExplorer.vue`)
- **Easier primary instruction management:** drop the redundant "Primary instruction" heading in the agent view and add a **Change** picker to swap the primary instruction inline.
- **Primary selector for single-agent instructions:** when an instruction is scoped to exactly one agent, show a **Primary / Not primary** selector that sets/clears that agent's `primary_instruction_id` (read from the existing `primary_for` field).
- **Training session:** when there is no primary instruction, offer **Start a training session** (training-mode gated) — creates a report scoped to only that agent, in training mode, with a pre-filled prompt.

### Demo data source (`demo_data_source_service.py`)
- Scope auto instructions to the newly created data source and drop the misleading `force_global` flag; add a safety net to guarantee the association.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159pLq2tcZcDDi9tRMgzNw3)_