### PR TITLE
Fix connection delete race condition and optimize SQLite test performance

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -417,36 +417,83 @@ class ConnectionService:
 
         Data sources that only have this connection will also be deleted.
         """
-        connection = await self.get_connection(db, connection_id, organization)
+        # Capture the org id as a plain string up front. The retry path below
+        # rolls back on a concurrent-write FK violation, and a rollback expires
+        # every ORM instance — so touching `organization.id` afterwards would
+        # fire implicit (sync) lazy IO and raise MissingGreenlet under asyncpg.
+        organization_id = str(organization.id)
+        current_user_id = str(current_user.id)
 
-        # Capture details before deletion for audit
-        connection_name = connection.name
+        # Drain any in-flight schema indexing for this connection before we
+        # delete. The indexer runs on a background loop with its own session
+        # and inserts `connection_tables` rows asynchronously (see
+        # ConnectionIndexingService). If it commits a row after our ORM has
+        # snapshotted the (delete-orphan) collection, the parent DELETE leaves
+        # an orphan child and Postgres rejects it with a foreign-key violation
+        # ("connection_tables_connection_id_fkey"). SQLite doesn't enforce the
+        # FK so it silently passed there — this was the flaky e2e failure.
+        # Waiting for the writer to reach a terminal state means the eager load
+        # below sees every committed child, so the cascade deletes them all.
+        from app.services.connection_indexing_service import ConnectionIndexingService
+        indexing_service = ConnectionIndexingService()
 
-        # Log impact for audit
-        agent_count = len(connection.data_sources) if connection.data_sources else 0
-        deleted_agent_names = []
+        async def _drain() -> None:
+            try:
+                await indexing_service.wait_for_active(db, connection_id, timeout_s=120.0)
+            except TimeoutError:
+                logger.warning(
+                    "delete_connection: indexing still active after wait; proceeding",
+                    extra={"connection_id": str(connection_id)},
+                )
 
-        if agent_count > 0:
-            agent_names = [ds.name for ds in connection.data_sources]
-            logger.info(f"Deleting connection {connection.name} ({connection_id}) which is linked to {agent_count} agent(s): {agent_names}")
+        async def _load_and_delete(org: Organization) -> tuple[str, int, list]:
+            connection = await self.get_connection(db, connection_id, org)
+            connection_name = connection.name
 
-            # Delete data sources that only have this connection
-            for ds in connection.data_sources:
-                if len(ds.connections) == 1:
-                    deleted_agent_names.append(ds.name)
-                    logger.info(f"Deleting data source {ds.name} ({ds.id}) as it only has this connection")
-                    await db.delete(ds)
+            agent_count = len(connection.data_sources) if connection.data_sources else 0
+            deleted_agent_names: list = []
+            if agent_count > 0:
+                agent_names = [ds.name for ds in connection.data_sources]
+                logger.info(f"Deleting connection {connection.name} ({connection_id}) which is linked to {agent_count} agent(s): {agent_names}")
 
-        await db.delete(connection)
-        await db.commit()
+                # Delete data sources that only have this connection
+                for ds in connection.data_sources:
+                    if len(ds.connections) == 1:
+                        deleted_agent_names.append(ds.name)
+                        logger.info(f"Deleting data source {ds.name} ({ds.id}) as it only has this connection")
+                        await db.delete(ds)
+
+            await db.delete(connection)
+            await db.commit()
+            return connection_name, agent_count, deleted_agent_names
+
+        await _drain()
+        try:
+            connection_name, agent_count, deleted_agent_names = await _load_and_delete(organization)
+        except IntegrityError:
+            # Safety net for the (now narrow) window where a concurrent writer
+            # committed a child row after our eager load. Roll back, drain the
+            # indexer again, then re-fetch so the eager load picks up the
+            # straggler children and the ORM cascade deletes the full chain.
+            # The rollback expired `organization`, so re-load it (by id) before
+            # reusing it — see the MissingGreenlet note above.
+            await db.rollback()
+            logger.warning(
+                "delete_connection: FK violation on delete; draining indexer "
+                "and retrying",
+                extra={"connection_id": str(connection_id)},
+            )
+            organization = await db.get(Organization, organization_id)
+            await _drain()
+            connection_name, agent_count, deleted_agent_names = await _load_and_delete(organization)
 
         # Audit log
         try:
             await audit_service.log(
                 db=db,
-                organization_id=str(organization.id),
+                organization_id=organization_id,
                 action="connection.deleted",
-                user_id=str(current_user.id),
+                user_id=current_user_id,
                 resource_type="connection",
                 resource_id=str(connection_id),
                 details={"name": connection_name, "impacted_agents": agent_count, "deleted_agents": deleted_agent_names},

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import os
 import sys
 import atexit
+import shutil
 import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Generator, AsyncGenerator
@@ -290,6 +291,57 @@ def _reset_postgres_schema(alembic_config):
     engine.dispose()
 
 
+def _sqlite_db_file(alembic_config):
+    """Filesystem path of the SQLite test DB from the alembic url."""
+    return alembic_config.get_main_option("sqlalchemy.url").replace('sqlite:///', '')
+
+
+def _remove_sqlite_files(db_file):
+    """Remove a SQLite DB file and any WAL/SHM sidecars."""
+    for path in (db_file, db_file + "-wal", db_file + "-shm"):
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def _build_sqlite_template(db_file):
+    """Build the per-session SQLite template DB and return its path.
+
+    The sqlite leg used to replay the entire alembic history (150+ revisions)
+    on a file DB for *every* test via upgrade→head / downgrade→base. That
+    per-test cost grew with each new migration until the suite stopped
+    finishing inside the CI timeout and was cancelled mid-run.
+
+    We can't just `create_all` from the ORM models: several revisions are data
+    migrations (e.g. default RBAC roles/permissions, connection backfills) that
+    a schema-only build would skip, breaking permission-dependent tests. So we
+    run the real migration chain exactly once per session into a template file,
+    then each test clones that file (a millisecond filesystem copy) for full
+    fidelity with no per-test replay. The postgres leg still replays migrations
+    per test, keeping the migration chain under CI coverage there.
+    """
+    template_file = db_file + ".template"
+    _remove_sqlite_files(template_file)
+    template_url = f"sqlite:///{template_file}"
+    template_cfg = Config("alembic.ini")
+    template_cfg.set_main_option("sqlalchemy.url", template_url)
+    # alembic/env.py resolves the URL via get_db_url() -> settings.TEST_DATABASE_URL
+    # under TESTING (it ignores the alembic config url), so point that at the
+    # template for the duration of the build, then restore.
+    saved_setting = settings.TEST_DATABASE_URL
+    saved_env = os.environ.get("TEST_DATABASE_URL")
+    settings.TEST_DATABASE_URL = template_url
+    os.environ["TEST_DATABASE_URL"] = template_url
+    try:
+        command.upgrade(template_cfg, "head")
+    finally:
+        settings.TEST_DATABASE_URL = saved_setting
+        if saved_env is not None:
+            os.environ["TEST_DATABASE_URL"] = saved_env
+        else:
+            os.environ.pop("TEST_DATABASE_URL", None)
+    return template_file
+
+
 def _dispose_async_engine():
     """Dispose of the async engine to release all SQLite connections."""
     from app.dependencies import engine
@@ -317,23 +369,51 @@ def _dispose_async_engine():
     time.sleep(0.1)
 
 
+@pytest.fixture(scope="session")
+def sqlite_template(db_backend, alembic_config):
+    """Build the SQLite template DB once per session (see `_build_sqlite_template`).
+
+    Yields the template path for the sqlite backend, or None otherwise.
+    """
+    if db_backend != "sqlite":
+        yield None
+        return
+    template_file = _build_sqlite_template(_sqlite_db_file(alembic_config))
+    yield template_file
+    _remove_sqlite_files(template_file)
+
+
 @pytest.fixture(scope="function", autouse=True)
-def run_migrations(alembic_config, db_backend):
-    """Run migrations per test function for isolation."""
-    
-    if db_backend in ("postgres", "external"):
-        # PostgreSQL (testcontainer or external): reset schema BEFORE test to
-        # avoid stale async connections and to start each test from a clean slate.
-        # Also dispose the engine so the in-memory pool drops any connections
-        # that the prior test left in a closed/aborted state — without this,
-        # the next test inherits half-dead conns and gets "underlying connection
-        # is closed" on first rollback.
-        print("Resetting PostgreSQL schema...")
+def run_migrations(alembic_config, db_backend, sqlite_template):
+    """Build a fresh schema per test for isolation.
+
+    SQLite clones a session-built template DB (fast — see
+    `_build_sqlite_template`); PostgreSQL/external replay the alembic migration
+    chain so that leg still exercises the migrations end-to-end in CI.
+    """
+    if db_backend == "sqlite":
+        # SQLite: dispose engine to release stale connections, then clone the
+        # session template instead of replaying the full migration history.
         _dispose_async_engine()
-        _reset_postgres_schema(alembic_config)
-    elif db_backend == "sqlite":
-        # SQLite: dispose engine before migrations to release any stale connections
+        db_file = _sqlite_db_file(alembic_config)
+        _remove_sqlite_files(db_file)
+        shutil.copyfile(sqlite_template, db_file)
+
+        yield
+
         _dispose_async_engine()
+        _remove_sqlite_files(db_file)
+        return
+
+    # PostgreSQL (testcontainer or external): reset schema BEFORE test to
+    # avoid stale async connections and to start each test from a clean slate.
+    # Also dispose the engine so the in-memory pool drops any connections
+    # that the prior test left in a closed/aborted state — without this,
+    # the next test inherits half-dead conns and gets "underlying connection
+    # is closed" on first rollback.
+    print("Resetting PostgreSQL schema...")
+    _dispose_async_engine()
+    _reset_postgres_schema(alembic_config)
 
     print("Starting migrations...")
     command.upgrade(alembic_config, "head")
@@ -341,13 +421,4 @@ def run_migrations(alembic_config, db_backend):
 
     yield
 
-    # Cleanup after test
-    if db_backend == "sqlite":
-        # SQLite: dispose engine first to release connections, then downgrade and remove file
-        print("Cleaning up SQLite...")
-        _dispose_async_engine()
-        command.downgrade(alembic_config, "base")
-        db_file = alembic_config.get_main_option("sqlalchemy.url").replace('sqlite:///', '')
-        if os.path.exists(db_file):
-            os.remove(db_file)
     # PostgreSQL cleanup happens at START of next test (or container shutdown)

--- a/backend/tests/e2e/test_connection_delete_race_repro.py
+++ b/backend/tests/e2e/test_connection_delete_race_repro.py
@@ -1,0 +1,91 @@
+"""Regression test for the connection-delete FK race (CI flaky e2e failure).
+
+Creating a connection kicks off background schema indexing that inserts
+`connection_tables` rows in a *separate* session. If such a row commits after
+`delete_connection` has eager-loaded the (delete-orphan) collection, the parent
+DELETE leaves an orphan child and Postgres rejects it with
+`connection_tables_connection_id_fkey`. SQLite doesn't enforce the FK, so the
+postgres CI leg failed while sqlite silently orphaned the row.
+
+`delete_connection` now drains in-flight indexing first and, as a safety net,
+retries after re-fetching if a concurrent writer still slips a row in. This test
+deterministically forces that concurrent-write window and asserts the delete
+still succeeds and removes every child row.
+"""
+import uuid
+import pytest
+from sqlalchemy.future import select
+
+from app.dependencies import async_session_maker
+from app.models.connection import Connection
+from app.models.connection_table import ConnectionTable
+from app.models.organization import Organization
+from app.models.user import User
+from app.services.connection_service import ConnectionService
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_delete_connection_survives_concurrent_child_insert(monkeypatch):
+    org_id = str(uuid.uuid4())
+    conn_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    async with async_session_maker() as s:
+        s.add(Organization(id=org_id, name=f"org-{org_id[:8]}"))
+        await s.commit()
+        org = (await s.execute(
+            select(Organization).where(Organization.id == org_id))).scalar_one()
+        s.add(User(id=user_id, email=f"u-{user_id[:8]}@e.x", name="u", hashed_password="x"))
+        s.add(Connection(id=conn_id, name=f"c-{conn_id[:8]}", type="sqlite",
+                         config={}, organization_id=org_id))
+        await s.commit()
+
+    # Wrap get_connection so that, on its FIRST call inside delete_connection, a
+    # concurrent session commits a connection_tables row AFTER the eager-load
+    # snapshot is taken — exactly the indexer race. Only inject once so the
+    # retry's re-fetch sees a clean, fully-loaded collection.
+    original_get = ConnectionService.get_connection
+    state = {"injected": False}
+
+    async def racing_get_connection(self, db, cid, organization):
+        conn = await original_get(self, db, cid, organization)
+        if not state["injected"] and str(cid) == conn_id:
+            state["injected"] = True
+            async with async_session_maker() as other:
+                other.add(ConnectionTable(
+                    id=str(uuid.uuid4()), name="late_table", connection_id=conn_id,
+                    columns=[], pks=[], fks=[], no_rows=0))
+                await other.commit()
+        return conn
+
+    monkeypatch.setattr(ConnectionService, "get_connection", racing_get_connection)
+
+    async with async_session_maker() as db:
+        org = (await db.execute(
+            select(Organization).where(Organization.id == org_id))).scalar_one()
+        user = (await db.execute(
+            select(User).where(User.id == user_id))).scalar_one()
+        result = await ConnectionService().delete_connection(
+            db=db, connection_id=conn_id, organization=org, current_user=user)
+        assert result["message"] == "Connection deleted successfully"
+
+    assert state["injected"], "test did not exercise the concurrent-insert window"
+
+    async with async_session_maker() as s:
+        # The connection must be gone regardless of backend.
+        assert (await s.execute(
+            select(Connection).where(Connection.id == conn_id))).scalar_one_or_none() is None
+        leftover = (await s.execute(
+            select(ConnectionTable).where(
+                ConnectionTable.connection_id == conn_id))).scalars().all()
+
+    # On Postgres the FK is enforced: the first DELETE raises, the retry
+    # re-fetches and the cascade removes the straggler child — no orphan left.
+    # SQLite doesn't enforce the FK, so the first DELETE succeeds and the
+    # concurrently-inserted row is orphaned (harmless there, and exactly why the
+    # bug was invisible on the sqlite CI leg) — so we only assert the strict
+    # no-orphan guarantee on FK-enforcing backends.
+    import os
+    if "postgres" in (os.environ.get("TEST_DATABASE_URL") or ""):
+        assert leftover == [], "retry safety net should have removed the orphan child"


### PR DESCRIPTION
## Summary

This PR addresses a flaky e2e test failure caused by a race condition in connection deletion, and significantly improves SQLite test performance by eliminating per-test migration replays.

## Key Changes

### Connection Delete Race Condition Fix
- **Root cause**: Background schema indexing inserts `connection_tables` rows asynchronously in a separate session. If a row commits after `delete_connection` has eager-loaded the collection, the parent DELETE leaves an orphan child, causing Postgres FK violations.
- **Solution**: 
  - Drain in-flight indexing before deletion via `ConnectionIndexingService.wait_for_active()`
  - Implement retry logic with re-fetch if a concurrent write still slips a row in
  - Capture organization/user IDs as strings upfront to avoid MissingGreenlet errors after rollback
  - Added comprehensive regression test (`test_delete_connection_survives_concurrent_child_insert`) that deterministically forces the concurrent-write window

### SQLite Test Performance Optimization
- **Problem**: SQLite tests were replaying the entire alembic migration history (150+ revisions) for every test, causing CI timeouts as migrations accumulated.
- **Solution**: Build a session-scoped template database once by running migrations to `head`, then clone it (millisecond filesystem copy) for each test instead of replaying migrations.
- **Trade-off**: Postgres still replays migrations per-test to maintain end-to-end migration coverage in CI, while SQLite gets the performance benefit since it doesn't enforce FKs anyway.
- **Implementation details**:
  - New `sqlite_template` session fixture builds and cleans up the template
  - New `_build_sqlite_template()` function handles template creation with proper settings management
  - New `_sqlite_db_file()` and `_remove_sqlite_files()` helpers for SQLite file management
  - `run_migrations` fixture refactored to clone template for SQLite or replay migrations for Postgres

## Notable Implementation Details

- The retry safety net in `delete_connection` uses `IntegrityError` catching to detect FK violations and automatically re-fetch the organization after rollback (which expires ORM instances)
- Template building temporarily overrides `settings.TEST_DATABASE_URL` and environment variables to ensure alembic uses the template path
- SQLite cleanup removes both the main DB file and WAL/SHM sidecar files
- The regression test includes backend-specific assertions (strict no-orphan guarantee only on FK-enforcing backends)

https://claude.ai/code/session_01SjuU28KG9X6NgGXFTgnZeR