### PR TITLE
fix: single-value cards show the asked-for value over melted KPI tables

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -4426,8 +4426,12 @@ class AgentV2:
                                 # Preserve existing type; only set if missing
                                 if not merged.get("type") and data_model_from_tool.get("type"):
                                     merged["type"] = data_model_from_tool.get("type")
-                                # Merge series/grouping fields
-                                for key in ("series", "group_by", "sort", "limit"):
+                                # Merge series/grouping fields. `filters` MUST be
+                                # included: it carries the default filter that
+                                # narrows a melted/long KPI table to the asked-for
+                                # row for single-value cards — dropping it makes
+                                # count/metric_card render row 0 (the date/label).
+                                for key in ("series", "group_by", "sort", "limit", "filters"):
                                     if data_model_from_tool.get(key) is not None:
                                         merged[key] = data_model_from_tool.get(key)
                                 await self.project_manager.update_step_with_data_model(fresh_db, step_obj, merged)

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -184,6 +184,100 @@ def _first_series_aggregation(series: List[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
+# Keys carried from the inferred (viz-inference) data_model into the final one.
+# The final type is forced to the user/early-requested type, but these shaping
+# fields come from inference. `filters` MUST be here: the inference prompt tells
+# the model to emit top-level default filters to reduce a granular/melted table
+# (e.g. a `Metric | Value | Format` KPI table) down to the one relevant row.
+# Dropping it makes count/metric_card render the first (unfiltered) row — the
+# date or the metric label — instead of the value the user asked for.
+_INFERRED_DM_CARRY_KEYS = ("series", "group_by", "sort", "limit", "filters")
+
+
+def finalize_inferred_data_model(
+    fallback_type: str,
+    inferred_dm: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build the final data_model: forced type + shaping fields from inference.
+
+    The visualization type is pinned to the user/early-requested ``fallback_type``;
+    only the series/grouping/sort/limit/filters come from the inference pass.
+    """
+    final_dm: Dict[str, Any] = {"type": fallback_type, "series": []}
+    if isinstance(inferred_dm, dict):
+        for key in _INFERRED_DM_CARRY_KEYS:
+            if inferred_dm.get(key) is not None:
+                final_dm[key] = inferred_dm.get(key)
+    return final_dm
+
+
+# Single-value card types: they render exactly one row (the frontend shows
+# rows[0]), so a melted/long table must be narrowed to the asked-for row.
+_SINGLE_VALUE_CARD_TYPES = {"count", "metric_card"}
+
+
+def _norm(s: Any) -> str:
+    return str(s).strip().lower() if s is not None else ""
+
+
+def derive_kpi_row_filter(
+    final_dm: Dict[str, Any],
+    formatted: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Derive a row-selecting filter for a single-value card over a melted table.
+
+    A ``count``/``metric_card`` shows one row. When the underlying result is a
+    *melted / long* KPI table — a label column plus a single shared value column,
+    one row per metric (``Metric | Value | Format``) — picking ``value="Value"``
+    is ambiguous: the frontend falls back to ``rows[0]`` (the date/first metric)
+    unless a filter narrows the data to the asked-for metric.
+
+    The viz-inference prompt asks the model to emit that filter, but it does so
+    only sometimes (it may emit an ``aggregation`` instead, which the card
+    ignores). This is the deterministic safeguard: if no filter is present, match
+    the series' display name against the cells of a non-value column and, on a
+    hit, return a filter selecting that row. Conservative — returns ``None``
+    unless there is a clear single match, so normal results are untouched.
+    """
+    if (final_dm or {}).get("type") not in _SINGLE_VALUE_CARD_TYPES:
+        return None
+    if final_dm.get("filters"):
+        return None
+
+    rows = (formatted or {}).get("rows") or []
+    if len(rows) < 2:  # one row: rows[0] is already the answer
+        return None
+
+    series = final_dm.get("series") or []
+    first = series[0] if series and isinstance(series[0], dict) else {}
+    value_col = first.get("value")
+    label = first.get("name")
+    if not value_col or not label:
+        return None
+
+    columns = [
+        c.get("field")
+        for c in (formatted.get("columns") or [])
+        if isinstance(c, dict) and c.get("field")
+    ]
+    label_norm = _norm(label)
+
+    # Prefer an exact cell match; fall back to a substring match (the series name
+    # is often a shortened form of the label cell, e.g. "Revenue" vs
+    # "Total Revenue (Revenue)"). Require a single matching row to stay safe.
+    for matcher in (
+        lambda cell: _norm(cell) == label_norm,
+        lambda cell: len(label_norm) >= 3 and (label_norm in _norm(cell) or _norm(cell) in label_norm),
+    ):
+        for col in columns:
+            if col == value_col:
+                continue
+            hits = [r for r in rows if isinstance(r, dict) and r.get(col) is not None and matcher(r.get(col))]
+            if len(hits) == 1:
+                return {"column": col, "operator": "equals", "value": hits[0].get(col)}
+    return None
+
+
 def build_view_from_data_model(
     data_model: Dict[str, Any],
     title: Optional[str] = None,
@@ -1405,12 +1499,17 @@ Do not use generic placeholders like "value" unless that is the actual column na
             fallback_type = effective_type if 'effective_type' in locals() and effective_type else "table"
         except Exception:
             fallback_type = "table"
-        # Force the final type to the early/user-requested type; only take series/grouping from inference
-        final_dm = {"type": fallback_type, "series": []}
-        if isinstance(inferred_dm, dict):
-            for key in ("series", "group_by", "sort", "limit"):
-                if inferred_dm.get(key) is not None:
-                    final_dm[key] = inferred_dm.get(key)
+        # Force the final type to the early/user-requested type; only take
+        # series/grouping/sort/limit/filters from inference. (filters carry the
+        # default-filter that narrows a melted KPI table to the asked-for row.)
+        final_dm = finalize_inferred_data_model(fallback_type, inferred_dm)
+        # Safeguard: a single-value card over a melted/long table needs a filter
+        # to pick the asked-for row. If the model didn't emit one, derive it from
+        # the series name so the card shows the metric value, not row 0.
+        if not final_dm.get("filters"):
+            derived_filter = derive_kpi_row_filter(final_dm, formatted)
+            if derived_filter:
+                final_dm["filters"] = [derived_filter]
         palette_theme = _infer_palette_theme(runtime_ctx) or "default"
         # Extract available column names from formatted data for fallback inference
         available_columns = [c.get("field") for c in formatted.get("columns", []) if c.get("field")]

--- a/frontend/components/KnowledgeGroup.vue
+++ b/frontend/components/KnowledgeGroup.vue
@@ -119,9 +119,13 @@
                     Open
                   </button>
                 </div>
-                <!-- Pending: inline per-hunk accept/reject, collapsed to changed regions -->
+                <!-- Pending EDIT: inline per-hunk accept/reject, collapsed to changed regions.
+                     Creates are excluded: a brand-new instruction has no main text to diff
+                     against, so review-hunks yields zero hunks ("No pending changes"). They
+                     fall through to the static full-insertion diff below, which shows the
+                     whole new instruction body. -->
                 <div
-                  v-if="ch.instructionId && canCreateInstructions && resolutionFor(ch) === null"
+                  v-if="ch.type === 'edit' && ch.instructionId && canCreateInstructions && resolutionFor(ch) === null"
                   class="px-3 py-2 bg-white dark:bg-gray-900"
                 >
                   <InstructionTrackedChanges
@@ -133,7 +137,7 @@
                     @empty="refreshChangeResolution(ch)"
                   />
                 </div>
-                <!-- Resolved / read-only: static diff -->
+                <!-- Create, or resolved / read-only: static diff (full insertion for a create) -->
                 <div
                   v-else
                   class="px-3 py-2 bg-white dark:bg-gray-900 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -457,14 +457,55 @@ const activeFilterCount = computed(() => {
 
 // Apply shared filters to get filtered rows
 const filteredRows = computed(() => {
-  const rows = effectiveStep.value?.data?.rows
+  let rows = effectiveStep.value?.data?.rows
   if (!Array.isArray(rows)) return []
+
+  // Apply the view's own defaultFilters directly. The standalone preview has no
+  // dashboard shared-filter pipeline guaranteed to be ready on first paint, so
+  // relying solely on the seeded shared filters races: a single-value card over
+  // a melted/long KPI table (Metric | Value | Format) would otherwise render
+  // row 0 / a sum of every metric instead of the asked-for row. Dashboards do
+  // not use this component (they filter rows upstream), so this is safe and does
+  // not interfere with user-overridable shared filters there.
+  const v = normalizedView.value as any
+  const viewInner = v?.view || v
+  const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
+  if (defaults.length) {
+    rows = rows.filter((row: any) => defaults.every((f: any) => matchDefaultFilter(row, f)))
+  }
+
   if (sharedFilters.value.length === 0 || !visualizationId.value) return rows
 
   return rows.filter((row: any) =>
     sharedEvaluateFilters(row, sharedFilters.value, visualizationId.value)
   )
 })
+
+// Lightweight evaluator for a view's plain-column defaultFilters (no vizId
+// prefix). Mirrors the operators in DefaultFilterCondition.
+function matchDefaultFilter(row: any, f: any): boolean {
+  if (!row || !f || !f.column) return true
+  const key = Object.keys(row).find(k => k.toLowerCase() === String(f.column).toLowerCase())
+  if (key === undefined) return true
+  const cell = row[key]
+  const s = (x: any) => (x === null || x === undefined) ? '' : String(x)
+  const op = String(f.operator || 'equals')
+  switch (op) {
+    case 'equals': return s(cell) === s(f.value)
+    case 'not_equals': return s(cell) !== s(f.value)
+    case 'contains': return s(cell).includes(s(f.value))
+    case 'not_contains': return !s(cell).includes(s(f.value))
+    case 'starts_with': return s(cell).startsWith(s(f.value))
+    case 'ends_with': return s(cell).endsWith(s(f.value))
+    case 'greater_than': return Number(cell) > Number(f.value)
+    case 'less_than': return Number(cell) < Number(f.value)
+    case 'gte': return Number(cell) >= Number(f.value)
+    case 'lte': return Number(cell) <= Number(f.value)
+    case 'is_empty': return s(cell) === ''
+    case 'is_not_empty': return s(cell) !== ''
+    default: return true
+  }
+}
 
 // Normalize the view to ensure it's in the v2 format { view: {...}, version: 'v2' }
 const normalizedView = computed(() => {


### PR DESCRIPTION
## Problem

A `count` / `metric_card` renders a single row. When `create_data` produces a **melted / long** KPI result — a `Metric | Value | Format` table with one row per metric — a single-value card has no way to know which row to show. The value the user asked for is selected by a **default filter** on the label column.

That filter was being dropped in two backend places and never applied in the standalone widget preview, so the card showed the wrong thing:
- the **date** row (`2026-06-23`) — the originally reported bug (it rendered `rows[0]` / the first column), or
- with `aggregation: "sum"`, the **sum of every metric** (e.g. `2328.6 + 2240 + 412 = 4980.6`).

## Root cause & fix

**Backend**
1. `create_data._run_stream_traced` built `final_dm` copying only `series/group_by/sort/limit` from the inferred model — dropping `filters`.
2. `agent_v2` merged the tool's `data_model` into the step with the same truncated key set — dropping `filters` again.

   Both now carry `filters`.
3. The viz-inference model only emits the selecting filter *sometimes* (it may emit an `aggregation` the card sums instead). So `create_data` now derives a row-selecting filter deterministically (`derive_kpi_row_filter`): for a single-value card with no filter over a multi-row table, it matches the series' display name against a non-value column and, on a single hit, narrows to that row. Conservative — no-ops on normal results.

**Frontend**
4. `ToolWidgetPreview` now applies the view's own `defaultFilters` directly when deriving rows. The standalone preview has no dashboard shared-filter pipeline guaranteed ready on first paint, so a melted KPI card would otherwise sum every metric. Dashboards don't use this component (they filter rows upstream via `DashboardComponent`), so user-overridable shared filters there are unaffected.

## Verification

Reproduced and fixed end-to-end against the live app (backend + Nuxt frontend) with a real agent completion on the Chinook demo. The agent produces the melted KPI table; the metric card on `/reports/[id]` now renders **2,328.6** (Total Revenue) — not the date, and not the `4,980.6` all-rows sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXWdCv6MFNe8ouPh6MoEek)_