### PR TITLE
Render follow-up suggestions in the conversation's language and direction

### DIFF
--- a/frontend/components/report/FollowUpSuggestions.vue
+++ b/frontend/components/report/FollowUpSuggestions.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="items.length > 0" class="mt-4 max-w-2xl">
+  <div v-if="items.length > 0" class="mt-4 max-w-2xl" :dir="contentDir">
     <!-- Header -->
     <div class="px-1 pb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
-      {{ $t('reportView.followUp') }}
+      {{ heading }}
     </div>
 
     <!-- Suggestions list (hairline dividers between rows, OpenWebUI-style) -->
@@ -28,6 +28,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
   suggestions?: string[] | null
@@ -38,9 +39,43 @@ const emit = defineEmits<{
   select: [question: string]
 }>()
 
+const { t } = useI18n()
+
 const items = computed(() =>
   (props.suggestions || []).map((s) => String(s ?? '').trim()).filter(Boolean)
 )
+
+/**
+ * Follow-ups are generated in the conversation's language, which can differ
+ * from the UI locale (English UI, Hebrew conversation). Like the answer text
+ * above (dir="auto"), the section must follow the CONTENT: detect the script
+ * of the first strong character across the suggestions, set the section's
+ * `dir` from it (the existing `[dir="rtl"]` CSS then also flips the arrow
+ * icon), and translate the heading when the script maps unambiguously to a
+ * supported locale. Latin can't be told apart (en/es/fr/…), so it keeps the
+ * UI locale; no strong character keeps the document direction.
+ */
+const SCRIPTS: Array<{ re: RegExp; dir: 'rtl' | 'ltr'; locale?: string }> = [
+  { re: /[\u0590-\u05FF\uFB1D-\uFB4F]/, dir: 'rtl', locale: 'he' }, // Hebrew
+  { re: /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFC]/, dir: 'rtl', locale: 'ar' }, // Arabic
+  { re: /[\u0400-\u04FF]/, dir: 'ltr', locale: 'ru' }, // Cyrillic
+  { re: /[A-Za-z\u00C0-\u024F]/, dir: 'ltr' }, // Latin
+]
+
+const contentScript = computed(() => {
+  for (const ch of items.value.join(' ')) {
+    const script = SCRIPTS.find((s) => s.re.test(ch))
+    if (script) return script
+  }
+  return null
+})
+
+const contentDir = computed(() => contentScript.value?.dir)
+
+const heading = computed(() => {
+  const locale = contentScript.value?.locale
+  return locale ? t('reportView.followUp', {}, { locale }) : t('reportView.followUp')
+})
 
 function select(q: string) {
   if (props.disabled) return


### PR DESCRIPTION
## Problem

The follow-up suggestions themselves are generated in the conversation's language (the reporter prompt already asks for this), but the section's chrome followed the **UI** locale. With an English UI and a Hebrew conversation, the result was a left-aligned English "Follow up" header sitting above RTL Hebrew suggestions.

## Fix

All in `frontend/components/report/FollowUpSuggestions.vue`:

- Detect the script of the first strong character across the suggestions (same first-strong-char heuristic as the existing `useMarkdownAutoDir` composable used for answer markdown).
- Set `dir` on the whole section from the detected script — the header right-aligns, rows flip, and the existing RTL stylesheet's `[dir="rtl"] .heroicons--arrow-up-right` rule mirrors the hover arrow automatically.
- Translate the heading into the content's language when the script maps unambiguously to a supported locale: Hebrew → "שאלות המשך", Arabic → "أسئلة للمتابعة", Cyrillic → Russian. Latin scripts can't distinguish en/es/fr/…, so those keep the UI locale; content with no strong character inherits the document direction.

## Verification

Compiled the actual SFC and server-rendered it with the real locale files:

| Case | dir | heading |
|---|---|---|
| en UI + Hebrew content | rtl | שאלות המשך |
| en UI + Arabic content | rtl | أسئلة للمتابعة |
| en UI + English content | ltr | Follow up |
| he UI + English content | ltr | שאלות המשך |
| en UI + numeric-only content | inherited | Follow up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NfuCcnCbZADXgoaTTgrpD

---
_Generated by [Claude Code](https://claude.ai/code/session_018NfuCcnCbZADXgoaTTgrpD)_