### PR TITLE
Fix scheduled task edit modal showing default time instead of saved schedule

### DIFF
--- a/frontend/components/ScheduledPromptModal.vue
+++ b/frontend/components/ScheduledPromptModal.vue
@@ -323,6 +323,14 @@ function parseCronToStructured(cron: string) {
     }
 }
 
+// Hydrate the schedule form from the existing cron on setup. The watch below is
+// not `immediate` (and can't be — its callback touches refs declared further
+// down), so without this the first mount would keep the default schedule and
+// show e.g. "day at 08:00" instead of the task's saved time.
+if (props.scheduledPrompt?.cron_schedule) {
+    parseCronToStructured(props.scheduledPrompt.cron_schedule)
+}
+
 // Reset form when scheduledPrompt changes
 watch(() => props.scheduledPrompt, (sp) => {
     isActive.value = sp?.is_active ?? true


### PR DESCRIPTION
## Problem

The Scheduled Tasks list and the edit modal displayed different schedules for the **same** task — e.g. the list showed "Daily at 10:00 PM" while the edit modal showed "Every day at 08:00".

Both read the identical `cron_schedule` string, so this was not a timezone issue or two different crons. The modal simply wasn't hydrating its schedule form from the saved cron.

## Root cause

In `ScheduledPromptModal.vue`, `parseCronToStructured()` — the function that turns the cron back into the form fields — was only called inside a `watch(() => props.scheduledPrompt, ...)` that is **not** `immediate`.

The modal is mounted lazily (`v-if="modalReportId"`) and `editingTask` is set *before* it mounts, so from the watcher's perspective `props.scheduledPrompt` never *changes* after setup → the callback never fires on first open. The schedule refs therefore kept their hardcoded defaults (`recurInterval = 'day'`, `recurHour = 8`), rendering "day at 08:00" regardless of the real schedule.

The `is_active` toggle and prompt text looked correct because those read props at setup time; only the schedule block depended on the dead watcher. Saving from that stale state would also silently overwrite the real schedule (`0 22 * * *` → `0 8 * * *`).

## Fix

Parse the existing cron once at setup, right after `parseCronToStructured` is defined, so the form hydrates on first mount. The existing watch still handles switching between tasks without a remount.

`{ immediate: true }` on the watch was **not** used on purpose: its callback assigns to `subscribers`, which is declared further down, so running it during setup would hit a temporal-dead-zone `ReferenceError`. The setup-time parse only touches the schedule refs (all declared above it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dtr5yWwL31XFrdno8S3J3)_