### PR TITLE
Fix Trivy action version references in GitHub workflows

### DIFF
--- a/.github/workflows/docker-image-branch.yml
+++ b/.github/workflows/docker-image-branch.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Trivy scan summary (stdout)
         if: ${{ success() }}
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: bagofwords/bagofwords:${{ env.image_tag }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Scan image with Trivy (SARIF)
         if: ${{ success() }}
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: bagofwords/bagofwords:${{ env.image_tag }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Trivy scan summary (stdout)
         if: ${{ success() }}
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: bagofwords/bagofwords:${{ env.version_tag }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Scan image with Trivy
         if: ${{ success() }}
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
 
         with:
           scan-type: image


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow files to use properly formatted version references for the Trivy security scanning action.

## Changes
- Added `v` prefix to `aquasecurity/trivy-action` version references in both Docker image workflows
  - Updated `docker-image-branch.yml`: Changed `@0.36.0` to `@v0.36.0` (2 occurrences)
  - Updated `docker-image.yml`: Changed `@0.36.0` to `@v0.36.0` (2 occurrences)

## Details
The Trivy action version references were missing the `v` prefix, which is the standard semantic versioning format expected by GitHub Actions. This change ensures consistency with GitHub Actions best practices and the action's official documentation.

https://claude.ai/code/session_01MfNr1gXmtfPeMiWqceDB3x