### PR TITLE
Fix pending-changes badge counting rows the pending view can't show

### DIFF
--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -419,6 +419,12 @@ async def get_pending_change_instruction_ids(
     pending = await instruction_service.get_pending_change_instruction_ids(
         db, organization=organization, current_user=current_user
     )
+    # The sweep reads builds/versions only — re-scope through the caller's
+    # instruction-row visibility (deleted, private-agent membership, hidden) so
+    # these ids never disagree with the counts badge or the pending_only list.
+    pending = await instruction_service._visible_pending_instruction_ids(
+        db, organization, current_user, pending
+    )
     await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
     return {"instruction_ids": sorted(pending)}
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -582,6 +582,49 @@ class InstructionService:
             conditions.append(or_(~Instruction.data_sources.any(), *visible_clauses))
         return conditions
 
+    async def _visible_pending_instruction_ids(self, db, organization, current_user, pending_ids: set) -> set:
+        """Re-scope the pending sweep's output through the same instruction-row
+        filters the "Pending changes" list applies (GET /instructions?pending_only=
+        true with include_own/include_drafts/include_archived, as the explorer
+        sends it). The sweep (get_pending_change_instruction_ids) reads builds and
+        versions only — it knows nothing about instruction rows — so without this
+        cut the "N pending" badge counts rows that view can never return: a
+        soft-deleted instruction whose suggestion build is still live, one
+        attached to a private agent the caller isn't a member of, or another
+        user's hidden/is_seen=False row."""
+        from app.core.permission_resolver import get_member_data_source_ids
+
+        if not pending_ids:
+            return set()
+        conditions = [
+            Instruction.id.in_([str(i) for i in pending_ids]),
+            Instruction.organization_id == organization.id,
+            Instruction.deleted_at == None,  # noqa: E711
+        ]
+        if current_user is not None:
+            member_ds_ids = await get_member_data_source_ids(
+                db, str(current_user.id), str(organization.id)
+            )
+            public_ds_subq = select(DataSource.id).where(and_(
+                DataSource.organization_id == organization.id,
+                DataSource.is_public == True,  # noqa: E712
+            ))
+            visible_clauses = [Instruction.data_sources.any(DataSource.id.in_(public_ds_subq))]
+            if member_ds_ids:
+                visible_clauses.append(Instruction.data_sources.any(DataSource.id.in_(member_ds_ids)))
+            conditions.append(or_(~Instruction.data_sources.any(), *visible_clauses))
+            user_permissions = await self._get_user_permissions(db, current_user, organization)
+            conditions.append(or_(
+                self._get_own_instructions_condition(current_user.id),
+                self._get_others_instructions_condition(
+                    current_user.id, user_permissions,
+                    include_drafts=True, include_archived=True, include_hidden=False,
+                ),
+            ))
+        return {str(i) for i in (await db.execute(
+            select(Instruction.id).where(and_(*conditions))
+        )).scalars().all()}
+
     async def get_instruction_counts(self, db, organization, current_user) -> dict:
         """Aggregate counts that drive the /agents tree badges WITHOUT hydrating
         rows: global, skills, total pending, plus per-agent count and per-agent
@@ -610,6 +653,7 @@ class InstructionService:
         # Fold not-in-main pending instructions into the same surfaces so the
         # badges match the rows the lazy list now returns (which include pending).
         pending_ids = {str(i) for i in await self.get_pending_change_instruction_ids(db, organization, current_user)}
+        pending_ids = await self._visible_pending_instruction_ids(db, organization, current_user, pending_ids)
         pending_by_agent: dict = {}
         if pending_ids:
             pid_list = list(pending_ids)
@@ -1621,6 +1665,32 @@ class InstructionService:
         await db.commit()
         return await self.get_instruction(db, instruction.id, organization, current_user), "ok"
 
+    async def _void_pending_suggestions(self, db: AsyncSession, instruction, *, organization: Organization) -> None:
+        """Record every live hunk of every pending suggestion build as rejected
+        for this instruction, and clear its Review-feed item. Called on delete:
+        the org-wide pending sweep reads builds only (it never sees
+        Instruction.deleted_at), so a leftover live suggestion build would keep
+        a deleted instruction counting as "pending" forever. Hunk keys are
+        derived from the immutable base->proposed intent, so the rejections stay
+        matched no matter how main moves afterwards. Leaves the rejections
+        uncommitted — they ride the caller's commit (the review-feed resolve may
+        commit earlier; both changes are final either way)."""
+        from app.services.text_hunks import rebased_hunks_against_main
+        iid = str(instruction.id)
+        main_text, _vid, _meta = await self._main_text_of(db, instruction)
+        for build, proposed_text, _v in await self._pending_suggestion_builds(db, iid, organization):
+            rejected = self._rejected_keys(build, iid)
+            base_text = await self._build_base_text(db, build, iid)
+            for h in rebased_hunks_against_main(base_text, proposed_text or "", main_text):
+                if h["key"] in rejected:
+                    continue
+                await self._record_resolved_hunk(db, build, iid, h["key"], "reject", commit=False)
+        try:
+            from app.services.review_service import review_service
+            await review_service.resolve_for_instruction(db, organization_id=str(organization.id), instruction_id=iid)
+        except Exception:
+            pass
+
     async def reject_all_hunks(self, db: AsyncSession, instruction_id: str, *,
                                organization: Organization, current_user: User,
                                build_id: Optional[str] = None):
@@ -1754,6 +1824,14 @@ class InstructionService:
             raise HTTPException(status_code=404, detail="Instruction not found")
 
         # Permission check is handled by the decorator, so we can proceed with deletion
+        # Void live suggestion builds BEFORE the soft delete (the reject path
+        # resolves rows through queries that filter deleted_at) so the deleted
+        # instruction stops counting as a pending change everywhere.
+        try:
+            await self._void_pending_suggestions(db, instruction, organization=organization)
+        except Exception as e:
+            logger.warning(f"Failed to void pending suggestions for deleted instruction {instruction_id}: {e}")
+
         # Soft delete (using BaseSchema's soft delete functionality)
         from datetime import datetime
         instruction.deleted_at = datetime.utcnow()
@@ -2120,8 +2198,15 @@ class InstructionService:
         # Apply soft deletes
         for instruction in instructions:
             try:
+                # Void live suggestion builds first — same reason as the single
+                # delete: the pending sweep never sees deleted_at.
+                try:
+                    await self._void_pending_suggestions(db, instruction, organization=organization)
+                except Exception as e:
+                    logger.warning(f"Failed to void pending suggestions for deleted instruction {instruction.id}: {e}")
+
                 instruction.deleted_at = datetime.utcnow()
-                
+
                 # Remove from build if we have one
                 if bulk_build:
                     try:

--- a/backend/tests/e2e/test_instruction.py
+++ b/backend/tests/e2e/test_instruction.py
@@ -1102,3 +1102,229 @@ def test_agent_count_matches_list_under_inaccessible_table(
     assert list_count() == 0, "list must hide an instruction whose only table is inaccessible"
     assert by_agent_count() == 0, "badge count must match the list (no 3->0 flicker)"
     assert by_agent_count() == list_count()
+
+
+@pytest.mark.e2e
+def test_pending_badge_clears_when_instruction_deleted(
+    create_global_instruction,
+    delete_instruction,
+    create_user,
+    login_user,
+    whoami,
+    test_client,
+):
+    """Regression: the "N pending" badge counting rows the Pending-changes view
+    can't show.
+
+    The org-wide pending sweep reads suggestion builds only — it never sees
+    Instruction.deleted_at. Deleting an instruction that still had a live
+    pending suggestion used to leave that build producing hunks forever, so
+    /instructions/counts kept reporting pending_total=N while the pending_only
+    list (which filters deleted rows) showed nothing. Delete must clear the
+    signal from ALL pending surfaces: the counts badge, the pending_only list,
+    and /instructions/pending-changes.
+    """
+    import os, uuid, datetime
+    from sqlalchemy import create_engine, text
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="Delete-me original alpha beta",
+        user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+
+    # Inject a REAL pending suggestion build (changed text -> live hunk).
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            main = conn.execute(
+                text(
+                    """SELECT bc.build_id AS build_id
+                         FROM build_contents bc
+                         JOIN instruction_builds ib ON ib.id = bc.build_id
+                        WHERE bc.instruction_id = :iid AND ib.is_main = :is_main
+                          AND ib.deleted_at IS NULL"""
+                ),
+                {"iid": iid, "is_main": True},
+            ).mappings().fetchone()
+            assert main is not None, "new instruction should be in the main build"
+            now = datetime.datetime.utcnow()
+            vid, bid, bcid = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+            vnum = conn.execute(
+                text("SELECT COALESCE(MAX(version_number),0)+1 FROM instruction_versions WHERE instruction_id=:iid"),
+                {"iid": iid},
+            ).scalar()
+            bnum = conn.execute(
+                text("SELECT COALESCE(MAX(build_number),0)+1 FROM instruction_builds WHERE organization_id=:org"),
+                {"org": org_id},
+            ).scalar()
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_versions (id,created_at,updated_at,instruction_id,version_number,text,status,load_mode,content_hash)"
+                    " VALUES (:id,:ca,:ua,:iid,:vnum,:txt,:status,:load_mode,:chash)"
+                ),
+                {"id": vid, "ca": now, "ua": now, "iid": iid, "vnum": vnum,
+                 "txt": "Delete-me PROPOSED gamma delta",
+                 "status": "published", "load_mode": "always", "chash": "h" + uuid.uuid4().hex[:12]},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_builds (id,created_at,updated_at,build_number,status,source,is_main,organization_id,base_build_id,title)"
+                    " VALUES (:id,:ca,:ua,:bnum,:status,:source,:is_main,:org,:base,:title)"
+                ),
+                {"id": bid, "ca": now, "ua": now, "bnum": bnum, "status": "pending_approval", "source": "ai",
+                 "is_main": False, "org": org_id, "base": main["build_id"], "title": "pending suggestion"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO build_contents (id,created_at,updated_at,build_id,instruction_id,instruction_version_id)"
+                    " VALUES (:id,:ca,:ua,:bid,:iid,:vid)"
+                ),
+                {"id": bcid, "ca": now, "ua": now, "bid": bid, "iid": iid, "vid": vid},
+            )
+    finally:
+        engine.dispose()
+
+    def pending_total():
+        r = test_client.get("/api/instructions/counts", headers=headers)
+        assert r.status_code == 200, r.json()
+        return r.json()["pending_total"]
+
+    def pending_list_ids():
+        r = test_client.get(
+            "/api/instructions",
+            params={"pending_only": "true", "include_own": "true",
+                    "include_drafts": "true", "include_archived": "true", "limit": 200},
+            headers=headers,
+        )
+        assert r.status_code == 200, r.json()
+        return [x["id"] for x in r.json()["items"]]
+
+    def sweep_ids():
+        r = test_client.get("/api/instructions/pending-changes", headers=headers)
+        assert r.status_code == 200, r.json()
+        return r.json()["instruction_ids"]
+
+    # Alive: all three pending surfaces agree the change is pending.
+    assert pending_total() == 1
+    assert pending_list_ids() == [iid]
+    assert sweep_ids() == [iid]
+
+    delete_instruction(iid, user_token=token, org_id=org_id)
+
+    # Deleted: no surface may keep counting the leftover suggestion build.
+    assert pending_list_ids() == []
+    assert pending_total() == 0, "badge must not count a deleted instruction's leftover suggestion"
+    assert sweep_ids() == []
+
+
+@pytest.mark.e2e
+def test_pending_badge_excludes_inaccessible_private_agent(
+    create_user,
+    login_user,
+    whoami,
+    test_client,
+):
+    """The pending sweep is build-based and org-wide; the counts badge must
+    re-scope it through the caller's instruction visibility. A pending change on
+    an instruction attached to a PRIVATE agent the caller is not a member of is
+    invisible in the pending_only list — so it must not be counted in
+    pending_total (or returned by /instructions/pending-changes) either.
+    """
+    import os, uuid, datetime
+    from sqlalchemy import create_engine, text
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    now = datetime.datetime.utcnow()
+    ds_id, iid, vid, bid = (str(uuid.uuid4()) for _ in range(4))
+    try:
+        with engine.begin() as conn:
+            # Private agent with NO membership for the caller.
+            conn.execute(
+                text(
+                    "INSERT INTO data_sources (id,created_at,updated_at,name,is_active,organization_id,"
+                    "is_public,use_llm_sync,publish_status,reliability_status)"
+                    " VALUES (:id,:ca,:ua,:name,:active,:org,:pub,:llm,:pubst,:rel)"
+                ),
+                {"id": ds_id, "ca": now, "ua": now, "name": "Members-only Agent", "active": True,
+                 "org": org_id, "pub": False, "llm": False, "pubst": "published", "rel": "unknown"},
+            )
+            # Instruction attached to it (not in main; a proposed-new instruction).
+            conn.execute(
+                text(
+                    "INSERT INTO instructions (id,created_at,updated_at,text,thumbs_up,status,category,kind,"
+                    "is_seen,can_user_toggle,organization_id,source_type,load_mode)"
+                    " VALUES (:id,:ca,:ua,:txt,:tu,:status,:cat,:kind,:seen,:tog,:org,:st,:lm)"
+                ),
+                {"id": iid, "ca": now, "ua": now, "txt": "Members-only current text", "tu": 0,
+                 "status": "published", "cat": "general", "kind": "instruction",
+                 "seen": True, "tog": True, "org": org_id, "st": "ai", "lm": "always"},
+            )
+            conn.execute(
+                text("INSERT INTO instruction_data_source_association (instruction_id,data_source_id) VALUES (:iid,:ds)"),
+                {"iid": iid, "ds": ds_id},
+            )
+            bnum = conn.execute(
+                text("SELECT COALESCE(MAX(build_number),0)+1 FROM instruction_builds WHERE organization_id=:org"),
+                {"org": org_id},
+            ).scalar()
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_versions (id,created_at,updated_at,instruction_id,version_number,text,status,load_mode,content_hash)"
+                    " VALUES (:id,:ca,:ua,:iid,:vnum,:txt,:status,:load_mode,:chash)"
+                ),
+                {"id": vid, "ca": now, "ua": now, "iid": iid, "vnum": 1,
+                 "txt": "Members-only PROPOSED text",
+                 "status": "published", "load_mode": "always", "chash": "h" + uuid.uuid4().hex[:12]},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_builds (id,created_at,updated_at,build_number,status,source,is_main,organization_id,title)"
+                    " VALUES (:id,:ca,:ua,:bnum,:status,:source,:is_main,:org,:title)"
+                ),
+                {"id": bid, "ca": now, "ua": now, "bnum": bnum, "status": "pending_approval", "source": "ai",
+                 "is_main": False, "org": org_id, "title": "pending on private agent"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO build_contents (id,created_at,updated_at,build_id,instruction_id,instruction_version_id)"
+                    " VALUES (:id,:ca,:ua,:bid,:iid,:vid)"
+                ),
+                {"id": str(uuid.uuid4()), "ca": now, "ua": now, "bid": bid, "iid": iid, "vid": vid},
+            )
+    finally:
+        engine.dispose()
+
+    counts = test_client.get("/api/instructions/counts", headers=headers)
+    assert counts.status_code == 200, counts.json()
+    assert counts.json()["pending_total"] == 0, \
+        "badge must not count a pending change on a private agent the caller can't access"
+    assert ds_id not in counts.json()["pending_by_agent"]
+    assert iid not in counts.json().get("pending_instruction_ids", [])
+
+    plist = test_client.get(
+        "/api/instructions",
+        params={"pending_only": "true", "include_own": "true",
+                "include_drafts": "true", "include_archived": "true", "limit": 200},
+        headers=headers,
+    )
+    assert plist.status_code == 200, plist.json()
+    assert plist.json()["items"] == []
+
+    sweep = test_client.get("/api/instructions/pending-changes", headers=headers)
+    assert sweep.status_code == 200, sweep.json()
+    assert sweep.json()["instruction_ids"] == []


### PR DESCRIPTION
## What

The "N pending" badge on the /agents page could permanently disagree with the "Pending changes" view — e.g. the badge says **2 pending** while the view says *No pending changes*.

Both surfaces start from the same org-wide pending sweep (`get_pending_change_instruction_ids`), but the badge (`GET /instructions/counts` → `pending_total`) used its raw output, while the pending list (`GET /instructions?pending_only=true`) intersects it with the instruction-row visibility filters. The sweep reads suggestion builds/versions only — it never sees `Instruction.deleted_at`, private-agent membership, or hidden rows — so any of those produced a phantom badge count. The most common trigger: deleting an instruction that still had a live pending suggestion left its suggestion build producing hunks forever.

## How

- **Re-scope the sweep for counting** — new `_visible_pending_instruction_ids` filters the sweep's output through the same row filters the pending list applies (not deleted, member/public data source, own-or-visible-others rows). Applied in `get_instruction_counts` (badge, per-agent pending dots, `pending_instruction_ids`) and in the `/instructions/pending-changes` route, so every pending surface agrees.
- **Void suggestions on delete** — new `_void_pending_suggestions` records every live hunk of every pending suggestion build as rejected and resolves the Review-feed item; wired into both `delete_instruction` and `bulk_delete_instructions` before the soft delete. Hunk keys derive from the immutable base→proposed intent, so rejections stay matched as main moves.

## Verification

- Two new e2e regression tests, both confirmed to **fail without the fixes** and pass with them:
  - `test_pending_badge_clears_when_instruction_deleted` — delete clears the badge, the pending_only list, and `/instructions/pending-changes`.
  - `test_pending_badge_excludes_inaccessible_private_agent` — a pending change on a private agent the caller isn't a member of is not counted.
- Full `test_instruction.py`, `test_instruction_resolve.py`, `test_build.py`, `test_instruction_sync.py`, `test_instruction_label.py`, `test_git_sync_builds.py` suites pass (110 tests).
- No new ruff findings on the touched files.

Targets the umbrella branch for PR #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKzd8JYe5Y2FTdQFHVovfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKzd8JYe5Y2FTdQFHVovfs)_