### PR TITLE
Prompts tools in Training mode (create / search / edit_prompt) with rich, localized tool cards

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -106,6 +106,10 @@ class PromptBuilderV3:
                 "- list_agent_executions: list past agent runs with prompts, responses, tool outcomes, feedback\n"
                 "- search_instructions: find existing instructions before creating new ones\n"
                 "- create_instruction / edit_instruction: write or update instructions\n"
+                "- search_prompts: find existing reusable prompts before creating new ones\n"
+                "- create_prompt / edit_prompt: save or update reusable prompts (re-runnable requests, "
+                "conversation starters, templated {{param}} prompts) attached to the agent(s) you manage. "
+                "create_prompt defaults to the current report's agents — no need to pass data_source_ids.\n"
                 "- create_data: create data visualizations as usual\n\n"
                 "Training mode routing examples (follow these exactly):\n"
                 "- User: \"show low confidence responses\" → list_agent_executions(filter='low_confidence')\n"
@@ -114,6 +118,9 @@ class PromptBuilderV3:
                 "- User: \"review negative feedback\" → list_agent_executions(filter='negative_feedback')\n"
                 "- User: \"find instruction gaps\" → list_agent_executions(filter='low_instruction_coverage')\n"
                 "- User: \"show recent agent runs\" → list_agent_executions() (no filter)\n"
+                "- User: \"add a prompt for monthly revenue\" → create_prompt(text='...', is_starter=true)\n"
+                "- User: \"list the saved prompts\" / \"what prompts do we have\" → search_prompts()\n"
+                "- User: \"rename / update that prompt\" → edit_prompt(prompt_id='...', ...)\n"
                 "No clarification, no capability disclaimer, no schema inspection before calling list_agent_executions.\n"
             )
 

--- a/backend/app/ai/tools/implementations/create_prompt.py
+++ b/backend/app/ai/tools/implementations/create_prompt.py
@@ -1,0 +1,233 @@
+"""Create Prompt Tool - Save a reusable prompt for an agent (training mode).
+
+A prompt is a saved, completion-shaped instruction users can re-run or that
+surfaces as a conversation starter. This tool lets the training-mode agent
+curate the reusable prompts attached to the agent(s) the user manages.
+
+Authoring is governed by the agent-manager tier: PromptService.create_prompt
+requires `manage` on each target data source (or org admin for 'global').
+Created prompts go live immediately — there is no draft/approval build flow for
+prompts (unlike instructions).
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from fastapi import HTTPException
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.create_prompt import CreatePromptInput, CreatePromptOutput
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_SCOPES = {"agent", "private", "global"}
+VALID_MODES = {"chat", "deep", "training"}
+
+
+class CreatePromptTool(Tool):
+    """Create a reusable prompt and attach it to the agent(s) being trained."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="create_prompt",
+            description=(
+                "ACTION: Save a reusable prompt for an agent. A prompt is a saved, "
+                "re-runnable analytical request (optionally a conversation starter or a "
+                "templated prompt with {{parameters}}). Use search_prompts FIRST to avoid "
+                "duplicates. Defaults to scope='agent', attaching to the agent(s) on the "
+                "current report — omit data_source_ids to use them. You must manage the "
+                "target agent(s). Created prompts are live immediately."
+            ),
+            category="action",
+            version="1.0.0",
+            input_schema=CreatePromptInput.model_json_schema(),
+            output_schema=CreatePromptOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=30,
+            idempotent=False,
+            required_permissions=[],
+            tags=["training", "prompt", "curation"],
+            allowed_modes=["training"],
+            examples=[
+                {
+                    "input": {
+                        "text": "Show monthly revenue by product category for the last 12 months.",
+                        "title": "Monthly revenue by category",
+                        "is_starter": True,
+                    },
+                    "description": "Agent-scoped conversation starter attached to the current report's agents.",
+                },
+                {
+                    "input": {
+                        "text": "Summarize {{metric}} trends for {{period}}.",
+                        "title": "Metric trend summary",
+                        "parameters": [
+                            {"name": "metric", "type": "text", "required": True},
+                            {"name": "period", "type": "date_range", "required": True},
+                        ],
+                    },
+                    "description": "Templated prompt with two parameters.",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return CreatePromptInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return CreatePromptOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = CreatePromptInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {e}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={
+                "title": data.title,
+                "scope": data.scope,
+                "is_starter": data.is_starter,
+            },
+        )
+
+        if data.scope not in VALID_SCOPES:
+            yield self._reject(f"Invalid scope '{data.scope}'. Must be one of: {', '.join(sorted(VALID_SCOPES))}", "invalid_scope")
+            return
+        if data.mode not in VALID_MODES:
+            yield self._reject(f"Invalid mode '{data.mode}'. Must be one of: {', '.join(sorted(VALID_MODES))}", "invalid_mode")
+            return
+
+        db = runtime_ctx.get("db")
+        organization = runtime_ctx.get("organization")
+        user = runtime_ctx.get("user")
+        report = runtime_ctx.get("report")
+
+        if not all([db, organization, user]):
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": "Missing required runtime context (db, organization, user)",
+                    "code": "MISSING_CONTEXT",
+                },
+            )
+            return
+
+        # Resolve target agents for agent-scoped prompts: explicit ids win, else
+        # fall back to the active agents attached to the current report.
+        ds_ids = list(data.data_source_ids or [])
+        if data.scope == "agent" and not ds_ids and report is not None:
+            try:
+                ds_ids = [
+                    str(ds.id)
+                    for ds in (report.data_sources or [])
+                    if getattr(ds, "is_active", False) and getattr(ds, "deleted_at", None) is None
+                ]
+            except Exception:
+                ds_ids = []
+
+        if data.scope == "agent" and not ds_ids:
+            yield self._reject(
+                "An agent-scoped prompt needs at least one agent. Pass data_source_ids or run on a report with agents attached.",
+                "no_data_sources",
+            )
+            return
+
+        try:
+            from app.schemas.prompt_schema import PromptCreate, PromptParameter
+            from app.services.prompt_service import prompt_service
+
+            parameters = None
+            if data.parameters:
+                parameters = [PromptParameter(**p.model_dump()) for p in data.parameters]
+
+            payload = PromptCreate(
+                title=data.title,
+                text=data.text,
+                mode=data.mode,
+                scope=data.scope,
+                is_starter=data.is_starter,
+                parameters=parameters,
+                data_source_ids=ds_ids if data.scope == "agent" else [],
+            )
+
+            prompt = await prompt_service.create_prompt(db, payload, user, organization)
+
+            title = prompt.title or (prompt.text or "")[:60]
+            attached = [str(ds.id) for ds in (prompt.data_sources or [])]
+            logger.info(
+                f"Training mode created prompt {prompt.id}: '{title}' "
+                f"(scope={prompt.scope}, starter={prompt.is_starter}, agents={attached})"
+            )
+
+            output = CreatePromptOutput(
+                success=True,
+                prompt_id=str(prompt.id),
+                title=title,
+                scope=prompt.scope,
+                data_source_ids=attached,
+                is_starter=prompt.is_starter,
+                message=f"Prompt created: {title}",
+            )
+
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": output.model_dump(),
+                    "observation": {
+                        "summary": (
+                            f"Created prompt '{title}' (scope={prompt.scope}, "
+                            f"starter={prompt.is_starter}, agents={len(attached)})"
+                        ),
+                        "artifacts": [
+                            {
+                                "type": "prompt",
+                                "id": str(prompt.id),
+                                "title": title,
+                                "scope": prompt.scope,
+                                "is_starter": prompt.is_starter,
+                                "data_source_ids": attached,
+                            }
+                        ],
+                    },
+                },
+            )
+        except HTTPException as he:
+            reason = "permission_denied" if he.status_code == 403 else "rejected"
+            yield self._reject(str(he.detail), reason)
+        except Exception as e:
+            logger.exception(f"create_prompt failed: {e}")
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Failed to create prompt: {e}", "code": "CREATE_FAILED"},
+            )
+
+    @staticmethod
+    def _reject(message: str, reason: str) -> ToolEndEvent:
+        return ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": CreatePromptOutput(
+                    success=False, message=message, rejected_reason=reason
+                ).model_dump(),
+                "observation": {"summary": f"Prompt rejected: {message}", "artifacts": []},
+            },
+        )

--- a/backend/app/ai/tools/implementations/edit_prompt.py
+++ b/backend/app/ai/tools/implementations/edit_prompt.py
@@ -1,0 +1,186 @@
+"""Edit Prompt Tool - Update an existing reusable prompt (training mode).
+
+Mirrors create_prompt's authorization: PromptService.update_prompt requires the
+caller to own the prompt, hold `manage` on all its agents, or be org admin.
+Edits are live immediately.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from fastapi import HTTPException
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.edit_prompt import EditPromptInput, EditPromptOutput
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_SCOPES = {"agent", "private", "global"}
+VALID_MODES = {"chat", "deep", "training"}
+
+
+class EditPromptTool(Tool):
+    """Edit an existing reusable prompt."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="edit_prompt",
+            description=(
+                "ACTION: Update an existing reusable prompt — refine its text/title, change "
+                "the agents it's attached to (data_source_ids), toggle conversation-starter, "
+                "or adjust mode/parameters. Only the fields you set are changed. Find the "
+                "prompt_id via search_prompts. You must manage the prompt (own it, manage its "
+                "agents, or be org admin)."
+            ),
+            category="action",
+            version="1.0.0",
+            input_schema=EditPromptInput.model_json_schema(),
+            output_schema=EditPromptOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=30,
+            idempotent=False,
+            required_permissions=[],
+            tags=["training", "prompt", "curation"],
+            allowed_modes=["training"],
+            examples=[
+                {
+                    "input": {"prompt_id": "abc123", "title": "Monthly revenue by category (v2)"},
+                    "description": "Rename a prompt.",
+                },
+                {
+                    "input": {"prompt_id": "abc123", "is_starter": True, "data_source_ids": ["ds-1", "ds-2"]},
+                    "description": "Make it a starter and re-attach it to two agents.",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return EditPromptInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return EditPromptOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = EditPromptInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {e}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={"prompt_id": data.prompt_id},
+        )
+
+        if data.scope is not None and data.scope not in VALID_SCOPES:
+            yield self._reject(data.prompt_id, f"Invalid scope '{data.scope}'.", "invalid_scope")
+            return
+        if data.mode is not None and data.mode not in VALID_MODES:
+            yield self._reject(data.prompt_id, f"Invalid mode '{data.mode}'.", "invalid_mode")
+            return
+
+        db = runtime_ctx.get("db")
+        organization = runtime_ctx.get("organization")
+        user = runtime_ctx.get("user")
+
+        if not all([db, organization, user]):
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": "Missing required runtime context (db, organization, user)",
+                    "code": "MISSING_CONTEXT",
+                },
+            )
+            return
+
+        try:
+            from app.schemas.prompt_schema import PromptUpdate, PromptParameter
+            from app.services.prompt_service import prompt_service
+
+            fields: Dict[str, Any] = {}
+            for key in ("text", "title", "scope", "mode", "is_starter", "data_source_ids"):
+                val = getattr(data, key)
+                if val is not None:
+                    fields[key] = val
+            if data.parameters is not None:
+                fields["parameters"] = [PromptParameter(**p.model_dump()) for p in data.parameters]
+
+            if not fields:
+                yield self._reject(data.prompt_id, "No fields to update.", "no_changes")
+                return
+
+            payload = PromptUpdate(**fields)
+            prompt = await prompt_service.update_prompt(
+                db, data.prompt_id, payload, user, organization
+            )
+
+            title = prompt.title or (prompt.text or "")[:60]
+            logger.info(f"Training mode edited prompt {prompt.id}: '{title}'")
+
+            output = EditPromptOutput(
+                success=True,
+                prompt_id=str(prompt.id),
+                title=title,
+                message=f"Prompt updated: {title}",
+            )
+
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": output.model_dump(),
+                    "observation": {
+                        "summary": f"Edited prompt '{title}' (fields: {', '.join(sorted(fields))})",
+                        "artifacts": [
+                            {
+                                "type": "prompt",
+                                "id": str(prompt.id),
+                                "title": title,
+                                "scope": prompt.scope,
+                                "is_starter": prompt.is_starter,
+                            }
+                        ],
+                    },
+                },
+            )
+        except HTTPException as he:
+            if he.status_code == 404:
+                reason = "not_found"
+            elif he.status_code == 403:
+                reason = "permission_denied"
+            else:
+                reason = "rejected"
+            yield self._reject(data.prompt_id, str(he.detail), reason)
+        except Exception as e:
+            logger.exception(f"edit_prompt failed: {e}")
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Failed to edit prompt: {e}", "code": "EDIT_FAILED"},
+            )
+
+    @staticmethod
+    def _reject(prompt_id: str, message: str, reason: str) -> ToolEndEvent:
+        return ToolEndEvent(
+            type="tool.end",
+            payload={
+                "output": EditPromptOutput(
+                    success=False, prompt_id=prompt_id, message=message, rejected_reason=reason
+                ).model_dump(),
+                "observation": {"summary": f"Prompt edit rejected: {message}", "artifacts": []},
+            },
+        )

--- a/backend/app/ai/tools/implementations/search_prompts.py
+++ b/backend/app/ai/tools/implementations/search_prompts.py
@@ -1,0 +1,207 @@
+"""Search Prompts Tool - Discover existing reusable prompts (training mode).
+
+Lists prompts visible to the caller (access-scoped by PromptService) and applies
+keyword/regex union filtering in-process, mirroring search_instructions. Use
+before create_prompt to avoid duplicates or to find a prompt to edit.
+"""
+
+from typing import AsyncIterator, Dict, Any, Type
+from pydantic import BaseModel
+import logging
+
+from app.ai.tools.base import Tool
+from app.ai.tools.metadata import ToolMetadata
+from app.ai.tools.schemas.search_prompts import (
+    SearchPromptsInput,
+    SearchPromptsOutput,
+    SearchPromptsItem,
+)
+from app.ai.tools.schemas.events import (
+    ToolEvent,
+    ToolStartEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SearchPromptsTool(Tool):
+    """Search/list existing reusable prompts."""
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="search_prompts",
+            description=(
+                "RESEARCH: Search existing reusable prompts by a list of keyword OR regex "
+                "queries (case-insensitive, unioned over title + text). Filter by scope, "
+                "agent (data_source_id), or starters_only. Use BEFORE create_prompt to check "
+                "for duplicates or to find a prompt to edit. Leave query empty to list all "
+                "visible prompts."
+            ),
+            category="research",
+            version="1.0.0",
+            input_schema=SearchPromptsInput.model_json_schema(),
+            output_schema=SearchPromptsOutput.model_json_schema(),
+            max_retries=1,
+            timeout_seconds=20,
+            idempotent=True,
+            required_permissions=[],
+            tags=["training", "prompt", "search", "curation"],
+            allowed_modes=["training"],
+            examples=[
+                {
+                    "input": {"query": ["revenue", "monthly"], "limit": 20},
+                    "description": "Find prompts mentioning revenue or monthly.",
+                },
+                {
+                    "input": {"starters_only": True},
+                    "description": "List the conversation starters across visible agents.",
+                },
+            ],
+        )
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return SearchPromptsInput
+
+    @property
+    def output_model(self) -> Type[BaseModel]:
+        return SearchPromptsOutput
+
+    async def run_stream(
+        self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]
+    ) -> AsyncIterator[ToolEvent]:
+        try:
+            data = SearchPromptsInput(**tool_input)
+        except Exception as e:
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Invalid input: {e}", "code": "INVALID_INPUT"},
+            )
+            return
+
+        yield ToolStartEvent(
+            type="tool.start",
+            payload={
+                "query": data.query,
+                "scope": data.scope,
+                "data_source_id": data.data_source_id,
+                "starters_only": data.starters_only,
+                "limit": data.limit,
+            },
+        )
+
+        db = runtime_ctx.get("db")
+        organization = runtime_ctx.get("organization")
+        user = runtime_ctx.get("user")
+
+        if not all([db, organization, user]):
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={
+                    "error": "Missing required runtime context (db, organization, user)",
+                    "code": "MISSING_CONTEXT",
+                },
+            )
+            return
+
+        try:
+            import re
+            from app.services.prompt_service import prompt_service
+
+            result = await prompt_service.list_prompts(
+                db=db,
+                current_user=user,
+                organization=organization,
+                scope=data.scope,
+                data_source_id=data.data_source_id,
+                starters_only=data.starters_only,
+            )
+            candidates = result.get("prompts", []) if isinstance(result, dict) else []
+
+            # --- Resolve queries into compiled patterns (literal + optional regex) ---
+            queries = [q for q in (data.query or []) if isinstance(q, str) and q.strip()]
+            special = re.compile(r"[\^\$\.\*\+\?\[\]\(\)\{\}\|]")
+            patterns = []
+            pattern_errors = []
+            for q in queries:
+                stripped = q.strip()
+                try:
+                    patterns.append(re.compile(re.escape(stripped), re.IGNORECASE))
+                except re.error:
+                    pass
+                if special.search(stripped):
+                    try:
+                        patterns.append(re.compile(stripped, re.IGNORECASE))
+                    except re.error as re_err:
+                        pattern_errors.append(f"'{stripped}': {re_err}")
+
+            if patterns:
+                matched = []
+                for p in candidates:
+                    haystack = (
+                        (p.get("text") or "") + "\n"
+                        + (p.get("title") or "") + "\n"
+                        + str(p.get("id") or "")
+                    )
+                    if any(pat.search(haystack) for pat in patterns):
+                        matched.append(p)
+                items = matched[: data.limit]
+                total = len(matched)
+            else:
+                items = candidates[: data.limit]
+                total = len(candidates)
+
+            search_items = [
+                SearchPromptsItem(
+                    id=str(p.get("id", "")),
+                    title=p.get("title"),
+                    text=p.get("text", "") or "",
+                    scope=p.get("scope"),
+                    mode=p.get("mode"),
+                    is_starter=p.get("is_starter"),
+                    data_source_ids=[str(d) for d in (p.get("data_source_ids") or [])],
+                    can_manage=bool(p.get("can_manage", False)),
+                )
+                for p in items
+            ]
+
+            msg = f"Found {len(search_items)} prompt(s) (total matching: {total})"
+            if pattern_errors:
+                msg = f"{msg}. Invalid regex(es) skipped: {'; '.join(pattern_errors)}"
+
+            output = SearchPromptsOutput(
+                success=True, prompts=search_items, total=total, message=msg
+            )
+
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": output.model_dump(),
+                    "observation": {
+                        "summary": (
+                            f"Found {len(search_items)} prompt(s) "
+                            f"(query={queries}, scope={data.scope or 'any'})"
+                        ),
+                        "artifacts": [
+                            {
+                                "type": "prompt_search_result",
+                                "count": len(search_items),
+                                "total": total,
+                                "items": [
+                                    {"id": i.id, "title": i.title, "scope": i.scope, "is_starter": i.is_starter}
+                                    for i in search_items
+                                ],
+                            }
+                        ],
+                    },
+                },
+            )
+        except Exception as e:
+            logger.exception(f"search_prompts failed: {e}")
+            yield ToolErrorEvent(
+                type="tool.error",
+                payload={"error": f"Search failed: {e}", "code": "SEARCH_FAILED"},
+            )

--- a/backend/app/ai/tools/schemas/create_prompt.py
+++ b/backend/app/ai/tools/schemas/create_prompt.py
@@ -1,0 +1,85 @@
+from typing import Optional, List, Any
+from pydantic import BaseModel, Field
+
+
+class PromptParameterSpec(BaseModel):
+    """A single template parameter for a prompt (mirrors PromptParameter)."""
+    name: str = Field(..., description="Placeholder key referenced in the text as {{name}}.")
+    label: Optional[str] = Field(None, description="Human-friendly label shown when filling the prompt.")
+    type: str = Field('text', description="One of: 'text', 'number', 'enum', 'date', 'date_range'.")
+    required: bool = Field(False, description="Whether the user must supply a value before running.")
+    default: Optional[Any] = Field(None, description="Default value used when none is supplied.")
+    options: Optional[List[str]] = Field(None, description="Allowed values when type == 'enum'.")
+
+
+class CreatePromptInput(BaseModel):
+    """Input schema for create_prompt tool — saves a reusable prompt for an agent.
+
+    A prompt is a saved, completion-shaped instruction users can re-run (or that
+    surfaces as a conversation starter). Use this in training mode to curate the
+    reusable prompts attached to the agent(s) you manage.
+    """
+
+    text: str = Field(
+        ...,
+        description=(
+            "The prompt body — what gets sent as the user message when the prompt "
+            "is run. Write it as a clear, self-contained analytical request. "
+            "Templated placeholders use {{name}} and must be declared in `parameters`."
+        ),
+        min_length=4,
+    )
+
+    title: Optional[str] = Field(
+        None,
+        description="Short human-friendly title. Auto-derived from the text when omitted.",
+        max_length=200,
+    )
+
+    scope: str = Field(
+        'agent',
+        description=(
+            "'agent' (default) attaches the prompt to the agent(s) in `data_source_ids` "
+            "(falls back to the agents on the current report); 'private' is visible only "
+            "to you. 'global' (org-wide) requires org admin and is usually not appropriate "
+            "in training mode."
+        ),
+    )
+
+    data_source_ids: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Agent (data source) IDs to attach an 'agent'-scoped prompt to. When omitted, "
+            "the agents attached to the current report are used. Ignored for 'private'/'global'."
+        ),
+    )
+
+    mode: str = Field(
+        'chat',
+        description="Mode the prompt runs in: 'chat' (default), 'deep', or 'training'.",
+    )
+
+    is_starter: bool = Field(
+        False,
+        description="When true, the prompt is surfaced as a conversation starter for the agent.",
+    )
+
+    parameters: Optional[List[PromptParameterSpec]] = Field(
+        None,
+        description="Template parameters for {{placeholders}} in the text.",
+    )
+
+
+class CreatePromptOutput(BaseModel):
+    """Output schema for create_prompt tool response."""
+
+    success: bool = Field(..., description="Whether the prompt was created")
+    prompt_id: Optional[str] = Field(None, description="ID of the created prompt")
+    title: Optional[str] = Field(None, description="Resolved title of the prompt")
+    scope: Optional[str] = Field(None, description="Scope the prompt was created with")
+    data_source_ids: List[str] = Field(default_factory=list, description="Agents the prompt is attached to")
+    is_starter: Optional[bool] = Field(None, description="Whether it surfaces as a conversation starter")
+    message: str = Field(..., description="Status message")
+    rejected_reason: Optional[str] = Field(
+        None, description="Reason if rejected (e.g. permission_denied, no_data_sources, invalid_scope)"
+    )

--- a/backend/app/ai/tools/schemas/edit_prompt.py
+++ b/backend/app/ai/tools/schemas/edit_prompt.py
@@ -1,0 +1,64 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+from app.ai.tools.schemas.create_prompt import PromptParameterSpec
+
+
+class EditPromptInput(BaseModel):
+    """Input schema for edit_prompt tool — updates an existing reusable prompt.
+
+    Use this to refine a prompt's text/title, change which agents it's attached
+    to, toggle conversation-starter, or adjust its mode/parameters. Only the
+    fields you set are changed.
+    """
+
+    prompt_id: str = Field(
+        ...,
+        description=(
+            "ID of the prompt to edit. Find it via search_prompts or from a prior "
+            "create_prompt observation."
+        ),
+    )
+
+    text: Optional[str] = Field(
+        None,
+        description="New prompt body. Leave unset to keep the current text.",
+        min_length=4,
+    )
+
+    title: Optional[str] = Field(None, description="New title.", max_length=200)
+
+    scope: Optional[str] = Field(
+        None,
+        description="New scope: 'agent', 'private', or 'global' (global requires org admin).",
+    )
+
+    data_source_ids: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Replacement set of agent (data source) IDs to attach the prompt to. "
+            "Pass an empty list to detach from all agents."
+        ),
+    )
+
+    mode: Optional[str] = Field(None, description="New mode: 'chat', 'deep', or 'training'.")
+
+    is_starter: Optional[bool] = Field(
+        None, description="Toggle whether the prompt surfaces as a conversation starter."
+    )
+
+    parameters: Optional[List[PromptParameterSpec]] = Field(
+        None, description="Replacement template parameters."
+    )
+
+
+class EditPromptOutput(BaseModel):
+    """Output schema for edit_prompt tool response."""
+
+    success: bool = Field(..., description="Whether the prompt was updated")
+    prompt_id: str = Field(..., description="ID of the prompt that was edited")
+    title: Optional[str] = Field(None, description="Title after the edit")
+    message: str = Field(..., description="Status message")
+    rejected_reason: Optional[str] = Field(
+        None, description="Reason if rejected (e.g. not_found, permission_denied, invalid_scope)"
+    )

--- a/backend/app/ai/tools/schemas/search_prompts.py
+++ b/backend/app/ai/tools/schemas/search_prompts.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class SearchPromptsInput(BaseModel):
+    """Input schema for search_prompts tool.
+
+    Lists/searches existing reusable prompts visible to the caller. Use BEFORE
+    create_prompt to avoid duplicates, or to find a prompt to edit.
+    """
+
+    query: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Keywords OR regex patterns (case-insensitive, unioned). A prompt matches if "
+            "ANY query hits its title or text. Regex is auto-detected by metacharacters "
+            "(`^$.*+?[](){}|`). Leave empty to list all visible prompts filtered by the "
+            "other params."
+        ),
+        max_length=10,
+    )
+
+    scope: Optional[str] = Field(
+        None,
+        description="Filter by scope: 'agent', 'global', or 'private'.",
+    )
+
+    data_source_id: Optional[str] = Field(
+        None,
+        description="Filter to prompts attached to this agent (data source) ID.",
+    )
+
+    starters_only: bool = Field(
+        False,
+        description="When true, only return prompts flagged as conversation starters.",
+    )
+
+    limit: int = Field(
+        20,
+        description="Maximum number of prompts to return (1-50).",
+        ge=1,
+        le=50,
+    )
+
+
+class SearchPromptsItem(BaseModel):
+    """A single prompt in the search results."""
+    id: str
+    title: Optional[str] = None
+    text: str
+    scope: Optional[str] = None
+    mode: Optional[str] = None
+    is_starter: Optional[bool] = None
+    data_source_ids: List[str] = []
+    can_manage: bool = False
+
+
+class SearchPromptsOutput(BaseModel):
+    """Output schema for search_prompts tool response."""
+
+    success: bool = Field(..., description="Whether the search succeeded")
+    prompts: List[SearchPromptsItem] = Field(
+        default_factory=list, description="Matching prompts."
+    )
+    total: int = Field(0, description="Total number of matching prompts.")
+    message: Optional[str] = Field(None, description="Status or error message.")

--- a/backend/tests/prompts/test_prompt_training_tools.py
+++ b/backend/tests/prompts/test_prompt_training_tools.py
@@ -1,0 +1,134 @@
+"""Training-mode prompt tools: create_prompt / search_prompts / edit_prompt.
+
+Exercises the tools through their run_stream against the real PromptService,
+including the manage_agent (`manage` grant) authorization gate.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      .venv/bin/python -m pytest tests/prompts/test_prompt_training_tools.py -v -s
+"""
+import uuid
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.data_source import DataSource
+from app.models.resource_grant import ResourceGrant
+from app.models.membership import Membership
+from app.models.role import Role
+from app.models.role_assignment import RoleAssignment
+
+from app.ai.tools.implementations.create_prompt import CreatePromptTool
+from app.ai.tools.implementations.edit_prompt import EditPromptTool
+from app.ai.tools.implementations.search_prompts import SearchPromptsTool
+
+
+async def _final(tool, tool_input, ctx):
+    """Drain run_stream and return the terminal event's payload."""
+    last = None
+    async for ev in tool.run_stream(tool_input, ctx):
+        last = ev
+    return last
+
+
+def _u(suffix, name):
+    return User(name=f"{name} {suffix}", email=f"{name.lower()}-{suffix}@example.com",
+                hashed_password="x", is_active=True, is_verified=True)
+
+
+async def _grant(db, org_id, ds_id, user_id, perms):
+    db.add(ResourceGrant(
+        organization_id=org_id, resource_type="data_source", resource_id=ds_id,
+        principal_type="user", principal_id=user_id, permissions=perms,
+    ))
+
+
+async def _seed():
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"PromptTool Org {suffix}")
+        db.add(org); await db.flush()
+        # manager: only a per-agent `manage` grant (no admin role) — the manage_agent tier
+        manager = _u(suffix, "Manager")
+        # outsider: member with no grant on the agent
+        outsider = _u(suffix, "Outsider")
+        db.add_all([manager, outsider]); await db.flush()
+        for u in (manager, outsider):
+            db.add(Membership(user_id=u.id, organization_id=org.id, role="member"))
+        ds = DataSource(name=f"Agent {suffix}", organization_id=org.id, is_active=True, owner_user_id=manager.id)
+        db.add(ds); await db.flush()
+        await _grant(db, org.id, ds.id, manager.id, ["view", "manage"])
+        await db.commit()
+        return {"org": org.id, "manager": manager.id, "outsider": outsider.id, "ds": ds.id}
+
+
+@pytest.mark.asyncio
+async def test_prompt_training_tools_end_to_end():
+    ids = await _seed()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org"])
+        manager = await db.get(User, ids["manager"])
+        outsider = await db.get(User, ids["outsider"])
+
+        mgr_ctx = {"db": db, "organization": org, "user": manager}
+        out_ctx = {"db": db, "organization": org, "user": outsider}
+
+        # --- create (manager, agent-scoped) ---
+        ev = await _final(CreatePromptTool(), {
+            "text": "Show monthly revenue by product category for the last 12 months.",
+            "title": "Monthly revenue by category",
+            "is_starter": True,
+            "data_source_ids": [ids["ds"]],
+        }, mgr_ctx)
+        out = ev.payload["output"]
+        assert out["success"] is True, out
+        assert out["scope"] == "agent"
+        assert ids["ds"] in out["data_source_ids"]
+        assert out["is_starter"] is True
+        prompt_id = out["prompt_id"]
+        print(f"[create] ok -> {prompt_id} attached to agent {ids['ds']}")
+
+        # --- create denied for a non-manager of the agent ---
+        ev = await _final(CreatePromptTool(), {
+            "text": "Outsider should not be able to attach this.",
+            "data_source_ids": [ids["ds"]],
+        }, out_ctx)
+        out = ev.payload["output"]
+        assert out["success"] is False and out["rejected_reason"] == "permission_denied", out
+        print("[create] correctly denied for non-manager (manage_agent gate)")
+
+        # --- search finds it ---
+        ev = await _final(SearchPromptsTool(), {"query": ["revenue"]}, mgr_ctx)
+        out = ev.payload["output"]
+        assert out["success"] is True
+        assert prompt_id in {p["id"] for p in out["prompts"]}, out
+        print(f"[search] found {out['total']} prompt(s) for 'revenue'")
+
+        # --- search starters_only ---
+        ev = await _final(SearchPromptsTool(), {"starters_only": True}, mgr_ctx)
+        assert prompt_id in {p["id"] for p in ev.payload["output"]["prompts"]}
+        print("[search] starters_only returns the starter")
+
+        # --- edit (rename + toggle starter off) ---
+        ev = await _final(EditPromptTool(), {
+            "prompt_id": prompt_id,
+            "title": "Monthly revenue by category (v2)",
+            "is_starter": False,
+        }, mgr_ctx)
+        out = ev.payload["output"]
+        assert out["success"] is True and out["title"].endswith("(v2)"), out
+        print("[edit] renamed + starter toggled off")
+
+        # --- edit denied for outsider ---
+        ev = await _final(EditPromptTool(), {"prompt_id": prompt_id, "title": "hijack"}, out_ctx)
+        out = ev.payload["output"]
+        assert out["success"] is False and out["rejected_reason"] == "permission_denied", out
+        print("[edit] correctly denied for non-manager")
+
+        # --- confirm edit persisted via search ---
+        ev = await _final(SearchPromptsTool(), {"query": ["v2"]}, mgr_ctx)
+        titles = {p["title"] for p in ev.payload["output"]["prompts"]}
+        assert any(t and t.endswith("(v2)") for t in titles), titles
+        print("[verify] edit persisted")

--- a/frontend/components/tools/CreatePromptTool.vue
+++ b/frontend/components/tools/CreatePromptTool.vue
@@ -8,26 +8,26 @@
       >
         <span v-if="status === 'running'" class="tool-shimmer flex items-center">
           <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1.5 text-gray-400" />
-          <span v-if="promptTitle" dir="auto" class="truncate max-w-[300px]">Saving prompt: {{ promptTitle }}</span>
-          <span v-else>Saving prompt…</span>
+          <span v-if="promptTitle" dir="auto" class="truncate max-w-[300px]">{{ $t('tools.createPrompt.savingPrefix', { title: promptTitle }) }}</span>
+          <span v-else>{{ $t('tools.createPrompt.saving') }}</span>
         </span>
         <span v-else-if="isSuccess" class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1.5 text-green-500" />
           <span dir="auto" class="truncate max-w-[300px]">{{ promptTitle }}</span>
           <span class="ms-1.5 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded text-[10px] shrink-0">{{ scope }}</span>
-          <span v-if="isStarter" class="ms-1 px-1.5 py-0.5 bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 rounded text-[10px] shrink-0">starter</span>
-          <span v-if="paramCount > 0" class="ms-1 px-1.5 py-0.5 bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded text-[10px] shrink-0">{{ paramCount }} params</span>
+          <span v-if="isStarter" class="ms-1 px-1.5 py-0.5 bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 rounded text-[10px] shrink-0">{{ $t('tools.createPrompt.starter') }}</span>
+          <span v-if="paramCount > 0" class="ms-1 px-1.5 py-0.5 bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded text-[10px] shrink-0">{{ $t('tools.createPrompt.paramsBadge', { n: paramCount }) }}</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip" />
         </span>
         <span v-else-if="isRejected" class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-orange-500" />
-          <span>Prompt not saved</span>
+          <span>{{ $t('tools.createPrompt.notSaved') }}</span>
           <span v-if="rejectedReason" class="ms-1.5 text-orange-600 text-[10px]">({{ rejectedReason }})</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
         </span>
         <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
-          <span>Failed to save prompt</span>
+          <span>{{ $t('tools.createPrompt.failed') }}</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
         </span>
       </div>
@@ -45,36 +45,36 @@
           <!-- Metadata row -->
           <div class="flex flex-wrap items-center gap-2 text-[10px] mb-1">
             <div class="flex items-center gap-1">
-              <span class="text-gray-500 dark:text-gray-400">Scope</span>
+              <span class="text-gray-500 dark:text-gray-400">{{ $t('tools.createPrompt.scope') }}</span>
               <span class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ scope }}</span>
             </div>
             <div v-if="mode && mode !== 'chat'" class="flex items-center gap-1">
-              <span class="text-gray-500 dark:text-gray-400">Mode</span>
+              <span class="text-gray-500 dark:text-gray-400">{{ $t('tools.createPrompt.mode') }}</span>
               <span class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ mode }}</span>
             </div>
             <div v-if="isStarter" class="flex items-center gap-1">
               <Icon name="heroicons-sparkles" class="w-3 h-3 text-amber-500" />
-              <span class="text-gray-600 dark:text-gray-400">conversation starter</span>
+              <span class="text-gray-600 dark:text-gray-400">{{ $t('tools.createPrompt.conversationStarter') }}</span>
             </div>
             <div v-if="agentCount > 0" class="flex items-center gap-1">
               <Icon name="heroicons-cube" class="w-3 h-3 text-gray-400" />
-              <span class="text-gray-600 dark:text-gray-400">{{ agentCount === 1 ? '1 agent' : agentCount + ' agents' }}</span>
+              <span class="text-gray-600 dark:text-gray-400">{{ agentCount === 1 ? $t('tools.createPrompt.agentSingular', { n: agentCount }) : $t('tools.createPrompt.agentPlural', { n: agentCount }) }}</span>
             </div>
           </div>
 
           <!-- Parameters -->
           <div v-if="paramCount > 0" class="flex flex-wrap items-center gap-1 mb-2">
-            <span class="text-[10px] text-gray-500 dark:text-gray-400">Parameters:</span>
+            <span class="text-[10px] text-gray-500 dark:text-gray-400">{{ $t('tools.createPrompt.parameters') }}</span>
             <code v-for="chip in paramChips" :key="chip" class="text-[10px] px-1 py-0.5 bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded">{{ chip }}</code>
           </div>
 
           <!-- Live + open -->
           <div v-if="isSuccess" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
             <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
-            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">Live</span>
+            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">{{ $t('tools.createPrompt.live') }}</span>
             <button class="ms-auto text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click.stop="openPrompts">
               <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
-              <span>Open in Prompts</span>
+              <span>{{ $t('tools.createPrompt.openInPrompts') }}</span>
             </button>
           </div>
 
@@ -90,6 +90,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 interface ToolExecution {
   id: string
@@ -119,7 +121,7 @@ const promptTitle = computed(() => {
   if (t) return t
   const txt = String(promptText.value || '').trim()
   const firstLine = txt.split('\n')[0].replace(/^#+\s*/, '').trim()
-  return firstLine.length > 60 ? firstLine.slice(0, 57) + '…' : (firstLine || 'Prompt')
+  return firstLine.length > 60 ? firstLine.slice(0, 57) + '…' : (firstLine || t('tools.createPrompt.saving'))
 })
 const scope = computed(() => result.value.scope || args.value.scope || 'agent')
 const mode = computed(() => args.value.mode || 'chat')

--- a/frontend/components/tools/CreatePromptTool.vue
+++ b/frontend/components/tools/CreatePromptTool.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="mt-1">
+    <!-- Status header -->
+    <Transition name="fade" appear>
+      <div
+        class="flex items-center text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300"
+        @click="toggleExpanded"
+      >
+        <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+          <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1.5 text-gray-400" />
+          <span v-if="promptTitle" dir="auto" class="truncate max-w-[300px]">Saving prompt: {{ promptTitle }}</span>
+          <span v-else>Saving prompt…</span>
+        </span>
+        <span v-else-if="isSuccess" class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1.5 text-green-500" />
+          <span dir="auto" class="truncate max-w-[300px]">{{ promptTitle }}</span>
+          <span class="ms-1.5 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded text-[10px] shrink-0">{{ scope }}</span>
+          <span v-if="isStarter" class="ms-1 px-1.5 py-0.5 bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 rounded text-[10px] shrink-0">starter</span>
+          <span v-if="paramCount > 0" class="ms-1 px-1.5 py-0.5 bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded text-[10px] shrink-0">{{ paramCount }} params</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip" />
+        </span>
+        <span v-else-if="isRejected" class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-orange-500" />
+          <span>Prompt not saved</span>
+          <span v-if="rejectedReason" class="ms-1.5 text-orange-600 text-[10px]">({{ rejectedReason }})</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
+        </span>
+        <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
+          <span>Failed to save prompt</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
+        </span>
+      </div>
+    </Transition>
+
+    <!-- Expandable content -->
+    <Transition name="slide">
+      <div v-if="isExpanded && (status !== 'running' || promptText)" class="mt-2 space-y-2">
+        <div class="hover:bg-gray-50 dark:hover:bg-gray-800 border border-gray-150 dark:border-gray-700 rounded-md p-3 transition-colors">
+          <!-- Prompt text -->
+          <div v-if="promptText" dir="auto" class="prompt-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2">
+            <MDC :value="promptText" class="markdown-content" />
+          </div>
+
+          <!-- Metadata row -->
+          <div class="flex flex-wrap items-center gap-2 text-[10px] mb-1">
+            <div class="flex items-center gap-1">
+              <span class="text-gray-500 dark:text-gray-400">Scope</span>
+              <span class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ scope }}</span>
+            </div>
+            <div v-if="mode && mode !== 'chat'" class="flex items-center gap-1">
+              <span class="text-gray-500 dark:text-gray-400">Mode</span>
+              <span class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ mode }}</span>
+            </div>
+            <div v-if="isStarter" class="flex items-center gap-1">
+              <Icon name="heroicons-sparkles" class="w-3 h-3 text-amber-500" />
+              <span class="text-gray-600 dark:text-gray-400">conversation starter</span>
+            </div>
+            <div v-if="agentCount > 0" class="flex items-center gap-1">
+              <Icon name="heroicons-cube" class="w-3 h-3 text-gray-400" />
+              <span class="text-gray-600 dark:text-gray-400">{{ agentCount === 1 ? '1 agent' : agentCount + ' agents' }}</span>
+            </div>
+          </div>
+
+          <!-- Parameters -->
+          <div v-if="paramCount > 0" class="flex flex-wrap items-center gap-1 mb-2">
+            <span class="text-[10px] text-gray-500 dark:text-gray-400">Parameters:</span>
+            <code v-for="chip in paramChips" :key="chip" class="text-[10px] px-1 py-0.5 bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded">{{ chip }}</code>
+          </div>
+
+          <!-- Live + open -->
+          <div v-if="isSuccess" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
+            <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
+            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">Live</span>
+            <button class="ms-auto text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click.stop="openPrompts">
+              <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
+              <span>Open in Prompts</span>
+            </button>
+          </div>
+
+          <!-- Error / rejection message -->
+          <div v-if="errorMessage" class="text-[10px] text-orange-600 bg-orange-50/50 dark:bg-orange-950 rounded px-2 py-1 mt-2">
+            {{ errorMessage }}
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  status: string
+  result_summary?: string
+  result_json?: any
+  arguments_json?: any
+}
+const props = defineProps<{ toolExecution: ToolExecution }>()
+
+const isExpanded = ref(true)
+const status = computed<string>(() => props.toolExecution?.status || '')
+
+const isSuccess = computed(() => status.value === 'success' && (props.toolExecution?.result_json || {}).success === true)
+const isRejected = computed(() => {
+  const rj = props.toolExecution?.result_json || {}
+  return status.value === 'success' && rj.success === false && rj.rejected_reason
+})
+
+const args = computed(() => props.toolExecution?.arguments_json || {})
+const result = computed(() => props.toolExecution?.result_json || {})
+
+const promptText = computed(() => args.value.text || '')
+const promptTitle = computed(() => {
+  const t = result.value.title || args.value.title
+  if (t) return t
+  const txt = String(promptText.value || '').trim()
+  const firstLine = txt.split('\n')[0].replace(/^#+\s*/, '').trim()
+  return firstLine.length > 60 ? firstLine.slice(0, 57) + '…' : (firstLine || 'Prompt')
+})
+const scope = computed(() => result.value.scope || args.value.scope || 'agent')
+const mode = computed(() => args.value.mode || 'chat')
+const isStarter = computed(() => result.value.is_starter ?? args.value.is_starter ?? false)
+const agentCount = computed(() => {
+  const ids = result.value.data_source_ids || args.value.data_source_ids || []
+  return Array.isArray(ids) ? ids.length : 0
+})
+const paramNames = computed(() => (Array.isArray(args.value.parameters) ? args.value.parameters.map((p: any) => p?.name).filter(Boolean) : []))
+const paramCount = computed(() => paramNames.value.length)
+const paramChips = computed(() => paramNames.value.map((p: string) => '{' + '{' + p + '}' + '}'))
+const rejectedReason = computed(() => result.value.rejected_reason || '')
+const errorMessage = computed(() => {
+  if (status.value === 'error') return result.value.error || result.value.message || 'An error occurred'
+  if (isRejected.value) return result.value.message || ''
+  return ''
+})
+
+function toggleExpanded() {
+  if (status.value !== 'running' || promptText.value) isExpanded.value = !isExpanded.value
+}
+function openPrompts() {
+  navigateTo('/prompts')
+}
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+@keyframes shimmer { 0% { background-position: 0% 0; } 100% { background-position: 100% 0; } }
+.fade-enter-active, .fade-leave-active { transition: opacity 0.2s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.slide-enter-active, .slide-leave-active { transition: all 0.15s ease; overflow: hidden; }
+.slide-enter-from, .slide-leave-to { opacity: 0; max-height: 0; }
+.slide-enter-to, .slide-leave-from { opacity: 1; max-height: 500px; }
+.prompt-content :deep(.markdown-content) { font-size: 12px; line-height: 1.5; }
+.prompt-content :deep(.markdown-content p) { margin: 0 0 0.5em 0; }
+.prompt-content :deep(.markdown-content p:last-child) { margin-bottom: 0; }
+.prompt-content :deep(.markdown-content code) { font-size: 10px; padding: 0.1em 0.3em; background: rgba(0,0,0,0.05); border-radius: 3px; }
+</style>

--- a/frontend/components/tools/EditPromptTool.vue
+++ b/frontend/components/tools/EditPromptTool.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="mt-1">
+    <!-- Status header -->
+    <Transition name="fade" appear>
+      <div
+        class="flex items-center text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300"
+        @click="toggleExpanded"
+      >
+        <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+          <Icon name="heroicons-pencil-square" class="w-3 h-3 me-1.5 text-gray-400" />
+          <span>Updating prompt…</span>
+        </span>
+        <span v-else-if="isSuccess" class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-pencil-square" class="w-3 h-3 me-1.5 text-green-500" />
+          <span dir="auto" class="truncate max-w-[300px]">Updated: {{ promptTitle }}</span>
+          <span v-if="changedFields.length" class="ms-1.5 text-[10px] text-gray-400 shrink-0">· {{ changedFields.join(', ') }}</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip" />
+        </span>
+        <span v-else-if="isRejected" class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-orange-500" />
+          <span>Prompt not updated</span>
+          <span v-if="rejectedReason" class="ms-1.5 text-orange-600 text-[10px]">({{ rejectedReason }})</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
+        </span>
+        <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
+          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
+          <span>Failed to update prompt</span>
+          <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
+        </span>
+      </div>
+    </Transition>
+
+    <!-- Expandable content -->
+    <Transition name="slide">
+      <div v-if="isExpanded && status !== 'running'" class="mt-2 space-y-2">
+        <div class="hover:bg-gray-50 dark:hover:bg-gray-800 border border-gray-150 dark:border-gray-700 rounded-md p-3 transition-colors">
+          <div v-if="newText" dir="auto" class="prompt-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2">
+            <MDC :value="newText" class="markdown-content" />
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-[10px] mb-1">
+            <span class="text-gray-500 dark:text-gray-400">Changed:</span>
+            <span v-for="f in changedFields" :key="f" class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ f }}</span>
+            <span v-if="!changedFields.length" class="text-gray-400">no fields</span>
+          </div>
+          <div v-if="isSuccess" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
+            <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
+            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">Live</span>
+            <button class="ms-auto text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click.stop="openPrompts">
+              <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
+              <span>Open in Prompts</span>
+            </button>
+          </div>
+          <div v-if="errorMessage" class="text-[10px] text-orange-600 bg-orange-50/50 dark:bg-orange-950 rounded px-2 py-1 mt-2">
+            {{ errorMessage }}
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  status: string
+  result_summary?: string
+  result_json?: any
+  arguments_json?: any
+}
+const props = defineProps<{ toolExecution: ToolExecution }>()
+
+const isExpanded = ref(true)
+const status = computed<string>(() => props.toolExecution?.status || '')
+const args = computed(() => props.toolExecution?.arguments_json || {})
+const result = computed(() => props.toolExecution?.result_json || {})
+
+const isSuccess = computed(() => status.value === 'success' && result.value.success === true)
+const isRejected = computed(() => status.value === 'success' && result.value.success === false && result.value.rejected_reason)
+
+const promptTitle = computed(() => result.value.title || args.value.title || 'prompt')
+const newText = computed(() => args.value.text || '')
+const changedFields = computed(() => {
+  const keys = ['text', 'title', 'scope', 'mode', 'is_starter', 'data_source_ids', 'parameters']
+  return keys.filter((k) => args.value[k] !== undefined && args.value[k] !== null)
+    .map((k) => (k === 'is_starter' ? 'starter' : k === 'data_source_ids' ? 'agents' : k))
+})
+const rejectedReason = computed(() => result.value.rejected_reason || '')
+const errorMessage = computed(() => {
+  if (status.value === 'error') return result.value.error || result.value.message || 'An error occurred'
+  if (isRejected.value) return result.value.message || ''
+  return ''
+})
+
+function toggleExpanded() { if (status.value !== 'running') isExpanded.value = !isExpanded.value }
+function openPrompts() { navigateTo('/prompts') }
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+@keyframes shimmer { 0% { background-position: 0% 0; } 100% { background-position: 100% 0; } }
+.fade-enter-active, .fade-leave-active { transition: opacity 0.2s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.slide-enter-active, .slide-leave-active { transition: all 0.15s ease; overflow: hidden; }
+.slide-enter-from, .slide-leave-to { opacity: 0; max-height: 0; }
+.slide-enter-to, .slide-leave-from { opacity: 1; max-height: 500px; }
+.prompt-content :deep(.markdown-content) { font-size: 12px; line-height: 1.5; }
+.prompt-content :deep(.markdown-content p) { margin: 0 0 0.5em 0; }
+.prompt-content :deep(.markdown-content p:last-child) { margin-bottom: 0; }
+.prompt-content :deep(.markdown-content code) { font-size: 10px; padding: 0.1em 0.3em; background: rgba(0,0,0,0.05); border-radius: 3px; }
+</style>

--- a/frontend/components/tools/EditPromptTool.vue
+++ b/frontend/components/tools/EditPromptTool.vue
@@ -8,23 +8,23 @@
       >
         <span v-if="status === 'running'" class="tool-shimmer flex items-center">
           <Icon name="heroicons-pencil-square" class="w-3 h-3 me-1.5 text-gray-400" />
-          <span>Updating prompt…</span>
+          <span>{{ $t('tools.editPrompt.updating') }}</span>
         </span>
         <span v-else-if="isSuccess" class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-pencil-square" class="w-3 h-3 me-1.5 text-green-500" />
-          <span dir="auto" class="truncate max-w-[300px]">Updated: {{ promptTitle }}</span>
+          <span dir="auto" class="truncate max-w-[300px]">{{ $t('tools.editPrompt.updatedPrefix', { title: promptTitle }) }}</span>
           <span v-if="changedFields.length" class="ms-1.5 text-[10px] text-gray-400 shrink-0">· {{ changedFields.join(', ') }}</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 shrink-0 rtl-flip" />
         </span>
         <span v-else-if="isRejected" class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-orange-500" />
-          <span>Prompt not updated</span>
+          <span>{{ $t('tools.editPrompt.notUpdated') }}</span>
           <span v-if="rejectedReason" class="ms-1.5 text-orange-600 text-[10px]">({{ rejectedReason }})</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
         </span>
         <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon name="heroicons-x-circle" class="w-3 h-3 me-1.5 text-red-500" />
-          <span>Failed to update prompt</span>
+          <span>{{ $t('tools.editPrompt.failed') }}</span>
           <Icon :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 ms-1 text-gray-400 rtl-flip" />
         </span>
       </div>
@@ -38,16 +38,16 @@
             <MDC :value="newText" class="markdown-content" />
           </div>
           <div class="flex flex-wrap items-center gap-2 text-[10px] mb-1">
-            <span class="text-gray-500 dark:text-gray-400">Changed:</span>
+            <span class="text-gray-500 dark:text-gray-400">{{ $t('tools.editPrompt.changed') }}</span>
             <span v-for="f in changedFields" :key="f" class="px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ f }}</span>
-            <span v-if="!changedFields.length" class="text-gray-400">no fields</span>
+            <span v-if="!changedFields.length" class="text-gray-400">{{ $t('tools.editPrompt.noFields') }}</span>
           </div>
           <div v-if="isSuccess" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
             <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
-            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">Live</span>
+            <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">{{ $t('tools.editPrompt.live') }}</span>
             <button class="ms-auto text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click.stop="openPrompts">
               <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
-              <span>Open in Prompts</span>
+              <span>{{ $t('tools.editPrompt.openInPrompts') }}</span>
             </button>
           </div>
           <div v-if="errorMessage" class="text-[10px] text-orange-600 bg-orange-50/50 dark:bg-orange-950 rounded px-2 py-1 mt-2">
@@ -61,6 +61,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 interface ToolExecution {
   id: string
@@ -82,10 +84,14 @@ const isRejected = computed(() => status.value === 'success' && result.value.suc
 
 const promptTitle = computed(() => result.value.title || args.value.title || 'prompt')
 const newText = computed(() => args.value.text || '')
+const FIELD_LABEL: Record<string, string> = {
+  text: 'fieldText', title: 'fieldTitle', scope: 'fieldScope', mode: 'fieldMode',
+  is_starter: 'fieldStarter', data_source_ids: 'fieldAgents', parameters: 'fieldParameters',
+}
 const changedFields = computed(() => {
   const keys = ['text', 'title', 'scope', 'mode', 'is_starter', 'data_source_ids', 'parameters']
   return keys.filter((k) => args.value[k] !== undefined && args.value[k] !== null)
-    .map((k) => (k === 'is_starter' ? 'starter' : k === 'data_source_ids' ? 'agents' : k))
+    .map((k) => t('tools.editPrompt.' + FIELD_LABEL[k]))
 })
 const rejectedReason = computed(() => result.value.rejected_reason || '')
 const errorMessage = computed(() => {

--- a/frontend/components/tools/SearchPromptsTool.vue
+++ b/frontend/components/tools/SearchPromptsTool.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="mt-1">
+    <!-- Status header -->
+    <Transition name="fade" appear>
+      <div class="mb-2 flex items-center text-xs text-gray-500 dark:text-gray-400">
+        <span v-if="status === 'running'" class="tool-shimmer flex items-center">
+          <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
+          <span>Searching prompts for {{ queryLabel }}…</span>
+        </span>
+        <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
+          <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
+          <span class="align-middle">Searched prompts for {{ queryLabel }}</span>
+          <span v-if="total > 0" class="ms-1.5 text-[10px] text-gray-400">· {{ total === 1 ? '1 match' : total + ' matches' }}</span>
+        </span>
+      </div>
+    </Transition>
+
+    <!-- Results list -->
+    <Transition name="fade" appear>
+      <div v-if="prompts.length" class="text-xs text-gray-600 dark:text-gray-400">
+        <ul class="ms-1 space-y-1 leading-snug">
+          <li v-for="(item, idx) in prompts" :key="item.id || idx">
+            <div
+              class="flex items-center py-1 px-1 rounded cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+              @click="toggleItem(idx)"
+              :aria-expanded="isExpanded(idx)"
+            >
+              <Icon :name="isExpanded(idx) ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 text-gray-400 me-1 rtl-flip" />
+              <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1 text-indigo-400 flex-shrink-0" />
+              <div class="font-medium text-gray-700 dark:text-gray-300 truncate">{{ displayTitle(item) }}</div>
+              <span v-if="item.scope" class="ms-1.5 text-[9px] px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 flex-shrink-0">{{ item.scope }}</span>
+              <span v-if="item.is_starter" class="ms-1 text-[9px] px-1 py-0.5 rounded bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 flex-shrink-0">starter</span>
+            </div>
+            <Transition name="fade">
+              <div v-if="isExpanded(idx)" class="ps-6 pe-1 pb-2">
+                <div class="prompt-content text-[12px] text-gray-700 dark:text-gray-300 leading-relaxed mb-1">
+                  <MDC :value="item.text || ''" class="markdown-content" />
+                </div>
+                <button class="text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click="openPrompts">
+                  <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
+                  <span>Open in Prompts</span>
+                </button>
+              </div>
+            </Transition>
+          </li>
+        </ul>
+      </div>
+    </Transition>
+
+    <!-- Empty state -->
+    <div v-if="status !== 'running' && !prompts.length" class="text-xs text-gray-400 ms-1">
+      No matching prompts.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface ToolExecution {
+  id: string
+  tool_name: string
+  status: string
+  result_summary?: string
+  result_json?: any
+  arguments_json?: any
+}
+const props = defineProps<{ toolExecution: ToolExecution }>()
+
+const status = computed<string>(() => props.toolExecution?.status || '')
+const result = computed(() => props.toolExecution?.result_json || {})
+const args = computed(() => props.toolExecution?.arguments_json || {})
+
+const queryLabel = computed<string>(() => {
+  let q: any = args.value.query
+  if (Array.isArray(q)) {
+    const s = q.filter(Boolean).map((x: string) => `"${x}"`).join(', ')
+    if (s) return s
+  } else if (typeof q === 'string' && q) {
+    return `"${q}"`
+  }
+  if (args.value.starters_only) return 'conversation starters'
+  if (args.value.scope) return `${args.value.scope} prompts`
+  if (args.value.data_source_id) return 'this agent'
+  return 'all prompts'
+})
+
+const prompts = computed<any[]>(() => Array.isArray(result.value.prompts) ? result.value.prompts : [])
+const total = computed<number>(() => typeof result.value.total === 'number' ? result.value.total : prompts.value.length)
+
+const expandedItems = ref<Set<number>>(new Set())
+function toggleItem(index: number) {
+  if (expandedItems.value.has(index)) expandedItems.value.delete(index)
+  else expandedItems.value.add(index)
+}
+function isExpanded(index: number): boolean { return expandedItems.value.has(index) }
+
+function displayTitle(item: any): string {
+  if (item?.title) return item.title
+  const text = String(item?.text || '').trim()
+  const firstLine = text.split('\n')[0].replace(/^#+\s*/, '').trim()
+  return firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : (firstLine || 'Untitled')
+}
+function openPrompts() { navigateTo('/prompts') }
+</script>
+
+<style scoped>
+.tool-shimmer {
+  animation: shimmer 1.6s linear infinite;
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(160,160,160,0.15) 50%, rgba(0,0,0,0) 100%);
+  background-size: 300% 100%;
+  background-clip: text;
+}
+@keyframes shimmer { 0% { background-position: 0% 0; } 100% { background-position: 100% 0; } }
+.fade-enter-active, .fade-leave-active { transition: opacity 0.25s ease, transform 0.25s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; transform: translateY(2px); }
+.prompt-content :deep(.markdown-content) { font-size: 12px; line-height: 1.5; }
+.prompt-content :deep(.markdown-content p) { margin: 0 0 0.4em 0; }
+.prompt-content :deep(.markdown-content p:last-child) { margin-bottom: 0; }
+.prompt-content :deep(.markdown-content code) { font-size: 10px; padding: 0.1em 0.3em; background: rgba(0,0,0,0.05); border-radius: 3px; }
+</style>

--- a/frontend/components/tools/SearchPromptsTool.vue
+++ b/frontend/components/tools/SearchPromptsTool.vue
@@ -5,12 +5,12 @@
       <div class="mb-2 flex items-center text-xs text-gray-500 dark:text-gray-400">
         <span v-if="status === 'running'" class="tool-shimmer flex items-center">
           <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
-          <span>Searching prompts for {{ queryLabel }}…</span>
+          <span>{{ $t('tools.searchPrompts.searching', { query: queryLabel }) }}</span>
         </span>
         <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
           <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
-          <span class="align-middle">Searched prompts for {{ queryLabel }}</span>
-          <span v-if="total > 0" class="ms-1.5 text-[10px] text-gray-400">· {{ total === 1 ? '1 match' : total + ' matches' }}</span>
+          <span class="align-middle">{{ $t('tools.searchPrompts.searched', { query: queryLabel }) }}</span>
+          <span v-if="total > 0" class="ms-1.5 text-[10px] text-gray-400">· {{ total === 1 ? $t('tools.searchPrompts.matchSingular', { count: total }) : $t('tools.searchPrompts.matchPlural', { count: total }) }}</span>
         </span>
       </div>
     </Transition>
@@ -29,7 +29,7 @@
               <Icon name="heroicons-bookmark-square" class="w-3 h-3 me-1 text-indigo-400 flex-shrink-0" />
               <div class="font-medium text-gray-700 dark:text-gray-300 truncate">{{ displayTitle(item) }}</div>
               <span v-if="item.scope" class="ms-1.5 text-[9px] px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 flex-shrink-0">{{ item.scope }}</span>
-              <span v-if="item.is_starter" class="ms-1 text-[9px] px-1 py-0.5 rounded bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 flex-shrink-0">starter</span>
+              <span v-if="item.is_starter" class="ms-1 text-[9px] px-1 py-0.5 rounded bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-400 flex-shrink-0">{{ $t('tools.searchPrompts.starter') }}</span>
             </div>
             <Transition name="fade">
               <div v-if="isExpanded(idx)" class="ps-6 pe-1 pb-2">
@@ -38,7 +38,7 @@
                 </div>
                 <button class="text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5" @click="openPrompts">
                   <Icon name="heroicons:arrow-top-right-on-square" class="w-3 h-3" />
-                  <span>Open in Prompts</span>
+                  <span>{{ $t('tools.searchPrompts.open') }}</span>
                 </button>
               </div>
             </Transition>
@@ -49,13 +49,15 @@
 
     <!-- Empty state -->
     <div v-if="status !== 'running' && !prompts.length" class="text-xs text-gray-400 ms-1">
-      No matching prompts.
+      {{ $t('tools.searchPrompts.empty') }}
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 interface ToolExecution {
   id: string
@@ -79,10 +81,10 @@ const queryLabel = computed<string>(() => {
   } else if (typeof q === 'string' && q) {
     return `"${q}"`
   }
-  if (args.value.starters_only) return 'conversation starters'
-  if (args.value.scope) return `${args.value.scope} prompts`
-  if (args.value.data_source_id) return 'this agent'
-  return 'all prompts'
+  if (args.value.starters_only) return t('tools.searchPrompts.queryStarters')
+  if (args.value.scope) return t('tools.searchPrompts.queryScope', { scope: args.value.scope })
+  if (args.value.data_source_id) return t('tools.searchPrompts.queryThisAgent')
+  return t('tools.searchPrompts.queryAll')
 })
 
 const prompts = computed<any[]>(() => Array.isArray(result.value.prompts) ? result.value.prompts : [])
@@ -99,7 +101,7 @@ function displayTitle(item: any): string {
   if (item?.title) return item.title
   const text = String(item?.text || '').trim()
   const firstLine = text.split('\n')[0].replace(/^#+\s*/, '').trim()
-  return firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : (firstLine || 'Untitled')
+  return firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : (firstLine || t('tools.searchPrompts.untitled'))
 }
 function openPrompts() { navigateTo('/prompts') }
 </script>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -774,6 +774,9 @@ import WebFetchTool from '~/components/tools/WebFetchTool.vue'
 import WebSearchTool from '~/components/tools/WebSearchTool.vue'
 import ClarifyTool from '~/components/tools/ClarifyTool.vue'
 import SearchInstructionsTool from '~/components/tools/SearchInstructionsTool.vue'
+import CreatePromptTool from '~/components/tools/CreatePromptTool.vue'
+import EditPromptTool from '~/components/tools/EditPromptTool.vue'
+import SearchPromptsTool from '~/components/tools/SearchPromptsTool.vue'
 import SearchEvalsTool from '~/components/tools/SearchEvalsTool.vue'
 import CreateEvalTool from '~/components/tools/CreateEvalTool.vue'
 import RunEvalTool from '~/components/tools/RunEvalTool.vue'
@@ -1633,6 +1636,12 @@ function getToolComponent(toolName: string) {
 			return ListAgentExecutionsTool
 		case 'search_instructions':
 			return SearchInstructionsTool
+		case 'create_prompt':
+			return CreatePromptTool
+		case 'edit_prompt':
+			return EditPromptTool
+		case 'search_prompts':
+			return SearchPromptsTool
 		case 'search_evals':
 			return SearchEvalsTool
 		case 'create_eval':
@@ -2185,6 +2194,12 @@ async function handleStreamingEvent(eventType: string | null, payload: any, sysM
 							const qStr = Array.isArray(q) ? q.join(', ') : (typeof q === 'string' ? q : (q ? JSON.stringify(q) : 'instructions'))
 							;(lastBlock.tool_execution.result_json as any).search_query = q
 							lastBlock.tool_execution.result_summary = `Searching instructions for ${qStr}…`
+						}
+						if ((payload.tool_name === 'create_prompt' || payload.tool_name === 'edit_prompt') && payload.arguments) {
+							;(lastBlock.tool_execution as any).arguments_json = payload.arguments
+						}
+						if (payload.tool_name === 'search_prompts' && payload.arguments) {
+							;(lastBlock.tool_execution as any).arguments_json = payload.arguments
 						}
 						if (payload.tool_name === 'clarify' && payload.arguments) {
 							;(lastBlock.tool_execution as any).arguments_json = payload.arguments

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -893,6 +893,53 @@
       "running": "جارٍ التشغيل...",
       "success": "نجاح",
       "failed": "فشل"
+    },
+    "createPrompt": {
+      "savingPrefix": "جارٍ حفظ المطالبة: {title}",
+      "saving": "جارٍ حفظ المطالبة…",
+      "notSaved": "لم يتم حفظ المطالبة",
+      "failed": "فشل حفظ المطالبة",
+      "starter": "بادئة",
+      "paramsBadge": "{n} معلمات",
+      "scope": "النطاق",
+      "mode": "الوضع",
+      "conversationStarter": "بادئة محادثة",
+      "agentSingular": "وكيل {n}",
+      "agentPlural": "{n} وكلاء",
+      "parameters": "المعلمات:",
+      "live": "نشط",
+      "openInPrompts": "فتح في المطالبات"
+    },
+    "editPrompt": {
+      "updating": "جارٍ تحديث المطالبة…",
+      "updatedPrefix": "تم التحديث: {title}",
+      "notUpdated": "لم يتم تحديث المطالبة",
+      "failed": "فشل تحديث المطالبة",
+      "changed": "تم التغيير:",
+      "noFields": "لا حقول",
+      "live": "نشط",
+      "openInPrompts": "فتح في المطالبات",
+      "fieldText": "النص",
+      "fieldTitle": "العنوان",
+      "fieldScope": "النطاق",
+      "fieldMode": "الوضع",
+      "fieldStarter": "بادئة",
+      "fieldAgents": "الوكلاء",
+      "fieldParameters": "المعلمات"
+    },
+    "searchPrompts": {
+      "searching": "البحث عن مطالبات لـ {query}…",
+      "searched": "تم البحث عن مطالبات لـ {query}",
+      "matchSingular": "{count} نتيجة",
+      "matchPlural": "{count} نتائج",
+      "empty": "لا توجد مطالبات مطابقة.",
+      "open": "فتح في المطالبات",
+      "untitled": "بدون عنوان",
+      "starter": "بادئة",
+      "queryStarters": "بوادئ المحادثة",
+      "queryScope": "مطالبات {scope}",
+      "queryThisAgent": "هذا الوكيل",
+      "queryAll": "كل المطالبات"
     }
   },
   "entityCreate": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -893,6 +893,53 @@
       "running": "Läuft ...",
       "success": "Erfolgreich",
       "failed": "Fehlgeschlagen"
+    },
+    "createPrompt": {
+      "savingPrefix": "Prompt wird gespeichert: {title}",
+      "saving": "Prompt wird gespeichert…",
+      "notSaved": "Prompt nicht gespeichert",
+      "failed": "Prompt konnte nicht gespeichert werden",
+      "starter": "Starter",
+      "paramsBadge": "{n} Parameter",
+      "scope": "Geltungsbereich",
+      "mode": "Modus",
+      "conversationStarter": "Gesprächseinstieg",
+      "agentSingular": "{n} Agent",
+      "agentPlural": "{n} Agenten",
+      "parameters": "Parameter:",
+      "live": "Aktiv",
+      "openInPrompts": "In Prompts öffnen"
+    },
+    "editPrompt": {
+      "updating": "Prompt wird aktualisiert…",
+      "updatedPrefix": "Aktualisiert: {title}",
+      "notUpdated": "Prompt nicht aktualisiert",
+      "failed": "Prompt konnte nicht aktualisiert werden",
+      "changed": "Geändert:",
+      "noFields": "keine Felder",
+      "live": "Aktiv",
+      "openInPrompts": "In Prompts öffnen",
+      "fieldText": "Text",
+      "fieldTitle": "Titel",
+      "fieldScope": "Bereich",
+      "fieldMode": "Modus",
+      "fieldStarter": "Starter",
+      "fieldAgents": "Agenten",
+      "fieldParameters": "Parameter"
+    },
+    "searchPrompts": {
+      "searching": "Suche nach Prompts für {query}…",
+      "searched": "Prompts gesucht für {query}",
+      "matchSingular": "{count} Treffer",
+      "matchPlural": "{count} Treffer",
+      "empty": "Keine passenden Prompts.",
+      "open": "In Prompts öffnen",
+      "untitled": "Ohne Titel",
+      "starter": "Starter",
+      "queryStarters": "Gesprächseinstiege",
+      "queryScope": "{scope}-Prompts",
+      "queryThisAgent": "dieser Agent",
+      "queryAll": "alle Prompts"
     }
   },
   "entityCreate": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -984,6 +984,53 @@
       "running": "Running...",
       "success": "Success",
       "failed": "Failed"
+    },
+    "createPrompt": {
+      "savingPrefix": "Saving prompt: {title}",
+      "saving": "Saving prompt…",
+      "notSaved": "Prompt not saved",
+      "failed": "Failed to save prompt",
+      "starter": "starter",
+      "paramsBadge": "{n} params",
+      "scope": "Scope",
+      "mode": "Mode",
+      "conversationStarter": "conversation starter",
+      "agentSingular": "{n} agent",
+      "agentPlural": "{n} agents",
+      "parameters": "Parameters:",
+      "live": "Live",
+      "openInPrompts": "Open in Prompts"
+    },
+    "editPrompt": {
+      "updating": "Updating prompt…",
+      "updatedPrefix": "Updated: {title}",
+      "notUpdated": "Prompt not updated",
+      "failed": "Failed to update prompt",
+      "changed": "Changed:",
+      "noFields": "no fields",
+      "live": "Live",
+      "openInPrompts": "Open in Prompts",
+      "fieldText": "text",
+      "fieldTitle": "title",
+      "fieldScope": "scope",
+      "fieldMode": "mode",
+      "fieldStarter": "starter",
+      "fieldAgents": "agents",
+      "fieldParameters": "parameters"
+    },
+    "searchPrompts": {
+      "searching": "Searching prompts for {query}…",
+      "searched": "Searched prompts for {query}",
+      "matchSingular": "{count} match",
+      "matchPlural": "{count} matches",
+      "empty": "No matching prompts.",
+      "open": "Open in Prompts",
+      "untitled": "Untitled",
+      "starter": "starter",
+      "queryStarters": "conversation starters",
+      "queryScope": "{scope} prompts",
+      "queryThisAgent": "this agent",
+      "queryAll": "all prompts"
     }
   },
   "entityCreate": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -903,6 +903,53 @@
       "running": "Ejecutando...",
       "success": "Éxito",
       "failed": "Falló"
+    },
+    "createPrompt": {
+      "savingPrefix": "Guardando prompt: {title}",
+      "saving": "Guardando prompt…",
+      "notSaved": "Prompt no guardado",
+      "failed": "Error al guardar el prompt",
+      "starter": "inicio",
+      "paramsBadge": "{n} parámetros",
+      "scope": "Alcance",
+      "mode": "Modo",
+      "conversationStarter": "iniciador de conversación",
+      "agentSingular": "{n} agente",
+      "agentPlural": "{n} agentes",
+      "parameters": "Parámetros:",
+      "live": "Activo",
+      "openInPrompts": "Abrir en Prompts"
+    },
+    "editPrompt": {
+      "updating": "Actualizando prompt…",
+      "updatedPrefix": "Actualizado: {title}",
+      "notUpdated": "Prompt no actualizado",
+      "failed": "Error al actualizar el prompt",
+      "changed": "Cambiado:",
+      "noFields": "sin campos",
+      "live": "Activo",
+      "openInPrompts": "Abrir en Prompts",
+      "fieldText": "texto",
+      "fieldTitle": "título",
+      "fieldScope": "alcance",
+      "fieldMode": "modo",
+      "fieldStarter": "inicio",
+      "fieldAgents": "agentes",
+      "fieldParameters": "parámetros"
+    },
+    "searchPrompts": {
+      "searching": "Buscando prompts de {query}…",
+      "searched": "Prompts buscados de {query}",
+      "matchSingular": "{count} coincidencia",
+      "matchPlural": "{count} coincidencias",
+      "empty": "No hay prompts coincidentes.",
+      "open": "Abrir en Prompts",
+      "untitled": "Sin título",
+      "starter": "inicio",
+      "queryStarters": "iniciadores de conversación",
+      "queryScope": "prompts de {scope}",
+      "queryThisAgent": "este agente",
+      "queryAll": "todos los prompts"
     }
   },
   "entityCreate": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -893,6 +893,53 @@
       "running": "Exécution...",
       "success": "Succès",
       "failed": "Échec"
+    },
+    "createPrompt": {
+      "savingPrefix": "Enregistrement du prompt : {title}",
+      "saving": "Enregistrement du prompt…",
+      "notSaved": "Prompt non enregistré",
+      "failed": "Échec de l'enregistrement du prompt",
+      "starter": "démarrage",
+      "paramsBadge": "{n} paramètres",
+      "scope": "Portée",
+      "mode": "Mode",
+      "conversationStarter": "amorce de conversation",
+      "agentSingular": "{n} agent",
+      "agentPlural": "{n} agents",
+      "parameters": "Paramètres :",
+      "live": "Actif",
+      "openInPrompts": "Ouvrir dans Prompts"
+    },
+    "editPrompt": {
+      "updating": "Mise à jour du prompt…",
+      "updatedPrefix": "Mis à jour : {title}",
+      "notUpdated": "Prompt non mis à jour",
+      "failed": "Échec de la mise à jour du prompt",
+      "changed": "Modifié :",
+      "noFields": "aucun champ",
+      "live": "Actif",
+      "openInPrompts": "Ouvrir dans Prompts",
+      "fieldText": "texte",
+      "fieldTitle": "titre",
+      "fieldScope": "portée",
+      "fieldMode": "mode",
+      "fieldStarter": "démarrage",
+      "fieldAgents": "agents",
+      "fieldParameters": "paramètres"
+    },
+    "searchPrompts": {
+      "searching": "Recherche de prompts pour {query}…",
+      "searched": "Prompts recherchés pour {query}",
+      "matchSingular": "{count} correspondance",
+      "matchPlural": "{count} correspondances",
+      "empty": "Aucun prompt correspondant.",
+      "open": "Ouvrir dans Prompts",
+      "untitled": "Sans titre",
+      "starter": "démarrage",
+      "queryStarters": "amorces de conversation",
+      "queryScope": "prompts {scope}",
+      "queryThisAgent": "cet agent",
+      "queryAll": "tous les prompts"
     }
   },
   "entityCreate": {

--- a/locales/he.json
+++ b/locales/he.json
@@ -903,6 +903,53 @@
       "running": "פועל...",
       "success": "הצלחה",
       "failed": "נכשל"
+    },
+    "createPrompt": {
+      "savingPrefix": "שומר פרומפט: {title}",
+      "saving": "שומר פרומפט…",
+      "notSaved": "הפרומפט לא נשמר",
+      "failed": "שמירת הפרומפט נכשלה",
+      "starter": "פתיח",
+      "paramsBadge": "{n} פרמטרים",
+      "scope": "היקף",
+      "mode": "מצב",
+      "conversationStarter": "פותח שיחה",
+      "agentSingular": "סוכן {n}",
+      "agentPlural": "{n} סוכנים",
+      "parameters": "פרמטרים:",
+      "live": "פעיל",
+      "openInPrompts": "פתח בפרומפטים"
+    },
+    "editPrompt": {
+      "updating": "מעדכן פרומפט…",
+      "updatedPrefix": "עודכן: {title}",
+      "notUpdated": "הפרומפט לא עודכן",
+      "failed": "עדכון הפרומפט נכשל",
+      "changed": "השתנה:",
+      "noFields": "אין שדות",
+      "live": "פעיל",
+      "openInPrompts": "פתח בפרומפטים",
+      "fieldText": "טקסט",
+      "fieldTitle": "כותרת",
+      "fieldScope": "היקף",
+      "fieldMode": "מצב",
+      "fieldStarter": "פתיח",
+      "fieldAgents": "סוכנים",
+      "fieldParameters": "פרמטרים"
+    },
+    "searchPrompts": {
+      "searching": "מחפש פרומפטים עבור {query}…",
+      "searched": "חיפוש פרומפטים עבור {query}",
+      "matchSingular": "התאמה {count}",
+      "matchPlural": "{count} התאמות",
+      "empty": "לא נמצאו פרומפטים תואמים.",
+      "open": "פתח בפרומפטים",
+      "untitled": "ללא כותרת",
+      "starter": "פתיח",
+      "queryStarters": "פותחי שיחה",
+      "queryScope": "פרומפטים של {scope}",
+      "queryThisAgent": "סוכן זה",
+      "queryAll": "כל הפרומפטים"
     }
   },
   "entityCreate": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -893,6 +893,53 @@
       "running": "In esecuzione...",
       "success": "Riuscito",
       "failed": "Non riuscito"
+    },
+    "createPrompt": {
+      "savingPrefix": "Salvataggio prompt: {title}",
+      "saving": "Salvataggio prompt…",
+      "notSaved": "Prompt non salvato",
+      "failed": "Impossibile salvare il prompt",
+      "starter": "iniziale",
+      "paramsBadge": "{n} parametri",
+      "scope": "Ambito",
+      "mode": "Modalità",
+      "conversationStarter": "avvio conversazione",
+      "agentSingular": "{n} agente",
+      "agentPlural": "{n} agenti",
+      "parameters": "Parametri:",
+      "live": "Attivo",
+      "openInPrompts": "Apri in Prompts"
+    },
+    "editPrompt": {
+      "updating": "Aggiornamento prompt…",
+      "updatedPrefix": "Aggiornato: {title}",
+      "notUpdated": "Prompt non aggiornato",
+      "failed": "Impossibile aggiornare il prompt",
+      "changed": "Modificato:",
+      "noFields": "nessun campo",
+      "live": "Attivo",
+      "openInPrompts": "Apri in Prompts",
+      "fieldText": "testo",
+      "fieldTitle": "titolo",
+      "fieldScope": "ambito",
+      "fieldMode": "modalità",
+      "fieldStarter": "iniziale",
+      "fieldAgents": "agenti",
+      "fieldParameters": "parametri"
+    },
+    "searchPrompts": {
+      "searching": "Ricerca di prompt per {query}…",
+      "searched": "Prompt cercati per {query}",
+      "matchSingular": "{count} corrispondenza",
+      "matchPlural": "{count} corrispondenze",
+      "empty": "Nessun prompt corrispondente.",
+      "open": "Apri in Prompts",
+      "untitled": "Senza titolo",
+      "starter": "iniziale",
+      "queryStarters": "avvii di conversazione",
+      "queryScope": "prompt {scope}",
+      "queryThisAgent": "questo agente",
+      "queryAll": "tutti i prompt"
     }
   },
   "entityCreate": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -893,6 +893,53 @@
       "running": "Executando...",
       "success": "Sucesso",
       "failed": "Falhou"
+    },
+    "createPrompt": {
+      "savingPrefix": "Salvando prompt: {title}",
+      "saving": "Salvando prompt…",
+      "notSaved": "Prompt não salvo",
+      "failed": "Falha ao salvar o prompt",
+      "starter": "inicial",
+      "paramsBadge": "{n} parâmetros",
+      "scope": "Escopo",
+      "mode": "Modo",
+      "conversationStarter": "iniciador de conversa",
+      "agentSingular": "{n} agente",
+      "agentPlural": "{n} agentes",
+      "parameters": "Parâmetros:",
+      "live": "Ativo",
+      "openInPrompts": "Abrir em Prompts"
+    },
+    "editPrompt": {
+      "updating": "Atualizando prompt…",
+      "updatedPrefix": "Atualizado: {title}",
+      "notUpdated": "Prompt não atualizado",
+      "failed": "Falha ao atualizar o prompt",
+      "changed": "Alterado:",
+      "noFields": "nenhum campo",
+      "live": "Ativo",
+      "openInPrompts": "Abrir em Prompts",
+      "fieldText": "texto",
+      "fieldTitle": "título",
+      "fieldScope": "escopo",
+      "fieldMode": "modo",
+      "fieldStarter": "inicial",
+      "fieldAgents": "agentes",
+      "fieldParameters": "parâmetros"
+    },
+    "searchPrompts": {
+      "searching": "Procurando prompts por {query}…",
+      "searched": "Prompts pesquisados por {query}",
+      "matchSingular": "{count} correspondência",
+      "matchPlural": "{count} correspondências",
+      "empty": "Nenhum prompt correspondente.",
+      "open": "Abrir em Prompts",
+      "untitled": "Sem título",
+      "starter": "inicial",
+      "queryStarters": "iniciadores de conversa",
+      "queryScope": "prompts de {scope}",
+      "queryThisAgent": "este agente",
+      "queryAll": "todos os prompts"
     }
   },
   "entityCreate": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -893,6 +893,53 @@
       "running": "Выполнение...",
       "success": "Успех",
       "failed": "Ошибка"
+    },
+    "createPrompt": {
+      "savingPrefix": "Сохранение промпта: {title}",
+      "saving": "Сохранение промпта…",
+      "notSaved": "Промпт не сохранён",
+      "failed": "Не удалось сохранить промпт",
+      "starter": "стартовый",
+      "paramsBadge": "{n} параметров",
+      "scope": "Область",
+      "mode": "Режим",
+      "conversationStarter": "начало разговора",
+      "agentSingular": "{n} агент",
+      "agentPlural": "{n} агентов",
+      "parameters": "Параметры:",
+      "live": "Активен",
+      "openInPrompts": "Открыть в Промптах"
+    },
+    "editPrompt": {
+      "updating": "Обновление промпта…",
+      "updatedPrefix": "Обновлено: {title}",
+      "notUpdated": "Промпт не обновлён",
+      "failed": "Не удалось обновить промпт",
+      "changed": "Изменено:",
+      "noFields": "нет полей",
+      "live": "Активен",
+      "openInPrompts": "Открыть в Промптах",
+      "fieldText": "текст",
+      "fieldTitle": "заголовок",
+      "fieldScope": "область",
+      "fieldMode": "режим",
+      "fieldStarter": "стартовый",
+      "fieldAgents": "агенты",
+      "fieldParameters": "параметры"
+    },
+    "searchPrompts": {
+      "searching": "Поиск промптов по {query}…",
+      "searched": "Поиск промптов по {query}",
+      "matchSingular": "{count} совпадение",
+      "matchPlural": "{count} совпадений",
+      "empty": "Нет подходящих промптов.",
+      "open": "Открыть в Промптах",
+      "untitled": "Без названия",
+      "starter": "стартовый",
+      "queryStarters": "начала разговора",
+      "queryScope": "промпты ({scope})",
+      "queryThisAgent": "этот агент",
+      "queryAll": "все промпты"
     }
   },
   "entityCreate": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -893,6 +893,53 @@
       "running": "Kör...",
       "success": "Klart",
       "failed": "Misslyckades"
+    },
+    "createPrompt": {
+      "savingPrefix": "Sparar prompt: {title}",
+      "saving": "Sparar prompt…",
+      "notSaved": "Prompten sparades inte",
+      "failed": "Det gick inte att spara prompten",
+      "starter": "startfras",
+      "paramsBadge": "{n} parametrar",
+      "scope": "Omfattning",
+      "mode": "Läge",
+      "conversationStarter": "konversationsstart",
+      "agentSingular": "{n} agent",
+      "agentPlural": "{n} agenter",
+      "parameters": "Parametrar:",
+      "live": "Aktiv",
+      "openInPrompts": "Öppna i Prompts"
+    },
+    "editPrompt": {
+      "updating": "Uppdaterar prompt…",
+      "updatedPrefix": "Uppdaterad: {title}",
+      "notUpdated": "Prompten uppdaterades inte",
+      "failed": "Det gick inte att uppdatera prompten",
+      "changed": "Ändrat:",
+      "noFields": "inga fält",
+      "live": "Aktiv",
+      "openInPrompts": "Öppna i Prompts",
+      "fieldText": "text",
+      "fieldTitle": "titel",
+      "fieldScope": "omfattning",
+      "fieldMode": "läge",
+      "fieldStarter": "startfras",
+      "fieldAgents": "agenter",
+      "fieldParameters": "parametrar"
+    },
+    "searchPrompts": {
+      "searching": "Söker prompter efter {query}…",
+      "searched": "Sökte prompter efter {query}",
+      "matchSingular": "{count} träff",
+      "matchPlural": "{count} träffar",
+      "empty": "Inga matchande prompter.",
+      "open": "Öppna i Prompts",
+      "untitled": "Namnlös",
+      "starter": "startfras",
+      "queryStarters": "konversationsstarter",
+      "queryScope": "{scope}-prompter",
+      "queryThisAgent": "den här agenten",
+      "queryAll": "alla prompter"
     }
   },
   "entityCreate": {

--- a/sandbox-feedback-loop-prompts-training-tools.md
+++ b/sandbox-feedback-loop-prompts-training-tools.md
@@ -1,0 +1,147 @@
+# Sandbox Feedback Loop — Prompts tools in Training mode
+
+Adds agent-facing tools so the **training-mode** agent can curate the new
+**Prompts** (reusable, completion-shaped saved requests / conversation starters /
+templated prompts) the same way it already curates Instructions:
+
+- `create_prompt` — save a reusable prompt and attach it to the agent(s) being trained
+- `search_prompts` — list/search existing prompts (dedupe before creating, or find one to edit)
+- `edit_prompt` — refine text/title, re-attach to agents, toggle starter, adjust mode/parameters
+
+This doc is the runnable feedback loop used to confirm the behavior in a fresh
+sandbox.
+
+---
+
+## Decisions baked in (from the request)
+
+1. **Prompts go live immediately.** Unlike instructions (which the training
+   agent stages into a draft *build* that an admin approves), prompts have no
+   build/version/approval model — `create_prompt` / `edit_prompt` write the live
+   `Prompt` row directly via `PromptService`.
+2. **Authoring is governed by the agent-manager tier (`manage_agent`).** This is
+   PR #489's per-`data_source` **`manage`** grant, which `RESOURCE_PERM_IMPLIES`
+   makes a superset (`manage` ⇒ `manage_instructions` / `create_entities` /
+   `manage_evals` / `manage_members`). `PromptService.create_prompt` /
+   `update_prompt` already enforce `manage` on every target agent (or org admin
+   for `scope='global'`), so the tools inherit exactly that gate — no new
+   permission key was introduced. Built on top of PR #490 (which carries #489).
+
+---
+
+## What changed (the feature)
+
+Tool schemas — `backend/app/ai/tools/schemas/`:
+- `create_prompt.py` (`CreatePromptInput/Output`, `PromptParameterSpec`)
+- `edit_prompt.py` (`EditPromptInput/Output`)
+- `search_prompts.py` (`SearchPromptsInput/Output`, `SearchPromptsItem`)
+
+Tool implementations — `backend/app/ai/tools/implementations/`:
+- `create_prompt.py` — `CreatePromptTool`, `category="action"`, `allowed_modes=["training"]`.
+  Defaults to `scope='agent'`; when `data_source_ids` is omitted it attaches to
+  the **active agents on the current report**. Maps `PromptService` 403 → a clean
+  `permission_denied` rejection observation (no blind retry).
+- `edit_prompt.py` — `EditPromptTool`, `category="action"`, `allowed_modes=["training"]`.
+  Patch-style: only the fields you pass are changed. 404→`not_found`, 403→`permission_denied`.
+- `search_prompts.py` — `SearchPromptsTool`, `category="research"`, `allowed_modes=["training"]`.
+  Lists visible prompts via `PromptService.list_prompts` (access-scoped) and
+  applies a literal+regex keyword union in-process, mirroring `search_instructions`.
+
+Planner prompt — `backend/app/ai/agents/planner/prompt_builder_v3.py`:
+- The `TRAINING MODE` block now lists `search_prompts` / `create_prompt` /
+  `edit_prompt` under **Key tools** and adds routing examples
+  (`"add a prompt for…"` → `create_prompt`, `"list saved prompts"` → `search_prompts`,
+  `"rename that prompt"` → `edit_prompt`).
+
+Gating is entirely via `allowed_modes=["training"]` + the registry mode filter
+(`ToolRegistry._matches_filter`) — `agent_v2` already builds the catalog with
+`mode=self.mode`, so no agent_v2 change was needed.
+
+---
+
+## Loop A — registry gating (no DB, no LLM)
+
+Confirms the tools exist **only** in training mode.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+.venv/bin/python - <<'PY'
+from app.ai.registry import ToolRegistry
+r = ToolRegistry()
+for mode in ("training", "chat"):
+    names = set()
+    for pt in ("action", "research"):
+        names |= {t["name"] for t in r.get_catalog_for_plan_type(pt, mode=mode)}
+    print(mode, "->", sorted(n for n in names if "prompt" in n))
+PY
+```
+
+**Observed (PASS):**
+```
+training -> ['create_prompt', 'edit_prompt', 'search_prompts']
+chat -> []
+```
+
+---
+
+## Loop B — tool behavior + manage_agent gate (DB, no LLM)
+
+Drives all three tools through `run_stream` against the real `PromptService`,
+including the authorization gate: a user holding only a per-agent `manage` grant
+(the manage_agent tier) can create/search/edit; a member without it is denied.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+mkdir -p db
+.venv/bin/python -m pytest tests/prompts/test_prompt_training_tools.py -v -s
+```
+
+**Asserts:**
+- create (manager, agent-scoped) → `success`, attached to the agent, `is_starter`.
+- create (non-manager of the agent) → `rejected_reason == "permission_denied"`.
+- `search_prompts(query=["revenue"])` and `starters_only` return the prompt.
+- `edit_prompt` renames + toggles starter; persists (re-search confirms).
+- `edit_prompt` by a non-manager → `permission_denied`.
+
+**Observed (PASS):** `1 passed`.
+
+---
+
+## Loop C — live UI + LLM (training mode, Haiku)
+
+Run the app, open an agent in **Training** mode, and confirm a real model turn
+creates/searches/edits a prompt that then shows up on the agent.
+
+```bash
+# backend (Anthropic Haiku key supplied out-of-band, never committed)
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+export ANTHROPIC_API_KEY=...   # haiku test key
+.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000
+
+# frontend
+cd frontend && npm run dev
+```
+
+Steps:
+1. Create/seed an agent (data source) you manage.
+2. Open a report on that agent and switch the composer to **Training** mode.
+3. Prompt: *"Add a saved prompt for monthly revenue by category and make it a starter."*
+   → the agent calls `create_prompt`; the prompt appears under the agent's prompts.
+4. Prompt: *"List the saved prompts."* → `search_prompts` returns it.
+5. Prompt: *"Rename that prompt to 'Monthly revenue v2'."* → `edit_prompt` updates it.
+
+Screenshot proof is captured in the PR / session.
+
+---
+
+## Notes / non-goals
+
+- No build/approval flow for prompts (decision #1) — writes are live.
+- `scope='global'` remains org-admin-only (enforced by `PromptService`); the
+  tool surfaces the 403 as `permission_denied` rather than failing hard.
+- `required_permissions` on the tool metadata is left empty on purpose: the real
+  gate is the service-layer `manage` check, and `agent_v2` does not pass
+  `required_permissions` into catalog filtering.


### PR DESCRIPTION
## Summary

Lets the **training-mode** agent curate the new reusable **Prompts** (saved completion-shaped requests / conversation starters / templated prompts) the same way it already curates Instructions — via three new agent tools, surfaced in the conversation as rich, localized tool cards.

Built on top of **#490** (which carries #489's agent-manager RBAC tier), so this PR targets that branch and the diff is scoped to the prompt-tools work only.

### Decisions baked in
1. **Prompts go live immediately** — unlike instructions (which stage into a draft *build* for admin approval), `create_prompt` / `edit_prompt` write the live `Prompt` row directly via `PromptService`. There is no build/approval flow for prompts.
2. **Authoring is governed by the agent-manager (`manage`) tier** from #489. `PromptService.create_prompt` / `update_prompt` already require `manage` on every target agent (or org admin for `scope='global'`), so the tools inherit exactly that gate — no new permission key.

## Backend

- New tool schemas (`backend/app/ai/tools/schemas/`): `create_prompt`, `edit_prompt`, `search_prompts`.
- New tool implementations (`backend/app/ai/tools/implementations/`), all `allowed_modes=["training"]`:
  - `create_prompt` (action) — defaults `scope='agent'`; when `data_source_ids` is omitted it attaches to the active agents on the current report. Maps `PromptService` 403 → a clean `permission_denied` rejection (no blind retry).
  - `edit_prompt` (action) — patch-style; 404→`not_found`, 403→`permission_denied`.
  - `search_prompts` (research) — lists access-scoped prompts via `PromptService.list_prompts` and applies a literal+regex keyword union in-process (mirrors `search_instructions`).
- Gating is entirely via `allowed_modes` + the registry mode filter — `agent_v2` already builds the catalog with `mode=self.mode`, so no `agent_v2` change was needed.
- `prompt_builder_v3.py`: the TRAINING MODE block now advertises the three tools + routing examples.

## Frontend

- Three tool-card components (`frontend/components/tools/`): `CreatePromptTool.vue`, `EditPromptTool.vue`, `SearchPromptsTool.vue` — expandable cards mirroring the instruction tool cards (prompt text, scope/starter/`{n} params` badges, agent count, `{{param}}` chips, Live state + "Open in Prompts"), instead of the plain `create_prompt → tool_call (success)` fallback text.
- `reports/[id]/index.vue`: registered the three components in `getToolComponent` and stream `arguments_json` on `tool.start` for live rendering.
- **Localized** across all 10 locales (`en, es, he, fr, sv, ar, ru, de, pt, it`) under `tools.createPrompt` / `editPrompt` / `searchPrompts`.

## Tests

- `backend/tests/prompts/test_prompt_training_tools.py` — drives create/search/edit through `run_stream` against the real `PromptService`, including the `manage` denial gate (a member without it is denied).

## Validation

- Tool-gating check: the three tools appear only in `training` mode, never `chat`.
- Integration test passes (`1 passed`).
- Live end-to-end in a sandbox (Haiku): the training agent created, searched, and renamed prompts via the real completion API; the prompts appear on the `/prompts` page badged to the agent. Tool cards verified rendering in EN and ES. A runnable feedback-loop doc is included: `sandbox-feedback-loop-prompts-training-tools.md`.

## Notes

- `create_prompt` defaults new prompts to run-mode `chat` (independent of the training session); the agent can override via the `mode` arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KAB5g2r21Fpeh3SgbmVDa)_