### PR TITLE
Fix report title sometimes not being set (Postgres) + live sidebar update

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1254,16 +1254,17 @@ class AgentV2:
             self.mode = prior_mode
 
     async def _generate_title_background(self, messages_context: str, plan_info: list, report_id: str):
-        """Generate report title in background after completion.finished is sent.
+        """Generate and persist the report title in its own DB session.
 
-        `report_id` is passed in as a plain string (captured while the request's
-        session is still alive). We must NOT read it off `self.report` here: this
-        runs as a fire-and-forget task that can outlive the request, at which point
-        `self.report` is detached from its (now-closed) session and any attribute
-        access raises "Instance is not bound to a Session". That silently skipped
-        title generation — most visibly on Postgres, whose pooled connections
-        return/expire faster than SQLite's, so the session was reliably gone by the
-        time this task ran.
+        Awaited inline by the caller (see main_execution) rather than spawned as a
+        fire-and-forget task — a discarded asyncio.create_task is only weakly
+        referenced by the loop and was routinely garbage-collected on Postgres
+        (pooled connections recycle the instant the response finishes) before its
+        LLM call returned, silently skipping the title.
+
+        `report_id` is passed in as a plain string and the report is re-fetched in
+        this method's own session, so we never touch a `self.report` that may be
+        detached from a closed session ("Instance is not bound to a Session").
         """
         import logging
         logger = logging.getLogger(__name__)
@@ -1275,6 +1276,7 @@ class AgentV2:
                     if not title or not title.strip():
                         logger.warning("Title generation returned empty result")
                         return
+                    title = title.strip()
                     # Re-fetch report using select query (more reliable than session.get with UUID).
                     # lazyload("*") suppresses Report's lazy="selectin" cascade (14 rels +
                     # downstream DS/widget/query graph) — update_report_title only touches title.
@@ -1282,11 +1284,20 @@ class AgentV2:
                     stmt = select(Report).where(Report.id == report_id).options(_lazyload("*"))
                     result = await session.execute(stmt)
                     report = result.scalar_one_or_none()
-                    if report:
-                        await self.project_manager.update_report_title(session, report, title)
-                        logger.info(f"Report title updated to: {title}")
-                    else:
+                    if not report:
                         logger.warning(f"Report not found for title update: {report_id}")
+                        return
+                    # Only write while the title is still a placeholder. The caller
+                    # now gates on the same condition, but it can run on multiple
+                    # turns (value-gated, self-healing); re-checking here under a
+                    # fresh read avoids clobbering a real title a concurrent turn
+                    # may have just set.
+                    existing = (report.title or "").strip()
+                    if existing.lower() not in ("", "untitled report"):
+                        logger.info(f"Report {report_id} already titled; skipping")
+                        return
+                    await self.project_manager.update_report_title(session, report, title)
+                    logger.info(f"Report title updated to: {title}")
                 except Exception as e:
                     logger.error(f"Failed to generate/update report title: {e}")
         except Exception as e:
@@ -3484,37 +3495,43 @@ class AgentV2:
             else:
                 asyncio.create_task(_bg_final_snap())
             
-            # Generate report title if this is the first completion (non-blocking)
+            # Generate report title while the report still has no real title.
+            #
+            # Run INLINE (awaited) — like follow-ups above, and unlike the old
+            # fire-and-forget asyncio.create_task. A discarded create_task keeps
+            # only a weak reference in the loop, so on Postgres — where the
+            # request's pooled connection is recycled the moment the response
+            # finishes — the suspended task was routinely garbage-collected before
+            # its small-model LLM call returned, leaving the report stuck on the
+            # placeholder title. Awaiting here keeps self.db alive and lands the
+            # write before main_execution returns.
+            #
+            # Gate on the title VALUE (empty or the frontend's "untitled report"
+            # placeholder), not on "is this the first completion". The old
+            # first-completion gate made generation one-shot: a single transient
+            # failure left the report untitled forever. Value-gating is
+            # self-healing — a later turn retries until a real title sticks.
             try:
-                if self.head_completion and self.report:
-                    first_completion = await self.db.execute(
-                        select(Completion)
-                        .filter(Completion.report_id == self.report.id)
-                        .order_by(Completion.created_at.asc())
-                        .limit(1)
-                    )
-                    first_completion = first_completion.scalar_one_or_none()
-                    
-                    if first_completion and self.head_completion.id == first_completion.id:
-                        # Generate title in background to not block completion
-                        messages_section = await self.context_hub.message_builder.build(max_messages=5)
-                        messages_context = messages_section.render()
+                current_title = (getattr(self.report, "title", "") or "").strip() if self.report else ""
+                if self.head_completion and self.report and current_title.lower() in ("", "untitled report"):
+                    # Generate title (small model)
+                    messages_section = await self.context_hub.message_builder.build(max_messages=5)
+                    messages_context = messages_section.render()
 
-                        # Extract plan information from current execution
-                        plan_info = []
-                        if current_plan_decision:
-                            if hasattr(current_plan_decision, 'action_name') and current_plan_decision.action_name:
-                                plan_info.append({"action": current_plan_decision.action_name})
+                    # Extract plan information from current execution
+                    plan_info = []
+                    if current_plan_decision:
+                        if hasattr(current_plan_decision, 'action_name') and current_plan_decision.action_name:
+                            plan_info.append({"action": current_plan_decision.action_name})
 
-                        # Capture the report id as a plain string NOW, while self.db is
-                        # still open. The background task can outlive the request, and
-                        # reading self.report.id after the session closes raises
-                        # "Instance is not bound to a Session" (the bug that silently
-                        # skipped title generation, esp. on Postgres).
-                        report_id_for_title = str(self.report.id)
+                    # Capture the report id as a plain string NOW, while self.db is
+                    # still open. _generate_title_background re-fetches by this id in
+                    # its own session, so reading self.report.id later (after the
+                    # session closes) can't raise "Instance is not bound to a Session"
+                    # (the bug that silently skipped title generation, esp. on Postgres).
+                    report_id_for_title = str(self.report.id)
 
-                        # Run title generation in background
-                        asyncio.create_task(self._generate_title_background(messages_context, plan_info, report_id_for_title))
+                    await self._generate_title_background(messages_context, plan_info, report_id_for_title)
             except Exception as e:
                 # Don't fail the entire execution if title generation fails
                 import logging

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -165,7 +165,10 @@
                 isRouteActive(`/reports/${report.id}`) ? 'text-gray-900 dark:text-white bg-gray-200/70 dark:bg-gray-800 font-medium' : 'text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/70'
               ]">
                 <UIcon :name="reportTypeIcon(report)" class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500" />
-                <span class="flex-1 truncate">{{ report.title || $t('reports.untitled') }}</span>
+                <span
+                  class="flex-1 truncate"
+                  :class="{ 'report-title-fade': titledReportIds.has(report.id) }"
+                >{{ report.title || $t('reports.untitled') }}</span>
                 <UIcon v-if="report.is_starred" name="i-heroicons-star-solid" class="w-3.5 h-3.5 shrink-0 text-amber-400 group-hover/report:opacity-0 transition-opacity" />
               </NuxtLink>
               <!-- Hover actions: ellipsis circle → teleported menu (see below) -->
@@ -540,6 +543,40 @@
     if (path === '/reports' || path.startsWith('/reports/')) fetchRecentReports()
   })
 
+  // Live title updates: the open report page (pages/reports/[id]) dispatches
+  // `report:updated` after it reloads, which is when the server-generated title
+  // first becomes available. Patch the matching sidebar item in place — no route
+  // change happens, so the route watcher above wouldn't catch it — and fade the
+  // new title in. ids in `titledReportIds` get the `.report-title-fade` class.
+  const titledReportIds = ref<Set<string>>(new Set())
+  const onReportUpdated = (e: Event) => {
+    const detail = (e as CustomEvent).detail || {}
+    const id = detail.id
+    const title = detail.title
+    if (!id) return
+    const item = recentReports.value.find((r: any) => r.id === id)
+    if (!item) {
+      // Report isn't in the recent list yet (e.g. freshly created) — pull it in.
+      fetchRecentReports()
+      return
+    }
+    // Only animate when the title actually changed (e.g. placeholder → real title).
+    if (title && item.title !== title) {
+      item.title = title
+      const next = new Set(titledReportIds.value)
+      next.add(id)
+      titledReportIds.value = next
+      // Clear after the animation so a later list re-render doesn't replay it.
+      setTimeout(() => {
+        const after = new Set(titledReportIds.value)
+        after.delete(id)
+        titledReportIds.value = after
+      }, 800)
+    }
+  }
+  onMounted(() => window.addEventListener('report:updated', onReportUpdated))
+  onBeforeUnmount(() => window.removeEventListener('report:updated', onReportUpdated))
+
   // ── Per-report hover menu: share / rename / star / delete ──────────────
   // Rendered via Teleport (see template) so it escapes the sidebar's
   // transform + overflow clipping; positioned at the click coordinates.
@@ -797,3 +834,18 @@ const createNewReport = async () => {
   }
 
   </script>
+
+<style scoped>
+/* Fade the report title in when it transitions from the "untitled report"
+   placeholder to the server-generated title (see onReportUpdated). */
+@keyframes report-title-fade {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.report-title-fade {
+  animation: report-title-fade 0.45s ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .report-title-fade { animation: none; }
+}
+</style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -2957,6 +2957,17 @@ async function loadReport() {
 	}
 	report.value = data.value
 	reportLoaded.value = true
+	// Notify the sidebar (layouts/default.vue) so it can refresh this report's
+	// title in its recent-reports list without a route change. The title is
+	// generated server-side after the agent finishes, so loadReport() (called
+	// on [DONE]) is the moment the fresh title becomes available here.
+	try {
+		if (data.value?.id) {
+			window.dispatchEvent(new CustomEvent('report:updated', {
+				detail: { id: data.value.id, title: data.value.title }
+			}))
+		}
+	} catch {}
 }
 
 async function loadVisualizations() {


### PR DESCRIPTION
## Problem

Reports frequently stayed stuck on the `untitled report` placeholder — most visibly on the Postgres backend, where many reports never received their auto-generated title.

## Root cause

The auto-generated report title was written by a **fire-and-forget** `asyncio.create_task` spawned after the response finished (`agent_v2.py`). A discarded task is only weakly referenced by the event loop, so on Postgres — where the request's pooled connection recycles the instant the response completes — the suspended task was routinely garbage-collected before its small-model LLM call returned, silently skipping the title write.

Two design issues compounded it:
- The write was **fire-and-forget**, so it raced against request teardown (worse on PG).
- Generation was gated on *"is this the first completion"*, making it **one-shot** — any single transient failure left the report untitled forever, with no retry on later turns.

## Changes

**Backend (`backend/app/ai/agent_v2.py`)**
- Await title generation **inline** (like the follow-ups path) instead of `asyncio.create_task`, so `self.db` stays alive and the write lands before `main_execution` returns. Removes the GC/teardown race.
- Gate on the **title value** (empty or the `"untitled report"` placeholder) rather than "first completion". This is self-healing — a later turn retries until a real title sticks.
- `_generate_title_background` re-checks the placeholder under a fresh read so a retry can't clobber a real title set by a concurrent turn.

**Frontend (`frontend/layouts/default.vue`, `frontend/pages/reports/[id]/index.vue`)**
- The sidebar's recent-reports list only refetched on route change, so a title generated moments after the agent finished (same route) kept showing the placeholder until the next navigation.
- `loadReport()` (already called on `[DONE]`, when the fresh title is available) now dispatches a `report:updated` CustomEvent — matching the existing `artifact:created` / `instruction:resolved` pattern.
- The sidebar listens, patches the matching item's title in place, and fades it in via a CSS keyframe (respecting `prefers-reduced-motion`). Falls back to a list refetch when the report isn't in the recent list yet.

## Testing

- Backend: syntax-checked; no existing tests reference the touched title-generation symbols.
- Frontend: SFC block structure verified and logic follows existing patterns in the file. Not yet exercised in a running browser — the repo has no lint/typecheck script and a full `nuxt build` was out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G347shUUu4TpNGy9yCdLf5)_