### PR TITLE
Sort report list by last activity instead of creation time

### DIFF
--- a/backend/alembic/versions/la1a2b3c4d5e_add_report_last_activity_at.py
+++ b/backend/alembic/versions/la1a2b3c4d5e_add_report_last_activity_at.py
@@ -1,0 +1,64 @@
+"""add report.last_activity_at for activity-based list sorting
+
+Revision ID: la1a2b3c4d5e
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-28 10:00:00.000000
+
+Adds `reports.last_activity_at`, a denormalized "last conversation activity"
+timestamp used to sort the report list (sidebar + /reports) by real chat
+activity instead of creation time.
+
+It is bumped at two coarse choke points (see completion_service +
+agent_v2): when a new user message is created and when an agent turn
+finalizes. It is intentionally distinct from `updated_at`, which bumps on
+any report-row metadata edit (rename / theme / sharing) and would conflate
+"settings edited" with "conversation activity".
+
+Existing rows are backfilled to the latest completion timestamp, falling
+back to the report's own created_at when it has no completions. The backfill
+is supported by the existing ix_completions_report_created index.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'la1a2b3c4d5e'
+down_revision: Union[str, None] = 'c1d2e3f4a5b6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'reports',
+        sa.Column('last_activity_at', sa.DateTime(), nullable=True),
+    )
+
+    # Backfill from the latest completion, falling back to the report's own
+    # created_at. Portable correlated subquery (works on Postgres + SQLite).
+    op.execute(
+        """
+        UPDATE reports
+        SET last_activity_at = COALESCE(
+            (SELECT MAX(c.created_at) FROM completions c WHERE c.report_id = reports.id),
+            reports.created_at
+        )
+        """
+    )
+
+    try:
+        op.create_index('ix_reports_last_activity_at', 'reports', ['last_activity_at'])
+    except Exception:
+        # Index already exists, skip
+        pass
+
+
+def downgrade() -> None:
+    try:
+        op.drop_index('ix_reports_last_activity_at', table_name='reports')
+    except Exception:
+        pass
+    op.drop_column('reports', 'last_activity_at')

--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time as _time
 import uuid as _uuid_mod
+from datetime import datetime
 from contextlib import asynccontextmanager
 from typing import Dict, Optional
 from pydantic import ValidationError
@@ -130,7 +131,7 @@ from app.models.widget import Widget
 from app.models.completion import Completion
 from app.models.report import Report
 from app.ai.agents.reporter.reporter import Reporter
-from sqlalchemy import select, func
+from sqlalchemy import select, func, update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.tool_execution import ToolExecution
 from app.models.agent_execution import AgentExecution
@@ -3567,6 +3568,20 @@ class AgentV2:
                 agent_execution=self.current_execution,
                 status=status,
             )
+            # Bump conversation activity so the finalized turn re-floats the report
+            # to the top of the list. Targeted UPDATE by id (not a mutation of
+            # self.report, which may be detached from self.db here — see the title
+            # generation note below) and best-effort so it never fails the turn.
+            try:
+                if self.report is not None:
+                    await self.db.execute(
+                        sa_update(Report)
+                        .where(Report.id == str(self.report.id))
+                        .values(last_activity_at=datetime.utcnow())
+                    )
+                    await self.db.commit()
+            except Exception as e:
+                logger.warning(f"Failed to bump report last_activity_at: {e}")
             # Telemetry: agent execution completed
             try:
                 await telemetry.capture(

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from sqlalchemy import Column, String, ForeignKey, Boolean, JSON, DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
@@ -27,6 +28,12 @@ class Report(BaseSchema):
 
     cron_schedule = Column(String, nullable=True)
     last_run_at = Column(DateTime, nullable=True, default=None)
+    # Last conversation activity: bumped when a new user message is created and
+    # when an agent turn finalizes. Distinct from `updated_at` (which bumps on any
+    # report-row metadata edit) so the report list can sort by real chat activity.
+    # See ReportService.get_reports ordering and the bump points in
+    # completion_service / agent_v2.
+    last_activity_at = Column(DateTime, nullable=True, default=datetime.utcnow, index=True)
     # Subscribers notified after each scheduled rerun
     # Format: [{"type": "user", "id": "..."}, {"type": "email", "address": "..."}]
     notification_subscribers = Column(JSON, nullable=True, default=None)

--- a/backend/app/schemas/report_schema.py
+++ b/backend/app/schemas/report_schema.py
@@ -42,6 +42,7 @@ class ReportSchema(ReportBase):
     user: UserSchema
     created_at: datetime
     updated_at: datetime
+    last_activity_at: Optional[datetime] = None
     last_run_at: Optional[datetime] = None
     cron_schedule: Optional[str] = None
     app_version: Optional[str] = None  # Version for routing decisions

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -535,6 +535,11 @@ class CompletionService:
 
             try:
                 db.add(head_completion)
+                # Bump conversation activity so the report sorts to the top of the
+                # list on a new message. `report` is already attached; the write
+                # piggybacks this commit. The agent turn bumps it again on finish.
+                report.last_activity_at = datetime.utcnow()
+                db.add(report)
                 await db.commit()
                 await db.refresh(head_completion)
             except Exception as e:

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1240,7 +1240,13 @@ class ReportService:
                     selectinload(DataSource.connections).options(lazyload("*")),
                 ),
                 selectinload(Report.artifacts)
-            ).order_by(is_starred_order.desc(), Report.created_at.desc()).offset(offset).limit(limit)
+            ).order_by(
+                is_starred_order.desc(),
+                # Sort by real conversation activity (new message / finalized agent
+                # turn), not creation time. Coalesce so reports that predate the
+                # column — or have no activity yet — fall back to created_at.
+                func.coalesce(Report.last_activity_at, Report.created_at).desc(),
+            ).offset(offset).limit(limit)
 
             result = await db.execute(query)
             span.add_event("query executed")

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -152,7 +152,7 @@
       <!-- Recent reports — pinned (starred) first; scrolls independently. -->
       <div v-if="!isCollapsed" class="flex-1 min-h-0 flex flex-col mt-4">
         <div class="px-2.5 pb-1 shrink-0 flex items-center justify-between group/hdr">
-          <span class="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">{{ $t('nav.reports') }}</span>
+          <NuxtLink to="/reports" class="text-[11px] font-semibold text-gray-400 uppercase tracking-wider hover:text-gray-700 dark:hover:text-gray-200 transition-colors">{{ $t('nav.reports') }}</NuxtLink>
           <NuxtLink to="/reports" class="inline-flex items-center gap-0.5 text-[11px] font-medium text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 opacity-0 group-hover/hdr:opacity-100 focus:opacity-100 transition-opacity">
             {{ $t('reports.viewAll') }}<UIcon name="i-heroicons-arrow-right" class="w-3 h-3" />
           </NuxtLink>
@@ -521,7 +521,8 @@
   const creatingReport = ref(false)
 
   // Recent reports list shown in the sidebar. The backend already orders
-  // these `is_starred DESC, created_at DESC`, so pinned reports come first.
+  // these `is_starred DESC, last_activity_at DESC`, so pinned reports come
+  // first and the rest sort by most recent conversation activity.
   const recentReports = ref<any[]>([])
   const fetchRecentReports = async () => {
     try {


### PR DESCRIPTION
## Summary

The sidebar report list (and `/reports`) ordered reports by `is_starred DESC, created_at DESC`, so an active conversation never moved up the list — only the creation date mattered. This switches the ordering to real conversation activity.

Implemented as **option C (denormalized timestamp)**: a `reports.last_activity_at` column bumped at two coarse choke points, rather than aggregating `MAX(completions.created_at)` on every list load. Read path stays cheap (single indexed column on the already-loaded reports table, no join to the high-volume `completions` table).

## Changes

**Storage**
- `models/report.py`: new indexed `last_activity_at` column. Kept distinct from `updated_at`, which bumps on any metadata edit (rename / theme / sharing) and would conflate settings changes with chat activity.

**Migration** (`la1a2b3c4d5e_add_report_last_activity_at.py`, chains onto head `c1d2e3f4a5b6`)
- Adds the column + `ix_reports_last_activity_at`.
- Backfills existing rows from `MAX(completions.created_at)`, falling back to `reports.created_at`. Backfill is supported by the existing `ix_completions_report_created` index.

**Write hooks (the two coarse choke points)**
- `completion_service.py`: bump when a new user message is created — piggybacks the existing commit, so a new chat sorts to the top immediately.
- `agent_v2.py`: bump when an agent turn finalizes, via a targeted `UPDATE ... WHERE id` (the report can be detached from the session here) — best-effort so it never fails the turn. Covers all entry points (web, Slack, webhook, scheduled).
- Deliberately **not** hooked into the streaming updater, which would write dozens of times per turn and cause row contention.

**Read side**
- `report_service.get_reports`: order by `is_starred DESC, COALESCE(last_activity_at, created_at) DESC`.
- `report_schema.py`: expose `last_activity_at`.

**Frontend** (`layouts/default.vue`)
- "REPORTS" sidebar header now links to `/reports`.
- Updated the stale ordering comment.

## Testing notes

- `py_compile` passes on all edited backend files + the migration.
- Backfill SQL validated on a throwaway SQLite DB (report with completions → latest completion timestamp; report without → its `created_at`).
- Confirmed the migration leaves a single alembic head.
- No existing tests assert report-list ordering.
- ⚠️ The migration has **not** been run against a real DB in this environment (alembic CLI unavailable) — run `alembic upgrade head` on a dev/staging DB before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Uo4n4EXZdFv5qBdnqufFY)_