### PR TITLE
Prompt RBAC: route-layer write policy, run-for public-agent fix, eligibility-aware picker

### DIFF
--- a/backend/app/routes/prompt.py
+++ b/backend/app/routes/prompt.py
@@ -15,6 +15,16 @@ from app.ee.audit.service import audit_service
 
 router = APIRouter(tags=["prompts"])
 
+# Write authorization: prompts have no org-level permission string, and the
+# required check depends on the request BODY (scope + data_source_ids), so —
+# like the instruction routes' check_resource_permissions pattern — the policy
+# is invoked imperatively in the route body via prompt_service.authorize_write:
+#   private → author must be able to SEE every referenced data source (or none)
+#   agent   → `manage` grant on every referenced agent
+#   global  → full_admin only
+# The service re-runs the same policy inside create/update as a backstop for
+# non-HTTP callers (AI training tools call the service directly).
+
 
 @router.get("/prompts", response_model=PromptListResponse)
 async def list_prompts(
@@ -53,6 +63,10 @@ async def create_prompt(
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
 ):
+    await prompt_service.authorize_write(
+        db, current_user, organization,
+        scope=data.scope, ds_ids=data.data_source_ids, endpoint='prompt.create',
+    )
     p = await prompt_service.create_prompt(db, data, current_user, organization)
     try:
         await audit_service.log(
@@ -74,6 +88,7 @@ async def update_prompt(
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
 ):
+    await prompt_service.authorize_update(db, prompt_id, data, current_user, organization)
     p = await prompt_service.update_prompt(db, prompt_id, data, current_user, organization)
     try:
         await audit_service.log(

--- a/backend/app/routes/prompt.py
+++ b/backend/app/routes/prompt.py
@@ -5,6 +5,7 @@ from typing import Optional
 from app.schemas.prompt_schema import (
     PromptCreate, PromptUpdate, PromptResponse, PromptListResponse,
     PromptRunRequest, PromptRunResponse, PromptRunForRequest, PromptRunForResponse,
+    PromptRunForTargetsResponse,
 )
 from app.services.prompt_service import prompt_service
 from app.core.auth import current_user
@@ -146,6 +147,19 @@ async def run_prompt(
     except Exception:
         pass
     return result
+
+
+@router.get("/prompts/{prompt_id}/run-for/targets", response_model=PromptRunForTargetsResponse)
+async def run_prompt_for_targets(
+    prompt_id: str,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Eligible targets for the run-for picker: members who could resolve the
+    prompt themselves (the same per-target gate run-for applies), and groups
+    annotated with how many of their members are eligible."""
+    return await prompt_service.run_for_targets(db, prompt_id, current_user, organization)
 
 
 @router.post("/prompts/{prompt_id}/run-for", response_model=PromptRunForResponse)

--- a/backend/app/schemas/prompt_schema.py
+++ b/backend/app/schemas/prompt_schema.py
@@ -81,3 +81,21 @@ class PromptRunForResponse(BaseModel):
     ran: int
     skipped: int
     skipped_user_ids: List[str] = []
+
+
+class RunForTargetUser(BaseModel):
+    id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+
+class RunForTargetGroup(BaseModel):
+    id: str
+    name: str
+    member_count: int
+    eligible_count: int
+
+
+class PromptRunForTargetsResponse(BaseModel):
+    users: List[RunForTargetUser] = []
+    groups: List[RunForTargetGroup] = []

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -4,8 +4,17 @@ Visibility is scoped to the caller's agent access (active data sources only):
   - global  → every org member
   - private → owner only
   - agent   → users with access to ALL of the prompt's ACTIVE agents
-Authoring an agent prompt needs `manage` on its agents; global prompts are
-admin-only. No UI, scheduling, or delivery here — just the model.
+
+Write policy (authorize_write — one source of truth for create AND update):
+  - private → any member; every referenced data source must be VISIBLE to
+              the author (public or explicit membership/grant), or none
+  - agent   → `manage` on every referenced agent (the same grant that gates
+              editing the agent itself)
+  - global  → full_admin only
+The routes invoke authorize_write explicitly (route-layer enforcement, with
+access.denied audit logging); create/update re-run it as a backstop because
+the AI training tools call this service directly, bypassing the routes.
+No UI, scheduling, or delivery here — just the model.
 """
 import logging
 import re
@@ -158,6 +167,70 @@ class PromptService:
 
     # ── writes ──
 
+    PROMPT_SCOPES = ('private', 'agent', 'global')
+
+    @staticmethod
+    async def _audit_denied(db, current_user, organization, detail: str, endpoint: str) -> None:
+        """Fire-and-forget access.denied audit entry, mirroring the
+        permissions_decorator helper so service-side denials are visible in
+        the audit log like decorator-based ones."""
+        try:
+            from app.ee.audit.service import audit_service
+            await audit_service.log(
+                db=db, organization_id=str(organization.id), action="access.denied",
+                user_id=str(current_user.id), resource_type="prompt",
+                details={"detail": detail, "endpoint": endpoint},
+            )
+        except Exception:
+            logger.debug("prompt access.denied audit failed", exc_info=True)
+
+    async def authorize_write(
+        self, db: AsyncSession, current_user: User, organization: Organization,
+        *, scope: str, ds_ids: List[str], endpoint: str = 'prompt.write',
+    ) -> List[DataSource]:
+        """Enforce the prompt write policy for a (scope, data_source_ids) pair.
+
+        private → any member, but every data source must be visible to the
+                  author (same filter report-create uses, so public data
+                  sources count); empty list is fine.
+        agent   → at least one agent and `manage` on all of them.
+        global  → full_admin only.
+
+        Returns the loaded (org-scoped, active) DataSource rows so callers can
+        attach them without re-querying. Raises 404 for unknown/inactive ids,
+        400 for a malformed scope/agent-list, 403 on policy denials (audited).
+        """
+        if scope not in self.PROMPT_SCOPES:
+            raise HTTPException(status_code=400, detail=f"invalid scope '{scope}'")
+        ds_ids = [str(i) for i in (ds_ids or [])]
+        data_sources = await self._load_data_sources(db, ds_ids, organization)
+        resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
+
+        if scope == 'global':
+            if FULL_ADMIN not in resolved.org_permissions:
+                detail = "admin required to create a global prompt"
+                await self._audit_denied(db, current_user, organization, detail, endpoint)
+                raise HTTPException(status_code=403, detail=detail)
+        elif scope == 'agent':
+            if not ds_ids:
+                raise HTTPException(status_code=400, detail="an agent prompt must reference at least one agent")
+            if not self._can_manage_all(resolved, ds_ids):
+                detail = "manage permission required on all agents"
+                await self._audit_denied(db, current_user, organization, detail, endpoint)
+                raise HTTPException(status_code=403, detail=detail)
+        else:  # private
+            if data_sources:
+                from app.services.data_source_service import DataSourceService
+                visible = await DataSourceService().filter_user_visible_data_sources(
+                    db, data_sources, current_user, organization
+                )
+                visible_ids = {str(ds.id) for ds in visible}
+                if any(str(ds.id) not in visible_ids for ds in data_sources):
+                    detail = "access denied to one or more data sources"
+                    await self._audit_denied(db, current_user, organization, detail, endpoint)
+                    raise HTTPException(status_code=403, detail=detail)
+        return data_sources
+
     async def _load_data_sources(self, db, ds_ids: List[str], organization: Organization) -> List[DataSource]:
         if not ds_ids:
             return []
@@ -180,16 +253,10 @@ class PromptService:
         return [p.dict() if hasattr(p, 'dict') else dict(p) for p in parameters]
 
     async def create_prompt(self, db, data: PromptCreate, current_user, organization) -> Prompt:
-        resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
-        if data.scope == 'global':
-            if FULL_ADMIN not in resolved.org_permissions:
-                raise HTTPException(status_code=403, detail="admin required to create a global prompt")
-        elif data.scope == 'agent':
-            if not data.data_source_ids:
-                raise HTTPException(status_code=400, detail="an agent prompt must reference at least one agent")
-            if not self._can_manage_all(resolved, data.data_source_ids):
-                raise HTTPException(status_code=403, detail="manage permission required on all agents")
-        data_sources = await self._load_data_sources(db, data.data_source_ids, organization)
+        data_sources = await self.authorize_write(
+            db, current_user, organization,
+            scope=data.scope, ds_ids=data.data_source_ids, endpoint='prompt.create',
+        )
         p = Prompt(
             title=data.title, text=data.text, mode=data.mode, model_id=data.model_id,
             mentions=data.mentions, parameters=self._params_to_json(data.parameters),
@@ -202,20 +269,45 @@ class PromptService:
         await db.refresh(p)
         return p
 
-    async def update_prompt(self, db, prompt_id, data: PromptUpdate, current_user, organization) -> Prompt:
+    async def authorize_update(self, db, prompt_id, data: PromptUpdate, current_user, organization) -> None:
+        """Pure pre-flight authorization for update_prompt (no mutation).
+
+        1. Editability: owner, full_admin, or `manage` on all the prompt's agents.
+        2. Re-run authorize_write against the POST-merge (scope, data_sources)
+           whenever either changes — an owner must not promote private→agent/
+           global or swap in data sources their own role couldn't have used at
+           create time. Edits that leave scope+agents untouched (title, text,
+           params) stay owner-editable even if the owner since lost `manage`.
+        """
         p = await self.get_prompt_or_404(db, prompt_id, organization)
         resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
-        is_admin = FULL_ADMIN in resolved.org_permissions
         can_edit = (
-            is_admin
+            FULL_ADMIN in resolved.org_permissions
             or str(p.user_id) == str(current_user.id)
             or (p.scope == 'agent' and self._can_manage_all(resolved, self._ds_ids(p)))
         )
         if not can_edit:
-            raise HTTPException(status_code=403, detail="manage permission required")
+            detail = "manage permission required"
+            await self._audit_denied(db, current_user, organization, detail, 'prompt.update')
+            raise HTTPException(status_code=403, detail=detail)
+
         fields = data.dict(exclude_unset=True)
-        if fields.get('scope') == 'global' and not is_admin:
-            raise HTTPException(status_code=403, detail="admin required to make a prompt global")
+        new_ds_ids = fields.get('data_source_ids')
+        effective_scope = fields.get('scope', p.scope)
+        current_ds_ids = self._ds_ids(p)
+        effective_ds_ids = [str(i) for i in new_ds_ids] if new_ds_ids is not None else current_ds_ids
+        scope_changed = effective_scope != p.scope
+        ds_changed = new_ds_ids is not None and set(effective_ds_ids) != set(current_ds_ids)
+        if scope_changed or ds_changed:
+            await self.authorize_write(
+                db, current_user, organization,
+                scope=effective_scope, ds_ids=effective_ds_ids, endpoint='prompt.update',
+            )
+
+    async def update_prompt(self, db, prompt_id, data: PromptUpdate, current_user, organization) -> Prompt:
+        await self.authorize_update(db, prompt_id, data, current_user, organization)
+        p = await self.get_prompt_or_404(db, prompt_id, organization)
+        fields = data.dict(exclude_unset=True)
         new_ds_ids = fields.pop('data_source_ids', None)
         if 'parameters' in fields:
             fields['parameters'] = self._params_to_json(data.parameters)

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -48,22 +48,29 @@ class PromptService:
         return [str(ds.id) for ds in (prompt.data_sources or [])]
 
     @staticmethod
-    def _active_ds_ids(prompt: Prompt) -> List[str]:
+    def _active_data_sources(prompt: Prompt) -> List[DataSource]:
         """Agents still usable by this prompt: connected/healthy (``is_active``),
         not soft-deleted, and not intentionally turned off
         (``publish_status == 'disabled'``). Hard-deleted agents never appear
         here — the relationship stops yielding a DataSource once its row is gone.
         """
         return [
-            str(ds.id) for ds in (prompt.data_sources or [])
+            ds for ds in (prompt.data_sources or [])
             if getattr(ds, 'is_active', False)
             and getattr(ds, 'deleted_at', None) is None
             and getattr(ds, 'publish_status', 'published') != 'disabled'
         ]
 
     @staticmethod
-    def _can_access_all(resolved: ResolvedPermissions, ds_ids: List[str]) -> bool:
-        return all(resolved.has_resource_membership('data_source', ds) for ds in ds_ids)
+    def _can_access_all(resolved: ResolvedPermissions, data_sources: List[DataSource]) -> bool:
+        """Target can use every agent: explicit membership/grant OR the data
+        source is public — the same OR that filter_user_visible_data_sources
+        applies when reports attach data sources."""
+        return all(
+            getattr(ds, 'is_public', False)
+            or resolved.has_resource_membership('data_source', str(ds.id))
+            for ds in data_sources
+        )
 
     @staticmethod
     def _can_manage_all(resolved: ResolvedPermissions, ds_ids: List[str]) -> bool:
@@ -73,7 +80,7 @@ class PromptService:
             return False
         return all(resolved.has_resource_permission('data_source', ds, 'manage') for ds in ds_ids)
 
-    def _is_visible(self, resolved: ResolvedPermissions, p: Prompt, user_id: str, active_ds_ids: List[str]) -> bool:
+    def _is_visible(self, resolved: ResolvedPermissions, p: Prompt, user_id: str, active_dss: List[DataSource]) -> bool:
         if FULL_ADMIN in resolved.org_permissions:
             return True
         if p.scope == 'global':
@@ -81,9 +88,9 @@ class PromptService:
         if p.scope == 'private':
             return str(p.user_id) == str(user_id)
         # agent
-        if not active_ds_ids:
+        if not active_dss:
             return str(p.user_id) == str(user_id)
-        return self._can_access_all(resolved, active_ds_ids)
+        return self._can_access_all(resolved, active_dss)
 
     def _to_response(self, p: Prompt, resolved: ResolvedPermissions, user_id: str) -> dict:
         ds_ids = self._ds_ids(p)
@@ -133,14 +140,14 @@ class PromptService:
 
         visible = []
         for p in prompts:
-            active_ds_ids = self._active_ds_ids(p)
-            if not self._is_visible(resolved, p, str(current_user.id), active_ds_ids):
+            active_dss = self._active_data_sources(p)
+            if not self._is_visible(resolved, p, str(current_user.id), active_dss):
                 continue
             # Hide agent-scoped prompts whose agents are ALL gone/unusable
             # (inactive, disabled, or deleted). They can't be run and would
             # otherwise surface a bare agent id in the UI. Global/private
             # prompts are never gated on agents.
-            if p.scope == 'agent' and not active_ds_ids:
+            if p.scope == 'agent' and not active_dss:
                 continue
             visible.append(self._to_response(p, resolved, str(current_user.id)))
         visible.sort(key=lambda r: r["created_at"] or datetime.min, reverse=True)
@@ -161,7 +168,7 @@ class PromptService:
     async def get_prompt_response(self, db, prompt_id, current_user, organization) -> dict:
         p = await self.get_prompt_or_404(db, prompt_id, organization)
         resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
-        if not self._is_visible(resolved, p, str(current_user.id), self._active_ds_ids(p)):
+        if not self._is_visible(resolved, p, str(current_user.id), self._active_data_sources(p)):
             raise HTTPException(status_code=403, detail="Access denied to this prompt")
         return self._to_response(p, resolved, str(current_user.id))
 
@@ -444,6 +451,73 @@ class PromptService:
 
     # ── run for (admin: run-on-behalf) ──
 
+    async def run_for_targets(
+        self, db: AsyncSession, prompt_id: str, current_user: User,
+        organization: Organization,
+    ) -> dict:
+        """Eligible run-for targets for this prompt, for the run-for picker.
+
+        A member is eligible when they could RESOLVE the prompt themselves —
+        the exact per-target check run_prompt_for applies — so the modal only
+        offers targets that would actually run instead of silently skipping.
+        Groups are returned with an eligible_count so empty ones can be hidden.
+
+        Authz mirrors run_prompt_for: full_admin or `manage` on all agents.
+        """
+        from app.models.membership import Membership
+        from app.models.group import Group
+        from app.models.group_membership import GroupMembership
+
+        prompt = await self.get_prompt_or_404(db, prompt_id, organization)
+        actor_resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
+        if not self._can_manage_all(actor_resolved, self._ds_ids(prompt)):
+            raise HTTPException(status_code=403, detail="manage permission required on the prompt's agents")
+
+        active_dss = self._active_data_sources(prompt)
+
+        member_rows = await db.execute(
+            select(User)
+            .join(Membership, Membership.user_id == User.id)
+            .filter(Membership.organization_id == organization.id)
+        )
+        members = list(member_rows.scalars().unique().all())
+
+        eligible_ids: set = set()
+        users = []
+        for u in members:
+            t_resolved = await resolve_permissions(db, str(u.id), str(organization.id))
+            if not self._is_visible(t_resolved, prompt, str(u.id), active_dss):
+                continue
+            eligible_ids.add(str(u.id))
+            users.append({"id": str(u.id), "name": u.name, "email": u.email})
+
+        group_rows = await db.execute(
+            select(Group)
+            .filter(Group.organization_id == organization.id)
+            .filter(Group.deleted_at == None)
+        )
+        gm_rows = await db.execute(
+            select(GroupMembership.group_id, GroupMembership.user_id)
+            .join(Group, Group.id == GroupMembership.group_id)
+            .filter(Group.organization_id == organization.id)
+            .filter(GroupMembership.user_id != None)
+            .filter(GroupMembership.deleted_at == None)
+        )
+        by_group: Dict[str, List[str]] = {}
+        for gid, uid in gm_rows.all():
+            by_group.setdefault(str(gid), []).append(str(uid))
+
+        groups = []
+        for g in group_rows.scalars().all():
+            member_ids = by_group.get(str(g.id), [])
+            groups.append({
+                "id": str(g.id), "name": g.name,
+                "member_count": len(member_ids),
+                "eligible_count": sum(1 for uid in member_ids if uid in eligible_ids),
+            })
+
+        return {"users": users, "groups": groups}
+
     async def run_prompt_for(
         self, db: AsyncSession, prompt_id: str, current_user: User,
         organization: Organization, principal_type: str,
@@ -478,7 +552,7 @@ class PromptService:
 
         report_service = ReportService()
         completion_service = CompletionService()
-        active_ds_ids = self._active_ds_ids(prompt)
+        active_dss = self._active_data_sources(prompt)
 
         ran: List[str] = []
         skipped: List[str] = []
@@ -492,7 +566,7 @@ class PromptService:
                 skipped.append(str(tid))
                 continue
             t_resolved = await resolve_permissions(db, str(tid), str(organization.id))
-            if not self._is_visible(t_resolved, prompt, str(tid), active_ds_ids):
+            if not self._is_visible(t_resolved, prompt, str(tid), active_dss):
                 skipped.append(str(tid))
                 continue
 

--- a/backend/tests/e2e/rbac/test_rbac_prompts.py
+++ b/backend/tests/e2e/rbac/test_rbac_prompts.py
@@ -17,8 +17,27 @@ it directly):
 Update re-authorizes against the POST-merge (scope, data_sources) whenever
 either changes, closing the historical bypass where an owner could promote a
 private prompt to agent/global scope or swap in agents they don't manage.
+
+Run-for coverage: per-target eligibility (public data sources count as
+accessible — the run_prompt_for fix), and the /run-for/targets endpoint the
+picker uses so it only offers targets that would actually run.
 """
 import pytest
+
+
+@pytest.fixture
+def stub_completion(monkeypatch):
+    """No-op CompletionService.create_completion recorder — run-for tests only
+    assert the fan-out bookkeeping, never a real agent/LLM run."""
+    calls = []
+
+    async def _fake(self, db, report_id, completion_data, current_user, organization, *a, **kw):
+        calls.append({"report_id": str(report_id), "user_id": str(current_user.id)})
+        return {"stubbed": True}
+
+    from app.services.completion_service import CompletionService
+    monkeypatch.setattr(CompletionService, "create_completion", _fake)
+    return calls
 
 
 def _hdr(token, org_id):
@@ -236,6 +255,125 @@ def test_update_private_prompt_data_source_visibility(test_client, prompts_world
     public = _update_prompt(test_client, prompts_world, "member", pid, {"data_source_ids": [ds_pub]})
     assert public.status_code == 200, public.text
     assert public.json()["data_source_ids"] == [ds_pub]
+
+
+# ────────────────────────────────────────────────────────────────────
+# Run-for — eligibility (public data sources count) + targets endpoint
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_run_for_public_agent_runs_for_plain_member(test_client, prompts_world, stub_completion):
+    """Regression: an agent prompt on a PUBLIC data source must run for a
+    member with no explicit grant — public access counts as membership in the
+    per-target eligibility gate (it used to be silently skipped)."""
+    org_id = prompts_world["org_id"]
+    admin = prompts_world["principals"]["admin"]
+    member = prompts_world["principals"]["member"]
+    ds_pub = prompts_world["ds_pub"]["id"]
+
+    created = _create_prompt(test_client, prompts_world, "admin", scope="agent", ds_ids=[ds_pub])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    resp = test_client.post(
+        f"/api/prompts/{pid}/run-for",
+        json={"principal_type": "users", "user_ids": [member["user_id"]]},
+        headers=_hdr(admin["token"], org_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ran"] == 1 and body["skipped"] == 0, body
+    assert stub_completion and stub_completion[0]["user_id"] == member["user_id"]
+
+    # And the member can now also SEE the prompt in their list (same fix).
+    listing = test_client.get("/api/prompts", headers=_hdr(member["token"], org_id))
+    assert pid in {p["id"] for p in listing.json()["prompts"]}
+
+
+@pytest.mark.e2e
+def test_run_for_private_agent_still_skips_nonmembers(test_client, prompts_world, stub_completion):
+    """Control: a prompt on a PRIVATE data source still skips members without
+    a grant — and runs for a member holding one."""
+    org_id = prompts_world["org_id"]
+    admin = prompts_world["principals"]["admin"]
+    member = prompts_world["principals"]["member"]
+    viewer = prompts_world["principals"]["ds_a_viewer"]
+    ds_a = prompts_world["ds_a"]["id"]
+
+    created = _create_prompt(test_client, prompts_world, "admin", scope="agent", ds_ids=[ds_a])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    resp = test_client.post(
+        f"/api/prompts/{pid}/run-for",
+        json={"principal_type": "users", "user_ids": [member["user_id"], viewer["user_id"]]},
+        headers=_hdr(admin["token"], org_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ran"] == 1 and body["skipped"] == 1, body
+    assert body["skipped_user_ids"] == [member["user_id"]]
+
+
+@pytest.mark.e2e
+def test_run_for_targets_endpoint(test_client, prompts_world):
+    """GET /prompts/{id}/run-for/targets: only eligible members are offered;
+    authz mirrors run-for (manage on the prompt's agents)."""
+    org_id = prompts_world["org_id"]
+    admin = prompts_world["principals"]["admin"]
+    member = prompts_world["principals"]["member"]
+    ds_a = prompts_world["ds_a"]["id"]
+    ds_pub = prompts_world["ds_pub"]["id"]
+
+    # Agent prompt on the private ds_a → viewer/manager/admin eligible, member not.
+    created = _create_prompt(test_client, prompts_world, "admin", scope="agent", ds_ids=[ds_a])
+    pid = created.json()["id"]
+    resp = test_client.get(f"/api/prompts/{pid}/run-for/targets", headers=_hdr(admin["token"], org_id))
+    assert resp.status_code == 200, resp.text
+    offered = {u["id"] for u in resp.json()["users"]}
+    assert prompts_world["principals"]["ds_a_viewer"]["user_id"] in offered
+    assert prompts_world["principals"]["ds_a_manager"]["user_id"] in offered
+    assert admin["user_id"] in offered
+    assert member["user_id"] not in offered
+
+    # Agent prompt on the public DS → everyone eligible.
+    created2 = _create_prompt(test_client, prompts_world, "admin", scope="agent", ds_ids=[ds_pub])
+    pid2 = created2.json()["id"]
+    resp2 = test_client.get(f"/api/prompts/{pid2}/run-for/targets", headers=_hdr(admin["token"], org_id))
+    offered2 = {u["id"] for u in resp2.json()["users"]}
+    assert member["user_id"] in offered2
+
+    # A plain member (no manage on the agents) cannot enumerate targets.
+    denied = test_client.get(f"/api/prompts/{pid}/run-for/targets", headers=_hdr(member["token"], org_id))
+    assert denied.status_code == 403, denied.text
+
+
+@pytest.mark.e2e
+def test_run_for_targets_group_counts(
+    test_client, prompts_world, enterprise_license, create_group, add_user_to_group
+):
+    """Groups are annotated with eligible_count so the picker can hide/size them."""
+    org_id = prompts_world["org_id"]
+    admin = prompts_world["principals"]["admin"]
+    member = prompts_world["principals"]["member"]
+    viewer = prompts_world["principals"]["ds_a_viewer"]
+    ds_a = prompts_world["ds_a"]["id"]
+
+    g = create_group(name="rf-group", user_token=admin["token"], org_id=org_id)
+    assert g.status_code == 200, g.text
+    gid = g.json()["id"]
+    for uid in (member["user_id"], viewer["user_id"]):
+        added = add_user_to_group(group_id=gid, user_id=uid, user_token=admin["token"], org_id=org_id)
+        assert added.status_code in (200, 201), added.text
+
+    created = _create_prompt(test_client, prompts_world, "admin", scope="agent", ds_ids=[ds_a])
+    pid = created.json()["id"]
+    resp = test_client.get(f"/api/prompts/{pid}/run-for/targets", headers=_hdr(admin["token"], org_id))
+    assert resp.status_code == 200, resp.text
+    group = next(x for x in resp.json()["groups"] if x["id"] == gid)
+    assert group["member_count"] == 2
+    assert group["eligible_count"] == 1  # viewer yes, plain member no
 
 
 @pytest.mark.e2e

--- a/backend/tests/e2e/rbac/test_rbac_prompts.py
+++ b/backend/tests/e2e/rbac/test_rbac_prompts.py
@@ -1,0 +1,256 @@
+"""
+RBAC end-to-end coverage for /api/prompts writes.
+
+The prompt routes have no org-level permission string; the write policy
+depends on the request body's (scope, data_source_ids) pair, so — like the
+instruction routes' check_resource_permissions pattern — it is enforced
+imperatively via ``prompt_service.authorize_write`` in the route body (and
+re-run inside the service as a backstop for the AI training tools that call
+it directly):
+
+    private → any member; every referenced data source must be VISIBLE to
+              the author (public or explicit membership/grant), or none
+    agent   → `manage` on every referenced agent (the grant that gates
+              editing the agent itself)
+    global  → full_admin only
+
+Update re-authorizes against the POST-merge (scope, data_sources) whenever
+either changes, closing the historical bypass where an owner could promote a
+private prompt to agent/global scope or swap in agents they don't manage.
+"""
+import pytest
+
+
+def _hdr(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+@pytest.fixture
+def prompts_world(
+    test_client,
+    bootstrap_admin,
+    invite_user_to_org,
+    sqlite_data_source,
+    grant_resource,
+):
+    admin = bootstrap_admin("admin")
+    org_id = admin["org_id"]
+
+    # Two private data sources + one public one.
+    ds_a = sqlite_data_source(name="pr_ds_a", user_token=admin["token"], org_id=org_id)
+    ds_b = sqlite_data_source(name="pr_ds_b", user_token=admin["token"], org_id=org_id)
+    ds_pub = sqlite_data_source(
+        name="pr_ds_pub", user_token=admin["token"], org_id=org_id, is_public=True
+    )
+
+    member = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    ds_a_viewer = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    ds_a_manager = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+
+    for principal, perms in ((ds_a_viewer, ["view"]), (ds_a_manager, ["manage"])):
+        resp = grant_resource(
+            resource_type="data_source",
+            resource_id=ds_a["id"],
+            principal_type="user",
+            principal_id=principal["user_id"],
+            permissions=perms,
+            user_token=admin["token"],
+            org_id=org_id,
+        )
+        assert resp.status_code == 200, resp.text
+
+    return {
+        "org_id": org_id,
+        "ds_a": ds_a,
+        "ds_b": ds_b,
+        "ds_pub": ds_pub,
+        "principals": {
+            "admin": admin,
+            "member": member,
+            "ds_a_viewer": ds_a_viewer,
+            "ds_a_manager": ds_a_manager,
+        },
+    }
+
+
+def _create_prompt(test_client, world, principal_name, *, scope, ds_ids, text="hello"):
+    token = world["principals"][principal_name]["token"]
+    return test_client.post(
+        "/api/prompts",
+        json={"text": text, "scope": scope, "data_source_ids": ds_ids},
+        headers=_hdr(token, world["org_id"]),
+    )
+
+
+def _update_prompt(test_client, world, principal_name, prompt_id, payload):
+    token = world["principals"][principal_name]["token"]
+    return test_client.put(
+        f"/api/prompts/{prompt_id}",
+        json=payload,
+        headers=_hdr(token, world["org_id"]),
+    )
+
+
+# ────────────────────────────────────────────────────────────────────
+# Create
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_create_private_prompt_data_source_visibility(test_client, prompts_world):
+    """Private prompts: anyone may create, but only with data sources they
+    can SEE (public counts) — or none at all."""
+    ds_a = prompts_world["ds_a"]["id"]
+    ds_b = prompts_world["ds_b"]["id"]
+    ds_pub = prompts_world["ds_pub"]["id"]
+
+    failures = []
+    for principal, ds_ids, want in [
+        ("member", [], 200),                 # no DS → always fine
+        ("member", [ds_a], 403),             # not visible to plain member
+        ("member", [ds_pub], 200),           # public DS is visible to all
+        ("ds_a_viewer", [ds_a], 200),        # explicit membership
+        ("ds_a_viewer", [ds_a, ds_b], 403),  # ALL must be visible
+        ("ds_a_manager", [ds_a], 200),       # manage grant implies membership
+        ("admin", [ds_a], 200),              # full_admin sees everything
+    ]:
+        resp = _create_prompt(test_client, prompts_world, principal, scope="private", ds_ids=ds_ids)
+        if resp.status_code != want:
+            failures.append(
+                f"{principal} ds={ds_ids}: want {want} got {resp.status_code} ({resp.text[:160]})"
+            )
+    assert not failures, "\n".join(failures)
+
+
+@pytest.mark.e2e
+def test_create_agent_prompt_requires_manage(test_client, prompts_world):
+    """Agent-scoped prompts: only principals holding `manage` on EVERY
+    referenced agent (view/membership is not enough)."""
+    ds_a = prompts_world["ds_a"]["id"]
+    ds_b = prompts_world["ds_b"]["id"]
+
+    failures = []
+    for principal, ds_ids, want in [
+        ("member", [ds_a], 403),
+        ("ds_a_viewer", [ds_a], 403),          # view ≠ manage
+        ("ds_a_manager", [ds_a], 200),
+        ("ds_a_manager", [ds_a, ds_b], 403),   # manage required on ALL
+        ("admin", [ds_b], 200),
+        ("ds_a_manager", [], 400),             # agent scope needs ≥1 agent
+    ]:
+        resp = _create_prompt(test_client, prompts_world, principal, scope="agent", ds_ids=ds_ids)
+        if resp.status_code != want:
+            failures.append(
+                f"{principal} ds={ds_ids}: want {want} got {resp.status_code} ({resp.text[:160]})"
+            )
+    assert not failures, "\n".join(failures)
+
+
+@pytest.mark.e2e
+def test_create_global_prompt_admin_only(test_client, prompts_world):
+    for principal, want in [("member", 403), ("ds_a_manager", 403), ("admin", 200)]:
+        resp = _create_prompt(test_client, prompts_world, principal, scope="global", ds_ids=[])
+        assert resp.status_code == want, f"{principal}: {resp.status_code} {resp.text[:160]}"
+
+
+@pytest.mark.e2e
+def test_create_unknown_scope_rejected(test_client, prompts_world):
+    """An unrecognized scope must 400 — it would otherwise skip the write
+    policy entirely while behaving like an agent prompt for visibility."""
+    resp = _create_prompt(test_client, prompts_world, "member", scope="weird", ds_ids=[])
+    assert resp.status_code == 400, f"{resp.status_code} {resp.text[:160]}"
+
+
+# ────────────────────────────────────────────────────────────────────
+# Update — post-merge re-authorization (bypass regressions)
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_update_cannot_promote_private_to_agent_without_manage(test_client, prompts_world):
+    """A viewer may own a private prompt pinned to ds_a, but promoting it to
+    agent scope requires `manage` on ds_a — this was the historical bypass."""
+    ds_a = prompts_world["ds_a"]["id"]
+
+    created = _create_prompt(test_client, prompts_world, "ds_a_viewer", scope="private", ds_ids=[ds_a])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    promote = _update_prompt(test_client, prompts_world, "ds_a_viewer", pid, {"scope": "agent"})
+    assert promote.status_code == 403, f"{promote.status_code} {promote.text[:160]}"
+
+    # Positive control: a manager CAN promote their own private prompt.
+    created2 = _create_prompt(test_client, prompts_world, "ds_a_manager", scope="private", ds_ids=[ds_a])
+    assert created2.status_code == 200, created2.text
+    promote2 = _update_prompt(
+        test_client, prompts_world, "ds_a_manager", created2.json()["id"], {"scope": "agent"}
+    )
+    assert promote2.status_code == 200, f"{promote2.status_code} {promote2.text[:160]}"
+    assert promote2.json()["scope"] == "agent"
+
+
+@pytest.mark.e2e
+def test_update_cannot_swap_agent_data_sources_without_manage(test_client, prompts_world):
+    """The owner of an agent prompt cannot repoint it at agents they don't
+    manage; benign edits (title, unchanged DS set) remain owner-editable."""
+    ds_a = prompts_world["ds_a"]["id"]
+    ds_b = prompts_world["ds_b"]["id"]
+
+    created = _create_prompt(test_client, prompts_world, "ds_a_manager", scope="agent", ds_ids=[ds_a])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    swap = _update_prompt(
+        test_client, prompts_world, "ds_a_manager", pid, {"data_source_ids": [ds_b]}
+    )
+    assert swap.status_code == 403, f"{swap.status_code} {swap.text[:160]}"
+
+    grow = _update_prompt(
+        test_client, prompts_world, "ds_a_manager", pid, {"data_source_ids": [ds_a, ds_b]}
+    )
+    assert grow.status_code == 403, f"{grow.status_code} {grow.text[:160]}"
+
+    # No over-tightening: title-only edit and an unchanged DS set still work.
+    title = _update_prompt(test_client, prompts_world, "ds_a_manager", pid, {"title": "renamed"})
+    assert title.status_code == 200, title.text
+    same_ds = _update_prompt(
+        test_client, prompts_world, "ds_a_manager", pid, {"data_source_ids": [ds_a]}
+    )
+    assert same_ds.status_code == 200, same_ds.text
+
+
+@pytest.mark.e2e
+def test_update_private_prompt_data_source_visibility(test_client, prompts_world):
+    """Attaching data sources to a private prompt on update follows the same
+    visibility rule as create."""
+    ds_a = prompts_world["ds_a"]["id"]
+    ds_pub = prompts_world["ds_pub"]["id"]
+
+    created = _create_prompt(test_client, prompts_world, "member", scope="private", ds_ids=[])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    hidden = _update_prompt(test_client, prompts_world, "member", pid, {"data_source_ids": [ds_a]})
+    assert hidden.status_code == 403, f"{hidden.status_code} {hidden.text[:160]}"
+
+    public = _update_prompt(test_client, prompts_world, "member", pid, {"data_source_ids": [ds_pub]})
+    assert public.status_code == 200, public.text
+    assert public.json()["data_source_ids"] == [ds_pub]
+
+
+@pytest.mark.e2e
+def test_update_promote_to_global_requires_admin(test_client, prompts_world):
+    created = _create_prompt(test_client, prompts_world, "member", scope="private", ds_ids=[])
+    assert created.status_code == 200, created.text
+    pid = created.json()["id"]
+
+    promote = _update_prompt(test_client, prompts_world, "member", pid, {"scope": "global"})
+    assert promote.status_code == 403, f"{promote.status_code} {promote.text[:160]}"
+
+    admin_created = _create_prompt(test_client, prompts_world, "admin", scope="private", ds_ids=[])
+    assert admin_created.status_code == 200, admin_created.text
+    admin_promote = _update_prompt(
+        test_client, prompts_world, "admin", admin_created.json()["id"], {"scope": "global"}
+    )
+    assert admin_promote.status_code == 200, admin_promote.text
+    assert admin_promote.json()["scope"] == "global"

--- a/frontend/components/prompt/RunForModal.vue
+++ b/frontend/components/prompt/RunForModal.vue
@@ -141,7 +141,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const toast = useToast()
 const { organization } = useOrganization()
-const { runPromptFor } = usePrompts()
+const { runPromptFor, getRunForTargets } = usePrompts()
 const { extractParamNames } = usePromptFill()
 
 const isOpen = computed({
@@ -164,6 +164,22 @@ const memberQuery = ref('')
 const showDropdown = ref(false)
 
 async function loadTargets() {
+  // Eligibility-aware picker: only members who can actually resolve the
+  // prompt (run-for silently skips anyone else), and only groups with at
+  // least one eligible member — counts reflect how many would run.
+  if (props.prompt?.id) {
+    try {
+      const res = await getRunForTargets(props.prompt.id)
+      if (res) {
+        allMembers.value = (res.users || []).map(u => ({ id: u.id, name: u.name || '', email: u.email || '' }))
+        groups.value = (res.groups || [])
+          .filter(g => g.eligible_count > 0)
+          .map(g => ({ id: g.id, name: g.name, member_count: g.eligible_count }))
+        return
+      }
+    } catch {}
+  }
+  // Fallback: unfiltered org lists (older backend without the targets endpoint).
   const orgId = organization.value?.id
   if (!orgId) return
   try {

--- a/frontend/composables/usePrompts.ts
+++ b/frontend/composables/usePrompts.ts
@@ -103,5 +103,13 @@ export function usePrompts() {
     return (data.value as any) || null
   }
 
-  return { listPrompts, getPrompt, createPrompt, updatePrompt, deletePrompt, runPrompt, runPromptFor }
+  async function getRunForTargets(id: string): Promise<{
+    users: { id: string; name?: string; email?: string }[]
+    groups: { id: string; name: string; member_count: number; eligible_count: number }[]
+  } | null> {
+    const { data } = await useMyFetch<any>(`/api/prompts/${id}/run-for/targets`)
+    return (data.value as any) || null
+  }
+
+  return { listPrompts, getPrompt, createPrompt, updatePrompt, deletePrompt, runPrompt, runPromptFor, getRunForTargets }
 }


### PR DESCRIPTION
## What

Two related prompt-permission fixes:

**1. Prompt write policy enforced at the route layer (+ update bypass closed)**

Prompt writes previously checked permissions only inside `PromptService`, with gaps:
- Private prompts could reference data sources invisible to their author.
- Update never re-checked scope/data-source changes — an owner could create a private prompt, then `PUT scope='agent'` (or swap `data_source_ids`) and expose it to an agent's audience without holding `manage` on that agent.
- An unrecognized `scope` string skipped the write policy entirely.

**2. Run-for silently skipped members on public agents (+ eligibility-aware picker)**

`POST /prompts/{id}/run-for` returned 200 but ran for nobody when the prompt's agent was a *public* data source: the per-target gate used `has_resource_membership` alone, which ignores `is_public`. The same gap hid agent prompts on public agents from members' prompt lists. The run-for modal also offered every org member/group with no eligibility filtering, so admins couldn't tell who would actually run.

## How

- **`PromptService.authorize_write`** — single source of truth for the write policy, invoked imperatively in the route body (mirrors the instruction routes' `check_resource_permissions` pattern; prompts have no org-level permission string and the required check depends on the request body) and re-run in the service as a backstop for the AI training tools that call it directly:
  - `private` → any member; every referenced data source must be **visible** to the author (public or explicit membership/grant), or none
  - `agent` → ≥1 agent and the `manage` grant on **every** one
  - `global` → `full_admin` only; unknown scope → 400
- **`PromptService.authorize_update`** — editability check plus re-running `authorize_write` against the **post-merge** (scope, data_source_ids) whenever either changes. Title/text/params edits stay owner-editable.
- **`_can_access_all`** now treats public data sources as accessible (same OR as `filter_user_visible_data_sources`), fixing run-for eligibility, member prompt-list visibility, and self-run on public agents.
- **`GET /prompts/{id}/run-for/targets`** — eligible members (the exact per-target check `run_prompt_for` applies) and groups annotated with `eligible_count`; authz mirrors run-for. `RunForModal.vue` loads this instead of raw org member/group lists and hides groups with zero eligible members (falls back to the old lists if the endpoint is unavailable).
- Denials get `access.denied` audit logging, matching the decorator-based routes.

## Tests

`backend/tests/e2e/rbac/test_rbac_prompts.py` (12 tests): write-policy matrix per scope (visibility for private, `manage` for agent, admin for global), update-bypass regressions (private→agent promotion, DS swap, unknown scope), run-for on public vs private agents, targets endpoint filtering + group eligible counts. Full RBAC e2e suite: **110 passed**.

Also verified live (backend + frontend + real LLM): admin ran an agent-scoped prompt on a public sqlite agent for a plain member via the modal — "Ran for 1, skipped 0", and the member received a private report with the completed answer plus the run-for notification.

(Pre-existing, unrelated: `tests/prompts/test_prompt_model.py::test_prompt_model_access_and_parameters` fails identically on the base commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq2cYev6Gms1mLNbcDxtNb