### PR TITLE
Support Claude Sonnet 5 / Opus 4.8: fix temperature 400, refresh Anthropic presets

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -31,21 +31,25 @@ THINKING_TRIGGERS = (
 # Map a user-facing effort level to the Anthropic ``thinking`` request param.
 # "off" returns None (no thinking sent). Anthropic 4.6+ supports
 # ``adaptive`` (model decides budget); older 4.x needs an explicit
-# budget_tokens. We use adaptive when reasonable so the model self-regulates.
+# budget_tokens. On Sonnet 5 / Opus 4.7+ / Fable 5, budget_tokens is removed
+# from the API (400 if sent) — adaptive is the only thinking mode, so those
+# models must always get adaptive regardless of effort.
 def _effort_to_thinking_config(effort: Optional[str], model_id: Optional[str]) -> Optional[dict]:
     if not effort or effort == "off":
         return None
     e = str(effort).lower()
     supports_adaptive = bool(model_id) and any(
-        tag in model_id for tag in ("sonnet-4-6", "opus-4-6", "opus-4-7", "sonnet-4-7")
+        tag in model_id
+        for tag in (
+            "sonnet-4-6", "opus-4-6", "opus-4-7", "sonnet-4-7",
+            "sonnet-5", "opus-4-8", "fable-5", "mythos",
+        )
     )
+    if supports_adaptive:
+        return {"type": "adaptive"}
     if e == "low":
-        if supports_adaptive:
-            return {"type": "adaptive"}
         return {"type": "enabled", "budget_tokens": 1024}
     if e == "medium":
-        if supports_adaptive:
-            return {"type": "adaptive"}
         return {"type": "enabled", "budget_tokens": 5000}
     if e == "high":
         return {"type": "enabled", "budget_tokens": 15000}

--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -30,6 +30,23 @@ _STOP_REASON_MAP = {
     "stop_sequence": "stop_sequence",
 }
 
+# Model families that reject sampling parameters (temperature/top_p/top_k)
+# with a 400. Sonnet 5 / Opus 4.7 / Opus 4.8 / Fable 5 removed them from the
+# API — prompting is the steering mechanism there. Older models (4.6 and
+# earlier) still accept temperature.
+_NO_SAMPLING_PARAM_TAGS = (
+    "sonnet-5",
+    "opus-4-7",
+    "opus-4-8",
+    "fable-5",
+    "mythos",
+)
+
+
+def _accepts_temperature(model_id: str) -> bool:
+    mid = (model_id or "").lower()
+    return not any(tag in mid for tag in _NO_SAMPLING_PARAM_TAGS)
+
 
 class Anthropic(LLMClient):
     def __init__(self, api_key: str, base_url: str = None):
@@ -69,6 +86,9 @@ class Anthropic(LLMClient):
         return content
 
     def inference(self, model_id: str, prompt: str, images: Optional[list[ImageInput]] = None) -> LLMResponse:
+        kwargs: dict[str, Any] = {}
+        if _accepts_temperature(model_id):
+            kwargs["temperature"] = self.temperature
         message = self.client.messages.create(
             model=model_id,
             messages=[
@@ -78,7 +98,7 @@ class Anthropic(LLMClient):
                 }
             ],
             max_tokens=self.max_tokens,
-            temperature=self.temperature,
+            **kwargs,
         )
         usage = self._extract_usage(getattr(message, "usage", None))
         self._set_last_usage(usage)
@@ -88,6 +108,9 @@ class Anthropic(LLMClient):
     async def inference_stream(
         self, model_id: str, prompt: str, images: Optional[list[ImageInput]] = None
     ) -> AsyncGenerator[str, None]:
+        kwargs: dict[str, Any] = {}
+        if _accepts_temperature(model_id):
+            kwargs["temperature"] = self.temperature
         stream = await self.async_client.messages.create(
             model=model_id,
             messages=[
@@ -97,8 +120,8 @@ class Anthropic(LLMClient):
                 }
             ],
             max_tokens=self.max_tokens,
-            temperature=self.temperature,
             stream=True,
+            **kwargs,
         )
 
         prompt_tokens = 0
@@ -242,23 +265,27 @@ class Anthropic(LLMClient):
             "model": model_id,
             "messages": msgs,
             "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
             "stream": True,
         }
+        # Sonnet 5 / Opus 4.7+ / Fable 5 reject temperature with a 400 —
+        # only send it to models that still accept sampling params.
+        if _accepts_temperature(model_id):
+            request_kwargs["temperature"] = self.temperature
 
         # Extended thinking. The installed Anthropic SDK (<=0.40.0) doesn't
         # expose `thinking` as a top-level kwarg, but the API server does
         # accept it — pass via `extra_body` so it's appended to the request
         # JSON. We also default display="summarized" so the UI gets readable
-        # text (Opus 4.7 defaults to "omitted" otherwise) and force
-        # temperature=1.0 (required by Anthropic when thinking is on).
+        # text (Opus 4.7+ defaults to "omitted" otherwise). Anthropic requires
+        # the default temperature when thinking is on, so drop ours entirely
+        # (omitting it is valid on every model).
         if thinking:
             t = dict(thinking)
             t.setdefault("display", "summarized")
             extra_body = dict(request_kwargs.pop("extra_body", {}) or {})
             extra_body["thinking"] = t
             request_kwargs["extra_body"] = extra_body
-            request_kwargs["temperature"] = 1.0
+            request_kwargs.pop("temperature", None)
             # max_tokens must exceed budget_tokens; bump if needed.
             budget = int(t.get("budget_tokens") or 0)
             if budget and request_kwargs.get("max_tokens", 0) <= budget:

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -53,18 +53,41 @@ LLM_MODEL_DETAILS = [
         "output_cost_per_million_tokens_usd": 14.00
     },
     {
-        "name": "Claude 4.6 Sonnet",
-        "model_id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 5",
+        "model_id": "claude-sonnet-5",
         "provider_type": "anthropic",
         "is_preset": True,
         "is_enabled": True,
         "is_default": True,
         "supports_vision": True,
-        "context_window_tokens": 200000,
+        "context_window_tokens": 1000000,
         "input_cost_per_million_tokens_usd": 3.00,
         "output_cost_per_million_tokens_usd": 15.00
     },
-  
+    {
+        "name": "Claude Opus 4.8",
+        "model_id": "claude-opus-4-8",
+        "provider_type": "anthropic",
+        "is_preset": True,
+        "is_enabled": True,
+        "is_default": False,
+        "supports_vision": True,
+        "context_window_tokens": 1000000,
+        "input_cost_per_million_tokens_usd": 5.00,
+        "output_cost_per_million_tokens_usd": 25.00
+    },
+    {
+        "name": "Claude 4.6 Sonnet",
+        "model_id": "claude-sonnet-4-6",
+        "provider_type": "anthropic",
+        "is_preset": True,
+        "is_enabled": True,
+        "is_default": False,
+        "supports_vision": True,
+        "context_window_tokens": 1000000,
+        "input_cost_per_million_tokens_usd": 3.00,
+        "output_cost_per_million_tokens_usd": 15.00
+    },
     {
         "name": "Claude 4.6 Opus",
         "model_id": "claude-opus-4-6",

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -100,30 +100,6 @@ LLM_MODEL_DETAILS = [
         "input_cost_per_million_tokens_usd": 5.00,
         "output_cost_per_million_tokens_usd": 25.00
     },
-  {
-        "name": "Claude 4.5 Sonnet",
-        "model_id": "claude-sonnet-4-5-20250929",
-        "provider_type": "anthropic",
-        "is_preset": True,
-        "is_enabled": True,
-        "is_default": False,
-        "supports_vision": True,
-        "context_window_tokens": 200000,
-        "input_cost_per_million_tokens_usd": 3.00,
-        "output_cost_per_million_tokens_usd": 15.00
-    },
-    {
-        "name": "Claude 4.5 Opus",
-        "model_id": "claude-opus-4-5-20251101",
-        "provider_type": "anthropic",
-        "is_preset": True,
-        "is_enabled": True,
-        "is_default": False,
-        "supports_vision": True,
-        "context_window_tokens": 200000,
-        "input_cost_per_million_tokens_usd": 5.00,
-        "output_cost_per_million_tokens_usd": 25.00
-    },
     {
         "name": "Claude 4.5 Haiku",
         "model_id": "claude-haiku-4-5-20251001",

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -89,18 +89,6 @@ LLM_MODEL_DETAILS = [
         "output_cost_per_million_tokens_usd": 15.00
     },
     {
-        "name": "Claude 4.6 Opus",
-        "model_id": "claude-opus-4-6",
-        "provider_type": "anthropic",
-        "is_preset": True,
-        "is_enabled": True,
-        "is_default": False,
-        "supports_vision": True,
-        "context_window_tokens": 1000000,
-        "input_cost_per_million_tokens_usd": 5.00,
-        "output_cost_per_million_tokens_usd": 25.00
-    },
-    {
         "name": "Claude 4.5 Haiku",
         "model_id": "claude-haiku-4-5-20251001",
         "provider_type": "anthropic",

--- a/bow-config.dev.yaml
+++ b/bow-config.dev.yaml
@@ -32,8 +32,8 @@ default_llm:
         is_default: true
         is_small_default: true
         is_enabled: true
-      - model_id: claude-sonnet-4-5-20250929
-        model_name: Claude Sonnet 4.5
+      - model_id: claude-sonnet-5
+        model_name: Claude Sonnet 5
         is_default: false
         is_small_default: false
         is_enabled: true


### PR DESCRIPTION
## Summary

Claude Sonnet 5, Opus 4.7/4.8, and Fable 5 removed sampling parameters from the Anthropic API — any request carrying `temperature` returns `400: temperature is deprecated for this model`. Our Anthropic client hard-coded `temperature=0.3` on every request, so these models were unusable. This PR fixes that and refreshes the Anthropic preset list.

## Changes

**`backend/app/ai/llm/clients/anthropic_client.py`**
- Gate `temperature` behind a new `_accepts_temperature()` check — omit it for Sonnet 5 / Opus 4.7 / Opus 4.8 / Fable 5, keep sending it to 4.6-and-older models.
- When extended thinking is on, drop `temperature` entirely instead of forcing `1.0` (omitting equals the required default on every model).

**`backend/app/ai/agent_v2.py`**
- `_effort_to_thinking_config` now always returns `{"type": "adaptive"}` for models where `budget_tokens` was removed (Sonnet 5, Opus 4.7+, Fable 5) — previously "high" effort sent `budget_tokens: 15000`, which is also a 400 on those models. Older models keep the budget-based path.

**`backend/app/models/llm_model.py`** — Anthropic presets are now:
- **Claude Sonnet 5** (`claude-sonnet-5`) — new Anthropic default, 1M context — *added*
- **Claude Opus 4.8** (`claude-opus-4-8`) — 1M context — *added*
- **Claude 4.6 Sonnet** — context window corrected to 1M
- **Claude 4.5 Haiku** — unchanged (small default)
- Removed legacy presets: Sonnet 4.5, Opus 4.5, Opus 4.6

**`bow-config.dev.yaml`** — dev seed now uses `claude-sonnet-5` instead of the removed Sonnet 4.5.

Removing presets is non-destructive for existing installs: provider sync only adds missing presets, it never deletes DB rows.

## Testing

Verified live against the Anthropic API using the actual repo client code:
- Reproduced the reported 400 (`temperature` on `claude-sonnet-5`) before the fix.
- `inference()` succeeds on Sonnet 5, Opus 4.8, and Sonnet 4.6 (the latter still receiving `temperature=0.3`).
- `inference_stream_v2()` succeeds on Sonnet 5 with adaptive thinking and on Opus 4.8 without thinking.
- Unit-checked `_accepts_temperature` gating and the effort→thinking mapping for all current model IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qXpuqSazyU46karsdjM4s

---
_Generated by [Claude Code](https://claude.ai/code/session_011qXpuqSazyU46karsdjM4s)_