### PR TITLE
Remove batch scan producers and consolidate to event-driven review items

### DIFF
--- a/backend/app/routes/review.py
+++ b/backend/app/routes/review.py
@@ -97,18 +97,6 @@ async def dismiss_review(
     return {"ok": item is not None}
 
 
-@router.post("/review/scan")
-async def scan_review(
-    current_user: User = Depends(current_user),
-    db: AsyncSession = Depends(get_async_db),
-    organization: Organization = Depends(get_current_organization),
-):
-    """Run the sweep producers (slow queries, low confidence, instruction
-    suggestions) for this org and emit/refresh items. Admin/cron entrypoint."""
-    from app.services.review_producers import run_scans
-    return await run_scans(db, str(organization.id))
-
-
 @router.post("/review/{item_id}/resolve")
 async def resolve_review(
     item_id: str,

--- a/backend/app/services/review_producers.py
+++ b/backend/app/services/review_producers.py
@@ -1,18 +1,17 @@
 """Producers for the Review feed.
 
-Each function detects a condition and emits (deduped) review items. Scans
-recompute absolute counts over a window; event emitters fire on a single
-occurrence. All attribution to an agent goes through
+Each function detects a condition and emits (deduped) review items on a single
+occurrence, fired from the event that caused it. All attribution to an agent
+goes through
 ``report_data_source_association`` (a report can belong to several agents → fan
 out one item per agent, so training/eval fired from the item stays agent-scoped).
 """
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
 from typing import List, Optional, Tuple
 
-from sqlalchemy import select, and_, func
+from sqlalchemy import select, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review_item import (
@@ -23,88 +22,7 @@ from app.services.review_service import review_service
 
 logger = logging.getLogger(__name__)
 
-SLOW_QUERY_MS = 90_000               # > 90s is "slow"
-QUERY_TOOLS = ("create_data", "read_query")  # tools that run a data query
 DEFAULT_WINDOW_HOURS = 24 * 7
-
-
-# ── slow queries ────────────────────────────────────────────────────────────
-async def scan_slow_queries(db: AsyncSession, organization_id: str, *,
-                            window_hours: int = DEFAULT_WINDOW_HOURS,
-                            threshold_ms: int = SLOW_QUERY_MS) -> int:
-    from app.models.tool_execution import ToolExecution
-    from app.models.agent_execution import AgentExecution
-    from app.models.report import Report
-    from app.models.report_data_source_association import report_data_source_association as assoc
-    since = datetime.utcnow() - timedelta(hours=window_hours)
-    rows = (await db.execute(
-        select(assoc.c.data_source_id, func.count(ToolExecution.id))
-        .select_from(ToolExecution)
-        .join(AgentExecution, AgentExecution.id == ToolExecution.agent_execution_id)
-        .join(Report, Report.id == AgentExecution.report_id)
-        .join(assoc, assoc.c.report_id == Report.id)
-        .where(and_(
-            Report.organization_id == organization_id,
-            ToolExecution.duration_ms.isnot(None),
-            ToolExecution.duration_ms > threshold_ms,
-            ToolExecution.tool_name.in_(QUERY_TOOLS),
-            ToolExecution.created_at >= since,
-        ))
-        .group_by(assoc.c.data_source_id)
-    )).all()
-    n = 0
-    secs = threshold_ms // 1000
-    days = max(1, window_hours // 24)
-    for ds_id, count in rows:
-        count = int(count)
-        await review_service.emit(
-            db, organization_id=organization_id, type=TYPE_SLOW_QUERY,
-            data_source_id=str(ds_id), severity=SEVERITY_WARNING,
-            title=f"{count} slow quer{'y' if count == 1 else 'ies'} (>{secs}s)",
-            why=f"{count} data quer{'y' if count == 1 else 'ies'} on this agent ran over {secs}s in the last {days}d. Consider a guardrail instruction or an index.",
-            group_key=f"slow_query:{ds_id}", occurrences=count,
-            subject={"kind": "query_group", "threshold_ms": threshold_ms, "window_hours": window_hours},
-            respect_dismissal=True, resurface_after_hours=window_hours,
-        )
-        n += 1
-    return n
-
-
-# ── low confidence (response_score < 3, reusing the console definition) ──────
-async def scan_low_confidence(db: AsyncSession, organization_id: str, *,
-                              window_hours: int = DEFAULT_WINDOW_HOURS) -> int:
-    from app.models.completion import Completion
-    from app.models.report import Report
-    from app.models.report_data_source_association import report_data_source_association as assoc
-    since = datetime.utcnow() - timedelta(hours=window_hours)
-    rows = (await db.execute(
-        select(assoc.c.data_source_id, func.count(Completion.id))
-        .select_from(Completion)
-        .join(Report, Report.id == Completion.report_id)
-        .join(assoc, assoc.c.report_id == Report.id)
-        .where(and_(
-            Report.organization_id == organization_id,
-            Completion.response_score.isnot(None),
-            Completion.response_score < 3,
-            Completion.created_at >= since,
-        ))
-        .group_by(assoc.c.data_source_id)
-    )).all()
-    n = 0
-    days = max(1, window_hours // 24)
-    for ds_id, count in rows:
-        count = int(count)
-        await review_service.emit(
-            db, organization_id=organization_id, type=TYPE_LOW_CONFIDENCE,
-            data_source_id=str(ds_id), severity=SEVERITY_WARNING,
-            title=f"{count} low-confidence answer{'' if count == 1 else 's'}",
-            why=f"{count} answer{' was' if count == 1 else 's were'} scored below 3/5 on this agent in the last {days}d. Run training to close the gaps.",
-            group_key=f"low_confidence:{ds_id}", occurrences=count,
-            subject={"kind": "low_confidence", "window_hours": window_hours},
-            respect_dismissal=True, resurface_after_hours=window_hours,
-        )
-        n += 1
-    return n
 
 
 # ── instruction suggestions (non-admin user edits + AI/harness) ─────────────
@@ -212,151 +130,6 @@ async def emit_instruction_suggestions_for_build(db, organization_id: str, build
     return n
 
 
-async def scan_instruction_suggestions(db: AsyncSession, organization_id: str) -> int:
-    """Backfill/scan: emit suggestion items for all current non-admin/AI pending
-    builds. (A pending 'user' build implies a non-admin author — admins
-    auto-promote their own edits.)
-
-    Two passes so each instruction's item carries a *real* change count =
-    number of distinct pending builds that changed it."""
-    from collections import Counter
-    from app.models.instruction_build import InstructionBuild
-    from app.models.build_content import BuildContent
-    builds = (await db.execute(
-        select(InstructionBuild).where(and_(
-            InstructionBuild.organization_id == organization_id,
-            InstructionBuild.is_main.is_(False),
-            InstructionBuild.deleted_at.is_(None),
-            InstructionBuild.status.in_(["draft", "pending_approval"]),
-            InstructionBuild.source.in_(["user", "ai"]),
-        ))
-    )).scalars().all()
-    # Supersede chained edits: build (instruction_id, version_id) pairs that are
-    # the base of some pending build. A pending build whose own version is one
-    # of these is an intermediate snapshot (v16 in v15->v16->v17) covered by the
-    # leaf, so we exclude it from counts and emission.
-    from collections import defaultdict
-    from app.models.instruction_version import InstructionVersion
-    from app.services.suggestion_merge import superseded_by_containment
-    base_ids = [str(b.base_build_id) for b in builds if getattr(b, "base_build_id", None)]
-    superseded_pairs = set()
-    base_text_lookup: dict = {}   # (base_build_id, instruction_id) -> base text
-    if base_ids:
-        base_rows = (await db.execute(
-            select(BuildContent.build_id, BuildContent.instruction_id,
-                   BuildContent.instruction_version_id, InstructionVersion.text)
-            .join(InstructionVersion, InstructionVersion.id == BuildContent.instruction_version_id)
-            .where(BuildContent.build_id.in_(base_ids))
-        )).all()
-        for b_id, i_id, v_id, t in base_rows:
-            superseded_pairs.add((str(i_id), str(v_id)))
-            base_text_lookup[(str(b_id), str(i_id))] = t or ""
-    # Per-(build, instruction) version + text, so we can compare only REAL
-    # changes for content supersede below (never inherited/base text — that would
-    # wrongly drop a deletion-only suggestion).
-    base_build_of = {str(b.id): (str(b.base_build_id) if getattr(b, "base_build_id", None) else None) for b in builds}
-    pend_build_ids = [str(b.id) for b in builds]
-    content_lookup: dict = {}   # (build_id, instruction_id) -> (version_id, text)
-    if pend_build_ids:
-        ct_rows = (await db.execute(
-            select(BuildContent.build_id, BuildContent.instruction_id,
-                   BuildContent.instruction_version_id, InstructionVersion.text)
-            .join(InstructionVersion, InstructionVersion.id == BuildContent.instruction_version_id)
-            .where(BuildContent.build_id.in_(pend_build_ids))
-        )).all()
-        for b_id, i_id, v_id, t in ct_rows:
-            content_lookup[(str(b_id), str(i_id))] = (str(v_id), t or "")
-
-    # No-op vs current: a suggestion whose text is already fully present in the
-    # live (main) text contributes nothing to review. Mark it superseded so it's
-    # not counted, emitted, or left as a stuck feed item ("0 changes · 1
-    # suggestion"). Uses pure-insertion containment so a version row that differs
-    # from main only by already-applied content still resolves out.
-    from app.services.suggestion_merge import covers
-    instr_ids = {i for (_b, i) in content_lookup.keys()}
-    main_text_by_instr: dict = {}
-    if instr_ids:
-        main_rows = (await db.execute(
-            select(BuildContent.instruction_id, InstructionVersion.text)
-            .join(InstructionBuild, InstructionBuild.id == BuildContent.build_id)
-            .join(InstructionVersion, InstructionVersion.id == BuildContent.instruction_version_id)
-            .where(and_(
-                InstructionBuild.organization_id == organization_id,
-                InstructionBuild.is_main.is_(True),
-                InstructionBuild.deleted_at.is_(None),
-                BuildContent.instruction_id.in_(list(instr_ids)),
-            ))
-        )).all()
-        main_text_by_instr = {str(i): (t or "") for i, t in main_rows}
-    for (b_id, i_id), (v_id, txt) in content_lookup.items():
-        mt = main_text_by_instr.get(i_id)
-        if mt is not None and (txt == mt or covers(txt, mt)):
-            superseded_pairs.add((i_id, v_id))
-
-    # Pass 1a: which instructions each build really changed (structural supersede
-    # only) — the basis for the content-supersede comparison.
-    changed_by_build = {}
-    for b in builds:
-        changed_by_build[str(b.id)] = await _changed_instructions_for_build(
-            db, organization_id, b, superseded_pairs
-        )
-
-    # Content-level supersede: sibling builds that don't chain structurally but
-    # whose text is a cumulative superset of one another (e.g. "+lorem" vs
-    # "+lorem +hello" from two separate chat turns). Compare only real-changed
-    # versions per instruction; keep the maximal (leaf) one, mark the rest
-    # superseded so they're neither counted nor emitted twice.
-    by_instr: dict = defaultdict(dict)   # instr -> {version_id: (text, base_text)}
-    for bid, changed in changed_by_build.items():
-        base_bid = base_build_of.get(bid)
-        for instr, _ds in changed:
-            vt = content_lookup.get((bid, instr))
-            if vt:
-                base_text = base_text_lookup.get((base_bid, instr), "") if base_bid else ""
-                by_instr[instr][vt[0]] = (vt[1], base_text)
-    for instr, vmap in by_instr.items():
-        for vid in superseded_by_containment(vmap):
-            superseded_pairs.add((instr, vid))
-
-    # Pass 1b: recount with content supersede applied (a build superseded for an
-    # instruction drops out of both the count and emission).
-    counts: Counter = Counter()
-    for b in builds:
-        kept = [(instr, ds) for (instr, ds) in changed_by_build[str(b.id)]
-                if (instr, content_lookup.get((str(b.id), instr), (None,))[0]) not in superseded_pairs]
-        changed_by_build[str(b.id)] = kept
-        for instruction_id, _ds in kept:
-            counts[instruction_id] += 1
-    # Pass 2: emit with the real count.
-    n = 0
-    for b in builds:
-        n += await emit_instruction_suggestions_for_build(db, organization_id, b, occurrences_map=counts, superseded_pairs=superseded_pairs)
-    # Auto-resolve any active suggestion items whose instruction no longer has a
-    # fresh pending change (accepted, rejected, or superseded by a newer state).
-    from datetime import datetime
-    from app.models.review_item import ReviewItem, ACTIVE_STATUSES, STATUS_RESOLVED
-    active_ids = set(counts.keys())
-    open_items = (await db.execute(
-        select(ReviewItem).where(and_(
-            ReviewItem.organization_id == organization_id,
-            ReviewItem.type == TYPE_INSTRUCTION_SUGGESTION,
-            ReviewItem.status.in_(list(ACTIVE_STATUSES)),
-            ReviewItem.deleted_at.is_(None),
-        ))
-    )).scalars().all()
-    stale = 0
-    for it in open_items:
-        gk = it.group_key or ""
-        iid = gk[len("instr:"):] if gk.startswith("instr:") else None
-        if iid and iid not in active_ids:
-            it.status = STATUS_RESOLVED
-            it.verified_at = datetime.utcnow()
-            stale += 1
-    if stale:
-        await db.commit()
-    return n
-
-
 # ── schema changed (event emitter, called from the table-change trigger) ─────
 async def emit_schema_changed(db, organization_id: str, data_source_id: str, *,
                               summary: Optional[str] = None, agent_name: Optional[str] = None) -> None:
@@ -392,13 +165,3 @@ def build_training_brief(item) -> str:
         return (f"Focus: {n} data query/queries on this agent errored. {why} "
                 f"Propose instructions/fixes so the agent forms valid queries.")
     return why or "Review recent runs on this agent and propose instructions that improve accuracy."
-
-
-async def run_scans(db: AsyncSession, organization_id: str) -> dict:
-    """Run all sweep-based producers for an org (slow queries, low confidence,
-    instruction suggestions). Returns counts emitted."""
-    return {
-        "slow_query": await scan_slow_queries(db, organization_id),
-        "low_confidence": await scan_low_confidence(db, organization_id),
-        "instruction_suggestion": await scan_instruction_suggestions(db, organization_id),
-    }

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -281,15 +281,6 @@ class ReviewService:
         search: Optional[str] = None,
         limit: int = 200,
     ) -> Dict[str, Any]:
-        # Self-populate from current pending builds so the feed reflects reality
-        # regardless of how a suggestion was created (harness, non-admin, or
-        # pre-existing). Cheap + idempotent (deduped, dismiss-aware). Never fatal.
-        try:
-            from app.services.review_producers import scan_instruction_suggestions
-            await scan_instruction_suggestions(db, str(organization.id))
-        except Exception as e:  # noqa: BLE001
-            logger.warning("review: scan_instruction_suggestions on list failed: %s", e)
-
         is_admin, ds_ids = await self._visible(db, organization, user)
         if not is_admin and not ds_ids:
             return {"items": [], "total": 0, "unread": 0}


### PR DESCRIPTION
## Summary
This PR removes the batch/scan-based review item producers (slow queries, low confidence, instruction suggestions) and their associated API endpoint, consolidating the system to event-driven emission only. The changes reflect a shift from periodic scanning to real-time event-based review item generation.

## Key Changes
- **Removed batch scan functions** from `review_producers.py`:
  - `scan_slow_queries()` - no longer scans for slow query patterns over time windows
  - `scan_low_confidence()` - no longer scans for low confidence responses
  - `scan_instruction_suggestions()` - no longer backfills suggestion items from pending builds
  - `run_scans()` - orchestrator function that coordinated all three scans

- **Removed API endpoint** from `review.py`:
  - `POST /review/scan` - admin/cron entrypoint for triggering batch scans

- **Removed auto-population logic** from `review_service.py`:
  - Removed `scan_instruction_suggestions()` call from `list_items()` that would auto-populate the feed on every list request

- **Cleaned up imports**:
  - Removed unused `datetime`, `timedelta`, and `func` imports
  - Removed constants `SLOW_QUERY_MS` and `QUERY_TOOLS`

- **Updated module docstring** to reflect event-driven approach: review items are now emitted on single occurrences from triggering events rather than computed over time windows

## Implementation Details
The system now relies entirely on event-driven producers (like `emit_instruction_suggestions_for_build()` and `emit_schema_changed()`) to generate review items in real-time, rather than periodic batch scans. This simplifies the architecture and ensures review items are generated immediately when conditions occur rather than waiting for scheduled scans.

https://claude.ai/code/session_01GYdnjekpgPiYCefZTc7yQY