### PR TITLE
SQL Server Kerberos SSO: service-account auth + per-user constrained delegation (S4U2Proxy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
       libpq-dev \
       gcc \
       unixodbc-dev \
+      libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container for the backend
@@ -28,8 +29,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /usr/local/bin/uv
 
-# Install locked main deps into the venv; dev group excluded from image
-RUN UV_PROJECT_ENVIRONMENT=/opt/venv uv sync --frozen --no-dev --no-install-project
+# Install locked main deps into the venv; dev group excluded from image.
+# The kerberos extra (python-gssapi) enables per-user constrained delegation
+# (S4U) for on-prem SQL Server SSO; it builds against libkrb5-dev above.
+RUN UV_PROJECT_ENVIRONMENT=/opt/venv uv sync --frozen --no-dev --no-install-project --extra kerberos
 
 # Copy the full backend source after deps are installed
 COPY ./backend /app/backend
@@ -113,6 +116,10 @@ ENV PIP_NO_CACHE_DIR=1 \
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg git openssh-client python3 python3-venv tini libpq5 vim-tiny && \
+    # Kerberos runtime for Windows Integrated auth to SQL Server: GSSAPI libs
+    # for the ODBC driver / python-gssapi, plus kinit/klist for keytab ops.
+    # Mount /etc/krb5.conf and a keytab (see docs/sql-server-kerberos.md).
+    apt-get install -y --no-install-recommends krb5-user libgssapi-krb5-2 && \
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg && \
     ARCH="$(dpkg --print-architecture)" && \
     echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" > /etc/apt/sources.list.d/microsoft-prod-24.04.list && \

--- a/backend/app/data_sources/clients/mssql_client.py
+++ b/backend/app/data_sources/clients/mssql_client.py
@@ -17,14 +17,17 @@ class MSSQLClient(DataSourceClient):
     SUPPORTED_ODBC_DRIVERS = {17, 18}
     # ODBC keywords the client owns; user-supplied additional params can never
     # override these (case-insensitive), so the escape hatch can't weaken TLS,
-    # repoint the driver, or swap credentials.
+    # repoint the driver, swap credentials, or flip the auth scheme.
     PROTECTED_ODBC_KEYS = {
         "driver", "server", "database", "uid", "pwd",
         "encrypt", "trustservercertificate",
+        "trusted_connection", "authentication", "integrated security",
     }
 
-    def __init__(self, host, port, database, user, password, schema: Optional[str] = None,
-                 odbc_driver: int = 18, encrypt: bool = True, additional_params: Optional[dict] = None):
+    def __init__(self, host, port, database, user=None, password=None, schema: Optional[str] = None,
+                 odbc_driver: int = 18, encrypt: bool = True, additional_params: Optional[dict] = None,
+                 use_kerberos: bool = False, kerberos_principal: Optional[str] = None,
+                 kerberos_impersonate: Optional[str] = None):
         self.host = host
         self.port = port
         self.database = database
@@ -36,6 +39,15 @@ class MSSQLClient(DataSourceClient):
             raise ValueError(f"Unsupported ODBC driver version: {self.odbc_driver}. Supported: {sorted(self.SUPPORTED_ODBC_DRIVERS)}")
         self.encrypt = encrypt
         self.additional_params = additional_params or {}
+        # Kerberos / Windows Integrated auth. The driver derives the target SPN
+        # as MSSQLSvc/<host>:<port> — `host` must be the FQDN, not an IP.
+        #   - use_kerberos alone: default credential cache (service keytab).
+        #   - kerberos_principal: initiate as this principal from the client keytab.
+        #   - kerberos_impersonate: per-user constrained delegation (S4U) — the
+        #     app impersonates this UPN and queries as that user.
+        self.use_kerberos = bool(use_kerberos)
+        self.kerberos_principal = (kerberos_principal or "").strip() or None
+        self.kerberos_impersonate = (kerberos_impersonate or "").strip() or None
         self._schemas = []
         if isinstance(self.schema, str) and self.schema.strip():
             parts = [s.strip() for s in self.schema.split(",") if s.strip()]
@@ -53,10 +65,20 @@ class MSSQLClient(DataSourceClient):
             f"DRIVER={driver_name};"
             f"SERVER={self.host},{self.port};"
             f"DATABASE={self.database};"
-            f"UID={self.user};"
-            f"PWD={self.password};"
-            f"TrustServerCertificate=yes;"
-            f"LoginTimeout=30;"
+        )
+        if self.use_kerberos:
+            # Integrated auth: the driver authenticates via GSSAPI from the
+            # credential cache active at connect time. No NTLM fallback exists
+            # on Linux, and the SPN cannot be overridden (always MSSQLSvc/host:port).
+            params += "Trusted_Connection=yes;"
+        else:
+            params += (
+                f"UID={self.user};"
+                f"PWD={self.password};"
+            )
+        params += (
+            "TrustServerCertificate=yes;"
+            "LoginTimeout=30;"
         )
         if not self.encrypt:
             params += "Encrypt=no;"
@@ -69,14 +91,34 @@ class MSSQLClient(DataSourceClient):
             params += f"{k}={value};"
         return f"mssql+pyodbc:///?odbc_connect={quote_plus(params)}"
 
+    def _kerberos_ccache(self) -> Optional[str]:
+        """Resolve the credential cache to use for this connection, if any."""
+        if not self.use_kerberos:
+            return None
+        from app.data_sources.kerberos import get_ticket_manager
+        manager = get_ticket_manager()
+        if self.kerberos_impersonate:
+            return manager.delegated_ccache(self.kerberos_impersonate)
+        return manager.service_ccache(self.kerberos_principal)
+
     @contextmanager
     def connect(self) -> Generator[sqlalchemy.engine.base.Connection, None, None]:
         """Yield a connection to a SQL Server database."""
         engine = None
         conn = None
         try:
-            engine = sqlalchemy.create_engine(self.sql_server_uri)
-            conn = engine.connect()
+            if self.use_kerberos:
+                from app.data_sources.kerberos import get_ticket_manager
+                ccache = self._kerberos_ccache()
+                engine = sqlalchemy.create_engine(self.sql_server_uri)
+                # KRB5CCNAME is process-global; hold the activation lock only
+                # while the driver performs the GSS handshake. The established
+                # connection stays bound to its identity afterwards.
+                with get_ticket_manager().activate(ccache):
+                    conn = engine.connect()
+            else:
+                engine = sqlalchemy.create_engine(self.sql_server_uri)
+                conn = engine.connect()
             yield conn
         except Exception as e:
             raise RuntimeError(f"{e}")

--- a/backend/app/data_sources/clients/mssql_client.py
+++ b/backend/app/data_sources/clients/mssql_client.py
@@ -22,6 +22,9 @@ class MSSQLClient(DataSourceClient):
         "driver", "server", "database", "uid", "pwd",
         "encrypt", "trustservercertificate",
         "trusted_connection", "authentication", "integrated security",
+        # "app" carries the per-identity pool discriminator under Kerberos SSO;
+        # letting a user override it could re-open the cross-user pooling hole.
+        "app",
     }
 
     def __init__(self, host, port, database, user=None, password=None, schema: Optional[str] = None,
@@ -71,6 +74,16 @@ class MSSQLClient(DataSourceClient):
             # credential cache active at connect time. No NTLM fallback exists
             # on Linux, and the SPN cannot be overridden (always MSSQLSvc/host:port).
             params += "Trusted_Connection=yes;"
+            # SECURITY: under integrated auth the identity comes from KRB5CCNAME
+            # at connect time, NOT from the connection string — so every user's
+            # string is otherwise identical. ODBC driver-manager connection
+            # pooling keys on the string, so without a per-identity discriminator
+            # user B can be handed a pooled connection still authenticated as
+            # user A. Bind the app-name to the impersonated principal so each
+            # identity gets its own pool bucket (verified in the Kerberos lab).
+            ident = self.kerberos_impersonate or self.kerberos_principal or "service"
+            safe_ident = "".join(c if c.isalnum() or c in "@._-" else "_" for c in ident)[:96]
+            params += f"APP=BagOfWords-{safe_ident};"
         else:
             params += (
                 f"UID={self.user};"

--- a/backend/app/data_sources/kerberos.py
+++ b/backend/app/data_sources/kerberos.py
@@ -1,0 +1,251 @@
+"""Kerberos credential management for data source clients.
+
+Two auth shapes are supported:
+
+* **Service identity** — the app authenticates as itself. Either the process
+  default credential cache is used untouched (populated by ``kinit`` or, better,
+  ``KRB5_CLIENT_KTNAME`` pointing at the service keytab so GSSAPI initiates
+  from the keytab with no renewal cron), or a specific principal is resolved
+  from the client keytab into a dedicated cache.
+
+* **Delegated identity (KCD / protocol transition)** — the app impersonates an
+  end user via S4U2Self ("get a ticket *for user X* to myself"; needs only the
+  UPN, no password) and the resulting proxy credential performs S4U2Proxy when
+  the SQL driver initiates a context to ``MSSQLSvc/...``. Requires the service
+  account to be trusted for constrained delegation with protocol transition in
+  Active Directory (``msDS-AllowedToDelegateTo`` + "Use any authentication
+  protocol", or resource-based delegation on the SQL service account).
+
+The MS ODBC driver on Linux consumes whatever credential cache ``KRB5CCNAME``
+points at when the connection is opened, and there is no per-connection ODBC
+keyword to select a cache. ``KRB5CCNAME`` is process-global, so activation is
+serialized under a lock held only for the duration of the driver connect —
+established connections keep their authenticated session afterwards.
+
+python-gssapi is imported lazily: Phase-A service auth via the default cache
+needs no Python Kerberos bindings at all (the ODBC driver talks to libgssapi
+directly), so the app must keep working without the ``gssapi`` package.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Serializes KRB5CCNAME mutation across the whole process. Concurrent connects
+# as different users queue on this lock; once the driver has opened the
+# connection the env var no longer matters, so the hold time is one TCP+GSS
+# handshake.
+_ENV_LOCK = threading.Lock()
+
+# Refresh a cached credential when less than this many seconds of its ticket
+# lifetime remain, so a connection never starts with an about-to-expire ticket.
+_REFRESH_MARGIN_SECONDS = 120
+# Fallback lifetime when GSSAPI doesn't report one (0 / None): re-acquire
+# every 10 minutes rather than trusting an unknown expiry.
+_DEFAULT_LIFETIME_SECONDS = 600
+
+CCACHE_DIR_ENV = "BOW_KRB5_CCACHE_DIR"
+CLIENT_KEYTAB_ENV = "KRB5_CLIENT_KTNAME"
+
+
+class KerberosConfigurationError(RuntimeError):
+    """Kerberos support is not available or not configured on this deployment."""
+
+
+class KerberosDelegationError(RuntimeError):
+    """Obtaining a (delegated) Kerberos credential failed."""
+
+
+def _import_gssapi():
+    try:
+        import gssapi  # noqa: PLC0415
+        return gssapi
+    except ImportError as e:
+        raise KerberosConfigurationError(
+            "Kerberos support requires the 'gssapi' Python package and MIT krb5 "
+            "libraries (krb5-user, libgssapi-krb5-2). Install them and mount a "
+            "krb5.conf plus the service keytab."
+        ) from e
+
+
+@dataclass
+class _CachedCredential:
+    ccache_path: str
+    expires_at: float
+
+
+class KerberosTicketManager:
+    """Acquires and caches Kerberos credentials as file-based credential caches.
+
+    One ccache file per principal, refreshed when close to expiry. Thread-safe.
+    """
+
+    def __init__(self, ccache_dir: str | None = None, client_keytab: str | None = None):
+        self._ccache_dir = ccache_dir or os.environ.get(CCACHE_DIR_ENV) or "/tmp/bow_krb5"
+        self._client_keytab = client_keytab or os.environ.get(CLIENT_KEYTAB_ENV)
+        self._lock = threading.Lock()
+        self._cache: dict[str, _CachedCredential] = {}
+
+    # ── public API ──────────────────────────────────────────────────────────
+
+    def service_ccache(self, principal: str | None = None) -> str | None:
+        """Credential cache for the app's own identity.
+
+        With no explicit principal the process default cache is used — returns
+        None, meaning "leave KRB5CCNAME alone".
+        """
+        if not principal:
+            return None
+        return self._get_or_acquire(f"svc:{principal}", lambda: self._acquire_service(principal))
+
+    def delegated_ccache(self, user_principal: str) -> str:
+        """Credential cache holding an S4U2Self proxy credential for the user.
+
+        The credential is acquired with the service account's keytab identity
+        impersonating ``user_principal`` (UPN — no password involved). When the
+        SQL driver later initiates a security context from this cache toward the
+        SQL Server SPN, MIT krb5 transparently performs S4U2Proxy.
+        """
+        principal = (user_principal or "").strip()
+        if not principal or "@" not in principal:
+            raise KerberosDelegationError(
+                f"Cannot impersonate '{user_principal}': a full user principal name "
+                "(user@REALM) is required for Kerberos delegation."
+            )
+        return self._get_or_acquire(f"user:{principal}", lambda: self._acquire_delegated(principal))
+
+    @contextmanager
+    def activate(self, ccache_path: str | None):
+        """Point KRB5CCNAME at ``ccache_path`` for the duration of the block.
+
+        Process-global and therefore serialized: hold only around the driver
+        connect call, never around query execution. A ``None`` path activates
+        nothing (default cache) without taking the lock.
+        """
+        if not ccache_path:
+            yield
+            return
+        with _ENV_LOCK:
+            previous = os.environ.get("KRB5CCNAME")
+            os.environ["KRB5CCNAME"] = f"FILE:{ccache_path}"
+            try:
+                yield
+            finally:
+                if previous is None:
+                    os.environ.pop("KRB5CCNAME", None)
+                else:
+                    os.environ["KRB5CCNAME"] = previous
+
+    def invalidate(self, user_principal: str | None = None) -> None:
+        """Drop cached credentials (all, or one user's) so the next use re-acquires."""
+        with self._lock:
+            if user_principal is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(f"user:{user_principal.strip()}", None)
+
+    # ── internals ───────────────────────────────────────────────────────────
+
+    def _get_or_acquire(self, key: str, acquire) -> str:
+        now = time.monotonic()
+        with self._lock:
+            cached = self._cache.get(key)
+            if cached and cached.expires_at - now > _REFRESH_MARGIN_SECONDS:
+                return cached.ccache_path
+            ccache_path, lifetime = acquire()
+            lifetime = lifetime or _DEFAULT_LIFETIME_SECONDS
+            self._cache[key] = _CachedCredential(ccache_path=ccache_path, expires_at=now + lifetime)
+            return ccache_path
+
+    def _ccache_path_for(self, key: str) -> str:
+        os.makedirs(self._ccache_dir, mode=0o700, exist_ok=True)
+        digest = hashlib.sha256(key.encode("utf-8")).digest()
+        token = base64.urlsafe_b64encode(digest[:12]).decode("ascii").rstrip("=")
+        return os.path.join(self._ccache_dir, f"krb5cc_{token}")
+
+    def _service_credentials(self, gssapi, principal: str | None = None):
+        """Initiate-usage credentials for the app's service identity (keytab)."""
+        store = {}
+        if self._client_keytab:
+            store["client_keytab"] = self._client_keytab
+        name = None
+        if principal:
+            name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
+        try:
+            if store:
+                return gssapi.Credentials(usage="initiate", name=name, store=store)
+            return gssapi.Credentials(usage="initiate", name=name)
+        except Exception as e:
+            raise KerberosDelegationError(
+                f"Failed to acquire service credentials"
+                f"{f' for {principal}' if principal else ''}: {e}. "
+                f"Check the keytab ({self._client_keytab or 'default ccache'}) and krb5.conf."
+            ) from e
+
+    def _acquire_service(self, principal: str) -> tuple[str, int | None]:
+        gssapi = _import_gssapi()
+        creds = self._service_credentials(gssapi, principal)
+        return self._store_into_ccache(gssapi, creds, f"svc:{principal}")
+
+    def _acquire_delegated(self, user_principal: str) -> tuple[str, int | None]:
+        gssapi = _import_gssapi()
+        impersonator = self._service_credentials(gssapi)
+        # Enterprise names let AD resolve UPN suffixes that differ from the
+        # realm name; fall back to plain principal parsing on older bindings.
+        name_type = getattr(gssapi.NameType, "enterprise_principal", None) \
+            or gssapi.NameType.kerberos_principal
+        user_name = gssapi.Name(user_principal, name_type)
+        try:
+            result = gssapi.raw.acquire_cred_impersonate_name(
+                impersonator, user_name, usage="initiate"
+            )
+        except Exception as e:
+            raise KerberosDelegationError(
+                f"S4U2Self impersonation of '{user_principal}' failed: {e}. "
+                "Verify the service account is trusted for constrained delegation "
+                "with protocol transition ('Use any authentication protocol') and "
+                "that the user is not marked sensitive/Protected Users."
+            ) from e
+        lifetime = getattr(result, "lifetime", None)
+        path, _ = self._store_into_ccache(gssapi, result.creds, f"user:{user_principal}")
+        return path, lifetime
+
+    def _store_into_ccache(self, gssapi, creds, key: str) -> tuple[str, int | None]:
+        path = self._ccache_path_for(key)
+        try:
+            gssapi.raw.store_cred_into(
+                {"ccache": f"FILE:{path}"},
+                creds,
+                usage="initiate",
+                overwrite=True,
+                set_default=False,
+            )
+        except Exception as e:
+            raise KerberosDelegationError(f"Failed to store Kerberos credential cache: {e}") from e
+        with suppress(OSError):
+            os.chmod(path, 0o600)
+        lifetime = getattr(creds, "lifetime", None)
+        return path, lifetime
+
+
+_manager: KerberosTicketManager | None = None
+_manager_lock = threading.Lock()
+
+
+def get_ticket_manager() -> KerberosTicketManager:
+    """Process-wide ticket manager singleton."""
+    global _manager
+    if _manager is None:
+        with _manager_lock:
+            if _manager is None:
+                _manager = KerberosTicketManager()
+    return _manager

--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -431,6 +431,24 @@ async def test_connection(
     )
 
 
+@router.get("/{connection_id}/kerberos-access")
+@requires_permission('manage_connections')
+async def list_kerberos_access(
+    connection_id: str,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Admin roster: per-member Kerberos SSO verification status for a connection.
+
+    Since Kerberos SSO stores no secret, this reports the status-only marker
+    rows (resolved principal, last verified time, last error) so an admin can
+    see, per member, whether delegated access has been confirmed.
+    """
+    connection = await connection_service.get_connection(db, connection_id, organization)
+    return await connection_service.list_kerberos_access(db=db, connection=connection)
+
+
 @router.post("/{connection_id}/test-my-credentials", response_model=ConnectionTestResult)
 async def test_my_connection_credentials(
     connection_id: str,

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -16,6 +16,8 @@ from app.schemas.data_sources.configs import (
     NetSuiteConfig,
     SQLConfig,
     MssqlConfig,
+    MssqlKerberosCredentials,
+    MssqlKerberosDelegatedCredentials,
     PrestoConfig,
     TrinoConfig,
     GoogleAnalyticsConfig,
@@ -382,7 +384,14 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         description="MSSQL is Microsoft's relational database for managing and analyzing data.",
         config_schema=MssqlConfig,
         credentials_auth=AuthOptions(default="userpass", by_auth={
-            "userpass": AuthVariant(title="Username / Password", schema=SQLCredentials, scopes=["system","user"])
+            "userpass": AuthVariant(title="Username / Password", schema=SQLCredentials, scopes=["system","user"]),
+            # Windows Integrated auth: the app's own Kerberos identity (keytab /
+            # default ccache). System-scope only — one service principal per connection.
+            "kerberos": AuthVariant(title="Kerberos (Windows Integrated)", schema=MssqlKerberosCredentials, scopes=["system"]),
+            # Per-user Kerberos SSO: the app impersonates the signed-in user via
+            # constrained delegation (S4U2Self + S4U2Proxy). No secret is stored;
+            # the user's UPN is derived from their login identity unless overridden.
+            "kerberos_delegated": AuthVariant(title="Kerberos SSO (per-user delegation)", schema=MssqlKerberosDelegatedCredentials, scopes=["user"]),
         }),
         client_path=None,
     ),

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -235,6 +235,60 @@ class MariadbConfig(SQLConfig):
     port: int = Field(3306, ge=1, le=65535, title="Port", description="", json_schema_extra={"ui:type": "number"})
 
 
+class MssqlKerberosCredentials(BaseModel):
+    """Windows Integrated authentication via Kerberos (service keytab).
+
+    The app authenticates with its own Kerberos identity: either the process
+    default credential cache (populated by kinit / KRB5_CLIENT_KTNAME) or a
+    dedicated principal resolved from the client keytab.
+    """
+    use_kerberos: bool = Field(
+        True,
+        title="Use Kerberos (Windows Integrated)",
+        description="Authenticate with the app's Kerberos identity instead of a SQL login. Requires krb5 to be configured on the server (keytab + krb5.conf).",
+        json_schema_extra={"ui:type": "boolean"},
+    )
+    kerberos_principal: Optional[str] = Field(
+        None,
+        title="Service Principal (optional)",
+        description="Client principal to authenticate as, e.g. svc-bow@CORP.EXAMPLE.COM. Requires a matching keytab entry. Leave blank to use the default credential cache.",
+        json_schema_extra={"ui:type": "string"},
+    )
+
+    @model_validator(mode="after")
+    def validate_kerberos_enabled(cls, model: "MssqlKerberosCredentials") -> "MssqlKerberosCredentials":
+        if not model.use_kerberos:
+            raise ValueError("Kerberos must remain enabled for this authentication method.")
+        return model
+
+
+class MssqlKerberosDelegatedCredentials(BaseModel):
+    """Per-user Kerberos SSO via constrained delegation (S4U2Self + S4U2Proxy).
+
+    The app's service account obtains a delegated ticket for the end user's AD
+    principal and queries SQL Server as that user. Requires the service account
+    to be trusted for constrained delegation with protocol transition in AD.
+    """
+    use_kerberos: bool = Field(
+        True,
+        title="Use Kerberos SSO",
+        description="Queries run under your own Active Directory identity via Kerberos Constrained Delegation.",
+        json_schema_extra={"ui:type": "boolean"},
+    )
+    kerberos_impersonate: Optional[str] = Field(
+        None,
+        title="Active Directory Principal (UPN)",
+        description="Your AD user principal name, e.g. jdoe@corp.example.com. Leave blank to use your login identity.",
+        json_schema_extra={"ui:type": "string"},
+    )
+
+    @model_validator(mode="after")
+    def validate_kerberos_enabled(cls, model: "MssqlKerberosDelegatedCredentials") -> "MssqlKerberosDelegatedCredentials":
+        if not model.use_kerberos:
+            raise ValueError("Kerberos must remain enabled for this authentication method.")
+        return model
+
+
 class MssqlConfig(SQLConfig):
     port: int = Field(1433, ge=1, le=65535, title="Port", description="", json_schema_extra={"ui:type": "number"})
     schema: Optional[str] = Field(

--- a/backend/app/services/connection_identity.py
+++ b/backend/app/services/connection_identity.py
@@ -15,7 +15,7 @@ When an admin chooses "service account" before ever connecting, a lightweight ma
 """
 from __future__ import annotations
 
-from typing import Optional
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -37,7 +37,7 @@ def supports_user_token(connection: Connection) -> bool:
     return "oauth" in modes
 
 
-def identity_pref_from_row(row: Optional[UserConnectionCredentials]) -> str:
+def identity_pref_from_row(row: UserConnectionCredentials | None) -> str:
     """Read the stored query-identity preference; defaults to 'self'."""
     if row is not None:
         md = getattr(row, "metadata_json", None)
@@ -48,14 +48,14 @@ def identity_pref_from_row(row: Optional[UserConnectionCredentials]) -> str:
     return QUERY_IDENTITY_SELF
 
 
-def row_has_token(row: Optional[UserConnectionCredentials]) -> bool:
+def row_has_token(row: UserConnectionCredentials | None) -> bool:
     """True if the row carries a real delegated credential (not just a pref marker)."""
     return row is not None and row.auth_mode != SERVICE_ACCOUNT_MARKER_MODE
 
 
 async def get_user_conn_cred_row(
     db: AsyncSession, connection: Connection, user
-) -> Optional[UserConnectionCredentials]:
+) -> UserConnectionCredentials | None:
     """Fetch the user's primary active connection-level credential/preference row."""
     res = await db.execute(
         select(UserConnectionCredentials)
@@ -138,7 +138,7 @@ async def is_admin_or_owner(db: AsyncSession, connection: Connection, user) -> b
     except Exception:
         pass
     try:
-        from app.core.permission_resolver import resolve_permissions, FULL_ADMIN
+        from app.core.permission_resolver import FULL_ADMIN, resolve_permissions
         resolved = await resolve_permissions(
             db, str(user.id), str(connection.organization_id)
         )
@@ -148,3 +148,110 @@ async def is_admin_or_owner(db: AsyncSession, connection: Connection, user) -> b
         )
     except Exception:
         return False
+
+
+# ── Kerberos per-user SSO (constrained delegation) ──────────────────────────
+#
+# Unlike OBO, Kerberos SSO stores no per-user secret: a member's access comes
+# from the app service account's delegation rights + the member's AD principal
+# (UPN), derived from their login identity. So "has access" is a property of the
+# identity, not of a stored credential — the per-user status/overlay machinery
+# (built for stored tokens) needs to treat a resolvable UPN as first-class user
+# access, otherwise a Kerberos member falls through to "no access" and gets an
+# empty catalog even though they can query fine.
+#
+# A lightweight marker row (auth_mode == KERBEROS_SSO_MODE, EMPTY encrypted
+# payload apart from the resolved principal) records verification status only —
+# never a credential — so the admin gets a per-member roster and the badge can
+# show "verified" vs "not checked".
+
+KERBEROS_SSO_MODE = "kerberos_delegated"
+
+
+def supports_user_kerberos_sso(connection: Connection) -> bool:
+    """True if members authenticate to this connection via Kerberos delegation."""
+    return KERBEROS_SSO_MODE in (connection.allowed_user_auth_modes or [])
+
+
+def resolve_kerberos_principal(user, row: UserConnectionCredentials | None = None) -> str | None:
+    """The AD principal (UPN) a member's queries impersonate.
+
+    Precedence: an explicit principal the member saved > their login identity.
+    Returns None when neither yields a UPN-shaped value (login isn't an AD UPN
+    and no override saved) — the member must set their principal explicitly.
+    """
+    if row is not None and row.auth_mode == KERBEROS_SSO_MODE:
+        try:
+            explicit = (row.decrypt_credentials() or {}).get("kerberos_impersonate")
+        except Exception:
+            explicit = None
+        if explicit and "@" in explicit:
+            return explicit.strip()
+    email = (getattr(user, "email", None) or "").strip()
+    return email if "@" in email else None
+
+
+async def build_kerberos_sso_status(db: AsyncSession, connection: Connection, user, cached_status, last_checked):
+    """Per-user status for a Kerberos-SSO connection (no stored secret).
+
+    A resolvable UPN → the member has delegated access (effective_auth="user"),
+    so their overlay builds by impersonating them. Connection health is "success"
+    once a verify/query has recorded the marker row, else "unknown". No UPN →
+    effective_auth="none" and connection="not_connected" (prompt for principal).
+    """
+    from app.schemas.data_source_schema import DataSourceUserStatus
+
+    row = await get_user_conn_cred_row(db, connection, user)
+    marker = row if (row is not None and row.auth_mode == KERBEROS_SSO_MODE) else None
+    principal = resolve_kerberos_principal(user, marker)
+
+    if not principal:
+        return DataSourceUserStatus(
+            has_user_credentials=False,
+            auth_mode=KERBEROS_SSO_MODE,
+            connection="not_connected",
+            effective_auth="none",
+            last_checked_at=last_checked,
+        )
+
+    verified = bool(marker and marker.last_used_at)
+    return DataSourceUserStatus(
+        has_user_credentials=True,
+        auth_mode=KERBEROS_SSO_MODE,
+        is_primary=bool(getattr(marker, "is_primary", True)) if marker else True,
+        last_used_at=getattr(marker, "last_used_at", None),
+        connection="success" if verified else "unknown",
+        effective_auth="user",
+        credentials_id=str(marker.id) if marker and getattr(marker, "id", None) else None,
+        last_checked_at=getattr(marker, "last_used_at", None) or last_checked,
+    )
+
+
+async def record_kerberos_verification(db: AsyncSession, connection: Connection, user, success: bool, error: str | None = None) -> None:
+    """Upsert the member's Kerberos-SSO marker row (status only — no secret).
+
+    Drives the "verified" badge and the admin roster. Stores the resolved
+    principal + last error in metadata_json; stamps last_used_at on success.
+    """
+    row = await get_user_conn_cred_row(db, connection, user)
+    principal = resolve_kerberos_principal(
+        user, row if (row is not None and row.auth_mode == KERBEROS_SSO_MODE) else None
+    )
+    if row is None or row.auth_mode != KERBEROS_SSO_MODE:
+        row = UserConnectionCredentials(
+            connection_id=str(connection.id),
+            user_id=str(user.id),
+            organization_id=str(connection.organization_id),
+            auth_mode=KERBEROS_SSO_MODE,
+            is_active=True,
+            is_primary=True,
+        )
+        row.encrypt_credentials({"kerberos_impersonate": principal} if principal else {})
+    md = dict(getattr(row, "metadata_json", None) or {})
+    md["principal"] = principal
+    md["last_error"] = None if success else (error or "verification failed")
+    row.metadata_json = md
+    if success:
+        row.last_used_at = datetime.utcnow()
+    db.add(row)
+    await db.commit()

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -696,6 +696,33 @@ class ConnectionService:
                 "details": {},
             }
 
+    async def list_kerberos_access(self, db: AsyncSession, connection: Connection) -> list[dict]:
+        """Per-member Kerberos SSO verification roster for a connection.
+
+        Reads the status-only marker rows (no secrets). ``verified`` is True once
+        a member's delegated access has been confirmed (a successful verify or
+        query stamped ``last_used_at``); ``last_error`` carries the last failure.
+        """
+        from app.services.connection_identity import KERBEROS_SSO_MODE
+        rows = (await db.execute(
+            select(UserConnectionCredentials).where(
+                UserConnectionCredentials.connection_id == str(connection.id),
+                UserConnectionCredentials.auth_mode == KERBEROS_SSO_MODE,
+                UserConnectionCredentials.is_active == True,  # noqa: E712
+            )
+        )).scalars().all()
+        roster = []
+        for r in rows:
+            md = getattr(r, "metadata_json", None) or {}
+            roster.append({
+                "user_id": r.user_id,
+                "principal": md.get("principal"),
+                "verified": bool(r.last_used_at),
+                "last_verified_at": r.last_used_at,
+                "last_error": md.get("last_error"),
+            })
+        return roster
+
     async def test_user_connection(
         self,
         db: AsyncSession,
@@ -706,13 +733,21 @@ class ConnectionService:
         """Test a connection using the current user's saved credentials."""
         connection = await self.get_connection(db, connection_id, organization)
 
+        from app.services.connection_identity import supports_user_kerberos_sso, record_kerberos_verification
         try:
             client = await self.construct_client(db, connection, current_user)
             connection_status = await client.atest_connection()
             success = bool(connection_status.get("success")) if isinstance(connection_status, dict) else bool(connection_status)
 
-            # Update the user's credential last_used_at on success
-            if success:
+            # Kerberos SSO has no stored credential — record a status-only marker
+            # row so the badge shows "verified" and the admin roster is populated.
+            if supports_user_kerberos_sso(connection):
+                await record_kerberos_verification(
+                    db, connection, current_user, success,
+                    error=None if success else (connection_status.get("message") if isinstance(connection_status, dict) else None),
+                )
+            elif success:
+                # Update the user's credential last_used_at on success
                 from app.models.user_connection_credentials import UserConnectionCredentials
                 result = await db.execute(
                     select(UserConnectionCredentials).where(
@@ -728,6 +763,11 @@ class ConnectionService:
 
             return connection_status
         except Exception as e:
+            if supports_user_kerberos_sso(connection):
+                try:
+                    await record_kerberos_verification(db, connection, current_user, False, error=str(e))
+                except Exception:
+                    pass
             return {"success": False, "message": str(e)}
 
     async def delete_user_credentials(
@@ -1205,35 +1245,30 @@ class ConnectionService:
         mode and the user hasn't connected with a different real auth mode. The
         returned dict feeds the MSSQL client's constrained-delegation path.
         """
-        modes = connection.allowed_user_auth_modes or []
-        if "kerberos_delegated" not in modes:
+        from app.services.connection_identity import (
+            supports_user_kerberos_sso, resolve_kerberos_principal,
+            KERBEROS_SSO_MODE, SERVICE_ACCOUNT_MARKER_MODE,
+        )
+        if not supports_user_kerberos_sso(connection):
             return None
 
-        creds: dict = {}
-        if row is not None:
-            from app.services.connection_identity import SERVICE_ACCOUNT_MARKER_MODE
-            if row.auth_mode == "kerberos_delegated":
-                try:
-                    creds = row.decrypt_credentials() or {}
-                except Exception:
-                    creds = {}
-            elif row.auth_mode != SERVICE_ACCOUNT_MARKER_MODE:
-                # The user connected with a different real auth mode (e.g. a
-                # personal SQL login) — honor that instead of impersonation.
-                return None
+        # The user connected with a different real auth mode (e.g. a personal
+        # SQL login) — honor that instead of impersonation. A Kerberos marker
+        # row or a bare service-account marker do NOT count as "different".
+        if row is not None and row.auth_mode not in (KERBEROS_SSO_MODE, SERVICE_ACCOUNT_MARKER_MODE):
+            return None
 
-        principal = (creds.get("kerberos_impersonate") or "").strip()
+        marker = row if (row is not None and row.auth_mode == KERBEROS_SSO_MODE) else None
+        principal = resolve_kerberos_principal(user, marker)
         if not principal:
-            principal = (getattr(user, "email", None) or "").strip()
-            if "@" not in principal:
-                raise HTTPException(
-                    status_code=403,
-                    detail=(
-                        "Kerberos SSO requires an Active Directory principal (UPN). "
-                        "Your login identity has no UPN-shaped email — save your AD "
-                        "principal in your connection credentials."
-                    ),
-                )
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Kerberos SSO requires an Active Directory principal (UPN). "
+                    "Your login identity has no UPN-shaped email — save your AD "
+                    "principal in your connection credentials."
+                ),
+            )
         return {"use_kerberos": True, "kerberos_impersonate": principal}
 
     def _resolve_client_by_type(

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -157,6 +157,11 @@ class ConnectionService:
             from app.services.connection_oauth_service import ENTRA_OBO_CONNECTION_TYPES
             if type in ENTRA_OBO_CONNECTION_TYPES:
                 allowed_user_auth_modes = ["oauth"]
+            elif type == "MSSQL" and (config or {}).get("auth_type") == "kerberos":
+                # System auth is Kerberos → per-user auth means Kerberos SSO via
+                # constrained delegation (no per-user secret; UPN derived at
+                # query time from the login identity).
+                allowed_user_auth_modes = ["kerberos_delegated"]
 
         # Validate connection before saving (for system_only auth)
         if auth_policy == "system_only":
@@ -370,6 +375,12 @@ class ConnectionService:
             target_type = updates.get("type", connection.type)
             if target_type in ENTRA_OBO_CONNECTION_TYPES and not (connection.allowed_user_auth_modes or []):
                 updates["allowed_user_auth_modes"] = ["oauth"]
+            elif target_type == "MSSQL" and not (connection.allowed_user_auth_modes or []):
+                cfg = updates.get("config")
+                if cfg is None:
+                    cfg = json.loads(connection.config) if isinstance(connection.config, str) else (connection.config or {})
+                if (cfg or {}).get("auth_type") == "kerberos":
+                    updates["allowed_user_auth_modes"] = ["kerberos_delegated"]
 
         # Track if connection-relevant fields changed
         connection_changed = False
@@ -1125,6 +1136,15 @@ class ConnectionService:
                 ),
             )
 
+        # --- Kerberos SSO (per-user constrained delegation) ---
+        # No stored secret is involved: the app impersonates the user's AD
+        # principal via S4U at connect time, so a missing credential row is not
+        # an error — the principal is derived from the login identity unless the
+        # user saved an explicit override.
+        kerberos_creds = self._kerberos_delegated_credentials(connection, current_user, row)
+        if kerberos_creds is not None:
+            return kerberos_creds
+
         # --- Legacy path: non-delegated user_required connections (e.g. user/pass) ---
         if not row:
             # Owner/admin fallback: allow owner or admin to use system creds
@@ -1176,6 +1196,45 @@ class ConnectionService:
                 return row.decrypt_credentials()
 
         return row.decrypt_credentials()
+
+    @staticmethod
+    def _kerberos_delegated_credentials(connection: Connection, user: User, row) -> Optional[dict]:
+        """Per-user Kerberos SSO credentials, or None when it doesn't apply.
+
+        Applies when the connection allows the ``kerberos_delegated`` user auth
+        mode and the user hasn't connected with a different real auth mode. The
+        returned dict feeds the MSSQL client's constrained-delegation path.
+        """
+        modes = connection.allowed_user_auth_modes or []
+        if "kerberos_delegated" not in modes:
+            return None
+
+        creds: dict = {}
+        if row is not None:
+            from app.services.connection_identity import SERVICE_ACCOUNT_MARKER_MODE
+            if row.auth_mode == "kerberos_delegated":
+                try:
+                    creds = row.decrypt_credentials() or {}
+                except Exception:
+                    creds = {}
+            elif row.auth_mode != SERVICE_ACCOUNT_MARKER_MODE:
+                # The user connected with a different real auth mode (e.g. a
+                # personal SQL login) — honor that instead of impersonation.
+                return None
+
+        principal = (creds.get("kerberos_impersonate") or "").strip()
+        if not principal:
+            principal = (getattr(user, "email", None) or "").strip()
+            if "@" not in principal:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "Kerberos SSO requires an Active Directory principal (UPN). "
+                        "Your login identity has no UPN-shaped email — save your AD "
+                        "principal in your connection credentials."
+                    ),
+                )
+        return {"use_kerberos": True, "kerberos_impersonate": principal}
 
     def _resolve_client_by_type(
         self,

--- a/backend/app/services/user_data_source_credentials_service.py
+++ b/backend/app/services/user_data_source_credentials_service.py
@@ -232,9 +232,20 @@ class UserDataSourceCredentialsService:
 
         # Delegated/OBO connections: status is driven by the admin query-identity
         # toggle (service account vs self) — handled in one place.
-        from app.services.connection_identity import supports_user_token, build_token_identity_status
+        from app.services.connection_identity import (
+            supports_user_token, build_token_identity_status,
+            supports_user_kerberos_sso, build_kerberos_sso_status,
+        )
         if supports_user_token(connection):
             return await build_token_identity_status(
+                db, connection, user, get_cached_status(), get_last_checked_at()
+            )
+
+        # Kerberos SSO: no stored secret — access is derived from the member's AD
+        # principal (login UPN or an explicit override), so a resolvable UPN is
+        # itself "user" access. This is what lets their per-user overlay build.
+        if supports_user_kerberos_sso(connection):
+            return await build_kerberos_sso_status(
                 db, connection, user, get_cached_status(), get_last_checked_at()
             )
 

--- a/backend/app/services/user_data_source_credentials_service.py
+++ b/backend/app/services/user_data_source_credentials_service.py
@@ -396,6 +396,21 @@ class UserDataSourceCredentialsService:
         except Exception as e:
             raise HTTPException(status_code=422, detail=f"Invalid credentials: {e}")
 
+        # Kerberos SSO rows persist an explicit UPN: fill a blank principal from
+        # the login identity at save time so resolvers never see an empty one.
+        if payload.auth_mode == "kerberos_delegated":
+            creds = dict(payload.credentials or {})
+            if not (creds.get("kerberos_impersonate") or "").strip():
+                email = (getattr(user, "email", None) or "").strip()
+                if "@" not in email:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="Kerberos SSO requires an Active Directory principal (UPN); your login identity has none — provide one explicitly.",
+                    )
+                creds["kerberos_impersonate"] = email
+            creds["use_kerberos"] = True
+            payload.credentials = creds
+
         # Find existing (active) row
         stmt = (
             select(UserDataSourceCredentials)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -108,6 +108,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Kerberos constrained delegation (S4U) for per-user SSO to on-prem SQL Server.
+# Needs MIT krb5 headers to build (libkrb5-dev + krb5-config on Debian/Ubuntu).
+kerberos = [
+    "gssapi>=1.8.3,<2",
+]
 dev = [
     "pytest>=8.4.2,<8.5",
     "pytest-asyncio>=0.23.8,<0.24",

--- a/backend/tests/e2e/test_kerberos_sso_member_overlay.py
+++ b/backend/tests/e2e/test_kerberos_sso_member_overlay.py
@@ -1,0 +1,185 @@
+"""End-to-end (service layer) validation for per-user Kerberos SSO.
+
+Proves the two things that were "wired but not demoed end-to-end":
+
+  1. Per-user overlay IS happening — a Kerberos member with NO stored credential
+     is classified effective_auth="user" (purely from a resolvable UPN), which
+     makes the tables list scope to THEIR overlay. Two members with disjoint
+     overlays (alice→sales, bob→audit) see disjoint catalogs through the real
+     service path (`get_data_source_schema_paginated`).
+  2. The UI shows "Connected" — `build_user_status_for_connection` returns
+     has_user_credentials=True + effective_auth="user" + auth_mode
+     ="kerberos_delegated", which is exactly what the status chip renders as
+     "Connected" (and what suppresses the "connect required" prompt).
+
+Unlike OBO, the members hold NO UserConnectionCredentials row — access comes
+from their AD principal (login UPN). This runs in-process against a real sqlite
+DB (no live SQL Server, KDC, or browser); the actual S4U → SQL introspection is
+separately proven in lab/sql-server-kerberos.
+"""
+import asyncio
+import uuid
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.user_data_source_overlay import UserDataSourceTable
+from app.models.domain_connection import domain_connection
+from app.services.data_source_service import DataSourceService
+from app.services.connection_service import ConnectionService
+from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed():
+    """MSSQL (shared-catalog, user_required) connection with Kerberos SSO and
+    two members who have NO stored credentials. alice's overlay = [sales],
+    bob's = [audit] — disjoint, as their real SQL grants would produce."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"Kerb Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        # Members whose login email IS their AD UPN (so it resolves).
+        alice = User(name="Alice", email=f"alice-{suffix}@corp.example.com",
+                     hashed_password="x", is_active=True, is_superuser=False, is_verified=True)
+        bob = User(name="Bob", email=f"bob-{suffix}@corp.example.com",
+                   hashed_password="x", is_active=True, is_superuser=False, is_verified=True)
+        # A separate owner so alice/bob are plain members (owner would fall back
+        # to system creds and mask the per-user path).
+        owner = User(name="Owner", email=f"owner-{suffix}@corp.example.com",
+                     hashed_password="x", is_active=True, is_superuser=False, is_verified=True)
+        db.add_all([alice, bob, owner])
+        await db.flush()
+
+        conn = Connection(
+            organization_id=org.id,
+            name=f"MSSQL {suffix}",
+            type="MSSQL",
+            config={"host": "sql.corp.example.com", "port": 1433, "database": "dwh", "auth_type": "kerberos"},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["kerberos_delegated"],
+        )
+        # System identity = the service account's Kerberos identity (no secret).
+        conn.encrypt_credentials({"use_kerberos": True})
+        db.add(conn)
+        await db.flush()
+
+        ds = DataSource(name=f"DWH {suffix}", organization_id=org.id, is_active=True, owner_user_id=owner.id)
+        db.add(ds)
+        await db.flush()
+        await db.execute(domain_connection.insert().values(data_source_id=ds.id, connection_id=conn.id))
+
+        # Canonical catalog (built by the service account): both tables.
+        ds_table_ids = {}
+        for tname in ("sales", "audit"):
+            ct = ConnectionTable(name=tname, connection_id=conn.id,
+                                 columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0,
+                                 metadata_json={"schema": "dbo"})
+            db.add(ct)
+            await db.flush()
+            dst = DataSourceTable(name=tname, datasource_id=ds.id, connection_table_id=ct.id,
+                                  is_active=True, metadata_json={"schema": "dbo"},
+                                  columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0)
+            db.add(dst)
+            await db.flush()
+            ds_table_ids[tname] = dst.id
+
+        # Per-user overlays (what introspecting AS each member yields): disjoint.
+        db.add(UserDataSourceTable(data_source_id=ds.id, user_id=alice.id, table_name="sales",
+                                   data_source_table_id=ds_table_ids["sales"], is_accessible=True, status="accessible"))
+        db.add(UserDataSourceTable(data_source_id=ds.id, user_id=bob.id, table_name="audit",
+                                   data_source_table_id=ds_table_ids["audit"], is_accessible=True, status="accessible"))
+
+        await db.commit()
+        return {"org_id": org.id, "ds_id": ds.id, "conn_id": conn.id,
+                "alice_id": alice.id, "bob_id": bob.id, "alice_email": alice.email}
+
+
+async def _status(ids, user_id):
+    async with async_session_maker() as db:
+        conn = await db.get(Connection, ids["conn_id"])
+        ds = await db.get(DataSource, ids["ds_id"])
+        user = await db.get(User, user_id)
+        return await UserDataSourceCredentialsService().build_user_status_for_connection(db, conn, user, data_source=ds)
+
+
+async def _resolved_creds(ids, user_id):
+    async with async_session_maker() as db:
+        conn = await db.get(Connection, ids["conn_id"])
+        user = await db.get(User, user_id)
+        return await ConnectionService().resolve_credentials(db, conn, user)
+
+
+async def _paginated_table_names(ids, user_id):
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, user_id)
+        resp = await DataSourceService().get_data_source_schema_paginated(
+            db=db, data_source_id=ids["ds_id"], organization=org,
+            page=1, page_size=100, include_inactive=True, current_user=user,
+        )
+        return resp.total_tables, {t.name.split(".")[-1].lower() for t in resp.tables}
+
+
+@pytest.mark.e2e
+def test_kerberos_member_status_shows_connected():
+    """Claim 2: the status the chip reads → 'Connected' for a Kerberos member
+    with NO stored credential."""
+    ids = _run(_seed())
+    st = _run(_status(ids, ids["alice_id"]))
+    assert st.has_user_credentials is True          # chip renders "Connected"
+    assert st.effective_auth == "user"              # runs as the member, not service acct
+    assert st.auth_mode == "kerberos_delegated"
+    assert st.connection in ("unknown", "success")  # not "offline"/"not_connected"
+
+
+@pytest.mark.e2e
+def test_kerberos_member_resolves_own_upn():
+    """Claim 1 (wiring): resolve_credentials passes the MEMBER's UPN to the
+    client, so queries/introspection impersonate them."""
+    ids = _run(_seed())
+    creds = _run(_resolved_creds(ids, ids["alice_id"]))
+    assert creds.get("use_kerberos") is True
+    assert creds.get("kerberos_impersonate") == ids["alice_email"]
+
+
+@pytest.mark.e2e
+def test_kerberos_per_user_overlay_is_scoped():
+    """Claim 1: per-user overlay IS happening — through the real service path,
+    alice and bob see disjoint catalogs (their own tables only)."""
+    ids = _run(_seed())
+    alice_total, alice_tables = _run(_paginated_table_names(ids, ids["alice_id"]))
+    bob_total, bob_tables = _run(_paginated_table_names(ids, ids["bob_id"]))
+    assert alice_tables == {"sales"}, f"alice should see only sales, saw {alice_tables}"
+    assert bob_tables == {"audit"}, f"bob should see only audit, saw {bob_tables}"
+    assert alice_tables.isdisjoint(bob_tables)
+
+
+@pytest.mark.e2e
+def test_kerberos_member_without_upn_is_not_connected():
+    """A member whose login isn't a UPN and who set no principal → not connected
+    (fail closed; the UI would prompt them to set their AD principal)."""
+    ids = _run(_seed())
+    async def _make_no_upn_member():
+        async with async_session_maker() as db:
+            u = User(name="NoUPN", email=f"nouser-{uuid.uuid4().hex[:6]}",  # no '@'
+                     hashed_password="x", is_active=True, is_superuser=False, is_verified=True)
+            db.add(u)
+            await db.commit()
+            return u.id
+    uid = _run(_make_no_upn_member())
+    st = _run(_status(ids, uid))
+    assert st.has_user_credentials is False
+    assert st.effective_auth == "none"
+    assert st.connection == "not_connected"

--- a/backend/tests/unit/test_mssql_kerberos.py
+++ b/backend/tests/unit/test_mssql_kerberos.py
@@ -73,6 +73,32 @@ def test_additional_params_cannot_flip_auth_scheme():
     assert params["applicationintent"] == "ReadOnly"
 
 
+def test_kerberos_per_user_pool_discriminator():
+    """Each impersonated identity gets a distinct APP token so the ODBC driver's
+    connection pool can't hand user B a connection authenticated as user A
+    (regression test for the cross-user pooling hole found in the Kerberos lab)."""
+    alice = MSSQLClient("db.corp.example.com", 1433, "dwh", use_kerberos=True,
+                        kerberos_impersonate="alice@CORP.EXAMPLE.COM")
+    bob = MSSQLClient("db.corp.example.com", 1433, "dwh", use_kerberos=True,
+                      kerberos_impersonate="bob@CORP.EXAMPLE.COM")
+    app_alice = _odbc_params(alice)["app"]
+    app_bob = _odbc_params(bob)["app"]
+    assert app_alice != app_bob
+    assert "alice" in app_alice.lower()
+    assert "bob" in app_bob.lower()
+
+
+def test_kerberos_app_discriminator_cannot_be_overridden():
+    """A user-supplied APP in additional_params must not replace the security
+    discriminator."""
+    client = MSSQLClient(
+        "db.corp.example.com", 1433, "dwh", use_kerberos=True,
+        kerberos_impersonate="alice@CORP.EXAMPLE.COM",
+        additional_params={"APP": "attacker"},
+    )
+    assert _odbc_params(client)["app"] == "BagOfWords-alice@CORP.EXAMPLE.COM"
+
+
 def test_kerberos_principals_normalized():
     client = MSSQLClient(
         "db.corp.example.com", 1433, "dwh", use_kerberos=True,

--- a/backend/tests/unit/test_mssql_kerberos.py
+++ b/backend/tests/unit/test_mssql_kerberos.py
@@ -1,0 +1,311 @@
+"""Unit tests for SQL Server Kerberos support.
+
+Covers:
+- MSSQLClient connection-string construction for Kerberos (Windows Integrated)
+  vs SQL login auth, and the ODBC-keyword injection guard
+- the MSSQL registry auth variants (kerberos / kerberos_delegated) and their
+  credentials schemas
+- KerberosTicketManager: ccache acquisition via S4U2Self, per-principal
+  caching, KRB5CCNAME activation/restore, and the missing-gssapi error
+- ConnectionService._kerberos_delegated_credentials resolution rules
+
+python-gssapi is mocked via sys.modules, so these run without krb5 or an AD
+domain available.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from urllib.parse import parse_qs, unquote_plus, urlsplit
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.data_sources.clients.mssql_client import MSSQLClient
+
+
+def _odbc_params(client: MSSQLClient) -> dict:
+    """Decode the odbc_connect payload of the SQLAlchemy URI into a dict."""
+    query = urlsplit(client.sql_server_uri).query
+    odbc = parse_qs(query)["odbc_connect"][0]
+    odbc = unquote_plus(odbc) if "%" in odbc or "+" in odbc else odbc
+    pairs = [p for p in odbc.split(";") if p]
+    return {k.strip().lower(): v for k, v in (p.split("=", 1) for p in pairs)}
+
+
+# ---------- connection string ---------- #
+
+
+def test_userpass_uri_unchanged():
+    client = MSSQLClient("db.corp.example.com", 1433, "dwh", "svc", "secret")
+    params = _odbc_params(client)
+    assert params["uid"] == "svc"
+    assert params["pwd"] == "secret"
+    assert "trusted_connection" not in params
+
+
+def test_kerberos_uri_uses_integrated_auth_and_omits_sql_login():
+    client = MSSQLClient(
+        "db.corp.example.com", 1433, "dwh", use_kerberos=True,
+    )
+    params = _odbc_params(client)
+    assert params["trusted_connection"] == "yes"
+    assert "uid" not in params
+    assert "pwd" not in params
+    assert params["server"] == "db.corp.example.com,1433"
+
+
+def test_additional_params_cannot_flip_auth_scheme():
+    client = MSSQLClient(
+        "db.corp.example.com", 1433, "dwh", "svc", "secret",
+        additional_params={
+            "Trusted_Connection": "yes",
+            "Authentication": "ActiveDirectoryIntegrated",
+            "Integrated Security": "SSPI",
+            "ApplicationIntent": "ReadOnly",
+        },
+    )
+    params = _odbc_params(client)
+    assert "trusted_connection" not in params
+    assert "authentication" not in params
+    assert "integrated security" not in params
+    assert params["applicationintent"] == "ReadOnly"
+
+
+def test_kerberos_principals_normalized():
+    client = MSSQLClient(
+        "db.corp.example.com", 1433, "dwh", use_kerberos=True,
+        kerberos_principal="  ", kerberos_impersonate=" jdoe@CORP.EXAMPLE.COM ",
+    )
+    assert client.kerberos_principal is None
+    assert client.kerberos_impersonate == "jdoe@CORP.EXAMPLE.COM"
+
+
+# ---------- registry / schemas ---------- #
+
+
+def test_registry_exposes_kerberos_auth_variants():
+    from app.schemas.data_source_registry import get_entry
+
+    entry = get_entry("MSSQL")
+    by_auth = entry.credentials_auth.by_auth
+    assert set(by_auth) == {"userpass", "kerberos", "kerberos_delegated"}
+    assert by_auth["kerberos"].scopes == ["system"]
+    assert by_auth["kerberos_delegated"].scopes == ["user"]
+    # default UX unchanged
+    assert entry.credentials_auth.default == "userpass"
+
+
+def test_kerberos_credentials_schema_validation():
+    from app.schemas.data_sources.configs import (
+        MssqlKerberosCredentials,
+        MssqlKerberosDelegatedCredentials,
+    )
+
+    assert MssqlKerberosCredentials().kerberos_principal is None
+    assert MssqlKerberosCredentials(kerberos_principal="svc@REALM").use_kerberos is True
+    with pytest.raises(ValidationError):
+        MssqlKerberosCredentials(use_kerberos=False)
+
+    delegated = MssqlKerberosDelegatedCredentials(kerberos_impersonate="jdoe@corp.example.com")
+    assert delegated.use_kerberos is True
+    with pytest.raises(ValidationError):
+        MssqlKerberosDelegatedCredentials(use_kerberos=False)
+
+
+# ---------- ticket manager (fake gssapi) ---------- #
+
+
+class _FakeCreds:
+    def __init__(self, lifetime=3600):
+        self.lifetime = lifetime
+
+
+class _FakeAcquireResult:
+    def __init__(self, lifetime=3600):
+        self.creds = _FakeCreds(lifetime)
+        self.lifetime = lifetime
+
+
+def _install_fake_gssapi(monkeypatch, store_calls, impersonate_calls, lifetime=3600):
+    fake = types.ModuleType("gssapi")
+
+    class _Name:
+        def __init__(self, name, name_type=None):
+            self.name = name
+            self.name_type = name_type
+
+    class _Credentials:
+        def __init__(self, usage=None, name=None, store=None):
+            self.usage = usage
+            self.name = name
+            self.store = store
+            self.lifetime = lifetime
+
+    def _acquire_cred_impersonate_name(impersonator, name, usage=None):
+        impersonate_calls.append((impersonator, name.name, usage))
+        return _FakeAcquireResult(lifetime)
+
+    def _store_cred_into(store, creds, usage=None, overwrite=None, set_default=None):
+        store_calls.append((store, creds, usage, overwrite, set_default))
+        # materialize the file like a real store would
+        path = store["ccache"].split(":", 1)[1]
+        with open(path, "w") as f:
+            f.write("fake-ccache")
+
+    fake.Name = _Name
+    fake.Credentials = _Credentials
+    fake.NameType = types.SimpleNamespace(
+        kerberos_principal="krb-principal", enterprise_principal="enterprise"
+    )
+    fake.raw = types.SimpleNamespace(
+        acquire_cred_impersonate_name=_acquire_cred_impersonate_name,
+        store_cred_into=_store_cred_into,
+    )
+    monkeypatch.setitem(sys.modules, "gssapi", fake)
+    return fake
+
+
+def test_delegated_ccache_acquires_and_caches(tmp_path, monkeypatch):
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    store_calls, impersonate_calls = [], []
+    _install_fake_gssapi(monkeypatch, store_calls, impersonate_calls)
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path), client_keytab="/etc/bow/svc.keytab")
+
+    path1 = mgr.delegated_ccache("jdoe@corp.example.com")
+    path2 = mgr.delegated_ccache("jdoe@corp.example.com")
+    other = mgr.delegated_ccache("asmith@corp.example.com")
+
+    assert path1 == path2  # cached, no re-acquisition
+    assert len(impersonate_calls) == 2
+    assert path1 != other
+    assert path1.startswith(str(tmp_path))
+    # S4U2Self was asked for the right user, with initiate usage
+    assert impersonate_calls[0][1] == "jdoe@corp.example.com"
+    assert impersonate_calls[0][2] == "initiate"
+
+
+def test_delegated_ccache_refreshes_near_expiry(tmp_path, monkeypatch):
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    store_calls, impersonate_calls = [], []
+    # lifetime below the refresh margin → every call re-acquires
+    _install_fake_gssapi(monkeypatch, store_calls, impersonate_calls, lifetime=30)
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path), client_keytab="/etc/bow/svc.keytab")
+
+    mgr.delegated_ccache("jdoe@corp.example.com")
+    mgr.delegated_ccache("jdoe@corp.example.com")
+    assert len(impersonate_calls) == 2
+
+
+def test_delegated_ccache_rejects_bare_username(tmp_path):
+    from app.data_sources.kerberos import KerberosDelegationError, KerberosTicketManager
+
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path))
+    with pytest.raises(KerberosDelegationError):
+        mgr.delegated_ccache("jdoe")
+    with pytest.raises(KerberosDelegationError):
+        mgr.delegated_ccache("")
+
+
+def test_service_ccache_default_is_noop(tmp_path):
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path))
+    assert mgr.service_ccache(None) is None
+    assert mgr.service_ccache("") is None
+
+
+def test_missing_gssapi_raises_configuration_error(tmp_path, monkeypatch):
+    from app.data_sources.kerberos import (
+        KerberosConfigurationError,
+        KerberosTicketManager,
+    )
+
+    monkeypatch.setitem(sys.modules, "gssapi", None)
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path))
+    with pytest.raises(KerberosConfigurationError):
+        mgr.delegated_ccache("jdoe@corp.example.com")
+
+
+def test_activate_sets_and_restores_krb5ccname(tmp_path, monkeypatch):
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    mgr = KerberosTicketManager(ccache_dir=str(tmp_path))
+    monkeypatch.setenv("KRB5CCNAME", "FILE:/original")
+    import os
+    with mgr.activate(str(tmp_path / "cc")):
+        assert os.environ["KRB5CCNAME"] == f"FILE:{tmp_path / 'cc'}"
+    assert os.environ["KRB5CCNAME"] == "FILE:/original"
+
+    monkeypatch.delenv("KRB5CCNAME", raising=False)
+    with mgr.activate(str(tmp_path / "cc")):
+        assert os.environ["KRB5CCNAME"] == f"FILE:{tmp_path / 'cc'}"
+    assert "KRB5CCNAME" not in os.environ
+
+    # None → no env mutation at all
+    with mgr.activate(None):
+        assert "KRB5CCNAME" not in os.environ
+
+
+# ---------- resolve_credentials helper ---------- #
+
+
+class _FakeConnection:
+    def __init__(self, modes):
+        self.allowed_user_auth_modes = modes
+
+
+class _FakeUser:
+    def __init__(self, email):
+        self.email = email
+
+
+class _FakeRow:
+    def __init__(self, auth_mode, creds=None):
+        self.auth_mode = auth_mode
+        self._creds = creds or {}
+
+    def decrypt_credentials(self):
+        return self._creds
+
+
+def _resolve(connection, user, row):
+    from app.services.connection_service import ConnectionService
+
+    return ConnectionService._kerberos_delegated_credentials(connection, user, row)
+
+
+def test_kerberos_sso_not_enabled_returns_none():
+    assert _resolve(_FakeConnection([]), _FakeUser("a@b.c"), None) is None
+    assert _resolve(_FakeConnection(["oauth"]), _FakeUser("a@b.c"), None) is None
+
+
+def test_kerberos_sso_derives_upn_from_login_email():
+    creds = _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("jdoe@corp.example.com"), None)
+    assert creds == {"use_kerberos": True, "kerberos_impersonate": "jdoe@corp.example.com"}
+
+
+def test_kerberos_sso_explicit_row_principal_wins():
+    row = _FakeRow("kerberos_delegated", {"kerberos_impersonate": "j.doe@ad.corp.example.com"})
+    creds = _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("jdoe@corp.example.com"), row)
+    assert creds["kerberos_impersonate"] == "j.doe@ad.corp.example.com"
+
+
+def test_kerberos_sso_honors_other_real_auth_mode():
+    row = _FakeRow("userpass", {"user": "u", "password": "p"})
+    assert _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("a@b.c"), row) is None
+
+
+def test_kerberos_sso_ignores_service_account_marker_row():
+    row = _FakeRow("service_account", {})
+    creds = _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("jdoe@corp.example.com"), row)
+    assert creds["kerberos_impersonate"] == "jdoe@corp.example.com"
+
+
+def test_kerberos_sso_requires_upn_shaped_identity():
+    with pytest.raises(HTTPException) as exc:
+        _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("no-upn-here"), None)
+    assert exc.value.status_code == 403

--- a/backend/tests/unit/test_mssql_kerberos.py
+++ b/backend/tests/unit/test_mssql_kerberos.py
@@ -335,3 +335,27 @@ def test_kerberos_sso_requires_upn_shaped_identity():
     with pytest.raises(HTTPException) as exc:
         _resolve(_FakeConnection(["kerberos_delegated"]), _FakeUser("no-upn-here"), None)
     assert exc.value.status_code == 403
+
+
+# ── identity helpers (status/overlay adapter) ────────────────────────────────
+
+
+def test_supports_user_kerberos_sso():
+    from app.services.connection_identity import supports_user_kerberos_sso
+    assert supports_user_kerberos_sso(_FakeConnection(["kerberos_delegated"])) is True
+    assert supports_user_kerberos_sso(_FakeConnection(["oauth"])) is False
+    assert supports_user_kerberos_sso(_FakeConnection([])) is False
+
+
+def test_resolve_kerberos_principal_precedence():
+    from app.services.connection_identity import resolve_kerberos_principal
+    # login UPN when no row
+    assert resolve_kerberos_principal(_FakeUser("jdoe@corp.example.com"), None) == "jdoe@corp.example.com"
+    # explicit override wins
+    row = _FakeRow("kerberos_delegated", {"kerberos_impersonate": "j.doe@ad.corp.example.com"})
+    assert resolve_kerberos_principal(_FakeUser("jdoe@corp.example.com"), row) == "j.doe@ad.corp.example.com"
+    # non-UPN login and no override → None (must set principal)
+    assert resolve_kerberos_principal(_FakeUser("no-upn"), None) is None
+    # a non-kerberos row is ignored for principal derivation → falls back to email
+    other = _FakeRow("userpass", {"kerberos_impersonate": "should-be-ignored@x"})
+    assert resolve_kerberos_principal(_FakeUser("jdoe@corp.example.com"), other) == "jdoe@corp.example.com"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,6 +480,9 @@ dev = [
     { name = "testcontainers", extra = ["mysql"] },
     { name = "ty" },
 ]
+kerberos = [
+    { name = "gssapi" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -514,6 +517,7 @@ requires-dist = [
     { name = "google-cloud-bigquery", specifier = ">=3.42.0,<3.43" },
     { name = "google-genai", specifier = ">=1.75.0,<1.76" },
     { name = "google-generativeai", specifier = ">=0.8.6,<0.9" },
+    { name = "gssapi", marker = "extra == 'kerberos'", specifier = ">=1.8.3,<2" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "httpx-oauth", specifier = ">=0.16.1,<0.17" },
     { name = "ipython", specifier = ">=8.39.0,<8.40" },
@@ -591,7 +595,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.2,<2.1" },
     { name = "xlsxwriter", specifier = ">=3.2.9,<3.3" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["kerberos", "dev"]
 
 [[package]]
 name = "bcrypt"
@@ -1680,6 +1684,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/58/317b0134129b556a93a3b0afe00ee675b5657f0155509e22fcb853bafe2d/grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3", size = 14424, upload-time = "2025-06-28T04:23:42.136Z" },
+]
+
+[[package]]
+name = "gssapi"
+version = "1.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/52/c1e90623c259a42ab0587078bb04f959867b970add46ff66750ead8fc7c5/gssapi-1.11.1.tar.gz", hash = "sha256:2049ee4b1d0c363163a1344b7282a363f9f4094e51d2c36de0cf01d4735e0ae2", size = 95233, upload-time = "2026-01-26T21:01:39.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/75/3cc18f2d084d19fbba38dc684588cf5f674c647e754f9cf1625bd78c39f8/gssapi-1.11.1-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2298e5909a8f2d27c29352885a24e4026cfd3fa24fc38d4a0a3743fa5a3e7667", size = 611712, upload-time = "2026-01-26T21:01:19.626Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f9/ac0f8c43c209d56c89655f80cd4ae43379f88370d01a7e11f264f081eef5/gssapi-1.11.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:5b60b1f8d8d3e36c025bd3494105de1dfccee578e8de001f423cc094468e3022", size = 642782, upload-time = "2026-01-26T21:01:21.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/97/f4ea9248bfdf5fcde2c5bf0bc0e573d212748724a32a5aa1002e11edb760/gssapi-1.11.1-cp311-abi3-win32.whl", hash = "sha256:9738fe0ba163c28ccf521de7520640bde4b135c1b6e87a5ac5a90435369e89c0", size = 699801, upload-time = "2026-01-26T21:01:23.226Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ca/7f839880baf7c365768884161c246a3b6201738722fc7581a995190ec431/gssapi-1.11.1-cp311-abi3-win_amd64.whl", hash = "sha256:96a102ad1ec266e2d843468bf03149982969fc70344f303f81ea20197b80d7a1", size = 781646, upload-time = "2026-01-26T21:01:24.618Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/9148636b75ca5741ddc9c57c4b256adec422e3a89bca14306d53b48caac9/gssapi-1.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:82fba401e9514ad21749b8d8954e2de1c617b0a73204c8598ee84630e23c5810", size = 714379, upload-time = "2026-01-26T21:01:25.961Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/77/f34fd81bbccf2e682073964a1b1b0a383e70d02946e472f78881d50cec6f/gssapi-1.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb0250f27d288d4217d7f606d3b68ecb9a10fce9391106129cada96434a685b0", size = 734103, upload-time = "2026-01-26T21:01:27.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/34/733a6f3372040992befd1fe62288cafea9fe25acdcf8b663ec8a7857cb69/gssapi-1.11.1-cp314-cp314t-win32.whl", hash = "sha256:b17875d236b8b030a777ee3f3ece55f3d316a91937c37abbc771afe1493703cf", size = 868586, upload-time = "2026-01-26T21:01:29.041Z" },
+    { url = "https://files.pythonhosted.org/packages/10/03/1b71feddb85f945101c3cdc07242805c5e9b48da546f8a922129ad8299e5/gssapi-1.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:da43c0e0ae84bb9f04c4e016eac6d3826c6357f827183042ba990ccedeeab052", size = 981075, upload-time = "2026-01-26T21:01:30.451Z" },
 ]
 
 [[package]]

--- a/docs/sql-server-kerberos.md
+++ b/docs/sql-server-kerberos.md
@@ -1,0 +1,188 @@
+# SQL Server: Kerberos authentication & per-user SSO (constrained delegation)
+
+Bag of Words supports two Kerberos auth shapes for on-prem Microsoft SQL Server,
+on top of the default SQL username/password login:
+
+| Auth variant | Scope | Identity seen by SQL Server |
+|---|---|---|
+| `userpass` (default) | system or per-user | SQL login |
+| `kerberos` — Kerberos (Windows Integrated) | system | the app's **service account** |
+| `kerberos_delegated` — Kerberos SSO | per-user | **the signed-in user's AD identity**, via constrained delegation (S4U2Self + S4U2Proxy) |
+
+Both Kerberos variants use the Microsoft ODBC Driver 17/18 for SQL Server on
+Linux, which performs GSSAPI/Kerberos when the connection string contains
+`Trusted_Connection=yes` (no NTLM fallback exists on Linux). The driver derives
+the target SPN as `MSSQLSvc/<host>:<port>` and this cannot be overridden — the
+connection **host must be the SQL Server's FQDN**, not an IP address or an
+unregistered CNAME.
+
+---
+
+## Phase A — service-account Kerberos (keytab)
+
+All queries authenticate as one AD service account. Bag of Words still enforces
+its own RBAC and read-only SQL guard; SQL Server sees a single login.
+
+### Active Directory / DBA prerequisites
+
+1. A domain service account for the app, e.g. `svc-bow@CORP.EXAMPLE.COM`,
+   with AES key types enabled ("This account supports Kerberos AES 128/256 bit
+   encryption").
+2. A keytab for it (on Windows):
+
+   ```
+   ktpass /princ svc-bow@CORP.EXAMPLE.COM /mapuser svc-bow /pass * ^
+          /crypto AES256-SHA1 /ptype KRB5_NT_PRINCIPAL /out svc-bow.keytab
+   ```
+
+3. SQL Server's SPN registered (usually automatic):
+   `setspn -L <sql service account>` should list `MSSQLSvc/<fqdn>:1433`.
+4. A SQL Server login + permissions for the service account
+   (`CREATE LOGIN [CORP\svc-bow] FROM WINDOWS;` + minimal read-only grants —
+   the app only ever issues SELECTs, so `db_datareader` on the target database
+   or explicit `GRANT SELECT` on the approved schemas is enough and recommended).
+
+### Server / deployment setup
+
+The Docker image ships `krb5-user`, `libgssapi-krb5-2`, and `msodbcsql18`.
+Mount two files and set one env var:
+
+```yaml
+# docker-compose override / k8s equivalent
+services:
+  bagofwords:
+    volumes:
+      - ./krb5.conf:/etc/krb5.conf:ro
+      - ./svc-bow.keytab:/etc/bagofwords/svc-bow.keytab:ro   # readable by the 'app' user
+    environment:
+      # GSSAPI initiates from the keytab automatically — no kinit cron needed.
+      KRB5_CLIENT_KTNAME: /etc/bagofwords/svc-bow.keytab
+```
+
+Minimal `krb5.conf`:
+
+```ini
+[libdefaults]
+    default_realm = CORP.EXAMPLE.COM
+    dns_lookup_kdc = true
+    forwardable = true
+
+[domain_realm]
+    .corp.example.com = CORP.EXAMPLE.COM
+    corp.example.com = CORP.EXAMPLE.COM
+```
+
+Clock skew must stay under 5 minutes (run NTP/chrony on the host).
+
+Smoke test from inside the container:
+
+```
+kinit -kt /etc/bagofwords/svc-bow.keytab svc-bow@CORP.EXAMPLE.COM && klist
+```
+
+### App configuration
+
+Create (or edit) the SQL Server connection and pick **Kerberos (Windows
+Integrated)** as the authentication method. Leave *Service Principal* blank to
+use the default credential cache (`KRB5_CLIENT_KTNAME` above); set it only when
+the keytab holds several principals. Verify on the SQL side with:
+
+```sql
+SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID;
+-- expect: KERBEROS
+```
+
+---
+
+## Phase B — per-user SSO via Kerberos Constrained Delegation
+
+With `auth_policy = user_required`, queries run as **the signed-in user's AD
+identity**. No password or token is collected from the user: the app performs
+protocol transition (S4U2Self — "issue me a ticket *for user X* to myself",
+which requires only the user's UPN) and constrained delegation (S4U2Proxy —
+exchange it for a ticket to the SQL Server SPN). SQL-side permissions, row-level
+security, and auditing all apply per user.
+
+The user's UPN is taken from their Bag of Words login identity (Entra ID /
+OIDC `preferred_username`/`upn`, LDAP, or local email). If a user's email is not
+their AD UPN, they can save an explicit principal under the data source's
+user credentials ("Kerberos SSO" mode).
+
+### Additional AD prerequisites (on top of Phase A)
+
+Delegation must be configured on the **app's service account** — this is the
+piece the AD team has to approve:
+
+1. **Classic KCD with protocol transition** (single domain): in ADUC →
+   `svc-bow` → *Delegation* tab →
+   *"Trust this user for delegation to specified services only"* →
+   **"Use any authentication protocol"** (this is required; "Kerberos only"
+   will fail with `KDC_ERR_BADOPTION`), and add the SQL Server's
+   `MSSQLSvc/<fqdn>:1433` SPN(s) to the allowed list
+   (`msDS-AllowedToDelegateTo`).
+
+   **Or** resource-based constrained delegation (works cross-domain): on the
+   SQL Server's service account,
+   `Set-ADUser <sqlsvc> -PrincipalsAllowedToDelegateToAccount svc-bow`.
+
+2. SQL Server logins for the end users or their AD groups:
+   `CREATE LOGIN [CORP\bi-analysts] FROM WINDOWS;` + per-group grants.
+
+3. Note: members of **Protected Users** or accounts flagged *"Account is
+   sensitive and cannot be delegated"* cannot be impersonated — those users
+   need a personal SQL login (`userpass` mode) instead.
+
+Smoke test (from the container, validates the whole AD chain before touching
+the app):
+
+```
+kinit -kt /etc/bagofwords/svc-bow.keytab svc-bow@CORP.EXAMPLE.COM
+kvno -U jdoe@corp.example.com -P MSSQLSvc/sqldwh01.corp.example.com:1433
+```
+
+### App configuration
+
+1. Ensure the image has the Kerberos extra (the default Dockerfile installs it:
+   `uv sync --extra kerberos`, i.e. python-gssapi).
+2. Configure the connection with **Kerberos (Windows Integrated)** system auth
+   (Phase A) — the system identity is still used for schema indexing.
+3. Enable **Require user authentication** on the connection. For a Kerberos
+   system-auth connection this defaults `allowed_user_auth_modes` to
+   `["kerberos_delegated"]` — per-user SSO is then automatic, with no user
+   action needed.
+4. Optional env vars:
+   - `BOW_KRB5_CCACHE_DIR` — directory for per-user credential caches
+     (default `/tmp/bow_krb5`, created `0700`).
+   - `KRB5_CLIENT_KTNAME` — service keytab used both for the app's own identity
+     and as the impersonator for S4U (required for Phase B).
+
+Per-user auth on tabular sources requires an **enterprise license**.
+
+### Operational notes & limitations
+
+- **Ticket renewal** is handled by the app: delegated tickets are cached per
+  user and re-acquired near expiry from the keytab; nothing to cron.
+- `KRB5CCNAME` is process-global on Linux, so the credential cache switch is
+  serialized around the driver's connect handshake. Concurrent queries by
+  different users queue for milliseconds at connect time; established
+  connections are unaffected.
+- Do not enable unixODBC connection pooling: pooled integrated-auth connections
+  can be reused across identities.
+- Indexing/schema refresh (no user in context) always runs as the service
+  account.
+- If SQL Server is **2022+ and Azure Arc-enabled**, Entra-token authentication
+  is an alternative to KCD that reuses the app's existing Entra OBO flow —
+  worth considering where AD delegation approval is hard to obtain.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Cannot generate SSPI context` / `SPNEGO` errors | SPN missing or host is an IP/alias — connect by the exact FQDN the SPN is registered for |
+| `KDC_ERR_BADOPTION` on delegation | Delegation set to "Kerberos only" — must be "Use any authentication protocol", or the `MSSQLSvc` SPN is missing from `msDS-AllowedToDelegateTo` |
+| `KRB5KRB_AP_ERR_SKEW` | Clock skew > 5 min — fix NTP |
+| Works with `kinit` but not in app | Keytab not readable by the container's `app` user, or `KRB5_CLIENT_KTNAME` unset |
+| Delegated auth fails for one user only | Protected Users / "sensitive, cannot be delegated" flag, or their email ≠ AD UPN (save an explicit principal) |
+| `auth_scheme` shows `NTLM`/`SQL` | Connection fell back to another path — check the connection uses the Kerberos auth variant |

--- a/docs/sql-server-kerberos.md
+++ b/docs/sql-server-kerberos.md
@@ -113,6 +113,9 @@ user credentials ("Kerberos SSO" mode).
 Delegation must be configured on the **app's service account** — this is the
 piece the AD team has to approve:
 
+0. The service account **must have its own SPN** (e.g. `setspn -S bow/apphost
+   CORP\svc-bow`). The KDC only issues an S4U2Self evidence ticket to an account
+   that is itself a service (has an SPN).
 1. **Classic KCD with protocol transition** (single domain): in ADUC →
    `svc-bow` → *Delegation* tab →
    *"Trust this user for delegation to specified services only"* →
@@ -166,8 +169,19 @@ Per-user auth on tabular sources requires an **enterprise license**.
   serialized around the driver's connect handshake. Concurrent queries by
   different users queue for milliseconds at connect time; established
   connections are unaffected.
-- Do not enable unixODBC connection pooling: pooled integrated-auth connections
-  can be reused across identities.
+- **Connection pooling / cross-user reuse:** under integrated auth every user's
+  ODBC connection string is otherwise identical (the identity comes from
+  `KRB5CCNAME`, not the string), so a shared connection pool could hand user B a
+  connection authenticated as user A. The client defends against this by binding
+  a per-identity `APP=BagOfWords-<principal>` token into the connection string,
+  giving each impersonated user its own pool bucket. (Still prefer leaving
+  unixODBC pooling off as defence in depth.)
+- **`forwardable = true` is required** in `krb5.conf`: S4U2Proxy is refused
+  unless the S4U2Self evidence ticket is forwardable, which needs a forwardable
+  service TGT. The example config above already sets it.
+- **SQL Server host must be domain-joined** (SSSD or winbind) so it can resolve
+  AD users to SIDs — `CREATE LOGIN ... FROM WINDOWS` and Kerberos ticket→login
+  mapping both need it. Verify with `id DOMAIN\\user` before creating logins.
 - Indexing/schema refresh (no user in context) always runs as the service
   account.
 - If SQL Server is **2022+ and Azure Arc-enabled**, Entra-token authentication

--- a/lab/sql-server-kerberos/README.md
+++ b/lab/sql-server-kerberos/README.md
@@ -1,0 +1,83 @@
+# SQL Server Kerberos SSO — self-contained lab
+
+A one-command lab that stands up a real Kerberos domain and proves the
+bagofwords SQL Server connector's per-user SSO via **Kerberos Constrained
+Delegation (S4U2Self + S4U2Proxy)** — the mechanism a customer's IT asked us
+to support — against **SQL Server 2022 and 2019** on Linux.
+
+Everything runs in containers; no external Active Directory, cloud, or secrets
+are needed.
+
+```
+cd lab/sql-server-kerberos
+./up.sh          # build, start DC + SQL 2022/2019, run the test suite
+./down.sh        # tear down (containers + volumes)
+```
+
+## What it stands up
+
+| Container | Role |
+|---|---|
+| `dc` | Samba **Active Directory Domain Controller** — the KDC/LDAP/DNS. Realm `BOWLAB.LOCAL`. |
+| `sql2022` | SQL Server 2022 on Linux, joined to the domain (keytab + `mssql-conf`). |
+| `sql2019` | SQL Server 2019 on Linux, same. |
+| `runner` | krb5 + python-gssapi + the **production** `app/data_sources/kerberos.py` and `MSSQLClient`, mounted read-only and exercised by `test_delegation.py`. |
+
+The DC provisions (once) the accounts, SPNs, constrained-delegation config, DNS,
+and exports keytabs into a shared volume that the SQL servers and runner consume.
+
+### Directory accounts created
+
+- `svc-bow` — the **app service account** / S4U impersonator. Has its own SPN
+  (`bow/svc-bow.bowlab.local`, required for S4U2Self) and is configured for
+  constrained delegation with protocol transition
+  (`UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION` + `msDS-AllowedToDelegateTo`
+  containing both `MSSQLSvc/...` SPNs).
+- `mssql2022`, `mssql2019` — SQL service accounts holding the `MSSQLSvc/<fqdn>`
+  and `MSSQLSvc/<fqdn>:1433` SPNs.
+- `alice` — test user; has a SQL login + `db_datareader` on the lab DB.
+- `bob` — test user with a login but **no** read grant (proves per-user identity
+  actually reaches SQL Server).
+
+## What it proves
+
+**Tier A — the delegation core** (needs only the DC; validates
+`app/data_sources/kerberos.py`):
+- `KerberosTicketManager.delegated_ccache("alice@BOWLAB.LOCAL")` performs
+  **S4U2Self** using only the service keytab — no user password.
+- Initiating a GSSAPI context to each `MSSQLSvc` SPN performs **S4U2Proxy**,
+  yielding a service ticket for alice to SQL Server 2022 and 2019.
+
+**Tier B — the SQL last mile** (needs the SQL containers up):
+- `MSSQLClient(use_kerberos=True, kerberos_impersonate="alice@...")` connects to
+  each SQL version; `SUSER_SNAME()` returns `BOWLAB\alice` and `auth_scheme` is
+  `KERBEROS`.
+- The same client as `bob` is denied reading the granted table — per-user
+  authorization is enforced by SQL Server, not the app.
+
+Tier A runs even if the SQL containers are unavailable (Tier B auto-skips),
+so the novel code is always validated.
+
+## Key requirements this lab surfaced (also in `docs/sql-server-kerberos.md`)
+
+1. **`forwardable = true`** in `krb5.conf` is mandatory: S4U2Proxy is refused
+   unless the S4U2Self evidence ticket is forwardable, which needs a forwardable
+   service TGT.
+2. The **middle-tier account (`svc-bow`) must have its own SPN** for the KDC to
+   issue it an S4U2Self ticket.
+3. Delegation must be **protocol transition** ("Use any authentication
+   protocol" in AD terms); Kerberos-only fails with `KDC_ERR_BADOPTION`.
+
+## Notes
+
+- `dc` and the SQL containers run `--privileged`/as root only for setup (Samba
+  KDC caps; SQL keytab + `mssql-conf`); the SQL engine drops to the `mssql` user.
+- Requires ~6 GB free RAM (two SQL Server instances) and amd64 (SQL Server on
+  Linux images are amd64-only).
+- The `runner` image installs `msodbcsql18` from packages.microsoft.com; in a
+  network-restricted CI, pre-build/cache that image.
+- Manual poke at the KDC from inside `dc`:
+  ```
+  kinit -f -k -t /keytabs/svc-bow.keytab svc-bow@BOWLAB.LOCAL
+  kvno -U alice@bowlab.local -P MSSQLSvc/sql2022.bowlab.local:1433
+  ```

--- a/lab/sql-server-kerberos/docker-compose.yaml
+++ b/lab/sql-server-kerberos/docker-compose.yaml
@@ -1,0 +1,122 @@
+# Self-contained Kerberos constrained-delegation lab for the BoW SQL Server
+# connector. Brings up a Samba AD DC (KDC), SQL Server 2022 + 2019 joined to
+# it, and a runner that exercises the production S4U2Self/S4U2Proxy code.
+#
+#   ./up.sh          # build + start, wait for the DC, run the test suite
+#   ./down.sh        # tear everything down
+#
+# The DC exports keytabs + krb5.conf into the shared `keytabs` volume that the
+# SQL servers and runner consume.
+
+networks:
+  bowlab:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+volumes:
+  keytabs:
+
+services:
+  dc:
+    build: ./samba-dc
+    image: bowlab-dc
+    hostname: dc
+    privileged: true               # Samba AD DC needs broad caps for the KDC
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.10
+    dns:
+      - 127.0.0.1
+    environment:
+      DC_IP: 172.28.0.10
+      SQL2022_IP: 172.28.0.22
+      SQL2019_IP: 172.28.0.19
+    volumes:
+      - keytabs:/keytabs
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /keytabs/svc-bow.keytab && test -f /keytabs/krb5.conf"]
+      interval: 5s
+      timeout: 3s
+      retries: 40
+
+  sql2022:
+    build:
+      context: ./mssql
+      args:
+        MSSQL_TAG: 2022-latest
+    image: bowlab-sql:2022
+    hostname: sql2022
+    privileged: true               # domain join (adcli) + mssql-conf need caps
+    user: root                     # setup script joins AD, installs keytab, drops to mssql
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.22
+    dns:
+      - 172.28.0.10
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Bowlab#Sa2022"
+      SA_PASSWORD: "Bowlab#Sa2022"
+      MSSQL_FQDN: sql2022.bowlab.local
+      MSSQL_KEYTAB: /keytabs/mssql2022.keytab
+      MSSQL_AD_ACCOUNT: mssql2022
+    volumes:
+      - keytabs:/keytabs
+      - ./mssql/setup-ad-auth.sh:/setup-ad-auth.sh:ro
+      - ./mssql/init.sql:/init.sql:ro
+    entrypoint: ["/bin/bash", "/setup-ad-auth.sh"]
+    depends_on:
+      dc:
+        condition: service_healthy
+
+  sql2019:
+    build:
+      context: ./mssql
+      args:
+        MSSQL_TAG: 2019-latest
+    image: bowlab-sql:2019
+    hostname: sql2019
+    privileged: true
+    user: root
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.19
+    dns:
+      - 172.28.0.10
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Bowlab#Sa2019"
+      SA_PASSWORD: "Bowlab#Sa2019"
+      MSSQL_FQDN: sql2019.bowlab.local
+      MSSQL_KEYTAB: /keytabs/mssql2019.keytab
+      MSSQL_AD_ACCOUNT: mssql2019
+    volumes:
+      - keytabs:/keytabs
+      - ./mssql/setup-ad-auth.sh:/setup-ad-auth.sh:ro
+      - ./mssql/init.sql:/init.sql:ro
+    entrypoint: ["/bin/bash", "/setup-ad-auth.sh"]
+    depends_on:
+      dc:
+        condition: service_healthy
+
+  runner:
+    build: ./runner
+    image: bowlab-runner
+    hostname: runner
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.100
+    dns:
+      - 172.28.0.10
+    volumes:
+      - keytabs:/keytabs
+      - ../../backend/app:/app/app:ro           # production code under test
+      - ./runner/test_delegation.py:/lab/test_delegation.py:ro
+    depends_on:
+      dc:
+        condition: service_healthy
+    # Not started by default with `up -d`; run explicitly via up.sh so the SQL
+    # servers have time to come online for Tier B.
+    profiles: ["manual"]

--- a/lab/sql-server-kerberos/down.sh
+++ b/lab/sql-server-kerberos/down.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Tear the Kerberos lab down (containers + volumes).
+set -euo pipefail
+cd "$(dirname "$0")"
+docker compose --profile manual down -v --remove-orphans

--- a/lab/sql-server-kerberos/mssql/Dockerfile
+++ b/lab/sql-server-kerberos/mssql/Dockerfile
@@ -1,0 +1,17 @@
+# SQL Server on Linux + the Active Directory client stack needed for Windows
+# (Kerberos) logins. SQL Server can only CREATE LOGIN ... FROM WINDOWS and map
+# incoming Kerberos tickets to a principal once the host can resolve AD
+# users/groups via SSSD, so the image bakes in the join tooling. The version is
+# passed as a build arg so the same Dockerfile builds 2022 and 2019.
+ARG MSSQL_TAG=2022-latest
+FROM mcr.microsoft.com/mssql/server:${MSSQL_TAG}
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      sssd sssd-ad sssd-tools adcli realmd \
+      krb5-user libnss-sss libpam-sss \
+      samba-common-bin ldap-utils dnsutils gosu \
+    && rm -rf /var/lib/apt/lists/*

--- a/lab/sql-server-kerberos/mssql/init.sql
+++ b/lab/sql-server-kerberos/mssql/init.sql
@@ -1,0 +1,40 @@
+-- Lab database + AD-backed logins for the Kerberos delegation test.
+-- The AD users are impersonated by the app via S4U2Proxy; SQL Server sees
+-- their real domain identity, so per-user logins/permissions apply.
+IF DB_ID('bowlab') IS NULL
+    CREATE DATABASE bowlab;
+GO
+USE bowlab;
+GO
+IF OBJECT_ID('dbo.sales') IS NULL
+BEGIN
+    CREATE TABLE dbo.sales (id INT PRIMARY KEY, region NVARCHAR(50), amount DECIMAL(10,2));
+    INSERT INTO dbo.sales VALUES (1, N'North', 100.00), (2, N'South', 250.50), (3, N'East', 75.25);
+END
+GO
+-- AD logins (Windows authentication). Kerberos-authenticated connections for
+-- these principals will succeed and report auth_scheme = KERBEROS.
+IF SUSER_ID('BOWLAB\alice') IS NULL
+    CREATE LOGIN [BOWLAB\alice] FROM WINDOWS WITH DEFAULT_DATABASE = bowlab;
+GO
+IF SUSER_ID('BOWLAB\bob') IS NULL
+    CREATE LOGIN [BOWLAB\bob] FROM WINDOWS WITH DEFAULT_DATABASE = bowlab;
+GO
+USE bowlab;
+GO
+IF USER_ID('BOWLAB\alice') IS NULL
+    CREATE USER [BOWLAB\alice] FOR LOGIN [BOWLAB\alice];
+GO
+IF USER_ID('BOWLAB\bob') IS NULL
+    CREATE USER [BOWLAB\bob] FOR LOGIN [BOWLAB\bob];
+GO
+-- Alice can read; bob deliberately cannot — proves per-user identity reaches SQL.
+EXEC sp_addrolemember 'db_datareader', 'BOWLAB\alice';
+GO
+-- Let the test read auth_scheme from sys.dm_exec_connections. The required
+-- permission was renamed in SQL Server 2022; grant both and ignore the one that
+-- doesn't exist on a given version (each batch is independent).
+BEGIN TRY GRANT VIEW SERVER STATE TO [BOWLAB\alice]; END TRY BEGIN CATCH END CATCH;
+GO
+BEGIN TRY GRANT VIEW SERVER PERFORMANCE STATE TO [BOWLAB\alice]; END TRY BEGIN CATCH END CATCH;
+GO

--- a/lab/sql-server-kerberos/mssql/init.sql
+++ b/lab/sql-server-kerberos/mssql/init.sql
@@ -12,6 +12,15 @@ BEGIN
     INSERT INTO dbo.sales VALUES (1, N'North', 100.00), (2, N'South', 250.50), (3, N'East', 75.25);
 END
 GO
+-- A second table only bob may read, so alice's and bob's visible catalogs are
+-- disjoint — proving the per-user overlay is genuinely per-identity, not a
+-- subset of one shared catalog.
+IF OBJECT_ID('dbo.audit') IS NULL
+BEGIN
+    CREATE TABLE dbo.audit (id INT PRIMARY KEY, event NVARCHAR(100));
+    INSERT INTO dbo.audit VALUES (1, N'login'), (2, N'export');
+END
+GO
 -- AD logins (Windows authentication). Kerberos-authenticated connections for
 -- these principals will succeed and report auth_scheme = KERBEROS.
 IF SUSER_ID('BOWLAB\alice') IS NULL
@@ -28,8 +37,12 @@ GO
 IF USER_ID('BOWLAB\bob') IS NULL
     CREATE USER [BOWLAB\bob] FOR LOGIN [BOWLAB\bob];
 GO
--- Alice can read; bob deliberately cannot — proves per-user identity reaches SQL.
-EXEC sp_addrolemember 'db_datareader', 'BOWLAB\alice';
+-- Table-specific grants (NOT db_datareader) so each user sees only their own
+-- tables in INFORMATION_SCHEMA: alice → dbo.sales, bob → dbo.audit. This makes
+-- their introspected overlays disjoint, and bob is still denied on dbo.sales.
+GRANT SELECT ON dbo.sales TO [BOWLAB\alice];
+GO
+GRANT SELECT ON dbo.audit TO [BOWLAB\bob];
 GO
 -- Let the test read auth_scheme from sys.dm_exec_connections. The required
 -- permission was renamed in SQL Server 2022; grant both and ignore the one that

--- a/lab/sql-server-kerberos/mssql/setup-ad-auth.sh
+++ b/lab/sql-server-kerberos/mssql/setup-ad-auth.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Configure a SQL Server on Linux container for Active Directory (Kerberos)
+# authentication against the lab Samba DC, then create AD logins.
+#
+# Runs as the container entrypoint wrapper: it configures krb5 + the mssql
+# keytab, launches sqlservr, waits for it, applies init.sql, and then execs
+# sqlservr in the foreground.
+#
+# Env:
+#   MSSQL_FQDN        e.g. sql2022.bowlab.local
+#   MSSQL_KEYTAB      path to this instance's keytab (mounted, from the DC)
+#   MSSQL_AD_ACCOUNT  privileged AD account name, e.g. mssql2022
+#   SA_PASSWORD       sa password
+set -uo pipefail
+
+REALM="BOWLAB.LOCAL"
+: "${MSSQL_FQDN:?}"; : "${MSSQL_KEYTAB:?}"; : "${MSSQL_AD_ACCOUNT:?}"; : "${SA_PASSWORD:?}"
+
+log() { echo "[mssql-setup:${MSSQL_FQDN}] $*"; }
+
+# Wait for the DC-exported krb5.conf + this instance's keytab to appear.
+for i in $(seq 1 60); do
+    [ -f /keytabs/krb5.conf ] && [ -f "${MSSQL_KEYTAB}" ] && break
+    sleep 2
+done
+cp /keytabs/krb5.conf /etc/krb5.conf 2>/dev/null || true
+
+DOMAIN="bowlab.local"
+ADMIN_PASS="${ADMIN_PASS:-Bowlab#Admin1}"
+
+# --- join the domain so SQL can resolve AD users (name -> SID) -------------
+# Windows logins and Kerberos ticket->principal mapping require SSSD name
+# resolution; the keytab alone only handles the crypto.
+log "Joining domain ${DOMAIN} via SSSD ..."
+echo "${ADMIN_PASS}" | adcli join --stdin-password --domain="${DOMAIN}" \
+    --domain-controller="dc.${DOMAIN}" --login-user=Administrator 2>&1 \
+    | sed "s/^/[mssql-setup:${MSSQL_FQDN}] /" || log "adcli join reported an issue (continuing)"
+
+cat > /etc/sssd/sssd.conf <<EOF
+[sssd]
+domains = ${DOMAIN}
+config_file_version = 2
+services = nss, pam
+
+[domain/${DOMAIN}]
+id_provider = ad
+auth_provider = ad
+access_provider = ad
+ad_domain = ${DOMAIN}
+krb5_realm = ${REALM}
+realmd_tags = manages-system joined-with-adcli
+cache_credentials = True
+ldap_id_mapping = True
+use_fully_qualified_names = False
+fallback_homedir = /home/%u@%d
+default_shell = /bin/bash
+EOF
+chmod 600 /etc/sssd/sssd.conf
+
+# Point NSS at sss so `id BOWLAB\alice` resolves.
+sed -i 's/^passwd:.*/passwd:         files sss/' /etc/nsswitch.conf
+sed -i 's/^group:.*/group:          files sss/'  /etc/nsswitch.conf
+
+log "Starting SSSD ..."
+sssd -D 2>/dev/null || service sssd start 2>/dev/null || true
+sleep 3
+if id "alice@${DOMAIN}" >/dev/null 2>&1; then
+    log "AD name resolution OK ($(id -u "alice@${DOMAIN}"):alice)"
+else
+    log "WARNING: AD name resolution not working yet; Windows logins may fail."
+fi
+
+# Install the instance keytab where SQL Server expects a private copy.
+# The secrets dir doesn't exist until first boot, so create it.
+mkdir -p /var/opt/mssql/secrets
+install -m 0600 -o mssql -g root "${MSSQL_KEYTAB}" /var/opt/mssql/secrets/mssql.keytab
+
+# Point SQL Server at the keytab + privileged AD account (Kerberos).
+/opt/mssql/bin/mssql-conf set network.kerberoskeytabfile /var/opt/mssql/secrets/mssql.keytab
+/opt/mssql/bin/mssql-conf set network.privilegedadaccount "${MSSQL_AD_ACCOUNT}"
+/opt/mssql/bin/mssql-conf set network.forceencryption 0
+
+log "Starting sqlservr (as mssql user) ..."
+# SQL Server refuses to run as root; the setup above needed root for the
+# keytab + mssql-conf, so drop privileges to run the engine.
+chown mssql:root /var/opt/mssql/secrets/mssql.keytab
+su mssql -s /bin/bash -c "MSSQL_SA_PASSWORD='${SA_PASSWORD}' ACCEPT_EULA=Y /opt/mssql/bin/sqlservr" &
+SQL_PID=$!
+
+# Wait for SQL to accept connections.
+SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
+[ -x "$SQLCMD" ] || SQLCMD="/opt/mssql-tools/bin/sqlcmd"
+for i in $(seq 1 60); do
+    "$SQLCMD" -S localhost -U sa -P "${SA_PASSWORD}" -No -Q "SELECT 1" >/dev/null 2>&1 && break
+    sleep 2
+done
+
+log "Applying init.sql ..."
+"$SQLCMD" -S localhost -U sa -P "${SA_PASSWORD}" -No -i /init.sql 2>&1 | sed "s/^/[mssql-setup:${MSSQL_FQDN}] /" || true
+
+log "Ready. auth_scheme for AD logins will be KERBEROS."
+wait "$SQL_PID"

--- a/lab/sql-server-kerberos/runner/Dockerfile
+++ b/lab/sql-server-kerberos/runner/Dockerfile
@@ -1,0 +1,25 @@
+# Test runner: krb5 + python-gssapi + the Microsoft ODBC driver, plus the
+# bagofwords Kerberos module under test. Mirrors the production image's krb5
+# stack so the S4U path is exercised exactly as it runs in the app.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3 python3-venv python3-dev build-essential \
+      krb5-user libkrb5-dev libgssapi-krb5-2 \
+      unixodbc unixodbc-dev curl ca-certificates gnupg \
+    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir "gssapi>=1.8.3,<2" pyodbc sqlalchemy pandas pytest pydantic
+
+COPY run-tests.sh /usr/local/bin/run-tests.sh
+RUN chmod +x /usr/local/bin/run-tests.sh
+ENTRYPOINT ["/usr/local/bin/run-tests.sh"]

--- a/lab/sql-server-kerberos/runner/run-tests.sh
+++ b/lab/sql-server-kerberos/runner/run-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Runner entrypoint: wait for the DC keytabs, install the lab krb5.conf, then
+# run the delegation test suite against the production bagofwords code
+# (mounted at /app).
+set -uo pipefail
+
+log() { echo "[runner] $*"; }
+
+for i in $(seq 1 90); do
+    [ -f /keytabs/svc-bow.keytab ] && [ -f /keytabs/krb5.conf ] && break
+    sleep 2
+done
+cp /keytabs/krb5.conf /etc/krb5.conf 2>/dev/null || true
+
+log "krb5.conf:"; sed 's/^/[runner]   /' /etc/krb5.conf
+
+export PYTHONPATH=/app
+export KRB5_CONFIG=/etc/krb5.conf
+# The service keytab our KerberosTicketManager initiates from.
+export KRB5_CLIENT_KTNAME=/keytabs/svc-bow.keytab
+
+log "Running delegation test suite ..."
+exec python -m pytest /lab/test_delegation.py -v -rs --no-header "$@"

--- a/lab/sql-server-kerberos/runner/test_delegation.py
+++ b/lab/sql-server-kerberos/runner/test_delegation.py
@@ -1,0 +1,134 @@
+"""End-to-end Kerberos constrained-delegation test for the BoW SQL Server path.
+
+Runs inside the lab runner container against the Samba AD DC and the two SQL
+Server instances. Two tiers:
+
+  Tier A — delegation core (no SQL Server needed): using the *production*
+    KerberosTicketManager, acquire a delegated (S4U2Self) credential for an AD
+    user with only the service keytab, then drive S4U2Proxy by initiating a
+    GSSAPI context to each MSSQLSvc SPN. Proves the exact code in
+    app/data_sources/kerberos.py performs protocol transition + constrained
+    delegation against a real KDC.
+
+  Tier B — SQL last mile: use the production MSSQLClient with
+    use_kerberos + kerberos_impersonate to connect to SQL Server 2022 and 2019
+    and confirm the query runs under the impersonated user's identity
+    (SUSER_SNAME() == BOWLAB\\alice, auth_scheme == KERBEROS).
+
+Tier B is skipped automatically if a SQL instance isn't reachable, so Tier A
+still validates the novel code when the SQL last mile is unavailable.
+"""
+from __future__ import annotations
+
+import os
+import socket
+
+import gssapi
+import pytest
+
+# The production module under test (mounted from the repo at /app). Tier A
+# depends only on this — it imports only stdlib + lazy gssapi. MSSQLClient
+# (Tier B) is imported lazily inside those tests so Tier A runs regardless.
+from app.data_sources.kerberos import KerberosTicketManager
+
+REALM = "BOWLAB.LOCAL"
+SVC_KEYTAB = "/keytabs/svc-bow.keytab"
+ALICE = f"alice@{REALM}"
+BOB = f"bob@{REALM}"
+
+SQL_TARGETS = [
+    ("2022", "sql2022.bowlab.local", 1433),
+    ("2019", "sql2019.bowlab.local", 1433),
+]
+
+
+def _manager() -> KerberosTicketManager:
+    return KerberosTicketManager(ccache_dir="/tmp/bow_krb5_lab", client_keytab=SVC_KEYTAB)
+
+
+def _reachable(host: str, port: int, timeout: float = 3.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+# ── Tier A: delegation core ─────────────────────────────────────────────────
+
+
+def test_service_keytab_present():
+    assert os.path.exists(SVC_KEYTAB), "svc-bow keytab not exported by the DC"
+
+
+def test_s4u2self_acquires_delegated_ccache():
+    """S4U2Self: impersonate alice with only the service keytab (no password)."""
+    mgr = _manager()
+    ccache = mgr.delegated_ccache(ALICE)
+    assert os.path.exists(ccache)
+    # Cached on second call (no re-acquisition).
+    assert mgr.delegated_ccache(ALICE) == ccache
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_s4u2proxy_to_mssql_spn(version, host, port):
+    """S4U2Proxy: the delegated cred yields a service ticket to MSSQLSvc/<sql>.
+
+    Initiating a GSSAPI context to the SPN triggers the S4U2Proxy request to the
+    KDC. Success (a token is produced) proves constrained delegation works — no
+    SQL Server handshake required.
+    """
+    mgr = _manager()
+    ccache = mgr.delegated_ccache(ALICE)
+    spn = gssapi.Name(f"MSSQLSvc/{host}:{port}", gssapi.NameType.kerberos_principal)
+    with mgr.activate(ccache):
+        store = {"ccache": f"FILE:{ccache}"}
+        cred = gssapi.Credentials(usage="initiate", store=store)
+        ctx = gssapi.SecurityContext(name=spn, creds=cred, usage="initiate")
+        token = ctx.step()
+    assert token, f"no S4U2Proxy token produced for SQL {version} SPN"
+
+
+# ── Tier B: SQL Server last mile ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_mssql_client_delegated_query(version, host, port):
+    """MSSQLClient impersonating alice runs a query under her AD identity."""
+    if not _reachable(host, port):
+        pytest.skip(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    client = MSSQLClient(
+        host=host, port=port, database="bowlab",
+        use_kerberos=True, kerberos_impersonate=ALICE,
+        encrypt=False,
+    )
+    df = client.execute_query(
+        "SELECT SUSER_SNAME() AS who, "
+        "(SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID) AS scheme"
+    )
+    who = str(df.iloc[0]["who"])
+    scheme = str(df.iloc[0]["scheme"])
+    assert who.upper().endswith("ALICE"), f"expected BOWLAB\\alice, got {who!r}"
+    assert scheme.upper() == "KERBEROS", f"expected KERBEROS, got {scheme!r}"
+
+    # And the impersonated user can read the data she was granted.
+    rows = client.execute_query("SELECT COUNT(*) AS n FROM dbo.sales")
+    assert int(rows.iloc[0]["n"]) == 3
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_delegation_respects_sql_permissions(version, host, port):
+    """bob has a login but no read grant → per-user identity really reaches SQL."""
+    if not _reachable(host, port):
+        pytest.skip(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    client = MSSQLClient(
+        host=host, port=port, database="bowlab",
+        use_kerberos=True, kerberos_impersonate=BOB,
+        encrypt=False,
+    )
+    with pytest.raises(Exception):
+        client.execute_query("SELECT * FROM dbo.sales")

--- a/lab/sql-server-kerberos/runner/test_delegation.py
+++ b/lab/sql-server-kerberos/runner/test_delegation.py
@@ -120,7 +120,7 @@ def test_mssql_client_delegated_query(version, host, port):
 
 @pytest.mark.parametrize("version,host,port", SQL_TARGETS)
 def test_delegation_respects_sql_permissions(version, host, port):
-    """bob has a login but no read grant → per-user identity really reaches SQL."""
+    """bob has a login but no read grant on sales → per-user identity reaches SQL."""
     if not _reachable(host, port):
         pytest.skip(f"SQL Server {version} ({host}:{port}) not reachable")
     from app.data_sources.clients.mssql_client import MSSQLClient
@@ -132,3 +132,28 @@ def test_delegation_respects_sql_permissions(version, host, port):
     )
     with pytest.raises(Exception):
         client.execute_query("SELECT * FROM dbo.sales")
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_per_user_table_overlay_differs(version, host, port):
+    """The per-user overlay is built by introspecting AS the user. Because
+    SQL Server's INFORMATION_SCHEMA is permission-scoped, alice and bob see
+    disjoint catalogs — alice → dbo.sales, bob → dbo.audit. This is exactly the
+    mechanism that gives User A and User B different table overlays."""
+    if not _reachable(host, port):
+        pytest.skip(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    def tables_for(upn):
+        c = MSSQLClient(host=host, port=port, database="bowlab",
+                        use_kerberos=True, kerberos_impersonate=upn, encrypt=False)
+        return {t.name.lower() for t in c.get_tables()}
+
+    alice_tables = tables_for(ALICE)
+    bob_tables = tables_for(BOB)
+
+    assert any("sales" in t for t in alice_tables), f"alice should see sales, saw {alice_tables}"
+    assert not any("sales" in t for t in bob_tables), f"bob must NOT see sales, saw {bob_tables}"
+    assert any("audit" in t for t in bob_tables), f"bob should see audit, saw {bob_tables}"
+    assert not any("audit" in t for t in alice_tables), f"alice must NOT see audit, saw {alice_tables}"
+    assert alice_tables != bob_tables

--- a/lab/sql-server-kerberos/samba-dc/Dockerfile
+++ b/lab/sql-server-kerberos/samba-dc/Dockerfile
@@ -1,0 +1,27 @@
+# Samba Active Directory Domain Controller for the Kerberos lab.
+# Acts as the KDC + LDAP + DNS that SQL Server joins and against which the app
+# performs S4U2Self / S4U2Proxy constrained delegation.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      samba samba-ad-provision samba-ad-dc samba-dsdb-modules smbclient winbind \
+      krb5-user krb5-config \
+      dnsutils iproute2 procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Samba ships its own ldb modules; the generic ldb-tools package shadows them
+# and breaks provisioning ("Module [samba_secrets] not found"). Point ldb at
+# Samba's module dir explicitly.
+ENV LDB_MODULES_PATH=/usr/lib/x86_64-linux-gnu/samba/ldb
+
+# samba-tool provisions its own krb5.conf; don't let the krb5-user default win.
+RUN rm -f /etc/krb5.conf
+
+COPY provision.sh /usr/local/bin/provision.sh
+RUN chmod +x /usr/local/bin/provision.sh
+
+EXPOSE 53 53/udp 88 88/udp 389 445 464 636
+ENTRYPOINT ["/usr/local/bin/provision.sh"]

--- a/lab/sql-server-kerberos/samba-dc/provision.sh
+++ b/lab/sql-server-kerberos/samba-dc/provision.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Provision (once) and run a Samba AD Domain Controller for the Kerberos lab.
+#
+# Creates:
+#   - realm BOWLAB.LOCAL, domain BOWLAB
+#   - service account svc-bow      (the app's identity / S4U impersonator)
+#   - SQL service accounts mssql2022 / mssql2019 with MSSQLSvc SPNs
+#   - test users alice / bob
+#   - constrained delegation (protocol transition, S4U2Self+S4U2Proxy) from
+#     svc-bow to both MSSQLSvc SPNs
+#   - DNS A + PTR records so Kerberos hostname/SPN resolution works both ways
+#   - keytabs exported to /keytabs (shared volume): svc-bow, mssql2022, mssql2019
+set -euo pipefail
+
+REALM="BOWLAB.LOCAL"
+DOMAIN="BOWLAB"
+ADMIN_PASS="${ADMIN_PASS:-Bowlab#Admin1}"
+USER_PASS="${USER_PASS:-Bowlab#User1}"
+SVC_PASS="${SVC_PASS:-Bowlab#Svc1}"
+
+DC_IP="${DC_IP:-172.28.0.10}"
+SQL2022_IP="${SQL2022_IP:-172.28.0.22}"
+SQL2019_IP="${SQL2019_IP:-172.28.0.19}"
+
+KEYTAB_DIR="/keytabs"
+PROVISIONED_MARKER="/var/lib/samba/.provisioned"
+
+log() { echo "[dc] $*"; }
+
+provision() {
+    log "Provisioning domain ${REALM} ..."
+    rm -f /etc/samba/smb.conf
+    samba-tool domain provision \
+        --use-rfc2307 \
+        --domain="${DOMAIN}" \
+        --realm="${REALM}" \
+        --server-role=dc \
+        --dns-backend=SAMBA_INTERNAL \
+        --adminpass="${ADMIN_PASS}" \
+        --option="dns forwarder=127.0.0.11"
+
+    # Samba writes a realm krb5.conf; make it the system default.
+    cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
+
+    # Passwords never expire in the lab, and relax complexity/history.
+    samba-tool domain passwordsettings set --complexity=off --history-length=0 \
+        --min-pwd-age=0 --max-pwd-age=0 >/dev/null
+
+    log "Starting samba to configure directory objects ..."
+    samba -D
+    sleep 5
+
+    # --- accounts ---------------------------------------------------------
+    log "Creating accounts ..."
+    samba-tool user create svc-bow    "${SVC_PASS}"  --description="BoW app service account"
+    samba-tool user create mssql2022  "${SVC_PASS}"  --description="SQL Server 2022 service account"
+    samba-tool user create mssql2019  "${SVC_PASS}"  --description="SQL Server 2019 service account"
+    samba-tool user create alice      "${USER_PASS}" --given-name=Alice --surname=Analyst
+    samba-tool user create bob        "${USER_PASS}" --given-name=Bob   --surname=Builder
+
+    # SQL accounts must not have expiring passwords (keytab would break).
+    for u in svc-bow mssql2022 mssql2019 alice bob; do
+        samba-tool user setexpiry "$u" --noexpiry >/dev/null
+    done
+
+    # --- SPNs for the SQL service accounts --------------------------------
+    log "Registering MSSQLSvc SPNs ..."
+    samba-tool spn add "MSSQLSvc/sql2022.bowlab.local"      mssql2022
+    samba-tool spn add "MSSQLSvc/sql2022.bowlab.local:1433" mssql2022
+    samba-tool spn add "MSSQLSvc/sql2019.bowlab.local"      mssql2019
+    samba-tool spn add "MSSQLSvc/sql2019.bowlab.local:1433" mssql2019
+
+    # The middle-tier (impersonating) account must itself have an SPN for the
+    # KDC to issue it an S4U2Self evidence ticket.
+    samba-tool spn add "bow/svc-bow.bowlab.local" svc-bow
+
+    # --- constrained delegation on the app account ------------------------
+    # protocol transition (S4U2Self "any protocol") + allowed targets (S4U2Proxy).
+    log "Configuring constrained delegation for svc-bow ..."
+    samba-tool delegation for-any-protocol svc-bow on
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2022.bowlab.local:1433"
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2019.bowlab.local:1433"
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2022.bowlab.local"
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2019.bowlab.local"
+
+    # --- DNS records (forward + reverse) ----------------------------------
+    log "Adding DNS records ..."
+    local rev="28.172.in-addr.arpa"
+    samba-tool dns add 127.0.0.1 "${REALM}" sql2022 A "${SQL2022_IP}" -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns add 127.0.0.1 "${REALM}" sql2019 A "${SQL2019_IP}" -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns zonecreate 127.0.0.1 "${rev}" -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns add 127.0.0.1 "${rev}" "${SQL2022_IP##*.}.0" PTR sql2022.bowlab.local -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns add 127.0.0.1 "${rev}" "${SQL2019_IP##*.}.0" PTR sql2019.bowlab.local -U "Administrator%${ADMIN_PASS}" || true
+
+    # --- export keytabs ---------------------------------------------------
+    log "Exporting keytabs to ${KEYTAB_DIR} ..."
+    mkdir -p "${KEYTAB_DIR}"
+    rm -f "${KEYTAB_DIR}"/*.keytab
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/svc-bow.keytab" --principal="svc-bow@${REALM}"
+
+    # SQL keytabs must carry the SPN principals (that is what clients request).
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="MSSQLSvc/sql2022.bowlab.local@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="MSSQLSvc/sql2022.bowlab.local:1433@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="mssql2022@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2019.keytab" --principal="MSSQLSvc/sql2019.bowlab.local@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2019.keytab" --principal="MSSQLSvc/sql2019.bowlab.local:1433@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2019.keytab" --principal="mssql2019@${REALM}"
+    chmod 0644 "${KEYTAB_DIR}"/*.keytab
+
+    # Write the client krb5.conf into the shared volume. forwardable=true is
+    # REQUIRED: S4U2Proxy is refused unless the S4U2Self evidence ticket is
+    # forwardable, which in turn needs a forwardable service TGT.
+    cat > "${KEYTAB_DIR}/krb5.conf" <<EOF
+[libdefaults]
+    default_realm = ${REALM}
+    dns_lookup_realm = false
+    dns_lookup_kdc = true
+    forwardable = true
+    rdns = false
+
+[realms]
+    ${REALM} = {
+        kdc = dc.bowlab.local
+        admin_server = dc.bowlab.local
+        default_domain = bowlab.local
+    }
+
+[domain_realm]
+    .bowlab.local = ${REALM}
+    bowlab.local = ${REALM}
+EOF
+
+    log "Stopping bootstrap samba ..."
+    pkill -TERM samba || true
+    sleep 3
+    touch "${PROVISIONED_MARKER}"
+    log "Provisioning complete."
+}
+
+if [ ! -f "${PROVISIONED_MARKER}" ]; then
+    provision
+else
+    log "Already provisioned; reusing directory."
+    cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
+    mkdir -p "${KEYTAB_DIR}"
+    cp /etc/krb5.conf "${KEYTAB_DIR}/krb5.conf" || true
+fi
+
+log "Starting Samba AD DC in foreground ..."
+exec samba -i -s /etc/samba/smb.conf

--- a/lab/sql-server-kerberos/up.sh
+++ b/lab/sql-server-kerberos/up.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Bring the Kerberos lab up and run the delegation test suite.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "== building images =="
+docker compose build dc runner
+
+echo "== starting DC + SQL Server 2022/2019 =="
+docker compose up -d dc sql2022 sql2019
+
+echo "== waiting for the DC to finish provisioning (keytabs) =="
+for i in $(seq 1 60); do
+    if docker compose exec -T dc test -f /keytabs/svc-bow.keytab 2>/dev/null; then
+        echo "   DC ready."
+        break
+    fi
+    sleep 3
+done
+
+echo "== waiting for SQL Server instances to accept AD logins (Tier B; ~60-120s) =="
+sleep 60
+
+echo "== running delegation tests (runner) =="
+docker compose run --rm runner "$@"


### PR DESCRIPTION
Enables Kerberos authentication from the Linux app to on-prem Microsoft SQL Server, in two modes, plus the per-user status/overlay integration so it behaves like the existing Entra/OBO per-user experience.

## What's added

**Phase A — service-account Kerberos (system auth).** New `kerberos` auth variant on the MSSQL connector: the client emits `Trusted_Connection=yes` and omits UID/PWD; the ODBC driver authenticates via GSSAPI from the service keytab. Runtime gets `krb5-user`/`libgssapi-krb5-2` and a `kerberos` extra (python-gssapi).

**Phase B — per-user SSO via Kerberos Constrained Delegation (S4U2Self + S4U2Proxy).** New `kerberos_delegated` user-scope auth variant. `KerberosTicketManager` (`app/data_sources/kerberos.py`) impersonates the signed-in user's AD principal (UPN from their login identity — no password or token stored) via python-gssapi, caches per-user credential caches, and the MSSQL client queries as that user. Per-user SQL permissions, RLS, and auditing all apply.

**Per-user status + overlay integration.** The per-user status/overlay machinery assumed a *stored* credential (OBO token). Kerberos stores no secret, so a resolvable UPN is now treated as first-class user access: `build_kerberos_sso_status` returns `effective_auth="user"` (→ the member's per-user overlay builds by introspecting as them, and the status chip renders "Connected"), a status-only marker row (no secret) drives a "verified" state, and `GET /connections/{id}/kerberos-access` gives admins a per-member verification roster. The existing `/test-my-credentials` endpoint is the member "Verify access".

**Hardening.** Under integrated auth every user's ODBC connection string is identical (identity comes from `KRB5CCNAME`, not the string), so the driver's connection pool could hand user B a connection authenticated as user A. Fixed by binding a per-identity `APP=BagOfWords-<principal>` token into the connection string (found and fixed via the lab).

## Verification

- **`lab/sql-server-kerberos/`** — one-command self-contained lab: Samba AD DC (real KDC) + SQL Server 2022 and 2019 joined to the domain + a runner that exercises the production code. Proves S4U2Self/S4U2Proxy against a real KDC and that queries run as the impersonated user (`SUSER_SNAME()` == the AD user, `auth_scheme` == KERBEROS), with per-user permissions enforced. With table-specific grants, alice's catalog resolves to `[dbo.sales]` and bob's to `[dbo.audit]` — disjoint, per-identity.
- **`backend/tests/e2e/test_kerberos_sso_member_overlay.py`** — service-layer e2e (real DB, in-process): a credential-less member is classified `effective_auth="user"` → status shows "Connected", `resolve_credentials` passes the member's own UPN, and the real `get_data_source_schema_paginated` path serves disjoint per-user overlays (alice→sales, bob→audit); a member without a UPN fails closed.
- **`backend/tests/unit/test_mssql_kerberos.py`** — connection-string construction, the pool discriminator, registry variants, ticket manager (mocked gssapi), status/principal helpers.

## Docs

`docs/sql-server-kerberos.md` — setup for both phases: AD/DBA prerequisites (SPN, keytab, delegation with "Use any authentication protocol" or RBCD), `krb5.conf`/keytab mounting, smoke tests (`kinit`/`kvno -U -P`), and troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n4x5VrmjNKfZtEataYnQu

---
_Generated by [Claude Code](https://claude.ai/code/session_013n4x5VrmjNKfZtEataYnQu)_