### PR TITLE
Enforce license seat cap on all membership auto-provisioning paths

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -481,6 +481,16 @@ class UserManager(BaseUserManager[User, str]):
             )).scalar_one_or_none()
             if dupe:
                 continue
+            # Respect the license seat cap: auto-provisioning must not push an org
+            # past its paid seat count. Full org → skip this invite (and log), don't
+            # abort the whole signup — other admitting orgs may still have room.
+            from app.core.seats import has_seat_for
+            if not await has_seat_for(session, s.organization_id):
+                logging.getLogger(__name__).warning(
+                    "Domain signup: org %s is at its license seat limit; "
+                    "skipping auto-invite for %s", s.organization_id, email
+                )
+                continue
             role = str(policy.get("auto_invite_role") or "member")
             session.add(Membership(
                 email=email,
@@ -830,6 +840,19 @@ async def auto_provision_user_for_org(
 
     if not open_invite and not domain_admitted:
         return None
+
+    # A brand-new membership is minted only when there's no open invite to attach
+    # to (an existing invite already occupies a seat). Enforce the license seat cap
+    # before creating anything, so a full org can't be grown via chat onboarding —
+    # and so we never leave an orphan User with no membership.
+    if not open_invite:
+        from app.core.seats import has_seat_for
+        if not await has_seat_for(db, organization_id):
+            logging.getLogger(__name__).warning(
+                "Chat auto-provision: org %s is at its license seat limit; "
+                "refusing to provision %s", organization_id, email_norm
+            )
+            return None
 
     if existing_user:
         if open_invite:

--- a/backend/app/core/seats.py
+++ b/backend/app/core/seats.py
@@ -1,0 +1,88 @@
+# Seat-limit enforcement for organization memberships.
+#
+# The enterprise license can cap the number of members (active members + pending
+# invites) per organization via ``max_users``. This module is the single source of
+# truth for counting memberships and deciding whether new ones fit under that cap,
+# so every path that creates a Membership enforces the same rule:
+#   - admin invite / CSV import      (app.services.organization_service)
+#   - domain signup + chat provision (app.core.auth)
+#   - LDAP group sync                (app.ee.ldap.sync_service)
+#   - SCIM provisioning              (app.ee.scim.service)
+#   - OIDC group sync                (app.ee.oidc.group_sync_service)
+#
+# Semantics ("block only truly new members"): only the creation of a *new*
+# membership beyond the cap is refused. Existing members already count toward the
+# total and are never re-added, so a re-login or re-sync of someone already in the
+# org always passes — nobody is ever removed or locked out by the cap.
+
+from typing import Optional
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException
+
+
+async def count_org_memberships(db: AsyncSession, organization_id) -> int:
+    """Count live memberships in an org — active members and pending invites alike.
+
+    Pending invites (user_id is NULL) count too, so the seat cap can't be bypassed
+    by leaving invites unaccepted. Soft-deleted rows are excluded (membership
+    removal is a hard delete today, so this matches the live total either way).
+    """
+    from app.models.membership import Membership
+
+    result = await db.execute(
+        select(func.count(Membership.id)).where(
+            Membership.organization_id == organization_id,
+            Membership.deleted_at.is_(None),
+        )
+    )
+    return result.scalar() or 0
+
+
+async def seats_remaining(db: AsyncSession, organization_id) -> Optional[int]:
+    """Seats still available under the license cap, or ``None`` if unlimited.
+
+    Returns ``None`` when no active license cap applies (``max_users == -1``).
+    Otherwise returns ``max(0, cap - current_members)``; ``0`` means the org is full.
+    """
+    from app.ee.license import get_max_users
+
+    max_users = get_max_users()
+    if max_users < 0:
+        return None
+    current = await count_org_memberships(db, organization_id)
+    return max(0, max_users - current)
+
+
+async def has_seat_for(db: AsyncSession, organization_id, adding: int = 1) -> bool:
+    """True if ``adding`` new membership(s) fit under the license seat cap.
+
+    Always True when unlicensed/unset (unlimited). Use this on auto-provisioning
+    paths that should degrade gracefully (skip/deny) rather than surface an error.
+    """
+    remaining = await seats_remaining(db, organization_id)
+    if remaining is None:
+        return True
+    return adding <= remaining
+
+
+async def enforce_seat_limit(db: AsyncSession, organization_id, adding: int = 1) -> None:
+    """Raise HTTP 402 if ``adding`` member(s) would exceed the license seat cap.
+
+    No-op when unlicensed/unset (unlimited). Use this on paths that surface the cap
+    to a caller as an error (admin invite, SCIM provisioning).
+    """
+    if await has_seat_for(db, organization_id, adding):
+        return
+
+    from app.ee.license import get_max_users
+
+    max_users = get_max_users()
+    raise HTTPException(
+        status_code=402,
+        detail=(
+            f"User limit reached for your license ({max_users}). "
+            "Contact sales to increase your seat count."
+        ),
+    )

--- a/backend/app/ee/ldap/sync_service.py
+++ b/backend/app/ee/ldap/sync_service.py
@@ -261,8 +261,24 @@ class LDAPGroupSyncService:
         )
         existing_ids = set((await db.execute(stmt)).scalars().all())
 
+        # New members to create (users in LDAP groups but not yet in the org).
+        # Enforce the license seat cap: fill up to the remaining seats and skip the
+        # rest (sorted for a deterministic selection), logging the overflow — never
+        # abort the whole sync. Existing members are untouched (already excluded).
+        to_create = sorted(user_ids - existing_ids)
+        if to_create:
+            from app.core.seats import seats_remaining
+            remaining = await seats_remaining(db, organization_id)
+            if remaining is not None and len(to_create) > remaining:
+                logger.warning(
+                    "LDAP sync: %d new users would exceed the license seat cap for "
+                    "org %s; adding %d, skipping %d (raise seats to add the rest)",
+                    len(to_create), organization_id, remaining, len(to_create) - remaining,
+                )
+                to_create = to_create[:remaining]
+
         from app.core.permission_resolver import ensure_system_role_assignment
-        for user_id in user_ids - existing_ids:
+        for user_id in to_create:
             db.add(Membership(
                 user_id=user_id,
                 organization_id=organization_id,

--- a/backend/app/ee/oidc/group_sync_service.py
+++ b/backend/app/ee/oidc/group_sync_service.py
@@ -164,6 +164,16 @@ async def _ensure_org_membership(
     )
     existing = (await db.execute(stmt)).scalar_one_or_none()
     if not existing:
+        # Enforce the license seat cap: a full org can't gain new members via OIDC
+        # group sync. Existing members hit the branch above and are unaffected — only
+        # a brand-new membership beyond the cap is refused (skipped + logged).
+        from app.core.seats import has_seat_for
+        if not await has_seat_for(db, organization_id):
+            logger.warning(
+                "OIDC group sync: org %s is at its license seat limit; "
+                "skipping new membership for user %s", organization_id, user_id
+            )
+            return
         db.add(Membership(
             user_id=user_id,
             organization_id=organization_id,

--- a/backend/app/ee/scim/service.py
+++ b/backend/app/ee/scim/service.py
@@ -253,6 +253,12 @@ class ScimUserService:
             if membership_result.scalar_one_or_none():
                 raise HTTPException(status_code=409, detail="User already exists in this organization")
 
+            # Enforce the license seat cap before adding a new member. Checked after
+            # the duplicate guard so re-provisioning an existing member still 409s
+            # rather than being masked by a seat-limit 402.
+            from app.core.seats import enforce_seat_limit
+            await enforce_seat_limit(db, organization_id)
+
             # Add membership to existing user
             membership = Membership(
                 user_id=existing_user.id,
@@ -272,6 +278,12 @@ class ScimUserService:
             await db.commit()
             await db.refresh(membership)
             return _user_to_scim(existing_user, membership, base_url)
+
+        # Enforce the license seat cap before creating a brand-new user + membership,
+        # so a full org can't be grown via SCIM provisioning (and we don't leave an
+        # orphan User with no membership).
+        from app.core.seats import enforce_seat_limit
+        await enforce_seat_limit(db, organization_id)
 
         # Create new user
         display_name = data.displayName

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -296,35 +296,19 @@ class OrganizationService:
     async def _count_org_memberships(self, db: AsyncSession, organization_id) -> int:
         """Count all memberships in an org — active members and pending invites alike.
 
-        Pending invites (user_id is NULL) count too, so the license seat cap can't be
-        bypassed by leaving invites unaccepted.
+        Thin wrapper over the shared seat helper (single source of truth), kept for
+        the CSV-import projection that counts once and tracks its own running total.
         """
-        from sqlalchemy import func
-        result = await db.execute(
-            select(func.count(Membership.id)).where(
-                Membership.organization_id == organization_id
-            )
-        )
-        return result.scalar() or 0
+        from app.core.seats import count_org_memberships
+        return await count_org_memberships(db, organization_id)
 
     async def _enforce_user_limit(self, db: AsyncSession, organization_id, adding: int = 1) -> None:
         """Raise 402 if adding `adding` member(s) would exceed the license seat cap.
 
         No-op when unlicensed/unset (max_users == -1 → unlimited).
         """
-        from app.ee.license import get_max_users
-        max_users = get_max_users()
-        if max_users < 0:
-            return
-        current = await self._count_org_memberships(db, organization_id)
-        if current + adding > max_users:
-            raise HTTPException(
-                status_code=402,
-                detail=(
-                    f"User limit reached for your license ({max_users}). "
-                    "Contact sales to increase your seat count."
-                ),
-            )
+        from app.core.seats import enforce_seat_limit
+        await enforce_seat_limit(db, organization_id, adding)
 
     async def add_member(self, db: AsyncSession, membership_data: MembershipCreate, current_user: User) -> MembershipSchema:
         #check if email is already a user

--- a/backend/scripts/gen_sandbox_license.py
+++ b/backend/scripts/gen_sandbox_license.py
@@ -1,0 +1,71 @@
+"""Generate a test enterprise license for the seat-cap sandbox feedback loop and
+install its public key so a locally-run server trusts it.
+
+FOR LOCAL SANDBOX VERIFICATION ONLY — this mints a throwaway keypair, it does not
+touch or reveal the real signing key. It backs up the tracked public-key pem to
+``<pem>.orig`` first; restore it when done:
+
+    mv app/ee/license_public_key.pem.orig app/ee/license_public_key.pem
+
+Usage (run from the backend/ dir):
+    LIC=$(python scripts/gen_sandbox_license.py 3)
+    BOW_LICENSE_KEY="$LIC" BOW_DATABASE_URL=sqlite:///db/app_sandbox.db python main.py
+
+Prints the signed license key (bow_lic_...) to stdout; progress goes to stderr.
+"""
+import os
+import sys
+import shutil
+from datetime import datetime, timezone, timedelta
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+
+# Resolve the pem path relative to this file so the script works from any cwd.
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PEM_PATH = os.path.join(_BACKEND_DIR, "app", "ee", "license_public_key.pem")
+
+
+def main():
+    max_users = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    # Back up and install the test public key so the server verifies our license.
+    if not os.path.exists(PEM_PATH + ".orig"):
+        shutil.copyfile(PEM_PATH, PEM_PATH + ".orig")
+    with open(PEM_PATH, "w") as f:
+        f.write(public_pem)
+
+    now = datetime.now(timezone.utc)
+    payload = {
+        "iss": "bagofwords.com",
+        "sub": "lic_sandbox_seatcap",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(days=365)).timestamp()),
+        "tier": "enterprise",           # tier defaults include scim + domain_signup
+        "org_name": "Seat Cap Sandbox",
+        "max_users": max_users,         # the cap under test
+    }
+    token = jwt.encode(payload, private_pem, algorithm="RS256")
+    sys.stderr.write(f"Installed test public key at {PEM_PATH} (backup at {PEM_PATH}.orig)\n")
+    sys.stderr.write(f"License: tier=enterprise max_users={max_users}\n")
+    sys.stderr.write("Restore with: mv app/ee/license_public_key.pem.orig app/ee/license_public_key.pem\n")
+    print(f"bow_lic_{token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/verify_seat_cap.py
+++ b/backend/scripts/verify_seat_cap.py
@@ -1,0 +1,149 @@
+"""End-to-end verification of license seat-cap enforcement on the AUTO-PROVISIONING
+paths, against a running server.
+
+Regression harness for the bug where an EE org with a user cap kept gaining
+uninvited members (Entra SCIM / domain signup) while the admin's manual invite —
+the only guarded path — was blocked at the overflowed count.
+
+Prereqs: start the server with an active enterprise license whose ``max_users``
+is a small cap (the sandbox uses 3). The script reads the cap from
+``GET /api/license/usage`` and drives to exactly fill + overflow, so it adapts to
+whatever cap the server was started with (must be >= 2).
+
+    BOW_LICENSE_KEY=$(python setup_license.py 3) \
+        BOW_DATABASE_URL=sqlite:///db/app.db python main.py &
+    python scripts/verify_seat_cap.py
+
+Drives, over real HTTP:
+  1. license loaded with the cap (GET /license/usage)
+  2. SCIM provisioning fills seats up to the cap, then the next create -> 402
+     (Entra's provisioning path — the representative auto-provision bypass)
+  3. SCIM re-provisioning an existing member -> 409 (not masked by the 402)
+  4. domain-signup registration over the cap -> user created but NO org membership
+     (auto-provision refused, not a login error)
+  5. the admin's own manual invite is also blocked at the cap -> 402
+  6. member count never exceeds the cap
+"""
+import sys
+import uuid
+
+import httpx
+
+BASE = "http://localhost:8000"
+ADMIN = {"name": "Admin User", "email": "admin@seatcap-sandbox.com", "password": "supersecret123"}
+SIGNUP_DOMAIN = "signup-sandbox.com"
+
+
+def _rand_email(domain):
+    return f"u_{uuid.uuid4().hex[:8]}@{domain}"
+
+
+def main():
+    c = httpx.Client(base_url=BASE, timeout=30)
+    results = []
+
+    def check(label, cond, extra=""):
+        results.append(cond)
+        print(("PASS" if cond else "FAIL"), "-", label, ("" if cond else f"  >> {extra}"))
+
+    # 1. Bootstrap admin + org.
+    c.post("/api/auth/register", json=ADMIN)
+    r = c.post("/api/auth/jwt/login", data={"username": ADMIN["email"], "password": ADMIN["password"]})
+    jwt = r.json()["access_token"]
+    admin_h = {"Authorization": f"Bearer {jwt}"}
+    org_id = c.get("/api/organizations", headers=admin_h).json()[0]["id"]
+    org_h = {**admin_h, "X-Organization-Id": org_id}
+
+    # 2. License is active with a seat cap.
+    r = c.get("/api/license/usage", headers=org_h)
+    usage = r.json()
+    cap = usage.get("max_users", -1)
+    current = usage.get("current_users", 0)
+    check("license loaded with a seat cap", r.status_code == 200 and cap >= 2,
+          f"{r.status_code} usage={usage}")
+    if cap < 2:
+        print("\nServer must run with an enterprise license and max_users>=2. Aborting.")
+        sys.exit(1)
+    check("org starts below the cap (admin seat only)", current == 1, f"current={current}")
+
+    # 3. Mint a SCIM token (Entra's provisioning credential).
+    r = c.post("/api/enterprise/scim/tokens", headers=org_h, json={"name": "entra"})
+    check("create SCIM token", r.status_code in (200, 201), f"{r.status_code} {r.text[:200]}")
+    scim_token = r.json()["token"]
+    scim_h = {
+        "Authorization": f"Bearer {scim_token}",
+        "Content-Type": "application/scim+json",
+    }
+
+    def scim_create(email):
+        return c.post("/scim/v2/Users", headers=scim_h, json={
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "userName": email,
+            "emails": [{"value": email, "primary": True}],
+            "active": True,
+        })
+
+    # 4. SCIM fills the remaining seats exactly (block only truly new members: each
+    #    fresh provision consumes one seat up to the cap).
+    seats_to_fill = cap - 1  # admin already holds one
+    first_emails = [_rand_email("scimsandbox.com") for _ in range(seats_to_fill)]
+    fill_ok = True
+    for email in first_emails:
+        rr = scim_create(email)
+        if rr.status_code != 201:
+            fill_ok = False
+            print(f"    unexpected SCIM fill status {rr.status_code}: {rr.text[:160]}")
+    check(f"SCIM provisions up to the cap ({seats_to_fill} new members -> 201)", fill_ok)
+
+    # 5. The next SCIM provision is over the cap -> 402 (the bug: this used to be 201).
+    over = scim_create(_rand_email("scimsandbox.com"))
+    check("SCIM create over the cap -> 402", over.status_code == 402,
+          f"{over.status_code} {over.text[:200]}")
+
+    # 6. Re-provisioning an EXISTING member still -> 409, not masked by the 402.
+    dup = scim_create(first_emails[0])
+    check("SCIM re-provision of existing member -> 409 (ordering preserved)",
+          dup.status_code == 409, f"{dup.status_code} {dup.text[:200]}")
+
+    # 7. Domain-signup path: enable the org policy, then a brand-new user registers
+    #    with an allowed domain while the org is full -> account is created but gets
+    #    NO membership (auto-provision refused, not a hard login error).
+    r = c.put("/api/organization/signup-policy", headers=org_h, json={
+        "enabled": True, "allowed_domains": [SIGNUP_DOMAIN], "auto_invite_role": "member",
+    })
+    check("enable domain-signup policy", r.status_code == 200, f"{r.status_code} {r.text[:200]}")
+
+    newcomer = {"name": "Newcomer", "email": _rand_email(SIGNUP_DOMAIN), "password": "supersecret123"}
+    r = c.post("/api/auth/register", json=newcomer)
+    check("over-cap domain signup still registers the user", r.status_code in (200, 201),
+          f"{r.status_code} {r.text[:200]}")
+    r = c.post("/api/auth/jwt/login",
+               data={"username": newcomer["email"], "password": newcomer["password"]})
+    newcomer_orgs = c.get("/api/organizations",
+                          headers={"Authorization": f"Bearer {r.json()['access_token']}"}).json()
+    check("over-cap domain signup grants NO org membership", newcomer_orgs == [],
+          f"orgs={newcomer_orgs}")
+
+    # 8. The admin's own manual invite is blocked at the cap too (the reported symptom).
+    r = c.post(f"/api/organizations/{org_id}/members",
+               json={"organization_id": org_id, "email": _rand_email("invitesandbox.com"), "role": "member"},
+               headers=org_h)
+    check("admin manual invite over the cap -> 402", r.status_code == 402,
+          f"{r.status_code} {r.text[:200]}")
+
+    # 9. Member count never exceeded the cap.
+    final = c.get("/api/license/usage", headers=org_h).json().get("current_users", -1)
+    check(f"member count held at the cap ({cap})", final == cap, f"current_users={final}")
+
+    passed = sum(1 for x in results if x)
+    print("\n==== SUMMARY ====")
+    print(f"{passed}/{len(results)} passed")
+    if passed == len(results):
+        print("ALL PASSED")
+        sys.exit(0)
+    print("FAILURES PRESENT")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/e2e/test_seat_cap_autoprovision.py
+++ b/backend/tests/e2e/test_seat_cap_autoprovision.py
@@ -1,0 +1,284 @@
+"""e2e tests: the license seat cap (max_users) is enforced on the AUTO-PROVISIONING
+paths, not just admin invites.
+
+Regression coverage for the bug where an EE org with a user cap kept gaining
+uninvited members through Entra/SSO domain signup, chat auto-provision, LDAP sync,
+SCIM provisioning, and OIDC group sync — while the admin's manual invite (the only
+guarded path) was blocked at the now-overflowed count.
+
+Semantics under test ("block only truly new members"): existing members are never
+removed or blocked; only the creation of a *new* membership beyond the cap is
+refused. Each path degrades in its own idiomatic way:
+  - chat auto-provision / OIDC sync → skip (return None / no-op)
+  - LDAP sync                       → fill up to the cap, skip the rest
+  - SCIM provisioning               → reject with HTTP 402
+
+The cap is driven by seeding the in-process license cache directly (same approach
+as test_license_limits.py) — no signing key needed.
+"""
+import contextlib
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import select, func
+
+import app.ee.license as license_mod
+from app.ee.license import LicenseInfo
+
+
+@contextlib.contextmanager
+def _license(*, max_users: int = -1, max_agents: int = -1):
+    prev_cache = license_mod._cached_license
+    prev_init = license_mod._cache_initialized
+    license_mod._cached_license = LicenseInfo(
+        licensed=True,
+        tier="enterprise",
+        org_name="Test Org",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=365),
+        max_users=max_users,
+        max_agents=max_agents,
+    )
+    license_mod._cache_initialized = True
+    try:
+        yield
+    finally:
+        license_mod._cached_license = prev_cache
+        license_mod._cache_initialized = prev_init
+
+
+def _admin_setup(create_user, login_user, whoami):
+    admin = create_user()
+    token = login_user(admin["email"], admin["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    return org_id
+
+
+async def _count(db, org_id) -> int:
+    from app.models.membership import Membership
+    return (await db.execute(
+        select(func.count(Membership.id)).where(
+            Membership.organization_id == org_id,
+            Membership.deleted_at.is_(None),
+        )
+    )).scalar() or 0
+
+
+async def _fill_to(db, org_id, target):
+    """Top the org up to `target` memberships with pending-invite rows."""
+    from app.models.membership import Membership
+    current = await _count(db, org_id)
+    for _ in range(target - current):
+        db.add(Membership(
+            email=f"seed_{uuid.uuid4().hex[:8]}@seed.com",
+            organization_id=org_id,
+            role="member",
+        ))
+    await db.commit()
+
+
+async def _make_user(db, email=None):
+    from app.models.user import User
+    from fastapi_users.password import PasswordHelper
+    ph = PasswordHelper()
+    email = email or f"u_{uuid.uuid4().hex[:8]}@ext.com"
+    user = User(
+        email=email,
+        name=email.split("@")[0],
+        hashed_password=ph.hash(ph.generate()),
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _set_signup_policy(db, org_id, domains):
+    """Enable the org's domain-signup policy for the given domains."""
+    from app.models.organization_settings import OrganizationSettings
+    s = (await db.execute(
+        select(OrganizationSettings).where(OrganizationSettings.organization_id == org_id)
+    )).scalar_one_or_none()
+    assert s is not None, "org should have a settings row"
+    config = dict(s.config or {})
+    config["signup_policy"] = {
+        "enabled": True,
+        "allowed_domains": domains,
+        "auto_invite_role": "member",
+    }
+    s.config = config
+    # SQLAlchemy JSON mutation tracking: reassign so the change is flushed.
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# shared helper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_seats_helper_counts_caps_and_enforces(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.core.seats import (
+        count_org_memberships, seats_remaining, has_seat_for, enforce_seat_limit,
+    )
+    from fastapi import HTTPException
+
+    org_id = _admin_setup(create_user, login_user, whoami)  # 1 membership (admin)
+
+    async with async_session_maker() as db:
+        # Unlimited when no cap: remaining is None, always has a seat.
+        assert await seats_remaining(db, org_id) is None
+        assert await has_seat_for(db, org_id, adding=1000) is True
+
+        with _license(max_users=3):
+            assert await count_org_memberships(db, org_id) == 1
+            assert await seats_remaining(db, org_id) == 2
+            assert await has_seat_for(db, org_id, adding=2) is True
+            assert await has_seat_for(db, org_id, adding=3) is False
+            # enforce raises 402 once over
+            await enforce_seat_limit(db, org_id, adding=2)  # ok
+            with pytest.raises(HTTPException) as ei:
+                await enforce_seat_limit(db, org_id, adding=3)
+            assert ei.value.status_code == 402
+
+
+# ---------------------------------------------------------------------------
+# chat auto-provision (domain-admitted path)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_auto_provision_blocked_when_full(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.core.auth import auto_provision_user_for_org
+
+    org_id = _admin_setup(create_user, login_user, whoami)
+
+    async with async_session_maker() as db:
+        await _set_signup_policy(db, org_id, ["ext.com"])
+        await _fill_to(db, org_id, 2)  # org now full at cap 2
+
+    with _license(max_users=2):
+        async with async_session_maker() as db:
+            user = await auto_provision_user_for_org(
+                db, org_id, f"new_{uuid.uuid4().hex[:6]}@ext.com"
+            )
+        assert user is None  # refused — org is at the seat cap
+
+    async with async_session_maker() as db:
+        assert await _count(db, org_id) == 2  # no new membership minted
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_auto_provision_allowed_when_seat_free(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.core.auth import auto_provision_user_for_org
+
+    org_id = _admin_setup(create_user, login_user, whoami)  # 1 membership
+
+    async with async_session_maker() as db:
+        await _set_signup_policy(db, org_id, ["ext.com"])
+
+    with _license(max_users=5):  # room to spare
+        async with async_session_maker() as db:
+            user = await auto_provision_user_for_org(
+                db, org_id, f"new_{uuid.uuid4().hex[:6]}@ext.com"
+            )
+        assert user is not None
+
+    async with async_session_maker() as db:
+        assert await _count(db, org_id) == 2
+
+
+# ---------------------------------------------------------------------------
+# OIDC group sync
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_oidc_ensure_membership_blocked_when_full(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.ee.oidc.group_sync_service import _ensure_org_membership
+
+    org_id = _admin_setup(create_user, login_user, whoami)
+
+    async with async_session_maker() as db:
+        await _fill_to(db, org_id, 2)  # full at cap 2
+        outsider = await _make_user(db)
+
+    with _license(max_users=2):
+        async with async_session_maker() as db:
+            await _ensure_org_membership(db, org_id, str(outsider.id))
+            await db.commit()
+
+    async with async_session_maker() as db:
+        assert await _count(db, org_id) == 2  # outsider not added
+
+
+# ---------------------------------------------------------------------------
+# LDAP sync — fills up to the cap, skips the rest
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_ldap_ensure_memberships_fills_up_to_cap(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.ee.ldap.sync_service import LDAPGroupSyncService
+
+    org_id = _admin_setup(create_user, login_user, whoami)  # 1 membership, cap 3 → 2 seats
+
+    async with async_session_maker() as db:
+        users = [await _make_user(db) for _ in range(4)]
+        user_ids = {str(u.id) for u in users}
+
+    with _license(max_users=3):
+        async with async_session_maker() as db:
+            # _ensure_org_memberships doesn't touch self; skip the LDAPConfig-heavy
+            # __init__ and call it on a bare instance.
+            svc = object.__new__(LDAPGroupSyncService)
+            await svc._ensure_org_memberships(db, org_id, user_ids)
+            await db.commit()
+
+    async with async_session_maker() as db:
+        # admin (1) + exactly the 2 remaining seats filled = 3, not 5
+        assert await _count(db, org_id) == 3
+
+
+# ---------------------------------------------------------------------------
+# SCIM provisioning — rejects with 402
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_scim_create_user_blocked_when_full(create_user, login_user, whoami):
+    from app.dependencies import async_session_maker
+    from app.ee.scim.service import ScimUserService
+    from app.ee.scim.schemas import ScimUserCreate, ScimEmail
+    from fastapi import HTTPException
+
+    org_id = _admin_setup(create_user, login_user, whoami)
+
+    async with async_session_maker() as db:
+        await _fill_to(db, org_id, 2)  # full at cap 2
+
+    email = f"scim_{uuid.uuid4().hex[:6]}@ext.com"
+    payload = ScimUserCreate(
+        userName=email,
+        emails=[ScimEmail(value=email, primary=True)],
+        active=True,
+    )
+
+    with _license(max_users=2):
+        async with async_session_maker() as db:
+            svc = ScimUserService()
+            with pytest.raises(HTTPException) as ei:
+                await svc.create_user(db, org_id, payload)
+            assert ei.value.status_code == 402
+
+    async with async_session_maker() as db:
+        assert await _count(db, org_id) == 2  # nothing provisioned

--- a/sandbox-feedback-loop-seat-cap-autoprovision.md
+++ b/sandbox-feedback-loop-seat-cap-autoprovision.md
@@ -1,0 +1,163 @@
+# Sandbox Feedback Loop — License Seat Cap on Auto-Provisioning
+
+Validates the fix for the reported bug: an **EE org with a 25-seat cap kept
+gaining uninvited members** (Entra provisioning), while the **admin's own invite
+was blocked** at the overflowed count.
+
+This is the runnable feedback loop used to confirm the fix works end-to-end
+against a live server.
+
+---
+
+## Root cause
+
+The license seat cap (`max_users`) was enforced on exactly two paths — admin
+invite and CSV import (`app/services/organization_service.py`). Every
+**auto-provisioning** path minted memberships with no seat check:
+
+- domain-signup invites — `app/core/auth.py::_create_domain_invites`
+- chat auto-provision — `app/core/auth.py::auto_provision_user_for_org`
+- LDAP group sync — `app/ee/ldap/sync_service.py::_ensure_org_memberships`
+- **SCIM provisioning** — `app/ee/scim/service.py::create_user`
+- OIDC group sync — `app/ee/oidc/group_sync_service.py::_ensure_org_membership`
+
+For an **Entra ID** customer the live leak is SCIM provisioning and/or
+domain-signup JIT (both enterprise-tier features that ship on the same license
+carrying the cap). Those paths pushed the org past the cap; the admin's invite —
+the one guarded path — then 402'd on the now-overflowed count. Exactly the
+reported symptom.
+
+---
+
+## What was built
+
+`app/core/seats.py` — single source of truth for counting memberships and
+deciding whether new ones fit:
+
+- `count_org_memberships` — live members + pending invites (`deleted_at IS NULL`)
+- `seats_remaining` — `None` if unlimited, else `max(0, cap − current)`
+- `has_seat_for(adding=1)` — graceful boolean for auto-provisioning paths
+- `enforce_seat_limit(adding=1)` — raises HTTP 402 for paths that surface errors
+
+Wired into all five bypass sites, each degrading per the chosen policy
+(**block only truly new members** — existing members are never removed or blocked;
+only creation beyond the cap is refused):
+
+| Path | Behavior when full |
+|------|--------------------|
+| Domain-signup invites | Skip that org's invite + log; other admitting orgs still processed |
+| Chat auto-provision | Return `None` before creating anything (no orphan user) |
+| LDAP sync | Fill up to remaining seats (sorted, deterministic), skip + log the rest |
+| SCIM provisioning | Reject with 402, after the existing 409 duplicate guard |
+| OIDC group sync | Skip new membership + log; existing members untouched |
+
+`organization_service` now delegates to the shared helper — the already-guarded
+admin invite / CSV import paths are unchanged.
+
+---
+
+## Environment setup (fresh sandbox)
+
+The app targets **Python 3.12**.
+
+```bash
+cd backend
+python3.12 -m venv .venv && . .venv/bin/activate
+pip install -e .            # or: uv sync --frozen --extra dev
+
+export BOW_DATABASE_URL="sqlite:///db/app_sandbox.db"
+mkdir -p db
+python -m alembic upgrade head
+```
+
+The seat cap is license-driven, so the sandbox needs an **active enterprise
+license with a small `max_users`**. `backend/scripts/gen_sandbox_license.py`
+generates a throwaway RSA keypair, installs the test public key at
+`app/ee/license_public_key.pem` (backing up the original to `.orig`), and prints
+a signed `bow_lic_…` license with `tier=enterprise, max_users=3`. It only uses a
+local throwaway key — it never touches the real signing key:
+
+```bash
+LIC=$(python scripts/gen_sandbox_license.py 3)   # backs up + swaps the public-key pem
+BOW_LICENSE_KEY="$LIC" BOW_DATABASE_URL="sqlite:///db/app_sandbox.db" python main.py &
+# ... run the check below ...
+# afterwards, restore the tracked key:  mv app/ee/license_public_key.pem.orig app/ee/license_public_key.pem
+```
+
+Server log confirms load: `Enterprise license active: Seat Cap Sandbox, tier: enterprise`.
+
+---
+
+## Backend end-to-end check (no UI needed)
+
+`backend/scripts/verify_seat_cap.py` drives the whole flow over real HTTP against
+a running server. It reads the cap from `GET /api/license/usage` and drives to
+exactly fill + overflow:
+
+```bash
+python scripts/verify_seat_cap.py
+```
+
+It asserts (11/11 passing):
+
+1. License is active with a seat cap (`GET /license/usage`).
+2. Org starts at 1 seat (the admin).
+3. Mint a SCIM token (Entra's provisioning credential).
+4. **SCIM provisions up to the cap** (each fresh user → 201).
+5. **SCIM create over the cap → 402** — the bug: this used to be 201.
+6. SCIM re-provision of an existing member → **409** (not masked by the 402;
+   ordering preserved).
+7. Enable the org's domain-signup policy.
+8. **Over-cap domain-signup registration still creates the user account…**
+9. **…but grants NO org membership** (auto-provision refused, not a login error).
+10. The admin's **manual invite over the cap → 402** (the reported symptom).
+11. **Member count held at the cap (3)** — never exceeded.
+
+Expected tail:
+
+```
+==== SUMMARY ====
+11/11 passed
+ALL PASSED
+```
+
+### Negative control (harness has teeth)
+
+With the two `enforce_seat_limit` calls in `app/ee/scim/service.py` temporarily
+neutered (simulating the pre-fix path) and the DB reset, the same run reports:
+
+```
+FAIL - SCIM create over the cap -> 402   >> 201 {... userName: u_…@scimsandbox.com ...}
+FAIL - member count held at the cap (3)   >> current_users=4
+9/11 passed
+```
+
+i.e. the leak reproduces (a 4th member slips past a cap of 3), confirming the
+check — not a false green — is what makes the fixed run pass.
+
+---
+
+## Automated tests
+
+- `backend/tests/e2e/test_seat_cap_autoprovision.py` — new: the shared helper
+  plus one case per path (auto-provision blocked & allowed, OIDC skip, LDAP
+  fill-to-cap, SCIM 402). **6/6 passing.**
+- `backend/tests/e2e/test_license_limits.py` — unchanged, still **21/21** (admin
+  invite + CSV import behavior preserved by the refactor).
+- Touched suites regression-checked green: `test_oidc_group_sync.py` (8),
+  `test_scim.py` + `test_ldap.py` (27).
+
+---
+
+## Status
+
+- [x] Migration/setup runs on fresh SQLite; enterprise license loads with a cap.
+- [x] Live e2e over HTTP: **11/11 passing** with the fix.
+- [x] Negative control: with the SCIM check disabled, over-cap SCIM leaks
+      (201 / count=4) — the harness catches the regression.
+- [x] Unit/e2e suites: 6 new + 21 license + 8 OIDC + 27 SCIM/LDAP green.
+- [x] Test public key restored; no license material committed.
+
+Note: LDAP and OIDC *login-time* provisioning are covered by the pytest e2e
+suite (they need a live directory / IdP to drive over HTTP); SCIM and
+domain-signup — the two Entra-relevant paths — are driven live here.


### PR DESCRIPTION
## Problem

An EE org with a `max_users` seat cap kept gaining **uninvited** members while the **admin's own invite was blocked**. Reported against an Entra ID customer.

Root cause: the seat cap was enforced on only two paths — admin invite and CSV import (`organization_service.py`). Every **auto-provisioning** path minted memberships with no seat check:

- domain-signup invites — `core/auth.py::_create_domain_invites`
- chat auto-provision — `core/auth.py::auto_provision_user_for_org`
- LDAP group sync — `ee/ldap/sync_service.py::_ensure_org_memberships`
- **SCIM provisioning** — `ee/scim/service.py::create_user`
- OIDC group sync — `ee/oidc/group_sync_service.py::_ensure_org_membership`

For an Entra customer the leak is SCIM and/or domain-signup JIT (enterprise-tier features shipping on the same license that carries the cap). They pushed the org past the cap; the admin's invite — the one guarded path — then 402'd on the overflowed count. Exactly the reported symptom.

## Fix

New `app/core/seats.py` — single source of truth for counting memberships and deciding whether new ones fit:

- `count_org_memberships` — live members + pending invites (`deleted_at IS NULL`)
- `seats_remaining` — `None` if unlimited, else `max(0, cap − current)`
- `has_seat_for(adding=1)` — graceful boolean for auto-provisioning paths
- `enforce_seat_limit(adding=1)` — raises HTTP 402 for paths that surface errors

Wired into all five bypass sites. Policy: **block only truly new members** — existing members are never removed or blocked (re-login/re-sync always passes); only creation beyond the cap is refused.

| Path | Behavior when full |
|------|--------------------|
| Domain-signup invites | Skip that org's invite + log; other admitting orgs still processed |
| Chat auto-provision | Return `None` before creating anything (no orphan user) |
| LDAP sync | Fill up to remaining seats (deterministic), skip + log the rest; never aborts the sync |
| SCIM provisioning | Reject with 402, after the existing 409 duplicate guard |
| OIDC group sync | Skip new membership + log; existing members untouched |

`organization_service` now delegates to the shared helper — the already-guarded admin invite / CSV import paths are behavior-preserving.

## Verification

**Live HTTP feedback loop** (`scripts/verify_seat_cap.py`, documented in `sandbox-feedback-loop-seat-cap-autoprovision.md`) — **11/11 passing** against a running server with an enterprise license capped at 3:

- SCIM provisions up to the cap, then over-cap create → **402** (was 201)
- SCIM re-provision of an existing member → **409** (not masked by the 402)
- Over-cap domain-signup registration creates the account but grants **no membership**
- Admin manual invite over the cap → **402** (the reported symptom)
- Member count held at the cap

**Negative control**: with the SCIM check disabled, the same run reproduces the leak (over-cap SCIM → 201, count → 4), confirming the harness catches the regression rather than passing vacuously.

**Automated tests**:
- `tests/e2e/test_seat_cap_autoprovision.py` — new, 6/6 (helper + one case per path)
- `tests/e2e/test_license_limits.py` — unchanged, 21/21 (admin/CSV behavior preserved)
- Regression-checked green: `test_oidc_group_sync.py` (8), `test_scim.py` + `test_ldap.py` (27)

## Notes

- This stops *new* uninvited members; an org already over its cap stays over until a member is removed (no auto-eviction, per the "never block existing members" policy).
- SCIM returns 402 on overflow, which Entra surfaces as a provisioning failure/quarantine — the intended reject signal.
- `scripts/gen_sandbox_license.py` is a local-only sandbox helper (throwaway keypair); it never touches the real signing key. No license material is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GJGVkX1PewFX84unuqDXz

---
_Generated by [Claude Code](https://claude.ai/code/session_017GJGVkX1PewFX84unuqDXz)_