### PR TITLE
fix(dark-mode): restore prose contrast in agent description markdown

### DIFF
--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -239,4 +239,19 @@ const renderedHtml = computed(() => {
   font-size: 0.95em;
   white-space: nowrap;
 }
+
+/* Dark mode overrides. The `.dark` class lives on <html> (Tailwind darkMode:
+   'class'), outside this component's scope, so these rules are authored as
+   :global and matched by the unique `.instruction-prose` class. */
+:global(.dark .instruction-prose) { color: #e5e7eb; }
+:global(.dark .instruction-prose h1),
+:global(.dark .instruction-prose h2),
+:global(.dark .instruction-prose h3) { color: #f9fafb; }
+:global(.dark .instruction-prose code) { background: #374151; color: #e5e7eb; }
+:global(.dark .instruction-prose pre) { background: #1f2937; }
+:global(.dark .instruction-prose blockquote) { border-left-color: #374151; color: #9ca3af; }
+:global(.dark .instruction-prose .instruction-mention) {
+  background-color: rgba(129, 140, 248, 0.18);
+  color: #c7d2fe;
+}
 </style>


### PR DESCRIPTION
## Problem

In dark mode, markdown descriptions rendered by `InstructionText.vue` (e.g. the agent/data-source description panel in `KnowledgeExplorer`) showed dark-gray text on a dark background — nearly invisible. Inline code pills stayed legible only because they happened to use light backgrounds.

## Cause

The component's scoped `<style>` block hardcoded light-mode colors (`color: #111827`, light code/blockquote backgrounds) with no dark-mode counterparts.

## Fix

The `.dark` class lives on `<html>` (Tailwind `darkMode: 'class'`), outside this component's scope, and the block is `scoped` — so I added `:global(.dark .instruction-prose …)` plain-CSS overrides for prose body, headings, inline `code`, `pre`, `blockquote`, and instruction mentions. Matching on the unique `.instruction-prose` class avoids any scope-attribute / `:deep` interplay.

This fixes the markdown renderer everywhere it's used with `:markdown="true"`, not just this one panel.

## Verification

- `yarn build` passes (exit 0) — the `:global(.dark …)` CSS compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)