### PR TITLE
i18n: translate nav.notifications for all locales

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -64,7 +64,7 @@
     "prompts": "المطالبات",
     "starOnGithub": "Star our GitHub",
     "admin": "الإدارة",
-    "notifications": "Notifications"
+    "notifications": "الإشعارات"
   },
   "auth": {
     "signIn": "تسجيل الدخول",

--- a/locales/de.json
+++ b/locales/de.json
@@ -64,7 +64,7 @@
     "prompts": "Prompts",
     "starOnGithub": "Star our GitHub",
     "admin": "Verwaltung",
-    "notifications": "Notifications"
+    "notifications": "Benachrichtigungen"
   },
   "auth": {
     "signIn": "Anmelden",

--- a/locales/es.json
+++ b/locales/es.json
@@ -67,7 +67,7 @@
     "prompts": "Prompts",
     "starOnGithub": "Star our GitHub",
     "admin": "Administración",
-    "notifications": "Notifications"
+    "notifications": "Notificaciones"
   },
   "auth": {
     "signIn": "Iniciar sesión",

--- a/locales/he.json
+++ b/locales/he.json
@@ -67,7 +67,7 @@
     "prompts": "פרומפטים",
     "starOnGithub": "Star our GitHub",
     "admin": "ניהול",
-    "notifications": "Notifications"
+    "notifications": "התראות"
   },
   "auth": {
     "signIn": "התחברות",

--- a/locales/it.json
+++ b/locales/it.json
@@ -64,7 +64,7 @@
     "prompts": "Prompt",
     "starOnGithub": "Star our GitHub",
     "admin": "Amministrazione",
-    "notifications": "Notifications"
+    "notifications": "Notifiche"
   },
   "auth": {
     "signIn": "Accedi",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -64,7 +64,7 @@
     "prompts": "Prompts",
     "starOnGithub": "Star our GitHub",
     "admin": "Administração",
-    "notifications": "Notifications"
+    "notifications": "Notificações"
   },
   "auth": {
     "signIn": "Entrar",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -64,7 +64,7 @@
     "prompts": "Промпты",
     "starOnGithub": "Star our GitHub",
     "admin": "Администрирование",
-    "notifications": "Notifications"
+    "notifications": "Уведомления"
   },
   "auth": {
     "signIn": "Вход",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -64,7 +64,7 @@
     "prompts": "Prompter",
     "starOnGithub": "Star our GitHub",
     "admin": "Administration",
-    "notifications": "Notifications"
+    "notifications": "Aviseringar"
   },
   "auth": {
     "signIn": "Logga in",


### PR DESCRIPTION
## Summary

The **Notifications** sidebar menu item was showing literal English "Notifications" in every non-English locale. The menu is wired correctly (`layouts/default.vue` renders `$t('nav.notifications')`) — the `nav.notifications` value simply was never translated.

This PR adds the proper translation for the 8 locales that were untranslated. French already had the correct term ("Notifications"), and English is unchanged.

## Changes

| Locale | Before | After |
| --- | --- | --- |
| he | Notifications | התראות |
| de | Notifications | Benachrichtigungen |
| es | Notifications | Notificaciones |
| it | Notifications | Notifiche |
| pt | Notifications | Notificações |
| ru | Notifications | Уведомления |
| sv | Notifications | Aviseringar |
| ar | Notifications | الإشعارات |

Each term matches the wording already used for "system notifications" elsewhere in the same locale file.

## Notes

- 8 files changed, one line each — no formatting/key-order churn.
- All locale JSON files validated after the change.
- This addresses only the missing Notifications translation. The separate `/agents` page (KnowledgeExplorer) i18n + RTL layout issues identified during review are **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATMaRLtGb82pS4LrNfxAJr)_