### PR TITLE
Show disabled agents in admin 'Show all' view

### DIFF
--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1151,11 +1151,12 @@ class DataSourceService:
         items: list[DataSourceListItemSchema] = []
         for d in data_sources:
             # Publishing-lifecycle visibility:
-            #   disabled → never usable, hidden from everyone
+            #   disabled → off everywhere; only surfaced in the admin "show all"
+            #              view so managers can find and re-enable them
             #   draft    → only managers (governance / per-DS manage)
             #   published → everyone with access
             publish_status = getattr(d, "publish_status", "published") or "published"
-            if publish_status == "disabled":
+            if publish_status == "disabled" and not show_all_effective:
                 continue
             if publish_status == "draft" and not (is_gov or str(d.id) in manage_ids):
                 continue

--- a/backend/tests/e2e/rbac/test_rbac_data_sources.py
+++ b/backend/tests/e2e/rbac/test_rbac_data_sources.py
@@ -524,7 +524,7 @@ def test_publish_status_visibility_and_validation(
     assert ds_id in active_ids(manager["token"])
     assert ds_id not in active_ids(member["token"])
 
-    # disabled → nobody sees it in the selector, not even admin.
+    # disabled → hidden from the normal selector for everyone, even admin.
     assert (
         test_client.put(
             f"/api/data_sources/{ds_id}",
@@ -535,6 +535,19 @@ def test_publish_status_visibility_and_validation(
     assert ds_id not in active_ids(admin["token"])
     assert ds_id not in active_ids(manager["token"])
     assert ds_id not in active_ids(member["token"])
+
+    # ...but the admin "show all" view surfaces disabled agents so a manager
+    # can find and re-enable them. A plain member's show_all is still ignored.
+    def active_ids_show_all(token):
+        r = test_client.get(
+            "/api/data_sources/active?include_unconnected=true&show_all=true",
+            headers=_hdr(token, org_id),
+        )
+        assert r.status_code == 200, r.text
+        return {d["id"] for d in r.json()}
+
+    assert ds_id in active_ids_show_all(admin["token"])
+    assert ds_id not in active_ids_show_all(member["token"])
 
     # Invalid value is rejected by the schema validator.
     bad = test_client.put(

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -93,7 +93,7 @@
           </div>
 
           <template v-for="agent in agents" :key="agent.id">
-            <TreeGroup :label="agent.name" :count="agentCount(agent.id)" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? 'Sign in' : ''" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
+            <TreeGroup :label="agent.name" :count="agentCount(agent.id)" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? 'Sign in' : (agent.publish_status === 'disabled' ? 'Disabled' : '')" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
               <template #icon><DataSourceIcon :type="agent.type" class="w-4 h-4 shrink-0" /></template>
 
               <TreeGroup label="Tables" icon="i-heroicons-table-cells" :count="agentTables[agent.id]?.length" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
@@ -1789,10 +1789,10 @@ const fetchAgents = async () => {
     const query: Record<string, any> = { include_unconnected: true }
     if (showAllAgents.value) query.show_all = true
     const { data } = await useMyFetch<any[]>('/data_sources/active', { method: 'GET', query })
-    agents.value = (data.value || []).map((d: any) => ({ id: d.id, name: d.name, type: d.type, connections: d.connections || [], user_status: d.user_status, is_public: d.is_public, status: d.status, description: d.description, conversation_starters: d.conversation_starters || [], auth_policy: d.auth_policy, admin_only: d.admin_only }))
+    agents.value = (data.value || []).map((d: any) => ({ id: d.id, name: d.name, type: d.type, connections: d.connections || [], user_status: d.user_status, is_public: d.is_public, status: d.status, publish_status: d.publish_status, description: d.description, conversation_starters: d.conversation_starters || [], auth_policy: d.auth_policy, admin_only: d.admin_only }))
   } catch (e) { console.error(e) }
 }
-const agentStatusDot = (a: any) => a?.status === 'active' ? 'bg-green-400' : 'bg-gray-300'
+const agentStatusDot = (a: any) => a?.publish_status === 'disabled' ? 'bg-gray-300' : (a?.status === 'active' ? 'bg-green-400' : 'bg-gray-300')
 // Group an agent's tools by their connection (MCP server / custom API), resolving
 // the connection name + type from the agent's connections for the tree headers.
 const toolGroups = (agentId: string) => {


### PR DESCRIPTION
Disabled agents are hidden everywhere by design, but that also hid them
from managers who need to re-enable them — a one-way door. Now the
admin/manager 'Show all' view (show_all_effective) surfaces disabled
agents so they can be found and turned back on; they stay hidden from
the normal selector and from the AI for everyone else.

The sidebar marks them with a 'Disabled' badge and a grey status dot.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0152boWfpD7waFHxakuFiUN6