### PR TITLE
Review tab: durable dismiss, consistent count, no flicker, eval-gated actions

### DIFF
--- a/backend/app/services/review_producers.py
+++ b/backend/app/services/review_producers.py
@@ -64,6 +64,7 @@ async def scan_slow_queries(db: AsyncSession, organization_id: str, *,
             why=f"{count} data quer{'y' if count == 1 else 'ies'} on this agent ran over {secs}s in the last {days}d. Consider a guardrail instruction or an index.",
             group_key=f"slow_query:{ds_id}", occurrences=count,
             subject={"kind": "query_group", "threshold_ms": threshold_ms, "window_hours": window_hours},
+            respect_dismissal=True, resurface_after_hours=window_hours,
         )
         n += 1
     return n
@@ -100,6 +101,7 @@ async def scan_low_confidence(db: AsyncSession, organization_id: str, *,
             why=f"{count} answer{' was' if count == 1 else 's were'} scored below 3/5 on this agent in the last {days}d. Run training to close the gaps.",
             group_key=f"low_confidence:{ds_id}", occurrences=count,
             subject={"kind": "low_confidence", "window_hours": window_hours},
+            respect_dismissal=True, resurface_after_hours=window_hours,
         )
         n += 1
     return n
@@ -365,6 +367,7 @@ async def emit_schema_changed(db, organization_id: str, data_source_id: str, *,
         why=summary or "Tables or columns changed on this connection. Re-run evals or training to keep instructions accurate.",
         group_key=f"schema_changed:{data_source_id}",
         subject={"kind": "schema", "summary": summary},
+        respect_dismissal=True, resurface_after_hours=DEFAULT_WINDOW_HOURS,
     )
 
 

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -67,7 +67,7 @@ def actions_for(item: ReviewItem) -> List[Dict[str, Any]]:
     return menu
 
 
-def to_dict(item: ReviewItem) -> Dict[str, Any]:
+def to_dict(item: ReviewItem, *, agent_has_evals: Optional[bool] = None) -> Dict[str, Any]:
     return {
         "id": str(item.id),
         "type": item.type,
@@ -79,6 +79,9 @@ def to_dict(item: ReviewItem) -> Dict[str, Any]:
         "subject": item.subject_json or {},
         "group_count": item.group_count,
         "agent_id": str(item.data_source_id) if item.data_source_id else None,
+        # Whether the item's agent has any active eval to run/train against —
+        # drives whether run_eval/run_training are offered. None = N/A (global).
+        "agent_has_evals": agent_has_evals,
         "resolution": item.resolution_json,
         "spawned": item.spawned_json or [],
         "source_run_id": item.source_run_id,
@@ -88,6 +91,32 @@ def to_dict(item: ReviewItem) -> Dict[str, Any]:
         "last_seen_at": (item.last_seen_at or item.created_at).isoformat() if (item.last_seen_at or item.created_at) else None,
         "actions": actions_for(item),
     }
+
+
+async def _agents_with_active_evals(db: AsyncSession, organization_id: str) -> tuple[bool, set[str]]:
+    """(any_auto_eval, {agent_id, …}) over active eval cases in the org. An
+    Auto/empty-scope case applies to *every* agent (like a global instruction),
+    so it's tracked separately."""
+    from app.models.eval import TestCase, TestSuite, TEST_CASE_STATUS_ACTIVE
+    rows = (await db.execute(
+        select(TestCase.data_source_ids_json)
+        .join(TestSuite, TestSuite.id == TestCase.suite_id)
+        .where(and_(
+            TestSuite.organization_id == str(organization_id),
+            TestCase.deleted_at.is_(None),
+            TestCase.status == TEST_CASE_STATUS_ACTIVE,
+        ))
+    )).all()
+    any_auto = False
+    agents: set[str] = set()
+    for (ds_ids_json,) in rows:
+        ds_list = ds_ids_json or []
+        if isinstance(ds_list, list) and len(ds_list) > 0:
+            for x in ds_list:
+                agents.add(str(x))
+        else:
+            any_auto = True
+    return any_auto, agents
 
 
 class ReviewService:
@@ -295,7 +324,18 @@ class ReviewService:
             -((r.last_seen_at or r.created_at or datetime.min).timestamp()),
         ))
         unread = sum(1 for r in rows if r.read_at is None and r.status in (STATUS_OPEN, STATUS_IN_PROGRESS))
-        return {"items": [to_dict(r) for r in rows], "total": len(rows), "unread": unread}
+        # Gate run_eval/run_training on whether the agent actually has evals.
+        any_auto, agents_with_evals = await _agents_with_active_evals(db, str(organization.id))
+
+        def _has_evals(r: ReviewItem) -> Optional[bool]:
+            if r.data_source_id is None:
+                return None  # global item — eval actions don't apply
+            return any_auto or str(r.data_source_id) in agents_with_evals
+
+        return {
+            "items": [to_dict(r, agent_has_evals=_has_evals(r)) for r in rows],
+            "total": len(rows), "unread": unread,
+        }
 
     async def count_open(self, db, organization, user) -> Dict[str, int]:
         res = await self.list_items(db, organization, user)
@@ -367,6 +407,20 @@ class ReviewService:
         if kind in ("run_eval", "run_training"):
             if not item.data_source_id:
                 return {"ok": False, "error": "no_agent"}
+            # Pre-flight: both run_eval and run_training measure against the
+            # agent's eval suite (training is eval-driven), so with no active
+            # evals the workflow is a guaranteed no-op. Reject synchronously
+            # with a clear reason instead of spinning up a run that resolves to
+            # "no_evals" and silently marks the item done.
+            from app.services.agent_reliability_service import AgentReliabilityService
+            case_ids = await AgentReliabilityService().list_agent_eval_case_ids(
+                db, str(organization.id), str(item.data_source_id)
+            )
+            if not case_ids:
+                return {
+                    "ok": False, "error": "no_evals",
+                    "message": "No active evals are scoped to this agent. Add a test case before running an eval or training.",
+                }
             # Fire the existing agent workflow in the background, scoped to THIS
             # agent only (even if the suggestion is shared across agents).
             train_override = "auto" if kind == "run_training" else "off"
@@ -448,14 +502,19 @@ class ReviewService:
                         spawned.append(s)
                     item.spawned_json = spawned
                     item.source_run_id = run_id or item.source_run_id
-                    # Eval/training fired: mark resolved (the loop's own outputs —
-                    # e.g. new suggestions — surface as their own items).
-                    item.status = STATUS_RESOLVED
                     item.resolution_json = {
                         "action": kind, "ref": run_id, "by": user_id,
                         "at": datetime.utcnow().isoformat(), "outcome": outcome_status,
                     }
-                    item.resolved_by_user_id = user_id
+                    # Only a productive outcome resolves the item. A no-op or
+                    # failure (no_evals / skipped / error / gave_up) reopens it so
+                    # it stays actionable instead of showing a misleading green
+                    # "Resolved". The loop's own outputs surface as their own items.
+                    if outcome_status in ("passed", "passed_pending"):
+                        item.status = STATUS_RESOLVED
+                        item.resolved_by_user_id = user_id
+                    else:
+                        item.status = STATUS_OPEN
                     await db.commit()
         except Exception as e:  # noqa: BLE001
             logger.exception("review workflow %s: failed to record outcome: %s", kind, e)

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select, and_, or_, func
@@ -109,12 +109,21 @@ class ReviewService:
         caused_by_id: Optional[str] = None,
         disposition: str = DISPOSITION_NOTIFY,
         occurrences: Optional[int] = None,
-    ) -> ReviewItem:
+        respect_dismissal: bool = False,
+        resurface_after_hours: Optional[int] = None,
+    ) -> Optional[ReviewItem]:
         """Create or bump a review item. At most one ACTIVE item per
         (org, agent, type, group_key) — repeats bump group_count + last_seen.
 
         ``occurrences`` lets a sweep SET the absolute count (recomputed over a
-        window) instead of incrementing by one."""
+        window) instead of incrementing by one.
+
+        ``respect_dismissal`` makes a prior dismissal stick: if the dedup slot
+        has no active item but a recent DISMISSED one, don't resurrect it (so a
+        re-scan/cron doesn't immediately re-create what a human just cleared).
+        ``resurface_after_hours`` lets it come back after that long (None =
+        suppress until the condition's group_key changes). Returns ``None`` when
+        emission is suppressed by a dismissal."""
         now = datetime.utcnow()
         if group_key:
             existing = (
@@ -129,6 +138,25 @@ class ReviewService:
                     )).limit(1)
                 )
             ).scalar_one_or_none()
+            if existing is None and respect_dismissal:
+                dismissed = (
+                    await db.execute(
+                        select(ReviewItem).where(and_(
+                            ReviewItem.organization_id == organization_id,
+                            ReviewItem.data_source_id == data_source_id,
+                            ReviewItem.type == type,
+                            ReviewItem.group_key == group_key,
+                            ReviewItem.status == STATUS_DISMISSED,
+                            ReviewItem.deleted_at.is_(None),
+                        )).order_by(ReviewItem.updated_at.desc()).limit(1)
+                    )
+                ).scalar_one_or_none()
+                if dismissed is not None:
+                    if resurface_after_hours is None:
+                        return None
+                    last = dismissed.updated_at or dismissed.last_seen_at or dismissed.created_at
+                    if last is not None and last >= now - timedelta(hours=resurface_after_hours):
+                        return None
             if existing is not None:
                 existing.group_count = occurrences if occurrences is not None else (existing.group_count or 1) + 1
                 existing.last_seen_at = now

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -182,7 +182,12 @@
       <!-- ── Pane 2: Detail ───────────────────────────── -->
       <section class="flex-1 min-w-0 flex flex-col">
         <!-- Review feed -->
-        <ReviewFeed v-if="reviewView" :agents="agents" :initial-agent-id="reviewView.agentId" @close="closeReview" @count="reviewCount = $event" @open-instruction="openInstructionFromReview" />
+        <div v-if="reviewView" class="relative flex-1 min-h-0 flex flex-col">
+          <ReviewFeed :agents="agents" :initial-agent-id="reviewView.agentId" @close="closeReview" @count="reviewCount = $event" @open-instruction="openInstructionFromReview" />
+          <div v-if="reviewNavLoading" class="absolute inset-0 z-10 flex items-center justify-center bg-white/70 backdrop-blur-[1px]">
+            <UIcon name="i-heroicons-arrow-path" class="w-5 h-5 text-gray-400 animate-spin" />
+          </div>
+        </div>
         <!-- Agent overview -->
         <template v-else-if="agentView">
           <div class="shrink-0 px-6 pt-4 pb-4 border-b border-gray-100">
@@ -1124,11 +1129,20 @@ const openReview = (agentId: string | null = null) => {
   reviewView.value = { agentId }
 }
 // Open an instruction (from a Review item) and surface its pending diff.
+// Resolve the instruction BEFORE swapping panes so the Review feed → detail
+// transition happens in one tick (no flash of the agents list underneath). The
+// Review pane stays mounted with a spinner overlay while we fetch.
+const reviewNavLoading = ref(false)
 const openInstructionFromReview = async (p: { instructionId: string; buildId?: string }) => {
-  closeReview()
   let ins = allInstructions.value.find(i => i.id === p.instructionId)
-  if (!ins) { try { const { data } = await useMyFetch<any>(`/api/instructions/${p.instructionId}`, { method: 'GET' }); ins = data.value } catch {} }
+  if (!ins) {
+    reviewNavLoading.value = true
+    try { const { data } = await useMyFetch<any>(`/api/instructions/${p.instructionId}`, { method: 'GET' }); ins = data.value } catch {}
+    reviewNavLoading.value = false
+  }
+  // openInstruction() closes the Review pane and sets detail synchronously.
   if (ins) openInstruction(ins)
+  else closeReview()
 }
 
 // tree pane resize

--- a/frontend/components/ReviewFeed.vue
+++ b/frontend/components/ReviewFeed.vue
@@ -99,8 +99,9 @@
             <div class="flex items-center gap-1 shrink-0 self-center" @click.stop>
               <template v-if="row.status === 'open' || row.status === 'snoozed'">
                 <button v-for="a in rowActions(row)" :key="a.id"
-                        class="h-7 px-2.5 rounded-md text-[12px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-40 bg-gray-50 hover:bg-gray-100 border border-gray-150 text-gray-700"
-                        :disabled="busy === row.key"
+                        class="h-7 px-2.5 rounded-md text-[12px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed bg-gray-50 hover:bg-gray-100 border border-gray-150 text-gray-700"
+                        :disabled="busy === row.key || !!actionUnavailable(row, a)"
+                        :title="actionUnavailable(row, a) || a.label"
                         @click="runAction(row, a)">
                   <UIcon v-if="busy === row.key" name="i-heroicons-arrow-path" class="w-3.5 h-3.5 animate-spin text-gray-400" />
                   <UIcon v-else-if="a.id === 'run_eval'" name="i-heroicons-beaker" class="w-3.5 h-3.5 text-gray-400" />
@@ -247,6 +248,14 @@ const rowActions = (row: any) => {
   return (row.rep.actions || []).filter((a: any) => a.id !== 'dismiss')
 }
 
+// run_eval/run_training need the agent to have at least one active eval; the
+// backend reports this per item. Returns a reason string when unavailable.
+const actionUnavailable = (row: any, a: any): string | null => {
+  if ((a.id === 'run_eval' || a.id === 'run_training') && row.rep?.agent_has_evals === false)
+    return 'No evals for this agent — add a test case first'
+  return null
+}
+
 const fmtDate = (s: string) => {
   if (!s) return ''
   const d = new Date(s); const diff = (Date.now() - d.getTime()) / 1000
@@ -285,11 +294,23 @@ const runAction = async (row: any, a: any) => {
     if (s.instruction_id) emit('open-instruction', { instructionId: s.instruction_id, buildId: s.build_id })
     return
   }
+  const reason = actionUnavailable(row, a)
+  if (reason) { toast.add({ title: 'Nothing to run', description: reason, color: 'amber' }); return }
   busy.value = row.key
   try {
     // Single-item (non-instruction) actions resolve the representative item.
-    const { error } = await useMyFetch<any>(`/api/review/${row.rep.id}/resolve`, { method: 'POST', body: { action_id: a.id } })
+    const { data, error } = await useMyFetch<any>(`/api/review/${row.rep.id}/resolve`, { method: 'POST', body: { action_id: a.id } })
     if (error.value) throw new Error((error.value as any)?.data?.detail || 'Failed')
+    const resp = data.value
+    // The backend may decline (e.g. no evals) with a 200 + { ok: false }.
+    if (resp && resp.ok === false) {
+      const msg = resp.error === 'no_evals'
+        ? (resp.message || 'No evals for this agent — add a test case first.')
+        : (resp.message || resp.error || 'Action unavailable')
+      toast.add({ title: 'Nothing to run', description: msg, color: 'amber' })
+      await fetchItems()
+      return
+    }
     const label = a.id === 'run_training' ? 'Training started' : a.id === 'run_eval' ? 'Eval started' : 'Done'
     toast.add({ title: label, color: 'blue' })
     await fetchItems()

--- a/frontend/components/ReviewFeed.vue
+++ b/frontend/components/ReviewFeed.vue
@@ -266,10 +266,16 @@ const fetchItems = async () => {
     const { data } = await useMyFetch<any>('/api/review', { method: 'GET', query: q })
     items.value = data.value?.items || []
     unread.value = data.value?.unread || 0
-    emit('count', unread.value)
+    emit('count', openCount.value)
   } catch (e) { /* noop */ } finally { loading.value = false }
 }
 const refresh = () => fetchItems()
+
+// "To review" count = active (unresolved) items, matching /api/review/count's
+// `open`. Kept distinct from `unread` (the header's read/unread badge) so
+// marking an item read doesn't make the parent's "N to review" badge vanish.
+const openCount = computed(() => items.value.filter((i: any) => i.status !== 'resolved' && i.status !== 'dismissed').length)
+watch(openCount, (n) => emit('count', n))
 
 watch([agentFilter, showResolved], fetchItems)
 
@@ -290,17 +296,33 @@ const runAction = async (row: any, a: any) => {
   } catch (e: any) { toast.add({ title: 'Action failed', description: e?.message, color: 'red' }) } finally { busy.value = null }
 }
 const dismiss = async (row: any) => {
+  const ids = new Set((row.items || []).map((it: any) => it.id))
+  const prev = items.value
+  // Optimistic: drop the row now, reconcile (and roll back) from the server.
+  items.value = items.value.filter((it: any) => !ids.has(it.id))
   try {
-    await Promise.all((row.items || []).map((it: any) => useMyFetch(`/api/review/${it.id}/dismiss`, { method: 'POST' })))
+    const res = await Promise.all((row.items || []).map((it: any) => useMyFetch(`/api/review/${it.id}/dismiss`, { method: 'POST' })))
+    if (res.some((r: any) => r?.error?.value)) throw new Error('Failed')
     await fetchItems()
-  } catch {}
+  } catch (e: any) {
+    items.value = prev
+    toast.add({ title: 'Failed to dismiss', description: e?.message, color: 'red' })
+  }
 }
 const toggleRead = async (row: any) => {
   const next = !row.read
+  const ids = new Set((row.items || []).map((it: any) => it.id))
+  const prev = items.value
+  // Optimistic flip so the dot/bold update instantly.
+  items.value = items.value.map((it: any) => ids.has(it.id) ? { ...it, read: next } : it)
   try {
-    await Promise.all((row.items || []).map((it: any) => useMyFetch(`/api/review/${it.id}/read`, { method: 'POST', body: { read: next } })))
+    const res = await Promise.all((row.items || []).map((it: any) => useMyFetch(`/api/review/${it.id}/read`, { method: 'POST', body: { read: next } })))
+    if (res.some((r: any) => r?.error?.value)) throw new Error('Failed')
     await fetchItems()
-  } catch {}
+  } catch (e: any) {
+    items.value = prev
+    toast.add({ title: 'Failed to update', description: e?.message, color: 'red' })
+  }
 }
 const markAllRead = async () => {
   try { await useMyFetch('/api/review/read-all', { method: 'POST', body: { agent_id: agentFilter.value } }); await fetchItems() } catch {}


### PR DESCRIPTION
Follow-up fixes to the Agents **Review** tab (built in #390).

## Why
Three reported problems plus the original "run eval / run training is weird — it doesn't check if I have evals":

1. **Dismiss didn't stick.** Sweep/event producers (slow query, low confidence, schema changed) had no dismissal guard, so `emit()` re-created a fresh open item on the next scan/cron.
2. **"N to review" badge flip-flopped.** The parent stored one `reviewCount` written by two sources with different meanings (open count vs unread count), so marking an item *read* made the badge vanish.
3. **Flicker** of the agents list when opening an instruction from a Review item.
4. **Run eval / Run training** were offered on every item and always reported success — even with no evals, where the workflow bailed and then silently marked the item green "Resolved".

## What changed

### Dismiss durability — `review_service.py`, `review_producers.py`
- `emit()` gains an opt-in `respect_dismissal` (+ `resurface_after_hours`) guard: with no active item but a recent dismissed one, it returns `None` instead of resurrecting. Wired into the slow-query / low-confidence / schema-changed producers. Instruction suggestions keep their existing build-scoped guard.

### Consistent count — `ReviewFeed.vue`
- The feed now emits an **open/active** count (matching `/api/review/count`), so read state no longer affects the parent's "N to review" badge.

### No flicker — `KnowledgeExplorer.vue`
- `openInstructionFromReview` resolves the instruction *before* swapping panes (one tick, no agents-list flash), with a spinner overlay covering any fetch gap.

### Eval-gated actions — `review_service.py`, `ReviewFeed.vue`
- `list_items` annotates each item with `agent_has_evals` (active evals scoped to the agent, incl. Auto/global cases).
- `resolve()` rejects run_eval/run_training synchronously with `{ ok: false, error: "no_evals" }` when there's nothing to run.
- `_run_workflow` only resolves the item on a productive outcome (`passed` / `passed_pending`); `no_evals` / `skipped` / `error` / `gave_up` reopen it instead of a misleading green "Resolved".
- Frontend disables the buttons (reason tooltip) when the agent has no evals and surfaces the decline as an amber "Nothing to run".

### Robustness — `ReviewFeed.vue`
- Dismiss/read are optimistic with rollback + error toasts instead of silently swallowing failures.

## Testing
There is no existing automated test suite for the Review service; changes are verified by static/syntax checks. Happy to add unit tests for the dismiss guard and eval-gating if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjEq3DP4fL1obZjniTkDqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEq3DP4fL1obZjniTkDqk)_