### PR TITLE
remove file logging and fix asyncpg SSL for OCP deployments

### DIFF
--- a/backend/app/settings/database.py
+++ b/backend/app/settings/database.py
@@ -126,10 +126,15 @@ def _get_async_database_url() -> str:
 
 
 def _get_async_ssl_connect_args(db_config) -> dict:
-    """Build SSL connect_args for asyncpg (uses a different ssl param format)."""
+    """Build SSL connect_args for asyncpg (uses a different ssl param format).
+
+    When ssl_mode is empty, explicitly pass ssl=False to prevent asyncpg from
+    auto-detecting client certificates in ~/.postgresql/ (which fails on OCP
+    where the container runs under an arbitrary UID that cannot read those files).
+    """
     ssl_mode = db_config.auth.ssl_mode
     if not ssl_mode:
-        return {}
+        return {"ssl": False}
     import ssl
     ssl_ctx = ssl.create_default_context()
     if ssl_mode == "verify-full":
@@ -218,7 +223,7 @@ def _build_async_database_engine():
         database_url = _get_async_database_url()
 
         if "postgresql+asyncpg" in database_url:
-            connect_args = _get_async_ssl_connect_args(db_config) if db_config.uses_iam_auth else {}
+            connect_args = _get_async_ssl_connect_args(db_config)
             # Server-side safety timeouts. Without these, any transaction that
             # holds a row lock (e.g. the agent's long-lived shared
             # agent-execution transaction, or a leaked/abandoned session) blocks
@@ -333,7 +338,7 @@ def create_async_database_engine_for_indexing():
         db_config = settings.bow_config.database
         database_url = _get_async_database_url()
         if "postgresql+asyncpg" in database_url:
-            connect_args = _get_async_ssl_connect_args(db_config) if db_config.uses_iam_auth else {}
+            connect_args = _get_async_ssl_connect_args(db_config)
             engine = create_async_engine(
                 database_url,
                 echo=False,

--- a/backend/app/settings/logging_config.py
+++ b/backend/app/settings/logging_config.py
@@ -1,8 +1,6 @@
 import json
 import logging
-import os
 import sys
-from logging.handlers import RotatingFileHandler
 
 from app.settings.config import settings
 
@@ -37,9 +35,6 @@ class JsonFormatter(logging.Formatter):
 
 def setup_logging():
     """Configure application-wide logging"""
-    # Create logs directory if it doesn't exist
-    os.makedirs("logs", exist_ok=True)
-    
     # Configure root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO if settings.ENVIRONMENT == "production" else logging.DEBUG)
@@ -67,15 +62,6 @@ def setup_logging():
     stderr_handler.setFormatter(formatter)
     stderr_handler.setLevel(logging.ERROR)
     root_logger.addHandler(stderr_handler)
-    
-    # File handler with rotation
-    file_handler = RotatingFileHandler(
-        "logs/app.log",
-        maxBytes=10*1024*1024,  # 10MB
-        backupCount=5
-    )
-    file_handler.setFormatter(formatter)
-    root_logger.addHandler(file_handler)
     
     # Set levels for third-party loggers to reduce noise
     logging.getLogger("uvicorn.access").setLevel(logging.INFO)


### PR DESCRIPTION
Two related issues were found when running the application on OpenShift
Container Platform (OCP), both caused by assumptions that break under
OCP's restricted security policies.

## 1. File-based log handler removed (logging_config.py)

The application was writing logs to logs/app.log via a RotatingFileHandler
in addition to stdout/stderr. In a containerised environment this is wrong:

- The container runtime (Docker, OCP) already collects stdout/stderr and
  forwards them to the cluster log aggregator, making the file a redundant
  duplicate.
- OCP enforces a read-only root filesystem by default. The os.makedirs("logs")
  call at startup either fails outright or requires an explicit writable
  volume mount just to hold a copy of what stdout already provides.
- 12-factor / OCP best practice: treat logs as event streams on stdout/stderr
  and let the platform handle collection, rotation, and retention.

Removed: RotatingFileHandler, os.makedirs("logs"), and the now-unused
os and RotatingFileHandler imports. The two stream handlers (stdout for
INFO and below, stderr for ERROR and above) are kept unchanged.

## 2. asyncpg SSL auto-detection disabled for unconfigured connections (database.py)

OCP pods run under an arbitrary UID assigned by the namespace SCC, not the
fixed UID baked into the image. asyncpg follows libpq conventions and
:

Two related issues were found when running the application on OpenShift
Container Platform (OCP), both caused by assumptions that break under
OCP's restricted security policies.

## 1. File-based log handler removed (logging_config.py)

The application was writing logs to logs/app.log via a RotatingFileHandler
in addition to stdout/stderr. In a containerised environment this is wrong:

- The container runtime (Docker, OCP) already collects stdout/stderr and
  forwards them to the cluster log aggregator, making the file a redundant
  duplicate.
- OCP enforces a read-only root filesystem by default. The os.makedirs("logs")
  call at startup either fails outright or requires an explicit writable
  volume mount just to hold a copy of what stdout already provides.
- 12-factor / OCP best practice: treat logs as event streams on stdout/stderr
  and let the platform handle collection, rotation, and retention.

Removed: RotatingFileHandler, os.makedirs("logs"), and the now-unused
os and RotatingFileHandler imports. The two stream handlers (stdout for
INFO and below, stderr for ERROR and above) are kept unchanged.

## 2. asyncpg SSL auto-detection disabled for unconfigured connections (database.py)

OCP pods run under an arbitrary UID assigned by the namespace SCC, not the
fixed UID baked into the image. asyncpg follows libpq conventions and
automatically looks for client certificates at ~/.postgresql/postgresql.key
and ~/.postgresql/postgresql.crt when establishing a connection. If those
files exist (e.g. mounted as a Kubernetes Secret) but are owned by a
different UID with mode 0600, the arbitrary OCP UID gets:

  [Errno 13] Permission denied: '/home/app/.postgresql/postgresql.key'

Previously, _get_async_ssl_connect_args() returned {} when ssl_mode was
empty, and the IAM-auth gate in _build_async_database_engine meant SSL
connect_args were not passed at all for non-IAM connections. This left
asyncpg free to auto-detect SSL and attempt to read the default cert paths.

Fix: _get_async_ssl_connect_args() now returns {"ssl": False} when ssl_mode
is empty, explicitly disabling SSL and preventing the ~/.postgresql/ lookup.
The IAM-auth gate is removed from both the main and indexing engine builders
so that ssl_mode is respected for all PostgreSQL connections, not just IAM
ones.

Operator behaviour (no breaking change):
- ssl_mode unset (default) → ssl=False, no cert lookup, no file access
- ssl_mode: require         → SSL enabled, server cert not verified
- ssl_mode: verify-full     → SSL + server cert verified against RDS CA bundle

