### PR TITLE
fix: single-value cards never render an arbitrary cell (label/date) as the metric

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -4503,6 +4503,15 @@ class AgentV2:
                                 # Preserve existing type; only set if missing
                                 if not merged.get("type") and data_model_from_tool.get("type"):
                                     merged["type"] = data_model_from_tool.get("type")
+                                # Exception: create_data demotes an unresolvable
+                                # single-value card to a table (no value column /
+                                # no row selector). Adopt that so the step's
+                                # data_model stays consistent with the view.
+                                elif (
+                                    data_model_from_tool.get("type") == "table"
+                                    and merged.get("type") in ("count", "metric_card")
+                                ):
+                                    merged["type"] = "table"
                                 # Merge series/grouping fields. `filters` MUST be
                                 # included: it carries the default filter that
                                 # narrows a melted/long KPI table to the asked-for

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -334,6 +334,40 @@ class Coder:
         result = re.sub(r'(?s)return\s+df.*$', 'return df', result)
         return result
     
+    _SINGLE_VALUE_VIZ_TYPES = {"count", "metric_card"}
+
+    @classmethod
+    def _build_viz_directive(cls, target_visualization_type: str | None) -> str:
+        """Data-shape contract for the visualization the result will render as.
+
+        Measures must stay raw numeric dtypes: the renderer parses cells as
+        numbers, so a display-formatted string ("₪29,134,139") breaks cards,
+        chart axes and aggregations. For single-value cards the result must be
+        a single row so the card never has to guess which row is the answer.
+        These rules outrank org instructions asking for formatted output — the
+        UI applies currency symbols and separators at display time.
+        """
+        t = (target_visualization_type or "").strip().lower()
+        if not t or t == "table":
+            return ""
+        base = (
+            "**Visualization data contract (takes precedence over any conflicting "
+            "formatting instructions):**\n"
+            f"            - The result will be rendered as a `{t}` visualization.\n"
+            "            - Keep every measure column as a raw numeric dtype (int/float). Never "
+            "format numbers into display strings — no currency symbols, no thousands "
+            "separators, no units inside values. Presentation formatting is applied by the "
+            "visualization layer, not the data.\n"
+        )
+        if t in cls._SINGLE_VALUE_VIZ_TYPES:
+            base += (
+                "            - This is a single-value KPI card: return exactly ONE row, with the "
+                "metric the user asked for as a numeric column (plus optional numeric "
+                "comparison columns). Do NOT return a label/value summary table with one row "
+                "per metric.\n"
+            )
+        return base
+
     @staticmethod
     def _build_reuse_directive(loadables_context: str, prompt_text: str) -> str:
         """Force load_step reuse when the user refers to an available step.
@@ -414,6 +448,7 @@ class Coder:
                 loadables_context,
                 f"{context.user_prompt or ''}\n{context.interpreted_prompt or ''}",
             )
+            viz_directive = self._build_viz_directive(getattr(context, "target_visualization_type", None))
             # Retrieve top successful snippets based on targeted tables if provided
             similar_successful_code_snippets = ""
             try:
@@ -454,6 +489,7 @@ class Coder:
             Goal: Given the user's prompt and the provided context, generate a Python function named `generate_df(ds_clients, excel_files)`
             that produces a Pandas DataFrame grounded only in the provided schemas and resources.
             {reuse_directive}
+            {viz_directive}
 
             **Organization Instructions** (authored by the user; apply them):
             {instructions_context}
@@ -595,6 +631,9 @@ class Coder:
 
             6. **Data Formatting**:
                - Ensure the DataFrame is two-dimensional and handle missing values.
+               - Keep numeric measures as numeric dtypes (int/float). Do not format numbers
+                 into display strings (no currency symbols or thousands separators inside
+                 values) — the visualization layer handles presentation formatting.
 
             7. **No Extra Formatting**:
                - Return ONLY the Python function code for `generate_df`.

--- a/backend/app/ai/prompt_formatters.py
+++ b/backend/app/ai/prompt_formatters.py
@@ -10,6 +10,7 @@ async def build_codegen_context(
     interpreted_prompt: str | None,
     schemas_excerpt: str,
     tables_by_source: list | None = None,
+    target_visualization_type: str | None = None,
 ) -> CodeGenContext:
     """
     Build a CodeGenContext from runtime_ctx (ContextHub/ContextView) with safe fallbacks.
@@ -162,6 +163,7 @@ async def build_codegen_context(
         past_observations=past_observations,
         last_observation=last_observation,
         tables_by_source=norm_tables_by_source,
+        target_visualization_type=target_visualization_type,
     )
 
 

--- a/backend/app/ai/schemas/codegen.py
+++ b/backend/app/ai/schemas/codegen.py
@@ -29,6 +29,9 @@ class CodeGenContext(BaseModel):
     successful_queries: List[str] = []
     # New: optional targeting info to drive snippet retrieval
     tables_by_source: Optional[List[Dict[str, Any]]] = None
+    # The visualization type the result will render as (e.g. "metric_card"),
+    # when known before codegen. Lets the coder shape the DataFrame for it.
+    target_visualization_type: Optional[str] = None
 
 
 class CodeGenRequest(BaseModel):

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -221,6 +221,272 @@ def _norm(s: Any) -> str:
     return str(s).strip().lower() if s is not None else ""
 
 
+_CURRENCY_SEPARATOR_RE = re.compile(r"[₪$€£¥,\s]")
+_NUMERIC_STRING_RE = re.compile(r"^[+-]?\d+(\.\d+)?$")
+_DATE_STRING_RE = re.compile(
+    r"^\d{4}-\d{1,2}-\d{1,2}([ T].*)?$"      # 2025-12-22 / ISO
+    r"|^\d{1,2}[./-]\d{1,2}[./-]\d{2,4}$"     # 23.06.2026, 6/23/26
+    r"|^\d{4}[./]\d{1,2}[./]\d{1,2}$"         # 2026.06.23
+)
+_TIME_COLUMN_NAME_RE = re.compile(
+    r"(date|time|day|month|week|year|period|timestamp|תאריך|חודש|שנה|יום|שבוע)",
+    re.IGNORECASE,
+)
+
+
+def _parse_numeric_like(value: Any) -> Optional[float]:
+    """Parse a raw or display-formatted numeric cell.
+
+    Accepts real numbers and strings like "1234", "₪29,134,139", "4,125.04",
+    "45.2%". Returns None for anything else (dates, labels, mixed text) so
+    callers can tell "numeric measure" from "label/date" reliably.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:
+            return None
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    s = _CURRENCY_SEPARATOR_RE.sub("", s)
+    if s.endswith("%"):
+        s = s[:-1]
+    if not _NUMERIC_STRING_RE.match(s):
+        return None
+    try:
+        return float(s)
+    except Exception:
+        return None
+
+
+def _looks_like_date_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(_DATE_STRING_RE.match(value.strip()))
+
+
+def _column_fields(formatted: Dict[str, Any]) -> List[str]:
+    return [
+        c.get("field")
+        for c in ((formatted or {}).get("columns") or [])
+        if isinstance(c, dict) and c.get("field")
+    ]
+
+
+def _column_cells(rows: List[Dict[str, Any]], col: str, cap: int = 50) -> List[Any]:
+    out = []
+    for r in rows[:cap]:
+        if isinstance(r, dict) and r.get(col) is not None:
+            out.append(r.get(col))
+    return out
+
+
+def _numeric_like_ratio(cells: List[Any]) -> float:
+    if not cells:
+        return 0.0
+    return sum(1 for c in cells if _parse_numeric_like(c) is not None) / len(cells)
+
+
+def _pick_value_column(rows: List[Dict[str, Any]], columns: List[str]) -> Optional[str]:
+    """Deterministically pick the measure column when inference didn't provide one.
+
+    Rules (strict on purpose — returning None demotes the card to a table):
+    - single column → that column (a deliberate single-value result);
+    - exactly one numeric-looking column → that column;
+    - several numeric-looking columns → drop time/id-named ones; if one remains
+      use it; for single-row results fall back to the first (mirrors the
+      legacy frontend behaviour for wide KPI rows); multi-row stays ambiguous.
+    """
+    if not rows or not columns:
+        return None
+    if len(columns) == 1:
+        return columns[0]
+    numericish = []
+    for col in columns:
+        cells = _column_cells(rows, col)
+        if cells and _numeric_like_ratio(cells) >= 0.5:
+            numericish.append(col)
+    if len(numericish) == 1:
+        return numericish[0]
+    if not numericish:
+        return None
+    deprioritized = re.compile(r"(date|year|month|week|day|time|id)$", re.IGNORECASE)
+    preferred = [c for c in numericish if not deprioritized.search(str(c))]
+    pool = preferred or numericish
+    if len(pool) == 1:
+        return pool[0]
+    if len(rows) == 1:
+        return pool[0]
+    return None
+
+
+def _match_default_filter(row: Dict[str, Any], f: Dict[str, Any]) -> bool:
+    """Mirror of the frontend's matchDefaultFilter (ToolWidgetPreview.vue)."""
+    if not isinstance(row, dict) or not isinstance(f, dict) or not f.get("column"):
+        return True
+    key = next((k for k in row.keys() if _norm(k) == _norm(f.get("column"))), None)
+    if key is None:
+        return True
+    cell = row.get(key)
+    s_cell = "" if cell is None else str(cell)
+    s_val = "" if f.get("value") is None else str(f.get("value"))
+    op = str(f.get("operator") or "equals")
+    if op == "equals":
+        return s_cell == s_val
+    if op == "not_equals":
+        return s_cell != s_val
+    if op == "contains":
+        return s_val in s_cell
+    if op == "not_contains":
+        return s_val not in s_cell
+    if op == "starts_with":
+        return s_cell.startswith(s_val)
+    if op == "ends_with":
+        return s_cell.endswith(s_val)
+    if op == "is_empty":
+        return s_cell == ""
+    if op == "is_not_empty":
+        return s_cell != ""
+    if op in ("greater_than", "less_than", "gte", "lte"):
+        a = _parse_numeric_like(cell)
+        b = _parse_numeric_like(f.get("value"))
+        if a is None or b is None:
+            return False
+        return {
+            "greater_than": a > b,
+            "less_than": a < b,
+            "gte": a >= b,
+            "lte": a <= b,
+        }[op]
+    return True
+
+
+def _count_filter_hits(rows: List[Dict[str, Any]], filters: List[Dict[str, Any]]) -> int:
+    return sum(
+        1
+        for r in rows
+        if isinstance(r, dict) and all(_match_default_filter(r, f) for f in filters if isinstance(f, dict))
+    )
+
+
+def _has_time_like_column(
+    formatted: Dict[str, Any],
+    rows: List[Dict[str, Any]],
+    columns: List[str],
+    exclude: Optional[str],
+) -> bool:
+    """A time axis next to the measure marks the legit multi-row card pattern
+    (latest value + sparkline), which must keep its legacy behaviour."""
+    column_info = ((formatted or {}).get("info") or {}).get("column_info") or {}
+    for col in columns:
+        if col == exclude:
+            continue
+        if _TIME_COLUMN_NAME_RE.search(str(col)):
+            return True
+        dtype = str((column_info.get(col) or {}).get("dtype") or "")
+        if "datetime" in dtype or dtype == "date":
+            return True
+        cells = _column_cells(rows, col)
+        if cells and sum(1 for c in cells if _looks_like_date_string(c)) / len(cells) >= 0.8:
+            return True
+    return False
+
+
+def ensure_single_value_card_renderable(
+    final_dm: Dict[str, Any],
+    formatted: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Deterministic last line of defense for count/metric_card.
+
+    A single-value card must be able to point at one numeric cell: a concrete
+    value column, plus (for multi-row results) a row selector — a filter that
+    matches exactly one row, an aggregation, or a time axis (the sparkline /
+    "latest value" pattern). When none of that holds — the exact state produced
+    by a melted ``Metric | Value`` display table with a failed inference pass —
+    the card would render an arbitrary cell (the date row or a label), so the
+    type is demoted to ``table``, which is always a truthful rendering.
+
+    Purely structural: no LLM calls, no text matching beyond what
+    ``derive_kpi_row_filter`` already does.
+    """
+    if not isinstance(final_dm, dict) or final_dm.get("type") not in _SINGLE_VALUE_CARD_TYPES:
+        return final_dm
+
+    rows = (formatted or {}).get("rows") or []
+    if not rows:
+        return final_dm  # empty result renders as '—' honestly
+    columns = _column_fields(formatted)
+    if not columns:
+        return final_dm
+
+    out = dict(final_dm)
+    series = [dict(s) for s in (out.get("series") or []) if isinstance(s, dict)]
+    first = series[0] if series else {}
+
+    # 1) Resolve the value column; drop hallucinated ones.
+    value_col = first.get("value") or first.get("metric")
+    if value_col is not None and not any(_norm(value_col) == _norm(c) for c in columns):
+        value_col = None
+    if value_col is None:
+        value_col = _pick_value_column(rows, columns)
+        if value_col is not None:
+            first = {**first, "value": value_col}
+            series = [first] + series[1:] if series else [first]
+            out["series"] = series
+    if value_col is None:
+        return _demote_card_to_table(out, reason="no resolvable value column")
+
+    if len(rows) == 1:
+        return out  # rows[0] is the answer and the column is pinned
+
+    # 2) Multi-row: an existing filter must select exactly one row.
+    filters = [f for f in (out.get("filters") or []) if isinstance(f, dict)]
+    if filters:
+        if _count_filter_hits(rows, filters) == 1:
+            return out
+        out["filters"] = None  # invalid filter — drop rather than mislead
+
+    # 3) Melted-table row selection by series-name match (existing safeguard).
+    derived = derive_kpi_row_filter(out, formatted)
+    if derived:
+        out["filters"] = [derived]
+        return out
+
+    # 4) Aggregation over a numeric measure is a valid row-reducer — unless the
+    #    measure column mixes in date strings (melted-table symptom: summing a
+    #    date together with the metrics would show garbage).
+    agg = first.get("aggregation")
+    if agg in _VALID_AGGREGATIONS:
+        cells = _column_cells(rows, value_col)
+        mixed_with_dates = any(_looks_like_date_string(c) for c in cells)
+        if agg == "count" or (_numeric_like_ratio(cells) >= 0.5 and not mixed_with_dates):
+            return out
+
+    # 5) Time series next to the measure: legacy "latest value (+sparkline)" card.
+    if (
+        first.get("sparkline_column")
+        or first.get("time_series")
+        or out.get("has_time_series")
+        or _has_time_like_column(formatted, rows, columns, exclude=value_col)
+    ):
+        return out
+
+    return _demote_card_to_table(out, reason="multi-row result with no row selector")
+
+
+def _demote_card_to_table(final_dm: Dict[str, Any], reason: str) -> Dict[str, Any]:
+    logger.info(
+        "create_data: demoting %s to table (%s)", final_dm.get("type"), reason
+    )
+    demoted = dict(final_dm)
+    demoted["type"] = "table"
+    demoted["filters"] = None
+    return demoted
+
+
 def derive_kpi_row_filter(
     final_dm: Dict[str, Any],
     formatted: Dict[str, Any],
@@ -1026,6 +1292,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
         context_hub = runtime_ctx.get("context_hub")
 
         # Early: signal intended artifact type and request step creation before code-gen
+        early_viz_type = None
         try:
             # Single signal: declare type and pass the intended query title
             allowed_types = ALLOWED_VIZ_TYPES
@@ -1035,6 +1302,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
             except Exception:
                 requested_type = None
             viz_type = requested_type if requested_type in allowed_types else "table"
+            early_viz_type = viz_type
             yield ToolProgressEvent(
                 type="tool.progress",
                 payload={
@@ -1271,6 +1539,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
             interpreted_prompt=(data.interpreted_prompt or None),
             schemas_excerpt=(schemas_excerpt or ""),
             tables_by_source=resolved_tables or None,
+            target_visualization_type=(early_viz_type if early_viz_type and early_viz_type != "table" else None),
         )
 
         # Combine schemas with files for additional grounding (keep previous semantics)
@@ -1500,13 +1769,12 @@ Do not use generic placeholders like "value" unless that is the actual column na
         # series/grouping/sort/limit/filters from inference. (filters carry the
         # default-filter that narrows a melted KPI table to the asked-for row.)
         final_dm = finalize_inferred_data_model(fallback_type, inferred_dm)
-        # Safeguard: a single-value card over a melted/long table needs a filter
-        # to pick the asked-for row. If the model didn't emit one, derive it from
-        # the series name so the card shows the metric value, not row 0.
-        if not final_dm.get("filters"):
-            derived_filter = derive_kpi_row_filter(final_dm, formatted)
-            if derived_filter:
-                final_dm["filters"] = [derived_filter]
+        # Deterministic guard: a single-value card must resolve to one numeric
+        # cell (value column + row selector). It repairs what it can (missing
+        # value column, series-name row filter via derive_kpi_row_filter) and
+        # demotes the type to table when unresolvable — a card must never
+        # render an arbitrary cell (the date row or a metric label).
+        final_dm = ensure_single_value_card_renderable(final_dm, formatted)
         palette_theme = _infer_palette_theme(runtime_ctx) or "default"
         # Extract available column names from formatted data for fallback inference
         available_columns = [c.get("field") for c in formatted.get("columns", []) if c.get("field")]

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -192,7 +192,37 @@ def _first_series_aggregation(series: List[Dict[str, Any]]) -> Optional[str]:
 # (e.g. a `Metric | Value | Format` KPI table) down to the one relevant row.
 # Dropping it makes count/metric_card render the first (unfiltered) row — the
 # date or the metric label — instead of the value the user asked for.
-_INFERRED_DM_CARRY_KEYS = ("series", "group_by", "sort", "limit", "filters")
+# `display` carries presentation formatting (currency/percent/prefix) — the
+# data itself stays raw numeric; symbols are applied at render time.
+_INFERRED_DM_CARRY_KEYS = ("series", "group_by", "sort", "limit", "filters", "display")
+
+
+_ALLOWED_DISPLAY_FORMATS = {"number", "currency", "percent", "compact"}
+_CURRENCY_CODE_RE = re.compile(r"^[A-Za-z]{3}$")
+
+
+def sanitize_display_options(d: Any) -> Optional[Dict[str, str]]:
+    """Validate the inference-emitted `display` object down to safe values.
+
+    Presentation only — format/currency/prefix/suffix for single-value cards.
+    Anything malformed is dropped rather than propagated to the view.
+    """
+    if not isinstance(d, dict):
+        return None
+    out: Dict[str, str] = {}
+    fmt = str(d.get("format") or "").strip().lower()
+    if fmt in _ALLOWED_DISPLAY_FORMATS:
+        out["format"] = fmt
+    cur = d.get("currency")
+    if isinstance(cur, str) and _CURRENCY_CODE_RE.match(cur.strip()):
+        out["currency"] = cur.strip().upper()
+        # A currency code implies currency formatting unless stated otherwise.
+        out.setdefault("format", "currency")
+    for key in ("prefix", "suffix"):
+        v = d.get(key)
+        if isinstance(v, str) and 0 < len(v.strip()) <= 8:
+            out[key] = v.strip()
+    return out or None
 
 
 def finalize_inferred_data_model(
@@ -668,6 +698,10 @@ def build_view_from_data_model(
         view = TableView(title=title, defaultFilters=default_filters)
         return ViewSchema(view=view)
 
+    # Presentation formatting for single-value cards (validated upstream by
+    # sanitize_display_options; re-sanitize here so direct callers are safe too).
+    display = sanitize_display_options(data_model.get("display")) or {}
+
     # CountView - simple single value display (value is optional)
     if chart_type == "count":
         base = series[0] if series else {}
@@ -675,6 +709,10 @@ def build_view_from_data_model(
         view = CountView(
             title=title,
             value=str(value_key) if value_key else None,
+            format=display.get("format", "number"),
+            currency=display.get("currency"),
+            prefix=display.get("prefix"),
+            suffix=display.get("suffix"),
             palette=palette,
             aggregation=_first_series_aggregation(series),
             defaultFilters=default_filters,
@@ -714,13 +752,25 @@ def build_view_from_data_model(
 
         # value is REQUIRED for MetricCardView - if we don't have it, fall back to CountView
         if not value_key:
-            view = CountView(title=title, palette=palette, defaultFilters=default_filters)
+            view = CountView(
+                title=title,
+                format=display.get("format", "number"),
+                currency=display.get("currency"),
+                prefix=display.get("prefix"),
+                suffix=display.get("suffix"),
+                palette=palette,
+                defaultFilters=default_filters,
+            )
             return ViewSchema(view=view)
 
         view = MetricCardView(
             title=title,
             value=str(value_key),
             comparison=str(comparison_key) if comparison_key else None,
+            format=display.get("format", "number"),
+            currency=display.get("currency"),
+            prefix=display.get("prefix"),
+            suffix=display.get("suffix"),
             comparisonLabel=comparison_label,
             invertTrend=invert_trend,
             sparkline=sparkline,
@@ -983,11 +1033,28 @@ Prefer aggregation when the intent is "all data, summarized". Prefer filters
 when the intent is "this specific slice". Setting both is rarely useful.
 
 ═══════════════════════════════════════════════════════════════════════════════
+DISPLAY FORMATTING (optional, for count / metric_card)
+═══════════════════════════════════════════════════════════════════════════════
+
+The data is raw numeric; presentation is applied at render time. For a
+single-value card you may add a top-level "display" object:
+
+{{"display": {{"format": "currency", "currency": "ILS"}}}}
+
+- format: "number" | "currency" | "percent" | "compact"
+- currency: ISO-4217 code (ILS, USD, EUR, ...) — set it whenever format is "currency"
+- prefix / suffix: short literal unit strings (e.g. "%", " units") when a currency code doesn't apply
+
+Choose based on the metric's meaning, the user's language/locale, and the
+organization instructions (e.g. revenue for an Israeli org → {{"format": "currency", "currency": "ILS"}};
+a ratio → {{"format": "percent"}}). Omit "display" when plain numbers are right.
+
+═══════════════════════════════════════════════════════════════════════════════
 OUTPUT FORMAT
 ═══════════════════════════════════════════════════════════════════════════════
 
 Return only valid JSON:
-{{"type": "...", "series": [...], "group_by": "column_name_or_null", "filters": [...]}}
+{{"type": "...", "series": [...], "group_by": "column_name_or_null", "filters": [...], "display": {{...}}}}
 
 Include "group_by" when the data has multiple rows per x-axis category that should be shown as separate colored series.
 Include "aggregation" on each series entry when rows are granular.
@@ -1030,6 +1097,11 @@ Do not use generic placeholders like "value" unless that is the actual column na
                     candidate = dm.model_dump()
                 except Exception:
                     candidate = {"type": "table", "series": []}
+                # Presentation formatting (currency/percent/prefix) — validated
+                # separately since it's a view concern, not part of DataModel.
+                display = sanitize_display_options(candidate_json.get("display"))
+                if display:
+                    candidate["display"] = display
                 # Extract optional view mappings (limit/sort/colors) from candidate_json.view
                 try:
                     view = candidate_json.get("view") if isinstance(candidate_json, dict) else None

--- a/backend/app/schemas/view_schema.py
+++ b/backend/app/schemas/view_schema.py
@@ -211,6 +211,8 @@ class CountView(BaseView):
     type: Literal["count"] = "count"
     value: Optional[str] = None
     format: Literal["number", "currency", "percent", "compact"] = "number"
+    # ISO-4217 code used when format == "currency" (e.g. "ILS", "USD")
+    currency: Optional[str] = None
     prefix: Optional[str] = None
     suffix: Optional[str] = None
     palette: Palette = Field(default_factory=Palette)
@@ -232,6 +234,8 @@ class MetricCardView(BaseView):
     value: str                                    # Column for main value (first row)
     comparison: Optional[str] = None              # Column for trend % (first row)
     format: Literal["number", "currency", "percent", "compact"] = "number"
+    # ISO-4217 code used when format == "currency" (e.g. "ILS", "USD")
+    currency: Optional[str] = None
     prefix: Optional[str] = None
     suffix: Optional[str] = None
     # Trend configuration

--- a/backend/tests/unit/test_create_data_card_guard.py
+++ b/backend/tests/unit/test_create_data_card_guard.py
@@ -8,8 +8,10 @@ repairs what it can deterministically and demotes to table otherwise.
 import pytest
 
 from app.ai.tools.implementations.create_data import (
+    build_view_from_data_model,
     ensure_single_value_card_renderable,
     finalize_inferred_data_model,
+    sanitize_display_options,
     _parse_numeric_like,
     _pick_value_column,
 )
@@ -213,3 +215,83 @@ class TestCardGuard:
         }
         out = ensure_single_value_card_renderable(dm, formatted)
         assert out["type"] == "metric_card"
+
+
+class TestDisplayFormatting:
+    def test_sanitize_valid_currency(self):
+        assert sanitize_display_options({"format": "currency", "currency": "ils"}) == {
+            "format": "currency",
+            "currency": "ILS",
+        }
+
+    def test_currency_code_implies_currency_format(self):
+        assert sanitize_display_options({"currency": "USD"}) == {
+            "format": "currency",
+            "currency": "USD",
+        }
+
+    def test_sanitize_drops_garbage(self):
+        assert sanitize_display_options({"format": "bold", "currency": "shekels"}) is None
+        assert sanitize_display_options({"prefix": "x" * 20}) is None
+        assert sanitize_display_options("currency") is None
+        assert sanitize_display_options(None) is None
+
+    def test_sanitize_prefix_suffix(self):
+        assert sanitize_display_options({"format": "percent", "suffix": " pts"}) == {
+            "format": "percent",
+            "suffix": "pts",
+        }
+
+    def test_display_carried_from_inference(self):
+        inferred = {
+            "type": "metric_card",
+            "series": [{"name": "Revenue", "value": "revenue"}],
+            "display": {"format": "currency", "currency": "ILS"},
+        }
+        dm = finalize_inferred_data_model("metric_card", inferred)
+        assert dm["display"] == {"format": "currency", "currency": "ILS"}
+
+    def test_display_flows_into_metric_card_view(self):
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "Revenue", "value": "revenue"}],
+            "display": {"format": "currency", "currency": "ILS"},
+        }
+        view = build_view_from_data_model(dm, title="t", palette_theme="default")
+        v = view.model_dump(exclude_none=True)["view"]
+        assert v["format"] == "currency"
+        assert v["currency"] == "ILS"
+
+    def test_display_flows_into_count_view(self):
+        dm = {
+            "type": "count",
+            "series": [{"name": "Share", "value": "share"}],
+            "display": {"format": "percent"},
+        }
+        view = build_view_from_data_model(dm, title="t", palette_theme="default")
+        v = view.model_dump(exclude_none=True)["view"]
+        assert v["format"] == "percent"
+        assert "currency" not in v
+
+    def test_display_survives_guard_repair(self):
+        dm = {
+            "type": "metric_card",
+            "series": [],
+            "display": {"format": "currency", "currency": "ILS"},
+        }
+        formatted = _formatted(
+            ["Label", "Revenue"], [{"Label": "Total", "Revenue": 99.5}]
+        )
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+        assert out["display"] == {"format": "currency", "currency": "ILS"}
+
+    def test_invalid_display_ignored_by_view_builder(self):
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "Revenue", "value": "revenue"}],
+            "display": {"format": "sparkles"},
+        }
+        view = build_view_from_data_model(dm, title="t", palette_theme="default")
+        v = view.model_dump(exclude_none=True)["view"]
+        assert v["format"] == "number"

--- a/backend/tests/unit/test_create_data_card_guard.py
+++ b/backend/tests/unit/test_create_data_card_guard.py
@@ -1,0 +1,215 @@
+"""Unit tests for the single-value-card guard in create_data.
+
+Covers the production failure class: a count/metric_card over a melted
+``Metric | Value`` display table (label column + shared value column, values
+pre-formatted as strings) must never render an arbitrary cell — the guard
+repairs what it can deterministically and demotes to table otherwise.
+"""
+import pytest
+
+from app.ai.tools.implementations.create_data import (
+    ensure_single_value_card_renderable,
+    finalize_inferred_data_model,
+    _parse_numeric_like,
+    _pick_value_column,
+)
+
+
+def _formatted(columns, rows, column_info=None):
+    return {
+        "columns": [{"headerName": c, "field": c} for c in columns],
+        "rows": rows,
+        "info": {
+            "total_rows": len(rows),
+            "column_info": column_info or {c: {"dtype": "object"} for c in columns},
+        },
+    }
+
+
+MELTED = _formatted(
+    ["מדד", "ערך"],
+    [
+        {"מדד": "תאריך", "ערך": "2025"},
+        {"מדד": "מכר", "ערך": "₪4,125.04"},
+        {"מדד": "כמות", "ערך": "442"},
+        {"מדד": "מספר חשבוניות", "ערך": "80"},
+    ],
+)
+
+
+class TestParseNumericLike:
+    def test_formatted_currency(self):
+        assert _parse_numeric_like("₪29,134,139") == 29134139.0
+        assert _parse_numeric_like("$1,234.56") == 1234.56
+        assert _parse_numeric_like("4,125.04") == 4125.04
+
+    def test_plain_numbers(self):
+        assert _parse_numeric_like(42) == 42.0
+        assert _parse_numeric_like(4.5) == 4.5
+        assert _parse_numeric_like("80") == 80.0
+        assert _parse_numeric_like("-12.5") == -12.5
+        assert _parse_numeric_like("45.2%") == 45.2
+
+    def test_rejects_non_numbers(self):
+        assert _parse_numeric_like("תאריך") is None
+        assert _parse_numeric_like("23.06.2026") is None
+        assert _parse_numeric_like("2025-12-22 00:00:00") is None
+        assert _parse_numeric_like(None) is None
+        assert _parse_numeric_like(True) is None
+        assert _parse_numeric_like("") is None
+        assert _parse_numeric_like("1.2.3") is None
+
+
+class TestPickValueColumn:
+    def test_single_column(self):
+        assert _pick_value_column([{"total": "x"}], ["total"]) == "total"
+
+    def test_single_numeric_like_column(self):
+        rows = MELTED["rows"]
+        assert _pick_value_column(rows, ["מדד", "ערך"]) == "ערך"
+
+    def test_multi_numeric_single_row_prefers_non_time(self):
+        rows = [{"year": 2025, "revenue": 100.0}]
+        assert _pick_value_column(rows, ["year", "revenue"]) == "revenue"
+
+    def test_multi_numeric_multi_row_is_ambiguous(self):
+        rows = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        assert _pick_value_column(rows, ["a", "b"]) is None
+
+
+class TestCardGuard:
+    def test_melted_with_empty_series_demotes_to_table(self):
+        # The exact reproduced production state: inference returned nothing.
+        dm = finalize_inferred_data_model("metric_card", {"type": "table", "series": []})
+        out = ensure_single_value_card_renderable(dm, MELTED)
+        assert out["type"] == "table"
+
+    def test_melted_with_matching_series_name_stays_card_with_filter(self):
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "מכר", "value": "ערך"}],
+        }
+        out = ensure_single_value_card_renderable(dm, MELTED)
+        assert out["type"] == "metric_card"
+        assert out["filters"] == [{"column": "מדד", "operator": "equals", "value": "מכר"}]
+
+    def test_melted_with_valid_filter_stays_card(self):
+        dm = {
+            "type": "count",
+            "series": [{"name": "Sales", "value": "ערך"}],
+            "filters": [{"column": "מדד", "operator": "equals", "value": "מכר"}],
+        }
+        out = ensure_single_value_card_renderable(dm, MELTED)
+        assert out["type"] == "count"
+        assert out["filters"] == [{"column": "מדד", "operator": "equals", "value": "מכר"}]
+
+    def test_filter_matching_zero_rows_is_dropped_and_demotes(self):
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "לא קיים", "value": "ערך"}],
+            "filters": [{"column": "מדד", "operator": "equals", "value": "לא קיים"}],
+        }
+        out = ensure_single_value_card_renderable(dm, MELTED)
+        assert out["type"] == "table"
+        assert not out.get("filters")
+
+    def test_single_row_wide_numeric_stays_card(self):
+        formatted = _formatted(
+            ["TotalSales", "TotalQuantity"],
+            [{"TotalSales": 4125.04, "TotalQuantity": 442}],
+            {"TotalSales": {"dtype": "float64"}, "TotalQuantity": {"dtype": "int64"}},
+        )
+        dm = {"type": "metric_card", "series": [{"name": "Total Sales", "value": "TotalSales"}]}
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+        assert out["series"][0]["value"] == "TotalSales"
+
+    def test_hallucinated_value_column_repaired_on_single_row(self):
+        formatted = _formatted(
+            ["Label", "Revenue"],
+            [{"Label": "Total", "Revenue": 99.5}],
+        )
+        dm = {"type": "metric_card", "series": [{"name": "Revenue", "value": "revnue_typo"}]}
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+        assert out["series"][0]["value"] == "Revenue"
+
+    def test_aggregation_over_numeric_entity_table_stays_card(self):
+        formatted = _formatted(
+            ["customer", "revenue"],
+            [{"customer": "Acme", "revenue": 100.0}, {"customer": "Bob", "revenue": 50.0}],
+        )
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "Revenue", "value": "revenue", "aggregation": "sum"}],
+        }
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+
+    def test_aggregation_over_date_mixed_column_demotes(self):
+        # Melted table whose value column mixes a date string with metrics —
+        # summing them would be garbage; the spurious aggregation must not
+        # keep the card alive.
+        formatted = _formatted(
+            ["מדד", "ערך"],
+            [
+                {"מדד": "תאריך", "ערך": "23.06.2026"},
+                {"מדד": "מכר", "ערך": "₪29,134,139"},
+                {"מדד": "כמות", "ערך": "2,889,903"},
+            ],
+        )
+        dm = {
+            "type": "count",
+            "series": [{"name": "KPI", "value": "ערך", "aggregation": "sum"}],
+        }
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "table"
+
+    def test_time_series_multi_row_keeps_legacy_card(self):
+        formatted = _formatted(
+            ["month", "revenue"],
+            [{"month": "2025-06", "revenue": 900}, {"month": "2025-05", "revenue": 800}],
+        )
+        dm = {"type": "metric_card", "series": [{"name": "Revenue", "value": "revenue"}]}
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+
+    def test_datetime_dtype_column_keeps_legacy_card(self):
+        formatted = _formatted(
+            ["d", "v"],
+            [{"d": "2025-06-01", "v": 900}, {"d": "2025-05-01", "v": 800}],
+            {"d": {"dtype": "datetime64[ns]"}, "v": {"dtype": "int64"}},
+        )
+        dm = {"type": "metric_card", "series": [{"name": "V", "value": "v"}]}
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"
+
+    def test_entity_table_without_selector_demotes(self):
+        formatted = _formatted(
+            ["customer", "revenue"],
+            [{"customer": "Acme", "revenue": 100.0}, {"customer": "Bob", "revenue": 50.0}],
+        )
+        dm = {"type": "metric_card", "series": [{"name": "Revenue", "value": "revenue"}]}
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "table"
+
+    def test_non_card_types_untouched(self):
+        dm = {"type": "bar_chart", "series": []}
+        assert ensure_single_value_card_renderable(dm, MELTED) is dm
+
+    def test_empty_rows_untouched(self):
+        dm = {"type": "count", "series": []}
+        out = ensure_single_value_card_renderable(dm, _formatted(["a"], []))
+        assert out["type"] == "count"
+
+    def test_sparkline_series_keeps_card(self):
+        formatted = _formatted(
+            ["label", "v"],
+            [{"label": "a", "v": 1}, {"label": "b", "v": 2}],
+        )
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "V", "value": "v", "sparkline_column": "v"}],
+        }
+        out = ensure_single_value_card_renderable(dm, formatted)
+        assert out["type"] == "metric_card"

--- a/frontend/components/dashboard/kpi/MetricCard.vue
+++ b/frontend/components/dashboard/kpi/MetricCard.vue
@@ -77,22 +77,48 @@ const subtitle = computed(() =>
   viewConfig.value?.subtitle || viewConfig.value?.description || ''
 )
 
-// Get value column from view or first numeric column
+// Parse a raw or display-formatted numeric cell ("1234", "₪29,134,139",
+// "4,125.04", "45.2%") into a number. Returns null for anything else (dates,
+// labels, mixed text). parseFloat must never be used on cell values here: it
+// silently truncates at the first separator (parseFloat("29,134,139") === 29).
+function parseNumericLike(val: any): number | null {
+  if (typeof val === 'number') return Number.isFinite(val) ? val : null
+  if (typeof val !== 'string') return null
+  let s = val.trim()
+  if (!s) return null
+  s = s.replace(/[₪$€£¥,\s  ]/g, '')
+  if (s.endsWith('%')) s = s.slice(0, -1)
+  if (!/^[+-]?\d+(\.\d+)?$/.test(s)) return null
+  const n = Number(s)
+  return Number.isFinite(n) ? n : null
+}
+
+// Get value column from view (validated against the data), else auto-detect a
+// numeric-looking column. Never falls back to an arbitrary first column — a
+// label column rendered as the metric ("תאריך") is worse than showing '—'.
 const valueColumn = computed(() => {
-  const v = viewConfig.value?.value
-  if (v) return v.toLowerCase()
-  
-  // Fallback: first column from data
   const rows = props.data?.rows
-  if (Array.isArray(rows) && rows.length > 0) {
-    const firstRow = rows[0]
-    const keys = Object.keys(firstRow || {})
-    // Prefer numeric columns
-    for (const k of keys) {
-      if (typeof firstRow[k] === 'number') return k.toLowerCase()
-    }
-    return keys[0]?.toLowerCase()
+  const firstRow = (Array.isArray(rows) && rows.length > 0) ? rows[0] : null
+  const keys = Object.keys(firstRow || {})
+
+  const v = viewConfig.value?.value
+  if (v) {
+    const wanted = String(v).toLowerCase()
+    // Only trust the configured column if it exists in the data; otherwise
+    // (hallucinated/renamed column) fall through to auto-detection.
+    if (!firstRow || keys.some(k => k.toLowerCase() === wanted)) return wanted
   }
+
+  if (!firstRow) return null
+  // Prefer truly numeric cells, then numeric-looking strings ("₪1,234").
+  for (const k of keys) {
+    if (typeof firstRow[k] === 'number') return k.toLowerCase()
+  }
+  for (const k of keys) {
+    if (typeof firstRow[k] === 'string' && parseNumericLike(firstRow[k]) !== null) return k.toLowerCase()
+  }
+  // A single-column result is a deliberate single value even if non-numeric.
+  if (keys.length === 1) return keys[0].toLowerCase()
   return null
 })
 
@@ -151,8 +177,8 @@ const rawValue = computed(() => {
       if (!row) continue
       const key = Object.keys(row).find(k => k.toLowerCase() === col)
       if (!key) continue
-      const num = Number(row[key])
-      if (!Number.isNaN(num)) values.push(num)
+      const num = parseNumericLike(row[key])
+      if (num !== null) values.push(num)
     }
     return aggregateNumbers(values, fn)
   }
@@ -162,11 +188,41 @@ const rawValue = computed(() => {
 
   if (col) {
     const key = Object.keys(firstRow).find(k => k.toLowerCase() === col)
-    if (key) return firstRow[key]
+    if (key) {
+      // Melted label/value table with no row selector (no filter narrowed the
+      // rows, no aggregation): rows[0] is an arbitrary metric's row — showing
+      // its value would be silently wrong. '—' is the honest render.
+      if (looksMeltedWithoutRowSelector(rows, col)) return null
+      return firstRow[key]
+    }
   }
 
-  return Object.values(firstRow)[0]
+  // No resolvable value column: show '—' rather than an arbitrary first cell
+  // (which is how a melted table's label ended up rendered as the metric).
+  return null
 })
+
+const TIME_NAME_RE = /(date|time|day|month|week|year|period|timestamp|תאריך|חודש|שנה|יום|שבוע)/i
+const DATE_STR_RE = /^\d{4}-\d{1,2}-\d{1,2}([ T].*)?$|^\d{1,2}[./-]\d{1,2}[./-]\d{2,4}$|^\d{4}[./]\d{1,2}[./]\d{1,2}$/
+
+// A melted KPI table is a label column next to the value column, one row per
+// metric ("מדד | ערך"). Time-series data (a date/month column next to the
+// measure) is NOT melted — that's the legit "latest value + sparkline" card
+// and keeps the legacy rows[0] behaviour.
+function looksMeltedWithoutRowSelector(rows: any[], col: string): boolean {
+  if (!Array.isArray(rows) || rows.length < 2) return false
+  const keys = Object.keys(rows[0] || {})
+  const others = keys.filter(k => k.toLowerCase() !== col)
+  if (others.length !== 1) return false
+  const label = others[0]
+  if (TIME_NAME_RE.test(label)) return false
+  const cells = rows.slice(0, 50).map(r => r?.[label]).filter(v => v !== null && v !== undefined)
+  if (!cells.length) return false
+  const allNonNumeric = cells.every(v => parseNumericLike(v) === null)
+  const mostlyDates = cells.filter(v => typeof v === 'string' && DATE_STR_RE.test(v.trim())).length / cells.length >= 0.8
+  const mostlyDistinct = new Set(cells.map(v => String(v))).size / cells.length >= 0.9
+  return allNonNumeric && !mostlyDates && mostlyDistinct
+}
 
 const comparisonValue = computed(() => {
   if (!comparisonColumn.value) return null
@@ -191,8 +247,9 @@ const invertTrend = computed(() => viewConfig.value?.invertTrend === true)
 
 function formatNumber(val: any, format?: string): string {
   if (val === null || val === undefined) return '—'
-  
-  const num = typeof val === 'number' ? val : parseFloat(String(val))
+
+  const parsed = parseNumericLike(val)
+  const num = parsed === null ? NaN : parsed
   if (isNaN(num)) return String(val)
   
   const fmt = format || formatType.value
@@ -235,9 +292,8 @@ const formattedValue = computed(() => {
 
 const formattedComparison = computed(() => {
   if (comparisonValue.value === null) return ''
-  const num = typeof comparisonValue.value === 'number' 
-    ? comparisonValue.value 
-    : parseFloat(String(comparisonValue.value))
+  const parsed = parseNumericLike(comparisonValue.value)
+  const num = parsed === null ? NaN : parsed
   if (isNaN(num)) return ''
   
   const sign = num >= 0 ? '+' : ''
@@ -260,10 +316,8 @@ const trendDirection = computed(() => {
   
   // Infer from comparison value
   if (comparisonValue.value !== null) {
-    const num = typeof comparisonValue.value === 'number' 
-      ? comparisonValue.value 
-      : parseFloat(String(comparisonValue.value))
-    if (!isNaN(num)) {
+    const num = parseNumericLike(comparisonValue.value)
+    if (num !== null) {
       if (num > 0) return 'up'
       if (num < 0) return 'down'
       return 'flat'

--- a/frontend/components/dashboard/kpi/MetricCard.vue
+++ b/frontend/components/dashboard/kpi/MetricCard.vue
@@ -239,6 +239,27 @@ const comparisonValue = computed(() => {
 
 // Formatting
 const formatType = computed(() => viewConfig.value?.format || 'number')
+const currencyCode = computed(() => {
+  const c = viewConfig.value?.currency
+  return (typeof c === 'string' && /^[A-Za-z]{3}$/.test(c.trim())) ? c.trim().toUpperCase() : 'USD'
+})
+
+// Legacy salvage: older widgets store display-formatted strings ("₪4,125.04").
+// The parser strips the symbol to get the number — instead of losing it,
+// promote the detected symbol to a prefix when the view doesn't specify one.
+const detectedPrefix = computed(() => {
+  if (viewConfig.value?.prefix || formatType.value !== 'number') return ''
+  const rows = props.data?.rows
+  if (!Array.isArray(rows) || rows.length === 0) return ''
+  const col = valueColumn.value
+  if (!col) return ''
+  const firstRow = rows[0] || {}
+  const key = Object.keys(firstRow).find(k => k.toLowerCase() === col)
+  const cell = key ? firstRow[key] : null
+  if (typeof cell !== 'string') return ''
+  const m = cell.match(/[₪$€£¥]/)
+  return m ? m[0] : ''
+})
 const comparisonFormatType = computed(() => viewConfig.value?.comparisonFormat || 'percent')
 const prefix = computed(() => viewConfig.value?.prefix || '')
 const suffix = computed(() => viewConfig.value?.suffix || '')
@@ -256,12 +277,20 @@ function formatNumber(val: any, format?: string): string {
   
   switch (fmt) {
     case 'currency':
-      return new Intl.NumberFormat('en-US', { 
-        style: 'currency', 
-        currency: 'USD',
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 2
-      }).format(num)
+      try {
+        return new Intl.NumberFormat('en-US', {
+          style: 'currency',
+          currency: currencyCode.value,
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2
+        }).format(num)
+      } catch {
+        // Unknown currency code: fall back to a plain grouped number.
+        return new Intl.NumberFormat('en-US', {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2
+        }).format(num)
+      }
     
     case 'percent':
       return new Intl.NumberFormat('en-US', { 
@@ -287,7 +316,10 @@ function formatNumber(val: any, format?: string): string {
 const formattedValue = computed(() => {
   const formatted = formatNumber(rawValue.value)
   if (formatted === '—') return formatted
-  return `${prefix.value}${formatted}${suffix.value}`
+  // Salvaged symbol applies only when the value actually parsed as a number
+  // (a raw unparseable string passes through untouched, symbol included).
+  const salvage = (!prefix.value && parseNumericLike(rawValue.value) !== null) ? detectedPrefix.value : ''
+  return `${prefix.value || salvage}${formatted}${suffix.value}`
 })
 
 const formattedComparison = computed(() => {


### PR DESCRIPTION
# Problem

Two production bugs in the `create_data` → viz-inference → card-render pipeline (reported with Hebrew KPI reports, reproduced end-to-end on Chinook + Haiku in a dev sandbox):

1. **`29` instead of `29,134,139`** — when the generated DataFrame carries display-formatted string values (`"29,134,139"`, `"₪4,125.04"` — the shape org formatting instructions push the coder into), `MetricCard.vue` parsed them with `parseFloat`, which silently truncates at the first comma.
2. **The label `"תאריך"` rendered as the metric value** — a `count`/`metric_card` over a melted `Metric | Value` table with a failed/partial inference pass had no usable value column or row filter, so the frontend fallback landed on the label column of `rows[0]`.

The June fix (#6c8598c) repaired the filter *delivery* pipeline but assumed inference produces a usable series and that the series name text-matches a label cell — assumptions that fail on real (Hebrew) data. Reproduction confirmed inference returning `series: []` while the card rendered anyway.

# Fix (three layers)

**1. Deterministic card guard — `create_data.py`**
`ensure_single_value_card_renderable()` runs after inference, purely structural (no LLM):
- Validates the inferred value column against the actual columns; repairs missing/hallucinated ones via numeric-like column detection (`"₪4,125.04"` counts as numeric, `"23.06.2026"` doesn't).
- Multi-row results must have a row selector: an existing filter matching **exactly one** row (validated against the data, mirroring the frontend's operator semantics), a derived series-name filter (existing `derive_kpi_row_filter`), an aggregation over a clean numeric measure (ignored when the melted column mixes date strings — summing a date with metrics is garbage), or a time axis (preserves the legit "latest value + sparkline" card).
- Otherwise the type is **demoted to `table`** — a truthful rendering — instead of shipping a card that would show an arbitrary cell. Invalid filters (0/many hits) are dropped.
- `agent_v2`'s step merge adopts the card→table demotion so `step.data_model` stays consistent with the visualization view.

**2. Codegen data-shape contract — `CodeGenContext.target_visualization_type`**
`create_data` now tells the coder what the result will render as. The coder prompt pins raw numeric dtypes for measures (no currency symbols/thousands separators inside values — presentation belongs to the view layer, explicitly outranking conflicting org formatting instructions) and, for `count`/`metric_card`, exactly one row with the asked-for metric.

**3. Frontend hardening — `MetricCard.vue`** (repairs already-saved widgets, whose stored data can't be fixed server-side)
- `parseNumericLike()` replaces `parseFloat`/`Number()` on cell values: strips `₪$€£¥`, thousands separators and spaces before parsing; refuses dates/labels. Fixes the `29` truncation and makes aggregation work over formatted strings.
- The value-column fallback recognizes numeric-looking strings and **never** falls back to an arbitrary first column; a melted table with no row selector renders `—` (honest) instead of a wrong cell; single-column results and time-series sparkline cards keep their legacy behavior.

# Display formatting (follow-up commit in this PR)

Since measures now stay raw numeric, presentation formatting gets a first-class path (data stays raw; symbols applied at render time):

- **Viz inference emits a `display` object** (`{format, currency, prefix, suffix}`) for single-value cards, chosen from the metric's meaning, user language, and org instructions. Validated by `sanitize_display_options` (ISO-4217 currency codes, whitelisted formats, length-capped prefix/suffix) and carried into the view.
- **`CountView`/`MetricCardView` gain a `currency` field**; `MetricCard.vue`'s currency formatting honors it via `Intl` (was hardcoded USD), falling back to a plain grouped number on unknown codes.
- **Legacy salvage**: widgets whose stored cells are formatted strings (`"₪4,125.04"`) get the stripped symbol promoted to a display prefix instead of losing it.

# Verification

- **30 unit tests** (`tests/unit/test_create_data_card_guard.py`), including the exact recorded production data — all pass.
- **Full backend unit suite**: 671 passed; the 15 failures are pre-existing — verified by running the same tests on the pre-change commit in a clean worktree (identical 15 failures).
- **Live E2E in a dev sandbox** (Chinook demo + `claude-haiku-4-5`, real completions through the API, screenshots via Playwright):
  - *Clean org*: KPI question → coder returns 1×1 `float64` (contract shape) → card renders **450.58**, which matches ground truth (`SELECT SUM(Total) FROM invoices WHERE 2025` = 450.58).
  - *Org with customer-style formatting instruction* (forces the melted `מדד | ערך` table): inference emitted a valid row filter → card renders the correct **4,125.04** with `1/4 rows` filtered.
  - *Same org, ambiguous case* (series name matched two label cells): guard refused to guess → **live demotion to table**, step and view consistent, answer text states the correct metric.
  - *Legacy widget from the original bug repro* (stored melted data, no filter): renders **—** instead of the label `"תאריך"`.
  - *Currency*: with an org instruction "monetary metrics display as ₪ (ILS)", inference emitted `{"format": "currency", "currency": "ILS"}` → persisted view carries `format/currency` → card renders **₪450.58**; a pre-fix legacy widget with stored `"₪4,125.04"` strings renders **₪4,125.04** via salvage.
- Frontend logic additionally verified with a simulation of the component's exact resolution chain (truncation, melted, sparkline, aggregation, hallucinated column, single-column, entity-table, currency and salvage cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BtubUAXrokA8FR66dwFby