### PR TITLE
fix(security): quote SQL identifiers in DB clients to prevent injection

### DIFF
--- a/backend/app/data_sources/clients/aws_redshift_client.py
+++ b/backend/app/data_sources/clients/aws_redshift_client.py
@@ -295,7 +295,11 @@ class AwsRedshiftClient(DataSourceClient):
             if self.schema:
                 logger.info(f"Setting search_path to: {self.schema}")
                 with conn.cursor() as cursor:
-                    cursor.execute(f"SET search_path TO {self.schema}")
+                    # Quote the schema as an identifier to prevent SQL injection.
+                    from psycopg2 import sql
+                    cursor.execute(
+                        sql.SQL("SET search_path TO {}").format(sql.Identifier(self.schema))
+                    )
                     conn.commit()
             
             yield conn

--- a/backend/app/data_sources/clients/duckdb_client.py
+++ b/backend/app/data_sources/clients/duckdb_client.py
@@ -44,6 +44,17 @@ class DuckDBClient(DataSourceClient):
         # escape single quotes by doubling them
         return "'" + str(value).replace("'", "''") + "'"
 
+    def _quote_identifier(self, identifier: str) -> str:
+        """Quote a table/view/column identifier to prevent SQL injection.
+
+        DuckDB identifiers are wrapped in double quotes; any embedded double
+        quote is escaped by doubling it.
+        """
+        if identifier is None:
+            raise ValueError("Identifier cannot be None")
+        escaped = str(identifier).replace('"', '""')
+        return f'"{escaped}"'
+
     def _configure_httpfs(self, con: duckdb.DuckDBPyConnection) -> None:
         con.execute("INSTALL httpfs;")
         con.execute("LOAD httpfs;")
@@ -116,12 +127,13 @@ class DuckDBClient(DataSourceClient):
                 # strip extension
                 candidate = last_segment.rsplit(".", 1)[0]
             view = self._safe_view_name(candidate, used)
+            quoted_view = self._quote_identifier(view)
             lower = normalized.lower()
             if lower.endswith(".parquet") or ".parquet" in lower:
-                con.execute(f"CREATE OR REPLACE VIEW {view} AS SELECT * FROM read_parquet({self._sql_literal(normalized)})")
+                con.execute(f"CREATE OR REPLACE VIEW {quoted_view} AS SELECT * FROM read_parquet({self._sql_literal(normalized)})")
             else:
                 # default to CSV auto
-                con.execute(f"CREATE OR REPLACE VIEW {view} AS SELECT * FROM read_csv_auto({self._sql_literal(normalized)})")
+                con.execute(f"CREATE OR REPLACE VIEW {quoted_view} AS SELECT * FROM read_csv_auto({self._sql_literal(normalized)})")
             created.append(view)
         return created
 
@@ -200,8 +212,9 @@ class DuckDBClient(DataSourceClient):
                 """).fetchall()
             for (name,) in rows:
                 cols = []
+                quoted_name = self._quote_identifier(name)
                 try:
-                    desc = con.execute(f"DESCRIBE {name}").fetchall()
+                    desc = con.execute(f"DESCRIBE {quoted_name}").fetchall()
                     for d in desc:
                         # DuckDB DESCRIBE columns: column_name, column_type, null, key, default, extra
                         col_name = d[0]
@@ -210,7 +223,7 @@ class DuckDBClient(DataSourceClient):
                 except Exception:
                     # Fallback: zero-row scan
                     try:
-                        df = con.execute(f"SELECT * FROM {name} LIMIT 0").df()
+                        df = con.execute(f"SELECT * FROM {quoted_name} LIMIT 0").df()
                         for c in df.columns:
                             cols.append(TableColumn(name=str(c), dtype="unknown"))
                     except Exception:
@@ -221,15 +234,16 @@ class DuckDBClient(DataSourceClient):
     def get_schema(self, table_name: str) -> Table:
         cols: List[TableColumn] = []
         with self.connect() as con:
+            quoted_name = self._quote_identifier(table_name)
             try:
-                desc = con.execute(f"DESCRIBE {table_name}").fetchall()
+                desc = con.execute(f"DESCRIBE {quoted_name}").fetchall()
                 for d in desc:
                     col_name = d[0]
                     col_type = d[1]
                     cols.append(TableColumn(name=col_name, dtype=str(col_type)))
             except Exception:
                 try:
-                    df = con.execute(f"SELECT * FROM {table_name} LIMIT 0").df()
+                    df = con.execute(f"SELECT * FROM {quoted_name} LIMIT 0").df()
                     for c in df.columns:
                         cols.append(TableColumn(name=str(c), dtype="unknown"))
                 except Exception:
@@ -261,7 +275,7 @@ class DuckDBClient(DataSourceClient):
                     view_names = con.execute("SELECT table_name FROM information_schema.tables WHERE table_schema='main' AND table_type='VIEW' ORDER BY table_name LIMIT 1").fetchall()
                     if view_names:
                         vn = view_names[0][0]
-                        con.execute(f"SELECT * FROM {vn} LIMIT 1")
+                        con.execute(f"SELECT * FROM {self._quote_identifier(vn)} LIMIT 1")
                 return {"success": True, "message": "DuckDB connected and views ready"}
         except Exception as e:
             return {"success": False, "message": str(e)}

--- a/backend/app/data_sources/clients/oracledb_client.py
+++ b/backend/app/data_sources/clients/oracledb_client.py
@@ -47,7 +47,8 @@ class OracledbClient(DataSourceClient):
             conn = engine.connect()
             # Set current schema if provided (Oracle has no search_path; use first schema)
             if self._schemas:
-                current_schema = self._schemas[0]
+                # Quote the schema as an identifier to prevent SQL injection.
+                current_schema = conn.dialect.identifier_preparer.quote(self._schemas[0])
                 try:
                     conn.execute(text(f'ALTER SESSION SET CURRENT_SCHEMA = {current_schema}'))
                 except Exception:

--- a/backend/app/data_sources/clients/postgresql_client.py
+++ b/backend/app/data_sources/clients/postgresql_client.py
@@ -49,7 +49,11 @@ class PostgresqlClient(DataSourceClient):
             conn = engine.connect()
             # Set search_path if schemas are provided
             if self._schemas:
-                search_path = ", ".join(self._schemas)
+                # Quote each schema as an identifier to prevent SQL injection.
+                # Use SQLAlchemy's dialect preparer so this stays driver-agnostic
+                # (handles embedded quotes, reserved words, and casing correctly).
+                preparer = conn.dialect.identifier_preparer
+                search_path = ", ".join(preparer.quote(s) for s in self._schemas)
                 try:
                     conn.execute(text(f"SET search_path TO {search_path}"))
                 except Exception:


### PR DESCRIPTION
## Summary

User-controlled **schema / table / view names** were interpolated directly into SQL statements in several data-source clients. This quotes them as identifiers so they can't break out of their context.

This adopts and extends the approach from community PR #52 by @ivosetyadi (Redshift + DuckDB), with a cleaner SQLAlchemy-based Postgres fix and the previously-missed Oracle path.

## Changes

| Client | Vulnerable site | Fix |
|---|---|---|
| `postgresql_client.py` | `SET search_path TO {", ".join(schemas)}` | quote each schema via `conn.dialect.identifier_preparer` (driver-agnostic; no raw-connection reach-through) |
| `oracledb_client.py` | `ALTER SESSION SET CURRENT_SCHEMA = {schema}` | quote via the dialect preparer |
| `aws_redshift_client.py` | `SET search_path TO {schema}` | `psycopg2.sql.Identifier(schema)` |
| `duckdb_client.py` | `CREATE VIEW` / `DESCRIBE` / `SELECT` × 7 sites | new `_quote_identifier()` helper (DuckDB double-quote + escape) applied at every site |

## Threat model

These names originate from **data-source connection config**, so this is defense-in-depth against a malicious or compromised data-source configuration rather than anonymous end-user injection. Real, but narrower than a public-facing injection — calibrating expectations vs. the original PR's "HIGH severity" framing.

## Testing

Verified with a standalone harness driving the **real** `DuckDBClient` against an in-memory DuckDB plus the actual SQLAlchemy dialect preparers (not committed — throwaway script):

- ✅ Legit-but-awkward identifiers still work end-to-end: `my view`, `Orders 2024`, `select` (reserved word), `weird"name` (embedded quote), `a.b`
- ✅ Injection payloads (`x; DROP TABLE victim;--`, embedded-quote breakout, `UNION SELECT`) are rejected as single non-existent identifiers; the victim table survives
- ✅ Control: the **old** unquoted interpolation does drop the victim table (vulnerability reproduced, then confirmed fixed)
- ✅ Postgres & Oracle preparers wrap malicious schemas and double inner quotes
- All four files compile

> Note: the Redshift `psycopg2.sql.Identifier` path is a library primitive that needs a live connection to render, so it's covered by library semantics + the equivalent Postgres assertion rather than an offline run.

Credit to @ivosetyadi (#52) for the original Redshift/DuckDB approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019RFtLe4KgC1frDUQYWRWqi)_