### PR TITLE
Monitoring: surface origin platform + refine columns in diagnosis/trace

### DIFF
--- a/backend/app/schemas/agent_execution_trace_schema.py
+++ b/backend/app/schemas/agent_execution_trace_schema.py
@@ -83,6 +83,7 @@ class ConversationTraceResponse(BaseModel):
     report_title: Optional[str] = None
     user_name: Optional[str] = None
     user_email: Optional[str] = None
+    external_platform: Optional[str] = None  # 'slack', 'teams', 'email'; null = web UI
     total_turns: int = 0
     failed_turns: int = 0
     negative_feedback_turns: int = 0

--- a/backend/app/schemas/console_schema.py
+++ b/backend/app/schemas/console_schema.py
@@ -331,6 +331,7 @@ class AgentExecutionSummaryItem(BaseModel):
     tool_names: List[str] = []
     user_name: Optional[str] = None
     user_email: Optional[str] = None
+    external_platform: Optional[str] = None  # 'slack', 'teams', 'email'; null = web UI
     report_id: str
     report_name: Optional[str] = None
     report_link: Optional[str] = None

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -2408,22 +2408,28 @@ class ConsoleService:
 
         # Prompts for completions - get from parent user completion, not system completion
         prompts: dict[str, str] = {}
+        # Origin platform per completion, also from the parent user completion.
+        platforms: dict[str, str] = {}
         if completion_ids:
             # Get system completions and their parent_ids
             system_completions_q = select(Completion.id, Completion.parent_id).where(Completion.id.in_(completion_ids))
             system_completions_res = await db.execute(system_completions_q)
             system_completions = system_completions_res.all()
-            
+
             # Collect parent completion IDs
             parent_ids = [sc.parent_id for sc in system_completions if sc.parent_id]
-            
-            # Get prompts from parent user completions
+
+            # Get prompts + origin platform from parent user completions
             if parent_ids:
-                prompt_q = select(Completion.id, Completion.prompt).where(Completion.id.in_(parent_ids))
+                prompt_q = select(Completion.id, Completion.prompt, Completion.external_platform).where(Completion.id.in_(parent_ids))
                 pres = await db.execute(prompt_q)
-                parent_prompts = {str(cid): prompt for cid, prompt in pres.all()}
-                
-                # Map system completion IDs to their parent's prompts
+                parent_prompts = {}
+                parent_platforms = {}
+                for cid, prompt, plat in pres.all():
+                    parent_prompts[str(cid)] = prompt
+                    parent_platforms[str(cid)] = plat
+
+                # Map system completion IDs to their parent's prompts + platform
                 for sc in system_completions:
                     if sc.parent_id and str(sc.parent_id) in parent_prompts:
                         prompt = parent_prompts[str(sc.parent_id)]
@@ -2434,6 +2440,9 @@ class ConsoleService:
                                 prompts[str(sc.id)] = str(prompt or '')
                         except Exception:
                             prompts[str(sc.id)] = ''
+                        plat = parent_platforms.get(str(sc.parent_id))
+                        if plat:
+                            platforms[str(sc.id)] = plat
 
         # Tool execution counts per AE + distinct tool names (ordered by first invocation)
         te_counts = {str(ae_id): {'total': 0, 'success': 0, 'failed': 0} for ae_id in ae_ids}
@@ -2557,6 +2566,7 @@ class ConsoleService:
                 tool_names=ae_tool_names.get(str(r.ae_id), [])[:5],
                 user_name=r.user_name,
                 user_email=r.user_email,
+                external_platform=platforms.get(str(r.completion_id)),
                 report_id=str(r.report_id) if r.report_id else '',
                 report_name=r.report_title or '',
                 report_link=report_link

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -2060,6 +2060,7 @@ class ConsoleService:
                 UserCompletion.id.label('user_completion_id'),
                 UserCompletion.prompt.label('user_prompt'),
                 UserCompletion.role.label('user_role'),
+                UserCompletion.external_platform.label('external_platform'),
                 UserCompletion.instructions_effectiveness.label('instructions_effectiveness'),
                 UserCompletion.context_effectiveness.label('context_effectiveness'),
                 UserCompletion.response_score.label('response_score'),
@@ -2227,6 +2228,10 @@ class ConsoleService:
                 completion_blocks=blocks_by_ae.get(str(r.ae_id), []),
             ))
 
+        # Conversation-level origin platform = first turn that carries one
+        # (rows are ordered ascending by created_at). null = web UI.
+        external_platform = next((r.external_platform for r in rows if r.external_platform), None)
+
         # Header user = the report owner.
         owner_name = None
         owner_email = None
@@ -2241,6 +2246,7 @@ class ConsoleService:
             report_title=report.title or '',
             user_name=owner_name,
             user_email=owner_email,
+            external_platform=external_platform,
             total_turns=len(turns),
             failed_turns=failed_turns,
             negative_feedback_turns=negative_feedback_turns,

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -14,6 +14,11 @@
                                 {{ conversation.user_name }}
                             </span>
                             <span v-if="conversation?.user_email" class="text-gray-400 dark:text-gray-500">{{ conversation.user_email }}</span>
+                            <span v-if="platformBadge" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                                <img v-if="platformBadge.img" :src="platformBadge.img" class="h-3 w-3 inline" :alt="platformBadge.label" />
+                                <UIcon v-else-if="platformBadge.icon" :name="platformBadge.icon" class="w-3 h-3" />
+                                {{ platformBadge.label }}
+                            </span>
                         </div>
                     </div>
                     <div class="flex items-center gap-3 flex-shrink-0">
@@ -668,6 +673,7 @@ interface ConversationTraceResponse {
     report_title?: string
     user_name?: string
     user_email?: string
+    external_platform?: string | null
     total_turns: number
     failed_turns: number
     negative_feedback_turns: number
@@ -731,6 +737,26 @@ const selectedItemDataSources = computed(() => {
 const isOpen = computed({
     get: () => props.modelValue,
     set: (value) => emit('update:modelValue', value)
+})
+
+// Origin platform badge for the header. null/unknown = web UI (no badge —
+// the UI is the default and adding a chip for it just adds noise). Icons reuse
+// the same /icons/<platform>.png assets as the Members table; platforms with
+// no PNG (email) fall back to a heroicons glyph.
+const PLATFORM_LABELS: Record<string, string> = {
+    slack: 'Slack', teams: 'Teams', whatsapp: 'WhatsApp', mcp: 'MCP', email: 'Email',
+}
+const PLATFORM_FALLBACK_ICON: Record<string, string> = {
+    email: 'i-heroicons-envelope',
+}
+const platformBadge = computed(() => {
+    const p = (conversation.value?.external_platform || '').toLowerCase()
+    if (!p || !(p in PLATFORM_LABELS)) return null
+    return {
+        label: PLATFORM_LABELS[p],
+        img: p in PLATFORM_FALLBACK_ICON ? null : `/icons/${p}.png`,
+        icon: PLATFORM_FALLBACK_ICON[p] || null,
+    }
 })
 
 const systemCompletions = computed(() => [])

--- a/frontend/pages/monitoring/diagnosis.vue
+++ b/frontend/pages/monitoring/diagnosis.vue
@@ -129,7 +129,13 @@
                             <td class="px-6 py-4">
                                 <div class="text-xs text-gray-900 dark:text-white">
                                     <div class="relative group max-w-[320px] w-[320px]">
-                                        <p class="truncate">{{ truncate(item.prompt || '', 40) }}</p>
+                                        <p class="truncate flex items-center gap-1.5">
+                                            <UTooltip v-if="platformOf(item)" :text="platformOf(item).label">
+                                                <img v-if="platformOf(item).img" :src="platformOf(item).img" class="h-3.5 w-3.5 inline flex-shrink-0" :alt="platformOf(item).label" />
+                                                <UIcon v-else-if="platformOf(item).icon" :name="platformOf(item).icon" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500" />
+                                            </UTooltip>
+                                            <span class="truncate">{{ truncate(item.prompt || '', 40) }}</span>
+                                        </p>
                                         <div class="pointer-events-none absolute start-0 top-full mt-1 z-10 hidden group-hover:block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md shadow-sm p-2 text-xs whitespace-pre-wrap max-w-[520px] max-h-56 overflow-auto">
                                             {{ item.prompt || '—' }}
                                         </div>
@@ -523,6 +529,25 @@ const formatDate = (dateString: string) => {
 const formatDateTime = (dateString: string) => {
     if (!dateString) return ''
     return _df.formatDateTime(dateString)
+}
+
+// Origin platform icon for a run. null/unknown = web UI (no icon — the default).
+// Icons reuse the /icons/<platform>.png assets from the Members table; platforms
+// with no PNG (email) fall back to a heroicons glyph.
+const PLATFORM_LABELS: Record<string, string> = {
+    slack: 'Slack', teams: 'Teams', whatsapp: 'WhatsApp', mcp: 'MCP', email: 'Email',
+}
+const PLATFORM_FALLBACK_ICON: Record<string, string> = {
+    email: 'i-heroicons-envelope',
+}
+const platformOf = (item: any) => {
+    const p = (item?.external_platform || '').toLowerCase()
+    if (!p || !(p in PLATFORM_LABELS)) return null
+    return {
+        label: PLATFORM_LABELS[p],
+        img: p in PLATFORM_FALLBACK_ICON ? null : `/icons/${p}.png`,
+        icon: PLATFORM_FALLBACK_ICON[p] || null,
+    }
 }
 
 // Add these methods to the existing script section

--- a/frontend/pages/monitoring/diagnosis.vue
+++ b/frontend/pages/monitoring/diagnosis.vue
@@ -192,7 +192,7 @@
                                 <span v-else>{{ item.report_name || item.report_id }}</span>
                             </td>
                             <td class="px-3 py-1">
-                                <span class="text-xs text-gray-500 dark:text-gray-400">{{ formatDate(item.created_at as any) }}</span>
+                                <span class="text-xs text-gray-500 dark:text-gray-400">{{ formatDateTime(item.created_at as any) }}</span>
                             </td>
                         </tr>
                     </tbody>
@@ -519,6 +519,10 @@ const _df = useFormatDate()
 const formatDate = (dateString: string) => {
     if (!dateString) return ''
     return _df.formatDate(dateString)
+}
+const formatDateTime = (dateString: string) => {
+    if (!dateString) return ''
+    return _df.formatDateTime(dateString)
 }
 
 // Add these methods to the existing script section

--- a/frontend/pages/monitoring/diagnosis.vue
+++ b/frontend/pages/monitoring/diagnosis.vue
@@ -115,12 +115,12 @@
                     <thead class="bg-gray-50 dark:bg-gray-900">
                         <tr>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-[320px] w-[320px]">{{ $t('monitoring.diagnosis.colPrompt') }}</th>
+                            <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colUser') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colStatus') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colData') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colTools') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colFeedback') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colReport') }}</th>
-                            <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colUser') }}</th>
                             <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('monitoring.diagnosis.colDate') }}</th>
                         </tr>
                     </thead>
@@ -135,6 +135,9 @@
                                         </div>
                                     </div>
                                 </div>
+                            </td>
+                            <td class="px-2 py-1">
+                                <div class="text-xs text-gray-900 dark:text-white">{{ item.user_name || '—' }}</div>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 <div class="relative inline-block group">
@@ -187,9 +190,6 @@
                                     {{ item.report_name || item.report_id }}
                                 </NuxtLink>
                                 <span v-else>{{ item.report_name || item.report_id }}</span>
-                            </td>
-                            <td class="px-2 py-1">
-                                <div class="text-xs text-gray-900 dark:text-white">{{ item.user_name || '—' }}</div>
                             </td>
                             <td class="px-3 py-1">
                                 <span class="text-xs text-gray-500 dark:text-gray-400">{{ formatDate(item.created_at as any) }}</span>


### PR DESCRIPTION
## Summary

Improvements to the monitoring diagnosis table and the trace modal, focused on surfacing **where each agent run originated** (Slack / Teams / WhatsApp / MCP / Email vs. the web UI), plus a couple of column refinements.

### Changes

**Diagnosis table** (`frontend/pages/monitoring/diagnosis.vue`)
- Moved the **User** column to sit right after the message/prompt column.
- The **Date** column now shows date **and time**, rendered in the org's configured timezone (via the existing `useFormatDate` composable).
- Added the **origin platform icon** next to each run's message, using the same `/icons/<platform>.png` assets as the Members table (`email` falls back to a heroicons glyph since it has no PNG). Web-UI runs show no icon (it's the default).

**Trace modal** (`frontend/components/console/TraceModal.vue`)
- Added an **origin platform badge** in the header. Conversation-level origin = the first turn that carries a platform; web-UI conversations show no badge.

**Backend**
- `AgentExecutionSummaryItem` and `ConversationTraceResponse` now carry `external_platform`, sourced from the parent user completion (`Completion.external_platform`).
- `console_service.py`: the diagnosis summary and conversation-trace queries now read and map the platform through.

### Notes
- The trace-header badge is **conversation-level** (origin of the first turn). A single report can mix UI and external turns; per-turn accuracy would be a small follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRbWGN2HEBjypWPaoAjwM1)_