### PR TITLE
Notifications: scheduled-run + agent-access emit (notify-first)

### DIFF
--- a/backend/app/services/data_source_member_email.py
+++ b/backend/app/services/data_source_member_email.py
@@ -32,17 +32,15 @@ def schedule_member_added_email(
     added_by_user_id: str,
     organization_id: str,
 ) -> None:
-    """Schedule a delayed member-added email.
+    """Schedule a delayed member-added notification (in-app + email).
 
-    No-ops (silently) when SMTP isn't configured, when there's no recipient, or
-    when the actor added themselves. Never raises into the caller — a member is
-    added regardless of whether the notification can be scheduled.
+    No-ops (silently) when there's no recipient or when the actor added
+    themselves. The delay is the whole point: if the add was a mistake and the
+    membership is removed within the window, the send path re-checks and skips.
+    The in-app notification is created regardless of SMTP; email is only sent when
+    SMTP is configured. Never raises into the caller — a member is added
+    regardless of whether the notification can be scheduled.
     """
-    from app.settings.config import settings
-
-    # "if smtp is configured, an email is sent" — otherwise don't even schedule.
-    if settings.email_client is None:
-        return
     if not user_id:
         return
     # Don't notify someone for adding themselves (e.g. the creator/owner).
@@ -97,8 +95,6 @@ async def send_member_added_email(
     from app.settings.config import settings
 
     fm = settings.email_client
-    if fm is None:
-        return
 
     from sqlalchemy import select
 
@@ -108,7 +104,7 @@ async def send_member_added_email(
     from app.models.user import User
 
     async with async_session_maker() as db:
-        # Undo safety: only mail if the membership still exists. If the add was a
+        # Undo safety: only notify if the membership still exists. If the add was a
         # mistake and was removed within the delay window, the row is gone.
         membership = await db.execute(
             select(DataSourceMembership).where(
@@ -119,7 +115,7 @@ async def send_member_added_email(
         )
         if membership.scalar_one_or_none() is None:
             logger.info(
-                "Membership user=%s data_source=%s no longer exists; skipping email",
+                "Membership user=%s data_source=%s no longer exists; skipping notification",
                 user_id, data_source_id,
             )
             return
@@ -129,14 +125,39 @@ async def send_member_added_email(
             return
 
         user = await db.get(User, user_id)
-        if user is None or not getattr(user, "email", None):
+        if user is None:
             return
-        recipient = user.email
+        recipient = getattr(user, "email", None)
         recipient_name = getattr(user, "name", None)
         ds_name = data_source.name
 
         added_by = await db.get(User, added_by_user_id) if added_by_user_id else None
         added_by_name = getattr(added_by, "name", None) if added_by else None
+
+        # notify-first: the durable in-app "added to agent" notification, created
+        # regardless of SMTP. Email (below) is the downstream channel.
+        try:
+            from app.services.inbox_service import inbox_service
+            if added_by_name:
+                body = f"{added_by_name} added you to {ds_name}. You can now chat with this agent and explore its data."
+            else:
+                body = f"You've been added to {ds_name}. You can now chat with this agent and explore its data."
+            await inbox_service.notify_users(
+                db, organization_id=str(organization_id), user_ids=[str(user_id)],
+                source="share", type="agent_access",
+                title=f"You were added to {ds_name}",
+                body=body,
+                actor_user_id=str(added_by_user_id) if added_by_user_id else None,
+                link=f"/agents/{data_source_id}",
+                subject={"kind": "data_source", "data_source_id": str(data_source_id)},
+                group_key=f"agent_access:{data_source_id}:{user_id}",
+            )
+        except Exception:
+            logger.warning("agent-access in-app notification failed", exc_info=True)
+
+    # Email channel: only when SMTP is configured and the user has an email.
+    if fm is None or not recipient:
+        return
 
     from fastapi_mail import MessageSchema
 

--- a/backend/app/services/inbox_service.py
+++ b/backend/app/services/inbox_service.py
@@ -242,10 +242,15 @@ class InboxService:
             select(Notification).where(and_(*clauses))
             .order_by(Notification.created_at.desc()).limit(limit)
         )).scalars().all()
-        # Severity-first, then recency.
+        # Severity-first, then recency. Guard against rows with a null timestamp:
+        # datetime.min.timestamp() raises ("year 0 is out of range") on Linux, which
+        # would 500 the whole list (while count_unread stays fine) — so treat a
+        # missing created_at as the epoch instead.
+        def _ts(dt):
+            return dt.timestamp() if dt else 0.0
         rows.sort(key=lambda r: (
             SEVERITY_RANK.get(r.severity, 9),
-            -((r.created_at or datetime.min).timestamp()),
+            -_ts(r.created_at),
         ))
         unread_n = sum(1 for r in rows if r.read_at is None)
         return {

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -689,6 +689,24 @@ class ReportService:
             from app.settings.config import settings as app_settings
             from app.dependencies import _locale_from_org
             report_url = f"{app_settings.bow_config.base_url}/r/{report_id}"
+            # notify-first: durable in-app row for user subscribers (collapsed per
+            # report so repeated runs refresh one entry). Email follows.
+            try:
+                from app.services.inbox_service import inbox_service
+                user_ids = [str(s.get("id")) for s in report_orm.notification_subscribers
+                            if s.get("type") == "user" and s.get("id")]
+                if user_ids:
+                    await inbox_service.notify_users(
+                        db, organization_id=str(report_orm.organization_id), user_ids=user_ids,
+                        source="schedule", type="scheduled_run",
+                        title=f'"{report_orm.title or "Untitled"}" ran',
+                        body="Your scheduled report ran.",
+                        link=f"/reports/{report_id}",
+                        subject={"kind": "report", "report_id": str(report_id)},
+                        group_key=f"schedule:{report_id}",
+                    )
+            except Exception:
+                logger.warning("scheduled-report in-app notification failed", exc_info=True)
             asyncio.create_task(
                 notification_service.send_scheduled_report_results(
                     report_id=report_id,

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -346,10 +346,14 @@ class ReviewService:
         rows = (await db.execute(
             select(ReviewItem).where(and_(*clauses)).limit(limit)
         )).scalars().all()
-        # Sort by severity then recency (in Python — small N).
+        # Sort by severity then recency (in Python — small N). Guard a null
+        # timestamp: datetime.min.timestamp() raises on Linux and would 500 the
+        # feed, so treat a missing time as the epoch instead.
+        def _ts(dt):
+            return dt.timestamp() if dt else 0.0
         rows.sort(key=lambda r: (
             SEVERITY_RANK.get(r.severity, 9),
-            -((r.last_seen_at or r.created_at or datetime.min).timestamp()),
+            -_ts(r.last_seen_at or r.created_at),
         ))
         unread = sum(1 for r in rows if r.read_at is None and r.status in (STATUS_OPEN, STATUS_IN_PROGRESS))
         # Gate run_eval/run_training on whether the agent actually has evals.

--- a/backend/app/services/scheduled_prompt_service.py
+++ b/backend/app/services/scheduled_prompt_service.py
@@ -300,6 +300,26 @@ class ScheduledPromptService:
                 from app.dependencies import _locale_from_org
                 base_url = getattr(settings.bow_config, 'base_url', 'http://localhost:3000') if settings.bow_config else 'http://localhost:3000'
                 report_url = f"{base_url}/reports/{report.id}"
+                # notify-first: durable in-app row for user subscribers (collapsed
+                # per report so repeated runs refresh one entry). Email follows.
+                try:
+                    from app.services.inbox_service import inbox_service
+                    user_ids = [str(s.get("id")) for s in sp.notification_subscribers
+                                if s.get("type") == "user" and s.get("id")]
+                    if user_ids:
+                        es = exec_summary or {}
+                        await inbox_service.notify_users(
+                            db, organization_id=str(report.organization_id), user_ids=user_ids,
+                            source="schedule", type="scheduled_run",
+                            title=f'"{report.title or "Untitled"}" ran',
+                            body=(f"Your scheduled report ran — {es.get('iterations', 0)} steps, "
+                                  f"{es.get('queries', 0)} queries, {es.get('artifacts', 0)} artifacts."),
+                            link=f"/reports/{report.id}",
+                            subject={"kind": "report", "report_id": str(report.id)},
+                            group_key=f"schedule:{report.id}",
+                        )
+                except Exception:
+                    logger.warning("scheduled-run in-app notification failed", exc_info=True)
                 asyncio.create_task(
                     notification_service.send_scheduled_prompt_results(
                         report_id=report.id,

--- a/backend/tests/e2e/rbac/test_data_source_member_email.py
+++ b/backend/tests/e2e/rbac/test_data_source_member_email.py
@@ -1,9 +1,13 @@
 """E2E coverage for: data sources are private by default, and adding a member
-schedules a delayed "you've been added" email only when SMTP is configured.
+schedules a delayed "you've been added" notification.
 
-Exercises the real HTTP routes end to end. The delayed-email send itself is not
-driven here (it fires minutes later via APScheduler); we assert the scheduling
-decision, which is where the "only if SMTP configured" rule lives.
+Notify-first: the delayed job delivers a durable in-app notification regardless
+of SMTP, and additionally sends an email when SMTP is configured. So the job is
+scheduled whenever a genuinely new member is added; the SMTP setting only gates
+the email channel at send time, not the scheduling decision.
+
+Exercises the real HTTP routes end to end. The delayed send itself is not driven
+here (it fires minutes later via APScheduler); we assert the scheduling decision.
 """
 
 import uuid
@@ -129,10 +133,13 @@ def test_update_members_emails_only_newly_added(
     assert add_job.call_args.kwargs["args"][1] == m2["user_id"]
 
 
-def test_member_add_does_not_schedule_email_without_smtp(
+def test_member_add_schedules_notification_without_smtp(
     monkeypatch, restore_email_client, test_client, bootstrap_admin,
     invite_user_to_org, sqlite_data_source,
 ):
+    """Notify-first: even without SMTP, adding a member schedules the delayed job
+    because it delivers the in-app "added to agent" notification. (The email
+    channel is skipped at send time when SMTP is absent.)"""
     admin = bootstrap_admin("ds_nosmtp")
     member = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
     ds = sqlite_data_source(
@@ -148,4 +155,8 @@ def test_member_add_does_not_schedule_email_without_smtp(
 
     resp = _add_member(test_client, admin, ds, member)
     assert resp.status_code == 200, resp.json()
-    add_job.assert_not_called()
+    add_job.assert_called_once()
+    kwargs = add_job.call_args.kwargs
+    assert kwargs["trigger"] == "date"
+    assert kwargs["args"][0] == ds["id"]
+    assert kwargs["args"][1] == member["user_id"]

--- a/backend/tests/unit/test_data_source_member_email.py
+++ b/backend/tests/unit/test_data_source_member_email.py
@@ -1,9 +1,10 @@
-"""Unit tests for delayed member-added data source email notifications.
+"""Unit tests for delayed member-added data source notifications.
 
-Covers the two requirements:
-  1. Email is only sent when SMTP is configured.
+Notify-first. Covers:
+  1. The in-app "added to agent" notification is delivered regardless of SMTP;
+     email is additionally sent only when SMTP is configured.
   2. The send is delayed and re-validates membership, so an accidental add that
-     is undone within the window never results in an email.
+     is undone within the window never results in a notification or email.
 """
 
 import asyncio
@@ -36,12 +37,18 @@ def _session_maker(db):
 # --------------------------------------------------------------------------
 
 class TestScheduleMemberAddedEmail:
-    def test_noop_when_smtp_not_configured(self):
+    def test_schedules_job_without_smtp(self):
+        # Notify-first: the job is scheduled even without SMTP because it delivers
+        # the in-app notification (email is skipped at send time).
         with patch("app.settings.config.settings") as settings, \
              patch("app.core.scheduler.scheduler") as scheduler:
             settings.email_client = None
             mod.schedule_member_added_email("ds1", "user1", "admin1", "org1")
-            scheduler.add_job.assert_not_called()
+            scheduler.add_job.assert_called_once()
+            kwargs = scheduler.add_job.call_args.kwargs
+            assert kwargs["trigger"] == "date"
+            assert kwargs["args"][0] == "ds1"
+            assert kwargs["args"][1] == "user1"
 
     def test_schedules_job_when_smtp_configured(self):
         with patch("app.settings.config.settings") as settings, \
@@ -131,13 +138,27 @@ class TestSendMemberAddedEmail:
 
         fm.send_message.assert_not_called()
 
-    def test_skips_when_smtp_unconfigured_at_send_time(self):
+    def test_creates_inapp_but_no_email_without_smtp(self):
+        """Notify-first: without SMTP the session is still opened to create the
+        in-app notification, but no email is sent."""
+        fm = MagicMock()
+        fm.send_message = AsyncMock()
+        db = _make_db(membership=object(), data_source=_ds(), user=_user(),
+                      added_by=_user("admin@example.com", "Admin"))
+        maker = _session_maker(db)
+
         with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
              patch("app.settings.config.settings") as settings, \
-             patch("app.dependencies.async_session_maker") as maker:
-            settings.email_client = None
+             patch("app.dependencies.async_session_maker", maker), \
+             patch("app.services.inbox_service.inbox_service") as inbox:
+            inbox.notify_users = AsyncMock()
+            settings.email_client = None  # SMTP not configured
+            settings.bow_config = MagicMock(base_url="http://localhost:3000")
             asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
-            maker.assert_not_called()
+
+        maker.assert_called_once()                 # session opened for the in-app notification
+        inbox.notify_users.assert_awaited_once()   # in-app notification created
+        fm.send_message.assert_not_called()        # no email without SMTP
 
     def test_skips_when_not_claim_winner(self):
         with patch("app.core.scheduler.claim_scheduled_run", return_value=False), \

--- a/docs/design/user-inbox-notifications.md
+++ b/docs/design/user-inbox-notifications.md
@@ -143,7 +143,21 @@ Verified end-to-end in the sandbox: sharing a conversation/artifact creates the
 right `share_conversation`/`share_artifact` row with the canonical copy + deep
 link; re-sharing does not duplicate.
 
-### 4.3b Other emit sites *(to build)*
+### 4.3b Other emit sites — ✅ implemented (notify-first)
+
+- **Scheduled run** — `scheduled_prompt_service.py` and `report_service.py` (the
+  scheduled-report rerun) create an in-app `scheduled_run` notification for the
+  `type=="user"` subscribers, collapsed per report (`group_key=schedule:{report_id}`)
+  so repeated runs refresh one entry; email follows for all subscribers.
+- **Added to an agent** — `data_source_member_email.send_member_added_email`
+  creates an `agent_access` notification for the added user, **independent of
+  SMTP** (the scheduling SMTP gate was removed so it fires even without email),
+  inside the existing 5-min undo-delayed + re-validated job. Email is sent only
+  when SMTP is configured.
+
+Verified in the sandbox: adding a member created the `agent_access` row with the
+canonical copy + `/agents/{id}` link, and it was created even though the email
+send failed (dummy SMTP) — proving in-app is decoupled from email.
 
 In `POST /reports/{id}/notify` (`report.py:254`) and `ReportService.set_visibility`
 (`report_service.py:104`): for every recipient that is a **known user**
@@ -206,6 +220,7 @@ permission gymnastics — ownership is the recipient.
 5. ✅ `/api/notifications` routes + mount
 6. ✅ Share-path notify-first (conversation + artifact; `set_visibility` + `notify_report`)
 7. ⬜ Frontend: `InboxFeed`, `/inbox`, nav bell
+6b. ✅ Scheduled-run + agent-access emit sites (notify-first)
 8. ⬜ In-report tool notification (depends on 2)
 9. ⬜ Unit tests for `InboxService` (dedup / resurface / per-user read) + an
    integration test that `emit()` fans out to agent managers


### PR DESCRIPTION
## Summary

**Stacked on #460** (`claude/scheduled-prompt-subscriptions-6gwu3y`), which already contains the per-user notification foundation (`Notification` model, `InboxService`, `/api/notifications`, the sidebar bell + modal, the review fan-out, and the share-path emit). This PR adds the two remaining **notify-first** emit sites on top.

> Base is the #460 branch, not `main` — review/merge #460 first. The diff here is just the incremental commits.

## What's in this PR

- **Scheduled runs** — `scheduled_prompt_service` and the scheduled-report rerun in `report_service` create a durable in-app `scheduled_run` notification for `type=="user"` subscribers, collapsed per report (`group_key=schedule:{report_id}`) so repeated runs refresh one entry; email dispatch follows for all subscribers.
- **Added to an agent** — `data_source_member_email.send_member_added_email` creates an `agent_access` notification for the added user inside the existing 5-min undo-delayed, re-validated job. **Decoupled from SMTP** (the scheduling SMTP gate is removed) so the in-app notification fires even without email; email is sent only when SMTP is configured.
- **Tests** — updated the member-added tests to the new contract (the delayed job is scheduled regardless of SMTP because it carries the in-app notification; email is skipped at send time when SMTP is absent).

Both follow the same notify-first direction as the share path: the in-app `Notification` is the canonical record; email is a downstream channel.

## Verification

Exercised in a local sandbox: adding a member created the `agent_access` row with the canonical copy + `/agents/{id}` link — created even though the (dummy) email send failed, confirming in-app delivery is independent of email. e2e-tests (postgres) green on the prior run; the sqlite leg was cancelled (CI timeout on the slow leg, not a test failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)