### PR TITLE
Fix: only alert "Connection schema changed" on real backend schema changes, not user table activation

### DIFF
--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2993,11 +2993,13 @@ class DataSourceService:
                     trigger=TRIGGER_TABLE_CHANGE,
                     changed_hint=f"{activated_count} table(s) activated",
                 )
-                from app.services.review_producers import emit_schema_changed
-                await emit_schema_changed(
-                    db, str(organization.id), str(data_source_id),
-                    summary=f"{activated_count} table(s) activated on this connection.",
-                )
+                # NOTE: intentionally NO "Connection schema changed" review/notification
+                # here. Activating tables is a deliberate user action in the table
+                # selector — not a backend schema change — so notifying about it is
+                # noise. The schema-changed alert is reserved for genuine upstream
+                # structural drift detected during a schema sync (see
+                # sync_domain_tables, which emits emit_schema_changed on a real
+                # table/column structure change).
             except Exception:
                 logger.debug("update_tables_status_delta: reliability trigger skipped", exc_info=True)
 


### PR DESCRIPTION
## Why

The "Connection schema changed" notification was firing for a deliberate user action — activating tables in the table selector — instead of an actual backend schema change. In the notifications dropdown this showed up as noisy `N table(s) activated on this connection.` items.

## Root cause

`emit_schema_changed` had two callers in `data_source_service.py`:

- **`update_tables_status_delta`** — fired `"N table(s) activated on this connection."` whenever a user activated tables in the selector. That's a user action, not a schema change. ❌
- **`sync_domain_tables`** — fires `"Table/column structure changed: …"` only when a schema sync/reindex detects the table/column structure actually changed upstream. ✅

## Change

Remove the `emit_schema_changed` call from the table-activation path (`update_tables_status_delta`). The schema-changed alert is now reserved for genuine upstream structural drift detected during a schema sync. The internal agent-reliability re-measure on table activation is unchanged (it's not a user-facing notification), and the separate `instruction_suggestion` notifications are a different type and unaffected.

## Testing

- `py_compile` clean.
- Confirmed the genuine `sync_domain_tables` trigger is intact (still emits only on a real structural change).
- No tests referenced the removed notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED21qfJPHHtR7vZzehJnWa)_