### PR TITLE
Mobile: fix nav drawer showing icons-only + prompt box send button overflow

### DIFF
--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex-shrink-0 p-3 pb-3 sm:p-4 sm:pb-8 bg-white dark:bg-gray-900">
+    <div ref="rootRef" class="flex-shrink-0 p-3 pb-3 sm:p-4 sm:pb-8 bg-white dark:bg-gray-900">
         <!-- Query pills + Excel hint (above container) — hidden for now -->
         <div v-if="props.pendingTrainingBuild || (false && (props.queryList.length > 0 || props.scheduledPrompts.length > 0 || (isExcel && excelSelection && !excelSelectionDismissed)))" class="mb-2 flex items-center justify-between">
             <div v-if="props.queryList.length > 0 || props.scheduledPrompts.length > 0 || props.pendingTrainingBuild" class="flex items-center gap-2">
@@ -644,6 +644,8 @@ watch(selectedDataSources, (val) => {
 const isHydratingDataSources = ref(!!props.report_id && selectedDataSources.value.length === 0)
 const uploadedFiles = ref<any[]>([])
 const isCompactPrompt = ref(false)
+const rootRef = ref<HTMLElement | null>(null)
+let compactRO: ResizeObserver | null = null
 const inlineMentions = ref<any[]>([])
 const hasBootstrappedFromInitial = ref(selectedDataSources.value.length > 0)
 const isDraggingFiles = ref(false)
@@ -1307,18 +1309,26 @@ onMounted(async () => {
     } else {
         isHydratingDataSources.value = false
     }
-    // Compact mode: if container is narrow, hide labels
-    const root = document.querySelector('.flex-shrink-0') as HTMLElement
-    const ro = new ResizeObserver(() => {
-        const w = root?.clientWidth || 0
-        isCompactPrompt.value = w > 0 && w < 420
-    })
-    if (root) ro.observe(root)
+    // Compact mode: if the prompt box itself is narrow, hide the mode/model
+    // labels (icon-only) so the bottom toolbar can't overflow. Measure THIS
+    // component's own root — a bare document.querySelector('.flex-shrink-0')
+    // returns the first such element in the whole page (e.g. a wide header
+    // container), which on mobile reports left isCompactPrompt false and pushed
+    // the send button outside the box.
+    const root = rootRef.value
+    if (root) {
+        compactRO = new ResizeObserver(() => {
+            const w = root.clientWidth || 0
+            isCompactPrompt.value = w > 0 && w < 420
+        })
+        compactRO.observe(root)
+    }
 })
 
 onBeforeUnmount(() => {
     window.removeEventListener('prompt:prefill', handlePromptPrefill)
     window.removeEventListener('keydown', handleEscKey)
+    if (compactRO) { compactRO.disconnect(); compactRO = null }
 })
 
 watch(() => props.report_id, async (newId, oldId) => {

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -92,7 +92,7 @@
                 </button>
               </UTooltip>
               <!-- Collapse sidebar (expanded state only; collapsed uses the top expand button) -->
-              <UTooltip v-if="!isCollapsed" :text="$t('nav.collapseSidebar')" :popper="{ placement: tooltipPlacement }">
+              <UTooltip v-if="!isCollapsed && !mobileOpen" :text="$t('nav.collapseSidebar')" :popper="{ placement: tooltipPlacement }">
                 <button
                   @click="toggleSidebar"
                   class="flex items-center justify-center w-7 h-7 rounded-md text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800/70 transition-colors"
@@ -543,8 +543,17 @@
   })
   const { version, environment, app_url, intercom } = useRuntimeConfig().public
   
-  // Sidebar collapse state (shared via composable)
-  const { isCollapsed, showText, toggle: toggleSidebar, mobileOpen, openMobile, closeMobile } = useSidebar()
+  // Sidebar collapse state (shared via composable). The desktop sidebar and the
+  // mobile off-canvas drawer are the SAME <aside>. The raw collapse state is a
+  // desktop affordance; when the drawer is open on mobile we always want the
+  // full expanded layout (labels, left-aligned) inside the wide w-72 drawer —
+  // never the icon-only collapsed rendering. So the template binds to these
+  // "effective" computeds, which force expanded while the mobile drawer is open.
+  // On desktop mobileOpen is always false, so they equal the raw values and the
+  // desktop rendering is unchanged.
+  const { isCollapsed: rawCollapsed, showText: rawShowText, toggle: toggleSidebar, mobileOpen, openMobile, closeMobile } = useSidebar()
+  const isCollapsed = computed(() => mobileOpen.value ? false : rawCollapsed.value)
+  const showText = computed(() => mobileOpen.value ? true : rawShowText.value)
   const creatingReport = ref(false)
 
   // Mobile chrome. The report-detail page is full-height (h-dvh) and ships its


### PR DESCRIPTION
## Summary

Two mobile-web fixes, both scoped so desktop rendering is unchanged.

### 1. Nav drawer rendered icon-only on mobile
The off-canvas mobile drawer and the desktop sidebar are the **same** `<aside>`, keyed off the shared collapse state. If a user had collapsed the desktop sidebar, opening the drawer on a phone/narrow window rendered the icon-only collapsed layout inside the wide `w-72` drawer — no labels.

- The drawer's collapse/label rendering now binds to "effective" computeds that force the expanded layout whenever the mobile drawer is open (`mobileOpen`).
- The **collapse-sidebar button is hidden inside the drawer** (collapsing to icons makes no sense there; the drawer is dismissed via the backdrop or by tapping a nav item).
- `mobileOpen` is always `false` on desktop, so desktop rendering is byte-for-byte identical.

### 2. Prompt box send button overflowed the box (mobile / RTL)
`isCompactPrompt` was driven by a `ResizeObserver` on `document.querySelector('.flex-shrink-0')`, which returns the **first** such element in the whole document (e.g. a wide header container) rather than the prompt box. On mobile report views that element stayed ≥420px, so the mode/model labels never collapsed to icons and the bottom toolbar overflowed the narrow box — pushing the send button outside its bounds (most visible in RTL/Hebrew).

- The observer now binds to this component's **own root** via a template ref, and is disconnected on unmount.
- Result: on a narrow prompt box the mode/model selectors become icon-only and the whole toolbar (including the send button) stays inside the box, in both LTR and RTL.

## Testing
Reproduced locally with Playwright (backend + frontend + seeded data):
- Collapsed the sidebar on desktop, shrank to 600px, opened the drawer → renders fully expanded with labels.
- Verified desktop collapse/expand still works unchanged at 1440px.
- Opened a report at 390px in both English and Hebrew → prompt box is compact (icon-only selectors), send button contained within the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc)_