### PR TITLE
Fix [object Object] rendering for Custom API headers and endpoints

### DIFF
--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -1368,6 +1368,7 @@ class CustomAPIConfig(BaseModel):
         default={},
         title="Custom Headers",
         description="Additional headers to send with every request (e.g., ontology, results-limit)",
+        json_schema_extra={"ui:type": "keyvalue"}
     )
     endpoints: list = Field(
         default=[],

--- a/frontend/components/datasources/ConnectForm.vue
+++ b/frontend/components/datasources/ConnectForm.vue
@@ -33,6 +33,10 @@
               </div>
               <button type="button" @click="kvAdd(field.field_name)" class="text-xs text-blue-600 hover:text-blue-700 font-medium">+ Add parameter</button>
             </div>
+            <div v-else-if="uiType(field) === 'json'">
+              <textarea v-model="jsonTextMap[field.field_name]" @input="jsonSync(field.field_name)" :id="field.field_name" rows="6" class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:border-blue-500 text-xs font-mono bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500" :placeholder="field.title || field.field_name" />
+              <p v-if="jsonErrorMap[field.field_name]" class="text-xs text-red-500 mt-1">{{ jsonErrorMap[field.field_name] }}</p>
+            </div>
             <input v-else type="text" v-model="formData.config[field.field_name]" :id="field.field_name" class="block w-full px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:border-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500" :placeholder="field.title || field.field_name" />
           </div>
         </div>
@@ -224,6 +228,47 @@ function initKeyValueFields() {
     if ((schema?.['ui:type']) === 'keyvalue') kvInit(fieldName)
   }
 }
+
+// Raw text the user edits for any `ui:type: json` config field. The parsed value in
+// formData.config stays the source of truth that gets submitted; this text is just the
+// editable representation, synced back on every edit. jsonErrorMap surfaces parse errors.
+const jsonTextMap = reactive<Record<string, string>>({})
+const jsonErrorMap = reactive<Record<string, string>>({})
+
+function jsonDefault(fieldName: string): any {
+  const schema = fields.value?.config?.properties?.[fieldName]
+  if (schema && Object.prototype.hasOwnProperty.call(schema, 'default')) return schema.default
+  return schema?.type === 'object' ? {} : []
+}
+
+function jsonInit(fieldName: string) {
+  const cur = (formData.config as any)[fieldName]
+  jsonTextMap[fieldName] = (cur == null || cur === '') ? '' : JSON.stringify(cur, null, 2)
+  jsonErrorMap[fieldName] = ''
+}
+
+function jsonSync(fieldName: string) {
+  const raw = jsonTextMap[fieldName] ?? ''
+  if (!raw.trim()) {
+    ;(formData.config as any)[fieldName] = jsonDefault(fieldName)
+    jsonErrorMap[fieldName] = ''
+    return
+  }
+  try {
+    ;(formData.config as any)[fieldName] = JSON.parse(raw)
+    jsonErrorMap[fieldName] = ''
+  } catch {
+    jsonErrorMap[fieldName] = 'Invalid JSON'
+  }
+}
+
+// Initialize JSON editors for any `ui:type: json` config fields in the active schema.
+function initJsonFields() {
+  const configProps = fields.value?.config?.properties || {}
+  for (const [fieldName, schema] of Object.entries<any>(configProps)) {
+    if ((schema?.['ui:type']) === 'json') jsonInit(fieldName)
+  }
+}
 const selectedAuth = ref<string | undefined>(undefined)
 const is_public = ref(false)
 const require_user_auth = ref(Boolean(props.initialRequireUserAuth))
@@ -344,6 +389,7 @@ async function fetchFields() {
     const shouldSkipHydration = preserveOnNextFetch.value
     initFormDefaults(preserveOnNextFetch.value)
     initKeyValueFields()
+    initJsonFields()
     preserveOnNextFetch.value = false
     emit('change:type', selectedType.value)
     // hydrate initial values in edit mode (skip if user just toggled auth policy)
@@ -358,6 +404,7 @@ async function fetchFields() {
         const { auth_type: _ignoredAuthType, ...restConfig } = (iv.config || {})
         formData.config = { ...formData.config, ...restConfig }
         initKeyValueFields()
+        initJsonFields()
         formData.credentials = { ...formData.credentials, ...(iv.credentials || {}) }
         connectionTestPassed.value = true
         // Lock credentials if they already exist on the server
@@ -380,6 +427,7 @@ function initFormDefaults(preserveExisting: boolean = false) {
   if (configProps) {
     Object.entries(configProps).forEach(([k, v]: any) => {
       if (v?.['ui:type'] === 'keyvalue') nextConfig[k] = (v?.default && typeof v.default === 'object') ? { ...v.default } : {}
+      else if (v?.['ui:type'] === 'json') nextConfig[k] = (v?.default != null) ? v.default : (v?.type === 'object' ? {} : [])
       else nextConfig[k] = v?.default ?? ''
     })
     if (preserveExisting) {


### PR DESCRIPTION
## Problem

In the Custom API "Edit connection" form, the **Custom Headers** and **Endpoints** fields rendered as `[object Object]` instead of editable content.

Config fields in `ConnectForm.vue` are rendered by their schema's `ui:type`. Two fields in `CustomAPIConfig` had values that are objects but matched no rendering branch, so both fell through to a plain-text `<input>` bound to an object/array value:

- **Custom Headers** — a `dict` with no `ui:type`.
- **Endpoints** — a `list` declared as `ui:type: "json"`, but `ConnectForm.vue` had no `json` branch.

## Fix

- **`backend/app/schemas/data_sources/configs.py`** — tag the `headers` field with `ui:type: "keyvalue"` so it uses the form's existing key/value row editor (same pattern as MSSQL's `additional_params`).
- **`frontend/components/datasources/ConnectForm.vue`** — add a `json` field type:
  - Monospace JSON textarea backed by a per-field raw-text map with parse/serialize sync and an inline "Invalid JSON" error.
  - Wire `initJsonFields()` into the initial schema fetch and edit-mode hydration.
  - Give `json` fields a proper array/object default in `initFormDefaults` so an untouched field submits valid JSON rather than an empty string.

## Result

Headers now render as editable key/value rows and endpoints render as an editable JSON textarea — no more `[object Object]`.

## Testing

- Verified the affected schema/form paths by tracing field rendering through `ConnectForm.vue` (config field branches, `initFormDefaults`, edit-mode hydration). The edit modal (`ConnectionDetailModal.vue`) drives `ConnectForm` with `mode="edit"` + `connectionId`, which goes through the patched hydration path.
- Backend schema change mirrors the existing `json_schema_extra={"ui:type": ...}` pattern used throughout the file (pydantic wasn't installed in the dev environment to run a live schema dump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Megj5njRBnzYMhDSTiMddn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Megj5njRBnzYMhDSTiMddn)_