### PR TITLE
Agent notify tool: deliver messages to org members across channels

### DIFF
--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -430,6 +430,21 @@ def _digest_notification_tool(tool_execution) -> str:
         if rj.get('error'):
             parts.append(f"error: {rj.get('error')}")
         return "; ".join(parts)
+    if name == 'notify':
+        parts = []
+        results = rj.get('results') or []
+        reached = [r for r in results if r.get('delivered')]
+        if reached:
+            who = ", ".join(r.get('email', '?') for r in reached[:5])
+            parts.append(f"notified: {who}")
+        if rj.get('subject'):
+            subj = str(rj.get('subject'))
+            parts.append(f"subject: {subj[:80]}{'…' if len(subj) > 80 else ''}")
+        if rj.get('rejected'):
+            parts.append(f"skipped_non_members: {', '.join(rj.get('rejected'))}")
+        if rj.get('error'):
+            parts.append(f"error: {rj.get('error')}")
+        return "; ".join(parts) if parts else "notified"
     return ""
 
 
@@ -875,7 +890,7 @@ class MessageContextBuilder:
                                     digest = _digest_scheduled_tool(tool_execution)
                                     if digest:
                                         tool_info += " - " + digest
-                                elif tool_execution.tool_name == 'send_email' and tool_execution.result_json:
+                                elif tool_execution.tool_name in ('send_email', 'notify') and tool_execution.result_json:
                                     digest = _digest_notification_tool(tool_execution)
                                     if digest:
                                         tool_info += " - " + digest
@@ -1471,7 +1486,7 @@ class MessageContextBuilder:
                                 digest = _digest_scheduled_tool(tool_execution)
                                 if digest:
                                     tool_info += " - " + digest
-                            elif tool_execution.tool_name == 'send_email' and tool_execution.result_json:
+                            elif tool_execution.tool_name in ('send_email', 'notify') and tool_execution.result_json:
                                 digest = _digest_notification_tool(tool_execution)
                                 if digest:
                                     tool_info += " - " + digest

--- a/backend/app/ai/tools/implementations/notify.py
+++ b/backend/app/ai/tools/implementations/notify.py
@@ -1,0 +1,189 @@
+"""Notify Tool - deliver a free-form message to people in the organization.
+
+The channel-agnostic successor to send_email. Resolves recipients against the
+org's memberships (the requesting user is always included), then for each one
+delivers an in-app notification plus one external nudge — the recipient's
+verified Teams/Slack DM when reachable, otherwise email. Recipients, channel
+selection, and attachment scoping are all handled by ``NotifyService`` so the
+security boundary lives in exactly one place.
+
+Use send_email for the narrow "email myself" case; use notify whenever the user
+wants to reach other people or wants the message in their in-app inbox.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.notify import (
+    NotifyInput,
+    NotifyOutput,
+    NotifyRecipientResult,
+)
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyTool(Tool):
+    """Notify org members (in-app + one external channel) with a free-form message."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="notify",
+            description=(
+                "ACTION: Notify people in the user's organization with a free-form "
+                "message. Each recipient gets an in-app notification and, when "
+                "reachable, ONE external nudge (their verified Teams/Slack DM, "
+                "otherwise email). The requesting user is ALWAYS notified too.\n\n"
+                "When to use: the user asks to notify, ping, message, or email "
+                "someone — 'let Alice know when this is ready', 'email the finance "
+                "team the summary', 'send me and Bob the results'. To notify only "
+                "yourself, leave 'recipients' empty (this replaces emailing yourself).\n\n"
+                "Recipients are EMAIL ADDRESSES that must belong to members (or "
+                "pending invites) of this organization — outside addresses are "
+                "rejected. Use an address the user gave you or one already in "
+                "context; don't guess. You don't choose channels — that's resolved "
+                "per recipient automatically.\n\n"
+                "Writing it — like a person, not a marketing system: short, natural, "
+                "plain text by default. Use body_format='html' only when a few bullets "
+                "or a small table genuinely help; keep the HTML simple.\n\n"
+                "Attachments (optional, up to 5): reference a visualization_id / "
+                "query_id (CSV/XLSX), artifact_id (PPTX/PDF), or file_id from this "
+                "report. They ride the external channel; in-app recipients open the "
+                "report to view them."
+            ),
+            category="action",
+            version="1.0.0",
+            input_schema=NotifyInput.model_json_schema(),
+            output_schema=NotifyOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=60,
+            idempotent=False,
+            # Always advertised: even when no email transport is configured, the
+            # in-app channel still delivers — so unlike send_email this tool is not
+            # filtered out by email availability.
+            is_active=True,
+            required_permissions=[],
+            tags=["notification", "email", "in_app", "action"],
+            examples=[
+                {
+                    "input": {
+                        "subject": "Q2 revenue is final",
+                        "body": "Q2 closed at $1.24M, up 14% QoQ.",
+                        "recipients": ["alice@acme.com"],
+                    },
+                    "description": "Notify a teammate (and yourself) about a result.",
+                },
+                {
+                    "input": {
+                        "subject": "Your weekly digest",
+                        "body": "No anomalies this week — all clear.",
+                    },
+                    "description": "Notify only yourself (empty recipients).",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return NotifyInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return NotifyOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = NotifyInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {str(e)}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={"subject": data.subject, "recipient_count": len(data.recipients) + 1},
+        )
+
+        db = runtime_ctx.get("db")
+        user = runtime_ctx.get("user")
+        organization = runtime_ctx.get("organization")
+        report = runtime_ctx.get("report")
+
+        if not db or not user or not organization:
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": NotifyOutput(
+                        success=False,
+                        subject=data.subject,
+                        error="Notifications require an active user/organization context.",
+                    ).model_dump(),
+                    "observation": {
+                        "summary": "Could not notify: missing user/organization context.",
+                        "success": False,
+                        "artifacts": [],
+                    },
+                },
+            )
+            return
+
+        try:
+            from app.services.notify_service import notify_service
+
+            result = await notify_service.notify(
+                db,
+                sender=user,
+                organization=organization,
+                report=report,
+                subject=data.subject,
+                body=data.body,
+                body_format=data.body_format,
+                attachment_specs=data.attachments,
+                recipient_emails=data.recipients,
+                system_completion=runtime_ctx.get("system_completion"),
+            )
+        except Exception as e:
+            logger.exception("notify failed: %s", e)
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Failed to notify: {str(e)}", "code": "NOTIFY_FAILED"},
+            )
+            return
+
+        output = NotifyOutput(
+            success=result["success"],
+            subject=data.subject,
+            results=[NotifyRecipientResult(**r) for r in result["results"]],
+            rejected=result["rejected"],
+        )
+
+        reached = sum(1 for r in result["results"] if r["delivered"])
+        summary = (
+            f"Notified {reached} recipient(s): {data.subject}"
+            if result["success"]
+            else "Notification could not be delivered."
+        )
+        if result["rejected"]:
+            summary += f" (skipped non-members: {', '.join(result['rejected'])})"
+
+        yield ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": output.model_dump(),
+                "observation": {"summary": summary, "success": result["success"], "artifacts": []},
+            },
+        )

--- a/backend/app/ai/tools/mcp/send_email.py
+++ b/backend/app/ai/tools/mcp/send_email.py
@@ -18,7 +18,6 @@ from app.ai.tools.mcp.base import MCPTool
 from app.models.user import User
 from app.models.organization import Organization
 from app.schemas.mcp import MCPSendEmailInput, MCPSendEmailOutput
-from app.services.email_send_service import EmailSendService
 from app.settings.config import settings
 
 logger = logging.getLogger(__name__)
@@ -30,13 +29,14 @@ class SendEmailMCPTool(MCPTool):
 
     name = "send_email"
     description = (
-        "Send an email to the current user (yourself). The recipient is ALWAYS the "
-        "authenticated user — you cannot send to anyone else, so there is no recipient "
-        "argument. Use it when the user asks to be emailed something (a summary, a result, "
-        "an export). Keep the body short and natural; default to plain text. "
-        "Attachments (optional, up to 5) are generated from objects in a report — reference "
-        "a visualization_id / query_id (CSV/XLSX), artifact_id (PPTX/PDF), or file_id, and "
-        "pass the owning report_id."
+        "Send an email to the current user (yourself), and optionally to other members "
+        "of your organization via 'recipients' (their email addresses; outside addresses "
+        "are rejected). You are always included, and every recipient also gets an in-app "
+        "notification. Use it when the user asks to be emailed — or to notify a teammate — "
+        "something (a summary, a result, an export). Keep the body short and natural; "
+        "default to plain text. Attachments (optional, up to 5) are generated from objects "
+        "in a report — reference a visualization_id / query_id (CSV/XLSX), artifact_id "
+        "(PPTX/PDF), or file_id, and pass the owning report_id."
     )
 
     # Availability is decided per-org at request time (see is_available_for_org),
@@ -77,7 +77,6 @@ class SendEmailMCPTool(MCPTool):
                 error="Email is not configured for this organization.",
             ).model_dump()
 
-        # Recipient is always the authenticated user — never caller-controllable.
         recipient = getattr(user, "email", None)
         if not recipient:
             return MCPSendEmailOutput(
@@ -107,17 +106,32 @@ class SendEmailMCPTool(MCPTool):
                     success=False, subject=input_data.subject,
                     error="Report not found.",
                 ).model_dump()
+        elif input_data.report_id:
+            # No attachments but a report was named — used only for the in-app
+            # deep link; still verify org ownership before trusting it.
+            try:
+                report = await self._load_report(db, input_data.report_id)
+                if str(report.organization_id) != str(organization.id):
+                    report = None
+            except Exception:
+                report = None
 
+        # Resolve recipients (self always included; members validated; outsiders
+        # rejected) and fan out across in-app + email/chat via NotifyService —
+        # the same path the internal notify tool uses.
         try:
-            output = await EmailSendService().send(
+            from app.services.notify_service import notify_service
+
+            result = await notify_service.notify(
                 db,
-                recipient=recipient,
+                sender=user,
+                organization=organization,
+                report=report,
                 subject=input_data.subject,
                 body=input_data.body,
                 body_format=input_data.body_format,
                 attachment_specs=input_data.attachments,
-                report=report,
-                organization=organization,
+                recipient_emails=input_data.recipients,
             )
         except Exception as e:
             logger.exception("MCP send_email failed")
@@ -126,10 +140,12 @@ class SendEmailMCPTool(MCPTool):
                 error=f"Failed to send email: {e}",
             ).model_dump()
 
+        reached = [r["email"] for r in result["results"] if r["delivered"]]
         return MCPSendEmailOutput(
-            success=output.success,
-            recipient=output.recipient,
-            subject=output.subject,
-            attachments=output.attachments,
-            error=output.error,
+            success=result["success"],
+            recipient=recipient,
+            recipients=reached,
+            subject=input_data.subject,
+            rejected=result["rejected"],
+            error=None if result["success"] else "Notification could not be delivered.",
         ).model_dump()

--- a/backend/app/ai/tools/schemas/notify.py
+++ b/backend/app/ai/tools/schemas/notify.py
@@ -1,0 +1,84 @@
+from typing import Optional, Literal, List
+from pydantic import BaseModel, Field
+
+# Reuse the exact attachment contract from send_email — same report-scoped refs.
+from app.ai.tools.schemas.send_email import (
+    EmailAttachmentSpec,
+    SendEmailAttachmentResult,  # noqa: F401  (re-exported for convenience)
+)
+
+
+class NotifyInput(BaseModel):
+    """Input schema for the notify tool.
+
+    Delivers a free-form message to people in the user's organization. Each
+    recipient gets an in-app notification AND, when reachable, one external nudge
+    (their verified Teams/Slack, otherwise email). The requesting user is ALWAYS
+    notified too, so leave ``recipients`` empty to just notify yourself.
+    """
+
+    recipients: List[str] = Field(
+        default_factory=list,
+        max_length=20,
+        description=(
+            "Email addresses of the ORG MEMBERS to notify. Each must belong to a "
+            "member (or pending invite) of the current organization — arbitrary "
+            "outside addresses are rejected. You (the requesting user) are always "
+            "included automatically, so leave this empty to notify only yourself. "
+            "Use the address the user gave you or one already visible in context; "
+            "do not guess."
+        ),
+    )
+    subject: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        description="A clear, specific subject line (also the notification title).",
+    )
+    body: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The message body. Write it like a person would — short, natural, direct. "
+            "Plain text by default. If you set body_format='html', keep the HTML simple "
+            "(basic tags like <p>, <ul>/<li>, <strong>, small <table>); avoid heavy "
+            "templated layouts, inline CSS, banners, or branded headers/footers."
+        ),
+    )
+    body_format: Literal["text", "html"] = Field(
+        default="text",
+        description="'text' (default, preferred) or 'html' for light structure.",
+    )
+    attachments: List[EmailAttachmentSpec] = Field(
+        default_factory=list,
+        max_length=5,
+        description=(
+            "Optional files to attach (max 5), referenced by visualization_id / query_id "
+            "/ artifact_id / file_id from this report. Sent on the external channel "
+            "(email / Teams / Slack); in-app recipients open the report to view them."
+        ),
+    )
+
+
+class NotifyRecipientResult(BaseModel):
+    """Per-recipient delivery outcome."""
+
+    email: str
+    name: Optional[str] = None
+    is_self: bool = False
+    delivered: List[str] = Field(default_factory=list, description="Channels that succeeded, e.g. ['in_app','email'].")
+    failed: List[str] = Field(default_factory=list, description="Channels that were attempted but failed.")
+    error: Optional[str] = None
+
+
+class NotifyOutput(BaseModel):
+    """Output schema for the notify tool."""
+
+    success: bool = Field(..., description="True if at least one recipient was reached on at least one channel.")
+    subject: Optional[str] = None
+    results: List[NotifyRecipientResult] = Field(default_factory=list)
+    rejected: List[str] = Field(
+        default_factory=list,
+        description="Requested addresses that are not members of this org and were not notified.",
+    )
+    error: Optional[str] = None

--- a/backend/app/schemas/mcp.py
+++ b/backend/app/schemas/mcp.py
@@ -253,13 +253,25 @@ from app.ai.tools.schemas.send_email import (  # noqa: E402
 class MCPSendEmailInput(BaseModel):
     """Input for the send_email MCP tool.
 
-    Sends a free-form email to the requesting user themselves. The recipient is
-    ALWAYS the authenticated user — it is not selectable, so the tool can never
-    email anyone else.
+    Sends a free-form email to the authenticated user, and optionally to other
+    members of their organization. The requesting user is ALWAYS included, and
+    every recipient also gets an in-app notification. ``recipients`` may only
+    name members (or pending invites) of the caller's org — outside addresses
+    are rejected.
     """
     subject: str = Field(..., min_length=1, max_length=300, description="A clear, specific subject line.")
     body: str = Field(..., min_length=1, description="The email body. Plain text by default; keep it short and natural.")
     body_format: str = Field(default="text", description="'text' (default) or 'html'. Use 'html' only when light structure genuinely helps.")
+    recipients: List[str] = Field(
+        default_factory=list,
+        max_length=20,
+        description=(
+            "Optional email addresses of OTHER organization members to also notify. "
+            "Each must belong to a member/invite of the caller's org; outside addresses "
+            "are rejected. You are always included automatically — leave empty to email "
+            "only yourself."
+        ),
+    )
     report_id: Optional[str] = Field(default=None, description="Report ID that owns any attachments. Required when 'attachments' is non-empty; attachments are scoped to this report.")
     attachments: List[EmailAttachmentSpec] = Field(
         default_factory=list,
@@ -272,6 +284,8 @@ class MCPSendEmailOutput(BaseModel):
     """Output for the send_email MCP tool."""
     success: bool
     recipient: Optional[str] = None
+    recipients: List[str] = Field(default_factory=list, description="All addresses reached (self + members).")
     subject: Optional[str] = None
     attachments: List[SendEmailAttachmentResult] = Field(default_factory=list)
+    rejected: List[str] = Field(default_factory=list, description="Requested addresses that are not org members and were skipped.")
     error: Optional[str] = None

--- a/backend/app/services/notify_service.py
+++ b/backend/app/services/notify_service.py
@@ -1,0 +1,367 @@
+"""NotifyService — deliver a free-form message to org members across channels.
+
+This is the channel-agnostic generalization of ``send_email``. The agent (or a
+scheduled run) hands it a subject/body, optional report-scoped attachments, and a
+set of recipient **emails**; the service:
+
+1. **Resolves + authorizes recipients** against the org's ``memberships`` — only
+   active members or pending invites are accepted, never free-form outsiders.
+   The requesting user (self) is ALWAYS added, so the sender keeps a copy.
+2. **Always delivers in-app** via :class:`InboxService` (the per-user inbox from
+   the notification center) for every recipient that has a user account.
+3. **Adds one external nudge per recipient**: the recipient's preferred verified
+   chat platform (Teams → Slack) if reachable, else email. Never both — in-app is
+   the always-on layer, the external nudge is a one-way pointer back into the app.
+
+The membership check is the security boundary; it lives here so the internal
+``notify`` tool and the external MCP path share exactly one implementation.
+Reply-threading (a recipient replying re-attaches to a report) is kept owner-only
+by only passing ``system_completion`` through for the self recipient.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import SOURCE_REPORT_TOOL
+
+logger = logging.getLogger(__name__)
+
+# Preferred chat platforms for the external nudge, in order. Email is the
+# universal fallback when none of these is reachable for a recipient.
+_CHAT_PLATFORMS = ("teams", "slack")
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _snippet(body: str, body_format: str, limit: int = 280) -> str:
+    """A short plain-text preview of the body for the in-app row."""
+    text = body or ""
+    if body_format == "html":
+        text = _TAG_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+@dataclass
+class ResolvedRecipient:
+    email: str
+    user_id: Optional[str] = None  # None for a pending invite with no account yet
+    is_self: bool = False
+    name: Optional[str] = None
+
+
+@dataclass
+class RecipientDelivery:
+    email: str
+    name: Optional[str] = None
+    is_self: bool = False
+    delivered: List[str] = field(default_factory=list)  # channels that succeeded
+    failed: List[str] = field(default_factory=list)      # channels that failed
+    error: Optional[str] = None
+
+
+class NotifyService:
+    """Resolve recipients and fan a message out across in-app + one external channel."""
+
+    async def resolve_recipients(
+        self,
+        db: AsyncSession,
+        organization: Any,
+        sender: Any,
+        emails: List[str],
+    ) -> Tuple[List[ResolvedRecipient], List[str]]:
+        """Validate ``emails`` against the org's memberships and always include self.
+
+        Returns ``(resolved, rejected)``. ``rejected`` holds any requested address
+        that does not belong to an active member or pending invite in this org —
+        the caller surfaces it but it is never delivered to. Self is always first.
+        """
+        from app.models.membership import Membership
+        from app.models.user import User
+
+        org_id = str(getattr(organization, "id", "") or "")
+        resolved: List[ResolvedRecipient] = []
+        seen: set[str] = set()
+
+        self_email = (getattr(sender, "email", None) or "").strip().lower()
+        if self_email:
+            resolved.append(ResolvedRecipient(
+                email=self_email,
+                user_id=str(sender.id),
+                is_self=True,
+                name=getattr(sender, "name", None),
+            ))
+            seen.add(self_email)
+
+        wanted = [(e or "").strip().lower() for e in (emails or [])]
+        wanted = [e for e in wanted if e and e not in seen]
+        if not wanted:
+            return resolved, []
+
+        # Build an email → (user_id, name) map for the org's memberships. Active
+        # members are keyed by their user's email; pending invites by the
+        # membership's own email (no account yet).
+        rows = (await db.execute(
+            select(Membership, User)
+            .outerjoin(User, Membership.user_id == User.id)
+            .where(Membership.organization_id == org_id)
+        )).all()
+        member_map: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
+        for m, u in rows:
+            if u is not None and u.email:
+                member_map[u.email.strip().lower()] = (str(u.id), getattr(u, "name", None))
+            if m.email:
+                member_map.setdefault(m.email.strip().lower(), (str(u.id) if u else None, None))
+
+        rejected: List[str] = []
+        for email in wanted:
+            if email in seen:
+                continue
+            hit = member_map.get(email)
+            if hit is None:
+                rejected.append(email)
+                continue
+            user_id, name = hit
+            resolved.append(ResolvedRecipient(email=email, user_id=user_id, is_self=False, name=name))
+            seen.add(email)
+
+        return resolved, rejected
+
+    async def notify(
+        self,
+        db: AsyncSession,
+        *,
+        sender: Any,
+        organization: Any,
+        report: Any = None,
+        subject: str,
+        body: str,
+        body_format: str = "text",
+        attachment_specs: Optional[List[Any]] = None,
+        recipient_emails: Optional[List[str]] = None,
+        source: str = SOURCE_REPORT_TOOL,
+        system_completion: Any = None,
+    ) -> Dict[str, Any]:
+        """Deliver to all resolved recipients. Returns per-recipient channel results."""
+        attachment_specs = attachment_specs or []
+        resolved, rejected = await self.resolve_recipients(
+            db, organization, sender, recipient_emails or []
+        )
+
+        org_id = str(getattr(organization, "id", "") or "")
+        report_id = str(report.id) if report is not None and getattr(report, "id", None) else None
+        link = f"/reports/{report_id}" if report_id else None
+        source_id = str(getattr(system_completion, "id", None)) if system_completion is not None else None
+
+        # ---- in-app: one row per recipient that has an account ----
+        inapp_user_ids = [r.user_id for r in resolved if r.user_id]
+        inapp_ok: set[str] = set()
+        if inapp_user_ids:
+            try:
+                from app.services.inbox_service import inbox_service
+
+                await inbox_service.notify_users(
+                    db,
+                    organization_id=org_id,
+                    user_ids=inapp_user_ids,
+                    source=source,
+                    type="notify",
+                    title=subject,
+                    body=_snippet(body, body_format),
+                    link=link,
+                    subject={
+                        "kind": "report",
+                        "report_id": report_id,
+                        "attachments": [
+                            {"ref_type": a.ref_type, "ref_id": a.ref_id} for a in attachment_specs
+                        ],
+                    },
+                    # actor_user_id is intentionally None so the sender (self) also
+                    # receives the in-app copy — notify_users excludes the actor.
+                    actor_user_id=None,
+                    source_id=source_id,
+                    group_key=f"notify:{source_id or report_id or ''}:{(subject or '')[:60]}",
+                )
+                inapp_ok = set(inapp_user_ids)
+            except Exception:  # noqa: BLE001
+                logger.exception("notify: in-app delivery failed")
+
+        # ---- external nudge: one channel per recipient ----
+        deliveries: List[RecipientDelivery] = []
+        for r in resolved:
+            d = RecipientDelivery(email=r.email, name=r.name, is_self=r.is_self)
+            if r.user_id and r.user_id in inapp_ok:
+                d.delivered.append("in_app")
+
+            # Reply-threading stays owner-only: only the self recipient carries the
+            # system_completion (so the owner's reply re-attaches to their report).
+            sc = system_completion if r.is_self else None
+            channel, ok, err = await self._external_nudge(
+                db, organization, report, r, subject, body, body_format, attachment_specs, sc
+            )
+            if channel:
+                (d.delivered if ok else d.failed).append(channel)
+                if not ok and err:
+                    d.error = err
+            deliveries.append(d)
+
+        success = any(d.delivered for d in deliveries)
+        return {
+            "success": success,
+            "results": [
+                {
+                    "email": d.email,
+                    "name": d.name,
+                    "is_self": d.is_self,
+                    "delivered": d.delivered,
+                    "failed": d.failed,
+                    "error": d.error,
+                }
+                for d in deliveries
+            ],
+            "rejected": rejected,
+        }
+
+    # ---- internal: pick + send one external channel for a recipient ----
+
+    async def _external_nudge(
+        self, db, organization, report, recipient: ResolvedRecipient,
+        subject, body, body_format, attachment_specs, system_completion,
+    ) -> Tuple[Optional[str], bool, Optional[str]]:
+        """Try the recipient's preferred verified chat platform, else email.
+
+        Returns ``(channel, ok, error)``. ``channel`` is None only if nothing was
+        attempted (e.g. no email address at all, which shouldn't happen).
+        """
+        org_id = str(getattr(organization, "id", "") or "")
+
+        # Chat platforms need an account + a verified mapping; invites (no user)
+        # skip straight to email.
+        if recipient.user_id:
+            for ptype in _CHAT_PLATFORMS:
+                try:
+                    ch = await self._try_chat(
+                        db, org_id, ptype, report, recipient, body, body_format, attachment_specs
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.exception("notify: %s nudge failed for %s", ptype, recipient.email)
+                    ch = None
+                if ch is not None:
+                    return ptype, ch, None
+
+        return await self._send_email(
+            db, organization, report, recipient, subject, body, body_format,
+            attachment_specs, system_completion,
+        )
+
+    async def _try_chat(
+        self, db, org_id, ptype, report, recipient, body, body_format, attachment_specs
+    ) -> Optional[bool]:
+        """Send a DM on ``ptype`` if the org has it active and the recipient has a
+        verified mapping. Returns the send result, or None if not reachable here
+        (so the caller falls through to the next channel / email)."""
+        from app.services.external_platform_service import ExternalPlatformService
+        from app.services.external_user_mapping_service import ExternalUserMappingService
+        from app.services.platform_adapters.adapter_factory import PlatformAdapterFactory
+
+        platform = await ExternalPlatformService().get_platform_by_type(db, org_id, ptype)
+        if not platform or not getattr(platform, "is_active", False):
+            return None
+        mapping = await ExternalUserMappingService().get_mapping_by_app_user(
+            db, org_id, ptype, recipient.user_id
+        )
+        if not mapping or not mapping.is_verified or not mapping.external_user_id:
+            return None
+
+        adapter = PlatformAdapterFactory.create_adapter(platform)
+        text = self._with_link(body, body_format, report, plain=True)
+        ok = await adapter.send_dm(mapping.external_user_id, text)
+
+        # Best-effort attachments — never fail the message over an attachment.
+        if ok and attachment_specs:
+            files, temps = await self._resolve_files(db, report, None, attachment_specs)
+            try:
+                for path, filename in files:
+                    try:
+                        await adapter.send_file_in_dm(mapping.external_user_id, path, filename)
+                    except Exception:  # noqa: BLE001
+                        logger.exception("notify: %s attachment send failed", ptype)
+            finally:
+                self._cleanup(temps)
+        return bool(ok)
+
+    async def _send_email(
+        self, db, organization, report, recipient, subject, body, body_format,
+        attachment_specs, system_completion,
+    ) -> Tuple[str, bool, Optional[str]]:
+        from app.services.email_send_service import EmailSendService
+
+        try:
+            out = await EmailSendService().send(
+                db,
+                recipient=recipient.email,
+                subject=subject,
+                body=body,
+                body_format=body_format,
+                attachment_specs=attachment_specs,
+                report=report,
+                organization=organization,
+                system_completion=system_completion,
+            )
+            return "email", bool(out.success), (None if out.success else out.error)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("notify: email send failed for %s", recipient.email)
+            return "email", False, str(e)
+
+    async def _resolve_files(self, db, report, organization, specs) -> Tuple[List[Tuple[str, str]], List[str]]:
+        """Reuse EmailSendService's report-scoped attachment resolution to produce
+        on-disk files for a chat upload. Returns ([(path, filename)], temp_paths)."""
+        from app.services.email_send_service import EmailSendService
+
+        svc = EmailSendService()
+        files: List[Tuple[str, str]] = []
+        temps: List[str] = []
+        for spec in specs:
+            try:
+                res, att_dict, temp_path = await svc.resolve_attachment(spec, db, report, organization)
+            except Exception:  # noqa: BLE001
+                logger.exception("notify: attachment resolution failed")
+                continue
+            if att_dict and res.success:
+                path = att_dict.get("file")
+                if path:
+                    files.append((path, res.filename or os.path.basename(path)))
+                if temp_path:
+                    temps.append(temp_path)
+        return files, temps
+
+    @staticmethod
+    def _cleanup(paths: List[str]) -> None:
+        for p in paths:
+            try:
+                os.unlink(p)
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _with_link(body: str, body_format: str, report: Any, plain: bool) -> str:
+        rid = getattr(report, "id", None) if report is not None else None
+        if not rid:
+            return body
+        try:
+            from app.settings.config import settings
+            base = settings.bow_config.base_url
+        except Exception:  # noqa: BLE001
+            base = ""
+        url = f"{base}/reports/{rid}"
+        return f"{body}\n\n{url}"
+
+
+notify_service = NotifyService()

--- a/backend/tests/unit/test_notify_service.py
+++ b/backend/tests/unit/test_notify_service.py
@@ -1,0 +1,165 @@
+"""Unit tests for NotifyService — recipient resolution + channel fan-out.
+
+The membership/security boundary and the channel selection are covered here with
+the DB and downstream senders (inbox, email, chat adapters) mocked. The notify
+*tool* wrapper is thin over this service.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.notify_service import NotifyService, _snippet
+
+
+def _db_with_members(rows):
+    """A mock AsyncSession whose execute().all() returns the given (membership, user) rows."""
+    db = MagicMock()
+    result = MagicMock()
+    result.all = MagicMock(return_value=rows)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+SENDER = SimpleNamespace(id="u-self", email="me@acme.com", name="Me")
+ORG = SimpleNamespace(id="org-1")
+MEMBER_ROWS = [
+    (SimpleNamespace(user_id="u-bob", email=None), SimpleNamespace(id="u-bob", email="bob@acme.com", name="Bob")),
+    (SimpleNamespace(user_id=None, email="invite@acme.com"), None),
+]
+
+
+# ---- snippet helper --------------------------------------------------------
+
+
+def test_snippet_strips_html_and_truncates():
+    assert _snippet("<p>Hello <b>world</b></p>", "html") == "Hello world"
+    long = "x" * 400
+    out = _snippet(long, "text", limit=280)
+    assert len(out) == 281 and out.endswith("…")
+
+
+# ---- recipient resolution (the security boundary) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_always_includes_self():
+    db = _db_with_members(MEMBER_ROWS)
+    resolved, rejected = await NotifyService().resolve_recipients(db, ORG, SENDER, [])
+    assert [r.email for r in resolved] == ["me@acme.com"]
+    assert resolved[0].is_self is True
+    assert rejected == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_accepts_member_and_invite_rejects_outsider():
+    db = _db_with_members(MEMBER_ROWS)
+    resolved, rejected = await NotifyService().resolve_recipients(
+        db, ORG, SENDER, ["bob@acme.com", "OUTSIDER@evil.com", "invite@acme.com"]
+    )
+    emails = [r.email for r in resolved]
+    assert emails == ["me@acme.com", "bob@acme.com", "invite@acme.com"]
+    # Active member resolves to a user; pending invite has no account.
+    by_email = {r.email: r for r in resolved}
+    assert by_email["bob@acme.com"].user_id == "u-bob"
+    assert by_email["invite@acme.com"].user_id is None
+    assert rejected == ["outsider@evil.com"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_dedupes_self_and_repeats():
+    db = _db_with_members(MEMBER_ROWS)
+    resolved, _ = await NotifyService().resolve_recipients(
+        db, ORG, SENDER, ["me@acme.com", "bob@acme.com", "bob@acme.com"]
+    )
+    assert [r.email for r in resolved] == ["me@acme.com", "bob@acme.com"]
+
+
+# ---- fan-out: in-app always + email fallback (no chat configured) ----------
+
+
+@pytest.mark.asyncio
+async def test_notify_inapp_plus_email_and_threading_is_self_only():
+    db = _db_with_members(MEMBER_ROWS)
+    svc = NotifyService()
+    sc = SimpleNamespace(id="sc-1")
+    report = SimpleNamespace(id="r-1")
+
+    with patch("app.services.inbox_service.inbox_service.notify_users", new=AsyncMock()) as mock_inbox, \
+         patch("app.services.external_platform_service.ExternalPlatformService.get_platform_by_type",
+               new=AsyncMock(return_value=None)), \
+         patch("app.services.email_send_service.EmailSendService.send",
+               new=AsyncMock(return_value=SimpleNamespace(success=True, error=None))) as mock_email:
+        result = await svc.notify(
+            db,
+            sender=SENDER,
+            organization=ORG,
+            report=report,
+            subject="Q2 done",
+            body="All set.",
+            recipient_emails=["bob@acme.com"],
+            system_completion=sc,
+        )
+
+    # In-app: one call, both users with accounts, actor None so self is included.
+    mock_inbox.assert_awaited_once()
+    kw = mock_inbox.await_args.kwargs
+    assert set(kw["user_ids"]) == {"u-self", "u-bob"}
+    assert kw["actor_user_id"] is None
+    assert kw["link"] == "/reports/r-1"
+
+    # Email: sent to both; only the self send carries system_completion (one-way
+    # reply-threading stays owner-only).
+    sent = {c.kwargs["recipient"]: c.kwargs for c in mock_email.await_args_list}
+    assert set(sent) == {"me@acme.com", "bob@acme.com"}
+    assert sent["me@acme.com"]["system_completion"] is sc
+    assert sent["bob@acme.com"]["system_completion"] is None
+
+    assert result["success"] is True
+    by_email = {r["email"]: r for r in result["results"]}
+    assert by_email["me@acme.com"]["delivered"] == ["in_app", "email"]
+    assert by_email["bob@acme.com"]["delivered"] == ["in_app", "email"]
+    assert result["rejected"] == []
+
+
+# ---- fan-out: verified Teams mapping wins over email -----------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_prefers_verified_teams_over_email():
+    db = _db_with_members(MEMBER_ROWS)
+    svc = NotifyService()
+    teams_platform = SimpleNamespace(platform_type="teams", is_active=True)
+    teams_mapping = SimpleNamespace(is_verified=True, external_user_id="teams-bob")
+
+    async def _platform_by_type(self, _db, _org, ptype):
+        return teams_platform if ptype == "teams" else None
+
+    async def _mapping(self, _db, _org, ptype, app_user_id):
+        # Only Bob has a verified Teams identity; self does not → self falls to email.
+        return teams_mapping if (ptype == "teams" and app_user_id == "u-bob") else None
+
+    adapter = MagicMock()
+    adapter.send_dm = AsyncMock(return_value=True)
+
+    with patch("app.services.inbox_service.inbox_service.notify_users", new=AsyncMock()), \
+         patch("app.services.external_platform_service.ExternalPlatformService.get_platform_by_type", new=_platform_by_type), \
+         patch("app.services.external_user_mapping_service.ExternalUserMappingService.get_mapping_by_app_user", new=_mapping), \
+         patch("app.services.platform_adapters.adapter_factory.PlatformAdapterFactory.create_adapter", return_value=adapter), \
+         patch("app.services.email_send_service.EmailSendService.send",
+               new=AsyncMock(return_value=SimpleNamespace(success=True, error=None))) as mock_email:
+        result = await svc.notify(
+            db, sender=SENDER, organization=ORG, report=SimpleNamespace(id="r-1"),
+            subject="Hi", body="ping", recipient_emails=["bob@acme.com"],
+        )
+
+    # Bob reached on Teams (a DM), not email; self has no Teams mapping → email.
+    adapter.send_dm.assert_awaited_once()
+    assert adapter.send_dm.await_args.args[0] == "teams-bob"
+    emailed = {c.kwargs["recipient"] for c in mock_email.await_args_list}
+    assert emailed == {"me@acme.com"}  # only self fell back to email
+    by_email = {r["email"]: r for r in result["results"]}
+    assert "teams" in by_email["bob@acme.com"]["delivered"]
+    assert "email" in by_email["me@acme.com"]["delivered"]

--- a/backend/tests/unit/test_notify_tool.py
+++ b/backend/tests/unit/test_notify_tool.py
@@ -1,0 +1,76 @@
+"""Unit tests for the notify tool wrapper (thin over NotifyService)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.ai.tools.implementations.notify import NotifyTool
+from app.ai.tools.schemas.notify import NotifyInput
+
+
+def _ctx(**overrides):
+    ctx = {
+        "db": MagicMock(),
+        "user": SimpleNamespace(id="u-self", email="me@acme.com", name="Me"),
+        "organization": SimpleNamespace(id="org-1"),
+        "report": SimpleNamespace(id="r-1"),
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+async def _collect(tool, tool_input, ctx):
+    return [e async for e in tool.run_stream(tool_input, ctx)]
+
+
+def _end(events):
+    return [e for e in events if e.type == "tool.end"][-1].payload
+
+
+def test_notify_input_requires_subject_and_body():
+    with pytest.raises(Exception):
+        NotifyInput(subject="hi")  # missing body
+    # recipients optional → empty means self-only
+    assert NotifyInput(subject="hi", body="x").recipients == []
+
+
+@pytest.mark.asyncio
+async def test_notify_requires_context():
+    tool = NotifyTool()
+    events = await _collect(tool, {"subject": "s", "body": "b"}, _ctx(organization=None))
+    out = _end(events)["output"]
+    assert out["success"] is False
+    assert "organization" in (out["error"] or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_notify_happy_path_delegates_to_service():
+    tool = NotifyTool()
+    fake_result = {
+        "success": True,
+        "results": [
+            {"email": "me@acme.com", "name": "Me", "is_self": True, "delivered": ["in_app", "email"], "failed": [], "error": None},
+            {"email": "bob@acme.com", "name": "Bob", "is_self": False, "delivered": ["in_app", "teams"], "failed": [], "error": None},
+        ],
+        "rejected": ["outsider@evil.com"],
+    }
+    with patch("app.services.notify_service.notify_service.notify", new=AsyncMock(return_value=fake_result)) as mock_notify:
+        events = await _collect(
+            tool,
+            {"subject": "Q2", "body": "done", "recipients": ["bob@acme.com", "outsider@evil.com"]},
+            _ctx(),
+        )
+        mock_notify.assert_awaited_once()
+        kw = mock_notify.await_args.kwargs
+        assert kw["recipient_emails"] == ["bob@acme.com", "outsider@evil.com"]
+        assert kw["subject"] == "Q2"
+
+    payload = _end(events)
+    out = payload["output"]
+    assert out["success"] is True
+    assert {r["email"] for r in out["results"]} == {"me@acme.com", "bob@acme.com"}
+    assert out["rejected"] == ["outsider@evil.com"]
+    assert payload["observation"]["success"] is True
+    assert "skipped non-members" in payload["observation"]["summary"]

--- a/frontend/components/tools/NotifyTool.vue
+++ b/frontend/components/tools/NotifyTool.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="mt-1">
+    <Transition name="fade" appear>
+      <div
+        class="flex items-center text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300"
+        @click="toggleExpanded"
+      >
+        <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+          <Icon name="heroicons-bell" class="w-3 h-3 me-1.5 text-gray-400" />
+          Notifying…
+        </span>
+        <span v-else-if="isSuccess" class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-bell" class="w-3 h-3 me-1.5 text-blue-500" />
+          <span dir="auto" class="truncate max-w-[320px]">{{ summaryLine }}</span>
+          <Icon
+            :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+            class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip"
+          />
+        </span>
+        <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
+          <span>Couldn't send notification</span>
+          <Icon
+            :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
+            class="w-3 h-3 ms-1 text-gray-400 rtl-flip"
+          />
+        </span>
+      </div>
+    </Transition>
+
+    <Transition name="slide">
+      <div v-if="isExpanded && status !== 'running'" class="mt-2 space-y-2">
+        <div class="border border-gray-150 dark:border-gray-800 rounded-md overflow-hidden">
+          <div v-if="subject" class="px-3 py-1.5 bg-gray-50 dark:bg-gray-900 border-b border-gray-150 dark:border-gray-800 flex items-center gap-2">
+            <span class="text-[10px] text-gray-600 dark:text-gray-400 font-medium">Subject</span>
+            <span dir="auto" class="text-[11px] text-gray-800 dark:text-gray-200 truncate">{{ subject }}</span>
+          </div>
+          <div v-for="r in results" :key="r.email" class="px-3 py-1 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
+            <Icon :name="r.delivered && r.delivered.length ? 'heroicons-check-circle' : 'heroicons-x-circle'"
+              class="w-3 h-3 shrink-0" :class="r.delivered && r.delivered.length ? 'text-green-500' : 'text-red-500'" />
+            <span dir="auto" class="text-[11px] text-gray-700 dark:text-gray-300 truncate">{{ r.email }}<span v-if="r.is_self" class="text-gray-400"> (you)</span></span>
+            <span class="text-[10px] text-gray-400 ms-auto">{{ (r.delivered || []).join(', ') || 'failed' }}</span>
+          </div>
+        </div>
+
+        <div v-if="rejected.length" class="text-[10px] text-amber-600 bg-amber-50 dark:bg-amber-950/40 rounded px-2 py-1">
+          Skipped (not members of this org): {{ rejected.join(', ') }}
+        </div>
+        <div v-if="errorMessage" class="text-[10px] text-red-500 bg-red-50 dark:bg-red-950 rounded px-2 py-1">
+          {{ errorMessage }}
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  status: string
+  result_json?: any
+  arguments_json?: any
+}
+
+const props = defineProps<{ toolExecution: ToolExecution }>()
+
+const isExpanded = ref(false)
+
+const status = computed<string>(() => props.toolExecution?.status || '')
+const isSuccess = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  return status.value === 'success' && rj.success === true
+})
+
+const subject = computed<string>(() => props.toolExecution?.result_json?.subject || props.toolExecution?.arguments_json?.subject || '')
+const results = computed<any[]>(() => props.toolExecution?.result_json?.results || [])
+const rejected = computed<string[]>(() => props.toolExecution?.result_json?.rejected || [])
+
+const summaryLine = computed(() => {
+  const reached = results.value.filter((r) => (r.delivered || []).length).length
+  const subj = subject.value ? `: ${subject.value}` : ''
+  return `Notified ${reached} recipient${reached === 1 ? '' : 's'}${subj}`
+})
+
+const errorMessage = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  if (status.value === 'error') return rj.error || rj.message || ''
+  if (status.value === 'success' && rj.success === false) return rj.error || ''
+  return ''
+})
+
+function toggleExpanded() {
+  if (status.value !== 'running') isExpanded.value = !isExpanded.value
+}
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+@keyframes shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: 100% 0; }
+}
+.fade-enter-active, .fade-leave-active { transition: opacity 0.2s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.slide-enter-active, .slide-leave-active { transition: all 0.15s ease; overflow: hidden; }
+.slide-enter-from, .slide-leave-to { opacity: 0; max-height: 0; }
+.slide-enter-to, .slide-leave-from { opacity: 1; max-height: 500px; }
+</style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -765,6 +765,7 @@ import InstructionSuggestions from '@/components/InstructionSuggestions.vue'
 import CreateInstructionTool from '~/components/tools/CreateInstructionTool.vue'
 import EditInstructionTool from '~/components/tools/EditInstructionTool.vue'
 import SendEmailTool from '~/components/tools/SendEmailTool.vue'
+import NotifyTool from '~/components/tools/NotifyTool.vue'
 import CreateScheduledTaskTool from '~/components/tools/CreateScheduledTaskTool.vue'
 import CancelScheduledTaskTool from '~/components/tools/CancelScheduledTaskTool.vue'
 import EditScheduledTaskTool from '~/components/tools/EditScheduledTaskTool.vue'
@@ -1620,6 +1621,8 @@ function getToolComponent(toolName: string) {
 			return EditInstructionTool
 		case 'send_email':
 			return SendEmailTool
+		case 'notify':
+			return NotifyTool
 		case 'create_scheduled_task':
 			return CreateScheduledTaskTool
 		case 'cancel_scheduled_task':


### PR DESCRIPTION
## Summary

Stacks onto PR #460. Generalizes the self-only `send_email` into a channel-agnostic **`notify`** capability, built on the notification center (`Notification` model + `inbox_service`) that PR 460 introduced.

## `NotifyService` (new)
- **Recipient resolution = the security boundary**: validates each email against the org's `memberships` — only active members or pending invites are accepted, outside addresses are rejected. The requesting user (**self**) is always included.
- **Always in-app**: delivers via `inbox_service.notify_users` (actor `None` so self also gets a copy), then **one external nudge** per recipient — verified Teams → Slack DM if reachable, otherwise email. Never both; in-app is the always-on layer.
- **Reply-threading stays owner-only**: `system_completion` is only passed through for the self recipient, so a non-owner's reply still spins up their own report (unchanged behavior).
- Reuses `EmailSendService`'s report-scoped attachment resolution to upload files on Teams/Slack.

## `notify` agent tool (new)
- Inputs: `recipients` (member emails; empty → self only), `subject`, `body`, `body_format`, `attachments` (reused `EmailAttachmentSpec`). Thin wrapper over `NotifyService`, auto-registered, always advertised (in-app works even with no email transport).
- Frontend `NotifyTool.vue` result card shows per-recipient delivery. `send_email` stays for the narrow "email myself" case.

## MCP `send_email`
- Now also accepts member `recipients` (validated through the same resolver) and writes an **in-app notification** on every send, routing through `NotifyService`.

## Other
- Conversation-history digest records `notify` sends (recipients + subject + skipped non-members).

## Tests
- `tests/unit/test_notify_service.py`: recipient resolution (self always included, member/invite accepted, outsider rejected, dedup), in-app + email fan-out, one-way threading, Teams-preferred-over-email.
- `tests/unit/test_notify_tool.py`: tool guards + happy-path delegation.
- All pass (9 new), alongside the existing scheduled-task suite.

## Notes
- Membership validation is the hard boundary; the agent can't email outsiders even via injection.
- Attachment-level access gating intentionally **not** included (sender decides), per the agreed design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014LTPV6Zuijr68J8WjEPpH9)_