### PR TITLE
fix(console): remove TraceModal outer scrollbar clipping summary badges

### DIFF
--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -1,6 +1,6 @@
 <template>
     <UModal v-model="isOpen" :ui="{ width: 'sm:max-w-7xl'}">
-        <UCard>
+        <UCard :ui="{ body: { padding: '' }, header: { padding: 'px-4 py-3' } }">
             <!-- Header: conversation identity + roll-up -->
             <template #header>
                 <div class="flex items-start justify-between gap-4">
@@ -39,7 +39,7 @@
             </template>
 
             <!-- Content: conversation rail + per-turn detail -->
-            <div class="h-[620px] flex -mx-4 -mb-2">
+            <div class="h-[620px] flex">
                 <!-- Pane A: whole conversation, rendered like the chat -->
                 <div class="w-[40%] flex-shrink-0 border-e border-gray-200 dark:border-gray-800 flex flex-col min-h-0">
                     <div class="px-4 py-2.5 border-b border-gray-200 dark:border-gray-800 text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 flex items-center justify-between">


### PR DESCRIPTION
## Problem

In the trace modal, a full-height scrollbar appeared down the right edge and clipped the right-aligned LLM-judge score badge (`Resp x/5`) in the pane C summary strip.

## Root cause

`TraceModal.vue` used a bare `<UCard>`, which carries the default body padding `p-4 sm:p-6`, and tried to cancel it with `-mx-4 -mb-2` on the fixed-height content (`h-[620px]`). That compensation was incomplete — it removed 16px horizontally against 24px of `sm:` padding and left nearly all of the vertical padding. The leftover ~40px of vertical padding pushed the card past its intended height, so the **whole modal** picked up an outer scrollbar that overlaid the summary strip and clipped the badge.

## Fix

Match the well-behaved sibling `BuildExplorerModal.vue`:
- Remove the UCard body padding via `:ui="{ body: { padding: '' }, header: { padding: 'px-4 py-3' } }"`.
- Drop the now-unneeded `-mx-4 -mb-2` so the three panes lay out flush.

With no stray padding, the modal no longer overflows, the outer scrollbar is gone, and the summary-strip badges stay clear of pane C's own inner scrollbar.

Template-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0143hffcN6VooZydDx5AcqN2)_