### PR TITLE
/agents: lazy-load instructions (counts + per-agent on expand) + server-side cross-entity search

### DIFF
--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -158,6 +158,31 @@ async def get_instructions(
     )
 
 
+# COUNTS — drives the /agents tree badges (per-agent count + pending dot,
+# global/skills/total-pending) without hydrating instruction rows. Declared
+# before /instructions/{instruction_id} so "counts" isn't captured as an id.
+@router.get("/instructions/counts")
+async def get_instruction_counts(
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    return await instruction_service.get_instruction_counts(db, organization, current_user)
+
+
+# CROSS-ENTITY SEARCH for the /agents "Search everything" box — grouped shape
+# (agents + instructions), distinct from the instruction list.
+@router.get("/knowledge/search")
+async def search_knowledge(
+    q: str = Query("", description="Search query (matches agent names and instruction text/title)"),
+    limit: int = Query(20, ge=1, le=50),
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    return await instruction_service.search_knowledge(db, organization, current_user, q, limit=limit)
+
+
 # BULK UPDATE
 @router.put("/instructions/bulk", response_model=InstructionBulkResponse)
 @requires_permission('manage_instructions')

--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -97,6 +97,7 @@ async def get_instructions(
     search: Optional[str] = Query(None, description="Search in instruction text and title"),
     build_id: Optional[str] = Query(None, description="Load from specific build (defaults to main build)"),
     include_global: bool = Query(True, description="Include global instructions (no data sources) when filtering by data_source_ids"),
+    global_only: bool = Query(False, description="Return only global instructions (attached to no agent) — used by the lazy 'Global instructions' group"),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization)
@@ -154,7 +155,8 @@ async def get_instructions(
         label_ids=parsed_label_ids,
         search=search,
         build_id=build_id,
-        include_global=include_global
+        include_global=include_global,
+        global_only=global_only
     )
 
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -541,6 +541,115 @@ class InstructionService:
             current_user=current_user, kind=kind,
         )
 
+    async def _visible_main_build_conditions(self, db, organization, current_user):
+        """Base WHERE conditions shared by the counts query and the list:
+        org-scoped, not deleted, in the main build, and visible to the caller
+        (global, or attached to a member/public data source). Mirrors
+        `_execute_instructions_query` so counts never disagree with the list."""
+        from app.models.instruction_build import InstructionBuild
+        from app.models.build_content import BuildContent
+        from app.core.permission_resolver import get_member_data_source_ids
+
+        conditions = [
+            Instruction.organization_id == organization.id,
+            Instruction.deleted_at == None,  # noqa: E711
+        ]
+        main_build_id = (await db.execute(
+            select(InstructionBuild.id).where(and_(
+                InstructionBuild.organization_id == organization.id,
+                InstructionBuild.is_main == True,  # noqa: E712
+                InstructionBuild.deleted_at == None,  # noqa: E711
+            ))
+        )).scalar_one_or_none()
+        if main_build_id:
+            conditions.append(Instruction.id.in_(
+                select(BuildContent.instruction_id).where(BuildContent.build_id == main_build_id)
+            ))
+        if current_user is not None:
+            member_ds_ids = await get_member_data_source_ids(
+                db, str(current_user.id), str(organization.id)
+            )
+            public_ds_subq = select(DataSource.id).where(and_(
+                DataSource.organization_id == organization.id,
+                DataSource.is_public == True,  # noqa: E712
+            ))
+            visible_clauses = [Instruction.data_sources.any(DataSource.id.in_(public_ds_subq))]
+            if member_ds_ids:
+                visible_clauses.append(Instruction.data_sources.any(DataSource.id.in_(member_ds_ids)))
+            conditions.append(or_(~Instruction.data_sources.any(), *visible_clauses))
+        return conditions
+
+    async def get_instruction_counts(self, db, organization, current_user) -> dict:
+        """Aggregate counts that drive the /agents tree badges WITHOUT hydrating
+        rows: global, skills, total pending, plus per-agent count and per-agent
+        pending dot. Same visibility rules as the list, so the numbers match what
+        a lazy per-agent fetch would return."""
+        assoc = instruction_data_source_association
+        base = await self._visible_main_build_conditions(db, organization, current_user)
+
+        global_count = await db.scalar(
+            select(func.count()).select_from(Instruction)
+            .where(and_(*base, ~Instruction.data_sources.any()))
+        )
+        skills_count = await db.scalar(
+            select(func.count()).select_from(Instruction)
+            .where(and_(*base, Instruction.kind == 'skill'))
+        )
+        by_agent_rows = (await db.execute(
+            select(assoc.c.data_source_id, func.count(func.distinct(Instruction.id)))
+            .select_from(Instruction)
+            .join(assoc, assoc.c.instruction_id == Instruction.id)
+            .where(and_(*base))
+            .group_by(assoc.c.data_source_id)
+        )).all()
+        by_agent = {str(ds_id): cnt for ds_id, cnt in by_agent_rows}
+
+        pending_ids = await self.get_pending_change_instruction_ids(db, organization, current_user)
+        pending_by_agent: dict = {}
+        if pending_ids:
+            prows = (await db.execute(
+                select(assoc.c.data_source_id)
+                .where(assoc.c.instruction_id.in_([str(i) for i in pending_ids]))
+                .distinct()
+            )).all()
+            for (ds_id,) in prows:
+                pending_by_agent[str(ds_id)] = True
+
+        return {
+            "global": int(global_count or 0),
+            "skills": int(skills_count or 0),
+            "pending_total": len(pending_ids),
+            "by_agent": by_agent,
+            "pending_by_agent": pending_by_agent,
+        }
+
+    async def search_knowledge(self, db, organization, current_user, q: str, limit: int = 20) -> dict:
+        """Cross-entity search for the /agents 'Search everything' box. Returns a
+        grouped shape (distinct from the instruction list): matching agents
+        (data sources) AND matching instructions, each visibility-scoped."""
+        from app.services.data_source_service import DataSourceService
+
+        q = (q or "").strip()
+        if not q:
+            return {"agents": [], "instructions": []}
+
+        # Instructions: reuse the list path (server-side search + visibility).
+        inst_resp = await self.get_instructions(
+            db=db, organization=organization, current_user=current_user,
+            skip=0, limit=limit, search=q,
+            include_own=True, include_drafts=True, include_archived=True,
+        )
+        instructions = inst_resp.get("items", [])
+
+        # Agents: filter the caller's visible data sources by name (small list).
+        ql = q.lower()
+        agents_all = await DataSourceService().get_active_data_sources(
+            db, organization, current_user, include_unconnected=True
+        )
+        agents = [a for a in agents_all if ql in (getattr(a, "name", "") or "").lower()][:limit]
+
+        return {"agents": agents, "instructions": instructions}
+
     async def get_available_source_types(
         self,
         db: AsyncSession,

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -501,7 +501,8 @@ class InstructionService:
         label_ids: Optional[List[str]] = None,
         search: Optional[str] = None,
         build_id: Optional[str] = None,
-        include_global: bool = True
+        include_global: bool = True,
+        global_only: bool = False
     ) -> dict:
         """Get instructions with clean permission-based filtering. Returns paginated response.
         
@@ -538,7 +539,7 @@ class InstructionService:
             db, organization, conditions, status, categories, skip, limit,
             data_source_ids, source_types, load_modes, label_ids, search,
             build_id=build_id, include_global=include_global,
-            current_user=current_user, kind=kind,
+            current_user=current_user, kind=kind, global_only=global_only,
         )
 
     async def _visible_main_build_conditions(self, db, organization, current_user):
@@ -2530,6 +2531,7 @@ class InstructionService:
         include_global: bool = True,
         current_user: Optional[User] = None,
         kind: Optional[str] = None,
+        global_only: bool = False,
     ) -> dict:
         """Execute the instructions query with given conditions. Returns paginated response.
 
@@ -2623,6 +2625,9 @@ class InstructionService:
             filter_conditions.append(Instruction.status == status)
         if kind:
             filter_conditions.append(Instruction.kind == kind)
+        if global_only:
+            # Lazy "Global instructions" group: instructions attached to no agent.
+            filter_conditions.append(~Instruction.data_sources.any())
         if categories:
             filter_conditions.append(Instruction.category.in_(categories))
         if data_source_ids:

--- a/docs/design/agents-lazy-instructions.md
+++ b/docs/design/agents-lazy-instructions.md
@@ -1,0 +1,110 @@
+# /agents — stop loading ALL instructions on mount (design, not implemented)
+
+## Problem
+
+On mount, `KnowledgeExplorer.vue` calls `fetchAll()` →
+`GET /api/instructions?skip=0&limit=200&include_own&include_drafts&include_archived`
+and stores the full result in `allInstructions` (line 1860). **Everything** in
+the tree is then derived client-side from that one flat list:
+
+- counts: `globalCount`, `skillCount`, `pendingCount`, `agentCount(id)`,
+  `agentPending(id)` (lines 1956–1960)
+- rows: `listFor('global'|'skills')`, `listForAgent(id)`, `listForTable(id,tbl)`
+  (lines 1973–1982)
+- client-side **search + filters** via `applyFilters` (status/load/source/
+  category/text) (line 1963)
+- optimistic create/edit/delete patching of `allInstructions`
+  (lines 1233, 1994, 2040, 2062, 2079, 2278, …)
+
+So the page pays for hydrating up to 200 full instruction rows (text,
+structured_data, data_sources, labels, references, build status) just to draw a
+tree whose visible content is mostly counts + a few expanded rows.
+
+## Idea (confirmed viable)
+
+Load only what the initial render needs, lazy-load the rest:
+
+1. **Global + Skills rows on mount.** These are the two always-present top-level
+   groups; they're org-wide and typically few. One small list call each
+   (`data_source_ids` empty / `kind=skill`).
+2. **A counts endpoint** for everything the tree shows as a number/dot without
+   rows: per-agent count, per-agent pending dot, global count, skill count, and
+   total pending ("N pending" badge). One aggregate query, no row hydration.
+3. **Lazy per-agent rows on expand.** When an agent node (or a table under it)
+   is expanded, fetch `GET /instructions?data_source_ids=<agent>&include_global=false`
+   and cache it. That single fetch yields BOTH the agent-level rows
+   (`listForAgent`) and the table-referenced rows (`listForTable`) for that
+   agent — they're all that agent's instructions.
+
+The list endpoint already supports `data_source_ids`, `kind`, `include_global`,
+and `search` filters, so the lazy fetches and the server-side search path need no
+new list params.
+
+## Backend scope
+
+- **New `GET /api/instructions/counts`** (the only new endpoint). Returns, for the
+  caller's visible scope:
+  ```json
+  { "global": N, "skills": N, "pending_total": N,
+    "by_agent": { "<ds_id>": N, ... },
+    "pending_by_agent": { "<ds_id>": true, ... } }
+  ```
+  Implementation: a `GROUP BY` over main-build instructions joined to
+  `instruction_data_source_association`, applying the **same per-data-source
+  visibility filter as `_execute_instructions_query`** (members + public DSes;
+  global = no DS). Pending reuses the now-batched
+  `get_pending_change_instruction_ids`, mapped to agents via the association
+  (one extra query). Cheap and row-free.
+- No change needed to `GET /instructions` for the lazy/search fetches.
+
+## Frontend scope (the larger part)
+
+Replace the single `allInstructions` store with:
+- `globalRows`, `skillRows` — loaded on mount.
+- `agentRows: Map<agentId, Instruction[]>` — loaded on expand, cached.
+- `counts` — from the counts endpoint (drives all badges/dots).
+
+Rework:
+- `globalCount/skillCount/pendingCount/agentCount/agentPending` → read from
+  `counts` (not from rows).
+- `listFor('global'|'skills')` → from `globalRows`/`skillRows`.
+- `listForAgent/listForTable` → from `agentRows[id]` (trigger load on expand;
+  show a Spinner until loaded — pattern already exists via `instrLoading`).
+- **Search / filters** (`applyFilters`): lazy loading breaks client-side global
+  search. Route an active search/filter to a server query
+  (`GET /instructions?search=…&status=…&…`) and render those results in a flat
+  "search results" view, instead of filtering the in-memory list. (The endpoint
+  already supports all these filters.)
+- **Optimistic updates** (create/edit/delete/approve/discard): update the right
+  cache (global vs the agent's `agentRows[id]`) AND adjust `counts` so badges
+  stay correct without a full refetch. This is the fiddliest part and the main
+  source of risk.
+
+## Tradeoffs / risks
+
+- ✅ Mount stops hydrating up to 200 full rows; initial payload becomes
+  counts + a few global/skill rows. Per-agent rows load only when looked at.
+- ⚠️ More total requests (counts + one per expanded agent), but each is small and
+  most agents are never expanded.
+- ⚠️ Counts vs lazily-loaded rows can drift after mutations — must keep `counts`
+  in sync on every optimistic update (or refetch counts after mutations).
+- ⚠️ The counts endpoint MUST mirror the list's visibility filter exactly, or
+  agent badges will show counts the user can't drill into.
+- ⚠️ Frontend refactor touches the optimistic-update paths and search — medium
+  effort, the riskiest piece.
+
+## Answer to "only global + counts + pending count?"
+
+Almost — with two refinements:
+- The Global (and Skills) group needs the actual **rows**, not just a count, to
+  render its rules — so load those rows on mount (small).
+- "Counts" should be one endpoint covering per-agent count **and** per-agent
+  pending dot **and** global/skill/total-pending, so the tree draws fully without
+  any per-agent row fetch.
+- Then per-agent rows lazy-load on expand. Search/filter needs a server-side path.
+
+## Open questions for review
+1. Load Skills rows on mount too, or lazy-load Skills on expand like agents?
+2. Search behavior when lazy: server-side flat results view — acceptable UX?
+3. Keep counts fresh via per-mutation adjustment, or just refetch the counts
+   endpoint after each mutation (simpler, one cheap call)?

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -61,14 +61,39 @@
           </UPopover>
         </div>
 
-        <div class="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-0.5">
+        <!-- Server-side "Search everything" results (agents + instructions). -->
+        <div v-if="searchResults" class="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-2">
+          <div v-if="searching" class="flex items-center gap-2 h-8 text-[13px] text-gray-400 dark:text-gray-500 px-2"><Spinner class="w-3.5 h-3.5" /><span>Searching…</span></div>
+          <template v-else>
+            <div v-if="searchResults.agents.length">
+              <div class="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Agents</div>
+              <button v-for="a in searchResults.agents" :key="a.id" type="button" class="w-full flex items-center gap-2 h-8 rounded-md text-[13px] text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/70 px-2" @click="onAgentClick(a)">
+                <DataSourceIcon :type="a.type" class="w-4 h-4 shrink-0" />
+                <span class="flex-1 text-start truncate">{{ a.name }}</span>
+              </button>
+            </div>
+            <div v-if="searchResults.instructions.length">
+              <div class="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Instructions</div>
+              <InstrLeaf v-for="ins in searchResults.instructions" :key="ins.id" :ins="ins" />
+            </div>
+            <EmptyHint v-if="!searchResults.agents.length && !searchResults.instructions.length" text="No results." />
+          </template>
+        </div>
+
+        <div v-show="!searchResults" class="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-0.5">
           <TreeGroup :label="$t('agentsPage.globalInstructions')" icon="i-heroicons-globe-alt" :count="globalCount" addable :open="isOpen('global')" @toggle="expand('global')" @add="openCreate()">
-            <EmptyHint v-if="listFor('global').length === 0" :text="$t('agentsPage.noGlobalRules')" add @add="openCreate()" />
-            <InstrLeaf v-for="ins in listFor('global')" :key="ins.id" :ins="ins" />
+            <div v-if="groupLoading('global')" class="flex items-center gap-2 h-8 text-[13px] text-gray-400 dark:text-gray-500" style="padding-inline-start:32px"><Spinner class="w-3.5 h-3.5" /><span>Loading…</span></div>
+            <template v-else>
+              <EmptyHint v-if="loadedGroups.has('global') && listFor('global').length === 0" :text="$t('agentsPage.noGlobalRules')" add @add="openCreate()" />
+              <InstrLeaf v-for="ins in listFor('global')" :key="ins.id" :ins="ins" />
+            </template>
           </TreeGroup>
           <TreeGroup :label="$t('agentsPage.skills')" icon="i-heroicons-sparkles" :count="skillCount" :open="isOpen('skills')" @toggle="expand('skills')">
-            <EmptyHint v-if="skillCount === 0" :text="$t('agentsPage.noSkills')" />
-            <InstrLeaf v-for="ins in listFor('skills')" :key="ins.id" :ins="ins" />
+            <div v-if="groupLoading('skills')" class="flex items-center gap-2 h-8 text-[13px] text-gray-400 dark:text-gray-500" style="padding-inline-start:32px"><Spinner class="w-3.5 h-3.5" /><span>Loading…</span></div>
+            <template v-else>
+              <EmptyHint v-if="skillCount === 0" :text="$t('agentsPage.noSkills')" />
+              <InstrLeaf v-for="ins in listFor('skills')" :key="ins.id" :ins="ins" />
+            </template>
           </TreeGroup>
           <!-- Org-wide evals (apply to all agents). Admin-gated via manage_evals. -->
           <button v-if="canManageEvals" type="button" class="group w-full flex items-center gap-1.5 h-8 rounded-md text-[13px] transition-colors min-w-0" :class="panelView?.kind === 'global-evals' ? 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/70'" style="padding-inline-start:6px;padding-inline-end:8px" @click="openGlobalEvals()">
@@ -90,13 +115,13 @@
           </div>
 
           <template v-for="agent in agents" :key="agent.id">
-            <TreeGroup :label="agent.name" :count="instrLoading ? undefined : agentCount(agent.id)" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? $t('agentsPage.signInBadge') : (agent.publish_status === 'disabled' ? $t('agentsPage.disabledBadge') : '')" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
+            <TreeGroup :label="agent.name" :count="agentCount(agent.id) || undefined" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? $t('agentsPage.signInBadge') : (agent.publish_status === 'disabled' ? $t('agentsPage.disabledBadge') : '')" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
               <template #icon><DataSourceIcon :type="agent.type" class="w-4 h-4 shrink-0" /></template>
 
               <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id]?.length" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
                 <TreeGroup v-for="t in (agentTables[agent.id] || [])" :key="t.id" :label="t.name" :icon="t.is_active ? 'i-heroicons-check-circle' : 'i-heroicons-table-cells'" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
                   <InstrLeaf v-for="ins in listForTable(agent.id, t.id)" :key="ins.id" :ins="ins" :indent="3" />
-                  <EmptyHint v-if="listForTable(agent.id, t.id).length === 0" :text="$t('agentsPage.noRulesAttached')" add @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })" :pad="62" />
+                  <EmptyHint v-if="loadedGroups.has(agent.id) && listForTable(agent.id, t.id).length === 0" :text="$t('agentsPage.noRulesAttached')" add @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })" :pad="62" />
                 </TreeGroup>
                 <EmptyHint v-if="(agentTables[agent.id]?.length ?? -1) === 0" :text="$t('agentsPage.noAccessibleTables')" :pad="48" />
               </TreeGroup>
@@ -130,11 +155,11 @@
                 <div v-if="uploadingAgent === agent.id" class="text-[11px] text-gray-400 dark:text-gray-500 italic py-1" style="padding-inline-start:48px">{{ $t('agentsPage.uploading') }}</div>
               </TreeGroup>
 
-              <TreeGroup :label="$t('agentsPage.instructions')" icon="i-heroicons-document-text" :count="instrLoading ? undefined : listForAgent(agent.id).length" addable :indent="1" :open="isOpen('instr:' + agent.id)" @toggle="expand('instr:' + agent.id)" @add="openCreate({ agentId: agent.id })">
-                <div v-if="instrLoading" class="flex items-center gap-2 h-8 text-[13px] text-gray-400 dark:text-gray-500" style="padding-inline-start:48px"><Spinner class="w-3.5 h-3.5" /><span>{{ $t('agentsPage.loading') }}</span></div>
+              <TreeGroup :label="$t('agentsPage.instructions')" icon="i-heroicons-document-text" :count="loadedGroups.has(agent.id) ? listForAgent(agent.id).length : (agentCount(agent.id) || undefined)" addable :indent="1" :open="isOpen('instr:' + agent.id)" @toggle="expand('instr:' + agent.id)" @add="openCreate({ agentId: agent.id })">
+                <div v-if="groupLoading(agent.id)" class="flex items-center gap-2 h-8 text-[13px] text-gray-400 dark:text-gray-500" style="padding-inline-start:48px"><Spinner class="w-3.5 h-3.5" /><span>{{ $t('agentsPage.loading') }}</span></div>
                 <template v-else>
                   <InstrLeaf v-for="ins in listForAgent(agent.id)" :key="ins.id" :ins="ins" :indent="2" />
-                  <EmptyHint v-if="listForAgent(agent.id).length === 0" :text="$t('agentsPage.noInstructions')" add @add="openCreate({ agentId: agent.id })" :pad="48" />
+                  <EmptyHint v-if="loadedGroups.has(agent.id) && listForAgent(agent.id).length === 0" :text="$t('agentsPage.noInstructions')" add @add="openCreate({ agentId: agent.id })" :pad="48" />
                 </template>
               </TreeGroup>
 
@@ -837,11 +862,22 @@ const { isTrainingModeEnabled } = useOrgSettings()
 const agentCanStartTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
 
 // ── State ───────────────────────────────────────────────
+// `allInstructions` is the LAZY row cache — it holds only the instruction rows
+// for groups that have been expanded (global, skills, and per-agent), not the
+// whole org. Badges come from `counts` instead, so the tree draws without
+// loading every instruction on mount.
 const allInstructions = ref<Instruction[]>([])
-// True until the first /api/instructions load resolves. Drives a Spinner on the
-// Instructions tree nodes so they don't read as "0 / No instructions yet" while
-// the list is still in flight (the rows arrive late on large orgs).
 const instrLoading = ref(true)
+// Aggregate badge counts (GET /api/instructions/counts): { global, skills,
+// pending_total, by_agent: {id:n}, pending_by_agent: {id:true} }.
+const counts = ref<any>({ global: 0, skills: 0, pending_total: 0, by_agent: {}, pending_by_agent: {} })
+// Which lazy groups have had their rows loaded into `allInstructions`.
+const loadedGroups = ref<Set<string>>(new Set())   // 'global' | 'skills' | <agentId>
+const loadingGroups = ref<Set<string>>(new Set())
+// Server-side cross-entity search results ({ agents, instructions }); non-null
+// while a search is active, which swaps the tree for a flat results view.
+const searchResults = ref<{ agents: any[]; instructions: Instruction[] } | null>(null)
+const searching = ref(false)
 const agents = ref<any[]>([])
 // "Self Learning" per-agent automation modal (opened from the agent header).
 const showSelfLearning = ref(false)
@@ -853,6 +889,26 @@ watch(showAllAgents, () => { fetchAgents() })
 const labels = ref<{ id: string; name: string }[]>([])
 const categories = ref<string[]>([])
 const search = ref('')
+// Server-side "Search everything": debounced call to /api/knowledge/search that
+// returns matching agents AND instructions. While a query is present we render a
+// flat grouped results view instead of the lazy tree (the tree only has loaded
+// rows, so client-side search can't see everything).
+let searchTimer: any = null
+const runSearch = async (q: string) => {
+  const term = (q || '').trim()
+  if (!term) { searchResults.value = null; searching.value = false; return }
+  searching.value = true
+  try {
+    const { data } = await useMyFetch<any>('/api/knowledge/search', { method: 'GET', query: { q: term, limit: 30 } })
+    searchResults.value = { agents: data.value?.agents || [], instructions: data.value?.instructions || [] }
+  } catch (e) { console.error(e); searchResults.value = { agents: [], instructions: [] } }
+  finally { searching.value = false }
+}
+watch(search, (q) => {
+  if (searchTimer) clearTimeout(searchTimer)
+  if (!q.trim()) { searchResults.value = null; searching.value = false; return }
+  searchTimer = setTimeout(() => runSearch(q), 250)
+})
 
 const fStatus = ref<string[]>([]); const fLoad = ref<string[]>([]); const fSource = ref<string[]>([]); const fCategory = ref<string[]>([])
 
@@ -1852,17 +1908,57 @@ const expand = (key: string, force?: boolean) => {
   else if (expanded.value.has(key)) expanded.value.delete(key)
   else expanded.value.add(key)
   if (key.startsWith('agent:') && expanded.value.has(key)) { const id = key.slice('agent:'.length); expanded.value.add('instr:' + id); loadAgentMeta(id) }
+  // Lazy-load instruction rows on first expand of a group (rows arrive from the
+  // backend; counts/badges were already loaded on mount).
+  if (expanded.value.has(key)) {
+    if (key === 'global' || key === 'skills') loadGroup(key)
+    else if (key.startsWith('agent:')) loadGroup(key.slice('agent:'.length))
+    else if (key.startsWith('instr:')) loadGroup(key.slice('instr:'.length))
+  }
   expanded.value = new Set(expanded.value)
 }
 
-// ── Fetching ────────────────────────────────────────────
-const fetchAll = async () => {
-  try { const { data } = await useMyFetch<any>('/api/instructions', { method: 'GET', query: { skip: 0, limit: 200, include_own: true, include_drafts: true, include_archived: true } }); allInstructions.value = data.value?.items || [] } catch (e) { console.error(e) } finally { instrLoading.value = false }
+// ── Fetching (lazy) ─────────────────────────────────────
+// Aggregate badges — one cheap call, no rows. Drives every count/dot in the tree.
+const fetchCounts = async () => {
+  try { const { data } = await useMyFetch<any>('/api/instructions/counts', { method: 'GET' }); if (data.value) counts.value = data.value } catch (e) { console.error(e) }
 }
-// Refresh BOTH the instruction list and the pending-builds map so the left tree
-// (Pending review count, top "N pending" badge, per-row amber dots) stays in
-// sync after a mutation (approve / discard / save). fetchAll alone only updates
-// instruction statuses; pendingInstrIds is what drives the pending signals.
+// Merge fetched rows into the lazy cache (dedupe by id; newest wins).
+const mergeRows = (rows: Instruction[]) => {
+  if (!rows?.length) return
+  const byId = new Map(allInstructions.value.map(i => [i.id, i]))
+  for (const r of rows) byId.set(r.id, r)
+  allInstructions.value = Array.from(byId.values())
+}
+// Lazy-load a group's rows on first expand (cached after). Keys:
+//   'global' -> global_only ; 'skills' -> kind=skill ; <agentId> -> data_source_ids
+const loadGroup = async (key: string, force = false) => {
+  if (!key) return
+  if (!force && loadedGroups.value.has(key)) return
+  if (loadingGroups.value.has(key)) return
+  loadingGroups.value = new Set(loadingGroups.value).add(key)
+  try {
+    const query: Record<string, any> = { skip: 0, limit: 200, include_own: true, include_drafts: true, include_archived: true }
+    if (key === 'global') query.global_only = true
+    else if (key === 'skills') query.kind = 'skill'
+    else { query.data_source_ids = key; query.include_global = false }
+    const { data } = await useMyFetch<any>('/api/instructions', { method: 'GET', query })
+    mergeRows(data.value?.items || [])
+    loadedGroups.value = new Set(loadedGroups.value).add(key)
+  } catch (e) { console.error(e) } finally {
+    const s = new Set(loadingGroups.value); s.delete(key); loadingGroups.value = s
+  }
+}
+// True while a group is fetching for the first time (drives the per-node Spinner).
+const groupLoading = (key: string) => loadingGroups.value.has(key) && !loadedGroups.value.has(key)
+// Reload everything currently loaded (counts + each loaded group). Used after
+// a mutation so badges and the visible rows both stay correct.
+const fetchAll = async () => {
+  try {
+    await Promise.all([fetchCounts(), ...Array.from(loadedGroups.value).map(k => loadGroup(k, true))])
+  } finally { instrLoading.value = false }
+}
+// Refresh badges + pending dots + visible rows after a mutation.
 const refreshLists = async () => { await Promise.all([fetchAll(), fetchPendingMap()]) }
 const fetchAgents = async () => {
   try {
@@ -1953,11 +2049,13 @@ const openFile = async (f: any, agentId?: string) => {
 // Authoritative: an instruction is "pending" iff it has a real pending change
 // (from /pending-changes). Avoids the old over-count from inherited/stale rows.
 const isPending = (ins: Instruction) => pendingInstrIds.value.has(ins.id)
-const pendingCount = computed(() => allInstructions.value.filter(isPending).length)
-const globalCount = computed(() => allInstructions.value.filter(i => (i.data_sources || []).length === 0).length)
-const skillCount = computed(() => allInstructions.value.filter(i => (i as any).kind === 'skill').length)
-const agentCount = (id: string) => allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === id)).length
-const agentPending = (id: string) => allInstructions.value.some(i => isPending(i) && (i.data_sources || []).some(d => d.id === id))
+// Badges read from the aggregate `counts` (not from the lazy row cache), so they
+// are correct even before a group's rows have been loaded.
+const pendingCount = computed(() => counts.value?.pending_total || 0)
+const globalCount = computed(() => counts.value?.global || 0)
+const skillCount = computed(() => counts.value?.skills || 0)
+const agentCount = (id: string) => counts.value?.by_agent?.[id] || 0
+const agentPending = (id: string) => !!counts.value?.pending_by_agent?.[id]
 
 // ── Leaf lists ──────────────────────────────────────────
 const applyFilters = (list: Instruction[]) => {
@@ -1966,8 +2064,7 @@ const applyFilters = (list: Instruction[]) => {
   if (fLoad.value.length) out = out.filter(i => fLoad.value.includes(i.load_mode || 'always'))
   if (fSource.value.length) out = out.filter(i => fSource.value.includes(h.getSourceType(i)))
   if (fCategory.value.length) out = out.filter(i => fCategory.value.includes(i.category))
-  const q = search.value.trim().toLowerCase()
-  if (q) out = out.filter(i => (i.title || '').toLowerCase().includes(q) || (i.text || '').toLowerCase().includes(q))
+  // Text search is server-side now (see runSearch / searchResults) — not applied here.
   return out
 }
 const listFor = (kind: string) => {
@@ -2276,7 +2373,12 @@ const restoreFromRoute = () => {
     const insId = seg[1]
     if (selectedId.value === insId) return
     const ins = allInstructions.value.find(i => i.id === insId)
-    if (ins) openInstruction(ins)
+    if (ins) { openInstruction(ins); return }
+    // Lazy tree: the row may not be loaded — fetch the single instruction so the
+    // deep link still opens it.
+    useMyFetch<any>(`/api/instructions/${insId}`, { method: 'GET' })
+      .then(({ data }: any) => { if (data?.value) openInstruction(data.value) })
+      .catch(() => {})
     return
   }
   const agentId = seg[0]
@@ -2327,11 +2429,14 @@ const fetchActivity = async (agentId?: string) => {
 }
 
 onMounted(async () => {
-  // Render the tree as soon as agents + instructions are in. fetchPendingMap()
-  // only feeds the decorative amber "pending" dots / "N pending" badge, so it's
-  // fired without blocking — the dots fill in a beat later instead of gating the
-  // whole tree on the heaviest call.
-  await Promise.all([fetchAgents(), fetchConnections(), fetchAll(), fetchLabels(), fetchCategories(), fetchGitStatus(), fetchReviewCount()])
+  // Lazy tree: load agents + aggregate counts only (no instruction rows). Each
+  // group's rows load on first expand. fetchCounts also feeds the pending dots
+  // and the "N pending" badge, so fetchPendingMap is no longer on the hot path.
+  await Promise.all([fetchAgents(), fetchConnections(), fetchCounts(), fetchLabels(), fetchCategories(), fetchGitStatus(), fetchReviewCount()])
+  instrLoading.value = false
+  // Cheap (batched) id list that drives the per-row amber "pending" dots once
+  // rows lazy-load; fired non-blocking so it never gates the tree.
+  fetchPendingMap()
   restoreFromRoute()
   fetchPendingMap()
 })


### PR DESCRIPTION
## Problem

The `/agents` tree loaded **all** instructions on mount (`GET /instructions?limit=200`) and derived the entire tree client-side from that one flat list — counts, per-agent/per-table rows, search, and optimistic updates. On orgs with many instructions that's the heavy per-page payload.

## Change

Stop loading everything up front. The tree now draws from cheap **counts**, and rows load **lazily on expand**.

### Backend (new, tested)
- `GET /api/instructions/counts` — aggregate badges with **no row hydration**: `{ global, skills, pending_total, by_agent:{id:n}, pending_by_agent:{id:true} }`, using the **same visibility filter** as the list (so counts can't disagree with what a lazy fetch returns).
- `GET /api/knowledge/search?q=` — cross-entity grouped search returning `{ agents, instructions }` (distinct shape from the list). Instructions reuse the list's server-side search/visibility; agents are the caller's visible data sources matched by name.
- `GET /api/instructions?global_only=true` — new filter so the "Global instructions" group can lazy-load on expand.

### Frontend (`KnowledgeExplorer.vue`)
- **Mount** fetches `counts` + agents only — no instruction rows. Badges/dots come from `counts`, so the tree is fully drawn immediately.
- **Lazy rows on expand**: `global` → `global_only`, `skills` → `kind=skill`, per-agent → `data_source_ids` (one agent fetch covers both its agent-level and table-referenced rows). Per-node `Spinner` while loading; empty hints gated on "loaded".
- `allInstructions` becomes a lazy, deduped row cache; count helpers read from `counts`.
- **"Search everything"** is now server-side and grouped (agents **and** instructions), rendered as a flat results view that replaces the tree while a query is active. Client-side text search removed; the other filter chips still apply to loaded rows.
- Deep-link `/agents/instructions/<id>` fetches the single instruction when it isn't in the lazy cache; agent deep-links expand (triggering the lazy load).

## Validation

- `tests/e2e/test_instruction.py` — **17 passed**.
- Backend endpoints manually verified against a seeded Postgres: counts (global/skills/pending/by-agent/pending-by-agent), search (agent-name and instruction-text matches), `global_only`, and agent-scoped lazy fetch all return correctly.
- **Frontend note:** this environment has no frontend runtime (`node_modules` unavailable), so the Vue refactor is validated by CI (build + playwright) rather than locally. Worth a careful look at the lazy/expand + search-results paths in review.

## Follow-ups
- Search section headers ("Agents"/"Instructions"/"Searching…") are hardcoded English for now — i18n keys to be added.
- Filter chips (status/load/source/category) still apply client-side to loaded rows; pushing them server-side is a later step if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019hwcrqsDDwsj6PMAGvoRSV)_