### PR TITLE
feat: add mcp_public_url config and request-aware URL derivation for …

### DIFF
--- a/backend/app/core/base_url.py
+++ b/backend/app/core/base_url.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 from fastapi import Request
 
-from app.settings.config import settings
-
 
 # bow_config defaults that should be treated as "no base_url set" so
 # request-derived fallback kicks in instead of returning the placeholder.
@@ -33,6 +31,7 @@ _DEFAULT_PLACEHOLDERS = (
 
 def derive_base_url(request: Request) -> str:
     """Return the externally-reachable base URL with no trailing slash."""
+    from app.settings.config import settings
     configured = (settings.bow_config.base_url or "").rstrip("/")
     if configured and configured not in _DEFAULT_PLACEHOLDERS:
         return configured
@@ -48,3 +47,34 @@ def derive_base_url(request: Request) -> str:
     scheme = request.url.scheme
     host = request.headers.get("host", request.url.netloc or "localhost")
     return f"{scheme}://{host}"
+
+
+def derive_request_base_url(request: Request) -> str:
+    """Derive base URL from the incoming request headers only, ignoring config.
+
+    Unlike derive_base_url, bow_config.base_url is NOT consulted. Use when the
+    URL must reflect the domain the user actually arrived from — e.g. OAuth
+    redirect_uri must match the initiating domain, not the configured default.
+
+    Uses X-Forwarded-Proto for scheme (set by Cloudflare Tunnel and most
+    reverse proxies) and the Host header for the hostname.
+    """
+    host = request.headers.get("host", request.url.netloc or "localhost")
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    if forwarded_proto:
+        proto = forwarded_proto.split(",", 1)[0].strip()
+        return f"{proto}://{host}"
+    return f"{request.url.scheme}://{host}"
+
+
+def derive_mcp_base_url(request: Request) -> str:
+    """Like derive_base_url but checks mcp_public_url first.
+
+    Use for OAuth/MCP well-known endpoints so a Cloudflare Tunnel (or any
+    reverse-proxy) public URL can be configured independently of base_url.
+    """
+    from app.settings.config import settings
+    configured = (settings.bow_config.mcp_public_url or "").rstrip("/")
+    if configured:
+        return configured
+    return derive_base_url(request)

--- a/backend/app/routes/mcp.py
+++ b/backend/app/routes/mcp.py
@@ -36,8 +36,8 @@ MCP_PROTOCOL_VERSION = "2025-11-25"
 
 def _resource_metadata_url(request: Request) -> str:
     """Build the well-known URL for the WWW-Authenticate header."""
-    from app.core.base_url import derive_base_url
-    return f"{derive_base_url(request)}/.well-known/oauth-protected-resource"
+    from app.core.base_url import derive_mcp_base_url
+    return f"{derive_mcp_base_url(request)}/.well-known/oauth-protected-resource"
 
 
 async def mcp_auth(

--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -40,8 +40,8 @@ well_known_router = APIRouter(tags=["oauth-metadata"])
 
 def _base_url(request: Request) -> str:
     """Derive the public base URL from config, X-Forwarded-* headers, or request."""
-    from app.core.base_url import derive_base_url
-    return derive_base_url(request)
+    from app.core.base_url import derive_mcp_base_url
+    return derive_mcp_base_url(request)
 
 
 @well_known_router.get("/.well-known/oauth-protected-resource")

--- a/backend/app/services/auth_providers.py
+++ b/backend/app/services/auth_providers.py
@@ -66,9 +66,10 @@ def _get_scopes(scopes: Optional[list]) -> list:
     return scopes or ["openid", "profile", "email"]
 
 
-def _get_redirect_uri(provider: str, redirect_path: Optional[str] = None) -> str:
+def _get_redirect_uri(provider: str, request: Request, redirect_path: Optional[str] = None) -> str:
+    from app.core.base_url import derive_request_base_url
     path = redirect_path or f"/api/auth/{provider}/callback"
-    return f"{settings.bow_config.base_url}{path}"
+    return f"{derive_request_base_url(request)}{path}"
 
 
 def _issue_state_cookie(provider: str, response: JSONResponse, state: str) -> None:
@@ -140,7 +141,7 @@ async def build_authorize_url(provider: str, request: Request) -> JSONResponse:
 
         client = GoogleOAuth2(g.client_id, g.client_secret)
         state = uuid.uuid4().hex
-        redirect_uri = _get_redirect_uri(provider)
+        redirect_uri = _get_redirect_uri(provider, request)
         authorization_url = await client.get_authorization_url(
             redirect_uri=redirect_uri,
             state=state,
@@ -163,7 +164,7 @@ async def build_authorize_url(provider: str, request: Request) -> JSONResponse:
 
     code_verifier, code_challenge = _generate_pkce_pair()
     state = uuid.uuid4().hex
-    redirect_uri = _get_redirect_uri(provider, getattr(cfg, "redirect_path", None))
+    redirect_uri = _get_redirect_uri(provider, request, getattr(cfg, "redirect_path", None))
 
     authorization_url = await client.get_authorization_url(
         redirect_uri=redirect_uri,
@@ -199,7 +200,7 @@ def _friendly_error_message(detail: Any) -> str:
 def _error_redirect(message: str) -> RedirectResponse:
     """Redirect back to the sign-in page with a visible error message."""
     msg = urllib.parse.quote(message)
-    return RedirectResponse(f"{settings.bow_config.base_url}/users/sign-in?error={msg}", status_code=303)
+    return RedirectResponse(f"/users/sign-in?error={msg}", status_code=303)
 
 
 async def handle_callback(provider: str, request: Request, code: Optional[str], state: Optional[str], user_manager) -> RedirectResponse:
@@ -233,7 +234,7 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
         if not g or not g.enabled:
             raise HTTPException(status_code=404, detail="Google OAuth not enabled")
         client = GoogleOAuth2(g.client_id, g.client_secret)
-        redirect_uri = _get_redirect_uri(provider)
+        redirect_uri = _get_redirect_uri(provider, request)
         try:
             token = await client.get_access_token(code, redirect_uri)
         except httpx.HTTPStatusError as e:
@@ -286,7 +287,7 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
 
         strategy = get_jwt_strategy()
         jwt_token = await strategy.write_token(user)
-        return RedirectResponse(f"{settings.bow_config.base_url}/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
+        return RedirectResponse(f"/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
 
     # OIDC providers
     cfg = _get_oidc_config(provider)
@@ -296,7 +297,7 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
     issuer = cfg.issuer.rstrip("/")
     openid_cfg_endpoint = issuer if "well-known" in issuer else f"{issuer}/.well-known/openid-configuration"
     client = OpenID(cfg.client_id, cfg.client_secret, openid_configuration_endpoint=openid_cfg_endpoint, name=provider)
-    redirect_uri = _get_redirect_uri(provider, getattr(cfg, "redirect_path", None))
+    redirect_uri = _get_redirect_uri(provider, request, getattr(cfg, "redirect_path", None))
 
     try:
         token_endpoint = (await _discover_endpoints(openid_cfg_endpoint))["token_endpoint"]
@@ -431,7 +432,7 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
 
     strategy = get_jwt_strategy()
     jwt_token = await strategy.write_token(user)
-    return RedirectResponse(f"{settings.bow_config.base_url}/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
+    return RedirectResponse(f"/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
 
 
 async def _record_login(user) -> None:

--- a/backend/app/settings/bow_config.py
+++ b/backend/app/settings/bow_config.py
@@ -243,6 +243,7 @@ def generate_fernet_key():
 class BowConfig(BaseModel):
     deployment: DeploymentConfig = DeploymentConfig()
     base_url: Optional[str] = Field(default="http://0.0.0.0:3000")
+    mcp_public_url: Optional[str] = None
     features: FeatureFlags = FeatureFlags()
     auth: AuthConfig = AuthConfig()
     google_oauth: GoogleOAuth = GoogleOAuth()


### PR DESCRIPTION
Fixes OAuth/MCP discovery and OIDC auth flows for deployments where the
app is exposed on multiple domains (e.g. internal base_url + Cloudflare
Tunnel public URL) with no inbound connection on the internal host.

## mcp_public_url (bow_config)

New optional field `mcp_public_url` in BowConfig. When set, it overrides
`base_url` specifically for MCP/OAuth well-known endpoints so the
Cloudflare Tunnel public hostname is advertised to MCP clients without
affecting the rest of the app.

- `/.well-known/oauth-protected-resource` — authorization_servers uses tunnel URL
- `/.well-known/oauth-authorization-server` — issuer, authorization_endpoint,
  and token_endpoint use tunnel URL
- `GET /api/mcp` WWW-Authenticate header uses tunnel URL

## base_url.py — two new functions, circular import fix

`derive_mcp_base_url(request)`: checks mcp_public_url first, falls back
to existing derive_base_url chain (base_url config → X-Forwarded-* → request).

`derive_request_base_url(request)`: ignores bow_config.base_url entirely;
derives origin from X-Forwarded-Proto + Host headers only. Used where the
URL must reflect the domain the user actually arrived from.

Moved the top-level `from app.settings.config import settings` import
inside each function (lazy) to eliminate a circular import that surfaced
during alembic startup when bow_config.py was partially initialized.

## auth_providers.py — request-aware OIDC redirect_uri

`_get_redirect_uri()` now accepts `request` and uses
`derive_request_base_url` so the redirect_uri sent to the IdP matches the
domain the login flow was initiated from. Supports multiple registered
callback URLs in Auth0/OIDC providers (one per exposed domain).

Post-login and error redirects changed from absolute
(`{base_url}/users/sign-in`) to relative (`/users/sign-in`) so the user
always lands back on the domain they came from regardless of base_url.