### PR TITLE
Fix /agents instruction count flickering 3 → 0 (counts vs list table-access mismatch)

### DIFF
--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -628,6 +628,29 @@ class InstructionService:
             for iid in pending_ids - assigned:
                 global_ids.add(iid)
 
+        # Apply the SAME per-user table-accessibility cut the list applies
+        # (_filter_list_items_by_table_accessibility), so a table-pinned
+        # instruction the user can't see in the lazy list is not counted in the
+        # tree badge. Without this, the Instructions node shows the badge count
+        # (e.g. 3) then drops to the list length (0) once the rows load → the
+        # reported 3→0 flicker / "No instructions yet".
+        if current_user is not None:
+            all_counted = global_ids | skills_ids
+            for v in agent_sets.values():
+                all_counted |= v
+            hidden = await self._table_inaccessible_instruction_ids(
+                db, list(all_counted), str(current_user.id)
+            )
+            if hidden:
+                global_ids -= hidden
+                skills_ids -= hidden
+                for ds_id in list(agent_sets.keys()):
+                    agent_sets[ds_id] -= hidden
+                    if not agent_sets[ds_id]:
+                        del agent_sets[ds_id]
+                        pending_by_agent.pop(ds_id, None)
+                pending_ids -= hidden
+
         by_agent = {k: len(v) for k, v in agent_sets.items()}
 
         return {
@@ -2973,6 +2996,64 @@ class InstructionService:
             "pages": (total + limit - 1) // limit if limit > 0 else 1
         }
 
+    async def _table_inaccessible_instruction_ids(
+        self,
+        db: AsyncSession,
+        instruction_ids: List[str],
+        user_id: str,
+    ) -> set:
+        """Subset of ``instruction_ids`` that are HIDDEN from the user because
+        every datasource_table reference they carry is in the user's per-user
+        inaccessible-table overlay (``UserDataSourceTable.is_accessible == False``).
+
+        This is the single source of truth for the table-accessibility cut so the
+        list (``_filter_list_items_by_table_accessibility``) and the /agents tree
+        badges (``get_instruction_counts``) agree — otherwise a badge counts an
+        instruction the lazy list then drops, producing the 3→0 flicker.
+
+        Rules (an instruction is hidden iff ALL its table refs are inaccessible):
+        - No table references → not hidden (global / text-only instruction)
+        - At least one referenced table accessible → not hidden
+        - No inaccessible overlay rows for the user → nothing hidden
+        """
+        from app.models.user_data_source_overlay import UserDataSourceTable
+        from app.models.instruction_reference import InstructionReference
+
+        ids = [str(i) for i in instruction_ids]
+        if not ids:
+            return set()
+
+        # Get the set of table IDs this user cannot access
+        result = await db.execute(
+            select(UserDataSourceTable.data_source_table_id)
+            .where(
+                UserDataSourceTable.user_id == user_id,
+                UserDataSourceTable.is_accessible == False,
+                UserDataSourceTable.data_source_table_id.isnot(None),
+            )
+        )
+        inaccessible = {row[0] for row in result.all()}
+        if not inaccessible:
+            return set()
+
+        ref_result = await db.execute(
+            select(InstructionReference.instruction_id, InstructionReference.object_id)
+            .where(
+                InstructionReference.instruction_id.in_(ids),
+                InstructionReference.object_type == "datasource_table",
+            )
+        )
+        refs_by_instruction: dict[str, set[str]] = {}
+        for inst_id, table_id in ref_result.all():
+            refs_by_instruction.setdefault(str(inst_id), set()).add(table_id)
+
+        hidden: set = set()
+        for inst_id, table_refs in refs_by_instruction.items():
+            # All refs inaccessible (and there is at least one ref) → hidden.
+            if table_refs and not (table_refs - inaccessible):
+                hidden.add(inst_id)
+        return hidden
+
     async def _filter_list_items_by_table_accessibility(
         self,
         db: AsyncSession,
@@ -2987,47 +3068,14 @@ class InstructionService:
         - At least one referenced table accessible → keep
         - No overlay rows for user → keep all (no filtering)
         """
-        from app.models.user_data_source_overlay import UserDataSourceTable
-        from app.models.instruction_reference import InstructionReference
-
-        # Get the set of table IDs this user cannot access
-        result = await db.execute(
-            select(UserDataSourceTable.data_source_table_id)
-            .where(
-                UserDataSourceTable.user_id == user_id,
-                UserDataSourceTable.is_accessible == False,
-                UserDataSourceTable.data_source_table_id.isnot(None),
-            )
-        )
-        inaccessible = {row[0] for row in result.all()}
-        if not inaccessible:
+        if not items:
             return items
-
-        # Batch-load table references for all instruction IDs
-        item_ids = [str(item.id) for item in items]
-        if not item_ids:
-            return items
-
-        ref_result = await db.execute(
-            select(InstructionReference.instruction_id, InstructionReference.object_id)
-            .where(
-                InstructionReference.instruction_id.in_(item_ids),
-                InstructionReference.object_type == "datasource_table",
-            )
+        hidden = await self._table_inaccessible_instruction_ids(
+            db, [str(item.id) for item in items], user_id
         )
-        refs_by_instruction: dict[str, set[str]] = {}
-        for inst_id, table_id in ref_result.all():
-            refs_by_instruction.setdefault(inst_id, set()).add(table_id)
-
-        filtered = []
-        for item in items:
-            table_refs = refs_by_instruction.get(str(item.id))
-            if not table_refs:
-                filtered.append(item)
-            elif table_refs - inaccessible:
-                filtered.append(item)
-            # else: all refs inaccessible → exclude
-        return filtered
+        if not hidden:
+            return items
+        return [item for item in items if str(item.id) not in hidden]
 
     async def _get_user_permissions(self, db: AsyncSession, user: User, organization: Organization) -> set:
         """Get user's org-level permissions via the RBAC resolver."""

--- a/backend/scripts/seed_table_pinned.py
+++ b/backend/scripts/seed_table_pinned.py
@@ -1,0 +1,105 @@
+"""Seed an agent (DataSource) with N instructions all pinned to a table.
+
+Reproduces the /agents 3->0 scenario: counts.by_agent shows N but the per-agent
+flat Instructions node shows 0 because every instruction has a datasource_table
+reference (excluded by !hasTableRef in listForAgent).
+
+Run with: uv run python scripts/seed_table_pinned.py [N]
+"""
+import os, sys, asyncio, uuid
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app_3to0.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.datasource_table import DataSourceTable
+from app.models.data_source_membership import DataSourceMembership, PRINCIPAL_TYPE_USER
+from app.services.instruction_service import InstructionService
+from app.schemas.instruction_schema import InstructionCreate
+from app.schemas.instruction_reference_schema import InstructionReferenceCreate
+
+
+async def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    orphan = "--orphan" in sys.argv  # case (c): bad object_id that matches no table
+
+    url = os.environ["BOW_DATABASE_URL"].replace("sqlite://", "sqlite+aiosqlite://")
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as db:
+        org = (await db.execute(select(Organization))).scalars().first()
+        user = (await db.execute(select(User))).scalars().first()
+        print(f"org={org.id} user={user.id} ({user.email})")
+
+        # Agent (DataSource)
+        ds = DataSource(
+            name="Pinned Agent",
+            organization_id=org.id,
+            is_public=False,
+        )
+        db.add(ds)
+        await db.commit()
+        await db.refresh(ds)
+
+        # Admin is a member of the agent
+        db.add(DataSourceMembership(
+            data_source_id=ds.id,
+            principal_type=PRINCIPAL_TYPE_USER,
+            principal_id=user.id,
+            config={"role": "owner"},
+        ))
+
+        # A table belonging to the agent
+        tbl = DataSourceTable(
+            name="orders",
+            datasource_id=ds.id,
+            is_active=True,
+            columns=[],
+            pks=[],
+            fks=[],
+        )
+        db.add(tbl)
+        await db.commit()
+        await db.refresh(tbl)
+        print(f"data_source={ds.id} table={tbl.id} (name={tbl.name})")
+
+        svc = InstructionService()
+        ref_object_id = ("nonexistent-" + str(uuid.uuid4())) if orphan else tbl.id
+        created = []
+        for i in range(n):
+            payload = InstructionCreate(
+                text=f"Pinned instruction #{i} for orders table",
+                title=f"Pinned #{i}",
+                category="general",
+                status="published",
+                data_source_ids=[ds.id],
+                references=[InstructionReferenceCreate(
+                    object_type="datasource_table",
+                    object_id=ref_object_id,
+                    display_text="orders",
+                )],
+            )
+            schema = await svc.create_instruction(
+                db, payload, current_user=user, organization=org,
+            )
+            created.append(schema.id)
+        print(f"created {len(created)} instructions pinned to object_id={ref_object_id}")
+        print(f"AGENT_ID={ds.id}")
+        print(f"TABLE_ID={tbl.id}")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/e2e/test_instruction.py
+++ b/backend/tests/e2e/test_instruction.py
@@ -770,3 +770,129 @@ def test_pending_status_consistent_between_list_and_detail(
     assert effective(single) == "published"
     assert effective(row) == "published", "list must not show pending when detail shows Active"
     assert effective(single) == effective(row)
+
+
+@pytest.mark.e2e
+def test_agent_count_matches_list_under_inaccessible_table(
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Regression for the /agents tree 3->0 flicker.
+
+    An agent's Instructions node first renders the badge count
+    (GET /api/instructions/counts -> by_agent[agent]) then switches to the
+    per-agent lazy list length once it loads. When a table-pinned instruction's
+    only referenced table is in the user's per-user inaccessible-table overlay,
+    the list filters it out (_filter_list_items_by_table_accessibility) — so the
+    counts MUST apply the same cut, otherwise the badge counts an instruction the
+    list then drops and the node flickers 3 -> 0 / "No instructions yet".
+    """
+    import os, uuid, datetime
+    from sqlalchemy import create_engine, text
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    me = whoami(token)
+    org_id = me["organizations"][0]["id"]
+    user_id = me["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    ds_id = str(uuid.uuid4())
+    table_id = str(uuid.uuid4())
+
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    now = datetime.datetime.utcnow()
+    try:
+        with engine.begin() as conn:
+            # Agent (data source) the user is a member of, with one active table.
+            conn.execute(
+                text(
+                    "INSERT INTO data_sources (id,created_at,updated_at,name,is_active,organization_id,"
+                    "is_public,use_llm_sync,publish_status,reliability_status)"
+                    " VALUES (:id,:ca,:ua,:name,:active,:org,:pub,:llm,:pubst,:rel)"
+                ),
+                {"id": ds_id, "ca": now, "ua": now, "name": "Pinned Agent", "active": True,
+                 "org": org_id, "pub": False, "llm": False, "pubst": "published", "rel": "unknown"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO data_source_memberships (id,created_at,updated_at,data_source_id,principal_type,principal_id,config)"
+                    " VALUES (:id,:ca,:ua,:ds,:pt,:pid,:cfg)"
+                ),
+                {"id": str(uuid.uuid4()), "ca": now, "ua": now, "ds": ds_id,
+                 "pt": "user", "pid": user_id, "cfg": '{"role": "owner"}'},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO datasource_tables (id,created_at,updated_at,name,datasource_id,is_active,columns,no_rows,pks,fks)"
+                    " VALUES (:id,:ca,:ua,:name,:ds,:active,:cols,:nr,:pks,:fks)"
+                ),
+                {"id": table_id, "ca": now, "ua": now, "name": "orders", "ds": ds_id, "active": True,
+                 "cols": "[]", "nr": 0, "pks": "[]", "fks": "[]"},
+            )
+    finally:
+        engine.dispose()
+
+    # Create an instruction PINNED to that table via the real API (so it gets a
+    # main-build version and a datasource_table reference through the service).
+    resp = test_client.post(
+        "/api/instructions",
+        json={
+            "text": "Pinned instruction for orders",
+            "status": "published",
+            "category": "general",
+            "data_source_ids": [ds_id],
+            "references": [{
+                "object_type": "datasource_table",
+                "object_id": table_id,
+                "display_text": "orders",
+            }],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+
+    def by_agent_count():
+        r = test_client.get("/api/instructions/counts", headers=headers)
+        assert r.status_code == 200, r.json()
+        return r.json()["by_agent"].get(ds_id, 0)
+
+    def list_count():
+        r = test_client.get(
+            "/api/instructions",
+            params={"data_source_ids": ds_id, "include_global": "false", "limit": 200,
+                    "include_own": "true", "include_drafts": "true", "include_archived": "true"},
+            headers=headers,
+        )
+        assert r.status_code == 200, r.json()
+        return len(r.json()["items"])
+
+    # Table accessible (no overlay): badge and list agree at 1.
+    assert by_agent_count() == 1
+    assert list_count() == 1
+    assert by_agent_count() == list_count()
+
+    # Mark the table inaccessible for this user. Now the list hides the
+    # instruction; the count must match (no 3->0 flicker).
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO user_data_source_tables (id,created_at,updated_at,data_source_id,user_id,"
+                    "table_name,data_source_table_id,is_accessible,status)"
+                    " VALUES (:id,:ca,:ua,:ds,:uid,:tn,:tid,:acc,:st)"
+                ),
+                {"id": str(uuid.uuid4()), "ca": now, "ua": now, "ds": ds_id, "uid": user_id,
+                 "tn": "orders", "tid": table_id, "acc": False, "st": "inaccessible"},
+            )
+    finally:
+        engine.dispose()
+
+    assert list_count() == 0, "list must hide an instruction whose only table is inaccessible"
+    assert by_agent_count() == 0, "badge count must match the list (no 3->0 flicker)"
+    assert by_agent_count() == list_count()


### PR DESCRIPTION
## Symptom

On the Agents page, an agent's **Instructions** node shows a count (e.g. "3") on load, then a moment later drops to "0" / "No instructions yet" — even though the agent has instructions.

## Root cause (a real backend bug — it *is* about access)

The per-agent instruction list (`GET /api/instructions`) applies a **per-user table-accessibility cut**: `_filter_list_items_by_table_accessibility` drops any instruction whose `datasource_table` references are **all** in the user's inaccessible-table overlay (`UserDataSourceTable.is_accessible == False`).

The tree-badge counts (`GET /api/instructions/counts` → `by_agent`) did **not** apply that cut, so they counted table-pinned instructions the list then dropped. The frontend renders the badge from `agentCount(id)` (counts) on load, then switches to `listForAgent(id).length` once the lazy list loads — so the two disagreed and the node flickered **3 → 0**.

### Reproduced (sandbox env, curl)

One agent, 3 instructions all pinned to its `orders` table, table marked inaccessible for the user (`UserDataSourceTable.is_accessible = False`):

| | before | after |
|---|---|---|
| `/api/instructions/counts` → `by_agent[agent]` | **3** | **absent / 0** |
| `/api/instructions?data_source_ids=<agent>&include_global=false` | **0** | **0** |

With the table accessible, both are **3 ↔ 3**.

## Fix

Factor the accessibility rule into a shared `_table_inaccessible_instruction_ids()` helper used by **both** the list filter and `get_instruction_counts`, so the badge counts only what the list will actually show (subtracted from `global`, `skills`, per-agent and pending counts). Early-returns when the user has no inaccessible-table overlay, so there's no added cost in the common case.

## Tests

`tests/e2e/test_instruction.py`: **18 passed** (17 existing + a new regression test `test_agent_count_matches_list_under_inaccessible_table`, which fails without the fix and passes with it).

Also adds `backend/scripts/seed_table_pinned.py` (repro artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED21qfJPHHtR7vZzehJnWa)_