### PR TITLE
Make follow-up suggestions follow the conversation, not just the schema

### DIFF
--- a/backend/app/ai/agents/reporter/reporter.py
+++ b/backend/app/ai/agents/reporter/reporter.py
@@ -103,29 +103,39 @@ class Reporter:
             data_blocks += f"\n        Business context / instructions:\n        {instructions_context}\n"
 
         grounding_rule = (
-            "- Only suggest questions answerable from the available data above — reference dimensions, "
-            "metrics, segments, or time columns that actually exist. Never invent metrics the data can't support."
+            "- When a suggestion IS a data question, ground it in the available data above — reference "
+            "dimensions, metrics, segments, or time columns that actually exist, and never invent metrics the data can't support."
             if schemas_context else
-            "- Keep suggestions answerable from the kind of data discussed; do not invent specifics."
+            "- When a suggestion is a data question, keep it answerable from the kind of data discussed; do not invent specifics."
         )
 
         return f"""
-        You are helping a user explore their data with an analytics assistant.
-        Given the recent conversation and the available data context, propose up
-        to {max_suggestions} natural follow-up questions the user might ask next.
-        {data_blocks}
+        You are suggesting what a user might click to ask next in an assistant conversation.
+        The RECENT CONVERSATION is the primary driver: every suggestion must be a natural
+        continuation of what the user and assistant were just doing. Propose up to
+        {max_suggestions} follow-ups.
+
         Conversation so far:
         {messages_context}
+        {data_blocks}
+        First, read the conversation to decide what kind of follow-ups fit:
+        - If the last turn was a data/analytics question, suggest natural next data questions,
+          grounded in the available data above.
+        - If the last turn was NOT a data question (e.g. scheduling a task, sending an
+          email/notification, changing a setting, or another non-analytical request), suggest
+          follow-ups that continue THAT task. Do not pivot to unrelated data questions just
+          because data happens to be available — the available data is supporting context only.
 
         Rules:
-        - Each suggestion is a single, self-contained question the user could click to ask next.
+        - Each suggestion is a single, self-contained prompt the user could click to send next.
         - Keep them short (max ~12 words), specific, and genuinely useful given the conversation.
+        - Suggestions must follow from the recent conversation — never generic questions disconnected from it.
         {grounding_rule}
-        - Prefer drilling into dimensions, time trends, comparisons, or segments present in the data.
-        - Do not repeat questions already asked. Do not number them.
+        - Do not repeat questions or actions already done. Do not number them.
         - Write the suggestions in the SAME language the conversation above is in. Keep column names, identifiers, and metric names as-is.
         Return ONLY a JSON array of strings, nothing else.
-        Example: ["How did revenue trend last quarter?", "Which region grew fastest?"]
+        Example (data turn): ["How did revenue trend last quarter?", "Which region grew fastest?"]
+        Example (non-data turn, e.g. a scheduled email): ["Change the daily send time?", "Stop the daily email", "Also send it to my manager?"]
         """
 
     def _training_follow_ups_prompt(self, messages_context, schemas_context, instructions_context, max_suggestions):


### PR DESCRIPTION
## Problem

Follow-up suggestions on `/reports/[id]` could come back unrelated to the last few messages. On non-analytical turns — e.g. setting up a daily scheduled joke email — the chips were generic schema questions ("top selling tracks by revenue", "revenue by country", "top 10 customers") that had nothing to do with what the user just did.

## Root cause

The conversation **does** reach the model (via `MessageContextBuilder`, including the scheduled-task turn). The issue is the prompt in `reporter.py:_chat_follow_ups_prompt`: it was framed purely as data exploration and forced schema-grounding regardless of turn type —

- *"You are helping a user explore their data..."*
- *"Prefer drilling into dimensions, time trends... present in the data."*
- *"Only suggest questions answerable from the available data above."*

With ~6000 chars of schema vs a 2-line conversation on the small model, the schema dominated and the model discarded the conversation, emitting generic schema-derived questions.

## Fix

Rework `_chat_follow_ups_prompt` so the **recent conversation is the primary driver**:

- Conversation is placed first; schema/instructions are demoted to "supporting context only."
- Explicit branch on turn type:
  - **Data/analytics turn** → next data questions, grounded in the schema (unchanged behavior).
  - **Non-data turn** (scheduling, email/notification, settings, other non-analytical requests) → follow-ups that continue *that* task, with an explicit instruction not to pivot to unrelated data questions just because data is available.
- Grounding rule rescoped to apply only "when a suggestion IS a data question."
- Added a non-data example (`"Change the daily send time?"`, `"Stop the daily email"`) alongside the existing data example.

Scope is the suggestion **content** only — delivery/reliability of the `completion.follow_ups` event is unchanged.

## Testing

- Syntax-checked the module.
- No tests or eval shots assert the prompt text (`scripts/ui_followups_shots.py` is a Playwright walkthrough that reads persisted `follow_ups`, not the prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QtxsukBdzJbu872rdMtRx)_