### PR TITLE
Add CSV data source connector

### DIFF
--- a/backend/app/data_sources/clients/csv_client.py
+++ b/backend/app/data_sources/clients/csv_client.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import glob
+import os
+import re
+import time
+from contextlib import contextmanager
+from typing import Generator, List, Optional
+
+import duckdb
+import pandas as pd
+
+from app.ai.prompt_formatters import Table, TableColumn, TableFormatter
+from app.data_sources.clients.base import DataSourceClient
+from app.data_sources.clients.progress import ProgressCallback, make_reporter
+from app.settings.logging_config import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class CSVClient(DataSourceClient):
+    """Read CSV files and query them via SQL using DuckDB.
+
+    Unlike QVD (a proprietary binary format that must be converted first), CSV is
+    read natively by DuckDB via ``read_csv_auto``. So there is no conversion,
+    cache, or warmup layer here — each resolved file is exposed directly as an
+    in-memory DuckDB view at connect time. One file → one table.
+    """
+
+    def __init__(
+        self,
+        file_paths: str,
+        delimiter: str = "",
+        has_header: bool = True,
+        encoding: str = "utf-8",
+    ):
+        """
+        Args:
+            file_paths: Newline-separated list of file paths or glob patterns.
+                        e.g., "/data/*.csv" or "/data/Sales.csv\n/data/Products.csv"
+            delimiter:  Column delimiter. Empty string means auto-detect.
+            has_header: Whether the first row holds column names.
+            encoding:   File encoding (e.g. utf-8, latin-1).
+        """
+        self.file_paths_raw = file_paths or ""
+        self.patterns: List[str] = [
+            p.strip() for p in self.file_paths_raw.splitlines() if p.strip()
+        ]
+        self.delimiter = delimiter or ""
+        self.has_header = has_header if has_header is not None else True
+        self.encoding = encoding or "utf-8"
+        self._table_map: dict[str, str] = {}
+
+    def _resolve_files(self) -> List[str]:
+        """Expand glob patterns to actual file paths."""
+        files = []
+        for pattern in self.patterns:
+            matched = glob.glob(pattern, recursive=True)
+            files.extend([f for f in matched if f.lower().endswith('.csv')])
+        return sorted(set(files))
+
+    def _safe_table_name(self, filepath: str, used: set[str]) -> str:
+        """Generate a safe table name from filepath."""
+        basename = os.path.splitext(os.path.basename(filepath))[0]
+        name = re.sub(r"[^a-zA-Z0-9_]+", "_", basename).strip("_").lower() or "table"
+        original = name
+        i = 1
+        while name in used:
+            i += 1
+            name = f"{original}_{i}"
+        used.add(name)
+        return name
+
+    @staticmethod
+    def _sql_str(value: str) -> str:
+        """Single-quote a value for inlining in SQL, escaping embedded quotes."""
+        return "'" + str(value).replace("'", "''") + "'"
+
+    def _read_expr(self, filepath: str) -> str:
+        """Build the ``read_csv_auto(...)`` expression used for BOTH schema
+        discovery and query execution, so the two can never disagree on types.
+        """
+        opts: List[str] = [self._sql_str(filepath)]
+        opts.append(f"header={'true' if self.has_header else 'false'}")
+        if self.delimiter:
+            # Allow the literal two-char sequence "\t" from the form to mean a tab.
+            delim = "\t" if self.delimiter in ("\\t", "\t") else self.delimiter
+            opts.append(f"delim={self._sql_str(delim)}")
+        if self.encoding:
+            opts.append(f"encoding={self._sql_str(self.encoding)}")
+        return f"read_csv_auto({', '.join(opts)})"
+
+    @staticmethod
+    def _normalize_duckdb_type(dtype: str) -> str:
+        """Strip precision suffix so TIMESTAMP_NS/_MS/_S display as TIMESTAMP."""
+        if dtype.startswith("TIMESTAMP_"):
+            return "TIMESTAMP"
+        return dtype
+
+    def _describe_file(self, con: duckdb.DuckDBPyConnection, filepath: str) -> List[tuple[str, str]]:
+        """Schema for a single CSV via DuckDB DESCRIBE over the read expression."""
+        rows = con.execute(f"DESCRIBE SELECT * FROM {self._read_expr(filepath)}").fetchall()
+        return [(r[0], self._normalize_duckdb_type(str(r[1]))) for r in rows]
+
+    @contextmanager
+    def connect(self) -> Generator[duckdb.DuckDBPyConnection, None, None]:
+        t0 = time.perf_counter()
+        files = self._resolve_files()
+        logger.info(
+            "csv.connect.start",
+            extra={"csv_patterns": self.patterns, "csv_files_found": len(files)},
+        )
+        con: duckdb.DuckDBPyConnection | None = None
+        try:
+            con = duckdb.connect(database=":memory:")
+            used: set[str] = set()
+            table_map: dict[str, str] = {}
+            for filepath in files:
+                table_name = self._safe_table_name(filepath, used)
+                con.execute(
+                    f"CREATE VIEW {table_name} AS SELECT * FROM {self._read_expr(filepath)}"
+                )
+                table_map[table_name] = filepath
+
+            self._table_map = table_map
+            logger.info(
+                "csv.connect.done",
+                extra={
+                    "csv_tables": list(table_map.keys()),
+                    "csv_elapsed_s": round(time.perf_counter() - t0, 3),
+                },
+            )
+            yield con
+        except Exception as e:
+            logger.error(
+                "csv.connect.error",
+                extra={"csv_error": str(e), "csv_elapsed_s": round(time.perf_counter() - t0, 3)},
+            )
+            raise RuntimeError(f"Error connecting to CSV files: {e}")
+        finally:
+            if con is not None:
+                con.close()
+
+    def execute_query(self, sql: str) -> pd.DataFrame:
+        t0 = time.perf_counter()
+        logger.info("csv.query.start", extra={"csv_sql": sql})
+        try:
+            with self.connect() as con:
+                df = con.execute(sql).df()
+            logger.info(
+                "csv.query.done",
+                extra={
+                    "csv_sql": sql,
+                    "csv_rows": len(df),
+                    "csv_cols": len(df.columns),
+                    "csv_elapsed_s": round(time.perf_counter() - t0, 3),
+                },
+            )
+            return df
+        except Exception as exc:
+            logger.error(
+                "csv.query.error",
+                extra={
+                    "csv_sql": sql,
+                    "csv_error": str(exc),
+                    "csv_elapsed_s": round(time.perf_counter() - t0, 3),
+                },
+            )
+            raise
+
+    def get_tables(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
+        """Schema lookup via DuckDB DESCRIBE over each CSV's read expression —
+        the same expression used at query time, so types are ground truth.
+        """
+        tables: List[Table] = []
+        used: set[str] = set()
+        files = self._resolve_files()
+        logger.debug("csv.schema.start", extra={"csv_files": len(files)})
+        reporter = make_reporter(progress_callback)
+        reporter.phase("csv_files", total=len(files))
+        con = duckdb.connect(database=":memory:")
+        try:
+            for filepath in files:
+                reporter.item(os.path.basename(filepath))
+                table_name = self._safe_table_name(filepath, used)
+                cols: List[TableColumn] = []
+                try:
+                    for fname, ftype in self._describe_file(con, filepath):
+                        cols.append(TableColumn(name=fname, dtype=ftype))
+                except Exception as exc:
+                    logger.warning(
+                        "csv.schema.file.error",
+                        extra={"csv_file": filepath, "csv_error": str(exc)},
+                    )
+                tables.append(Table(
+                    name=table_name,
+                    columns=cols,
+                    pks=[],
+                    fks=[],
+                    metadata_json={"csv": {"source_file": filepath}}
+                ))
+        finally:
+            con.close()
+        reporter.done()
+        logger.debug("csv.schema.done", extra={"csv_tables": len(tables)})
+        return tables
+
+    def get_schemas(self, progress_callback: Optional[ProgressCallback] = None) -> List[Table]:
+        return self.get_tables(progress_callback=progress_callback)
+
+    def get_schema(self, table_name: str) -> Table:
+        for t in self.get_tables():
+            if t.name == table_name:
+                return t
+        return Table(name=table_name, columns=[], pks=[], fks=[], metadata_json={})
+
+    def prompt_schema(self) -> str:
+        return TableFormatter(self.get_schemas()).table_str
+
+    def test_connection(self) -> dict:
+        """Lightweight check: verifies files exist and are parseable. No full load."""
+        try:
+            files = self._resolve_files()
+            if not files:
+                return {
+                    "success": False,
+                    "message": "No CSV files found matching the patterns",
+                    "details": {"files_found": 0, "patterns": self.patterns},
+                }
+            total_bytes = 0
+            con = duckdb.connect(database=":memory:")
+            try:
+                for f in files:
+                    try:
+                        total_bytes += os.path.getsize(f)
+                    except OSError:
+                        pass
+                    # Header-only sniff — DESCRIBE reads just enough to type columns.
+                    self._describe_file(con, f)
+            finally:
+                con.close()
+            return {
+                "success": True,
+                "message": f"Successfully verified {len(files)} CSV file(s)",
+                "details": {
+                    "files_found": len(files),
+                    "total_bytes": total_bytes,
+                    "sample_files": [os.path.basename(f) for f in files[:5]],
+                },
+            }
+        except Exception as e:
+            return {"success": False, "message": str(e), "details": {}}
+
+    @property
+    def description(self) -> str:
+        files = self._resolve_files()
+        sample = ", ".join([os.path.basename(f) for f in files[:3]])
+        if len(files) > 3:
+            sample += ", ..."
+
+        return f"""CSV files: {sample}
+
+You can query these files using SQL (DuckDB syntax). Each file is exposed as a table.
+
+Examples:
+```python
+df = client.execute_query("SELECT * FROM sales LIMIT 10")
+```
+```python
+df = client.execute_query("SELECT product, SUM(amount) AS total FROM sales GROUP BY product")
+```
+"""
+
+
+CsvClient = CSVClient

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -58,6 +58,9 @@ from app.schemas.data_sources.configs import (
     # QVD Files
     QVDConfig,
     QVDCredentials,
+    # CSV Files
+    CSVConfig,
+    CSVCredentials,
     # Qlik Sense (live connector)
     QlikSenseConfig,
     QlikSenseApiKeyCredentials,
@@ -641,6 +644,23 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         ),
         client_path="app.data_sources.clients.qvd_client.QVDClient",
         requires_license="enterprise",
+    ),
+    "csv": DataSourceRegistryEntry(
+        type="csv",
+        title="CSV",
+        description="Query CSV (.csv) files with SQL. Point at file paths or glob patterns; each file becomes a table.",
+        config_schema=CSVConfig,
+        credentials_auth=AuthOptions(
+            default="none",
+            by_auth={
+                "none": AuthVariant(
+                    title="No Authentication",
+                    schema=CSVCredentials,
+                    scopes=["system"]
+                )
+            }
+        ),
+        client_path="app.data_sources.clients.csv_client.CSVClient",
     ),
     "qlik_sense": DataSourceRegistryEntry(
         type="qlik_sense",

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -974,6 +974,40 @@ class QVDConfig(BaseModel):
     )
 
 
+# CSV Files (comma/delimiter-separated values)
+class CSVCredentials(BaseModel):
+    """No credentials needed - file system access only."""
+    class Config:
+        extra = "allow"
+
+
+class CSVConfig(BaseModel):
+    file_paths: str = Field(
+        ...,
+        title="File Paths",
+        description="CSV file paths or glob patterns (one per line). e.g., /data/*.csv",
+        json_schema_extra={"ui:type": "textarea"}
+    )
+    delimiter: str = Field(
+        "",
+        title="Delimiter",
+        description="Column delimiter. Leave blank to auto-detect. e.g., ',' ';' '|' or '\\t' for tab.",
+        json_schema_extra={"ui:type": "string"}
+    )
+    has_header: bool = Field(
+        True,
+        title="Has Header Row",
+        description="Whether the first row contains column names.",
+        json_schema_extra={"ui:type": "boolean"}
+    )
+    encoding: str = Field(
+        "utf-8",
+        title="Encoding",
+        description="File encoding. e.g., utf-8, latin-1.",
+        json_schema_extra={"ui:type": "string"}
+    )
+
+
 # Qlik Sense (live connector — Qlik Cloud)
 class QlikSenseApiKeyCredentials(BaseModel):
     api_key: str = Field(
@@ -1439,6 +1473,8 @@ __all__ = [
     "PinotConfig",
     "MongoDBConfig",
     "PostHogConfig",
+    "CSVConfig",
+    "CSVCredentials",
     "DuckDBNoAuthCredentials",
     "DuckDBAwsCredentials",
     "DuckDBGcpCredentials",

--- a/backend/tests/config/test_source.csv
+++ b/backend/tests/config/test_source.csv
@@ -1,0 +1,6 @@
+OrderNumber,Product,Amount,OrderDate
+1001,Widget,19.99,2024-01-15
+1002,Gadget,49.50,2024-02-03
+1003,Widget,19.99,2024-02-20
+1004,Gizmo,5.00,2024-03-11
+1005,Gadget,49.50,2024-03-28

--- a/backend/tests/unit/test_csv_client.py
+++ b/backend/tests/unit/test_csv_client.py
@@ -1,0 +1,69 @@
+"""End-to-end test for CSVClient.
+
+Drives the real public API (schema → query) against a committed CSV fixture.
+Unlike QVD, CSV needs no external converter — DuckDB reads it natively — so this
+test always runs (no skip guard).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.data_sources.clients.csv_client import CSVClient
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "config" / "test_source.csv"
+
+
+def _columns(client: CSVClient) -> dict[str, str]:
+    tables = client.get_tables()
+    assert len(tables) == 1, "fixture should expose exactly one table"
+    assert tables[0].name == "test_source"
+    return {col.name: col.dtype for col in tables[0].columns}
+
+
+def test_schema_infers_types():
+    cols = _columns(CSVClient(file_paths=str(_FIXTURE)))
+    assert cols["OrderNumber"] == "BIGINT"
+    assert cols["Product"] == "VARCHAR"
+    assert cols["Amount"] == "DOUBLE"
+    # DuckDB auto-detects ISO dates.
+    assert cols["OrderDate"] == "DATE"
+
+
+def test_query_returns_rows():
+    client = CSVClient(file_paths=str(_FIXTURE))
+    df = client.execute_query("SELECT * FROM test_source ORDER BY OrderNumber")
+    assert len(df) == 5
+    assert list(df["Product"]) == ["Widget", "Gadget", "Widget", "Gizmo", "Gadget"]
+
+
+def test_query_aggregates():
+    client = CSVClient(file_paths=str(_FIXTURE))
+    df = client.execute_query(
+        "SELECT Product, SUM(Amount) AS total FROM test_source GROUP BY Product ORDER BY Product"
+    )
+    totals = dict(zip(df["Product"], df["total"]))
+    assert totals["Widget"] == pytest.approx(39.98)
+    assert totals["Gadget"] == pytest.approx(99.00)
+
+
+def test_query_returns_real_dates():
+    client = CSVClient(file_paths=str(_FIXTURE))
+    df = client.execute_query("SELECT OrderDate FROM test_source LIMIT 5")
+    assert not df.empty
+    assert pd.api.types.is_datetime64_any_dtype(df["OrderDate"])
+
+
+def test_test_connection_ok():
+    result = CSVClient(file_paths=str(_FIXTURE)).test_connection()
+    assert result["success"] is True
+    assert result["details"]["files_found"] == 1
+
+
+def test_test_connection_no_files(tmp_path):
+    result = CSVClient(file_paths=str(tmp_path / "*.csv")).test_connection()
+    assert result["success"] is False
+    assert result["details"]["files_found"] == 0


### PR DESCRIPTION
## Summary

Adds a first-class **CSV** data source connector, modeled on the QVD connector's UX (file paths / glob patterns, one file → one table, queried via DuckDB SQL) — but without QVD's conversion/cache/warmup machinery.

Unlike QVD (a proprietary binary format that requires a Rust converter, a Parquet cache, per-path locks, and an hourly warmup scheduler), CSV is read **natively** by DuckDB via `read_csv_auto`. So the connector is dramatically simpler: each resolved file is exposed directly as an in-memory DuckDB view at connect time, and schema discovery + query execution share a single `read_csv_auto(...)` expression so they can never disagree on inferred types.

## Changes

- **`configs.py`** — `CSVConfig` (`file_paths` + `delimiter` / `has_header` / `encoding` overrides; blank delimiter = auto-detect) and `CSVCredentials` (no-auth). Both exported in `__all__`.
- **`data_source_registry.py`** — new `"csv"` registry entry: `data_shape="tables"`, default auth `"none"` (credential-less, so it's indexable from `config` alone), `client_path` → `CSVClient`, and **not** license-gated.
- **`csv_client.py`** — new `CSVClient` (+ `CsvClient` alias for the dynamic resolver): glob resolution, safe per-file table names, DuckDB views over `read_csv_auto`, `DESCRIBE`-based schema discovery, and a data-free `test_connection`.
- **Tests** — `tests/unit/test_csv_client.py` over a committed `tests/config/test_source.csv` fixture. Unlike the QVD test, it needs no external binary and always runs.

## Design decisions

- **License tier:** free / all tiers — CSV is a commodity format with low serving cost, so it is intentionally *not* added to `ENTERPRISE_DATASOURCES`.
- **Format options:** auto-detect first, with `delimiter` / `has_header` / `encoding` overrides as an escape hatch for files DuckDB sniffs wrong.
- **Scope:** local server-side paths in v1 (same as QVD). Remote `s3://` / `https://` CSVs already have a home in the existing DuckDB connector.

## Verification

- All 6 unit tests pass.
- Registry wiring confirmed live: type resolves to `CSVClient`, credential-less indexing works, entry appears in the add-connection catalog, is not enterprise-gated, and `test_connection` succeeds.
- Smoke-tested paths not covered by the fixture: semicolon and tab (`\t`) delimiter overrides, and globs producing one table per file.
- Confirmed no existing test asserts a fixed data-source count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfACRPhMn5zq7HcokSuqKP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfACRPhMn5zq7HcokSuqKP)_