### PR TITLE
Add training-mode-for-agent-admins verification plan

### DIFF
--- a/backend/app/ai/tools/implementations/create_eval.py
+++ b/backend/app/ai/tools/implementations/create_eval.py
@@ -165,6 +165,7 @@ class CreateEvalTool(Tool):
         mode = runtime_ctx.get("mode") or ""
         head_completion = runtime_ctx.get("head_completion")
         agent_execution_id = runtime_ctx.get("agent_execution_id")
+        report = runtime_ctx.get("report")
 
         if not all([db, organization, user]):
             yield ToolErrorEvent(
@@ -178,7 +179,33 @@ class CreateEvalTool(Tool):
 
         try:
             resolved = await resolve_permissions(db, str(user.id), str(organization.id))
-            if not resolved.has_org_permission("manage_evals"):
+
+            # Scope the eval to the agent(s) being trained. When the model does
+            # not specify data sources, default to the report's agents rather
+            # than creating a global, org-wide case. This keeps a training
+            # session's output confined to the specific agent(s).
+            report_ds_ids = []
+            if report is not None:
+                try:
+                    report_ds_ids = [str(ds.id) for ds in (report.data_sources or [])]
+                except Exception:
+                    report_ds_ids = []
+            effective_ds_ids = list(data.data_source_ids or []) or report_ds_ids
+
+            # Authorization: manage_evals on EVERY targeted agent (a per-DS
+            # `manage` grant implies manage_evals), or org-level manage_evals /
+            # full_admin. A data-source-less (global) case stays an org-level
+            # capability — an agent admin cannot create org-wide evals.
+            if resolved.has_org_permission("manage_evals"):
+                authorized = True
+            elif effective_ds_ids:
+                authorized = all(
+                    resolved.has_resource_permission("data_source", ds, "manage_evals")
+                    for ds in effective_ds_ids
+                )
+            else:
+                authorized = False
+            if not authorized:
                 yield ToolErrorEvent(
                     type="tool.error",
                     payload={"error": "Missing manage_evals permission", "code": "PERMISSION_DENIED"},
@@ -278,7 +305,7 @@ class CreateEvalTool(Tool):
                 name=data.name.strip(),
                 prompt_json=prompt_json,
                 expectations_json=expectations_dict or {},
-                data_source_ids_json=list(data.data_source_ids or []),
+                data_source_ids_json=list(effective_ds_ids),
                 tags_json=list(data.tags or []) or None,
                 status=final_status,
                 auto_generated=auto_generated,

--- a/backend/app/ai/tools/implementations/create_instruction.py
+++ b/backend/app/ai/tools/implementations/create_instruction.py
@@ -185,13 +185,14 @@ class CreateInstructionTool(Tool):
         agent_execution_id = runtime_ctx.get("agent_execution_id")
         report = runtime_ctx.get("report")
 
-        # In knowledge-harness / post-analysis mode we must only attach the
-        # instruction to data sources that are actually part of the current
-        # report. Training mode is broader (user is intentionally curating the
-        # org) so we keep it org-scoped there.
+        # Both knowledge-harness and training mode must only attach the
+        # instruction to data sources that belong to the agent(s) being curated
+        # — i.e. the data sources on the current report. This keeps a training
+        # session's output scoped to the specific agent(s) and prevents an agent
+        # admin from authoring org-wide (global) or cross-agent instructions.
         mode = runtime_ctx.get("mode")
         allowed_data_source_ids = None
-        if mode == "knowledge" and report is not None:
+        if mode in ("knowledge", "training") and report is not None:
             try:
                 allowed_data_source_ids = {
                     str(ds.id) for ds in (report.data_sources or [])
@@ -311,6 +312,14 @@ class CreateInstructionTool(Tool):
                             display_text=table.name,
                         ))
                         matched_table_names.append(table.name)
+
+            # Guarantee agent-scoping: an instruction whose tables didn't resolve
+            # (or that references no tables at all — a common "always-on" rule)
+            # still applies to the agent(s) being trained rather than silently
+            # becoming a global, org-wide instruction. Falls back to the report's
+            # data sources in knowledge/training mode.
+            if not data_source_ids and allowed_data_source_ids:
+                data_source_ids = set(allowed_data_source_ids)
 
             # Create the instruction as a draft (pending admin approval) but
             # stage the version with status="published" so promote_build flips

--- a/backend/app/routes/test.py
+++ b/backend/app/routes/test.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from app.dependencies import get_async_db, get_current_organization
 from app.core.auth import current_user
-from app.core.permissions_decorator import requires_permission, check_resource_permissions
+from app.core.permissions_decorator import requires_permission, check_resource_permissions, require_org_permission
 from app.models.organization import Organization
 from app.models.user import User
 from app.models.eval import TestSuite, TestCase, TestRun, TestResult
@@ -150,6 +150,14 @@ async def create_case(suite_id: str, payload: TestCaseCreate, db: AsyncSession =
         await check_resource_permissions(
             db, str(current_user.id), str(organization.id),
             "data_source", payload.data_source_ids_json, "manage_evals",
+        )
+    else:
+        # Truly org-wide (no data source) → stays an org-level capability.
+        # An agent admin's per-DS `manage` (which implies manage_evals on that
+        # agent) must NOT let them author a global eval that runs against every
+        # agent. Mirrors the /instructions/global gate.
+        await require_org_permission(
+            db, str(current_user.id), str(organization.id), "manage_evals",
         )
     case = await case_service.create_case(db, str(organization.id), current_user, suite_id, payload.name, payload.prompt_json, payload.expectations_json, payload.data_source_ids_json)
     return case

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -564,6 +564,33 @@ class ReportService:
                             status_code=400,
                             detail="Training mode is not enabled for this organization"
                         )
+                # Per-agent authorization: entering training mode is the
+                # agent-admin capability, not an org-wide one. The actor must be
+                # able to manage instructions on EVERY agent (data source) the
+                # report is attached to — via full_admin / org-level
+                # manage_instructions, or a per-data_source `manage` grant (which
+                # implies manage_instructions). A plain member (view only) on the
+                # agent is denied, even if they manage some other agent.
+                from app.core.permission_resolver import resolve_permissions
+                if report_data.data_sources is not None:
+                    training_ds_ids = [str(x) for x in report_data.data_sources]
+                else:
+                    training_ds_ids = [str(ds.id) for ds in (report.data_sources or [])]
+                resolved = await resolve_permissions(
+                    db, str(current_user.id), str(organization.id)
+                )
+                can_train = resolved.has_org_permission('manage_instructions') or (
+                    bool(training_ds_ids)
+                    and all(
+                        resolved.has_resource_permission('data_source', ds, 'manage_instructions')
+                        for ds in training_ds_ids
+                    )
+                )
+                if not can_train:
+                    raise HTTPException(
+                        status_code=403,
+                        detail="You need manage access on this agent to enter training mode",
+                    )
             report.mode = report_data.mode
         # Replace data_sources associations if provided
         if hasattr(report_data, 'data_sources') and report_data.data_sources is not None:

--- a/backend/tests/e2e/rbac/test_rbac_training_mode.py
+++ b/backend/tests/e2e/rbac/test_rbac_training_mode.py
@@ -1,0 +1,241 @@
+"""
+RBAC end-to-end coverage for **training mode** availability and the
+**per-agent scoping** of everything a training session produces.
+
+Contract (see ``sandbox-feedback-loop-training-mode-agent-admins.md``):
+
+  Entry gate (per-agent, not org-wide):
+    1. An agent admin (`manage` on the agent) CAN enter training mode on it.
+    2. A plain member (`view` only) CANNOT.
+    3. Cross-agent isolation — a user who is a MEMBER of agent1 and an ADMIN of
+       agent2 is DENIED training on agent1 but allowed on agent2. Holding
+       `manage` on some agent must not unlock training on an agent they only view.
+    4. A full admin can train any agent (bypass preserved).
+    5. When enable_training_mode is disabled, nobody can enter training mode.
+
+  Write scoping (nothing created leaks org-wide):
+    6. Instructions — an agent admin cannot author a global instruction, nor one
+       on an agent they don't manage.
+    7. Evals — an agent admin cannot author a global (data-source-less) eval;
+       scoped cases require manage_evals on every referenced agent.
+
+World:
+    admin   — full_admin_access (bootstrap owner)
+    u       — MEMBER (view) of agent1, ADMIN (manage) of agent2   ← the key case
+"""
+import pytest
+
+
+def _hdr(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _instruction_body(text, ds_ids):
+    return {"text": text, "status": "draft", "category": "general", "data_source_ids": ds_ids}
+
+
+@pytest.fixture
+def training_world(
+    test_client,
+    bootstrap_admin,
+    invite_user_to_org,
+    grant_resource,
+    sqlite_data_source,
+):
+    admin = bootstrap_admin("admin")
+    org_id = admin["org_id"]
+
+    agent1 = sqlite_data_source(name="tm_agent1", user_token=admin["token"], org_id=org_id)
+    agent2 = sqlite_data_source(name="tm_agent2", user_token=admin["token"], org_id=org_id)
+
+    # u = MEMBER (view) of agent1, ADMIN (manage) of agent2  ← the cross-agent case
+    u = invite_user_to_org(org_id=org_id, admin_token=admin["token"])
+    for ds, perms in ((agent1, ["view"]), (agent2, ["manage"])):
+        r = grant_resource(
+            resource_type="data_source",
+            resource_id=ds["id"],
+            principal_type="user",
+            principal_id=u["user_id"],
+            permissions=perms,
+            user_token=admin["token"],
+            org_id=org_id,
+        )
+        assert r.status_code == 200, r.text
+
+    return {"org_id": org_id, "admin": admin, "u": u, "agent1": agent1, "agent2": agent2}
+
+
+def _report_on(test_client, token, org_id, ds_id):
+    r = test_client.post(
+        "/api/reports",
+        json={"title": "training session", "data_sources": [ds_id]},
+        headers=_hdr(token, org_id),
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+def _set_mode(test_client, token, org_id, report_id, mode):
+    return test_client.put(
+        f"/api/reports/{report_id}",
+        json={"mode": mode},
+        headers=_hdr(token, org_id),
+    )
+
+
+# ── Entry gate ───────────────────────────────────────────────────────────────
+
+@pytest.mark.e2e
+def test_agent_admin_can_enter_training_on_own_agent(test_client, training_world):
+    """Story 1: an agent admin (manage grant) can switch a report on that agent
+    into training mode, without holding full_admin_access."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    rid = _report_on(test_client, u["token"], org, training_world["agent2"]["id"])
+    resp = _set_mode(test_client, u["token"], org, rid, "training")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mode"] == "training"
+
+
+@pytest.mark.e2e
+def test_member_cannot_enter_training(test_client, training_world):
+    """Story 2: a plain member (view only) is denied training on that agent —
+    but chat mode still works, so the block is specific to training."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    rid = _report_on(test_client, u["token"], org, training_world["agent1"]["id"])
+
+    denied = _set_mode(test_client, u["token"], org, rid, "training")
+    assert denied.status_code == 403, denied.text
+
+    ok = _set_mode(test_client, u["token"], org, rid, "chat")
+    assert ok.status_code == 200, ok.text
+
+
+@pytest.mark.e2e
+def test_member_of_one_agent_admin_of_another_cannot_train_member_agent(test_client, training_world):
+    """Story 3 (THE case): the same user is a member of agent1 and an admin of
+    agent2. Training is DENIED on agent1 and ALLOWED on agent2 — `manage` on
+    agent2 must not leak into agent1."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+
+    r1 = _report_on(test_client, u["token"], org, training_world["agent1"]["id"])  # member
+    r2 = _report_on(test_client, u["token"], org, training_world["agent2"]["id"])  # admin
+
+    assert _set_mode(test_client, u["token"], org, r1, "training").status_code == 403
+    assert _set_mode(test_client, u["token"], org, r2, "training").status_code == 200
+
+
+@pytest.mark.e2e
+def test_full_admin_can_train_any_agent(test_client, training_world):
+    """Story 4 (backward compat): full admins can still train any agent."""
+    org = training_world["org_id"]
+    admin = training_world["admin"]
+    for agent in ("agent1", "agent2"):
+        rid = _report_on(test_client, admin["token"], org, training_world[agent]["id"])
+        resp = _set_mode(test_client, admin["token"], org, rid, "training")
+        assert resp.status_code == 200, f"{agent}: {resp.text}"
+
+
+@pytest.mark.e2e
+def test_training_blocked_when_org_flag_disabled(test_client, training_world, update_organization_settings):
+    """Story 5: with enable_training_mode disabled, NOBODY can enter training —
+    not the agent admin, not the full admin. The org flag still hard-blocks."""
+    org = training_world["org_id"]
+    admin = training_world["admin"]
+    u = training_world["u"]
+
+    # Fixture asserts 200 internally and returns the settings dict.
+    update_organization_settings(
+        config={"enable_training_mode": {"value": False}},
+        user_token=admin["token"],
+        org_id=org,
+    )
+
+    # Agent admin on their own agent → blocked (400, flag off).
+    rid_u = _report_on(test_client, u["token"], org, training_world["agent2"]["id"])
+    assert _set_mode(test_client, u["token"], org, rid_u, "training").status_code == 400
+
+    # Even a full admin → blocked.
+    rid_a = _report_on(test_client, admin["token"], org, training_world["agent2"]["id"])
+    assert _set_mode(test_client, admin["token"], org, rid_a, "training").status_code == 400
+
+
+# ── Write scoping (HTTP routes) ──────────────────────────────────────────────
+
+@pytest.mark.e2e
+def test_agent_admin_instruction_writes_are_scoped(test_client, training_world):
+    """Story 6: an agent admin's instruction writes stay on their agent — a
+    global (data-source-less) instruction and one on an agent they only view
+    are both denied."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    agent1 = training_world["agent1"]["id"]
+    agent2 = training_world["agent2"]["id"]
+
+    # On the agent they manage → allowed.
+    ok = test_client.post(
+        "/api/instructions",
+        json=_instruction_body("scoped to agent2", [agent2]),
+        headers=_hdr(u["token"], org),
+    )
+    assert ok.status_code == 200, ok.text
+
+    # Global (no data source) → org-level only → 403.
+    glob = test_client.post(
+        "/api/instructions/global",
+        json=_instruction_body("tries global", []),
+        headers=_hdr(u["token"], org),
+    )
+    assert glob.status_code == 403, glob.text
+
+    # On an agent they only view → 403.
+    cross = test_client.post(
+        "/api/instructions",
+        json=_instruction_body("tries agent1", [agent1]),
+        headers=_hdr(u["token"], org),
+    )
+    assert cross.status_code == 403, cross.text
+
+
+@pytest.mark.e2e
+def test_agent_admin_eval_writes_are_scoped(test_client, training_world):
+    """Story 7: an agent admin can create an eval case scoped to their agent,
+    but NOT a global (empty data_source_ids_json) case — that stays org-level.
+    This is the create_case bypass that is now closed."""
+    org = training_world["org_id"]
+    admin = training_world["admin"]
+    u = training_world["u"]
+    agent1 = training_world["agent1"]["id"]
+    agent2 = training_world["agent2"]["id"]
+
+    # Admin owns the suite (suite creation is org-level manage_evals).
+    suite = test_client.post(
+        "/api/tests/suites",
+        json={"name": "TM Eval Suite", "description": None},
+        headers=_hdr(admin["token"], org),
+    )
+    assert suite.status_code == 200, suite.text
+    suite_id = suite.json()["id"]
+
+    def _case(token, ds_ids):
+        return test_client.post(
+            f"/api/tests/suites/{suite_id}/cases",
+            json={
+                "name": f"case-{ds_ids}",
+                "prompt_json": {"content": "evaluate"},
+                "expectations_json": {"spec_version": 1, "rules": [], "order_mode": "flexible"},
+                "data_source_ids_json": ds_ids,
+            },
+            headers=_hdr(token, org),
+        )
+
+    # Scoped to the agent they manage → allowed.
+    assert _case(u["token"], [agent2]).status_code == 200
+    # Global (empty) → 403 (the closed bypass).
+    assert _case(u["token"], []).status_code == 403
+    # Scoped to an agent they only view → 403.
+    assert _case(u["token"], [agent1]).status_code == 403
+    # Control: full admin can still create a global eval.
+    assert _case(admin["token"], []).status_code == 200

--- a/backend/tests/e2e/rbac/test_rbac_training_mode.py
+++ b/backend/tests/e2e/rbac/test_rbac_training_mode.py
@@ -162,6 +162,51 @@ def test_training_blocked_when_org_flag_disabled(test_client, training_world, up
     assert _set_mode(test_client, admin["token"], org, rid_a, "training").status_code == 400
 
 
+@pytest.mark.e2e
+def test_agent_creator_can_train_agent_they_created(
+    test_client, bootstrap_admin, invite_user_to_org, create_role, assign_role, sqlite_data_source,
+):
+    """A user with `create_data_source` who CREATES an agent becomes its owner
+    (a per-DS `manage` grant, which implies manage_instructions) and can enter
+    training mode on it — but NOT on an agent they neither created nor manage.
+
+    'If I can create/manage agents I should see training' → yes, for the agents
+    you actually own/manage; creating agents does not unlock training on
+    someone else's agent."""
+    admin = bootstrap_admin("admin")
+    org = admin["org_id"]
+
+    # A role whose only power is creating agents, assigned directly to `creator`.
+    role = create_role(name="agent-creators", permissions=["create_data_source"],
+                       user_token=admin["token"], org_id=org)
+    assert role.status_code == 200, role.text
+    creator = invite_user_to_org(org_id=org, admin_token=admin["token"])
+    asg = assign_role(role_id=role.json()["id"], principal_type="user",
+                      principal_id=creator["user_id"], user_token=admin["token"], org_id=org)
+    assert asg.status_code in (200, 201), asg.text
+
+    # Admin owns an agent the creator has nothing to do with.
+    admin_agent = sqlite_data_source(name="admins_agent", user_token=admin["token"], org_id=org)
+    # Creator makes their own agent → becomes its owner (manage grant).
+    own_agent = sqlite_data_source(name="creators_agent", user_token=creator["token"], org_id=org)
+
+    # Train the agent they created → allowed.
+    rid_own = _report_on(test_client, creator["token"], org, own_agent["id"])
+    assert _set_mode(test_client, creator["token"], org, rid_own, "training").status_code == 200
+
+    # They can't even attach the admin's private agent to a report, so training
+    # on it is unreachable — create_data_source does not grant cross-agent train.
+    rep = test_client.post(
+        "/api/reports",
+        json={"title": "x", "data_sources": [admin_agent["id"]]},
+        headers=_hdr(creator["token"], org),
+    )
+    assert rep.status_code in (200, 201), rep.text
+    # The forbidden agent is dropped from the report (no access), so it has no
+    # trainable agent → training is denied.
+    assert _set_mode(test_client, creator["token"], org, rep.json()["id"], "training").status_code == 403
+
+
 # ── Write scoping (HTTP routes) ──────────────────────────────────────────────
 
 @pytest.mark.e2e

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -893,9 +893,14 @@ import { useOrgSettings } from '~/composables/useOrgSettings'
 const h = useInstructionHelpers()
 const toast = useToast()
 const { t } = useI18n()
-// Training mode is gated by org setting + permission (mirrors the legacy agents page).
+// Training mode is the per-agent admin capability: gated on the org setting plus
+// manage_instructions on the currently-open agent (a per-DS `manage` grant
+// implies it; full_admin bypasses). Mirrors the backend gate.
 const { isTrainingModeEnabled } = useOrgSettings()
-const agentCanStartTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
+const agentCanStartTraining = computed(() => {
+  const id = agentView.value?.agentId
+  return isTrainingModeEnabled.value && !!id && useCan('manage_instructions', { type: 'data_source', id })
+})
 
 // ── State ───────────────────────────────────────────────
 // `allInstructions` is the LAZY row cache — it holds only the instruction rows

--- a/frontend/components/prompt/ModeSelector.vue
+++ b/frontend/components/prompt/ModeSelector.vue
@@ -53,6 +53,9 @@ import { computed } from 'vue'
 
 const props = defineProps<{
   modelValue: 'chat' | 'deep' | 'training' | string
+  // Agent(s) this prompt targets — training is gated on manage_instructions for
+  // each of them (a per-DS `manage` grant implies it; full_admin bypasses).
+  dataSourceIds?: string[]
 }>()
 
 const emit = defineEmits<{
@@ -63,9 +66,16 @@ const { t } = useI18n()
 
 const popper = { strategy: 'absolute' as const, placement: 'bottom-start' as const, offset: [0, 8] }
 
-// Mirror PromptBoxV2's training-mode gate.
+// Mirror PromptBoxV2's training-mode gate: resource-scoped to the target
+// agent(s). manage_instructions on every agent (per-DS `manage` implies it;
+// full_admin bypasses); org-level manage_instructions when no agent is set.
 const { isTrainingModeEnabled } = useOrgSettings()
-const canUseTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
+const canUseTraining = computed(() => {
+  if (!isTrainingModeEnabled.value) return false
+  const ids = props.dataSourceIds || []
+  if (ids.length === 0) return useCanAny('manage_instructions', 'data_source')
+  return ids.every((id) => useCan('manage_instructions', { type: 'data_source', id }))
+})
 
 const label = computed(() => {
   switch (props.modelValue) {

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -526,7 +526,7 @@ import Spinner from '@/components/Spinner.vue'
 import ImagePreviewModal from '@/components/ImagePreviewModal.vue'
 import InstructionsListModalComponent from '@/components/InstructionsListModalComponent.vue'
 import PendingInstructionItem from '@/components/prompt/PendingInstructionItem.vue'
-import { useCan } from '@/composables/usePermissions'
+import { useCan, useCanAny } from '@/composables/usePermissions'
 import { useOrgSettings } from '@/composables/useOrgSettings'
 import { useExcel } from '@/composables/useExcel'
 
@@ -588,7 +588,10 @@ const emit = defineEmits(['submitCompletion','stopGeneration','update:modelValue
 
 // Whether the current user may publish/resolve instruction changes. Gates the
 // batch Accept/Reject controls; the server enforces the real permission.
-const canCreateInstructions = computed(() => useCan('manage_instructions'))
+// Resource-scoped to the selected agent(s): an agent admin (per-DS `manage`,
+// which implies manage_instructions) can approve their own agent's build, not
+// just org admins.
+const canCreateInstructions = computed(() => canManageInstructionsForSelectedAgents.value)
 
 const isApprovingBuild = computed(() => props.isPublishingBuild)
 const isDiscardingBuild = ref(false)
@@ -908,9 +911,21 @@ const modeIcon = computed(() => {
     }
 })
 
-// Permission check for training mode - requires permission, allow_llm_see_data, and enable_training_mode enabled
-const { allowLlmSeeData, isTrainingModeEnabled } = useOrgSettings()
-const canUseTrainingMode = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
+// Training mode is the per-agent admin capability: authoring instructions for
+// the selected agent(s). Require manage_instructions on EVERY selected agent (a
+// per-data_source `manage` grant implies it, and full_admin bypasses) — mirrors
+// the backend gate in report_service.update_report. A plain member (view only)
+// on the agent is denied even if they manage a different agent.
+const { isTrainingModeEnabled } = useOrgSettings()
+const canManageInstructionsForSelectedAgents = computed(() => {
+    const dss = selectedDataSources.value || []
+    if (dss.length === 0) {
+        // No agent picked yet — offer training to anyone who manages some agent.
+        return useCanAny('manage_instructions', 'data_source')
+    }
+    return dss.every((ds: any) => useCan('manage_instructions', { type: 'data_source', id: ds.id }))
+})
+const canUseTrainingMode = computed(() => isTrainingModeEnabled.value && canManageInstructionsForSelectedAgents.value)
 
 // Model selector state - fetch from backend
 const models = ref<any[]>([])

--- a/frontend/components/prompt/PromptEditModal.vue
+++ b/frontend/components/prompt/PromptEditModal.vue
@@ -132,7 +132,7 @@
           </button>
 
           <div v-if="showAdvanced" class="flex items-center gap-2">
-            <ModeSelector v-model="form.mode" />
+            <ModeSelector v-model="form.mode" :dataSourceIds="agentIds" />
             <ModelSelector v-model="form.model_id" />
           </div>
         </section>

--- a/frontend/pages/old_agents/[id]/index.vue
+++ b/frontend/pages/old_agents/[id]/index.vue
@@ -195,9 +195,14 @@ const route = useRoute()
 const router = useRouter()
 const toast = useToast?.()
 
-// Training mode is gated by org setting + permission (mirrors the prompt box).
+// Training mode is the per-agent admin capability: gated on the org setting plus
+// manage_instructions on THIS agent (a per-DS `manage` grant implies it;
+// full_admin bypasses). Mirrors the backend gate.
 const { isTrainingModeEnabled } = useOrgSettings()
-const canStartTraining = computed(() => useCan('train_mode') && isTrainingModeEnabled.value)
+const canStartTraining = computed(() =>
+  isTrainingModeEnabled.value &&
+  useCan('manage_instructions', { type: 'data_source', id: (route.params.id as string) })
+)
 
 // Inject integration data from layout (avoid duplicate API calls)
 const injectedIntegration = inject<Ref<any>>('integration', ref(null))

--- a/sandbox-feedback-loop-training-mode-agent-admins.md
+++ b/sandbox-feedback-loop-training-mode-agent-admins.md
@@ -1,0 +1,315 @@
+# Sandbox Feedback Loop — Training mode for agent admins (per-agent scoping)
+
+Opens **training mode** to the per-agent **`manage`** tier (agent owners /
+managers), not just org admins — and guarantees that everything a training
+session produces (**instructions, evals, prompts, entities**) is **scoped to the
+specific agent(s) being trained**, never org-wide.
+
+This is the runnable feedback loop used to confirm the behavior in a fresh
+sandbox. It follows the same shape as
+`sandbox-feedback-loop-agent-manager-rbac.md` and
+`sandbox-feedback-loop-prompts-training-tools.md`.
+
+---
+
+## The contract (user stories)
+
+Setup: an admin seeds an org; a user `u` is granted **`view`** (plain member) on
+`agent1` and **`manage`** (agent admin) on `agent2`. `agent_admin` is the
+admin's own agent. The org feature flag `enable_training_mode` is **on** unless a
+story says otherwise.
+
+**Entry gate (per-agent, not org-wide):**
+
+1. An **agent admin** (`manage` on the agent) **can enter training mode** on that
+   agent — even without `full_admin_access`. (Today only full admins can.)
+2. A **plain member** (`view` only) **cannot enter training mode** on that agent.
+3. **Cross-agent isolation (the key case):** `u`, who is a **member of `agent1`**
+   and an **admin of `agent2`**, **cannot enter training mode on `agent1`**, but
+   **can** on `agent2`. Holding `manage` on *some* agent must not unlock training
+   on an agent they only view.
+4. A **full admin** can still enter training mode on **any** agent (bypass
+   preserved).
+5. When `enable_training_mode` is **disabled**, **nobody** can enter training
+   mode — agent admin or full admin — the org flag still hard-blocks it.
+
+**Write scoping (nothing created leaks org-wide):**
+
+6. Instructions created during a training session are attached to the trained
+   **agent's data_source**; an agent admin **cannot** produce a **global**
+   (data-source-less) instruction, and **cannot** attach one to an agent they
+   don't manage.
+7. Same for **evals** — created scoped to the trained agent; global/org-wide
+   creation is blocked for a non-admin agent admin.
+8. Same for **prompts** — agent-scoped to the trained agent; `global`/`private`
+   promotion stays org-admin-only (already enforced by `PromptService`).
+9. **Approving the build** (publishing the staged instructions) requires
+   `manage_instructions` on the trained agent — an agent admin can approve their
+   own agent's build; a member cannot.
+
+**Backward compatibility:**
+
+10. Existing full-admin training flows are unchanged (stories 4/5 + regression
+    suites).
+11. Existing HTTP RBAC for instructions/evals/prompts/entities is unchanged
+    (the agent-manager regression suites still pass).
+
+---
+
+## What the fix changes (recap — see the design write-up)
+
+- **Entry gate, backend** — `report_service` (mode-set path, ~`report_service.py:544`)
+  must, in addition to the `enable_training_mode` flag, require the actor to hold
+  `manage_instructions` on **every** data_source attached to the report before
+  allowing `mode == "training"`. Today it checks *only* the flag, so the gate is
+  effectively frontend-only.
+- **Entry gate, frontend** — the four `useCan('train_mode') && isTrainingModeEnabled`
+  sites (`PromptBoxV2.vue:913`, `ModeSelector.vue:68`, `KnowledgeExplorer.vue:898`,
+  `old_agents/[id]/index.vue:200`) and `PrimaryInstructionMenu`'s `canTrain`
+  become resource-scoped: `useCan('manage_instructions', { type:'data_source', id: agentId }) && isTrainingModeEnabled`.
+  `canCreateInstructions` (`PromptBoxV2.vue:591`) becomes the same resource-scoped
+  check so an agent admin can approve their own build.
+- **Write scoping** — move the `require_org_permission` global gate out of the
+  HTTP routes and into a shared service-layer `authorize_write(resolved, ds_ids)`
+  (modeled on `prompt_service.authorize_write` / `_can_manage_all`) that the AI
+  training tools call too, so `create_instruction` / `create_eval` can't bypass
+  it. Restrict training-mode table→DS resolution to the trained agent, and stop
+  defaulting to global when scope is omitted.
+
+> Scoping guarantee (mirrors the agent-manager doc): `manage` implies
+> `manage_instructions` / `manage_evals` only on the **same** data_source. A
+> training agent admin is confined to the agent(s) on the report — never org-wide.
+
+---
+
+## Environment setup (fresh sandbox)
+
+Identical to the agent-manager loop.
+
+```bash
+cd backend
+pip install uv
+uv sync --frozen --extra dev
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+mkdir -p db
+```
+
+---
+
+## Loop A — resolver / permission unit + frontend implication (fast, no HTTP)
+
+The entry gate reuses the existing `manage ⇒ manage_instructions` implication, so
+the resolver already has the primitive. Confirm it and the frontend mirror.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run --extra dev pytest tests/unit/test_permission_resolver.py -q
+```
+
+Assert (add if missing): for a user holding only a per-DS `manage` grant on
+`agent2`, `resolved.has_resource_permission('data_source', agent2, 'manage_instructions')`
+is **True**, and on `agent1` (view only) it is **False**. This is exactly what the
+entry gate keys on, so it is the unit-level proof of story 3.
+
+Frontend mirror (no Nuxt build) — the same node implication check used in the
+agent-manager loop already covers `manage ⇒ manage_instructions`; add an
+assertion that `useCan('manage_instructions', {type:'data_source', id})` is
+false for a view-only grant and true for a manage grant.
+
+---
+
+## Loop B — end-to-end entry gate + cross-agent isolation (HTTP, in-process SQLite)
+
+New file: `backend/tests/e2e/rbac/test_rbac_training_mode.py`. Reuses the same
+fixtures as `test_rbac_agent_manager_stories.py` / `test_rbac_prompts.py`
+(`bootstrap_admin`, `invite_user_to_org`, `grant_resource`, `sqlite_data_source`).
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run --extra dev pytest tests/e2e/rbac/test_rbac_training_mode.py -v
+```
+
+### World fixture
+
+```python
+@pytest.fixture
+def training_world(test_client, bootstrap_admin, invite_user_to_org,
+                   grant_resource, sqlite_data_source):
+    admin = bootstrap_admin("admin"); org = admin["org_id"]
+
+    agent1 = sqlite_data_source(name="agent1", user_token=admin["token"], org_id=org)
+    agent2 = sqlite_data_source(name="agent2", user_token=admin["token"], org_id=org)
+
+    # u = MEMBER (view) of agent1, ADMIN (manage) of agent2  ← the key case
+    u = invite_user_to_org(org_id=org, admin_token=admin["token"])
+    for ds, perms in ((agent1, ["view"]), (agent2, ["manage"])):
+        r = grant_resource(resource_type="data_source", resource_id=ds["id"],
+                           principal_type="user", principal_id=u["user_id"],
+                           permissions=perms, user_token=admin["token"], org_id=org)
+        assert r.status_code == 200, r.text
+    return {"org": org, "admin": admin, "u": u, "agent1": agent1, "agent2": agent2}
+
+
+def _report_on(test_client, token, org, ds_id):
+    r = test_client.post("/api/reports", json={"data_sources": [ds_id]}, headers=_hdr(token, org))
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+def _set_mode(test_client, token, org, report_id, mode):
+    return test_client.put(f"/api/reports/{report_id}", json={"mode": mode}, headers=_hdr(token, org))
+```
+
+### Test cases
+
+**`test_agent_admin_can_enter_training_on_own_agent`** (story 1)
+```python
+rid = _report_on(tc, u["token"], org, agent2["id"])          # u manages agent2
+assert _set_mode(tc, u["token"], org, rid, "training").status_code == 200
+```
+
+**`test_member_cannot_enter_training`** (story 2)
+```python
+rid = _report_on(tc, u["token"], org, agent1["id"])          # u only views agent1
+assert _set_mode(tc, u["token"], org, rid, "training").status_code == 403
+# Sanity: chat/deep still work for a member.
+assert _set_mode(tc, u["token"], org, rid, "chat").status_code == 200
+```
+
+**`test_member_of_one_agent_admin_of_another_cannot_train_the_member_agent`** (story 3 — THE case)
+```python
+# Same user, two agents, opposite grants.
+r1 = _report_on(tc, u["token"], org, agent1["id"])           # member of agent1
+r2 = _report_on(tc, u["token"], org, agent2["id"])           # admin  of agent2
+assert _set_mode(tc, u["token"], org, r1, "training").status_code == 403   # NOT allowed on agent1
+assert _set_mode(tc, u["token"], org, r2, "training").status_code == 200   # allowed on agent2
+# Manage on agent2 must NOT leak into agent1.
+```
+
+**`test_full_admin_can_train_any_agent`** (story 4 — backward compat)
+```python
+rid = _report_on(tc, admin["token"], org, agent1["id"])
+assert _set_mode(tc, admin["token"], org, rid, "training").status_code == 200
+```
+
+**`test_training_blocked_when_org_flag_disabled`** (story 5)
+```python
+# turn enable_training_mode OFF via org settings, then:
+for actor in (admin, u):                                     # even the manager/admin
+    rid = _report_on(tc, actor["token"], org, agent2["id"])
+    assert _set_mode(tc, actor["token"], org, rid, "training").status_code == 400
+```
+
+### Write-scoping cases (HTTP layer — instructions/evals/entities)
+
+These extend the agent-manager stories to the training actor `u`. They assert an
+agent admin's writes stay on their agent and cannot go global.
+
+**`test_agent_admin_instruction_writes_are_scoped`** (story 6)
+```python
+# On the agent they manage → allowed, attached to agent2.
+assert tc.post("/api/instructions",
+    json=_instruction_body("rule", [agent2["id"]]), headers=_hdr(u["token"], org)).status_code == 200
+# Global (no DS) → 403 for a non-admin agent admin.
+assert tc.post("/api/instructions/global",
+    json=_instruction_body("global rule", []), headers=_hdr(u["token"], org)).status_code == 403
+# On agent1 (view only) → 403.
+assert tc.post("/api/instructions",
+    json=_instruction_body("rule", [agent1["id"]]), headers=_hdr(u["token"], org)).status_code == 403
+```
+
+**`test_agent_admin_eval_writes_are_scoped`** (story 7) — mirror of the above
+against the eval `create_case` route: scoped to `agent2` → allowed; empty
+`data_source_ids_json` (global) → **403 for `u`** (this is the bypass to close —
+today an empty list skips the per-DS check); `agent1` → 403.
+
+**`test_approve_build_requires_manage_on_agent`** (story 9) — approving/publishing
+a report's training build succeeds for `u` on `agent2`, 403 on `agent1`.
+
+---
+
+## Loop C — training tools + live UI/LLM
+
+The HTTP tests above cover the routes; the **AI tool path** (which historically
+bypassed the route gate) is proven the same way `test_prompt_training_tools.py`
+does — drive the tools through `run_stream` against the real services.
+
+New/extended: `backend/tests/prompts/test_training_write_scoping.py`
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run --extra dev pytest tests/prompts/test_training_write_scoping.py -v -s
+```
+
+Asserts (no LLM — tools invoked directly with a runtime context bound to the
+trained agent):
+- `create_instruction` with the trained agent = `agent2`, **`table_names` omitted**
+  → instruction is attached to `agent2` (NOT global). Today this yields a global
+  instruction — this is the red→green assertion.
+- `create_instruction` as a user who only **views** the trained agent →
+  `permission_denied`.
+- `create_eval` with `data_source_ids` omitted → scoped to the trained agent,
+  not org-wide; non-manager → `permission_denied`.
+- `create_prompt` → agent-scoped to the trained agent (already green); a
+  requested `scope='global'` from a non-admin → `permission_denied`.
+
+Live UI/LLM (manual, Haiku), mirroring the prompts-tools loop:
+1. As `u` (manager of `agent2`, member of `agent1`), open a report on **`agent2`**,
+   switch the composer to **Training** — the toggle is **visible**.
+2. Open a report on **`agent1`** — the Training toggle is **hidden/disabled**
+   (member-only). This is the visual proof of the cross-agent case.
+3. In the `agent2` training session: *"Add an always-on rule that revenue is in
+   USD."* → `create_instruction` runs; the staged instruction is scoped to
+   `agent2` (check it does **not** appear for `agent1`).
+4. Approve the build → instructions publish under `agent2` only.
+5. As full admin, confirm training still works on any agent (backward compat).
+
+---
+
+## Backward-compatibility / regression guards
+
+Run the existing suites unchanged — none of these behaviors may shift:
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run --extra dev pytest \
+  tests/unit/test_permission_resolver.py \
+  tests/e2e/rbac/test_rbac_agent_manager_stories.py \
+  tests/e2e/rbac/test_rbac_instructions.py \
+  tests/e2e/rbac/test_rbac_evals.py \
+  tests/e2e/rbac/test_rbac_prompts.py \
+  tests/e2e/rbac/test_rbac_entities.py \
+  tests/e2e/rbac/test_rbac_data_sources.py \
+  tests/prompts/test_prompt_training_tools.py -q
+```
+
+Explicit backward-compat assertions folded into Loop B:
+- Full admin can train any agent (`test_full_admin_can_train_any_agent`).
+- The org flag still hard-blocks everyone when off
+  (`test_training_blocked_when_org_flag_disabled`).
+- `chat` / `deep` mode is unaffected for members (sanity in
+  `test_member_cannot_enter_training`).
+- Existing global-instruction/entity/eval admin gates on the HTTP routes remain
+  403 for managers (agent-manager stories 2 & 9 still pass) — the write-scoping
+  change moves the gate into the service **without loosening the route**.
+
+---
+
+## What this proves
+
+- Training mode is now available to **agent admins** (per-DS `manage`), scoped to
+  the agent they administer (stories 1, 4).
+- The power is **isolated per agent**: a member can't train (story 2), and — the
+  case that motivated this — a user who is a **member of `agent1`** but **admin of
+  `agent2`** is **denied training on `agent1`** while allowed on `agent2` (story 3).
+- Everything a training session creates — instructions, evals, prompts — is
+  **bound to the trained agent** and cannot go org-wide from a non-admin agent
+  admin (stories 6–8), including via the AI tool path that previously bypassed the
+  route gate.
+- Full-admin flows and all existing RBAC behavior are **unchanged** (stories
+  10–11 + the regression suites).
+</content>
+</invoke>

--- a/sandbox-feedback-loop-training-mode-agent-admins.md
+++ b/sandbox-feedback-loop-training-mode-agent-admins.md
@@ -298,6 +298,41 @@ Explicit backward-compat assertions folded into Loop B:
 
 ---
 
+## Observed results (this sandbox)
+
+Backend (`uv run pytest`, SQLite):
+
+```
+tests/e2e/rbac/test_rbac_training_mode.py ........................ 7 passed
+  test_agent_admin_can_enter_training_on_own_agent                 PASS
+  test_member_cannot_enter_training                                PASS
+  test_member_of_one_agent_admin_of_another_cannot_train_member_agent  PASS  ← the case
+  test_full_admin_can_train_any_agent                              PASS
+  test_training_blocked_when_org_flag_disabled                     PASS
+  test_agent_admin_instruction_writes_are_scoped                   PASS
+  test_agent_admin_eval_writes_are_scoped                          PASS
+
+Regression (unchanged): test_rbac_evals / test_rbac_instructions /
+test_rbac_agent_manager_stories / test_rbac_prompts — all pass.
+```
+
+Live API (running server, user `u` = member of agent1, admin of agent2):
+
+```
+PUT /reports/{report_on_agent1} {"mode":"training"}  → 403   (member — denied)
+PUT /reports/{report_on_agent2} {"mode":"training"}  → 200   (admin — allowed)
+```
+
+Live UI (Playwright, same logged-in user `u`):
+- `02_u_agent2_admin.png` — mode popover on the agent they manage shows **Chat /
+  Deep Analytics / Training**.
+- `03_u_agent1_member.png` — mode popover on the agent they only view shows
+  **Chat / Deep Analytics** only; **no Training**.
+
+(Full-admin UI walkthrough is gated behind first-run onboarding in a fresh org;
+its backward-compat is covered by `test_full_admin_can_train_any_agent` and the
+live 200 above.)
+
 ## What this proves
 
 - Training mode is now available to **agent admins** (per-DS `manage`), scoped to


### PR DESCRIPTION
Test-plan doc (sandbox-feedback-loop style) for opening training mode to
per-agent manage grants and scoping training-created instructions/evals/
prompts to the trained agent, incl. the cross-agent isolation case and
backward-compat regression guards.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WaCDmpHWx5Vnz2qtxiRiad