### PR TITLE
Agents tree: show only active tables (full catalog stays on the Tables page)

### DIFF
--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -119,7 +119,7 @@
               <template #icon><DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" class="w-4 h-4 shrink-0" /></template>
 
               <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id] ? (activeTables(agent.id).length || undefined) : undefined" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
-                <TreeGroup v-for="t in activeTables(agent.id)" :key="t.id" :label="t.name" icon="i-heroicons-check-circle" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
+                <TreeGroup v-for="t in activeTables(agent.id)" :key="t.id" :label="t.name" icon="i-heroicons-table-cells" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
                   <InstrLeaf v-for="ins in listForTable(agent.id, t.id)" :key="ins.id" :ins="ins" :indent="3" />
                   <EmptyHint v-if="loadedGroups.has(agent.id) && listForTable(agent.id, t.id).length === 0" :text="$t('agentsPage.noRulesAttached')" add @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })" :pad="62" />
                 </TreeGroup>

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -118,12 +118,12 @@
             <TreeGroup :label="agent.name" :count="agentCount(agent.id) || undefined" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? $t('agentsPage.signInBadge') : (agent.publish_status === 'disabled' ? $t('agentsPage.disabledBadge') : (agent.is_connector ? $t('agentsPage.connectorBadge') : ''))" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
               <template #icon><DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" class="w-4 h-4 shrink-0" /></template>
 
-              <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id]?.length" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
-                <TreeGroup v-for="t in (agentTables[agent.id] || [])" :key="t.id" :label="t.name" :icon="t.is_active ? 'i-heroicons-check-circle' : 'i-heroicons-table-cells'" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
+              <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id] ? (activeTables(agent.id).length || undefined) : undefined" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
+                <TreeGroup v-for="t in activeTables(agent.id)" :key="t.id" :label="t.name" icon="i-heroicons-check-circle" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
                   <InstrLeaf v-for="ins in listForTable(agent.id, t.id)" :key="ins.id" :ins="ins" :indent="3" />
                   <EmptyHint v-if="loadedGroups.has(agent.id) && listForTable(agent.id, t.id).length === 0" :text="$t('agentsPage.noRulesAttached')" add @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })" :pad="62" />
                 </TreeGroup>
-                <EmptyHint v-if="(agentTables[agent.id]?.length ?? -1) === 0" :text="$t('agentsPage.noAccessibleTables')" :pad="48" />
+                <EmptyHint v-if="agentTables[agent.id] && activeTables(agent.id).length === 0" :text="$t('agentsPage.noActiveTables')" :pad="48" />
               </TreeGroup>
 
               <TreeGroup :label="$t('agentsPage.tools')" icon="i-heroicons-wrench-screwdriver" :count="agentTools[agent.id]?.length" :indent="1" reloadable :active="panelView?.kind === 'tools' && panelView?.agentId === agent.id" :open="isOpen('tools:' + agent.id)" @toggle="onPanelRowClick('tools', agent.id)" @reload="reloadTools(agent.id)">
@@ -2090,6 +2090,10 @@ const listFor = (kind: string) => {
 const hasTableRef = (ins: Instruction) => (ins.references || []).some((r: any) => r.object_type === 'datasource_table')
 const listForAgent = (id: string) => applyFilters(allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === id) && !hasTableRef(i)))
 const listForTable = (agentId: string, tableId: string) => applyFilters(allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === agentId) && (i.references || []).some((r: any) => r.object_type === 'datasource_table' && String(r.object_id) === tableId)))
+// The tree only surfaces ACTIVE (in-scope) tables — the lean working set the
+// agent actually reasons with. The full catalog (active + inactive) lives on the
+// agent's Tables page; the tree is not a schema browser.
+const activeTables = (agentId: string) => (agentTables.value[agentId] || []).filter((t: any) => t.is_active)
 
 // ── Detail / create ─────────────────────────────────────
 const openInstruction = async (ins: Instruction) => {

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -29,6 +29,7 @@
     "settings": "الإعدادات",
     "noRulesAttached": "لا توجد قواعد مرفقة.",
     "noAccessibleTables": "لا توجد جداول يمكن الوصول إليها.",
+    "noActiveTables": "لا توجد جداول نشطة.",
     "noToolsConnected": "لا توجد أدوات متصلة.",
     "noFiles": "لا توجد ملفات.",
     "noInstructions": "لا توجد تعليمات بعد.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -29,6 +29,7 @@
     "settings": "Einstellungen",
     "noRulesAttached": "Keine Regeln zugewiesen.",
     "noAccessibleTables": "Keine zugänglichen Tabellen.",
+    "noActiveTables": "Keine aktiven Tabellen.",
     "noToolsConnected": "Keine Werkzeuge verbunden.",
     "noFiles": "Keine Dateien.",
     "noInstructions": "Noch keine Anweisungen.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,6 +29,7 @@
     "settings": "Settings",
     "noRulesAttached": "No rules attached.",
     "noAccessibleTables": "No accessible tables.",
+    "noActiveTables": "No active tables.",
     "noToolsConnected": "No tools connected.",
     "noFiles": "No files.",
     "noInstructions": "No instructions yet.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -29,6 +29,7 @@
     "settings": "Ajustes",
     "noRulesAttached": "No hay reglas adjuntas.",
     "noAccessibleTables": "No hay tablas accesibles.",
+    "noActiveTables": "No hay tablas activas.",
     "noToolsConnected": "No hay herramientas conectadas.",
     "noFiles": "No hay archivos.",
     "noInstructions": "Aún no hay instrucciones.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -29,6 +29,7 @@
     "settings": "Paramètres",
     "noRulesAttached": "Aucune règle associée.",
     "noAccessibleTables": "Aucune table accessible.",
+    "noActiveTables": "Aucune table active.",
     "noToolsConnected": "Aucun outil connecté.",
     "noFiles": "Aucun fichier.",
     "noInstructions": "Aucune instruction pour le moment.",

--- a/locales/he.json
+++ b/locales/he.json
@@ -29,6 +29,7 @@
     "settings": "הגדרות",
     "noRulesAttached": "אין כללים מצורפים.",
     "noAccessibleTables": "אין טבלאות נגישות.",
+    "noActiveTables": "אין טבלאות פעילות.",
     "noToolsConnected": "אין כלים מחוברים.",
     "noFiles": "אין קבצים.",
     "noInstructions": "אין הנחיות עדיין.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -29,6 +29,7 @@
     "settings": "Impostazioni",
     "noRulesAttached": "Nessuna regola allegata.",
     "noAccessibleTables": "Nessuna tabella accessibile.",
+    "noActiveTables": "Nessuna tabella attiva.",
     "noToolsConnected": "Nessuno strumento collegato.",
     "noFiles": "Nessun file.",
     "noInstructions": "Ancora nessuna istruzione.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -29,6 +29,7 @@
     "settings": "Configurações",
     "noRulesAttached": "Nenhuma regra anexada.",
     "noAccessibleTables": "Nenhuma tabela acessível.",
+    "noActiveTables": "Nenhuma tabela ativa.",
     "noToolsConnected": "Nenhuma ferramenta conectada.",
     "noFiles": "Nenhum arquivo.",
     "noInstructions": "Nenhuma instrução ainda.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -29,6 +29,7 @@
     "settings": "Настройки",
     "noRulesAttached": "Правила не прикреплены.",
     "noAccessibleTables": "Нет доступных таблиц.",
+    "noActiveTables": "Нет активных таблиц.",
     "noToolsConnected": "Инструменты не подключены.",
     "noFiles": "Нет файлов.",
     "noInstructions": "Пока нет инструкций.",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -29,6 +29,7 @@
     "settings": "Inställningar",
     "noRulesAttached": "Inga regler kopplade.",
     "noAccessibleTables": "Inga åtkomliga tabeller.",
+    "noActiveTables": "Inga aktiva tabeller.",
     "noToolsConnected": "Inga verktyg anslutna.",
     "noFiles": "Inga filer.",
     "noInstructions": "Inga instruktioner ännu.",


### PR DESCRIPTION
## Why

The agents-page left tree listed **every** discovered table under an agent's "Tables" node — active *and* inactive (e.g. 21 for a SQL Server source, including views and unused tables). That turns the tree into a schema browser and buries the tables the agent actually uses.

This changes the tree to show only the agent's **active (in-scope) tables** — the lean working set it reasons with. The full catalog (active + inactive) remains available on the agent's **Tables page**; the tree is not a schema browser.

## Change

`frontend/components/KnowledgeExplorer.vue`:
- New `activeTables(agentId)` helper filtering the loaded `agentTables` to `is_active`.
- The Tables node's child `v-for`, its count badge, and its empty state all use `activeTables(...)`.
- Table rows now always render the active (check-circle) icon (the active/inactive icon split is moot when only active tables show).
- Empty state when an agent has no active tables uses a new `agentsPage.noActiveTables` string, added across all 10 locales.

No backend change — `/data_sources/{id}/full_schema` still returns the full catalog; this only filters what the tree renders.

## Note

A table-scoped instruction pinned to a table that is currently **inactive** will no longer appear in the tree (its table is hidden, and table-pinned rules don't show in the flat Instructions node). That's consistent with "the tree shows the agent's in-scope working set" — reactivating the table on the Tables page brings it (and its rules) back. Flagging in case we'd rather keep tables that still have rules attached visible regardless of active state.

## Testing

- Locale JSON validated for all 10 languages; `noActiveTables` present in each.
- Template change is display-only (filter + count + empty state); the underlying `agentTables` fetch (full schema) and reload are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED21qfJPHHtR7vZzehJnWa)_