### PR TITLE
Mobile: remove duplicate home menu; make Agents page master-detail

### DIFF
--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -36,7 +36,12 @@
     <!-- Body: tree → detail → versions -->
     <div class="flex-1 min-h-0 flex border-t border-gray-200 dark:border-gray-800">
       <!-- ── Pane 1: Tree ───────────────────────────────── -->
-      <aside class="shrink-0 border-e border-gray-200 dark:border-gray-800 flex flex-col relative" :style="{ width: treeWidth + 'px' }">
+      <!-- Desktop: fixed-width resizable pane. Mobile: full-width, and hidden
+           once a detail is open (single-column master → detail). -->
+      <aside
+        class="border-e border-gray-200 dark:border-gray-800 flex flex-col relative"
+        :class="isMobile ? (detailOpen ? 'hidden' : 'w-full') : 'shrink-0'"
+        :style="isMobile ? {} : { width: treeWidth + 'px' }">
         <div class="px-2 pt-2.5 pb-2 flex items-center gap-1.5">
           <div class="relative flex-1">
             <UIcon name="i-heroicons-magnifying-glass" class="absolute start-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />
@@ -247,12 +252,23 @@
           <button v-if="connections.length" type="button" class="ms-auto shrink-0 text-[11px] text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" @click="showConnectionsModal = true">{{ $t('agentsPage.viewAll') }}</button>
         </div>
 
-        <!-- Drag handle to resize the tree pane -->
-        <div class="absolute top-0 end-0 h-full w-1 cursor-col-resize hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors z-10" :title="$t('agentsPage.tipDragResize')" @mousedown="startTreeResize"></div>
+        <!-- Drag handle to resize the tree pane (desktop only) -->
+        <div v-if="!isMobile" class="absolute top-0 end-0 h-full w-1 cursor-col-resize hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors z-10" :title="$t('agentsPage.tipDragResize')" @mousedown="startTreeResize"></div>
       </aside>
 
       <!-- ── Pane 2: Detail ───────────────────────────── -->
-      <section class="flex-1 min-w-0 flex flex-col">
+      <!-- Detail pane. Mobile: full-width, hidden until an item is selected. -->
+      <section class="flex-1 min-w-0 flex flex-col" :class="{ hidden: isMobile && !detailOpen }">
+        <!-- Mobile back-to-tree bar -->
+        <button
+          v-if="isMobile && detailOpen"
+          type="button"
+          class="flex items-center gap-1.5 h-11 px-3 shrink-0 text-sm text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-800"
+          @click="backToTree"
+        >
+          <UIcon name="i-heroicons-arrow-left" class="w-4 h-4 rtl-flip" />
+          {{ $t('common.back') }}
+        </button>
         <!-- Review feed -->
         <div v-if="reviewView" class="relative flex-1 min-h-0 flex flex-col">
           <ReviewFeed :agents="agents" :initial-agent-id="reviewView.agentId" @close="closeReview" @count="reviewCount = $event" @open-instruction="openInstructionFromReview" />
@@ -1558,6 +1574,26 @@ const onConnModalChanged = async () => {
 // Top banner (license/onboarding) presence — so this full-height view subtracts
 // the banner height instead of overflowing 40px below the viewport.
 const { showTopBanner, bannerHeight } = useTopBanner()
+
+// Mobile master → detail: on phones the tree and detail can't sit side by side,
+// so we show one at a time. `detailOpen` is true whenever the detail pane has
+// something to show; `backToTree` clears every detail state to return to the tree.
+const { isMobile } = useMobile()
+const detailOpen = computed(() => !!(
+  reviewView.value || agentView.value || panelView.value ||
+  previewFile.value || detail.value || creating.value
+))
+const backToTree = () => {
+  closeReview()
+  closeAgentView()
+  closePanel()
+  closePreview()
+  closeDiff()
+  detail.value = null
+  selectedId.value = null
+  creating.value = false
+  editing.value = false
+}
 // perms
 const canApprove = computed(() => useCanAny('manage_instructions', 'data_source'))
 const canCreateDataSource = computed(() => useCan('create_data_source'))

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -51,31 +51,8 @@
                 mask-image: linear-gradient(to bottom, transparent, black);
                 -webkit-mask-image: linear-gradient(to bottom, transparent, black);">
     </div>
-    <!-- Top bar -->
-    <div class="flex justify-between items-center p-3">
-        <div class="logo md:hidden">
-            <img src="/assets/logo-128.png" alt="Bag of words" class="h-7" />
-        </div>
-        <div class="flex items-center gap-4 ms-auto">
-            <div class="hamburger md:hidden">
-                <UDropdown :items="menuItems" :popper="{ placement: 'bottom-start' }">
-                    <UButton color="white" label="" trailing-icon="i-heroicons-bars-3" />
-                    <template #queries="{ item }">
-                      <LibraryIcon class="w-4 h-4 text-gray-400" />
-                      <span class="truncate">{{ item.label }}</span>
-                    </template>
-                    <template #monitoring="{ item }">
-                      <ActivityIcon class="w-4 h-4 text-gray-400" />
-                      <span class="truncate">{{ item.label }}</span>
-                    </template>
-                    <template #mcp="{ item }">
-                      <McpIcon class="w-4 h-4 text-gray-400" />
-                      <span class="truncate">{{ item.label }}</span>
-                    </template>
-                </UDropdown>
-            </div>
-        </div>
-    </div>
+    <!-- Mobile navigation is provided by the global mobile top bar in the
+         default layout; the home page no longer renders its own duplicate. -->
 
     <div v-if="isLoading" class="flex flex-col items-center justify-center flex-grow py-20">
       <Spinner class="h-4 w-4 text-gray-400" />


### PR DESCRIPTION
## Summary

Two mobile-web follow-ups after the mobile UI pass. Both are gated so **desktop is unchanged**.

### 1. Home — remove the duplicate menu
On a phone the home page showed **two** top bars stacked: the new global mobile top bar (from `layouts/default.vue`) plus the home page's **own** header (BOW logo + hamburger dropdown, `md:hidden`).

- `pages/index.vue` — delete the home page's own mobile top bar. Navigation is covered by the global mobile bar (`< sm`) and the desktop sidebar (`sm+`); the old dropdown's items (Queries/Monitoring/MCP) are already in the global drawer.
- The Excel embedding header (`v-if="isExcel"`) is untouched.

### 2. Agents page — mobile master-detail
`/agents` (`components/KnowledgeExplorer.vue`) was a desktop **two-pane split** (fixed 300px tree + flex detail) with no mobile handling, so on a phone the tree ate ~300px and the detail pane was crushed into ~90px and overlapped.

Add an `isMobile`-gated single-column **master → detail** flow:
- The **tree** is full-width and hides once a detail opens.
- The **detail** pane goes full-width with a **"← Back"** bar that clears the selection (`backToTree`) to return to the tree.
- The tree resize drag-handle is desktop-only.

Every mobile branch is gated on `isMobile`, so the desktop two-pane layout, sidebar, and banner are unchanged.

## Verification

Ran the app locally and screenshotted both pages:
- **Home mobile:** single top bar only (duplicate gone).
- **Agents mobile:** tree full-width → tapping an item (e.g. Global Evals) opens the detail full-width with "← Back" → Back returns to the tree (verified functionally).
- **Agents desktop (1440px):** two-pane layout, sidebar, and banner render exactly as before — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc)_