### PR TITLE
Localize follow-up label and make suggestions RTL-aware

### DIFF
--- a/frontend/components/report/FollowUpSuggestions.vue
+++ b/frontend/components/report/FollowUpSuggestions.vue
@@ -10,6 +10,7 @@
       <li v-for="(q, idx) in items" :key="idx" class="group">
         <button
           type="button"
+          dir="auto"
           :disabled="disabled"
           @click="select(q)"
           class="w-full flex items-center justify-between gap-3 py-2.5 px-1 text-start text-[13px] leading-snug text-gray-500 dark:text-gray-400 transition-colors duration-150 hover:text-gray-900 dark:hover:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -600,7 +600,7 @@
     "widgetRef": "← عنصر: {id}",
     "stepRef": "← خطوة: {id}",
     "viewAgentTrace": "عرض أثر الوكيل",
-    "followUp": "Follow up"
+    "followUp": "أسئلة للمتابعة"
   },
   "tools": {
     "common": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Widget: {id}",
     "stepRef": "→ Schritt: {id}",
     "viewAgentTrace": "Agenten-Trace anzeigen",
-    "followUp": "Follow up"
+    "followUp": "Folgefragen"
   },
   "tools": {
     "common": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -610,7 +610,7 @@
     "widgetRef": "→ Widget: {id}",
     "stepRef": "→ Paso: {id}",
     "viewAgentTrace": "Ver traza del agente",
-    "followUp": "Follow up"
+    "followUp": "Preguntas de seguimiento"
   },
   "tools": {
     "common": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Widget : {id}",
     "stepRef": "→ Étape : {id}",
     "viewAgentTrace": "Voir la trace de l'agent",
-    "followUp": "Follow up"
+    "followUp": "Questions de suivi"
   },
   "tools": {
     "common": {

--- a/locales/he.json
+++ b/locales/he.json
@@ -610,7 +610,7 @@
     "widgetRef": "← ווידג'ט: {id}",
     "stepRef": "← שלב: {id}",
     "viewAgentTrace": "הצג מעקב סוכן",
-    "followUp": "Follow up"
+    "followUp": "שאלות המשך"
   },
   "tools": {
     "common": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Widget: {id}",
     "stepRef": "→ Passaggio: {id}",
     "viewAgentTrace": "Visualizza trace dell'agente",
-    "followUp": "Follow up"
+    "followUp": "Domande di approfondimento"
   },
   "tools": {
     "common": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Widget: {id}",
     "stepRef": "→ Etapa: {id}",
     "viewAgentTrace": "Ver trace do agente",
-    "followUp": "Follow up"
+    "followUp": "Perguntas de acompanhamento"
   },
   "tools": {
     "common": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Виджет: {id}",
     "stepRef": "→ Шаг: {id}",
     "viewAgentTrace": "Просмотр трассировки агента",
-    "followUp": "Follow up"
+    "followUp": "Дополнительные вопросы"
   },
   "tools": {
     "common": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -600,7 +600,7 @@
     "widgetRef": "→ Widget: {id}",
     "stepRef": "→ Steg: {id}",
     "viewAgentTrace": "Visa agentspår",
-    "followUp": "Follow up"
+    "followUp": "Följdfrågor"
   },
   "tools": {
     "common": {


### PR DESCRIPTION
The follow-up suggestions block on /reports/[id] showed an untranslated
"Follow up" header in every non-English locale, and the dynamic
suggestion text had no direction handling, so Hebrew/Arabic suggestions
rendered with the wrong alignment.

- Translate the reportView.followUp key in all 9 non-English locales
- Add dir="auto" to each suggestion button so the row direction and
  text alignment follow the suggestion's own language (the arrow icon
  already auto-flips under an RTL document via rtl.css)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RZPPupBMvzutBWrktPhP3V