### PR TITLE
perf(data_sources): cache MCP preset URL map in connector-key lookup (Show all)

### DIFF
--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -24,17 +24,32 @@ def _ds_is_connector(d) -> bool:
     return bool(conns) and all(getattr(c, "type", None) in tps for c in conns)
 
 
+import functools
+
+
+@functools.lru_cache(maxsize=1)
+def _mcp_preset_url_to_key() -> dict:
+    """``server_url -> preset key`` map for matching a connection's config to a
+    known MCP preset. Cached at module level: the presets are a static catalog,
+    so there's no reason to rebuild this on every call. This matters because
+    ``_conn_connector_key`` runs once per connection while building the agents
+    list (and again via ``_ds_connector_key``); without the cache, the admin
+    "show all" view re-did ``mcp_presets()`` (N Pydantic ``model_dump()`` calls)
+    O(connections) times, which dominated the request's Python time at scale."""
+    try:
+        from app.schemas.data_source_registry import mcp_presets
+        return {p["server_url"]: p["key"] for p in mcp_presets() if p.get("server_url")}
+    except Exception:
+        return {}
+
+
 def _conn_connector_key(conn):
     """The preset key (e.g. 'notion', 'monday') for a single connection so the UI
     can render the provider's icon (even though the connection type is just
     'mcp'). Read from config.catalog_key, else matched by server_url against the
     mcp presets. None if not a known preset connector."""
     import json as _json
-    try:
-        from app.schemas.data_source_registry import mcp_presets
-        by_url = {p["server_url"]: p["key"] for p in mcp_presets() if p.get("server_url")}
-    except Exception:
-        by_url = {}
+    by_url = _mcp_preset_url_to_key()
     cfg = getattr(conn, "config", None)
     if isinstance(cfg, str):
         try:

--- a/backend/scripts/profile_show_all.py
+++ b/backend/scripts/profile_show_all.py
@@ -1,0 +1,176 @@
+"""Profile get_active_data_sources(show_all=True) — the 'Show all' admin view.
+
+Bootstraps an org+admin user, seeds N agents x M connections x T tables
+(type=mssql, system_only — the user's case), then times the service call,
+counts SQL statements, and times _conn_connector_key / _ds_connector_key.
+"""
+import os, sys, uuid, asyncio, time, argparse
+from datetime import datetime
+
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app_showall.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy import event, select, insert
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.connection import Connection
+from app.models.domain_connection import domain_connection
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.data_source_membership import DataSourceMembership
+from app.services.organization_service import OrganizationService
+from app.schemas.organization_schema import OrganizationCreate
+from app.services.data_source_service import DataSourceService
+import app.services.data_source_service as dss_mod
+
+
+def _uid():
+    return str(uuid.uuid4())
+
+
+async def _bulk(db, table, rows, chunk=2000):
+    for i in range(0, len(rows), chunk):
+        await db.execute(insert(table), rows[i:i + chunk])
+    await db.commit()
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agents", type=int, default=50)
+    ap.add_argument("--conns-per-agent", type=int, default=3)
+    ap.add_argument("--tables-per-conn", type=int, default=10)
+    args = ap.parse_args()
+
+    u = os.environ["BOW_DATABASE_URL"].replace("sqlite:///", "sqlite+aiosqlite:///", 1)
+    engine = create_async_engine(u, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as db:
+        # bootstrap user + org (org create seeds admin full_admin_access role)
+        email = f"sandbox-{_uid()[:8]}@bow.dev"
+        user = User(email=email, name="Sandbox")
+        if hasattr(user, "hashed_password"):
+            user.hashed_password = "x"
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+
+        org_schema = await OrganizationService().create_organization(
+            db, OrganizationCreate(name=f"Org-{_uid()[:6]}"), user
+        )
+        org = (await db.execute(select(Organization).where(Organization.id == org_schema.id))).scalars().first()
+        org_id = str(org.id)
+        uid = str(user.id)
+        print(f"org={org_id} user={uid}")
+
+        # seed agents
+        agent_ids = [_uid() for _ in range(args.agents)]
+        await _bulk(db, DataSource.__table__, [
+            {"id": aid, "name": f"agent-{i}", "is_active": True,
+             "is_public": False, "organization_id": org_id, "use_llm_sync": False}
+            for i, aid in enumerate(agent_ids)
+        ])
+        await _bulk(db, DataSourceMembership.__table__, [
+            {"id": _uid(), "data_source_id": aid, "principal_type": "user", "principal_id": uid}
+            for aid in agent_ids
+        ])
+        conn_rows, link_rows, ctable_rows, dstable_rows = [], [], [], []
+        for ai, aid in enumerate(agent_ids):
+            for c in range(args.conns_per_agent):
+                cid = _uid()
+                conn_rows.append({
+                    "id": cid, "name": f"conn-{ai}-{c}", "type": "mssql",
+                    "config": {"host": "sql.example.com", "port": 1433, "database": f"wh_{ai}",
+                               "schema": "dbo", "catalog_key": None},
+                    "is_active": True, "auth_policy": "system_only",
+                    "allowed_user_auth_modes": None,
+                    "last_connection_status": "success",
+                    "last_connection_checked_at": datetime.utcnow(),
+                    "organization_id": org_id,
+                })
+                link_rows.append({"data_source_id": aid, "connection_id": cid})
+                for t in range(args.tables_per_conn):
+                    ctid = _uid()
+                    ctable_rows.append({
+                        "id": ctid, "name": f"tbl_{ai}_{c}_{t}", "connection_id": cid,
+                        "columns": [{"name": "id", "dtype": "int"}], "pks": ["id"], "fks": [], "no_rows": 1000,
+                    })
+                    dstable_rows.append({
+                        "id": _uid(), "name": f"tbl_{ai}_{c}_{t}", "datasource_id": aid,
+                        "connection_table_id": ctid, "is_active": True,
+                    })
+        await _bulk(db, Connection.__table__, conn_rows)
+        await _bulk(db, domain_connection, link_rows)
+        await _bulk(db, ConnectionTable.__table__, ctable_rows)
+        await _bulk(db, DataSourceTable.__table__, dstable_rows)
+        print(f"seeded agents={args.agents} conns={len(conn_rows)} tables={len(dstable_rows)}")
+
+    # --- profile in a fresh session ---
+    sql_count = {"n": 0}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, params, context, executemany):
+        sql_count["n"] += 1
+
+    # instrument the connector-key helpers
+    orig_conn_key = dss_mod._conn_connector_key
+    orig_ds_key = dss_mod._ds_connector_key
+    timing = {"conn_key_calls": 0, "conn_key_time": 0.0, "ds_key_calls": 0, "ds_key_time": 0.0}
+
+    def wrapped_conn_key(conn):
+        t = time.perf_counter()
+        r = orig_conn_key(conn)
+        timing["conn_key_time"] += time.perf_counter() - t
+        timing["conn_key_calls"] += 1
+        return r
+
+    def wrapped_ds_key(d):
+        t = time.perf_counter()
+        r = orig_ds_key(d)
+        timing["ds_key_time"] += time.perf_counter() - t
+        timing["ds_key_calls"] += 1
+        return r
+
+    dss_mod._conn_connector_key = wrapped_conn_key
+    dss_mod._ds_connector_key = wrapped_ds_key
+
+    async with Session() as db:
+        org = (await db.execute(select(Organization).where(Organization.id == org_id))).scalars().first()
+        user = (await db.execute(select(User).where(User.id == uid))).scalars().first()
+        svc = DataSourceService()
+
+        # warm up imports/caches once (not counted)
+        await svc.get_active_data_sources(db=db, organization=org, current_user=user,
+                                           include_unconnected=True, show_all=True)
+
+        sql_count["n"] = 0
+        for k in timing:
+            timing[k] = 0.0 if "time" in k else 0
+        t0 = time.perf_counter()
+        items = await svc.get_active_data_sources(db=db, organization=org, current_user=user,
+                                                  include_unconnected=True, show_all=True)
+        elapsed = time.perf_counter() - t0
+
+    print("\n===== PROFILE =====")
+    print(f"agents returned : {len(items)}")
+    print(f"total time      : {elapsed*1000:.1f} ms")
+    print(f"SQL statements  : {sql_count['n']}")
+    print(f"_conn_connector_key: calls={timing['conn_key_calls']} time={timing['conn_key_time']*1000:.1f} ms")
+    print(f"_ds_connector_key  : calls={timing['ds_key_calls']} time={timing['ds_key_time']*1000:.1f} ms")
+    ck = timing["conn_key_time"] + timing["ds_key_time"]
+    print(f"connector-key TOTAL: {ck*1000:.1f} ms ({100*ck/elapsed:.0f}% of request)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Why

Toggling **"Show all"** on the Agents page calls `GET /data_sources/active?show_all=true&include_unconnected=true`, which builds a `ConnectionEmbedded` for every connection of every org agent. For each connection, `_conn_connector_key()` rebuilt the `server_url → preset_key` map by calling `mcp_presets()` — `[p.model_dump() for p in MCP_PRESETS]`, a Pydantic dump over the whole preset catalog — **from scratch**, and ran **twice per connection** (directly in `_build_connections_list` and again via `_ds_connector_key`).

So the catalog was re-serialized **O(connections)** times per request — pure-Python work on top of the already-batched SQL. (The earlier `_bulk_connection_aux` change had already removed the SQL N+1; SQL is constant at 15 statements regardless of agent count. This was the remaining hot spot.)

This is also why it looked SQL-Server-specific without being an OBO/connectivity issue: the list path never live-connects (`build_user_status_for_connection` returns early for `system_only`), so the cost was entirely this Python catalog rebuild, which scales with connection count.

## Fix

Memoize the derived map with a module-level `@functools.lru_cache(maxsize=1)` helper (`_mcp_preset_url_to_key()`) — the preset catalog is static at runtime. `_conn_connector_key` reads the cached map instead of rebuilding it. `mcp_presets()` itself is untouched. Behavior-preserving.

## Profiling (sqlite, mssql/system_only agents — the user's case)

| Scale | Metric | Before | After |
|---|---|---|---|
| 500 agents × 5 conns (2,500 connections) | `_conn_connector_key` | 62.8 ms | 3.6 ms |
| | connector-key total | 93.8 ms (34% of request) | 6.0 ms (3%) |
| | endpoint total | 278 ms | 217 ms |
| | SQL statements | 15 | 15 |
| 50 agents × 3 conns | connector-key total | 5.6 ms | 0.4 ms |

cProfile after the fix shows the remaining time is legitimate `selectinload(connections)` + Pydantic construction — no Python hot spot left under our control.

## Honesty note on scale

At ~9–50 agents the endpoint is already fast in the sandbox (~25–30 ms), so if prod is "extremely slow" at that scale, part of it is likely **deployment lag** (the prior batching + this fix not yet deployed) or data-specific (very high connections-per-agent, or large `events_json` indexing payloads inflating serialization). This PR removes a genuine **O(connections)** Python bottleneck that amplifies clearly at higher connection counts (~22% faster at 2,500 connections).

## Tests

`tests/e2e/rbac/test_rbac_data_sources.py` + `tests/unit/test_mcp_presets.py`: **15 passed**.

Adds `backend/scripts/profile_show_all.py` (reusable profiler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED21qfJPHHtR7vZzehJnWa)_