### PR TITLE
Fix extreme slowness on report/artifact pages with large data (selectin cascade)

### DIFF
--- a/backend/app/core/permissions_decorator.py
+++ b/backend/app/core/permissions_decorator.py
@@ -1,5 +1,6 @@
 import logging as _logging
 from sqlalchemy import select
+from sqlalchemy.orm import lazyload
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import HTTPException
 from functools import wraps
@@ -83,7 +84,13 @@ def requires_permission(permission, model=None, owner_only=False, allow_public=F
             # If model is provided and object_id exists and is not None and is a valid UUID-like string, verify object belongs to organization
             obj = None
             if model and object_id is not None:
-                stmt = select(model).where(
+                # lazyload("*"): the checks below read scalar columns only
+                # (user_id, artifact_visibility, status). Models like Report
+                # declare lazy="selectin" on every relationship, which would
+                # hydrate the entire object graph (every step version's data
+                # JSON, all artifacts, the chat history) on EVERY decorated
+                # request just to run this permission check.
+                stmt = select(model).options(lazyload("*")).where(
                     model.id == object_id,
                     model.organization_id == organization.id
                 )

--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -356,12 +356,20 @@ async def get_public_report(
 ):
     schema = await report_service.get_public_report(db, report_id, user=user)
     result = schema.model_dump()
-    # Check fork eligibility for logged-in users
-    from sqlalchemy.orm import selectinload
+    # Check fork eligibility for logged-in users.
+    # lazyload("*"): check_eligibility only needs data_sources+connections;
+    # without it this second Report load re-runs the full selectin cascade.
+    from sqlalchemy.orm import selectinload, lazyload
     from app.models.data_source import DataSource
     report_result = await db.execute(
         select(Report)
-        .options(selectinload(Report.data_sources).selectinload(DataSource.connections))
+        .options(
+            lazyload("*"),
+            selectinload(Report.data_sources).options(
+                lazyload("*"),
+                selectinload(DataSource.connections).options(lazyload("*")),
+            ),
+        )
         .where(Report.id == report_id)
     )
     report_obj = report_result.unique().scalar_one_or_none()
@@ -383,11 +391,17 @@ async def get_public_conversation(
     # Attach fork eligibility if user is logged in
     report_id = result.get("report_id") if isinstance(result, dict) else None
     if report_id:
-        from sqlalchemy.orm import selectinload
+        from sqlalchemy.orm import selectinload, lazyload
         from app.models.data_source import DataSource
         report_result = await db.execute(
             select(Report)
-            .options(selectinload(Report.data_sources).selectinload(DataSource.connections))
+            .options(
+                lazyload("*"),
+                selectinload(Report.data_sources).options(
+                    lazyload("*"),
+                    selectinload(DataSource.connections).options(lazyload("*")),
+                ),
+            )
             .where(Report.id == report_id)
         )
         report_obj = report_result.unique().scalar_one_or_none()

--- a/backend/app/services/artifact_service.py
+++ b/backend/app/services/artifact_service.py
@@ -1,6 +1,7 @@
 from typing import Optional, List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.orm import lazyload
 
 from app.models.artifact import Artifact
 from app.models.report import Report
@@ -38,8 +39,13 @@ class ArtifactService:
         return artifact
 
     async def get(self, db: AsyncSession, artifact_id: str) -> Optional[Artifact]:
-        """Get an artifact by ID."""
-        stmt = select(Artifact).where(
+        """Get an artifact by ID.
+
+        lazyload("*"): consumers only use the artifact's own columns;
+        Artifact.report would otherwise selectin-cascade the entire report
+        graph (every step version's data JSON) on each fetch.
+        """
+        stmt = select(Artifact).options(lazyload("*")).where(
             Artifact.id == str(artifact_id),
             Artifact.deleted_at.is_(None),
         )
@@ -61,6 +67,7 @@ class ArtifactService:
         """
         stmt = (
             select(Artifact)
+            .options(lazyload("*"))
             .where(
                 Artifact.report_id == str(report_id),
                 Artifact.deleted_at.is_(None),
@@ -78,6 +85,7 @@ class ArtifactService:
         """Get the most recent artifact for a report."""
         stmt = (
             select(Artifact)
+            .options(lazyload("*"))
             .where(
                 Artifact.report_id == str(report_id),
                 Artifact.deleted_at.is_(None),

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -302,13 +302,21 @@ class ReportService:
         
 
     async def get_report(self, db: AsyncSession, report_id: str, current_user: User, organization: Organization) -> ReportSchema:
-        # Same pattern as get_reports: suppress only the DataSource cascade
-        # (the actual cost), let Report's own lazy="selectin" fire so
-        # downstream serialization of user/widgets/etc. works unchanged.
+        # Load only the relationships this method serializes (user,
+        # external_platform, data_sources+connections, shares). Report's
+        # mapper-level lazy="selectin" would otherwise hydrate the entire
+        # graph — every step version's data JSON, every artifact version,
+        # the chat history — on every report open. The summary counts below
+        # are computed with COUNT queries instead of loading the rows.
         result = await db.execute(
             select(Report)
             .options(
-                selectinload(Report.user),
+                lazyload("*"),
+                # UserSchema serializes external_user_mappings — load it, the
+                # top-level wildcard turned User's own eager defaults off too.
+                selectinload(Report.user).selectinload(User.external_user_mappings),
+                selectinload(Report.external_platform),
+                selectinload(Report.shares).options(lazyload("*")),
                 selectinload(Report.data_sources).options(
                     lazyload("*"),
                     selectinload(DataSource.connections).options(lazyload("*")),
@@ -371,15 +379,34 @@ class ReportService:
             # Per-user starred state
             is_starred=is_starred,
         )
-        # Summary counts (for auto-opening sidebar)
-        report_schema.query_count = len(report.queries or [])
-        report_schema.artifact_count = len(report.artifacts or [])
-        active_sps = [
-            sp for sp in (report.scheduled_prompts or [])
-            if sp.is_active and sp.deleted_at is None
-        ]
-        report_schema.has_scheduled_prompts = len(active_sps) > 0
-        report_schema.scheduled_prompt_count = len(active_sps)
+        # Summary counts (for auto-opening sidebar) — COUNT queries, not
+        # len(relationship): loading report.queries would drag in every step
+        # version's data via Query.steps' selectin cascade.
+        from app.models.artifact import Artifact
+        qc_result = await db.execute(
+            select(func.count(Query.id)).where(
+                Query.report_id == report.id,
+                Query.deleted_at.is_(None),
+            )
+        )
+        report_schema.query_count = qc_result.scalar() or 0
+        ac_result = await db.execute(
+            select(func.count(Artifact.id)).where(
+                Artifact.report_id == report.id,
+                Artifact.deleted_at.is_(None),
+            )
+        )
+        report_schema.artifact_count = ac_result.scalar() or 0
+        sp_result = await db.execute(
+            select(func.count(ScheduledPrompt.id)).where(
+                ScheduledPrompt.report_id == report.id,
+                ScheduledPrompt.is_active.is_(True),
+                ScheduledPrompt.deleted_at.is_(None),
+            )
+        )
+        sp_count = sp_result.scalar() or 0
+        report_schema.has_scheduled_prompts = sp_count > 0
+        report_schema.scheduled_prompt_count = sp_count
 
         # Instruction count
         from app.models.instruction import Instruction
@@ -873,7 +900,27 @@ class ReportService:
         return {"id": str(report_id), "is_starred": starred}
 
     async def get_public_report(self, db: AsyncSession, report_id: str, user=None) -> ReportSchema:
-        result = await db.execute(select(Report).filter(Report.id == report_id))
+        # Load only what ReportSchema serializes. Report's mapper-level
+        # lazy="selectin" relationships would otherwise hydrate the entire
+        # report graph — every step version's data JSON, every artifact
+        # version, the chat history — just to render report metadata.
+        result = await db.execute(
+            select(Report)
+            .options(
+                lazyload("*"),
+                # UserSchema serializes external_user_mappings — load it, the
+                # top-level wildcard turned User's own eager defaults off too.
+                selectinload(Report.user).selectinload(User.external_user_mappings),
+                selectinload(Report.external_platform),
+                selectinload(Report.widgets).options(lazyload("*")),
+                selectinload(Report.dashboard_layout_versions).options(lazyload("*")),
+                selectinload(Report.data_sources).options(
+                    lazyload("*"),
+                    selectinload(DataSource.connections).options(lazyload("*")),
+                ),
+            )
+            .filter(Report.id == report_id)
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Report not found")
@@ -902,15 +949,21 @@ class ReportService:
         return schema
 
     async def get_public_layouts(self, db: AsyncSession, report_id: str, user=None):
-        # Ensure report exists and has artifact visibility
-        result = await db.execute(select(Report).where(Report.id == report_id).where(Report.report_type == 'regular'))
+        # Ensure report exists and has artifact visibility.
+        # lazyload("*") — the visibility check needs the report row only, not
+        # the selectin cascade (all step data, artifacts, completions, ...).
+        result = await db.execute(
+            select(Report).options(lazyload("*"))
+            .where(Report.id == report_id).where(Report.report_type == 'regular')
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Report not found")
         await self._check_visibility(db, report, 'artifact_visibility', user)
 
         rows = await db.execute(
-            select(DashboardLayoutVersion).where(DashboardLayoutVersion.report_id == report_id).order_by(
+            select(DashboardLayoutVersion).options(lazyload("*"))
+            .where(DashboardLayoutVersion.report_id == report_id).order_by(
                 DashboardLayoutVersion.created_at.asc()
             )
         )
@@ -924,8 +977,13 @@ class ReportService:
 
         If artifact_id is provided, only returns queries for visualizations used by that artifact.
         """
-        # Verify report exists and check artifact visibility
-        result = await db.execute(select(Report).where(Report.id == report_id))
+        # Verify report exists and check artifact visibility.
+        # lazyload("*") everywhere below — these endpoints only serve small
+        # payloads; without it the mapper-level lazy="selectin" cascade
+        # hydrates every step version's data JSON on each request.
+        result = await db.execute(
+            select(Report).options(lazyload("*")).where(Report.id == report_id)
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Not found")
@@ -936,7 +994,7 @@ class ReportService:
         if artifact_id:
             from app.models.artifact import Artifact
             artifact_result = await db.execute(
-                select(Artifact).where(
+                select(Artifact).options(lazyload("*")).where(
                     Artifact.id == artifact_id,
                     Artifact.report_id == report_id,
                     Artifact.deleted_at.is_(None)
@@ -952,11 +1010,16 @@ class ReportService:
                     )
                     query_ids_filter = [row[0] for row in viz_result.all() if row[0]]
 
-        # Fetch queries that have a successful step, eagerly load visualizations
+        # Fetch queries that have a successful step, eagerly load visualizations.
+        # lazyload("*") stops Query.steps (every version, full data) / widget /
+        # report from cascading; PublicQuerySchema needs none of them.
         query_stmt = (
             select(Query)
             .join(Step, Step.id == Query.default_step_id)
-            .options(selectinload(Query.visualizations))
+            .options(
+                lazyload("*"),
+                selectinload(Query.visualizations).options(lazyload("*")),
+            )
             .where(Query.report_id == report_id, Step.status == 'success')
         )
 
@@ -972,8 +1035,13 @@ class ReportService:
 
     async def get_public_step(self, db: AsyncSession, report_id: str, query_id: str, user=None):
         """Get the default step for a query in a shared report."""
-        # Verify report exists and check artifact visibility
-        result = await db.execute(select(Report).where(Report.id == report_id))
+        # Verify report exists and check artifact visibility.
+        # lazyload("*") on every select here: PublicStepSchema serves the
+        # step's own columns; without it the selectin cascade re-hydrates
+        # the whole report graph (all step versions' data) per request.
+        result = await db.execute(
+            select(Report).options(lazyload("*")).where(Report.id == report_id)
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Not found")
@@ -981,7 +1049,8 @@ class ReportService:
 
         # Fetch query and verify it belongs to this report
         query_result = await db.execute(
-            select(Query).where(Query.id == query_id, Query.report_id == report_id)
+            select(Query).options(lazyload("*"))
+            .where(Query.id == query_id, Query.report_id == report_id)
         )
         query = query_result.scalar_one_or_none()
         if not query:
@@ -991,14 +1060,15 @@ class ReportService:
         step = None
         if query.default_step_id:
             step_result = await db.execute(
-                select(Step).where(Step.id == query.default_step_id, Step.status == 'success')
+                select(Step).options(lazyload("*"))
+                .where(Step.id == query.default_step_id, Step.status == 'success')
             )
             step = step_result.scalar_one_or_none()
 
         if not step:
             # Fallback to latest successful step
             step_result = await db.execute(
-                select(Step)
+                select(Step).options(lazyload("*"))
                 .where(Step.query_id == query_id, Step.status == 'success')
                 .order_by(Step.created_at.desc())
                 .limit(1)
@@ -1023,8 +1093,13 @@ class ReportService:
 
     async def get_public_artifacts(self, db: AsyncSession, report_id: str, user=None):
         """List artifacts for a shared report."""
-        # Verify report exists and check artifact visibility
-        result = await db.execute(select(Report).where(Report.id == report_id))
+        # Verify report exists and check artifact visibility.
+        # lazyload("*"): this endpoint returns artifact metadata only; the
+        # visibility check needs one report row, and Artifact.report would
+        # otherwise selectin-cascade the whole graph back in.
+        result = await db.execute(
+            select(Report).options(lazyload("*")).where(Report.id == report_id)
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Not found")
@@ -1033,7 +1108,7 @@ class ReportService:
         # Fetch artifacts for this report
         from app.models.artifact import Artifact
         artifacts_result = await db.execute(
-            select(Artifact)
+            select(Artifact).options(lazyload("*"))
             .where(Artifact.report_id == report_id, Artifact.deleted_at.is_(None))
             .order_by(Artifact.created_at.desc())
         )
@@ -1044,8 +1119,11 @@ class ReportService:
 
     async def get_public_artifact(self, db: AsyncSession, report_id: str, artifact_id: str, user=None):
         """Get a specific artifact for a shared report."""
-        # Verify report exists and check artifact visibility
-        result = await db.execute(select(Report).where(Report.id == report_id))
+        # Verify report exists and check artifact visibility (row only — see
+        # get_public_artifacts).
+        result = await db.execute(
+            select(Report).options(lazyload("*")).where(Report.id == report_id)
+        )
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Not found")
@@ -1054,7 +1132,7 @@ class ReportService:
         # Fetch the artifact and verify it belongs to this report
         from app.models.artifact import Artifact
         artifact_result = await db.execute(
-            select(Artifact).where(
+            select(Artifact).options(lazyload("*")).where(
                 Artifact.id == artifact_id,
                 Artifact.report_id == report_id,
                 Artifact.deleted_at.is_(None)
@@ -1552,8 +1630,12 @@ class ReportService:
         if forked_from_id:
             schema.forked_from_id = forked_from_id
             from app.models.user import User
+            # lazyload("*"): only the parent's title and owner name are read —
+            # don't cascade the parent report's whole graph.
             result = await db.execute(
-                select(Report).options(selectinload(Report.user)).where(Report.id == forked_from_id)
+                select(Report)
+                .options(lazyload("*"), selectinload(Report.user).options(lazyload("*")))
+                .where(Report.id == forked_from_id)
             )
             parent = result.scalar_one_or_none()
             if parent:

--- a/backend/scripts/pw_artifact_perf_repro.js
+++ b/backend/scripts/pw_artifact_perf_repro.js
@@ -1,0 +1,108 @@
+// Playwright: open the PUBLIC report page (/r/{id}) for a small and a large
+// report and record what the browser actually experiences — per-request
+// latency of every /api call (the DevTools "Network" view) and the total
+// time until the artifact iframe renders its charts.
+//
+// Companion to backend/scripts/seed_artifact_perf_repro.py, which prints
+// SMALL_REPORT_ID / LARGE_REPORT_ID.
+//
+// Usage:
+//   NODE_PATH=<dir-with-playwright-core> \
+//   FRONT=http://localhost:3000 SMALL=<id> LARGE=<id> OUT=/tmp/pw \
+//   node backend/scripts/pw_artifact_perf_repro.js
+const { chromium } = require('playwright-core');
+const fs = require('fs');
+
+const FRONT = process.env.FRONT || 'http://localhost:3000';
+const SMALL = process.env.SMALL;
+const LARGE = process.env.LARGE;
+const OUT = process.env.OUT || '/tmp/pw';
+const CHROME = process.env.PW_CHROME || '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+
+function shortUrl(u, reportId) {
+  return u
+    .replace(FRONT, '')
+    .replace(reportId, '{id}')
+    .replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/g, '{uuid}');
+}
+
+async function measure(browser, label, reportId) {
+  const ctx = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await ctx.newPage();
+
+  const reqStart = new Map();
+  const apiCalls = [];
+  page.on('request', (r) => reqStart.set(r, Date.now()));
+  page.on('requestfinished', async (r) => {
+    const t0 = reqStart.get(r);
+    if (t0 == null || !r.url().includes('/api/')) return;
+    let status = '', size = 0;
+    try {
+      const resp = await r.response();
+      status = resp ? resp.status() : '';
+      size = resp ? (await resp.body()).length : 0;
+    } catch {}
+    apiCalls.push({ url: shortUrl(r.url(), reportId), ms: Date.now() - t0, status, size });
+  });
+
+  const t0 = Date.now();
+  await page.goto(`${FRONT}/r/${reportId}`, { waitUntil: 'domcontentloaded', timeout: 600000 });
+  const tDom = Date.now() - t0;
+
+  // The page shows "Loading..." until report + artifacts + EVERY query's /step
+  // have been fetched; only then is the iframe srcdoc computed.
+  await page.waitForSelector('iframe', { state: 'attached', timeout: 600000 });
+  const tIframe = Date.now() - t0;
+
+  // Wait for the charts inside the iframe (real render, not just srcdoc set).
+  let tCharts = null;
+  try {
+    await page.frameLocator('iframe').locator('canvas').first()
+      .waitFor({ state: 'visible', timeout: 120000 });
+    tCharts = Date.now() - t0;
+  } catch {}
+  await page.waitForTimeout(1500); // let all four charts paint
+
+  fs.mkdirSync(OUT, { recursive: true });
+  const shot = `${OUT}/artifact-${label}.png`;
+  await page.screenshot({ path: shot, fullPage: false });
+
+  console.log(`\n=== ${label} report (${reportId}) ===`);
+  console.log(`DOMContentLoaded: ${tDom} ms`);
+  console.log(`iframe (all API data fetched): ${tIframe} ms`);
+  console.log(`charts rendered in iframe: ${tCharts == null ? 'n/a' : tCharts + ' ms'}`);
+  console.log(`screenshot: ${shot}`);
+  console.log('api requests (browser-observed, like the DevTools Network tab):');
+  for (const c of apiCalls.sort((a, b) => b.ms - a.ms)) {
+    console.log(`  ${String(c.ms).padStart(7)} ms  ${String(c.status).padStart(3)}  ${(c.size / 1024).toFixed(1).padStart(9)} kB  ${c.url}`);
+  }
+  await ctx.close();
+  return { label, tDom, tIframe, tCharts, apiCalls };
+}
+
+(async () => {
+  if (!SMALL || !LARGE) {
+    console.error('Set SMALL=<report_id> and LARGE=<report_id> (from seed_artifact_perf_repro.py)');
+    process.exit(1);
+  }
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: CHROME,
+    args: ['--no-sandbox'],
+  });
+
+  // Warm-up: first hit compiles the Nuxt dev route; do it on the small report
+  // and discard, so dev-server compile time doesn't pollute the comparison.
+  const warm = await browser.newPage();
+  await warm.goto(`${FRONT}/r/${SMALL}`, { waitUntil: 'domcontentloaded', timeout: 600000 });
+  await warm.waitForSelector('iframe', { state: 'attached', timeout: 600000 }).catch(() => {});
+  await warm.close();
+
+  const small = await measure(browser, 'small', SMALL);
+  const large = await measure(browser, 'large', LARGE);
+
+  const ratio = (large.tIframe / small.tIframe).toFixed(1);
+  console.log(`\n=== summary ===`);
+  console.log(`time to artifact iframe: small=${small.tIframe} ms, large=${large.tIframe} ms (${ratio}x slower)`);
+  await browser.close();
+})();

--- a/backend/scripts/seed_artifact_perf_repro.py
+++ b/backend/scripts/seed_artifact_perf_repro.py
@@ -1,0 +1,186 @@
+"""Seed two public reports (small / large datasets) with a REAL renderable
+artifact for the artifact-large-data perf repro.
+
+Each report gets:
+  - 4 queries, each with 3 step versions (only the last is the default);
+    every step version stores the full result rows in steps.data
+  - 4 visualizations (bar / line / area / pie)
+  - 1 artifact whose code is generated with the app's own codegen
+    (app/services/artifact_codegen.py) — the same code path the
+    "add visualization to dashboard" endpoint uses, so the public page
+    renders real charts from window.ARTIFACT_DATA.
+
+Usage:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db .venv/bin/python scripts/seed_artifact_perf_repro.py
+    # rows per step version for the LARGE report (default 15000):
+    BOW_REPRO_ROWS=30000 ... scripts/seed_artifact_perf_repro.py
+
+Prints the public URLs (/r/{id}) for both reports.
+"""
+import asyncio
+import json
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Import the app so the full SQLAlchemy model registry is loaded (string-based
+# relationships like "ApiKey" fail to resolve otherwise). Same approach as
+# tests/conftest.py. NB: don't sweep app/models/* blindly — application.py
+# references a class that no longer exists.
+import main  # noqa: E402,F401
+
+from app.dependencies import async_session_maker  # noqa: E402
+from app.models.organization import Organization  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.report import Report  # noqa: E402
+from app.models.widget import Widget  # noqa: E402
+from app.models.query import Query  # noqa: E402
+from app.models.step import Step  # noqa: E402
+from app.models.visualization import Visualization  # noqa: E402
+from app.models.artifact import Artifact  # noqa: E402
+from app.services.artifact_codegen import (  # noqa: E402
+    generate_echart_option_code,
+    generate_section_jsx,
+    generate_scaffold,
+)
+
+ROWS_LARGE = int(os.environ.get("BOW_REPRO_ROWS", "15000"))
+ROWS_SMALL = 50
+N_STEP_VERSIONS = 3
+
+# (title, data_model) per query — all supported by artifact_codegen
+VIZ_SPECS = [
+    ("Revenue by Region", {"type": "bar_chart", "series": [
+        {"key": "region", "value": "revenue", "name": "Revenue"}]}),
+    ("Revenue over Time", {"type": "line_chart", "series": [
+        {"key": "order_month", "value": "revenue", "name": "Revenue"}]}),
+    ("Quantity over Time", {"type": "area_chart", "series": [
+        {"key": "order_month", "value": "quantity", "name": "Quantity"}]}),
+    ("Revenue Share by Region", {"type": "pie_chart", "series": [
+        {"key": "region", "value": "revenue", "name": "Revenue"}]}),
+]
+
+
+def _make_rows(n):
+    return [
+        {
+            "order_id": i,
+            "customer_name": f"customer_{i % 997}",
+            "region": ("North", "South", "East", "West")[i % 4],
+            "product": f"product_{i % 251}",
+            "quantity": (i * 7) % 40 + 1,
+            "unit_price": round(3.5 + (i % 900) * 0.13, 2),
+            "revenue": round(((i * 7) % 40 + 1) * (3.5 + (i % 900) * 0.13), 2),
+            "order_month": f"2025-{(i % 12) + 1:02d}",
+        }
+        for i in range(n)
+    ]
+
+
+async def seed_report(db, org, user, label: str, rows_per_step: int) -> dict:
+    suffix = uuid.uuid4().hex[:8]
+    columns = [{"field": f, "headerName": f.replace("_", " ").title()}
+               for f in _make_rows(1)[0].keys()]
+
+    report = Report(
+        title=f"Perf {label} {suffix}",
+        slug=f"perf-{label}-{suffix}",
+        status="published",
+        artifact_visibility="public",
+        user_id=user.id,
+        organization_id=org.id,
+    )
+    db.add(report)
+    await db.flush()
+
+    viz_ids, sections = [], []
+    for qi, (title, data_model) in enumerate(VIZ_SPECS):
+        widget = Widget(title=f"W{qi} {suffix}", slug=f"w{qi}-{label}-{suffix}",
+                        report_id=report.id)
+        db.add(widget)
+        await db.flush()
+
+        query = Query(title=title, report_id=report.id, widget_id=widget.id,
+                      organization_id=org.id, user_id=user.id)
+        db.add(query)
+        await db.flush()
+
+        last_step = None
+        for si in range(N_STEP_VERSIONS):
+            step = Step(
+                title=f"{title} v{si + 1}",
+                slug=f"s{qi}-{si}-{label}-{suffix}",
+                status="success",
+                widget_id=widget.id,
+                query_id=query.id,
+                data={"rows": _make_rows(rows_per_step), "columns": columns},
+                data_model=data_model,
+                view={"type": data_model["type"]},
+            )
+            db.add(step)
+            last_step = step
+        await db.flush()
+        query.default_step_id = last_step.id
+
+        viz = Visualization(title=title, status="success", report_id=report.id,
+                            query_id=query.id, view={"type": data_model["type"]})
+        db.add(viz)
+        await db.flush()
+        viz_ids.append(str(viz.id))
+
+        option_code = generate_echart_option_code(data_model, qi)
+        sections.append(generate_section_jsx(title, option_code, viz_index=qi))
+
+    artifact = Artifact(
+        report_id=report.id,
+        user_id=user.id,
+        organization_id=org.id,
+        title=f"Perf Dashboard ({label})",
+        mode="page",
+        version=1,
+        content={"code": generate_scaffold(sections), "visualization_ids": viz_ids},
+        status="completed",
+    )
+    db.add(artifact)
+    await db.flush()
+
+    step_bytes = len(json.dumps({"rows": _make_rows(rows_per_step), "columns": columns}))
+    return {
+        "label": label,
+        "report_id": str(report.id),
+        "artifact_id": str(artifact.id),
+        "rows_per_step": rows_per_step,
+        "step_mb": round(step_bytes / 1e6, 2),
+        "stored_mb": round(step_bytes * len(VIZ_SPECS) * N_STEP_VERSIONS / 1e6, 1),
+    }
+
+
+async def main():
+    async with async_session_maker() as db:
+        suffix = uuid.uuid4().hex[:8]
+        org = Organization(name=f"Perf Org {suffix}")
+        db.add(org)
+        await db.flush()
+        user = User(name="Perf User", email=f"perf-{suffix}@example.com",
+                    hashed_password="x", is_active=True, is_superuser=False,
+                    is_verified=True)
+        db.add(user)
+        await db.flush()
+
+        small = await seed_report(db, org, user, "small", ROWS_SMALL)
+        large = await seed_report(db, org, user, "large", ROWS_LARGE)
+        await db.commit()
+
+    for info in (small, large):
+        print(f"[seed] {info['label']:5} report: /r/{info['report_id']} "
+              f"(artifact {info['artifact_id']}, {info['rows_per_step']} rows/step, "
+              f"{info['step_mb']} MB/step, {info['stored_mb']} MB stored across versions)")
+    print(f"SMALL_REPORT_ID={small['report_id']}")
+    print(f"LARGE_REPORT_ID={large['report_id']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/e2e/test_artifact_large_data_perf_repro.py
+++ b/backend/tests/e2e/test_artifact_large_data_perf_repro.py
@@ -1,0 +1,343 @@
+"""
+Perf reproduction: public report/artifact pages ("/r/{id}") are extremely slow
+when the report's queries hold a lot of data.
+
+Reported symptom: on a published report with large datasets, the browser shows
+GET /r/{id} ~18s and GET /r/{id}/artifacts ~17s even though both responses are
+tiny (~1-2 kB), and the page stays on "Loading..." while each query's /step is
+fetched one at a time.
+
+Hypothesis being validated (all backend-side):
+
+  1. CASCADE — every relationship on Report (and Query/Step) is mapper-level
+     ``lazy="selectin"`` (app/models/report.py:58-75, query.py, step.py), so a
+     plain ``select(Report)`` eagerly loads the ENTIRE report graph: all
+     queries -> ALL step versions each carrying the full result rows in the
+     ``steps.data`` JSON column, all artifact versions with full content, all
+     completions, widgets, visualizations, ...
+
+  2. EVERY PUBLIC ENDPOINT PAYS IT — get_public_report / get_public_artifacts /
+     get_public_queries / get_public_step all start with ``select(Report)``
+     just to check ``artifact_visibility`` (report_service.py), so even the
+     tiny artifacts-list response hydrates every stored dataset. GET /r/{id}
+     additionally re-selects the Report a second time for fork eligibility
+     (routes/report.py:362) — the cascade runs twice in one request.
+
+  3. VERSION AMPLIFICATION — ``Query.steps`` (lazy="selectin") loads every
+     historical step version, each with a full copy of the dataset, although
+     only the default step's data is ever served.
+
+No LLM or live data source needed: the report graph is seeded directly.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      .venv/bin/python -m pytest tests/e2e/test_artifact_large_data_perf_repro.py -v -s
+
+Tune dataset size with BOW_REPRO_ROWS (rows per step version, default 15000).
+"""
+import asyncio
+import json
+import os
+import re
+import time
+import uuid
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.report import Report
+from app.models.widget import Widget
+from app.models.query import Query
+from app.models.step import Step
+from app.models.visualization import Visualization
+from app.models.artifact import Artifact
+
+
+ROWS_PER_STEP = int(os.environ.get("BOW_REPRO_ROWS", "15000"))
+N_QUERIES = 4
+N_STEP_VERSIONS = 3        # each query was re-run 3 times
+N_ARTIFACT_VERSIONS = 3    # dashboard was edited 3 times
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# SQL statement recorder — counts every statement the (single-process) app
+# executes, grouped by the first table in FROM.
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def record_sql():
+    statements = []
+
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(Engine, "before_cursor_execute", _before)
+    try:
+        yield statements
+    finally:
+        event.remove(Engine, "before_cursor_execute", _before)
+
+
+def _tables_hit(statements):
+    counts = {}
+    for s in statements:
+        m = re.search(r"FROM\s+(\w+)", s)
+        if m:
+            counts[m.group(1)] = counts.get(m.group(1), 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Seeding
+# ---------------------------------------------------------------------------
+
+def _make_rows(n):
+    return [
+        {
+            "order_id": i,
+            "customer_name": f"customer_{i % 997}",
+            "region": ("north", "south", "east", "west")[i % 4],
+            "product": f"product_{i % 251}",
+            "quantity": (i * 7) % 40 + 1,
+            "unit_price": round(3.5 + (i % 900) * 0.13, 2),
+            "revenue": round(((i * 7) % 40 + 1) * (3.5 + (i % 900) * 0.13), 2),
+            "order_date": f"2025-{(i % 12) + 1:02d}-{(i % 28) + 1:02d}",
+        }
+        for i in range(n)
+    ]
+
+
+async def _seed(rows_per_step: int):
+    """Seed a public report: N_QUERIES queries, each with N_STEP_VERSIONS
+    steps holding `rows_per_step` result rows in steps.data, plus
+    N_ARTIFACT_VERSIONS artifact versions."""
+    suffix = uuid.uuid4().hex[:8]
+    columns = [{"field": f} for f in _make_rows(1)[0].keys()]
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Perf Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        user = User(
+            name="Perf User",
+            email=f"perf-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        db.add(user)
+        await db.flush()
+
+        report = Report(
+            title=f"Perf Report {suffix}",
+            slug=f"perf-report-{suffix}",
+            status="published",
+            artifact_visibility="public",
+            user_id=user.id,
+            organization_id=org.id,
+        )
+        db.add(report)
+        await db.flush()
+
+        query_ids, viz_ids = [], []
+        for qi in range(N_QUERIES):
+            widget = Widget(
+                title=f"W{qi} {suffix}",
+                slug=f"w{qi}-{suffix}",
+                report_id=report.id,
+            )
+            db.add(widget)
+            await db.flush()
+
+            query = Query(
+                title=f"Query {qi}",
+                report_id=report.id,
+                widget_id=widget.id,
+                organization_id=org.id,
+                user_id=user.id,
+            )
+            db.add(query)
+            await db.flush()
+
+            last_step = None
+            for si in range(N_STEP_VERSIONS):
+                step = Step(
+                    title=f"Step {qi}.{si}",
+                    slug=f"s{qi}-{si}-{suffix}",
+                    status="success",
+                    widget_id=widget.id,
+                    query_id=query.id,
+                    data={"rows": _make_rows(rows_per_step), "columns": columns},
+                    data_model={"type": "bar_chart", "columns": columns},
+                    view={"type": "bar_chart"},
+                )
+                db.add(step)
+                last_step = step
+            await db.flush()
+            query.default_step_id = last_step.id
+
+            viz = Visualization(
+                title=f"Viz {qi}",
+                status="success",
+                report_id=report.id,
+                query_id=query.id,
+                view={"type": "bar_chart"},
+            )
+            db.add(viz)
+            await db.flush()
+            query_ids.append(str(query.id))
+            viz_ids.append(str(viz.id))
+
+        # a realistic generated dashboard: ~100 kB of JSX per artifact version
+        fake_code = "function Dashboard() {\n" + ("  // chart section filler line of jsx code\n" * 2500) + "}\n"
+        for vi in range(N_ARTIFACT_VERSIONS):
+            db.add(Artifact(
+                report_id=report.id,
+                user_id=user.id,
+                organization_id=org.id,
+                title="Dashboard",
+                mode="page",
+                version=vi + 1,
+                content={"code": fake_code, "visualization_ids": viz_ids},
+                status="completed",
+            ))
+
+        await db.commit()
+
+        step_bytes = len(json.dumps({"rows": _make_rows(rows_per_step), "columns": columns}))
+        return {
+            "report_id": str(report.id),
+            "query_ids": query_ids,
+            "viz_ids": viz_ids,
+            "step_bytes": step_bytes,
+            "total_step_bytes": step_bytes * N_QUERIES * N_STEP_VERSIONS,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Claim 1 + 3: a plain select(Report) hydrates every dataset & every version
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_plain_select_report_cascades_all_step_data():
+    async def scenario():
+        seeded = await _seed(ROWS_PER_STEP)
+
+        async with async_session_maker() as db:
+            with record_sql() as statements:
+                t0 = time.perf_counter()
+                res = await db.execute(select(Report).where(Report.id == seeded["report_id"]))
+                report = res.scalar_one()
+                elapsed = time.perf_counter() - t0
+
+        tables = _tables_hit(statements)
+
+        # Everything below was already loaded by the cascade — no further IO.
+        loaded_steps = [s for q in report.queries for s in q.steps]
+        hydrated_bytes = sum(len(json.dumps(s.data)) for s in loaded_steps if "data" in s.__dict__)
+        artifact_bytes = sum(len(json.dumps(a.content)) for a in report.artifacts)
+
+        print(f"\n[cascade] select(Report) issued {len(statements)} SQL statements in {elapsed:.2f}s")
+        print(f"[cascade] tables hit: {dict(sorted(tables.items(), key=lambda kv: -kv[1]))}")
+        print(f"[cascade] steps hydrated: {len(loaded_steps)} "
+              f"(= {N_QUERIES} queries x {N_STEP_VERSIONS} versions; only {N_QUERIES} default steps are ever served)")
+        print(f"[cascade] step data hydrated: {hydrated_bytes / 1e6:.1f} MB; "
+              f"artifact content: {artifact_bytes / 1e6:.1f} MB")
+
+        # Claim 1: the steps table (with its data column) is pulled by a bare Report select
+        assert tables.get("steps", 0) >= 1
+        assert len(statements) > 10, "expected a selectin cascade, got a simple query"
+        # Claim 3: ALL versions load, not just the default step
+        assert len(loaded_steps) == N_QUERIES * N_STEP_VERSIONS
+        assert hydrated_bytes >= seeded["total_step_bytes"] * 0.9
+
+    _run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# Claim 2: every public /r endpoint pays the cascade; timings scale with the
+# stored dataset size even though the responses stay tiny.
+# ---------------------------------------------------------------------------
+
+def _fetch_public_page(client, report_id, query_ids):
+    """Replicate the browser waterfall of frontend/pages/r/[id]/index.vue and
+    return {endpoint: (seconds, response_bytes, n_sql, steps_sql)}."""
+    timings = {}
+
+    def timed(label, url):
+        with record_sql() as stmts:
+            t0 = time.perf_counter()
+            resp = client.get(url)
+            dt = time.perf_counter() - t0
+        assert resp.status_code == 200, f"{url} -> {resp.status_code}: {resp.text[:200]}"
+        timings[label] = (dt, len(resp.content), len(stmts), _tables_hit(stmts).get("steps", 0))
+        return resp
+
+    timed("GET /r/{id}", f"/api/r/{report_id}")
+    artifacts = timed("GET /r/{id}/artifacts", f"/api/r/{report_id}/artifacts").json()
+    artifact_id = artifacts[0]["id"]
+    timed("GET /r/{id}/artifacts/{aid}", f"/api/r/{report_id}/artifacts/{artifact_id}")
+    timed("GET /r/{id}/queries", f"/api/r/{report_id}/queries?artifact_id={artifact_id}")
+    # the frontend awaits each step sequentially (for-loop in loadVisualizationData)
+    t0 = time.perf_counter()
+    n_sql = steps_sql = size = 0
+    with record_sql() as stmts:
+        for qid in query_ids:
+            r = client.get(f"/api/r/{report_id}/queries/{qid}/step")
+            assert r.status_code == 200
+            size += len(r.content)
+    timings[f"{len(query_ids)} serial /step calls"] = (
+        time.perf_counter() - t0, size, len(stmts), _tables_hit(stmts).get("steps", 0))
+    return timings
+
+
+@pytest.mark.e2e
+def test_public_endpoints_scale_with_stored_step_data(test_client):
+    small = _run(_seed(rows_per_step=10))
+    large = _run(_seed(rows_per_step=ROWS_PER_STEP))
+
+    small_t = _fetch_public_page(test_client, small["report_id"], small["query_ids"])
+    large_t = _fetch_public_page(test_client, large["report_id"], large["query_ids"])
+
+    print(f"\n[endpoints] per-step dataset: small={small['step_bytes']/1e3:.0f} kB, "
+          f"large={large['step_bytes']/1e6:.1f} MB "
+          f"({N_QUERIES} queries x {N_STEP_VERSIONS} step versions stored)")
+    header = f"{'endpoint':38} {'small':>9} {'large':>9} {'ratio':>7} {'resp(large)':>12} {'SQL':>5} {'steps-SQL':>9}"
+    print("[endpoints] " + header)
+    for label in small_t:
+        s_dt, _, _, _ = small_t[label]
+        l_dt, l_size, l_sql, l_steps_sql = large_t[label]
+        ratio = l_dt / s_dt if s_dt > 0 else float("inf")
+        print(f"[endpoints] {label:38} {s_dt*1000:7.0f}ms {l_dt*1000:7.0f}ms {ratio:6.1f}x "
+              f"{l_size/1e3:10.1f}kB {l_sql:5d} {l_steps_sql:9d}")
+
+    total_small = sum(v[0] for v in small_t.values())
+    total_large = sum(v[0] for v in large_t.values())
+    print(f"[endpoints] full page waterfall: small={total_small*1000:.0f}ms large={total_large*1000:.0f}ms")
+
+    # The artifacts LIST returns a tiny payload yet its latency scales with the
+    # stored step data (the visibility check's select(Report) cascade).
+    l_dt, l_size, l_sql, l_steps_sql = large_t["GET /r/{id}/artifacts"]
+    s_dt = small_t["GET /r/{id}/artifacts"][0]
+    assert l_size < 5_000, "artifacts list response should be tiny"
+    assert l_steps_sql >= 1, "artifacts list should not touch steps at all — cascade proven if it does"
+    assert l_dt > s_dt * 3, (
+        f"artifacts list latency should scale with stored data if the cascade exists "
+        f"(small={s_dt*1000:.0f}ms large={l_dt*1000:.0f}ms)")
+
+    # GET /r/{id} runs the cascade twice (service + fork-eligibility re-select)
+    r_sql = large_t["GET /r/{id}"][2]
+    a_sql = large_t["GET /r/{id}/artifacts"][2]
+    print(f"[endpoints] GET /r/{{id}} SQL statements: {r_sql} (~2x the artifacts list's {a_sql}: cascade runs twice)")

--- a/backend/tests/e2e/test_artifact_large_data_perf_repro.py
+++ b/backend/tests/e2e/test_artifact_large_data_perf_repro.py
@@ -1,6 +1,13 @@
 """
-Perf reproduction: public report/artifact pages ("/r/{id}") are extremely slow
-when the report's queries hold a lot of data.
+Perf reproduction + regression guard: public report/artifact pages
+("/r/{id}") were extremely slow when the report's queries hold a lot of data.
+
+Now that the public endpoints (report_service.py) and the permission
+decorator use lazyload("*") whitelists, test_public_endpoints_* asserts the
+FIXED behavior: metadata endpoints never touch steps.data, and only the
+served step row is ever hydrated. test_plain_select_* still documents the
+mapper-level hazard (a bare select(Report) cascades) — that is WHY the
+endpoints must opt out explicitly.
 
 Reported symptom: on a published report with large datasets, the browser shows
 GET /r/{id} ~18s and GET /r/{id}/artifacts ~17s even though both responses are
@@ -327,17 +334,26 @@ def test_public_endpoints_scale_with_stored_step_data(test_client):
     total_large = sum(v[0] for v in large_t.values())
     print(f"[endpoints] full page waterfall: small={total_small*1000:.0f}ms large={total_large*1000:.0f}ms")
 
-    # The artifacts LIST returns a tiny payload yet its latency scales with the
-    # stored step data (the visibility check's select(Report) cascade).
-    l_dt, l_size, l_sql, l_steps_sql = large_t["GET /r/{id}/artifacts"]
+    # --- REGRESSION GUARDS (post-fix behavior) ---------------------------
+    # The public endpoints use lazyload("*") whitelists (report_service.py),
+    # so metadata endpoints must never hydrate steps.data.
+    for label in ("GET /r/{id}", "GET /r/{id}/artifacts",
+                  "GET /r/{id}/artifacts/{aid}", "GET /r/{id}/queries"):
+        assert large_t[label][3] == 0, (
+            f"{label} queried the steps table {large_t[label][3]}x — the "
+            f"lazy='selectin' cascade is back; it must not load step data")
+
+    # The step endpoint serves exactly ONE step per call (the default one),
+    # never every historical version of every query.
+    step_label = f"{len(large['query_ids'])} serial /step calls"
+    assert large_t[step_label][3] == len(large["query_ids"]), (
+        f"expected 1 steps SELECT per /step call, got {large_t[step_label][3]}")
+
+    # The artifacts LIST returns a tiny payload and its latency must no
+    # longer scale with the stored step data.
+    l_dt, l_size, l_sql, _ = large_t["GET /r/{id}/artifacts"]
     s_dt = small_t["GET /r/{id}/artifacts"][0]
     assert l_size < 5_000, "artifacts list response should be tiny"
-    assert l_steps_sql >= 1, "artifacts list should not touch steps at all — cascade proven if it does"
-    assert l_dt > s_dt * 3, (
-        f"artifacts list latency should scale with stored data if the cascade exists "
-        f"(small={s_dt*1000:.0f}ms large={l_dt*1000:.0f}ms)")
-
-    # GET /r/{id} runs the cascade twice (service + fork-eligibility re-select)
-    r_sql = large_t["GET /r/{id}"][2]
-    a_sql = large_t["GET /r/{id}/artifacts"][2]
-    print(f"[endpoints] GET /r/{{id}} SQL statements: {r_sql} (~2x the artifacts list's {a_sql}: cascade runs twice)")
+    assert l_dt < max(s_dt * 3, 0.5), (
+        f"artifacts list latency scales with stored data again "
+        f"(small={s_dt*1000:.0f}ms large={l_dt*1000:.0f}ms) — cascade regression")

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -782,12 +782,18 @@ async function fetchData(artifactId?: string) {
     const { data: queriesRes } = await useMyFetch(`/api/queries${queryParams}`);
     const queries = Array.isArray(queriesRes.value) ? queriesRes.value : [];
 
+    // Fetch all default steps in parallel — awaiting each one serially made
+    // load time scale linearly with the number of queries.
+    const stepResults = await Promise.all(
+      queries.map((query: any) => useMyFetch(`/api/queries/${query.id}/default_step`))
+    );
+
     // Build visualization data array
     const vizData: any[] = [];
 
-    for (const query of queries) {
-      // Fetch default step for this query
-      const { data: stepRes } = await useMyFetch(`/api/queries/${query.id}/default_step`);
+    for (let qi = 0; qi < queries.length; qi++) {
+      const query = queries[qi];
+      const { data: stepRes } = stepResults[qi];
       const step = (stepRes.value as any)?.step;
 
       // Process each visualization in the query

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -372,10 +372,17 @@ async function loadVisualizationData(artifactId?: string) {
         const { data: queriesRes } = await useMyFetch(`/api/r/${report_id}/queries${queryParams}`);
         const queries = Array.isArray(queriesRes.value) ? queriesRes.value : [];
 
+        // Fetch all steps in parallel — awaiting each one serially made the
+        // page's time-to-render scale linearly with the number of queries.
+        const stepResults = await Promise.all(
+            queries.map((query) => useMyFetch(`/api/r/${report_id}/queries/${(query as any).id}/step`))
+        );
+
         const vizData = [];
-        for (const query of queries) {
-            // Use public step endpoint - returns PublicStepSchema directly
-            const { data: step } = await useMyFetch(`/api/r/${report_id}/queries/${query.id}/step`);
+        for (let qi = 0; qi < queries.length; qi++) {
+            const query = queries[qi];
+            // Public step endpoint - returns PublicStepSchema directly
+            const { data: step } = stepResults[qi];
 
             // Process each visualization in the query (matches ArtifactFrame.vue structure)
             const visualizations = (query as any).visualizations || [];

--- a/sandbox-feedback-loop-artifact-large-data-perf.md
+++ b/sandbox-feedback-loop-artifact-large-data-perf.md
@@ -1,0 +1,150 @@
+# Sandbox Feedback Loop — Public report/artifact pages extremely slow with large data
+
+Reproduces the reported issue: opening a published report (`/r/{id}`) whose
+queries hold a lot of data is **extremely slow** — in the reported trace,
+`GET /r/{id}` took **18.4 s** and `GET /r/{id}/artifacts` **17.6 s** even though
+both responses are ~1–2 kB, and the page then sits on "Loading..." while each
+query's `/step` is fetched one at a time.
+
+This doc is the runnable feedback loop used to confirm the root cause in a
+fresh cloud sandbox.
+
+---
+
+## Root cause (validated)
+
+Three independent behaviors combine:
+
+1. **Mapper-level selectin cascade.** Every relationship on `Report` is
+   `lazy="selectin"` (`backend/app/models/report.py:58-75`), and so are
+   `Query.steps` / `Query.default_step` / `Step.query`
+   (`query.py:26-27`, `step.py:41`). A plain `select(Report)` therefore eagerly
+   hydrates the **entire report graph**: all queries → **all step versions**,
+   each carrying the full query result rows in the `steps.data` JSON column —
+   plus every artifact version's content, all completions, widgets,
+   visualizations, shares, stars, …
+
+2. **Every public endpoint pays it — including the visibility check.**
+   `get_public_report`, `get_public_artifacts`, `get_public_artifact`,
+   `get_public_queries` and `get_public_step`
+   (`backend/app/services/report_service.py:875-1068`) each begin with
+   `select(Report)` **just to check `artifact_visibility`**, so even the tiny
+   artifacts-list response hydrates every stored dataset. `GET /r/{id}`
+   additionally re-selects the `Report` a second time for fork eligibility
+   (`backend/app/routes/report.py:362`) — the cascade runs **twice** in one
+   request. All of this JSON hydration is CPU-bound Python on the asyncio
+   event loop, so concurrent requests stall each other too.
+
+3. **Version amplification + serial frontend waterfall.** `Query.steps` loads
+   **every historical step version** (each a full copy of the dataset) though
+   only the default step is ever served; and the public page fetches each
+   query's `/step` **sequentially** in a for-loop
+   (`frontend/pages/r/[id]/index.vue:376-378`), multiplying the per-request
+   cascade by the number of queries before anything renders (`dataReady`
+   gates the iframe).
+
+---
+
+## Environment setup (fresh sandbox)
+
+The app targets **Python 3.12** (the sandbox default `python` may be 3.11).
+
+```bash
+cd backend
+pip install uv
+uv sync --frozen --extra dev --python /usr/bin/python3.12
+
+# Required by bow-config.dev.yaml (database.url: ${BOW_DATABASE_URL})
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+mkdir -p db
+```
+
+Tests run on SQLite by default; the autouse `run_migrations` fixture builds the
+schema per test (`tests/conftest.py`).
+
+---
+
+## Loop — App-logic reproduction (no LLM / live data source needed)
+
+Self-contained: seeds a **public** report with 4 queries × 3 step versions
+(each version storing ~2.7 MB of result rows in `steps.data`, i.e. what "an
+artifact with a lot of data" looks like) plus 3 artifact versions, then
+
+- runs a bare `select(Report)` under a SQL recorder (Claims 1 & 3), and
+- replays the exact browser waterfall of `frontend/pages/r/[id]/index.vue`
+  against the public endpoints, timing each request and counting SQL
+  (Claim 2), against both a small and a large report of identical shape.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+.venv/bin/python -m pytest tests/e2e/test_artifact_large_data_perf_repro.py -v -s
+# dataset size per step version is tunable: BOW_REPRO_ROWS=30000 ... (default 15000)
+```
+
+**Observed (PASS) — cascade (Claims 1 & 3):**
+
+```
+[cascade] select(Report) issued 40 SQL statements in 2.27s
+[cascade] tables hit: {'steps': 7, 'entities': 7, 'external_user_mappings': 5,
+  'reports': 3, 'queries': 3, 'visualizations': 3, 'widgets': 3, 'artifacts': 1,
+  'scheduled_prompts': 1, 'report_shares': 1, 'report_stars': 1, 'text_widgets': 1,
+  'completions': 1, 'dashboard_layout_versions': 1, 'users': 1, 'organizations': 1}
+[cascade] steps hydrated: 12 (= 4 queries x 3 versions; only 4 default steps are ever served)
+[cascade] step data hydrated: 32.6 MB; artifact content: 0.3 MB
+```
+
+A one-row `select(Report)` fans out to 40 statements and hydrates **32.6 MB**
+of step data — 3× more than needed even if data were wanted, because all
+historical versions load.
+
+**Observed (PASS) — endpoints (Claim 2), small vs large report:**
+
+```
+[endpoints] per-step dataset: small=2 kB, large=2.7 MB (4 queries x 3 step versions stored)
+[endpoints] endpoint                                   small     large   ratio  resp(large)   SQL steps-SQL
+[endpoints] GET /r/{id}                                417ms    4563ms   10.9x        1.9kB    81        14
+[endpoints] GET /r/{id}/artifacts                      173ms    4498ms   26.0x        0.7kB    80        14
+[endpoints] GET /r/{id}/artifacts/{aid}                128ms    4500ms   35.1x      110.6kB    80        14
+[endpoints] GET /r/{id}/queries                        234ms    6560ms   28.0x        1.2kB   126        19
+[endpoints] 4 serial /step calls                       794ms   13824ms   17.4x     9902.6kB   488        52
+[endpoints] full page waterfall: small=1746ms large=33945ms
+[endpoints] GET /r/{id} SQL statements: 81 (~2x the artifacts list's 80: cascade runs twice)
+```
+
+This is on **local SQLite with zero network latency** — the same page load is
+**1.7 s** for a small report and **34 s** for the large one, matching the
+reported trace shape exactly: the **0.7 kB** artifacts-list response takes
+**4.5 s** (reported: 1.2 kB / 17.6 s on production Postgres), and each request
+re-queries the `steps` table 14–19 times.
+
+---
+
+## What this proves
+
+- The slowness is **not** the artifact payloads or the network: responses are
+  tiny; the time is server-side hydration of `steps.data` (and artifact/
+  completion history) triggered by any `select(Report)`.
+- **Every** `/r/{id}/*` endpoint pays the full cascade — even the pure
+  visibility check — and `GET /r/{id}` pays it twice.
+- All step **versions** load (N× data duplication), and the frontend's serial
+  `/step` loop multiplies the cascade by the number of queries before render.
+
+## Candidate fix (not yet implemented — for discussion)
+
+1. Remove the mapper-level `lazy="selectin"` defaults on
+   `Report`/`Query`/`Step` relationships (use lazy `select`/`raiseload` and
+   opt in per-endpoint with explicit `selectinload()` where genuinely needed).
+2. Mark `Step.data` as a `deferred()` column so result rows load only where
+   they are actually served (`get_public_step`, step detail routes).
+3. Make `_check_visibility` / fork-eligibility read only the columns they need
+   (`artifact_visibility`, `user_id`, `organization_id`) instead of hydrating
+   a full `Report`.
+4. Frontend: fetch steps with `Promise.all` (or a batch endpoint) instead of
+   the serial for-loop, and consider capping rows inlined into the iframe
+   `srcdoc` (`frontend/utils/artifactIframe.ts:48`).
+
+Items 1–3 should take the 4.5–18 s requests to milliseconds; the repro's
+assertions (`artifacts list latency scales with stored data`,
+`steps hydrated == queries × versions`) are written to **fail once the fix
+lands**, flipping this loop into a regression test.

--- a/sandbox-feedback-loop-artifact-large-data-perf.md
+++ b/sandbox-feedback-loop-artifact-large-data-perf.md
@@ -64,7 +64,7 @@ schema per test (`tests/conftest.py`).
 
 ---
 
-## Loop — App-logic reproduction (no LLM / live data source needed)
+## Loop A — App-logic reproduction (no LLM / live data source needed)
 
 Self-contained: seeds a **public** report with 4 queries × 3 step versions
 (each version storing ~2.7 MB of result rows in `steps.data`, i.e. what "an
@@ -120,11 +120,74 @@ re-queries the `steps` table 14–19 times.
 
 ---
 
+## Loop B — Live browser reproduction (backend + frontend + Playwright)
+
+Runs the real stack and drives the public report page in headless Chromium,
+recording exactly what the reporter's DevTools screenshot shows: tiny
+responses, multi-second latencies, and a long "Loading..." before the
+artifact appears. The artifact is REAL — generated with the app's own
+codegen (`app/services/artifact_codegen.py`, same path as the
+"add visualization to dashboard" endpoint) and renders 4 ECharts from
+`window.ARTIFACT_DATA`.
+
+```bash
+# 1. Backend (fresh dev DB + seed two public reports: small=50 rows/step,
+#    large=15000 rows/step; both 4 queries x 3 step versions + 1 artifact)
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+rm -f db/app.db && .venv/bin/python -m alembic upgrade head
+.venv/bin/python scripts/seed_artifact_perf_repro.py   # prints SMALL/LARGE_REPORT_ID
+.venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port 8000 &
+
+# 2. Frontend (proxies /api -> :8000) + vendored iframe libs
+#    (React/Babel/ECharts are not in-repo; without them the artifact iframe
+#    stays on "Loading..." forever)
+bash scripts/download-vendor-libs.sh frontend/public/libs
+cd frontend && yarn install && yarn dev &
+
+# 3. Playwright (uses the sandbox's preinstalled Chromium)
+npm i playwright-core   # anywhere; pass via NODE_PATH
+NODE_PATH=<that>/node_modules FRONT=http://localhost:3000 \
+  SMALL=<id> LARGE=<id> OUT=/tmp/pw \
+  node backend/scripts/pw_artifact_perf_repro.js
+```
+
+**Observed (browser-side, headless Chromium against the dev stack):**
+
+```
+=== small report ===  iframe (all API data fetched): 4649 ms, charts rendered: 4973 ms
+=== large report ===  iframe (all API data fetched): 37064 ms, charts rendered: 59184 ms
+api requests (large; sorted by duration — compare with the reported DevTools trace):
+     9080 ms  200        0.3 kB  /api/r/{id}/artifacts
+     9043 ms  200        1.8 kB  /api/r/{id}
+     6339 ms  200        1.3 kB  /api/r/{id}/queries?artifact_id={uuid}
+     4566 ms  200        3.7 kB  /api/r/{id}/artifacts/{uuid}
+     4188 ms  200     2388.4 kB  /api/r/{id}/queries/{uuid}/step
+     3404 ms  200     2388.4 kB  /api/r/{id}/queries/{uuid}/step
+     3329 ms  200     2388.4 kB  /api/r/{id}/queries/{uuid}/step
+     3295 ms  200     2388.4 kB  /api/r/{id}/queries/{uuid}/step
+=== summary ===
+time to artifact iframe: small=4649 ms, large=37064 ms (8.0x slower)
+```
+
+Same fingerprint as the report: `GET /r/{id}` **9.0 s for 1.8 kB** and the
+artifacts list **9.1 s for 0.3 kB** (reported: 18.4 s / 2.2 kB and
+17.6 s / 1.2 kB on production Postgres + network — this sandbox runs SQLite
+on localhost, so production is ~2x worse). The page sits on "Loading..."
+until report + artifacts + every query's `/step` complete, then spends
+**another ~22 s** parsing/rendering the ~10 MB of rows inlined into the
+iframe `srcdoc` before the charts paint (59 s total; the small report paints
+at 5 s).
+
+---
+
 ## What this proves
 
 - The slowness is **not** the artifact payloads or the network: responses are
   tiny; the time is server-side hydration of `steps.data` (and artifact/
-  completion history) triggered by any `select(Report)`.
+  completion history) triggered by any `select(Report)`. The artifact itself
+  never uses that data — its endpoints return metadata/code only, yet a real
+  browser sees them take ~9 s each (Loop B).
 - **Every** `/r/{id}/*` endpoint pays the full cascade — even the pure
   visibility check — and `GET /r/{id}` pays it twice.
 - All step **versions** load (N× data duplication), and the frontend's serial

--- a/sandbox-feedback-loop-artifact-large-data-perf.md
+++ b/sandbox-feedback-loop-artifact-large-data-perf.md
@@ -193,21 +193,80 @@ at 5 s).
 - All step **versions** load (N× data duplication), and the frontend's serial
   `/step` loop multiplies the cascade by the number of queries before render.
 
-## Candidate fix (not yet implemented — for discussion)
+## The fix (implemented, validated below)
 
-1. Remove the mapper-level `lazy="selectin"` defaults on
-   `Report`/`Query`/`Step` relationships (use lazy `select`/`raiseload` and
-   opt in per-endpoint with explicit `selectinload()` where genuinely needed).
-2. Mark `Step.data` as a `deferred()` column so result rows load only where
-   they are actually served (`get_public_step`, step detail routes).
-3. Make `_check_visibility` / fork-eligibility read only the columns they need
-   (`artifact_visibility`, `user_id`, `organization_id`) instead of hydrating
-   a full `Report`.
-4. Frontend: fetch steps with `Promise.all` (or a batch endpoint) instead of
-   the serial for-loop, and consider capping rows inlined into the iframe
-   `srcdoc` (`frontend/utils/artifactIframe.ts:48`).
+The mapper-level `lazy="selectin"` defaults are left in place (too many
+consumers to audit in one change); instead, every hot path opts out with
+`lazyload("*")` whitelists — the same pattern `get_reports` already used:
 
-Items 1–3 should take the 4.5–18 s requests to milliseconds; the repro's
-assertions (`artifacts list latency scales with stored data`,
-`steps hydrated == queries × versions`) are written to **fail once the fix
-lands**, flipping this loop into a regression test.
+1. **Public `/r` endpoints** (`report_service.py`): every `select(Report)`
+   visibility check, `select(Query)`, `select(Step)` and `select(Artifact)`
+   now carries `lazyload("*")`; `get_public_report` explicitly whitelists
+   only what `ReportSchema` serializes (user+external_user_mappings,
+   external_platform, widgets, dashboard_layout_versions,
+   data_sources→connections). `get_public_queries` loads only
+   `Query.visualizations`.
+2. **Fork-eligibility re-selects** (`routes/report.py`): `lazyload("*")` +
+   data_sources→connections only.
+3. **Authed `get_report`** (`report_service.py`): same whitelist, and the
+   sidebar summary counts (`query_count`, `artifact_count`,
+   `scheduled_prompt_count`) are now `COUNT(*)` queries instead of
+   `len(relationship)` — counting queries used to hydrate every step
+   version's data.
+4. **`ArtifactService.get/list_by_report/get_latest_by_report`**
+   (`artifact_service.py`): `lazyload("*")` — `Artifact.report` cascaded the
+   whole graph back in on every artifact fetch.
+5. **`@requires_permission` decorator** (`permissions_decorator.py`): the
+   object check (`select(model)`) reads scalar columns only, now with
+   `lazyload("*")` — this removed the cascade from EVERY authed
+   object-scoped route.
+6. **Frontend waterfall**: `pages/r/[id]/index.vue` and
+   `components/dashboard/ArtifactFrame.vue` fetch all step data with
+   `Promise.all` instead of a serial `for`-loop.
+
+### Result — Loop A (same run, after fix)
+
+```
+[endpoints] endpoint                                   small     large   ratio  resp(large)   SQL steps-SQL
+[endpoints] GET /r/{id}                                261ms      22ms    0.1x        1.9kB     9         0
+[endpoints] GET /r/{id}/artifacts                       18ms      12ms    0.7x        0.7kB     2         0
+[endpoints] GET /r/{id}/artifacts/{aid}                 13ms      12ms    0.9x      110.6kB     2         0
+[endpoints] GET /r/{id}/queries                         18ms      16ms    0.9x        1.2kB     5         0
+[endpoints] 4 serial /step calls                        50ms     228ms    4.5x     9902.6kB    12         4
+[endpoints] full page waterfall: small=362ms large=289ms   (was 33945ms)
+```
+
+The artifacts list went **4498 ms → 12 ms**; metadata endpoints no longer
+touch the `steps` table at all (steps-SQL 0), and `/step` hydrates exactly
+one step row per call (4, not 52). The test's assertions now guard this
+fixed behavior and fail if the cascade comes back.
+
+### Result — Loop B (real browser, after fix)
+
+```
+=== large report ===  iframe (all API data fetched): 3879 ms (was 37064), charts rendered: 32189 ms (was 59184)
+      1347 ms  200   2388.4 kB  /api/r/{id}/queries/{uuid}/step   (now parallel)
+       315 ms  200   2388.4 kB  /api/r/{id}/queries/{uuid}/step
+       252 ms  200   2388.4 kB  /api/r/{id}/queries/{uuid}/step
+       186 ms  200   2388.4 kB  /api/r/{id}/queries/{uuid}/step
+        43 ms  200      3.7 kB  /api/r/{id}/artifacts/{aid}       (was 4566 ms)
+        38 ms  200      1.8 kB  /api/r/{id}                       (was 9043 ms)
+        30 ms  200      1.3 kB  /api/r/{id}/queries               (was 6339 ms)
+        28 ms  200      0.3 kB  /api/r/{id}/artifacts             (was 9080 ms)
+=== summary ===
+time to artifact iframe: small=3186 ms, large=3879 ms (1.2x slower — was 8.0x)
+```
+
+Regression check: `tests/e2e/test_report.py test_public_routes.py
+test_report_sharing.py test_report_starring.py` (45 passed),
+`test_rbac.py + rbac/` (125 passed), `test_rbac_policies.py` (9 passed,
+6 skipped — pre-existing skips).
+
+### Known remaining cost (out of scope here)
+
+With the API fixed, the large report still takes ~28 s of pure browser time
+between "data fetched" and "charts painted": all raw rows (~10 MB) are
+inlined into the iframe `srcdoc` (`frontend/utils/artifactIframe.ts:48`) and
+re-parsed/Babel-transformed inside the iframe. Fixing that means changing the
+artifact data contract (aggregate server-side, cap rows, or postMessage
+chunks) — a product decision to take separately.


### PR DESCRIPTION
## Problem

Opening a published report (`/r/{id}`) whose queries hold a lot of data was extremely slow: in the reported trace, `GET /r/{id}` took **18.4 s** and `GET /r/{id}/artifacts` **17.6 s** even though both responses are ~1–2 kB, and the page sat on "Loading..." while each query's `/step` was fetched one at a time.

## Root cause

Every relationship on `Report` (and `Query.steps` / `Step.query` / `Artifact.report`) is mapper-level `lazy="selectin"`, so **any** `select(Report)` eagerly hydrates the entire report graph — every step version's result rows (`steps.data` JSON), every artifact version's content, the chat history. Every public `/r` endpoint (and the `@requires_permission` decorator on authed routes) ran exactly that query just to check one column (`artifact_visibility` / ownership), and `GET /r/{id}` ran it twice (fork-eligibility re-select). On top of that, the frontend fetched each query's step **serially**.

Full runnable analysis + repro: `sandbox-feedback-loop-artifact-large-data-perf.md`.

## Fix

The mapper defaults are left in place (too many consumers to audit at once); hot paths opt out with `lazyload("*")` whitelists — the same pattern `get_reports` already used:

- **Public `/r` endpoints** (`report_service.py`): visibility checks load the report row only; `get_public_report` whitelists exactly what `ReportSchema` serializes; query/step/artifact lookups no longer cascade back through `.report`.
- **Fork-eligibility re-selects** (`routes/report.py`): only `data_sources → connections`.
- **Authed `get_report`**: same whitelist; sidebar counts now use `COUNT(*)` instead of `len(relationship)`.
- **`ArtifactService.get/list_by_report/get_latest_by_report`**: artifact columns only.
- **`@requires_permission` decorator**: the org/ownership object check reads scalar columns — removes the cascade from every authed object-scoped route.
- **Frontend** (`pages/r/[id]/index.vue`, `ArtifactFrame.vue`): step data fetched with `Promise.all` instead of a serial for-loop.

## Benchmarks (seeded report: 4 queries × 3 step versions × 2.7 MB, local SQLite)

| measurement | before | after |
|---|---|---|
| GET /r/{id} (browser-observed) | 9,043 ms | 38 ms |
| GET /r/{id}/artifacts (0.3 kB response) | 9,080 ms | 28 ms |
| time until artifact iframe has all data | 37.1 s | 3.9 s |
| full public-page API waterfall (pytest) | 33.9 s | 289 ms |
| steps-table SELECTs per metadata request | 14–19 | 0 |

Measured two ways, both included in the repo:
- `tests/e2e/test_artifact_large_data_perf_repro.py` — seeds the graph, replays the page's request waterfall, counts SQL per endpoint. Its assertions now **guard the fixed behavior** (metadata endpoints issue zero `steps` selects; `/step` hydrates exactly one row per call) and fail if the cascade returns.
- `backend/scripts/seed_artifact_perf_repro.py` + `backend/scripts/pw_artifact_perf_repro.js` — live loop: real backend + Nuxt + headless Chromium driving `/r/{id}` with a real codegen-generated artifact (4 ECharts).

## Tests

- `test_artifact_large_data_perf_repro.py` (2 passed — regression guards)
- `test_report.py`, `test_public_routes.py`, `test_report_sharing.py`, `test_report_starring.py` (45 passed)
- `test_rbac.py` + `rbac/` (125 passed), `test_rbac_policies.py` (9 passed, 6 pre-existing skips)

## Known remaining cost (follow-up)

With the API fast, a large report still spends ~28 s of pure browser time rendering: all raw rows (~10 MB) are inlined into the iframe `srcdoc` and re-parsed inside it. Proposed follow-up (discussed, not in this PR): deliver viz data lazily per visualization over `postMessage` (the MCP artifact runtime already works this way) + a row cap on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN6v7M2RKXLmrRSQJ2pQ24

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN6v7M2RKXLmrRSQJ2pQ24)_