### PR TITLE
Limit command palette prompts to 5 and align prompts icon with sidebar

### DIFF
--- a/backend/app/routes/prompt.py
+++ b/backend/app/routes/prompt.py
@@ -24,6 +24,7 @@ async def list_prompts(
     created_by: Optional[str] = None,
     scope: Optional[str] = None,
     search: Optional[str] = None,
+    limit: Optional[int] = Query(default=None, ge=1),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
@@ -31,7 +32,7 @@ async def list_prompts(
     return await prompt_service.list_prompts(
         db, current_user, organization,
         category=category, starters_only=starters_only, data_source_id=data_source_id,
-        created_by=created_by, scope=scope, search=search,
+        created_by=created_by, scope=scope, search=search, limit=limit,
     )
 
 

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -98,6 +98,7 @@ class PromptService:
         data_source_id: Optional[str] = None,
         created_by: Optional[str] = None, scope: Optional[str] = None,
         search: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> dict:
         resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
         q = (
@@ -135,7 +136,12 @@ class PromptService:
                 continue
             visible.append(self._to_response(p, resolved, str(current_user.id)))
         visible.sort(key=lambda r: r["created_at"] or datetime.min, reverse=True)
-        return {"prompts": visible, "meta": {"total": len(visible)}}
+        # Visibility is resolved in Python, so the limit must apply here
+        # rather than in SQL. meta.total stays the pre-limit visible count.
+        total = len(visible)
+        if limit is not None:
+            visible = visible[:limit]
+        return {"prompts": visible, "meta": {"total": total}}
 
     async def get_prompt_or_404(self, db, prompt_id, organization) -> Prompt:
         rows = await db.execute(

--- a/backend/tests/prompts/test_prompt_model.py
+++ b/backend/tests/prompts/test_prompt_model.py
@@ -138,6 +138,29 @@ async def test_prompt_model_access_and_parameters():
 
 
 @pytest.mark.asyncio
+async def test_list_prompts_limit():
+    """`limit` caps the returned prompts after visibility filtering and
+    sorting, while meta.total keeps the full visible count. The command
+    palette relies on this (`/prompts?limit=5`)."""
+    ids = await _seed()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org"])
+        admin = await db.get(User, ids["admin"])
+        for i in range(7):
+            await prompt_service.create_prompt(
+                db, PromptCreate(title=f"P{i}", text=f"prompt {i}", scope="global", data_source_ids=[]), admin, org)
+
+        res = await prompt_service.list_prompts(db, admin, org, limit=5)
+        assert len(res["prompts"]) == 5
+        assert res["meta"]["total"] == 7
+
+        res_all = await prompt_service.list_prompts(db, admin, org)
+        assert len(res_all["prompts"]) == 7
+        assert res_all["meta"]["total"] == 7
+        print("[limit] limit=5 caps results, meta.total stays 7")
+
+
+@pytest.mark.asyncio
 async def test_materialize_starters_idempotent():
     """The agent-creation path: a data source's conversation_starters become
     agent-scoped starter Prompts (idempotent), visible via starters_only."""

--- a/frontend/components/CommandPalette.vue
+++ b/frontend/components/CommandPalette.vue
@@ -227,7 +227,7 @@ const promptsGroup = computed(() => ({
   commands: promptItems.value.map((p: any) => ({
     id: `prompt-${p.id}`,
     label: p.title || truncate(p.text),
-    icon: 'i-heroicons-command-line',
+    icon: 'i-heroicons-book-open',
     suffix: (p.parameters && p.parameters.length) ? `${p.parameters.length} ${p.parameters.length === 1 ? 'param' : 'params'}` : undefined,
     prompt: p,
   })),


### PR DESCRIPTION
## Summary

The command palette showed every prompt in the organization instead of the 5 it asked for, and used a different prompts icon than the sidebar nav.

- **Honor `limit` on `GET /prompts`**: the palette already requested `/prompts?limit=5`, but the route never declared the param, so FastAPI silently dropped it and every visible prompt was returned. The route now accepts `limit` (optional, ≥ 1) and the service applies it after visibility filtering and newest-first sorting — visibility is resolved in Python, so a SQL `LIMIT` would under-fill results. `meta.total` still reports the pre-limit visible count.
- **Prompts icon**: command palette prompt entries now use `i-heroicons-book-open`, matching the Prompts entry in the sidebar nav (`layouts/default.vue`), instead of `i-heroicons-command-line`.

## Changes

- `backend/app/routes/prompt.py` — add `limit` query param to `GET /prompts`
- `backend/app/services/prompt_service.py` — apply `limit` after visibility filtering + sort
- `backend/tests/prompts/test_prompt_model.py` — new `test_list_prompts_limit` regression test (7 prompts, `limit=5` → 5 returned, `meta.total == 7`)
- `frontend/components/CommandPalette.vue` — prompts icon `command-line` → `book-open`

## Testing

- `test_list_prompts_limit` and `test_materialize_starters_idempotent` pass.
- Note: `test_prompt_model_access_and_parameters` fails identically on the base branch (pre-existing, unrelated multi-agent visibility failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ6xB5W8JetoxyJxHwTk32

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZ6xB5W8JetoxyJxHwTk32)_