### PR TITLE
Perf: make the /agents page scale to thousands of agents, connections & pending changes

### DIFF
--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -636,6 +636,10 @@ class InstructionService:
             "pending_total": len(pending_ids),
             "by_agent": by_agent,
             "pending_by_agent": pending_by_agent,
+            # The full per-instruction pending set, already computed above. Returned
+            # so the client can drive the per-row "pending review" dots from this
+            # single call instead of a second org-wide /pending-changes sweep.
+            "pending_instruction_ids": sorted(pending_ids),
         }
 
     async def search_knowledge(self, db, organization, current_user, q: str, limit: int = 20) -> dict:
@@ -1344,25 +1348,7 @@ class InstructionService:
         from app.models.build_content import BuildContent
 
         org_id = str(organization.id)
-        cand_stmt = (
-            select(BuildContent.instruction_id)
-            .join(InstructionBuild, InstructionBuild.id == BuildContent.build_id)
-            .where(and_(
-                InstructionBuild.organization_id == org_id,
-                InstructionBuild.is_main.is_(False),
-                InstructionBuild.deleted_at.is_(None),
-                InstructionBuild.status.in_(["draft", "pending_approval"]),
-                InstructionBuild.source.in_(["user", "ai", "git"]),
-            ))
-            .distinct()
-        )
-        if candidate_ids is not None:
-            if not candidate_ids:
-                return set()
-            cand_stmt = cand_stmt.where(BuildContent.instruction_id.in_([str(i) for i in candidate_ids]))
-
-        cand_ids = [str(iid) for (iid,) in (await db.execute(cand_stmt)).all()]
-        if not cand_ids:
+        if candidate_ids is not None and not candidate_ids:
             return set()
 
         from app.models.instruction_version import InstructionVersion as _IV
@@ -1374,7 +1360,35 @@ class InstructionService:
         # fixed handful of bulk queries + an in-memory diff pass instead of
         # O(instructions × builds) serialized round-trips.
 
-        # (1) Live main text per candidate (authoritative is_main build content),
+        # (1) Every pending suggestion build, with its proposed text and build
+        #     metadata (rejected_hunks + base_build_id are already-loaded columns,
+        #     no lazy load). The WHERE already selects exactly the pending
+        #     suggestion rows, so the candidate instruction ids are DERIVED from
+        #     these rows — we deliberately do NOT additionally filter by a
+        #     separately-materialized id list in the org-wide case: feeding a
+        #     thousands-element IN(...) here made SQLite pick a pathological plan
+        #     (~40x slower). candidate_ids (the on-screen subset, small) is the
+        #     one case where narrowing helps, so it's applied then.
+        sug_where = [
+            InstructionBuild.is_main.is_(False),
+            InstructionBuild.organization_id == org_id,
+            InstructionBuild.deleted_at.is_(None),
+            InstructionBuild.status.in_(["draft", "pending_approval"]),
+            InstructionBuild.source.in_(["user", "ai", "git"]),
+        ]
+        if candidate_ids is not None:
+            sug_where.append(BuildContent.instruction_id.in_([str(i) for i in candidate_ids]))
+        sug_rows = (await db.execute(
+            select(BuildContent.instruction_id, InstructionBuild, _IV.text)
+            .join(InstructionBuild, InstructionBuild.id == BuildContent.build_id)
+            .join(_IV, _IV.id == BuildContent.instruction_version_id)
+            .where(and_(*sug_where))
+        )).all()
+        if not sug_rows:
+            return set()
+        cand_ids = list({str(iid) for iid, _b, _t in sug_rows})
+
+        # (2) Live main text per candidate (authoritative is_main build content),
         #     with a fallback to the live instruction row for legacy instructions
         #     that predate main-build content — mirrors _main_text_of().
         main_text: dict = {}
@@ -1396,23 +1410,6 @@ class InstructionService:
                 select(Instruction.id, Instruction.text).where(Instruction.id.in_(missing_main))
             )).all():
                 main_text[str(iid)] = txt or ""
-
-        # (2) Every pending suggestion build for all candidates, with its proposed
-        #     text and build metadata (rejected_hunks + base_build_id come from the
-        #     ORM row — both are already-loaded columns, no lazy load).
-        sug_rows = (await db.execute(
-            select(BuildContent.instruction_id, InstructionBuild, _IV.text)
-            .join(InstructionBuild, InstructionBuild.id == BuildContent.build_id)
-            .join(_IV, _IV.id == BuildContent.instruction_version_id)
-            .where(and_(
-                InstructionBuild.is_main.is_(False),
-                InstructionBuild.organization_id == org_id,
-                InstructionBuild.deleted_at.is_(None),
-                InstructionBuild.status.in_(["draft", "pending_approval"]),
-                InstructionBuild.source.in_(["user", "ai", "git"]),
-                BuildContent.instruction_id.in_(cand_ids),
-            ))
-        )).all()
 
         # (3) Base text for each (base_build_id, instruction_id) pair the
         #     suggestions forked from — what _build_base_text() resolves per build.
@@ -2657,8 +2654,33 @@ class InstructionService:
             # can render them highlighted as "Pending review". Skip when an
             # explicit build_id is requested (that caller wants exactly that build).
             if build_id is None and current_user is not None:
+                # The pending merge only needs to surface pending rows THIS list
+                # would actually show. When scoped to specific agents (or the
+                # global group), restrict the CPU-heavy per-hunk sweep to that
+                # subset instead of the whole org — output-identical (the
+                # data_source_ids / global_only filters below already exclude
+                # everything else) but bounded by the page, not the org. Without
+                # this, expanding one agent recomputes every pending change in the
+                # org (seconds at thousands of pending).
+                pending_candidates: Optional[List[str]] = None
+                if data_source_ids:
+                    pending_candidates = [
+                        str(r[0]) for r in (await db.execute(
+                            select(instruction_data_source_association.c.instruction_id)
+                            .where(instruction_data_source_association.c.data_source_id.in_(data_source_ids))
+                        )).all()
+                    ]
+                elif global_only:
+                    pending_candidates = [
+                        str(r[0]) for r in (await db.execute(
+                            select(Instruction.id).where(and_(
+                                Instruction.organization_id == organization.id,
+                                ~Instruction.data_sources.any(),
+                            ))
+                        )).all()
+                    ]
                 pending_ids = await self.get_pending_change_instruction_ids(
-                    db, organization, current_user
+                    db, organization, current_user, candidate_ids=pending_candidates
                 )
                 if pending_ids:
                     membership_clause = or_(

--- a/backend/scripts/seed_scale_agents.py
+++ b/backend/scripts/seed_scale_agents.py
@@ -1,0 +1,228 @@
+"""Seed a LARGE org to reproduce the /agents page slowness at scale.
+
+Creates many agents (DataSource) each with several connections (+ tables), plus
+thousands of instructions distributed across agents, a fraction of which carry a
+live pending suggestion build (a real "pending review" hunk).
+
+This stresses every hot path behind the agents sidebar:
+  * GET /data_sources/active[?show_all=true]  (agents list + embedded connections)
+  * GET /api/instructions/counts              (per-agent badge aggregation)
+  * GET /api/instructions/pending-changes     (org-wide pending sweep)
+
+Usage:
+  python scripts/seed_scale_agents.py \
+      --agents 1000 --conns-per-agent 3 --tables-per-conn 5 \
+      --instructions 5000 --pending-ratio 0.6
+
+Idempotent-ish: prefixes all seeded rows with a run tag so re-runs add a fresh
+batch without colliding on the unique (org,name) connection constraint.
+"""
+import os
+import sys
+import uuid
+import asyncio
+import hashlib
+import argparse
+from datetime import datetime
+
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select, insert
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.connection import Connection
+from app.models.domain_connection import domain_connection
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.instruction import Instruction, instruction_data_source_association
+from app.models.instruction_version import InstructionVersion
+from app.models.instruction_build import InstructionBuild
+from app.models.build_content import BuildContent
+from app.models.data_source_membership import DataSourceMembership
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _bulk(db, table, rows, chunk=2000):
+    """Insert rows in chunks via a core INSERT (fast path, no ORM unit-of-work)."""
+    for i in range(0, len(rows), chunk):
+        await db.execute(insert(table), rows[i:i + chunk])
+    await db.commit()
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agents", type=int, default=1000)
+    ap.add_argument("--conns-per-agent", type=int, default=3)
+    ap.add_argument("--tables-per-conn", type=int, default=5)
+    ap.add_argument("--instructions", type=int, default=5000)
+    ap.add_argument("--pending-ratio", type=float, default=0.6)
+    ap.add_argument("--user-required", action="store_true",
+                    help="make connections user_required+oauth (OBO) to exercise the per-connection auth path")
+    args = ap.parse_args()
+
+    tag = uuid.uuid4().hex[:6]
+    _u = os.environ["BOW_DATABASE_URL"]
+    _u = (_u.replace("postgresql://", "postgresql+asyncpg://", 1) if _u.startswith("postgresql://")
+          else _u.replace("sqlite:///", "sqlite+aiosqlite:///", 1) if _u.startswith("sqlite:///") else _u)
+    engine = create_async_engine(_u, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as db:
+        user = (await db.execute(select(User).where(User.email == "sandbox@bow.dev"))).scalars().first()
+        org = (await db.execute(select(Organization))).scalars().first()
+        assert user and org, "run signup first (sandbox@bow.dev) so user+org exist"
+        org_id = str(org.id)
+        uid = str(user.id)
+
+        auth_policy = "user_required" if args.user_required else "system_only"
+        auth_modes = ["oauth"] if args.user_required else None
+
+        print(f"[seed:{tag}] agents={args.agents} conns/agent={args.conns_per_agent} "
+              f"tables/conn={args.tables_per_conn} instructions={args.instructions} "
+              f"pending_ratio={args.pending_ratio} auth_policy={auth_policy}")
+
+        # ---- agents (data sources) + memberships ------------------------------
+        agent_ids = [_uid() for _ in range(args.agents)]
+        await _bulk(db, DataSource.__table__, [
+            {"id": aid, "name": f"agent-{tag}-{i}", "is_active": True,
+             "is_public": False, "organization_id": org_id, "use_llm_sync": False}
+            for i, aid in enumerate(agent_ids)
+        ])
+        await _bulk(db, DataSourceMembership.__table__, [
+            {"id": _uid(), "data_source_id": aid, "principal_type": "user", "principal_id": uid}
+            for aid in agent_ids
+        ])
+        print(f"  agents+memberships done ({len(agent_ids)})")
+
+        # ---- connections + domain links + tables ------------------------------
+        conn_rows, link_rows, ctable_rows, dstable_rows = [], [], [], []
+        for ai, aid in enumerate(agent_ids):
+            for c in range(args.conns_per_agent):
+                cid = _uid()
+                conn_rows.append({
+                    "id": cid, "name": f"conn-{tag}-{ai}-{c}", "type": "postgresql",
+                    "config": {"host": "db.example.com", "port": 5432, "database": f"warehouse_{ai}",
+                               "schema": "public", "catalog_key": None},
+                    "is_active": True, "auth_policy": auth_policy,
+                    "allowed_user_auth_modes": auth_modes,
+                    "last_connection_status": "success",
+                    "last_connection_checked_at": datetime.utcnow(),
+                    "organization_id": org_id,
+                })
+                link_rows.append({"data_source_id": aid, "connection_id": cid})
+                for t in range(args.tables_per_conn):
+                    ctid = _uid()
+                    ctable_rows.append({
+                        "id": ctid, "name": f"tbl_{ai}_{c}_{t}", "connection_id": cid,
+                        "columns": [{"name": "id", "dtype": "int"}, {"name": "amount", "dtype": "float"}],
+                        "pks": ["id"], "fks": [], "no_rows": 1000,
+                    })
+                    dstable_rows.append({
+                        "id": _uid(), "name": f"tbl_{ai}_{c}_{t}", "datasource_id": aid,
+                        "connection_table_id": ctid, "is_active": True,
+                    })
+        await _bulk(db, Connection.__table__, conn_rows)
+        await _bulk(db, domain_connection, link_rows)
+        await _bulk(db, ConnectionTable.__table__, ctable_rows)
+        await _bulk(db, DataSourceTable.__table__, dstable_rows)
+        print(f"  connections={len(conn_rows)} tables={len(dstable_rows)} done")
+
+        # ---- main build -------------------------------------------------------
+        main_build = (await db.execute(
+            select(InstructionBuild).where(
+                InstructionBuild.organization_id == org_id, InstructionBuild.is_main == True  # noqa: E712
+            )
+        )).scalars().first()
+        next_bn = ((await db.execute(
+            select(InstructionBuild.build_number).where(InstructionBuild.organization_id == org_id)
+            .order_by(InstructionBuild.build_number.desc()).limit(1)
+        )).scalar() or 0) + 1
+        if main_build is None:
+            mb_id = _uid()
+            await _bulk(db, InstructionBuild.__table__, [{
+                "id": mb_id, "build_number": next_bn, "status": "approved", "source": "user",
+                "is_main": True, "organization_id": org_id, "created_by_user_id": uid,
+            }])
+            next_bn += 1
+        else:
+            mb_id = str(main_build.id)
+
+        # ---- instructions (+ v1, main build content) + pending builds ---------
+        inst_rows, assoc_rows, v1_rows, mbc_rows = [], [], [], []
+        v2_rows, sug_rows, sbc_rows = [], [], []
+        n_pending = 0
+        n = args.instructions
+        for i in range(n):
+            iid = _uid()
+            aid = agent_ids[i % len(agent_ids)]  # spread across agents
+            base_text = (f"Instruction {tag}-{i}: exclude refunded orders; use completion date; "
+                         f"join orders to customers on customer_id; filter to active accounts.")
+            inst_rows.append({
+                "id": iid, "text": base_text, "title": f"Instruction {i}", "status": "published",
+                "category": "general", "kind": "instruction", "user_id": uid,
+                "organization_id": org_id, "source_type": "user", "load_mode": "always",
+                "thumbs_up": 0, "is_seen": True, "can_user_toggle": True,
+            })
+            assoc_rows.append({"instruction_id": iid, "data_source_id": aid})
+            v1id = _uid()
+            v1_rows.append({
+                "id": v1id, "instruction_id": iid, "version_number": 1, "text": base_text,
+                "title": f"Instruction {i}", "status": "published", "load_mode": "always",
+                "content_hash": _hash(base_text), "created_by_user_id": uid,
+            })
+            mbc_rows.append({"id": _uid(), "build_id": mb_id, "instruction_id": iid,
+                             "instruction_version_id": v1id})
+            if i < int(n * args.pending_ratio):
+                proposed = base_text.replace("active accounts", "active, non-trial accounts") + \
+                    " Cap lookback to trailing 24 months."
+                v2id = _uid()
+                v2_rows.append({
+                    "id": v2id, "instruction_id": iid, "version_number": 2, "text": proposed,
+                    "title": f"Instruction {i}", "status": "published", "load_mode": "always",
+                    "content_hash": _hash(proposed), "created_by_user_id": uid,
+                })
+                sb_id = _uid()
+                sug_rows.append({
+                    "id": sb_id, "build_number": next_bn, "status": "draft", "source": "ai",
+                    "is_main": False, "organization_id": org_id, "base_build_id": mb_id,
+                    "created_by_user_id": uid, "description": f"AI suggestion for instruction {i}",
+                })
+                next_bn += 1
+                sbc_rows.append({"id": _uid(), "build_id": sb_id, "instruction_id": iid,
+                                 "instruction_version_id": v2id})
+                n_pending += 1
+
+        await _bulk(db, Instruction.__table__, inst_rows)
+        await _bulk(db, instruction_data_source_association, assoc_rows)
+        await _bulk(db, InstructionVersion.__table__, v1_rows)
+        if v2_rows:
+            await _bulk(db, InstructionVersion.__table__, v2_rows)
+            await _bulk(db, InstructionBuild.__table__, sug_rows)
+        await _bulk(db, BuildContent.__table__, mbc_rows)
+        if sbc_rows:
+            await _bulk(db, BuildContent.__table__, sbc_rows)
+
+        print(f"  instructions={len(inst_rows)} pending={n_pending} done")
+        print(f"[seed:{tag}] DONE  org={org_id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/design-open-changes-review-center.md
+++ b/design-open-changes-review-center.md
@@ -1,0 +1,198 @@
+# Design — "Open changes" badge + review-center modal (Agents page)
+
+A top-of-page badge on the Agents page that opens a modal listing **all open
+instruction changes** the caller can see, grouped/filterable by **agent (file),
+date, and author**, scoped to the caller's access, and scalable to thousands of
+open changes.
+
+Status: design only — not implemented.
+
+---
+
+## TL;DR
+
+Most of this already exists and is wired up but disabled. The work is **enable +
+extend**, not build-new, plus **one decision** about the source of truth.
+
+- Badge: re-enable the stubbed amber badge already in `KnowledgeExplorer.vue`.
+- Modal: the `ReviewFeed.vue` component + `/api/review*` endpoints already list,
+  filter (agent/status/type/search), group, and act (read / dismiss / resolve)
+  on `ReviewItem` rows, already access-scoped per user.
+- Gaps to close: date/author grouping + filters, real pagination, and reconciling
+  the review inbox with the per-hunk "pending" set used by the tree dots.
+
+---
+
+## What already exists (don't rebuild)
+
+**Badge (disabled).** `frontend/components/KnowledgeExplorer.vue:10`
+```html
+<button v-if="false && reviewCount > 0" ... @click="openReview(null)">
+  <span ...></span>{{ $t('agentsPage.toReview', { n: reviewCount }) }}
+</button>
+```
+`reviewCount` comes from `GET /api/review/count` (`{ open: N }`,
+`KnowledgeExplorer.vue:1270`). `openReview(null)` already opens the review view.
+
+**Modal/feed.** `frontend/components/ReviewFeed.vue` (355 lines) — fetches
+`GET /api/review`, groups rows, and supports read / dismiss / resolve and an
+agent filter. Mounted at `KnowledgeExplorer.vue:216`.
+
+**Backend.** `backend/app/routes/review.py`:
+- `GET /review` → `review_service.list_items(...)` with `agent_id`, `status`,
+  `type`, `severity`, `search` filters.
+- `GET /review/count` → `count_open(...)`.
+- `POST /review/read-all`, `/review/{id}/read|dismiss|resolve`.
+
+**Model.** `backend/app/models/review_item.py` — `ReviewItem` with:
+- `type` (`instruction_suggestion` = an open instruction change; also
+  `low_confidence`, `slow_query`, `schema_changed`, …),
+- `status` (open / in_progress / snoozed / resolved / dismissed),
+- `data_source_id` (the agent → our "file/agent" axis),
+- `created_at` / `updated_at` (the "date" axis),
+- `payload` (polymorphic pointer: `{instruction_id, build_id, completion_id, …}`),
+- `why` (human-readable reason).
+
+**Access scoping (already correct).** `review_service.list_items` calls
+`_visible(db, org, user) → (is_admin, ds_ids)` and filters
+`ReviewItem.data_source_id.in_(ds_ids)` for non-admins (admins see all). This is
+exactly the "my instructions I have access to" requirement, and it already has
+the admin "see everything" mode (parallel to the agents "Show all" toggle).
+
+**Producer.** `review_producers.emit_instruction_suggestions_for_build(...)`
+(called from `instruction_service.py:3601` on build creation) upserts an
+`instruction_suggestion` `ReviewItem` per pending suggestion build.
+
+---
+
+## The one real decision: source of truth
+
+There are **two populations of "open change"** today and they are not guaranteed
+to be the same set:
+
+1. **Per-hunk pending set** — `get_pending_change_instruction_ids` (the authoritative
+   rule: a suggestion build counts only if it yields a *live* hunk vs current
+   main). This drives the **tree dots** and `counts.pending_total`.
+2. **`instruction_suggestion` ReviewItems** — emitted when a suggestion build is
+   created; drives `/review/count` and the feed. These can drift from (1): an
+   item can linger after its hunk is already applied/covered, or a build created
+   outside the producer path may have no item.
+
+**The badge and the modal must agree with the tree dots**, or users see "3
+pending" in the tree and "5 to review" in the badge. Pick one:
+
+- **Recommended:** make the per-hunk set authoritative for the
+  `instruction_suggestion` slice. On read, reconcile `ReviewItem` rows against
+  `get_pending_change_instruction_ids` (now ~1.9s for ~7.6k pending after the
+  recent fix; cache it per request) — hide/auto-resolve items whose change is no
+  longer live, and surface any live-but-itemless build. Keeps the rich inbox UX
+  (read/dismiss/snooze/assignee) while staying consistent with the tree.
+- Alternative: treat ReviewItems as the sole truth and switch the tree dots to
+  read from them too. Simpler to keep consistent, but loses the precise
+  "is there actually a live hunk" semantics the per-hunk model gives.
+
+This choice should be made before building grouping/pagination on top.
+
+---
+
+## Endpoint shape
+
+Extend the existing `GET /api/review` rather than add a parallel API.
+
+```
+GET /api/review
+  ?type=instruction_suggestion          # default the modal to open changes
+  &status=open,in_progress,snoozed      # active by default
+  &agent_id=<id>                        # optional filter
+  &author_id=<id>                       # NEW — "who"
+  &since=<iso>&until=<iso>              # NEW — "dates"
+  &group_by=agent|date|author           # NEW — server-applied grouping key
+  &sort=updated_at|created_at           # default updated_at desc
+  &search=<q>
+  &cursor=<opaque>&limit=50             # NEW — cursor pagination (today: limit=200, no skip)
+->
+{
+  "groups": [ { "key": "...", "label": "...", "count": N } ],   # for the chosen group_by
+  "items": [ {
+      "id", "type", "status", "why",
+      "agent": {id, name}, "author": {id, name, source: user|ai|git},
+      "created_at", "updated_at",
+      "instruction": {id, title, snippet},
+      "build_id"
+  } ],
+  "next_cursor": "..." | null,
+  "total": N
+}
+```
+
+Notes
+- `author`/`source` already available: the suggestion build carries
+  `created_by_user_id` + `source` (`user`/`ai`/`git`); the producer can denormalize
+  these onto the `ReviewItem` (or join at read time) so "who" is one field.
+- The **diff is loaded lazily** when a row is expanded, via the existing
+  `GET /instructions/{id}/review-hunks` — never compute hunks for the whole list.
+- `count_open` stays the badge source, but apply the same reconciliation as the
+  list so badge == modal == tree.
+
+---
+
+## Component plan (frontend)
+
+1. **Badge** — remove the `false &&` guard at `KnowledgeExplorer.vue:10`; keep
+   `reviewCount` from `/review/count`. Place it in the page header next to
+   "Connect Git / New".
+2. **Modal** — reuse `ReviewFeed.vue`. Add:
+   - a **group-by switch** (Agent / Date / Author) driving `group_by`,
+   - **author** and **date-range** filters (it already has agent + status + search),
+   - **pagination/virtualization** — today it renders the fetched list; switch to
+     `cursor`+`limit` with "load more" or a virtual list (the tree itself isn't
+     virtualized; same caution applies here at thousands of rows).
+3. **Row → diff** — clicking a row opens the existing per-instruction review/diff
+   view (`openInstructionFromReview` is already wired from the feed) with
+   accept/reject hunks. No new diff UI.
+
+---
+
+## Scale plan
+
+- **Don't** compute hunks for the list. Two-step, mirroring the perf fix:
+  1. resolve the authoritative pending id set **once** and cache it
+     (request-scope or short TTL) — used only for reconciliation/count;
+  2. the list query is a plain indexed `ReviewItem` scan with the filters +
+     **cursor pagination** (page-sized), returning denormalized metadata only.
+- Group counts come from a `GROUP BY` (data_source_id / date_trunc / author),
+  not Python aggregation over all rows.
+- Lazy per-row diff via `review-hunks`.
+- This keeps every interaction **O(page)**, independent of total backlog size.
+
+Index check before building: `review_items(organization_id, type, status,
+data_source_id)` and `(organization_id, type, status, updated_at)` for the
+sort/paginate path (SQLite/Postgres don't auto-index these).
+
+---
+
+## Access control
+
+Already handled by `_visible` (member data sources for non-admins, everything for
+admins). Surface an **admin-only "All" toggle** in the modal header — identical
+pattern and gating to the agents "Show all" — so a reviewer can triage the whole
+org's backlog while members see only their accessible changes. No new permission
+needed; reuse the governance perm that backs the agents toggle.
+
+---
+
+## Open question for product
+
+"**by files**" — default grouping is by **agent** (the `data_source_id` an
+instruction is attached to). True source *files* only exist for git/markdown-synced
+instructions; for those, show the file path as a sub-label. Confirm whether
+"files" means agents (assumed) or literally source files.
+
+---
+
+## Phasing
+
+1. Reconcile source-of-truth + enable the badge (count consistent with tree).
+2. Modal: author + date filters, group-by switch, cursor pagination.
+3. Group counts via `GROUP BY`; add the missing indexes.
+4. Admin "All" toggle; polish bulk actions (accept/reject/dismiss across a group).

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -1921,7 +1921,18 @@ const expand = (key: string, force?: boolean) => {
 // ── Fetching (lazy) ─────────────────────────────────────
 // Aggregate badges — one cheap call, no rows. Drives every count/dot in the tree.
 const fetchCounts = async () => {
-  try { const { data } = await useMyFetch<any>('/api/instructions/counts', { method: 'GET' }); if (data.value) counts.value = data.value } catch (e) { console.error(e) }
+  try {
+    const { data } = await useMyFetch<any>('/api/instructions/counts', { method: 'GET' })
+    if (data.value) {
+      counts.value = data.value
+      // Counts already carries the full per-instruction pending set, so the
+      // per-row "pending" dots come from this one call — no separate org-wide
+      // /pending-changes sweep needed on the hot path.
+      if (Array.isArray(data.value.pending_instruction_ids)) {
+        pendingInstrIds.value = new Set<string>(data.value.pending_instruction_ids.map((x: any) => String(x)))
+      }
+    }
+  } catch (e) { console.error(e) }
 }
 // Merge fetched rows into the lazy cache (dedupe by id; newest wins).
 const mergeRows = (rows: Instruction[]) => {
@@ -1958,8 +1969,10 @@ const fetchAll = async () => {
     await Promise.all([fetchCounts(), ...Array.from(loadedGroups.value).map(k => loadGroup(k, true))])
   } finally { instrLoading.value = false }
 }
-// Refresh badges + pending dots + visible rows after a mutation.
-const refreshLists = async () => { await Promise.all([fetchAll(), fetchPendingMap()]) }
+// Refresh badges + pending dots + visible rows after a mutation. fetchAll() runs
+// fetchCounts(), which also refreshes the per-row pending-dot set — so no extra
+// /pending-changes sweep is needed here.
+const refreshLists = async () => { await fetchAll() }
 const fetchAgents = async () => {
   try {
     // include_unconnected=true so members also see user_required (OBO) agents
@@ -2435,11 +2448,9 @@ onMounted(async () => {
   // and the "N pending" badge, so fetchPendingMap is no longer on the hot path.
   await Promise.all([fetchAgents(), fetchConnections(), fetchCounts(), fetchLabels(), fetchCategories(), fetchGitStatus(), fetchReviewCount()])
   instrLoading.value = false
-  // Cheap (batched) id list that drives the per-row amber "pending" dots once
-  // rows lazy-load; fired non-blocking so it never gates the tree.
-  fetchPendingMap()
+  // fetchCounts already populated the per-row "pending" dot set from its own
+  // response, so no separate org-wide /pending-changes sweep is needed here.
   restoreFromRoute()
-  fetchPendingMap()
 })
 </script>
 


### PR DESCRIPTION
## Why

The Agents page (`KnowledgeExplorer.vue`) degraded badly as an org grew — clicking **Show all**, and especially expanding agents, took tens of seconds. This fixes the query pathologies behind that, verified against a seeded org of **~1,010 agents · ~2,020 connections · ~10,000 instructions · ~7,610 pending changes**.

## What changed

**1. Batch the agent-list connection queries (`data_source_service.py`)**
`GET /data_sources/active` built each agent's connections with a per-connection indexing query + per-connection table-count query (an N+1 that grew with agent count). Added `_bulk_connection_aux` to precompute latest-indexing rows and active table counts for the whole list in a few grouped queries; `_build_connections_list` reads from those maps (single-data-source callers keep their original path).

**2. Fix the org-wide pending-changes sweep (`instruction_service.py`)**
`get_pending_change_instruction_ids` fed its own ~7,600-element candidate set back into the suggestion-build query as a redundant `IN (...)`, which made SQLite pick a ~40× worse plan. The WHERE already selects exactly the pending rows, so the candidate ids are now **derived** from the result instead of re-applied. **Sweep: ~16s → ~1.9s, identical result set.**

**3. Scope the per-agent list sweep (`instruction_service.py`)**
The instruction list re-ran the **org-wide** pending sweep on every per-agent expand. It now passes the on-screen agents' instructions as `candidate_ids`, so expanding one agent no longer recomputes every pending change in the org. Output-identical — the `data_source_ids` / `global_only` filters already exclude everything else.

**4. Drop redundant pending sweeps on mount (`instruction_service.py` + `KnowledgeExplorer.vue`)**
`GET /instructions/counts` already computes the full pending set; it now returns it (`pending_instruction_ids`). The client drives the per-row pending dots from that single call and no longer fires the two duplicate `/instructions/pending-changes` sweeps on mount (3 org-wide sweeps → 1).

## Measured before → after (seeded org above)

| Endpoint | Before | After |
|---|---|---|
| `GET /instructions/pending-changes` | 10.7s | **1.65s** |
| `GET /instructions/counts` (mount) | 18s | **5.9s** |
| per-agent expand (`/instructions?data_source_ids=…`) | 13.9s | **4.5s** |
| pending sweep itself | ~16s | **1.9s** |
| `GET /data_sources/active?show_all=true` | 0.32s | 0.32s |

The remaining `/counts` and per-agent residual is the membership-visibility aggregation, which scales with how many agents the caller is a member of (10 → 0.07s, 100 → 0.24s, 2010 → 2.06s) — high here only because the seed makes the admin a member of every agent; sub-second at realistic membership.

## Testing

- All 17 tests in `tests/e2e/test_instruction.py` pass, including `test_pending_status_consistent_between_list_and_detail` (the per-hunk pending source-of-truth check). The pending result set is unchanged by the fixes.
- Reproduced and re-measured end-to-end with a new repro seeder (`backend/scripts/seed_scale_agents.py`).
- Verified in the running UI: 2,010 agents + 2,016 connections render in ~7s, and expanding an agent (~4s) lazy-loads its Tables/Tools/Files/Instructions tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED21qfJPHHtR7vZzehJnWa)_