### PR TITLE
Scheduled prompt delete UI + edit_scheduled_task agent tool

### DIFF
--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -365,9 +365,9 @@ def _digest_excel_tool(tool_execution) -> str:
 def _digest_scheduled_tool(tool_execution) -> str:
     """One-line digest for scheduled-task tools.
 
-    Records in the conversation history what was scheduled / cancelled (task id
-    + cron), so the planner can dedupe new schedules and cancel the right task
-    on a follow-up turn. Returns an empty string for other tools so callers can
+    Records in the conversation history what was scheduled / edited / cancelled
+    (task id + cron), so the planner can dedupe new schedules and edit or cancel
+    the right task on a follow-up turn. Returns an empty string for other tools so callers can
     fall through to the next elif. The active tasks themselves are listed in the
     <scheduled_tasks> context section.
     """
@@ -389,6 +389,17 @@ def _digest_scheduled_tool(tool_execution) -> str:
         if rj.get('error'):
             parts.append(f"error: {rj.get('error')}")
         return "; ".join(parts) if parts else "cancelled"
+    if name == 'edit_scheduled_task':
+        parts = []
+        if rj.get('task_id'):
+            parts.append(f"task_id: {rj.get('task_id')}")
+        if rj.get('cron_schedule'):
+            parts.append(f"cron: {rj.get('cron_schedule')}")
+        if rj.get('is_active') is not None:
+            parts.append(f"active: {rj.get('is_active')}")
+        if rj.get('error'):
+            parts.append(f"error: {rj.get('error')}")
+        return "; ".join(parts) if parts else "edited"
     return ""
 
 
@@ -860,7 +871,7 @@ class MessageContextBuilder:
                                     digest = _digest_excel_tool(tool_execution)
                                     if digest:
                                         tool_info += " - " + digest
-                                elif tool_execution.tool_name in ('create_scheduled_task', 'cancel_scheduled_task') and tool_execution.result_json:
+                                elif tool_execution.tool_name in ('create_scheduled_task', 'cancel_scheduled_task', 'edit_scheduled_task') and tool_execution.result_json:
                                     digest = _digest_scheduled_tool(tool_execution)
                                     if digest:
                                         tool_info += " - " + digest
@@ -1456,7 +1467,7 @@ class MessageContextBuilder:
                                 digest = _digest_excel_tool(tool_execution)
                                 if digest:
                                     tool_info += " - " + digest
-                            elif tool_execution.tool_name in ('create_scheduled_task', 'cancel_scheduled_task') and tool_execution.result_json:
+                            elif tool_execution.tool_name in ('create_scheduled_task', 'cancel_scheduled_task', 'edit_scheduled_task') and tool_execution.result_json:
                                 digest = _digest_scheduled_tool(tool_execution)
                                 if digest:
                                     tool_info += " - " + digest

--- a/backend/app/ai/context/sections/scheduled_tasks_section.py
+++ b/backend/app/ai/context/sections/scheduled_tasks_section.py
@@ -16,6 +16,7 @@ class ScheduledTasksSection(ContextSection):
 
     Surfaced so the agent knows what is already scheduled — to avoid creating
     duplicates with create_scheduled_task, and to have the task id available for
+    edit_scheduled_task (change prompt/schedule/active state) and
     cancel_scheduled_task.
     """
 

--- a/backend/app/ai/tools/implementations/edit_scheduled_task.py
+++ b/backend/app/ai/tools/implementations/edit_scheduled_task.py
@@ -1,0 +1,252 @@
+"""Edit Scheduled Task Tool - edits an existing recurring task on the current report.
+
+Thin wrapper over ScheduledPromptService.update_scheduled_prompt. Lets the agent
+change a scheduled task's prompt, cron schedule, and/or active state in place
+(rather than cancelling and re-creating). Guards that the task belongs to the
+current report so the agent can't edit another report's or org's task. The
+task_id comes from the <scheduled_tasks> context block.
+
+Only the fields provided are changed; omitted fields are left as-is. The same
+1-hour cron floor as create_scheduled_task is enforced when a new schedule is
+given.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.edit_scheduled_task import (
+    EditScheduledTaskInput,
+    EditScheduledTaskOutput,
+)
+from app.ai.tools.implementations.create_scheduled_task import (
+    _minute_field_is_single_value,
+)
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EditScheduledTaskTool(Tool):
+    """Edit a recurring scheduled task on the current report."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="edit_scheduled_task",
+            description=(
+                "ACTION: Edit an existing RECURRING scheduled task on the current "
+                "report — change its instruction, its schedule, or pause/resume it. "
+                "Use this when the user wants to modify a task that already exists "
+                "rather than create a new one — 'run the weekly digest on Fridays "
+                "instead', 'also include refunds in that scheduled report', 'pause "
+                "the daily refresh for now', 'change it to 7am'. Prefer this over "
+                "cancel + create when the user is adjusting an existing task.\n\n"
+                "Find the task's id in the <scheduled_tasks> context block and pass "
+                "it as task_id. Only tasks belonging to the current report can be "
+                "edited. Provide ONLY the fields you want to change — 'task_prompt' "
+                "to rewrite the instruction (write the full self-contained prompt, "
+                "not just the delta), 'cron_schedule' to change when it runs, "
+                "'is_active' to pause (false) or resume (true). Omitted fields are "
+                "left unchanged.\n\n"
+                "Schedule: provide a 5-field cron expression "
+                "(minute hour day-of-month month day-of-week). The minute field must "
+                "be a single number — schedules more frequent than hourly are rejected."
+            ),
+            category="action",
+            version="1.0.0",
+            input_schema=EditScheduledTaskInput.model_json_schema(),
+            output_schema=EditScheduledTaskOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=30,
+            idempotent=False,
+            required_permissions=[],
+            tags=["scheduling", "task", "automation", "action"],
+            examples=[
+                {
+                    "input": {
+                        "task_id": "a1b2c3d4-0000-0000-0000-000000000000",
+                        "cron_schedule": "0 7 * * 5",
+                    },
+                    "description": "Move an existing task to run Fridays at 7am.",
+                },
+                {
+                    "input": {
+                        "task_id": "a1b2c3d4-0000-0000-0000-000000000000",
+                        "task_prompt": (
+                            "Pull yesterday's signups AND refunds and email me both counts."
+                        ),
+                    },
+                    "description": "Rewrite the task's instruction (full prompt).",
+                },
+                {
+                    "input": {
+                        "task_id": "a1b2c3d4-0000-0000-0000-000000000000",
+                        "is_active": False,
+                    },
+                    "description": "Pause a task without deleting it.",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return EditScheduledTaskInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return EditScheduledTaskOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = EditScheduledTaskInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {str(e)}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={"task_id": data.task_id, "cron_schedule": data.cron_schedule},
+        )
+
+        db = runtime_ctx.get("db")
+        user = runtime_ctx.get("user")
+        report = runtime_ctx.get("report")
+        organization = runtime_ctx.get("organization")
+
+        if not db or not user or not report or not organization:
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": EditScheduledTaskOutput(
+                        success=False,
+                        task_id=data.task_id,
+                        error="Editing scheduled tasks requires an active report context.",
+                    ).model_dump(),
+                    "observation": {
+                        "summary": "Could not edit scheduled task: missing report/user context.",
+                        "success": False,
+                        "artifacts": [],
+                    },
+                },
+            )
+            return
+
+        # Require at least one editable field so we don't issue a no-op write.
+        if data.task_prompt is None and data.cron_schedule is None and data.is_active is None:
+            msg = (
+                "Nothing to edit: provide at least one of task_prompt, cron_schedule, "
+                "or is_active."
+            )
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": EditScheduledTaskOutput(
+                        success=False, task_id=data.task_id, error=msg,
+                    ).model_dump(),
+                    "observation": {"summary": msg, "success": False, "artifacts": []},
+                },
+            )
+            return
+
+        # Enforce the 1-hour floor when a new schedule is supplied.
+        if data.cron_schedule is not None and not _minute_field_is_single_value(data.cron_schedule):
+            msg = (
+                "Invalid schedule: use a 5-field cron with a single-number minute "
+                "(e.g. '0 9 * * 1'). Schedules more frequent than hourly are not allowed."
+            )
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": EditScheduledTaskOutput(
+                        success=False,
+                        task_id=data.task_id,
+                        cron_schedule=data.cron_schedule,
+                        error=msg,
+                    ).model_dump(),
+                    "observation": {"summary": msg, "success": False, "artifacts": []},
+                },
+            )
+            return
+
+        try:
+            from app.models.scheduled_prompt import ScheduledPrompt
+            from app.services.scheduled_prompt_service import scheduled_prompt_service
+            from app.schemas.scheduled_prompt_schema import ScheduledPromptUpdate
+
+            sp = await db.get(ScheduledPrompt, data.task_id)
+            # Guard: must exist, not be deleted, and belong to the current report.
+            if not sp or sp.deleted_at is not None or str(sp.report_id) != str(report.id):
+                msg = "No active scheduled task with that id was found on this report."
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload={
+                        "output": EditScheduledTaskOutput(
+                            success=False, task_id=data.task_id, error=msg,
+                        ).model_dump(),
+                        "observation": {"summary": msg, "success": False, "artifacts": []},
+                    },
+                )
+                return
+
+            # Build the prompt patch: preserve the existing prompt's other fields
+            # (mode, model_id, mentions, ...) and only swap the content.
+            prompt_patch = None
+            if data.task_prompt is not None:
+                prompt_patch = {**(sp.prompt or {}), "content": data.task_prompt}
+
+            updated = await scheduled_prompt_service.update_scheduled_prompt(
+                db=db,
+                scheduled_prompt_id=str(sp.id),
+                data=ScheduledPromptUpdate(
+                    prompt=prompt_patch,
+                    cron_schedule=data.cron_schedule,
+                    is_active=data.is_active,
+                ),
+                current_user=user,
+                organization=organization,
+            )
+
+            changed = []
+            if data.task_prompt is not None:
+                changed.append("prompt")
+            if data.cron_schedule is not None:
+                changed.append(f"schedule -> {updated.cron_schedule}")
+            if data.is_active is not None:
+                changed.append("resumed" if updated.is_active else "paused")
+            summary = "Scheduled task updated (" + ", ".join(changed) + ")."
+
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": EditScheduledTaskOutput(
+                        success=True,
+                        task_id=str(updated.id),
+                        cron_schedule=updated.cron_schedule,
+                        is_active=updated.is_active,
+                    ).model_dump(),
+                    "observation": {"summary": summary, "success": True, "artifacts": []},
+                },
+            )
+        except Exception as e:
+            logger.exception("Failed to edit scheduled task: %s", e)
+            detail = getattr(e, "detail", None) or str(e)
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": f"Failed to edit scheduled task: {detail}",
+                    "code": "EDIT_FAILED",
+                },
+            )

--- a/backend/app/ai/tools/schemas/edit_scheduled_task.py
+++ b/backend/app/ai/tools/schemas/edit_scheduled_task.py
@@ -1,0 +1,61 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class EditScheduledTaskInput(BaseModel):
+    """Input schema for the edit_scheduled_task tool.
+
+    Edits an existing recurring scheduled task on the current report. The
+    ``task_id`` comes from the <scheduled_tasks> context block, which lists the
+    active tasks for this report. Only the fields you provide are changed; omit a
+    field to leave it as-is. At least one editable field must be provided.
+    """
+
+    task_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The ID of the scheduled task to edit. Take it from the "
+            "<scheduled_tasks> block in context, which lists each active task's id."
+        ),
+    )
+    task_prompt: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "The new full, self-contained instruction to run on each scheduled "
+            "execution. There is no user present when it runs, so write it as a "
+            "complete task, not a chat reply. Omit to keep the current prompt."
+        ),
+    )
+    cron_schedule: Optional[str] = Field(
+        default=None,
+        description=(
+            "A new standard 5-field cron expression: 'minute hour day month day_of_week'. "
+            "The minute field MUST be a single number (0-59) — sub-hourly schedules "
+            "are not allowed (minimum interval is 1 hour). The day_of_week field "
+            "accepts a comma-separated list or range (0=Sunday ... 6=Saturday) to "
+            "target specific days. Examples: "
+            "'0 9 * * 1' = every Monday at 09:00, '0 8 * * *' = every day at 08:00, "
+            "'0 9 * * 1,3,5' = Mon/Wed/Fri at 09:00, '0 8 * * 1-5' = weekdays at 08:00, "
+            "'30 7 1 * *' = 07:30 on the 1st of every month, '0 * * * *' = hourly. "
+            "Omit to keep the current schedule."
+        ),
+    )
+    is_active: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Set to false to pause the task (it stays saved but stops firing) or "
+            "true to resume it. Omit to leave its active state unchanged."
+        ),
+    )
+
+
+class EditScheduledTaskOutput(BaseModel):
+    """Output schema for the edit_scheduled_task tool."""
+
+    success: bool = Field(..., description="Whether the scheduled task was updated.")
+    task_id: Optional[str] = Field(default=None, description="ID of the edited scheduled task.")
+    cron_schedule: Optional[str] = Field(default=None, description="The task's cron expression after the edit.")
+    is_active: Optional[bool] = Field(default=None, description="The task's active state after the edit.")
+    error: Optional[str] = Field(default=None, description="Error message if the edit failed.")

--- a/backend/tests/unit/test_scheduled_task_tool.py
+++ b/backend/tests/unit/test_scheduled_task_tool.py
@@ -21,8 +21,10 @@ from app.ai.tools.implementations.create_scheduled_task import (
     _minute_field_is_single_value,
 )
 from app.ai.tools.implementations.cancel_scheduled_task import CancelScheduledTaskTool
+from app.ai.tools.implementations.edit_scheduled_task import EditScheduledTaskTool
 from app.ai.tools.schemas.create_scheduled_task import CreateScheduledTaskInput
 from app.ai.tools.schemas.cancel_scheduled_task import CancelScheduledTaskInput
+from app.ai.tools.schemas.edit_scheduled_task import EditScheduledTaskInput
 
 
 def _ctx(**overrides) -> dict:
@@ -88,6 +90,13 @@ def test_create_input_requires_fields():
 def test_cancel_input_requires_task_id():
     with pytest.raises(Exception):
         CancelScheduledTaskInput()
+
+
+def test_edit_input_requires_task_id():
+    with pytest.raises(Exception):
+        EditScheduledTaskInput()
+    # task_id alone is valid (the no-op guard lives in the tool, not the schema).
+    assert EditScheduledTaskInput(task_id="sp-1").task_id == "sp-1"
 
 
 # --- create: context guard --------------------------------------------------
@@ -195,6 +204,129 @@ async def test_cancel_rejects_other_report_task():
     assert out["success"] is False
 
 
+# --- edit: guards -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_requires_report_context():
+    tool = EditScheduledTaskTool()
+    events = await _collect(
+        tool,
+        {"task_id": "sp-1", "is_active": False},
+        _ctx(report=None),
+    )
+    out = _end_payload(events)["output"]
+    assert out["success"] is False
+    assert "report" in (out["error"] or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_requires_at_least_one_field():
+    tool = EditScheduledTaskTool()
+    with patch(
+        "app.services.scheduled_prompt_service.scheduled_prompt_service.update_scheduled_prompt",
+        new=AsyncMock(),
+    ) as mock_update:
+        events = await _collect(tool, {"task_id": "sp-1"}, _ctx())
+        mock_update.assert_not_called()
+    out = _end_payload(events)["output"]
+    assert out["success"] is False
+    assert "at least one" in (out["error"] or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_rejects_subhourly_cron():
+    tool = EditScheduledTaskTool()
+    with patch(
+        "app.services.scheduled_prompt_service.scheduled_prompt_service.update_scheduled_prompt",
+        new=AsyncMock(),
+    ) as mock_update:
+        events = await _collect(
+            tool,
+            {"task_id": "sp-1", "cron_schedule": "*/5 * * * *"},
+            _ctx(),
+        )
+        mock_update.assert_not_called()
+    out = _end_payload(events)["output"]
+    assert out["success"] is False
+    assert "hour" in (out["error"] or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_rejects_other_report_task():
+    tool = EditScheduledTaskTool()
+    other = SimpleNamespace(id="sp-9", report_id="other-report", deleted_at=None, prompt={"content": "x"})
+    db = MagicMock()
+    db.get = AsyncMock(return_value=other)
+    with patch(
+        "app.services.scheduled_prompt_service.scheduled_prompt_service.update_scheduled_prompt",
+        new=AsyncMock(),
+    ) as mock_update:
+        events = await _collect(tool, {"task_id": "sp-9", "is_active": False}, _ctx(db=db))
+        mock_update.assert_not_called()
+    out = _end_payload(events)["output"]
+    assert out["success"] is False
+
+
+# --- edit: happy path -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_happy_path_all_fields():
+    tool = EditScheduledTaskTool()
+    sp = SimpleNamespace(id="sp-1", report_id="report-1", deleted_at=None, prompt={"content": "old", "mode": "chat"})
+    updated = SimpleNamespace(id="sp-1", cron_schedule="0 7 * * 5", is_active=True)
+    db = MagicMock()
+    db.get = AsyncMock(return_value=sp)
+    with patch(
+        "app.services.scheduled_prompt_service.scheduled_prompt_service.update_scheduled_prompt",
+        new=AsyncMock(return_value=updated),
+    ) as mock_update:
+        events = await _collect(
+            tool,
+            {
+                "task_id": "sp-1",
+                "task_prompt": "new prompt",
+                "cron_schedule": "0 7 * * 5",
+                "is_active": True,
+            },
+            _ctx(db=db),
+        )
+        mock_update.assert_awaited_once()
+        kwargs = mock_update.await_args.kwargs
+        # The prompt patch preserves other prompt fields and swaps only content.
+        assert kwargs["data"].prompt == {"content": "new prompt", "mode": "chat"}
+        assert kwargs["data"].cron_schedule == "0 7 * * 5"
+        assert kwargs["data"].is_active is True
+
+    payload = _end_payload(events)
+    assert payload["output"]["success"] is True
+    assert payload["output"]["task_id"] == "sp-1"
+    assert payload["output"]["cron_schedule"] == "0 7 * * 5"
+    assert payload["output"]["is_active"] is True
+    assert payload["observation"]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_prompt_only_leaves_other_fields_unset():
+    tool = EditScheduledTaskTool()
+    sp = SimpleNamespace(id="sp-2", report_id="report-1", deleted_at=None, prompt={"content": "old"})
+    updated = SimpleNamespace(id="sp-2", cron_schedule="0 9 * * 1", is_active=True)
+    db = MagicMock()
+    db.get = AsyncMock(return_value=sp)
+    with patch(
+        "app.services.scheduled_prompt_service.scheduled_prompt_service.update_scheduled_prompt",
+        new=AsyncMock(return_value=updated),
+    ) as mock_update:
+        events = await _collect(tool, {"task_id": "sp-2", "task_prompt": "just the prompt"}, _ctx(db=db))
+        kwargs = mock_update.await_args.kwargs
+        assert kwargs["data"].prompt == {"content": "just the prompt"}
+        # Omitted fields stay None so the service leaves them unchanged.
+        assert kwargs["data"].cron_schedule is None
+        assert kwargs["data"].is_active is None
+    assert _end_payload(events)["output"]["success"] is True
+
+
 # --- conversation-history digest -------------------------------------------
 
 
@@ -214,6 +346,13 @@ def test_digest_scheduled_tool():
         result_json={"success": True, "task_id": "sp-1"},
     )
     assert "task_id: sp-1" in _digest_scheduled_tool(cancelled)
+
+    edited = SimpleNamespace(
+        tool_name="edit_scheduled_task",
+        result_json={"success": True, "task_id": "sp-1", "cron_schedule": "0 7 * * 5", "is_active": False},
+    )
+    de = _digest_scheduled_tool(edited)
+    assert "task_id: sp-1" in de and "cron: 0 7 * * 5" in de and "active: False" in de
 
     # Non-scheduled tool falls through (empty -> caller tries next digest).
     other = SimpleNamespace(tool_name="create_data", result_json={"x": 1})

--- a/frontend/components/ScheduledPromptModal.vue
+++ b/frontend/components/ScheduledPromptModal.vue
@@ -163,9 +163,21 @@
             </div>
 
             <template #footer>
-                <div class="flex justify-end gap-2">
-                    <UButton color="gray" variant="ghost" size="xs" @click="isOpen = false">{{ $t('scheduledPrompt.cancel') }}</UButton>
-                    <UButton color="blue" size="xs" :loading="isSaving" @click="saveFromCurrentState">{{ isEditing ? $t('scheduledPrompt.update') : $t('scheduledPrompt.scheduleAction') }}</UButton>
+                <div class="flex items-center justify-between gap-2">
+                    <UButton
+                        v-if="isEditing"
+                        color="red"
+                        variant="ghost"
+                        size="xs"
+                        icon="i-heroicons-trash"
+                        :loading="isDeleting"
+                        @click="deleteScheduledPrompt"
+                    >{{ $t('scheduledPrompt.delete') }}</UButton>
+                    <span v-else />
+                    <div class="flex justify-end gap-2">
+                        <UButton color="gray" variant="ghost" size="xs" @click="isOpen = false">{{ $t('scheduledPrompt.cancel') }}</UButton>
+                        <UButton color="blue" size="xs" :loading="isSaving" @click="saveFromCurrentState">{{ isEditing ? $t('scheduledPrompt.update') : $t('scheduledPrompt.scheduleAction') }}</UButton>
+                    </div>
                 </div>
             </template>
         </UCard>
@@ -190,10 +202,11 @@ const props = defineProps<{
     draftModel?: string
 }>()
 
-const emit = defineEmits(['saved'])
+const emit = defineEmits(['saved', 'deleted'])
 
 const isOpen = defineModel<boolean>({ default: false })
 const isSaving = ref(false)
+const isDeleting = ref(false)
 const promptBoxRef = ref<InstanceType<typeof PromptBoxV2> | null>(null)
 
 const isEditing = computed(() => !!props.scheduledPrompt)
@@ -412,6 +425,26 @@ async function saveScheduledPrompt(prompt: { content: string; mentions?: any[]; 
         toast.add({ title: t('scheduledPrompt.toastError'), color: 'red', description: t('scheduledPrompt.toastSaveFailed') })
     } finally {
         isSaving.value = false
+    }
+}
+
+async function deleteScheduledPrompt() {
+    if (!isEditing.value || isDeleting.value) return
+    if (!confirm(t('scheduledPrompt.deleteConfirm'))) return
+    isDeleting.value = true
+    try {
+        const response = await useMyFetch(`/api/reports/${props.reportId}/scheduled-prompts/${props.scheduledPrompt.id}`, {
+            method: 'DELETE',
+        })
+        if ((response as any).error?.value) throw new Error('Delete failed')
+        toast.add({ title: t('scheduledPrompt.toastDeleted'), color: 'green' })
+        isOpen.value = false
+        emit('deleted', props.scheduledPrompt.id)
+        emit('saved')
+    } catch {
+        toast.add({ title: t('scheduledPrompt.toastError'), color: 'red', description: t('scheduledPrompt.toastDeleteFailed') })
+    } finally {
+        isDeleting.value = false
     }
 }
 

--- a/frontend/components/tools/EditScheduledTaskTool.vue
+++ b/frontend/components/tools/EditScheduledTaskTool.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="mt-1">
+    <!-- Running -->
+    <div v-if="status === 'running'" class="flex items-center text-xs text-gray-500 dark:text-gray-400">
+      <span class="tool-shimmer flex items-center">
+        <Icon name="heroicons-clock" class="w-3 h-3 me-1.5 text-gray-400" />
+        Updating scheduled task…
+      </span>
+    </div>
+
+    <!-- Success: reuse the shared scheduled-task card; click opens the editor -->
+    <Transition v-else-if="isSuccess" name="fade" appear>
+      <ScheduledTaskCard
+        :scheduled-prompt="cardData"
+        @click="taskId && emit('openScheduledTask', taskId)"
+      />
+    </Transition>
+
+    <!-- Error -->
+    <div v-else class="text-xs text-gray-500 dark:text-gray-400">
+      <div class="flex items-center text-gray-600 dark:text-gray-400">
+        <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
+        <span>Couldn't update task</span>
+      </div>
+      <div v-if="errorMessage" class="mt-1 text-[10px] text-red-500 bg-red-50/50 dark:bg-red-950 rounded px-2 py-1">
+        {{ errorMessage }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  status: string
+  result_json?: any
+  arguments_json?: any
+}
+
+const props = defineProps<{ toolExecution: ToolExecution }>()
+const emit = defineEmits<{ (e: 'openScheduledTask', taskId: string): void }>()
+
+const status = computed<string>(() => props.toolExecution?.status || '')
+
+const isSuccess = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  return status.value === 'success' && rj.success === true
+})
+
+const taskId = computed<string>(() => props.toolExecution?.result_json?.task_id || props.toolExecution?.arguments_json?.task_id || '')
+
+// Build a scheduled-prompt-like object for the shared card.
+const cardData = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  const args = props.toolExecution?.arguments_json || {}
+  return {
+    id: rj.task_id || args.task_id,
+    cron_schedule: rj.cron_schedule || args.cron_schedule || '',
+    is_active: rj.is_active !== undefined ? rj.is_active : true,
+    prompt: { content: args.task_prompt || '' },
+  }
+})
+
+const errorMessage = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  if (status.value === 'error') return rj.error || rj.message || ''
+  if (status.value === 'success' && rj.success === false) return rj.error || ''
+  return ''
+})
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+
+@keyframes shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: 100% 0; }
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -767,6 +767,7 @@ import EditInstructionTool from '~/components/tools/EditInstructionTool.vue'
 import SendEmailTool from '~/components/tools/SendEmailTool.vue'
 import CreateScheduledTaskTool from '~/components/tools/CreateScheduledTaskTool.vue'
 import CancelScheduledTaskTool from '~/components/tools/CancelScheduledTaskTool.vue'
+import EditScheduledTaskTool from '~/components/tools/EditScheduledTaskTool.vue'
 import ListAgentExecutionsTool from '~/components/tools/ListAgentExecutionsTool.vue'
 import WebFetchTool from '~/components/tools/WebFetchTool.vue'
 import WebSearchTool from '~/components/tools/WebSearchTool.vue'
@@ -1613,6 +1614,8 @@ function getToolComponent(toolName: string) {
 			return CreateScheduledTaskTool
 		case 'cancel_scheduled_task':
 			return CancelScheduledTaskTool
+		case 'edit_scheduled_task':
+			return EditScheduledTaskTool
 		case 'list_agent_executions':
 			return ListAgentExecutionsTool
 		case 'search_instructions':

--- a/frontend/pages/scheduled-tasks/index.vue
+++ b/frontend/pages/scheduled-tasks/index.vue
@@ -58,7 +58,7 @@
           class="border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 rounded-lg p-4 hover:shadow-md hover:border-gray-200 dark:hover:border-gray-700 transition-all cursor-pointer"
           @click="openTask(task)"
         >
-          <div class="flex items-start justify-between gap-3">
+          <div class="group flex items-start justify-between gap-3">
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2 mb-1">
                 <span
@@ -82,6 +82,18 @@
                 </NuxtLink>
                 <span v-if="task.user_name" class="text-[11px] text-gray-400 dark:text-gray-500">{{ $t('scheduled.by', { name: task.user_name }) }}</span>
               </div>
+            </div>
+            <div class="shrink-0">
+              <UTooltip :text="$t('scheduled.delete')">
+                <button
+                  @click.stop="deleteTask(task)"
+                  :disabled="deletingId === task.id"
+                  class="p-1 rounded text-gray-300 dark:text-gray-600 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all disabled:opacity-50"
+                >
+                  <Spinner v-if="deletingId === task.id" class="w-3.5 h-3.5 animate-spin" />
+                  <UIcon v-else name="heroicons-trash" class="w-3.5 h-3.5" />
+                </button>
+              </UTooltip>
             </div>
           </div>
         </div>
@@ -141,6 +153,7 @@ const showModal = ref(false)
 const modalReportId = ref<string | null>(null)
 const editingTask = ref<any | null>(null)
 const creatingTask = ref(false)
+const deletingId = ref<string | null>(null)
 
 const openTask = (task: any) => {
   editingTask.value = task
@@ -177,6 +190,27 @@ const onTaskSaved = () => {
   showModal.value = false
   currentPage.value = 1
   fetchTasks(1, searchTerm.value)
+}
+
+const deleteTask = async (task: any) => {
+  if (deletingId.value) return
+  if (!confirm(t('scheduled.deleteConfirm'))) return
+  deletingId.value = task.id
+  try {
+    const response = await useMyFetch(`/reports/${task.report_id}/scheduled-prompts/${task.id}`, {
+      method: 'DELETE',
+    })
+    if ((response as any).error?.value) throw new Error('Delete failed')
+    // Drop it locally so the list updates without a full refetch.
+    tasks.value = tasks.value.filter((t: any) => t.id !== task.id)
+    pagination.value.total = Math.max(0, (pagination.value.total || 1) - 1)
+    toast.add({ title: t('scheduled.toastDeleted'), color: 'green' })
+  } catch (error) {
+    console.error('Error deleting scheduled task:', error)
+    toast.add({ title: t('common.error'), description: t('scheduled.deleteFailed'), color: 'red' })
+  } finally {
+    deletingId.value = null
+  }
 }
 
 const fetchTasks = async (page: number = 1, search: string = '') => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1816,7 +1816,11 @@
     "dayWed": "Wed",
     "dayThu": "Thu",
     "dayFri": "Fri",
-    "daySat": "Sat"
+    "daySat": "Sat",
+    "delete": "Delete",
+    "deleteConfirm": "Delete this scheduled task? This cannot be undone.",
+    "toastDeleted": "Scheduled task deleted",
+    "deleteFailed": "Failed to delete task"
   },
   "files": {
     "title": "Files",
@@ -2605,7 +2609,11 @@
     "toastScheduled": "Prompt scheduled",
     "toastError": "Error",
     "toastSaveFailed": "Failed to save scheduled prompt",
-    "viewReport": "View report"
+    "viewReport": "View report",
+    "delete": "Delete",
+    "deleteConfirm": "Delete this scheduled task? This cannot be undone.",
+    "toastDeleted": "Scheduled task deleted",
+    "toastDeleteFailed": "Failed to delete scheduled task"
   },
   "errorPage": {
     "notFoundTitle": "404",


### PR DESCRIPTION
## Summary

Stacks onto PR #460. Adds two capabilities to scheduled prompts:

1. **Delete a scheduled prompt from the UI (with confirmation)**
   - **Scheduled Tasks page** (`/scheduled-tasks`): per-card hover trash icon → confirmation → `DELETE /reports/{report_id}/scheduled-prompts/{id}`, removes the row locally and toasts.
   - **Editor modal** (`ScheduledPromptModal.vue`): a Delete button in the footer (edit mode) with its own confirmation; emits `deleted`/`saved` so the list refreshes.
   - Backend `DELETE` endpoint already existed (soft-delete + APScheduler job removal), so no backend change was needed for delete.

2. **New `edit_scheduled_task` agent tool** — edit an existing task across all fields, mirroring `create_scheduled_task`
   - Schema + implementation (`edit_scheduled_task.py`): inputs `task_id` + optional `task_prompt`, `cron_schedule`, `is_active`. Guards report ownership, enforces the 1-hour cron floor when a new schedule is given, preserves the prompt's other fields (mode/model) while swapping content, and requires at least one editable field. Auto-discovered by the registry (category `action`); delegates to `update_scheduled_prompt` which re-registers the cron job.
   - Frontend `EditScheduledTaskTool.vue` tool-result card, registered in the report page tool switch; reuses the shared scheduled-task card and opens the editor.
   - Conversation-history digest + `<scheduled_tasks>` context-section docs updated to cover the edit tool.

## Tests
- `tests/unit/test_scheduled_task_tool.py`: added edit-tool tests (context guard, no-op guard, cron floor, wrong-report guard, all-fields happy path, prompt-only edit, digest). Full file passes (28 tests).

## Notes
- New locale keys added to `en.json`; other locales fall back to English (`fallbackLocale: 'en'`).
- Merges cleanly into the PR #460 branch (verified locally — no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014LTPV6Zuijr68J8WjEPpH9)_