### PR TITLE
Add raw Basic-token auth mode for Druid (Imply Polaris API keys)

### DIFF
--- a/backend/app/data_sources/clients/druid_client.py
+++ b/backend/app/data_sources/clients/druid_client.py
@@ -1,9 +1,75 @@
 from app.data_sources.clients.base import DataSourceClient
 
 import pandas as pd
+import requests
 from typing import List, Generator, Optional, Dict, Any
 from contextlib import contextmanager
 from app.ai.prompt_formatters import Table, TableColumn, TableFormatter
+
+
+class _BasicTokenCursor:
+    """Minimal cursor that runs Druid SQL over HTTP with a verbatim
+    ``Authorization: Basic <token>`` header.
+
+    pydruid can only emit ``Bearer <token>`` (its ``jwt`` kwarg) or
+    ``Basic base64(user:password)`` (its user/password kwargs). Imply Polaris
+    authenticates its ``pok_…`` API keys with the token placed *raw* after
+    ``Basic`` — not base64-encoded — so that mode needs its own tiny client.
+    Only the surface that execute_query()/get_tables() rely on is implemented:
+    execute(), fetchall(), a ``description`` attribute, and close().
+    """
+
+    def __init__(self, url: str, token: str, ssl_verify_cert: bool):
+        self._url = url
+        self._token = token
+        self._ssl_verify_cert = ssl_verify_cert
+        self.description: Optional[List[tuple]] = None
+        self._rows: List[tuple] = []
+
+    def execute(self, sql: str, params: Any = None) -> "_BasicTokenCursor":
+        resp = requests.post(
+            self._url,
+            json={"query": sql, "resultFormat": "object", "header": False},
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Basic {self._token}",
+            },
+            verify=self._ssl_verify_cert,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Druid SQL request failed [{resp.status_code}]: {resp.text.strip()}"
+            )
+        # Druid's ``object`` result format returns a JSON array of row objects
+        # keyed by column name, in projection order. Derive the column list from
+        # the first row and read every row positionally so the tuples match what
+        # execute_query()/get_tables() expect.
+        data = resp.json() or []
+        cols = list(data[0].keys()) if data else []
+        self.description = [(c, None, None, None, None, None, None) for c in cols]
+        self._rows = [tuple(row.get(c) for c in cols) for row in data]
+        return self
+
+    def fetchall(self) -> List[tuple]:
+        return self._rows
+
+    def close(self) -> None:
+        pass
+
+
+class _BasicTokenConnection:
+    """Connection wrapper that hands out :class:`_BasicTokenCursor` instances."""
+
+    def __init__(self, url: str, token: str, ssl_verify_cert: bool):
+        self._url = url
+        self._token = token
+        self._ssl_verify_cert = ssl_verify_cert
+
+    def cursor(self) -> _BasicTokenCursor:
+        return _BasicTokenCursor(self._url, self._token, self._ssl_verify_cert)
+
+    def close(self) -> None:
+        pass
 
 
 class DruidClient(DataSourceClient):
@@ -15,6 +81,11 @@ class DruidClient(DataSourceClient):
     metadata approach the engine exposes to any SQL client. Datasources live
     in the ``druid`` schema; the ``sys`` and ``INFORMATION_SCHEMA`` schemas
     are Druid internals and are always excluded from discovery.
+
+    Authentication supports HTTP Basic (user/password), a bearer ``token``, and
+    a ``basic_token`` sent verbatim as ``Authorization: Basic <token>`` — the
+    form Imply Polaris expects for its ``pok_…`` API keys (the token is used
+    raw, not base64-encoded).
     """
 
     # Druid-internal schemas that should never surface as user tables.
@@ -27,6 +98,7 @@ class DruidClient(DataSourceClient):
         user: Optional[str] = None,
         password: Optional[str] = None,
         token: Optional[str] = None,
+        basic_token: Optional[str] = None,
         secure: bool = False,
         path: str = "/druid/v2/sql/",
         schema: Optional[str] = None,
@@ -37,6 +109,7 @@ class DruidClient(DataSourceClient):
         self.user = user
         self.password = password
         self.token = token
+        self.basic_token = basic_token
         self.secure = secure
         self.path = path
         self.schema = schema
@@ -61,11 +134,18 @@ class DruidClient(DataSourceClient):
             "scheme": ("https" if self.secure else "http"),
             "ssl_verify_cert": self.ssl_verify_cert,
         }
-        # Auth selection: a bearer token (e.g. Imply Polaris API token) maps to
-        # pydruid's ``jwt`` kwarg (Authorization: Bearer <token>). The driver
-        # prefers Basic over Bearer when ``user`` is set, so token auth must NOT
-        # also send user/password — they are mutually exclusive here, token wins.
-        if self.token:
+        # Auth selection (mutually exclusive, in precedence order):
+        #   1. basic_token — sent verbatim as ``Authorization: Basic <token>``
+        #      via the raw-HTTP path in connect(); pydruid cannot emit this, so
+        #      no pydruid auth kwargs are set here.
+        #   2. token — a bearer token (e.g. an Imply Polaris JWT) mapped to
+        #      pydruid's ``jwt`` kwarg (Authorization: Bearer <token>).
+        #   3. user/password — HTTP Basic as ``base64(user:password)``.
+        # The driver prefers Basic over Bearer when ``user`` is set, so a token
+        # must NOT also send user/password.
+        if self.basic_token:
+            pass
+        elif self.token:
             self._connect_kwargs["jwt"] = self.token
         else:
             if self.user:
@@ -80,6 +160,14 @@ class DruidClient(DataSourceClient):
 
     @contextmanager
     def connect(self) -> Generator[Any, None, None]:
+        # Raw ``Authorization: Basic <token>`` mode bypasses pydruid entirely
+        # (see _BasicTokenCursor). No connection resource needs closing.
+        if self.basic_token:
+            scheme = "https" if self.secure else "http"
+            url = f"{scheme}://{self.host}:{self.port}{self.path}"
+            yield _BasicTokenConnection(url, self.basic_token, self.ssl_verify_cert)
+            return
+
         from pydruid.db import connect as druid_connect
 
         conn = None

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -30,6 +30,7 @@ from app.schemas.data_sources.configs import (
     PinotConfig,
     DruidConfig,
     DruidTokenCredentials,
+    DruidBasicTokenCredentials,
     MongoDBConfig,
     PostHogConfig,
     # DuckDB
@@ -433,7 +434,8 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         config_schema=DruidConfig,
         credentials_auth=AuthOptions(default="userpass", by_auth={
             "userpass": AuthVariant(title="Username / Password", schema=SQLCredentials, scopes=["system","user"]),
-            "token": AuthVariant(title="API Token", schema=DruidTokenCredentials, scopes=["system","user"]),
+            "token": AuthVariant(title="API Token (Bearer)", schema=DruidTokenCredentials, scopes=["system","user"]),
+            "basic_token": AuthVariant(title="API Token (Basic)", schema=DruidBasicTokenCredentials, scopes=["system","user"]),
         }),
         client_path=None,
         version="beta",

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -499,7 +499,17 @@ class DruidTokenCredentials(BaseModel):
     token: str = Field(
         ...,
         title="API Token",
-        description="Bearer token sent as 'Authorization: Bearer <token>' (e.g. an Imply Polaris API token).",
+        description="Bearer token sent as 'Authorization: Bearer <token>'.",
+        json_schema_extra={"ui:type": "password"},
+    )
+
+
+class DruidBasicTokenCredentials(BaseModel):
+    basic_token: str = Field(
+        ...,
+        title="API Token",
+        description="Token sent verbatim as 'Authorization: Basic <token>' — not "
+        "base64-encoded. Use this for Imply Polaris 'pok_…' API keys.",
         json_schema_extra={"ui:type": "password"},
     )
 

--- a/backend/tests/unit/test_druid_client.py
+++ b/backend/tests/unit/test_druid_client.py
@@ -108,6 +108,99 @@ class TestConnectKwargs:
         assert kw["jwt"] == "tok"
         assert "user" not in kw and "password" not in kw
 
+    def test_basic_token_sets_no_pydruid_auth_kwargs(self):
+        # basic_token is handled by the raw-HTTP path, not pydruid, and wins over
+        # every other auth field.
+        c = DruidClient(
+            host="h", user="u", password="p", token="tok", basic_token="pok_abc"
+        )
+        kw = c._connect_kwargs
+        assert "jwt" not in kw
+        assert "user" not in kw and "password" not in kw
+
+
+# ---------- raw Basic-token auth path ---------- #
+
+
+class _FakeResponse:
+    def __init__(self, status_code, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else []
+        self.text = text
+
+    def json(self):
+        return self._json
+
+
+class _CapturingPost:
+    """Stand-in for ``requests.post`` that records the call and returns a
+    canned :class:`_FakeResponse`."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    def __call__(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self._response
+
+
+class TestBasicTokenAuth:
+    def test_execute_query_sends_verbatim_basic_header(self, monkeypatch):
+        post = _CapturingPost(_FakeResponse(200, [{"day": "2026-06-16", "cnt": 5}]))
+        monkeypatch.setattr(
+            "app.data_sources.clients.druid_client.requests.post", post
+        )
+        c = DruidClient(
+            host="broker.example",
+            port=443,
+            secure=True,
+            path="/v1/projects/p/query/sql/",
+            basic_token="pok_abc123",
+        )
+        df = c.execute_query("SELECT day, cnt FROM druid.events")
+
+        # DataFrame is built from the object-format rows.
+        assert list(df.columns) == ["day", "cnt"]
+        assert list(df["cnt"]) == [5]
+
+        # The token is sent raw after ``Basic`` — no base64, no Bearer.
+        call = post.calls[0]
+        assert call["url"] == "https://broker.example:443/v1/projects/p/query/sql/"
+        assert call["headers"]["Authorization"] == "Basic pok_abc123"
+        assert call["json"]["query"] == "SELECT day, cnt FROM druid.events"
+
+    def test_non_200_raises(self, monkeypatch):
+        post = _CapturingPost(_FakeResponse(401, [], text="Unauthorized"))
+        monkeypatch.setattr(
+            "app.data_sources.clients.druid_client.requests.post", post
+        )
+        c = DruidClient(host="h", basic_token="pok_bad")
+        with pytest.raises(RuntimeError, match="401"):
+            c.execute_query("SELECT 1")
+
+    def test_get_tables_maps_rows(self, monkeypatch):
+        rows = [
+            {"TABLE_SCHEMA": "druid", "TABLE_NAME": "events",
+             "COLUMN_NAME": "page", "DATA_TYPE": "VARCHAR"},
+        ]
+        post = _CapturingPost(_FakeResponse(200, rows))
+        monkeypatch.setattr(
+            "app.data_sources.clients.druid_client.requests.post", post
+        )
+        c = DruidClient(host="h", basic_token="pok_x")
+        tables = c.get_tables()
+        assert [t.name for t in tables] == ["druid.events"]
+        assert tables[0].columns[0].name == "page"
+
+    def test_test_connection_success(self, monkeypatch):
+        post = _CapturingPost(_FakeResponse(200, [{"EXPR$0": 1}]))
+        monkeypatch.setattr(
+            "app.data_sources.clients.druid_client.requests.post", post
+        )
+        res = DruidClient(host="h", basic_token="pok_x").test_connection()
+        assert res["success"] is True
+
 
 class TestSchemaParsing:
     def test_comma_separated_dedup_and_order(self):
@@ -250,6 +343,28 @@ class TestRegistryWiring:
         assert creds.token == "abc123"
         with pytest.raises(Exception):
             DruidTokenCredentials()  # token is required
+
+    def test_basic_token_auth_variant_registered(self):
+        from app.schemas.data_source_registry import (
+            credentials_schema_for,
+            get_entry,
+        )
+        from app.schemas.data_sources.configs import DruidBasicTokenCredentials
+
+        entry = get_entry("druid")
+        assert "basic_token" in entry.credentials_auth.by_auth
+        assert (
+            credentials_schema_for("druid", "basic_token")
+            is DruidBasicTokenCredentials
+        )
+
+    def test_basic_token_credentials_validate(self):
+        from app.schemas.data_sources.configs import DruidBasicTokenCredentials
+
+        creds = DruidBasicTokenCredentials(basic_token="pok_abc")
+        assert creds.basic_token == "pok_abc"
+        with pytest.raises(Exception):
+            DruidBasicTokenCredentials()  # basic_token is required
 
     def test_dynamic_resolution_returns_druid_client(self):
         from app.schemas.data_source_registry import resolve_client_class


### PR DESCRIPTION
## Problem

Connecting a Druid data source to **Imply Polaris** fails at "Test Connection" with a generic `Connection failed`, even when the same host / port / path / token works from `curl`.

Root cause is an auth-scheme mismatch. Imply Polaris authenticates its `pok_…` API keys with the token placed **verbatim** after `Authorization: Basic ` — it is *not* base64-encoded. A working request looks like:

```
POST https://<org>.<region>.aws.api.imply.io:443/v1/projects/<id>/query/sql/
Authorization: Basic pok_…        # the raw key, not base64(user:password)
```

But `pydruid` (our Druid driver) can only emit:
- `Authorization: Bearer <token>` — via its `jwt` kwarg (our existing **API Token** variant), or
- `Authorization: Basic base64(user:password)` — via its user/password kwargs (our **Username / Password** variant).

Neither reproduces `Basic <raw token>`, so Polaris returns 401 and the UI shows "Connection failed".

## Change

Add a dedicated `basic_token` auth mode that sends the token exactly as Polaris expects.

- **`druid_client.py`** — `DruidClient` gains a `basic_token` parameter. When set, `connect()` returns a small `_BasicTokenConnection` / `_BasicTokenCursor` that POSTs Druid SQL over HTTP with a verbatim `Authorization: Basic <token>` header (using Druid's `object` result format), bypassing pydruid for that mode only. All other modes are unchanged. Auth precedence: `basic_token` > `token` (bearer) > `user`/`password`.
- **`configs.py`** — new `DruidBasicTokenCredentials` schema (single `basic_token` field, password-masked).
- **`data_source_registry.py`** — new `basic_token` auth variant titled **"API Token (Basic)"**; the existing bearer variant is relabeled **"API Token (Bearer)"** so the two are distinguishable in the UI dropdown.
- **`test_druid_client.py`** — unit tests covering the verbatim `Basic` header, the constructed endpoint URL, non-200 error handling, table discovery via the new path, and registry wiring.

## How to use

In the Druid connection dialog, pick **System Credentials → API Token (Basic)** and paste the Polaris `pok_…` key. Keep Secure ON and port 443.

## Notes

- No database migration required.
- The bearer (`token`) and username/password modes are untouched, so existing Druid connections are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ysEYdnfCMoRu816MZTtd3)_