### PR TITLE
Fix pending-suggestion discrepancy between Report agent panel and /agents review

### DIFF
--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -929,6 +929,13 @@ async def reject_instruction_hunk(
 
 class AcceptAllRequest(BaseModel):
     against_main_version_id: Optional[str] = None
+    # Narrow the pass to one suggestion build (accept just that suggestion).
+    build_id: Optional[str] = None
+
+
+class RejectAllRequest(BaseModel):
+    # Narrow the pass to one suggestion build (reject just that suggestion).
+    build_id: Optional[str] = None
 
 
 @router.post("/instructions/{instruction_id}/hunks/accept-all", response_model=InstructionSchema)
@@ -950,7 +957,7 @@ async def accept_all_instruction_hunks(
         await check_resource_permissions(db, str(current_user.id), str(organization.id), "data_source", existing_ds_ids, "manage_instructions")
     resolved, status = await instruction_service.accept_all_hunks(
         db, instruction_id, against_main_version_id=body.against_main_version_id,
-        organization=organization, current_user=current_user,
+        organization=organization, current_user=current_user, build_id=body.build_id,
     )
     if status == "conflict":
         raise AppError.conflict(ErrorCode.RESOURCE_CONFLICT, "These changes moved since you viewed them — refresh and try again.")
@@ -960,6 +967,7 @@ async def accept_all_instruction_hunks(
         await audit_service.log(
             db=db, organization_id=organization.id, action="instruction.hunks_accepted_all",
             user_id=current_user.id, resource_type="instruction", resource_id=str(instruction_id),
+            details={"build_id": body.build_id} if body.build_id else None,
             request=request,
         )
     except Exception:
@@ -972,6 +980,7 @@ async def accept_all_instruction_hunks(
 async def reject_all_instruction_hunks(
     instruction_id: str,
     request: Request,
+    body: RejectAllRequest = RejectAllRequest(),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
@@ -984,7 +993,7 @@ async def reject_all_instruction_hunks(
     if existing_ds_ids:
         await check_resource_permissions(db, str(current_user.id), str(organization.id), "data_source", existing_ds_ids, "manage_instructions")
     resolved, _status = await instruction_service.reject_all_hunks(
-        db, instruction_id, organization=organization, current_user=current_user,
+        db, instruction_id, organization=organization, current_user=current_user, build_id=body.build_id,
     )
     if resolved is None:
         raise AppError.not_found(ErrorCode.INSTRUCTION_NOT_FOUND, "Instruction not found")
@@ -992,6 +1001,7 @@ async def reject_all_instruction_hunks(
         await audit_service.log(
             db=db, organization_id=organization.id, action="instruction.hunks_rejected_all",
             user_id=current_user.id, resource_type="instruction", resource_id=str(instruction_id),
+            details={"build_id": body.build_id} if body.build_id else None,
             request=request,
         )
     except Exception:
@@ -1096,7 +1106,12 @@ async def get_instruction_pending_builds(
 ):
     """List all pending/draft builds containing this instruction, with the
     pending version text. Used by the tracked-changes UI to show suggested
-    edits awaiting approval."""
+    edits awaiting approval.
+
+    Pendingness follows the same authoritative per-hunk rule as
+    GET /review-hunks (see live_hunks_by_build below), so this surface can
+    never disagree with the /agents tracked-changes review about whether an
+    instruction still has changes to review."""
     existing = await instruction_service.get_instruction(
         db, instruction_id, organization, current_user
     )
@@ -1226,6 +1241,26 @@ async def get_instruction_pending_builds(
         # No recorded base → fall back to comparing against current main.
         return main_version_id is None or str(version.id) != str(main_version_id)
 
+    # The authoritative per-hunk rule — same as GET /review-hunks: once the
+    # instruction exists in main, a suggestion build is only pending while it
+    # still has at least one LIVE hunk (not resolved via hunks/accept|reject,
+    # still anchorable onto current main, and actually changing it). Without
+    # this, a suggestion fully rejected in the per-hunk review kept resurfacing
+    # here — e.g. the Report agent panel showed "changes" the /agents review
+    # had already dropped. `None` marks a create suggestion (the instruction
+    # isn't in main yet), which stays reviewable as a whole snapshot.
+    from app.services.text_hunks import rebased_hunks_against_main
+    live_hunks_by_build: dict = {}
+    for _c, build, version in rows:
+        if main_text is None:
+            live_hunks_by_build[str(build.id)] = None
+            continue
+        rejected = instruction_service._rejected_keys(build, instruction_id)
+        live_hunks_by_build[str(build.id)] = [
+            h for h in rebased_hunks_against_main(_base_text_for(build), version.text or "", main_text)
+            if h["key"] not in rejected
+        ]
+
     # Resolve the originating report for AI suggestions, so the UI can show a
     # "generated from <report>" provenance link on each suggestion. The chain is
     # build.agent_execution_id -> AgentExecution.report_id.
@@ -1248,6 +1283,11 @@ async def get_instruction_pending_builds(
     def _passes_basic(build, version) -> bool:
         # Only builds that intentionally changed THIS instruction (vs their base).
         if not _build_changed_instruction(build, version):
+            return False
+        # Authoritative per-hunk rule: everything this build proposed was
+        # already resolved (accepted/rejected) or no longer applies to main.
+        live = live_hunks_by_build.get(str(build.id))
+        if live is not None and not live:
             return False
         # Skip intermediate snapshots of a chained edit — only the leaf (the
         # build no other pending build forked from) is a real suggestion.
@@ -1288,6 +1328,19 @@ async def get_instruction_pending_builds(
             continue  # an intermediate snapshot a later sibling already covers
         creator = getattr(build, "created_by_user", None)
         trace = trace_by_exec.get(str(build.agent_execution_id)) if getattr(build, "agent_execution_id", None) else None
+        # Render exactly the LIVE hunks: main + this build's unresolved changes.
+        # Diffing the raw snapshot against live text would resurrect hunks the
+        # user already rejected/accepted in the per-hunk review. Creates (not in
+        # main yet) keep the raw snapshot — the whole text IS the suggestion.
+        live = live_hunks_by_build.get(str(build.id))
+        if live is None:
+            pending_text = version.text or ""
+            base_text = _base_text_for(build)
+        else:
+            pending_text = main_text or ""
+            for h in sorted(live, key=lambda x: x["start"], reverse=True):
+                pending_text = pending_text[:h["start"]] + h["after"] + pending_text[h["end"]:]
+            base_text = main_text or ""
         result.append({
             "build_id": str(build.id),
             "build_number": build.build_number,
@@ -1300,11 +1353,14 @@ async def get_instruction_pending_builds(
             ),
             "pending_version_id": str(version.id),
             "pending_version_number": version.version_number,
-            "pending_text": version.text or "",
+            "pending_text": pending_text,
             # The text this suggestion forked from — lets the client rebase the
             # intended change onto current text (3-way merge) so siblings stay
             # applicable after one is accepted.
-            "base_text": _base_text_for(build),
+            "base_text": base_text,
+            # False = a create suggestion (instruction not in main yet): clients
+            # resolve it via build publish/discard, not the per-hunk endpoints.
+            "in_main": live is not None,
             "pending_title": version.title,
             # Build-level "commit message": auto-generated summary + free-text rationale.
             "build_title": build.title,

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -1533,10 +1533,13 @@ class InstructionService:
                 await db.commit()
 
     async def accept_all_hunks(self, db: AsyncSession, instruction_id: str, *,
-                               against_main_version_id: Optional[str], organization: Organization, current_user: User):
+                               against_main_version_id: Optional[str], organization: Organization, current_user: User,
+                               build_id: Optional[str] = None):
         """Accept EVERY live hunk in one pass: apply them all cumulatively onto
         main (newest suggestion wins on overlap), promote a SINGLE new build, and
-        record every accepted hunk. One request, one build — no per-hunk churn."""
+        record every accepted hunk. One request, one build — no per-hunk churn.
+        `build_id` narrows the pass to one suggestion build (accept just that
+        suggestion's live hunks, leaving sibling suggestions pending)."""
         from app.services.text_hunks import rebased_hunks_against_main
         user_permissions = await self._get_user_permissions(db, current_user, organization)
         instruction = await self._get_instruction_by_id(db, instruction_id, organization)
@@ -1546,6 +1549,8 @@ class InstructionService:
         if against_main_version_id and main_vid and str(against_main_version_id) != str(main_vid):
             return None, "conflict"
         rows = await self._pending_suggestion_builds(db, instruction_id, organization)  # newest first
+        if build_id:
+            rows = [r for r in rows if str(r[0].id) == str(build_id)]
         new_text = main_text
         accepted = []  # (build, key)
         for build, proposed_text, _vid in rows:
@@ -1583,14 +1588,18 @@ class InstructionService:
         return await self.get_instruction(db, instruction.id, organization, current_user), "ok"
 
     async def reject_all_hunks(self, db: AsyncSession, instruction_id: str, *,
-                               organization: Organization, current_user: User):
-        """Reject every live hunk in one pass (records them; main unchanged)."""
+                               organization: Organization, current_user: User,
+                               build_id: Optional[str] = None):
+        """Reject every live hunk in one pass (records them; main unchanged).
+        `build_id` narrows the pass to one suggestion build."""
         from app.services.text_hunks import rebased_hunks_against_main
         instruction = await self._get_instruction_by_id(db, instruction_id, organization)
         if not instruction:
             return None, "not_found"
         main_text, _vid, _meta = await self._main_text_of(db, instruction)
         rows = await self._pending_suggestion_builds(db, instruction_id, organization)
+        if build_id:
+            rows = [r for r in rows if str(r[0].id) == str(build_id)]
         for build, proposed_text, _v in rows:
             rejected = self._rejected_keys(build, instruction_id)
             base_text = await self._build_base_text(db, build, instruction_id)
@@ -1600,8 +1609,15 @@ class InstructionService:
                 await self._record_resolved_hunk(db, build, instruction_id, h["key"], "reject", commit=False)
         await db.commit()
         try:
-            from app.services.review_service import review_service
-            await review_service.resolve_for_instruction(db, organization_id=str(organization.id), instruction_id=str(instruction_id))
+            # Build-scoped rejection may leave sibling suggestions live — only
+            # clear the Review-feed item when nothing remains pending.
+            resolved_all = not build_id
+            if build_id:
+                remaining = await self.review_hunks(db, instruction_id, organization=organization, current_user=current_user)
+                resolved_all = bool(remaining) and not remaining.get("suggestions")
+            if resolved_all:
+                from app.services.review_service import review_service
+                await review_service.resolve_for_instruction(db, organization_id=str(organization.id), instruction_id=str(instruction_id))
         except Exception:
             pass
         return await self.get_instruction(db, instruction.id, organization, current_user), "ok"

--- a/backend/tests/e2e/test_instruction.py
+++ b/backend/tests/e2e/test_instruction.py
@@ -772,6 +772,212 @@ def test_pending_status_consistent_between_list_and_detail(
     assert effective(single) == effective(row)
 
 
+def _inject_suggestion_build(org_id, instruction_id, proposed_text, source="ai", status="pending_approval"):
+    """Insert a non-main pending suggestion build (forked from main) proposing
+    `proposed_text` for the instruction, straight into the test DB — a REAL
+    live suggestion, unlike the covered/no-op build above. Returns the build id.
+    Same portability notes as the injection in
+    test_pending_status_consistent_between_list_and_detail."""
+    import os, uuid, datetime
+    from sqlalchemy import create_engine, text
+
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            main = conn.execute(
+                text(
+                    """SELECT bc.build_id AS build_id
+                         FROM build_contents bc
+                         JOIN instruction_builds ib ON ib.id = bc.build_id
+                        WHERE bc.instruction_id = :iid AND ib.is_main = :is_main
+                          AND ib.deleted_at IS NULL"""
+                ),
+                {"iid": instruction_id, "is_main": True},
+            ).mappings().fetchone()
+            assert main is not None, "instruction should be in the main build"
+            now = datetime.datetime.utcnow()
+            vid, bid, bcid = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+            vnum = conn.execute(
+                text("SELECT COALESCE(MAX(version_number),0)+1 FROM instruction_versions WHERE instruction_id=:iid"),
+                {"iid": instruction_id},
+            ).scalar()
+            bnum = conn.execute(
+                text("SELECT COALESCE(MAX(build_number),0)+1 FROM instruction_builds WHERE organization_id=:org"),
+                {"org": org_id},
+            ).scalar()
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_versions (id,created_at,updated_at,instruction_id,version_number,text,status,load_mode,content_hash)"
+                    " VALUES (:id,:ca,:ua,:iid,:vnum,:txt,:status,:load_mode,:chash)"
+                ),
+                {"id": vid, "ca": now, "ua": now, "iid": instruction_id, "vnum": vnum, "txt": proposed_text,
+                 "status": "published", "load_mode": "always", "chash": "h" + uuid.uuid4().hex[:12]},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_builds (id,created_at,updated_at,build_number,status,source,is_main,organization_id,base_build_id,title)"
+                    " VALUES (:id,:ca,:ua,:bnum,:status,:source,:is_main,:org,:base,:title)"
+                ),
+                {"id": bid, "ca": now, "ua": now, "bnum": bnum, "status": status, "source": source,
+                 "is_main": False, "org": org_id, "base": main["build_id"], "title": "suggestion build"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO build_contents (id,created_at,updated_at,build_id,instruction_id,instruction_version_id)"
+                    " VALUES (:id,:ca,:ua,:bid,:iid,:vid)"
+                ),
+                {"id": bcid, "ca": now, "ua": now, "bid": bid, "iid": instruction_id, "vid": vid},
+            )
+    finally:
+        engine.dispose()
+    return bid
+
+
+@pytest.mark.e2e
+def test_pending_builds_agrees_with_review_hunks_after_reject_all(
+    test_client,
+    create_global_instruction,
+    get_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Regression: /pending-builds must follow the same authoritative per-hunk
+    rule as /review-hunks. A suggestion whose every hunk was rejected in the
+    per-hunk review used to stay in /pending-builds, so the Report agent panel
+    kept showing "changes" the /agents tracked-changes review had already
+    dropped (and could re-publish rejected content via build publish)."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="alpha beta gamma delta", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    bid = _inject_suggestion_build(org_id, iid, "alpha beta gamma delta epsilon")
+
+    # Both surfaces agree the suggestion is pending.
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert [b["build_id"] for b in pending] == [bid]
+    assert pending[0]["in_main"] is True
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert [s["build_id"] for s in review["suggestions"]] == [bid]
+
+    # Reject everything through the per-hunk review (what the /agents page does).
+    resp = test_client.post(f"/api/instructions/{iid}/hunks/reject-all", json={}, headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["suggestions"] == []
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert pending == [], "a fully-rejected suggestion must not resurface in /pending-builds"
+    # Main text untouched by the rejection.
+    assert get_instruction(iid, user_token=token, org_id=org_id)["text"] == "alpha beta gamma delta"
+
+
+@pytest.mark.e2e
+def test_pending_builds_partial_reject_shows_only_live_hunks(
+    test_client,
+    create_global_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """With one of two hunks rejected, /pending-builds must render the pending
+    text as main + the LIVE hunk only — diffing the raw snapshot would
+    resurrect the rejected change in every tracked-changes client."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="one two three four", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    bid = _inject_suggestion_build(org_id, iid, "one TWO three four five")
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    hunks = review["suggestions"][0]["hunks"]
+    assert len(hunks) == 2, hunks
+    replaced = next(h for h in hunks if "TWO" in h["after"])
+
+    resp = test_client.post(
+        f"/api/instructions/{iid}/hunks/reject",
+        json={"build_id": bid, "hunk_key": replaced["key"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert [b["build_id"] for b in pending] == [bid]
+    assert pending[0]["pending_text"] == "one two three four five"
+    assert "TWO" not in pending[0]["pending_text"]
+    # base_text is current main so clients diff exactly the live hunks.
+    assert pending[0]["base_text"] == "one two three four"
+
+
+@pytest.mark.e2e
+def test_accept_and_reject_all_scoped_to_build(
+    test_client,
+    create_global_instruction,
+    get_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """hunks/accept-all and hunks/reject-all with a build_id resolve ONLY that
+    suggestion, leaving siblings pending — the resolution model used by the
+    tracked-changes banner (Report agent panel / tool cards)."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="start middle end", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    build_a = _inject_suggestion_build(org_id, iid, "start MIDDLE end")
+    build_b = _inject_suggestion_build(org_id, iid, "start middle end tail")
+
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert {b["build_id"] for b in pending} == {build_a, build_b}
+
+    # Accept ONLY build A.
+    resp = test_client.post(
+        f"/api/instructions/{iid}/hunks/accept-all",
+        json={"build_id": build_a},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    assert get_instruction(iid, user_token=token, org_id=org_id)["text"] == "start MIDDLE end"
+
+    # B is still pending on BOTH surfaces, rebased onto the new main.
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert [s["build_id"] for s in review["suggestions"]] == [build_b]
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert [b["build_id"] for b in pending] == [build_b]
+    assert pending[0]["pending_text"] == "start MIDDLE end tail"
+
+    # Reject ONLY build B -> nothing pending anywhere, main unchanged.
+    resp = test_client.post(
+        f"/api/instructions/{iid}/hunks/reject-all",
+        json={"build_id": build_b},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["suggestions"] == []
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert pending == []
+    assert get_instruction(iid, user_token=token, org_id=org_id)["text"] == "start MIDDLE end"
+
+
 @pytest.mark.e2e
 def test_agent_count_matches_list_under_inaccessible_table(
     test_client,

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -608,12 +608,13 @@ const selectedInstruction = ref<any | null>(null)
 // Per-hunk review (tracked changes) state for the instruction view.
 const instructionReviewEmpty = ref(false)
 const forceInstructionEdit = ref(false)
-// Show the per-hunk review for an existing instruction when the user can
-// approve; the component reports `empty` (no live hunks) and we fall to the
+// Show the per-hunk review for any existing instruction — read-only when the
+// user can't approve (`can-approve` gates the buttons), matching the Knowledge
+// Explorer. The component reports `empty` (no live hunks) and we fall to the
 // editor. Robust to current_build_status not being populated.
 const showInstructionReview = computed(() =>
   !!selectedInstruction.value && !!selectedInstruction.value.id && !creatingInstruction.value
-  && canCreateInstructions.value && !instructionReviewEmpty.value && !forceInstructionEdit.value
+  && !instructionReviewEmpty.value && !forceInstructionEdit.value
 )
 const creatingInstruction = ref(false)
 const creatingPrimaryInstruction = ref(false)

--- a/frontend/composables/useTrackedChanges.ts
+++ b/frontend/composables/useTrackedChanges.ts
@@ -25,6 +25,10 @@ export interface PendingBuild {
   pending_version_number: number | null
   pending_text: string
   pending_title: string | null
+  // false = a create suggestion (the instruction isn't in main yet). Those are
+  // resolved by publishing/discarding the build; edits go through the per-hunk
+  // cherry-pick endpoints so they stay consistent with the /agents review.
+  in_main?: boolean
 }
 
 export type DiffOpType = -1 | 0 | 1
@@ -83,16 +87,26 @@ export function useTrackedChanges(
     }
   }
 
+  // Accept/reject go through the per-hunk cherry-pick endpoints (scoped to the
+  // suggestion's build) — the same resolution model as the /agents review, so
+  // hunks rejected there can't be re-published from here. Create suggestions
+  // (in_main === false) have no hunks against main: those keep the whole-build
+  // publish/discard semantics.
   async function accept() {
     const build = currentBuild.value
     const id = instructionId.value
     if (!build || !id || isResolving.value) return false
     isResolving.value = true
     try {
-      const { error } = await useMyFetch(`/builds/${build.build_id}/publish`, {
-        method: 'POST',
-        body: { instruction_ids: [id] },
-      })
+      const { error } = build.in_main === false
+        ? await useMyFetch(`/builds/${build.build_id}/publish`, {
+            method: 'POST',
+            body: { instruction_ids: [id] },
+          })
+        : await useMyFetch(`/instructions/${id}/hunks/accept-all`, {
+            method: 'POST',
+            body: { build_id: build.build_id },
+          })
       if (error.value) return false
       dispatchInstructionResolved({ instructionId: id, buildId: build.build_id, action: 'accept' })
       await refresh()
@@ -108,10 +122,12 @@ export function useTrackedChanges(
     if (!build || !id || isResolving.value) return false
     isResolving.value = true
     try {
-      const { error } = await useMyFetch(
-        `/builds/${build.build_id}/contents/${id}`,
-        { method: 'DELETE' },
-      )
+      const { error } = build.in_main === false
+        ? await useMyFetch(`/builds/${build.build_id}/contents/${id}`, { method: 'DELETE' })
+        : await useMyFetch(`/instructions/${id}/hunks/reject-all`, {
+            method: 'POST',
+            body: { build_id: build.build_id },
+          })
       if (error.value) return false
       dispatchInstructionResolved({ instructionId: id, buildId: build.build_id, action: 'reject' })
       await refresh()


### PR DESCRIPTION
## Problem

The same instruction could show pending "changes" in the Report agent panel while the /agents Knowledge Explorer showed none. The two surfaces read different sources of truth:

- **/agents review** reads `GET /instructions/{id}/review-hunks` — the authoritative per-hunk rule (a suggestion counts only while it has a live hunk: not rejected, still anchorable onto current main, actually changing it).
- **Report agent panel** (fallback banner in `InstructionGlobalCreateComponent` via `useTrackedChanges`) reads the legacy `GET /instructions/{id}/pending-builds`, which never consulted `rejected_hunks` and diffed raw snapshots — so a suggestion fully rejected (or already cherry-picked) in the per-hunk review kept resurfacing there.

Worse than a display bug: the banner's **Accept** called `POST /builds/{id}/publish` (publishing the raw snapshot, including hunks the user had already rejected) and **Reject** destructively deleted build contents.

## Fix

**Backend**
- `GET /instructions/{id}/pending-builds` now follows the same authoritative per-hunk rule as `review-hunks`: a build is listed only while it has ≥1 live hunk. `pending_text` is synthesized as *main + the build's live hunks* (so a partially-rejected suggestion renders only its live changes) and `base_text` is current main. Create suggestions (instruction not in main yet) keep raw-snapshot semantics, flagged `in_main: false`.
- `hunks/accept-all` and `hunks/reject-all` accept an optional `build_id` to resolve a single suggestion; build-scoped rejection only clears the Review-feed item when nothing remains pending.

**Frontend**
- `useTrackedChanges.accept()/reject()` now resolve through the build-scoped per-hunk endpoints (same model as the /agents review). Create suggestions (`in_main === false`) keep publish/discard.
- `ReportAgentPanel` shows the per-hunk review to users who can't approve too (read-only, buttons stay permission-gated), matching the Knowledge Explorer.

The instruction list/detail were already gated on the authoritative set (`get_pending_change_instruction_ids`, commit 1e25b37), so with this change every surface agrees.

## Tests

New e2e regression tests (`backend/tests/e2e/test_instruction.py`), green on the sqlite leg along with the full instruction, RBAC-instruction, build, and instruction-resolve suites (82 tests):
- reject-all empties `/pending-builds` and `/review-hunks` alike (the reproducer for this bug),
- partial rejection renders only live hunks in `pending_text`,
- build-scoped accept-all / reject-all resolve one suggestion and leave siblings pending.

## Not in scope (follow-up candidates)

The in-chat staged-build flows (`CreateInstructionTool` / `EditInstructionTool` cards, `KnowledgeGroup`, PromptBox pill) still resolve via build publish/discard — acceptable there since they act on the build just created in-session, and their *pending state* now reads consistently from the fixed endpoint. Migrating them to the per-hunk endpoints (and retiring `/pending-builds`) can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApaBJhW3SQ2zegnAzVWo56

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApaBJhW3SQ2zegnAzVWo56)_