### PR TITLE
Make inactive instruction status dot gray instead of yellow

### DIFF
--- a/frontend/components/InstructionDetailsModal.vue
+++ b/frontend/components/InstructionDetailsModal.vue
@@ -216,7 +216,7 @@ const getStatusIconClass = (instruction: Instruction) => {
         return 'bg-red-400'
     } else {
         const statusClasses = {
-            draft: 'bg-yellow-400',
+            draft: 'bg-gray-300',
             published: 'bg-green-400',
             archived: 'bg-gray-400'
         }

--- a/frontend/composables/useInstructionHelpers.ts
+++ b/frontend/composables/useInstructionHelpers.ts
@@ -117,8 +117,10 @@ export function useInstructionHelpers() {
   }
 
   const getStatusIconClass = (instruction: Instruction) => {
+    // Inactive (draft) must read as gray, not yellow/amber — amber is reserved
+    // for "pending review" and the two dots are easily confused otherwise.
     const statusClasses: Record<string, string> = {
-      draft: 'bg-yellow-400',
+      draft: 'bg-gray-300',
       published: 'bg-green-400',
       archived: 'bg-gray-400',
       pending_review: 'bg-amber-400'


### PR DESCRIPTION
## What

In the KnowledgeExplorer, inactive (draft) instructions rendered a `bg-yellow-400` status dot — nearly indistinguishable from the amber `pending review` dot, so inactive items looked like they had pending changes.

## How

- `frontend/composables/useInstructionHelpers.ts` — `getStatusIconClass` now maps `draft` to `bg-gray-300`, matching the existing gray-dot convention for inactive agents and connections in KnowledgeExplorer. Amber is now unambiguously "pending review".
- `frontend/components/InstructionDetailsModal.vue` — fixed the same yellow draft dot in that component's local copy of the logic.

Targets the umbrella branch for PR #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKzd8JYe5Y2FTdQFHVovfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKzd8JYe5Y2FTdQFHVovfs)_