### PR TITLE
Add Global Evals view to /agents tree

### DIFF
--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -3,7 +3,7 @@
         <div class="px-6 py-5">
             <!-- Inline stat row -->
             <div class="flex flex-wrap items-center gap-x-5 gap-y-1 text-xs text-gray-500 dark:text-gray-400 mb-4">
-                <span class="inline-flex items-center gap-1.5">
+                <span v-if="!isGlobal" class="inline-flex items-center gap-1.5">
                     Status:
                     <span :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium', reliabilityBadgeClass]">
                         <UIcon :name="reliabilityIcon" class="w-3 h-3" />{{ reliabilityLabel }}
@@ -27,7 +27,7 @@
                     <button type="button" :class="tabClass('tests')" @click="activeTab = 'tests'">{{ $t('evals.tabs.tests') }}</button>
                 </div>
                 <div class="ms-auto flex items-center gap-2">
-                    <button v-if="canManage" type="button" class="h-7 px-2.5 rounded-md border border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 text-xs font-medium hover:bg-gray-50 dark:hover:bg-gray-800/50 inline-flex items-center gap-1" title="Configure Self Learning" @click="showSelfLearning = true"><UIcon name="i-heroicons-sparkles" class="w-3.5 h-3.5 text-blue-500" />Self Learning</button>
+                    <button v-if="canManage && !isGlobal" type="button" class="h-7 px-2.5 rounded-md border border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 text-xs font-medium hover:bg-gray-50 dark:hover:bg-gray-800/50 inline-flex items-center gap-1" title="Configure Self Learning" @click="showSelfLearning = true"><UIcon name="i-heroicons-sparkles" class="w-3.5 h-3.5 text-blue-500" />Self Learning</button>
                     <input
                         v-if="activeTab === 'tests'"
                         v-model="searchTerm"
@@ -113,12 +113,12 @@
             <div v-else-if="activeTab === 'runs'">
                 <div class="flex items-center justify-between mb-3">
                     <div class="text-xs text-gray-500 dark:text-gray-400">Every eval run — manual checks and automation.</div>
-                    <UButton v-if="canManage && agentCases.length > 0" color="blue" size="xs" variant="soft" icon="i-heroicons-bolt"
+                    <UButton v-if="canManage && !isGlobal && agentCases.length > 0" color="blue" size="xs" variant="soft" icon="i-heroicons-bolt"
                         :loading="triggering" @click="runAutomationNow">
                         Run evals now
                     </UButton>
                 </div>
-                <div v-if="canManage && autoEnabled === false" class="mb-4 flex items-center justify-between gap-3 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/40 px-3 py-2">
+                <div v-if="canManage && !isGlobal && autoEnabled === false" class="mb-4 flex items-center justify-between gap-3 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/40 px-3 py-2">
                     <div class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
                         <UIcon name="i-heroicons-sparkles" class="w-4 h-4 text-blue-500 shrink-0" />
                         Self Learning is off — auto-run evals &amp; self-heal instructions when things change.
@@ -205,8 +205,11 @@ const { t } = useI18n()
 const router = useRouter()
 const toast = useToast()
 
-const props = defineProps<{ agentId: string }>()
+const props = defineProps<{ agentId?: string; global?: boolean }>()
 const agentId = computed(() => props.agentId || '')
+// Global mode shows org-wide evals (cases not scoped to any data source/agent),
+// which apply to ALL agents. Admin-gated via the `manage_evals` org permission.
+const isGlobal = computed(() => !!props.global)
 
 interface TestCaseRow {
     id: string
@@ -246,13 +249,15 @@ const selectedCaseId = ref('')
 // Filter cases to this agent
 const agentCases = computed(() => {
     const id = agentId.value
-    if (!id) return []
+    if (!isGlobal.value && !id) return []
     const term = searchTerm.value.trim().toLowerCase()
     return allCases.value.filter(c => {
         // Auto / empty data sources => "all agents" (like a global instruction).
         const dsids = c.data_source_ids_json || []
-        const hasAgent = dsids.length === 0 || dsids.includes(id)
-        if (!hasAgent) return false
+        // Global view: only org-wide cases (no data-source scope). Agent view:
+        // org-wide cases + cases scoped to this agent.
+        const matches = isGlobal.value ? dsids.length === 0 : (dsids.length === 0 || dsids.includes(id))
+        if (!matches) return false
         if (term) return (c.prompt_json?.content || '').toLowerCase().includes(term)
         return true
     })
@@ -261,7 +266,7 @@ const agentCases = computed(() => {
 // Filter runs that contain any of this agent's cases
 const agentCaseIds = computed(() => new Set(agentCases.value.map(c => c.id)))
 const agentRuns = computed(() => {
-    if (!agentId.value) return []
+    if (!isGlobal.value && !agentId.value) return []
     return allRuns.value.filter(r => {
         const caseIds = runResultsCaseIds.value[r.id]
         if (!caseIds) return false
@@ -567,14 +572,16 @@ async function loadRuns() {
     }
 }
 
-watch(agentId, (id) => {
-    if (id) { loadSuites().then(loadCases); loadRuns() }
+watch(agentId, () => {
+    if (isGlobal.value || agentId.value) { loadSuites().then(loadCases); loadRuns() }
 }, { immediate: true })
 
 // ===== Reliability automation =====
 
 const canManage = computed(() =>
-    agentId.value ? useCan('manage', { type: 'data_source', id: agentId.value }) : false,
+    isGlobal.value
+        ? useCan('manage_evals')
+        : (agentId.value ? useCan('manage', { type: 'data_source', id: agentId.value }) : false),
 )
 
 const autoEnabled = ref<boolean | null>(null)

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -70,6 +70,13 @@
             <EmptyHint v-if="skillCount === 0" text="No skills yet." />
             <InstrLeaf v-for="ins in listFor('skills')" :key="ins.id" :ins="ins" />
           </TreeGroup>
+          <!-- Org-wide evals (apply to all agents). Admin-gated via manage_evals. -->
+          <button v-if="canManageEvals" type="button" class="group w-full flex items-center gap-1.5 h-8 rounded-md text-[13px] transition-colors min-w-0" :class="panelView?.kind === 'global-evals' ? 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/70'" style="padding-left:6px;padding-right:8px" @click="openGlobalEvals()">
+            <span class="w-3 shrink-0"></span>
+            <UIcon name="i-heroicons-check-circle" class="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0" />
+            <span class="flex-1 text-left truncate">Global Evals</span>
+            <UIcon name="i-heroicons-chevron-right" class="w-3 h-3 text-gray-300 dark:text-gray-600 shrink-0 opacity-0 group-hover:opacity-100" />
+          </button>
           <div class="h-px bg-gray-100 dark:bg-gray-800 my-2 mx-1"></div>
 
           <div class="px-2 pt-1 pb-1 flex items-center justify-between">
@@ -323,18 +330,26 @@
         <template v-else-if="panelView">
           <div class="h-11 shrink-0 px-4 flex items-center justify-between border-b border-gray-100 dark:border-gray-800">
             <div class="flex items-center gap-1.5 min-w-0">
-              <button type="button" class="flex items-center gap-1.5 min-w-0 rounded px-1 -mx-1 hover:bg-gray-100 dark:hover:bg-gray-800/70" title="Open agent" @click="openAgent(panelView.agentId)">
-                <DataSourceIcon :type="panelAgent?.type" class="w-[18px] h-[18px] shrink-0" />
-                <span class="text-[13px] font-medium text-gray-700 dark:text-gray-300 truncate hover:text-gray-900 dark:hover:text-white">{{ panelAgent?.name || 'Agent' }}</span>
-              </button>
-              <UIcon name="i-heroicons-chevron-right" class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0" />
-              <span class="text-[13px] text-gray-500 dark:text-gray-400 shrink-0">{{ panelKindLabel }}</span>
-              <span v-if="(panelView.kind === 'tables' || panelView.kind === 'tools') && !panelCanUpdate" class="text-[11px] px-1.5 h-4 inline-flex items-center rounded bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 shrink-0">read-only</span>
+              <template v-if="panelView.kind === 'global-evals'">
+                <UIcon name="i-heroicons-check-circle" class="w-[18px] h-[18px] shrink-0 text-gray-400 dark:text-gray-500" />
+                <span class="text-[13px] font-medium text-gray-700 dark:text-gray-300 truncate">Global Evals</span>
+                <span class="text-[11px] px-1.5 h-4 inline-flex items-center rounded bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 shrink-0">all agents</span>
+              </template>
+              <template v-else>
+                <button type="button" class="flex items-center gap-1.5 min-w-0 rounded px-1 -mx-1 hover:bg-gray-100 dark:hover:bg-gray-800/70" title="Open agent" @click="openAgent(panelView.agentId)">
+                  <DataSourceIcon :type="panelAgent?.type" class="w-[18px] h-[18px] shrink-0" />
+                  <span class="text-[13px] font-medium text-gray-700 dark:text-gray-300 truncate hover:text-gray-900 dark:hover:text-white">{{ panelAgent?.name || 'Agent' }}</span>
+                </button>
+                <UIcon name="i-heroicons-chevron-right" class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0" />
+                <span class="text-[13px] text-gray-500 dark:text-gray-400 shrink-0">{{ panelKindLabel }}</span>
+                <span v-if="(panelView.kind === 'tables' || panelView.kind === 'tools') && !panelCanUpdate" class="text-[11px] px-1.5 h-4 inline-flex items-center rounded bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 shrink-0">read-only</span>
+              </template>
             </div>
             <button class="h-7 w-7 rounded-md flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800/70 shrink-0" @click="closePanel"><UIcon name="i-heroicons-x-mark" class="w-4 h-4" /></button>
           </div>
           <div class="flex-1 overflow-auto">
             <AgentEvalsPanel v-if="panelView.kind === 'evals'" :key="'evals-' + panelView.agentId" :agent-id="panelView.agentId" />
+            <AgentEvalsPanel v-else-if="panelView.kind === 'global-evals'" key="global-evals" global />
             <AgentSettingsPanel v-else-if="panelView.kind === 'settings'" :key="'settings-' + panelView.agentId" :agent-id="panelView.agentId" @updated="onAgentSettingsUpdated" @deleted="onAgentDeleted" />
             <div v-else class="px-6 py-4">
               <TablesSelector
@@ -934,9 +949,9 @@ const setPrimaryForSingleAgent = async (makePrimary: boolean) => {
 }
 
 // right-pane panel for Tables/Tools/Evals/Settings
-const panelView = ref<null | { kind: 'tables' | 'tools' | 'evals' | 'settings'; agentId: string }>(null)
+const panelView = ref<null | { kind: 'tables' | 'tools' | 'evals' | 'settings' | 'global-evals'; agentId: string }>(null)
 const closePanel = () => { panelView.value = null }
-const panelKindLabel = computed(() => ({ tables: 'Tables', tools: 'Tools', evals: 'Evals', settings: 'Settings' } as Record<string, string>)[panelView.value?.kind || ''] || '')
+const panelKindLabel = computed(() => ({ tables: 'Tables', tools: 'Tools', evals: 'Evals', settings: 'Settings', 'global-evals': 'Global Evals' } as Record<string, string>)[panelView.value?.kind || ''] || '')
 const panelAgent = computed(() => panelView.value ? agents.value.find(a => a.id === panelView.value!.agentId) : null)
 const panelConnections = computed(() => {
   const a = panelAgent.value as any
@@ -946,6 +961,11 @@ const openPanel = (kind: 'tables' | 'tools' | 'evals' | 'settings', agentId: str
   clearRightPane()
   loadAgentMeta(agentId)
   panelView.value = { kind, agentId }
+}
+// Org-wide evals view — not bound to any agent.
+const openGlobalEvals = () => {
+  clearRightPane()
+  panelView.value = { kind: 'global-evals', agentId: '' }
 }
 const onAgentSettingsUpdated = async () => { await fetchAgents(); if (agentView.value) refreshAgentDetail() }
 const onAgentDeleted = async () => { closePanel(); await Promise.all([fetchAgents(), fetchConnections()]) }
@@ -1369,6 +1389,8 @@ const usesServiceAccount = (a: any) => {
 }
 // Editing tables/tools requires manage on the data source (org-wide or on this resource).
 const canManageAgent = (id?: string) => id ? (useCan('update_data_source') || useCan('update_data_source', { type: 'data_source', id })) : false
+// Global Evals is an org-admin surface, gated by the org-level manage_evals perm.
+const canManageEvals = computed(() => useCan('manage_evals'))
 const panelCanUpdate = computed(() => canManageAgent(panelView.value?.agentId))
 
 const openConnectionDetail = (c: any) => { selectedConnection.value = c; showConnectionModal.value = true }


### PR DESCRIPTION
## Summary

Adds an org-wide **Global Evals** entry in the `/agents` KnowledgeExplorer tree, sitting just below **Skills**. It surfaces the evals that are global to the org — i.e. test cases that apply to **all agents** (those with no data-source scope) — in one place, rather than only showing up inside every individual agent's Evals panel.

The view is **admin-gated** by the org-level `manage_evals` permission, consistent with the existing standalone `/evals` page.

## Changes

**`frontend/components/KnowledgeExplorer.vue`**
- New "Global Evals" tree button below Skills, rendered only when `canManageEvals` (`useCan('manage_evals')`).
- Extended the right-pane `panelView` union with a `'global-evals'` kind and an `openGlobalEvals()` opener (clears the pane; no agent binding).
- Dedicated panel header for the global view ("Global Evals" + an "all agents" chip) instead of the per-agent breadcrumb.
- Renders `<AgentEvalsPanel global />` for that kind.

**`frontend/components/AgentEvalsPanel.vue`**
- New `global` prop. In global mode the panel filters to test cases with an empty `data_source_ids_json` (the codebase's existing definition of "applies to all agents"), instead of `empty || includes(agentId)`.
- `canManage` uses the org-level `manage_evals` permission in global mode.
- Hides per-agent-only controls (reliability status badge, Self Learning, "Run evals now" automation button/banner), which are agent-scoped.
- Load watcher and run filter updated to fire without an `agentId`.

## Notes

- **No backend changes.** `GET /api/tests/cases` already returns all org cases gated by `manage_evals`; the global filter is applied client-side. Creating a case from this view yields an unscoped (global) case automatically, since `AddTestCaseModal` leaves `data_source_ids_json` empty when no `agentId` is passed.
- The pre-existing standalone `/evals` page is unchanged and still reachable by URL; this tree entry is the in-context home for org-wide evals.

## Testing

- Not compile-checked in CI environment (`node_modules` not installed locally). Changes mirror the existing per-agent Evals button/panel patterns. Recommend a quick `nuxt dev` smoke test:
  - As a `manage_evals` admin, confirm "Global Evals" appears below Skills and opens a panel listing only unscoped cases/runs.
  - As a non-admin, confirm the entry is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESNQRjFT91W6mhw2jGe4QR)_