### PR TITLE
Add event-driven slow_query / low_confidence review emitters

### DIFF
--- a/backend/app/project_manager.py
+++ b/backend/app/project_manager.py
@@ -820,6 +820,13 @@ class ProjectManager:
         db.add(completion)
         await db.commit()
         await db.refresh(completion)
+        # Surface a Review item when the judge scored this answer low (<3/5).
+        # Cheap-guarded inside the emitter; never fatal to scoring.
+        try:
+            from app.services.review_producers import emit_low_confidence_for_completion
+            await emit_low_confidence_for_completion(db, completion)
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning("review: emit_low_confidence failed for completion %s: %s", completion.id, e)
         return completion
 
     async def create_instruction_from_draft(

--- a/backend/app/services/agent/tool_execution_service.py
+++ b/backend/app/services/agent/tool_execution_service.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Optional, Dict, Any
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.tool_execution import ToolExecution
+
+logger = logging.getLogger(__name__)
 
 
 class ToolExecutionService:
@@ -64,6 +67,13 @@ class ToolExecutionService:
         db.add(te)
         await db.commit()
         await db.refresh(te)
+        # Surface a Review item when a data query ran over the latency budget.
+        # Cheap-guarded inside the emitter; never fatal to tool execution.
+        try:
+            from app.services.review_producers import emit_slow_query_for_tool_execution
+            await emit_slow_query_for_tool_execution(db, te)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("review: emit_slow_query failed for tool_execution %s: %s", te.id, e)
         return te
 
 

--- a/backend/app/services/review_producers.py
+++ b/backend/app/services/review_producers.py
@@ -23,6 +23,93 @@ from app.services.review_service import review_service
 logger = logging.getLogger(__name__)
 
 DEFAULT_WINDOW_HOURS = 24 * 7
+SLOW_QUERY_MS = 90_000                        # > 90s is "slow"
+QUERY_TOOLS = ("create_data", "read_query")   # tools that run a data query
+
+
+async def _org_and_data_sources_for_report(db, report_id) -> Tuple[Optional[str], List[str]]:
+    """Resolve a report to its org + the data sources (agents) it's attached to.
+    A report can belong to several agents → callers fan one item out per agent."""
+    from app.models.report import Report
+    from app.models.report_data_source_association import report_data_source_association as assoc
+    report = await db.get(Report, str(report_id))
+    if report is None:
+        return None, []
+    ds_rows = (await db.execute(
+        select(assoc.c.data_source_id).where(assoc.c.report_id == str(report_id))
+    )).all()
+    return str(report.organization_id), [str(d[0]) for d in ds_rows]
+
+
+# ── slow query (event emitter, fired when a query tool finishes) ─────────────
+async def emit_slow_query_for_tool_execution(db, te) -> int:
+    """Bump a per-agent slow-query item when a data-query tool ran over the
+    latency budget. Fired once per slow execution from ``ToolExecutionService``;
+    ``group_count`` accumulates occurrences until the item is resolved/dismissed.
+
+    The cheap guards (tool name + duration, both already on ``te``) short-circuit
+    before any DB work, so the common fast-query path costs nothing."""
+    if te is None or te.tool_name not in QUERY_TOOLS:
+        return 0
+    if te.duration_ms is None or te.duration_ms <= SLOW_QUERY_MS:
+        return 0
+    from app.models.agent_execution import AgentExecution
+    ae = await db.get(AgentExecution, str(te.agent_execution_id))
+    if ae is None or not ae.report_id or getattr(ae, "is_eval_run", False):
+        return 0  # eval/test runs are synthetic — don't surface them in the feed
+    org_id, ds_ids = await _org_and_data_sources_for_report(db, ae.report_id)
+    org_id = (str(ae.organization_id) if ae.organization_id else None) or org_id
+    if not org_id or not ds_ids:
+        return 0
+    secs = SLOW_QUERY_MS // 1000
+    actual = int(te.duration_ms // 1000)
+    n = 0
+    for ds_id in ds_ids:
+        await review_service.emit(
+            db, organization_id=org_id, type=TYPE_SLOW_QUERY,
+            data_source_id=ds_id, severity=SEVERITY_WARNING,
+            title=f"Slow data queries (>{secs}s)",
+            why=f"A data query on this agent ran {actual}s, over the {secs}s budget. Consider a guardrail instruction or an index.",
+            group_key=f"slow_query:{ds_id}",
+            subject={"kind": "query_group", "threshold_ms": SLOW_QUERY_MS},
+            source_run_id=str(te.agent_execution_id),
+            respect_dismissal=True, resurface_after_hours=DEFAULT_WINDOW_HOURS,
+        )
+        n += 1
+    return n
+
+
+# ── low confidence (event emitter, fired when the judge scores a completion) ──
+async def emit_low_confidence_for_completion(db, completion) -> int:
+    """Bump a per-agent low-confidence item when a completion is scored below
+    3/5. Fired once per low score from the judge-score persist path;
+    ``group_count`` accumulates occurrences until resolved/dismissed."""
+    score = getattr(completion, "response_score", None)
+    if score is None or score >= 3:
+        return 0
+    # Skip eval/test runs — synthetic, shouldn't surface in the feed.
+    from app.models.agent_execution import AgentExecution
+    ae = (await db.execute(
+        select(AgentExecution).where(AgentExecution.completion_id == str(completion.id)).limit(1)
+    )).scalar_one_or_none()
+    if ae is not None and getattr(ae, "is_eval_run", False):
+        return 0
+    org_id, ds_ids = await _org_and_data_sources_for_report(db, completion.report_id)
+    if not org_id or not ds_ids:
+        return 0
+    n = 0
+    for ds_id in ds_ids:
+        await review_service.emit(
+            db, organization_id=org_id, type=TYPE_LOW_CONFIDENCE,
+            data_source_id=ds_id, severity=SEVERITY_WARNING,
+            title="Low-confidence answers",
+            why="An answer on this agent was scored below 3/5. Run training to close the gaps.",
+            group_key=f"low_confidence:{ds_id}",
+            subject={"kind": "low_confidence"},
+            respect_dismissal=True, resurface_after_hours=DEFAULT_WINDOW_HOURS,
+        )
+        n += 1
+    return n
 
 
 # ── instruction suggestions (non-admin user edits + AI/harness) ─────────────


### PR DESCRIPTION
## What

Follow-up to #419 (which removed the review-feed scans). This restores `slow_query` and `low_confidence` review items as **event emitters fired at the source**, mirroring how `emit_schema_changed` already works — no scans, no writes on the `GET /review` read path.

## Why

The old `scan_slow_queries` / `scan_low_confidence` only ran via `run_scans` → `POST /review/scan`, which was never wired to anything, so those item types effectively never generated. Converting them to event emitters makes them actually fire, at the moment the condition occurs, without reintroducing the lock-contention sweep #419 removed.

## How

- **`emit_slow_query_for_tool_execution`** — fired from `ToolExecutionService.finish` when a data-query tool (`create_data` / `read_query`) runs over the 90s budget. The cheap guards (tool name + `duration_ms`, both already on the in-memory record) short-circuit before any DB work, so the common fast-query path costs nothing.
- **`emit_low_confidence_for_completion`** — fired from the judge-score persist path (`update_completion_response_score`) when a completion scores below 3/5. The `score >= 3` guard short-circuits before any DB work.

Both:
- bump a per-agent item via the existing `review_service.emit` dedup (`group_count` accumulates occurrences until the item is resolved/dismissed), with `respect_dismissal` + resurface-after-window;
- fan out one item per attached data source (agent), matching the producer convention;
- skip synthetic eval/test runs (`is_eval_run`);
- are wrapped never-fatal at the call sites, so a review-feed write can never break tool execution or scoring.

## Behavior note

Counting semantics shift from the old windowed scan (absolute count over a rolling 7d window) to a **lifetime bump** on the open item — it accumulates until resolved/dismissed rather than aging out on a window. This matches the event-emitter pattern the other producers already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYdnjekpgPiYCefZTc7yQY)_