### PR TITLE
Hide prompts for inactive/disabled/deleted agents; fix stuck mention menu

### DIFF
--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -40,9 +40,16 @@ class PromptService:
 
     @staticmethod
     def _active_ds_ids(prompt: Prompt) -> List[str]:
+        """Agents still usable by this prompt: connected/healthy (``is_active``),
+        not soft-deleted, and not intentionally turned off
+        (``publish_status == 'disabled'``). Hard-deleted agents never appear
+        here — the relationship stops yielding a DataSource once its row is gone.
+        """
         return [
             str(ds.id) for ds in (prompt.data_sources or [])
-            if getattr(ds, 'is_active', False) and getattr(ds, 'deleted_at', None) is None
+            if getattr(ds, 'is_active', False)
+            and getattr(ds, 'deleted_at', None) is None
+            and getattr(ds, 'publish_status', 'published') != 'disabled'
         ]
 
     @staticmethod
@@ -115,11 +122,18 @@ class PromptService:
         rows = await db.execute(q)
         prompts = list(rows.scalars().unique().all())
 
-        visible = [
-            self._to_response(p, resolved, str(current_user.id))
-            for p in prompts
-            if self._is_visible(resolved, p, str(current_user.id), self._active_ds_ids(p))
-        ]
+        visible = []
+        for p in prompts:
+            active_ds_ids = self._active_ds_ids(p)
+            if not self._is_visible(resolved, p, str(current_user.id), active_ds_ids):
+                continue
+            # Hide agent-scoped prompts whose agents are ALL gone/unusable
+            # (inactive, disabled, or deleted). They can't be run and would
+            # otherwise surface a bare agent id in the UI. Global/private
+            # prompts are never gated on agents.
+            if p.scope == 'agent' and not active_ds_ids:
+                continue
+            visible.append(self._to_response(p, resolved, str(current_user.id)))
         visible.sort(key=lambda r: r["created_at"] or datetime.min, reverse=True)
         return {"prompts": visible, "meta": {"total": len(visible)}}
 

--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -22,8 +22,10 @@
       class="absolute z-50 w-80 max-h-80 overflow-y-auto bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md shadow-md text-start"
       :style="dropdownStyle"
     >
-      <!-- Loading state -->
-      <div v-if="isLoadingMentions" class="p-2 text-start text-xs text-gray-500 dark:text-gray-400 flex items-center gap-2">
+      <!-- Loading state — only blocks when there is genuinely nothing to show
+           yet. Category names are available immediately (rebuilt on mount), so
+           a slow/hung items fetch never leaves the menu stuck on "Loading…". -->
+      <div v-if="isLoadingMentions && !categoryList.length" class="p-2 text-start text-xs text-gray-500 dark:text-gray-400 flex items-center gap-2">
         <Spinner class="w-3 h-3" />
         <span>{{ $t('mentionInput.loading') }}</span>
       </div>
@@ -1415,10 +1417,12 @@ async function fetchAvailableMentions() {
 
   // Each category is fetched independently so one failing/forbidden endpoint
   // (e.g. /files 403 for users without manage_files) never blanks the menu.
+  // Each request is time-boxed so a slow/hung endpoint can't pin the menu in a
+  // permanent "Loading…" state (the reset below is also guaranteed via finally).
   const tasks = [
     (async () => {
       try {
-        const { data, error } = await useMyFetch('/data_sources/active', { method: 'GET', query: { include_unconnected: true } })
+        const { data, error } = await useMyFetch('/data_sources/active', { method: 'GET', query: { include_unconnected: true }, timeout: 8000 })
         if (!error.value && Array.isArray(data.value)) {
           agentCategoryItems.value = (data.value as any[]).map((ds: any) => ({
             id: String(ds.id),
@@ -1436,7 +1440,7 @@ async function fetchAvailableMentions() {
     })(),
     (async () => {
       try {
-        const { data, error } = await useMyFetch('/files', { method: 'GET' })
+        const { data, error } = await useMyFetch('/files', { method: 'GET', timeout: 8000 })
         if (!error.value && Array.isArray(data.value)) {
           fileCategoryItems.value = (data.value as any[]).map((file: any) => ({
             id: String(file.id),
@@ -1449,7 +1453,7 @@ async function fetchAvailableMentions() {
     })(),
     (async () => {
       try {
-        const { data, error } = await useMyFetch('/mentions/available?categories=entities', { method: 'GET' })
+        const { data, error } = await useMyFetch('/mentions/available?categories=entities', { method: 'GET', timeout: 8000 })
         if (!error.value && data.value) {
           const apiData = data.value as any
           entityCategoryItems.value = (apiData.entities || []).map((entity: any) => ({
@@ -1464,9 +1468,12 @@ async function fetchAvailableMentions() {
     })(),
   ]
 
-  await Promise.allSettled(tasks)
-  rebuildCategories()
-  isLoadingMentions.value = false
+  try {
+    await Promise.allSettled(tasks)
+    rebuildCategories()
+  } finally {
+    isLoadingMentions.value = false
+  }
 }
 
 // Instructions and skills are listed together (one category). Sourced from
@@ -1518,6 +1525,10 @@ onMounted(() => {
     textContent.value = props.modelValue
   }
 
+  // Populate the category NAMES immediately (empty item lists) so the '@' menu
+  // renders its categories right away instead of a blocking "Loading…" while
+  // the per-category item fetches are still in flight.
+  rebuildCategories()
   fetchAvailableMentions()
   fetchPromptMentions()
   fetchInstructionMentions()

--- a/frontend/components/prompt/PromptViewModal.vue
+++ b/frontend/components/prompt/PromptViewModal.vue
@@ -155,7 +155,9 @@ function placeholder(name: string): string {
 
 const agentChips = computed(() => {
   const ids = props.prompt?.data_source_ids || []
-  return ids.map(id => ({ id, name: props.agentMap?.[id]?.name || id, type: props.agentMap?.[id]?.type }))
+  // Fall back to the generic "Agent" label (matching PromptCard) when an agent
+  // id can't be resolved to a name — never leak a bare UUID into the UI.
+  return ids.map(id => ({ id, name: props.agentMap?.[id]?.name || t('prompts.scopeAgent'), type: props.agentMap?.[id]?.type }))
 })
 
 const authorName = computed(() => {


### PR DESCRIPTION
## Summary

Two related fixes to the Prompts feature, both reproduced from the screenshots:

1. **Dead prompts no longer show.** An agent-scoped prompt whose agents are all inactive, disabled, or deleted was still listed — and rendered a bare agent UUID (e.g. `003af1db-…`) in the view modal, because the frontend only has names for *active* agents.
2. **The "New prompt" `@`-mention menu no longer gets stuck on "Loading…".**

## Root cause

- The prompt API returns **all** bound agent ids (including inactive/disabled ones), while the frontend `agentMap` is built only from `/data_sources/active` (filters `is_active == True`). When those sets diverge, the view modal fell back to printing the raw id (`|| id`).
- Agent-scoped prompts with no *active* agents fell back to owner-only visibility instead of being hidden, so they lingered in the list.
- The mention dropdown's blocking "Loading…" state is driven by `isLoadingMentions`, which only cleared after every item fetch resolved — a single slow/hung endpoint (`/data_sources/active`, `/files`, `/mentions/available`) pinned it permanently.

## Changes

**Backend — `app/services/prompt_service.py`**
- `_active_ds_ids()` now also excludes agents with `publish_status == 'disabled'`, in addition to the existing `is_active` / `deleted_at` checks. (Hard-deleted agents already fall out via the relationship.)
- `list_prompts()` hides agent-scoped prompts that have zero usable agents. Global/private prompts are never gated on agents.

**Frontend — `components/prompt/PromptViewModal.vue`**
- Falls back to the generic "Agent" label (matching `PromptCard`) instead of the raw data-source id when a name can't be resolved — belt-and-suspenders for prompts that mix active + inactive agents.

**Frontend — `components/prompt/MentionInput.vue`**
- Category names render immediately on mount (`rebuildCategories()`), so the menu is usable while item fetches are in flight.
- Each item fetch is time-boxed to 8s and `isLoadingMentions` is cleared in a `finally`, so a slow/hung endpoint can't pin the menu.
- The blocking "Loading…" state only shows when there is genuinely nothing to display yet.

## Behavioral note

The list filter hides all-unusable agent prompts from everyone, including admins. A prompt whose agents were hard-deleted stays hidden permanently (it's inert regardless), and reappears if an agent's connection recovers and `is_active` flips back to true. If admins should instead still see these (e.g. to clean them up, with an "inactive agent" badge), that's an easy follow-up.

## Testing

Validated the filter decision logic across inactive / disabled / soft-deleted / hard-deleted / mixed / draft / global / private cases (all pass). Consistent with existing `tests/prompts/test_prompt_model.py` assertions. The full pytest suite couldn't run in this environment (missing app dependencies such as `fastapi`/`snowflake-sqlalchemy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013otcdjYLphULdTyx6GeVLC)_