### PR TITLE
Fix send_email tool availability to honor UI-configured org SMTP

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1473,6 +1473,34 @@ class AgentV2:
                 if t.name not in denied_tools
             ]
 
+    async def _apply_email_availability_filter(self) -> None:
+        """Hide ``send_email`` from the planner catalog when no outbound email
+        transport resolves for this org.
+
+        The tool is registered as always-active (so it stays executable), but it
+        must only be advertised to the planner when email can actually be sent.
+        Availability mirrors the send path's resolver (AI mailbox → org SMTP →
+        global), so a tool configured via the UI (org SMTP) counts even when the
+        global bow-config SMTP is empty.
+        """
+        catalog = self.planner.tool_catalog or []
+        if not any(t.name == "send_email" for t in catalog):
+            return
+
+        available = False
+        if self.db and self.organization:
+            try:
+                from app.services.email_client_resolver import is_outbound_available
+                available = await is_outbound_available(
+                    self.db, str(self.organization.id), purpose="analyst"
+                )
+            except Exception:
+                logger.warning("[agent] email availability check failed", exc_info=True)
+                available = False
+
+        if not available:
+            self.planner.tool_catalog = [t for t in catalog if t.name != "send_email"]
+
     def _schedule_bg_write(self, label: str, coro):
         """Schedule a background DB write coroutine.
 
@@ -1940,6 +1968,7 @@ class AgentV2:
 
             # Early scoring will be launched as a background task using an isolated session
             await self._apply_tool_permission_filter()
+            await self._apply_email_availability_filter()
             _mlog("loop_starting")
 
             for loop_index in range(step_limit):

--- a/backend/app/ai/tools/implementations/send_email.py
+++ b/backend/app/ai/tools/implementations/send_email.py
@@ -32,7 +32,6 @@ from app.ai.tools.schemas.events import (
     ToolErrorEvent,
 )
 from app.services.email_send_service import EmailSendService
-from app.settings.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +76,13 @@ class SendEmailTool(Tool):
             max_retries=1,
             timeout_seconds=60,
             idempotent=False,
-            # Hidden from the catalog when SMTP isn't configured. Evaluated at
-            # registry startup, where settings.email_client is already resolved.
-            is_active=settings.email_client is not None,
+            # Always registered/executable; per-org availability is decided at
+            # catalog-build time by the agent (AgentV2._apply_email_availability_
+            # filter), which resolves AI mailbox / org SMTP / global for the
+            # current org. Keying is_active on the startup global
+            # settings.email_client would wrongly hide the tool for orgs that
+            # configured SMTP via the UI (org SMTP) rather than bow-config.
+            is_active=True,
             required_permissions=[],
             tags=["notification", "email", "action"],
             examples=[

--- a/backend/app/ai/tools/mcp/send_email.py
+++ b/backend/app/ai/tools/mcp/send_email.py
@@ -39,10 +39,21 @@ class SendEmailMCPTool(MCPTool):
         "pass the owning report_id."
     )
 
+    # Availability is decided per-org at request time (see is_available_for_org),
+    # not by the startup-global is_available, so orgs that configured SMTP via the
+    # UI (org SMTP) are covered even when the global bow-config SMTP is empty.
     @property
     def is_available(self) -> bool:
-        """Only expose the tool when an SMTP/email client is configured."""
-        return settings.email_client is not None
+        return True
+
+    async def is_available_for_org(self, db, organization) -> bool:
+        """Whether outbound email resolves for this org (AI mailbox / org SMTP /
+        global), mirroring the analyst send path."""
+        org_id = getattr(organization, "id", None)
+        if not db or not org_id:
+            return settings.email_client is not None
+        from app.services.email_client_resolver import is_outbound_available
+        return await is_outbound_available(db, str(org_id), purpose="analyst")
 
     @property
     def input_schema(self) -> Dict[str, Any]:
@@ -60,10 +71,10 @@ class SendEmailMCPTool(MCPTool):
         except Exception as e:
             return MCPSendEmailOutput(success=False, error=f"Invalid input: {e}").model_dump()
 
-        if not self.is_available:
+        if not await self.is_available_for_org(db, organization):
             return MCPSendEmailOutput(
                 success=False, subject=input_data.subject,
-                error="Email is not configured on this server.",
+                error="Email is not configured for this organization.",
             ).model_dump()
 
         # Recipient is always the authenticated user — never caller-controllable.

--- a/backend/app/routes/mcp.py
+++ b/backend/app/routes/mcp.py
@@ -321,6 +321,13 @@ async def mcp_endpoint(
             if denied_perms:
                 tools = [t for t in tools if t.get("required_ds_permission") not in denied_perms]
 
+        # Hide send_email unless outbound email resolves for this org (AI mailbox
+        # / org SMTP / global). Availability is per-org, not a startup global.
+        if any(t["name"] == "send_email" for t in tools):
+            from app.services.email_client_resolver import is_outbound_available
+            if not await is_outbound_available(db, str(organization.id), purpose="analyst"):
+                tools = [t for t in tools if t["name"] != "send_email"]
+
         mcp_tools = []
         for tool in tools:
             entry: dict[str, Any] = {

--- a/backend/app/services/email_client_resolver.py
+++ b/backend/app/services/email_client_resolver.py
@@ -159,3 +159,20 @@ async def resolve_outbound(db, organization_id: str, purpose: str = "system") ->
         purpose, ai_config, ai_creds, org_smtp,
         global_present=settings.email_client is not None,
     )
+
+
+async def is_outbound_available(db, organization_id: str, purpose: str = "analyst") -> bool:
+    """Whether any outbound email transport resolves for ``organization_id``.
+
+    Mirrors :func:`resolve_outbound`'s precedence (AI mailbox → org SMTP →
+    global), so it returns True when the org configured SMTP via the UI even if
+    the global bow-config SMTP is empty. Used to gate tool *availability*
+    (e.g. the ``send_email`` tool) the same way sending is gated, instead of
+    keying only on the startup global ``settings.email_client``.
+    """
+    try:
+        resolved = await resolve_outbound(db, organization_id, purpose)
+    except Exception:
+        logger.warning("is_outbound_available: resolve failed", exc_info=True)
+        return False
+    return resolved.source != "none"

--- a/backend/email_sandbox/test_email_resolver.py
+++ b/backend/email_sandbox/test_email_resolver.py
@@ -4,7 +4,13 @@ Covers the requirements: backward orgs (no DB SMTP) fall back to global; orgs
 that set DB SMTP use it even when the global bow-config SMTP is empty; analyst
 mail always uses the AI mailbox.
 """
-from app.services.email_client_resolver import choose_outbound
+import pytest
+
+from app.services.email_client_resolver import (
+    ResolvedOutbound,
+    choose_outbound,
+    is_outbound_available,
+)
 
 
 AI_CONFIG = {"from_address": "analyst@acme.com", "from_name": "Acme Analyst", "smtp_host": "smtp.acme.com"}
@@ -71,3 +77,32 @@ def test_nothing_configured_is_none():
     r = choose_outbound("system", None, None, None, global_present=False)
     assert r.source == "none"
     assert not r.uses_smtp_config
+
+
+# ---- availability gate (used to show/hide the send_email tool) ----
+
+@pytest.mark.parametrize("source,expected", [
+    ("ai_mailbox", True),
+    ("org_smtp", True),   # org configured SMTP via UI, global env empty -> available
+    ("global", True),
+    ("none", False),      # nothing resolves -> tool hidden
+])
+async def test_is_outbound_available(monkeypatch, source, expected):
+    import app.services.email_client_resolver as r
+
+    async def fake_resolve(db, org_id, purpose="system"):
+        assert purpose == "analyst"
+        return ResolvedOutbound(source=source)
+
+    monkeypatch.setattr(r, "resolve_outbound", fake_resolve)
+    assert await is_outbound_available(object(), "org-1", purpose="analyst") is expected
+
+
+async def test_is_outbound_available_swallows_errors(monkeypatch):
+    import app.services.email_client_resolver as r
+
+    async def boom(db, org_id, purpose="system"):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(r, "resolve_outbound", boom)
+    assert await is_outbound_available(object(), "org-1") is False


### PR DESCRIPTION
## Problem

The `send_email` tool (both the internal agent tool and the external MCP tool) was hidden from the catalog whenever the **global bow-config SMTP** (`settings.email_client`) was unset — even when the organization had configured SMTP via the UI (org SMTP) or set up an AI Mailbox.

The mismatch: **sending** already honored the UI/DB config through `resolve_outbound` (AI mailbox → org SMTP → global), but the **availability gate** only checked the startup-global `settings.email_client`. Result: the tool never appeared in the planner/MCP catalog, so the agent couldn't call it — despite a send actually being able to succeed. This surfaced as the analyst failing to send email on a scheduled run even though org SMTP was configured in Settings → SMTP.

## Fix

Make availability **per-org**, mirroring the exact precedence the send path already uses (AI mailbox → org SMTP → global):

- **New helper** `email_client_resolver.is_outbound_available(db, org_id, purpose="analyst")` — returns True when any transport resolves, so UI-configured org SMTP counts even when the global bow-config SMTP is empty.
- **Internal agent tool** (`implementations/send_email.py`) — registered as always-active (so it stays executable); `AgentV2._apply_email_availability_filter()` now removes it from the planner catalog at build time only when no transport resolves for the org.
- **MCP tool** (`mcp/send_email.py` + `routes/mcp.py`) — the same latent bug existed there (it would block both `tools/list` and `execute()` for org-SMTP-only orgs). Replaced the global-only `is_available` with an org-aware `is_available_for_org()` used for both listing and the execute guard.

## Tests

- Added unit coverage for the new availability helper (`email_sandbox/test_email_resolver.py`): `ai_mailbox`/`org_smtp`/`global` → available, `none` → hidden, resolver errors → safe-hidden.
- Resolver suite: **13/13 pass** locally.
- The existing e2e MCP `send_email` tests remain valid by construction (global SMTP is still a fallback in `is_outbound_available`, so patching `settings.email_client` to `None`/`object()` yields the same hidden/listed outcome). These weren't run locally — the sandbox lacks the full app stack (sqlalchemy/DB) — so worth confirming in CI: `tests/e2e/rbac/test_mcp_analysis.py -k send_email`.

## Note

The Settings → SMTP page is, by design, the *system-email* transport; for the analyst (`send_email`) it's only used as a fallback after the AI Mailbox. This fix makes org SMTP correctly enable the tool. For a proper analyst sender identity / reply threading, configuring an AI Mailbox remains the intended path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aqZyK5X9VjS5NU2f9HFxh

---
_Generated by [Claude Code](https://claude.ai/code/session_017aqZyK5X9VjS5NU2f9HFxh)_