### PR TITLE
feat(reports): follow-up suggestions after web answers

### DIFF
--- a/backend/app/ai/agents/reporter/reporter.py
+++ b/backend/app/ai/agents/reporter/reporter.py
@@ -123,7 +123,7 @@ class Reporter:
         {grounding_rule}
         - Prefer drilling into dimensions, time trends, comparisons, or segments present in the data.
         - Do not repeat questions already asked. Do not number them.
-        {build_language_directive(self.organization_settings)}
+        - Write the suggestions in the SAME language the conversation above is in. Keep column names, identifiers, and metric names as-is.
         Return ONLY a JSON array of strings, nothing else.
         Example: ["How did revenue trend last quarter?", "Which region grew fastest?"]
         """
@@ -161,7 +161,7 @@ class Reporter:
         - Each suggestion is a single, self-contained training action phrased as a prompt.
         - Keep them short (max ~12 words), specific, and actionable.
         - Do not repeat actions already taken. Do not number them.
-        {build_language_directive(self.organization_settings)}
+        - Write the suggestions in the SAME language the conversation above is in. Keep instruction text, table names, and identifiers as-is.
         Return ONLY a JSON array of strings, nothing else.
         Example: ["Find conflicting instructions about revenue", "Which tables have no instructions?"]
         """


### PR DESCRIPTION
## Summary

After each answer in the **web** app, the agent now suggests a few follow-up questions the user can click to ask next — rendered as minimalist chips below the feedback (thumbs) bar, OpenWebUI-style.

Three gates, all built on existing primitives:
- **Web sessions only** — `platform is None` (Slack/Teams/Email/Excel/scheduled all carry a non-null platform and are skipped).
- **Org setting** — new `enable_follow_ups` FeatureConfig (default **on**; auto-surfaces in AI settings, backfills existing orgs via `_sync_new_features`).
- **Small model** — generated by the `Reporter` on `get_default_model(is_small=True)` (Haiku-class), recorded under `usage_scope=report.follow_ups` and counted against the per-agent quota.

## Reliability

Unlike report-title generation (fire-and-forget after `completion.finished`, never drained, errors swallowed), follow-ups are generated **inline at the tail of the run**:
- The result is **persisted** on a new `completions.follow_ups` JSON column (survives reload).
- A `completion.follow_ups` SSE event is enqueued **before `[DONE]`**, so chips appear live in the same stream.

The Alembic revision also merges the two pre-existing heads (`judge0001`, `usravatar01`) back into one.

## Mode-aware prompting

- **Chat / deep** — suggestions are grounded in the available schema (which already embeds data-source + column descriptions) and org instructions, so they reference dimensions/metrics that actually exist.
- **Training** — same schema + instructions, but the prompt steers toward curating the instruction set: finding conflicts, overlap/redundancy, duplicates, and coverage gaps, alongside reviewing weak runs. Verified live — caught seeded conflicting revenue definitions, duplicate VIP thresholds, a VIP/top-customer overlap, and uncovered tables.

Grounding context is capped (schema 6k / instructions 3k–6k chars) to keep the small-model call cheap.

## Language

Follow-ups mirror the **conversation** language (not the org locale) — so an English thread in a Hebrew-locale org gets English suggestions, and vice versa. Identifiers/column names stay in English.

## Frontend

- `components/report/FollowUpSuggestions.vue` — minimal chips, relaxed "Follow up" header, hairline dividers, slide-in arrow on hover.
- `useOrgSettings.ts` — `isFollowUpsEnabled` flag.
- `pages/reports/[id]/index.vue` — handles the SSE event, rehydrates the persisted field on reload, renders below the feedback bar on the latest message, gated on the org setting.

## Testing

Validated end-to-end against a live LLM with the chinook demo: SSE event ordering, persistence, enable/disable gate, click-to-submit, schema-grounded chat suggestions, instruction-audit training suggestions, and conversation-language mirroring. Screenshot walkthrough script at `backend/scripts/ui_followups_shots.py`; runbook at `sandbox-feedback-loop-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnb7r358SrmcEWnkqWsvu2)_