### PR TITLE
Filter disabled agents out of reports; open dashboards cards in dashboard view

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -224,8 +224,16 @@ class AgentV2:
 
         # Initialize data sources and clients (mirror agent.py pattern)
         if report:
-            # Handle case where data_sources or files might be None
-            self.data_sources = getattr(report, 'data_sources', []) or []
+            # Handle case where data_sources or files might be None. The
+            # report's attachments are a creation-time snapshot — drop agents
+            # disabled/deactivated since so their schema never enters the
+            # context, even for callers that pass no clients. (Local import:
+            # data_source_service pulls in app.ai modules at import time.)
+            from app.services.data_source_service import DataSourceService
+            self.data_sources = [
+                ds for ds in (getattr(report, 'data_sources', []) or [])
+                if DataSourceService.is_execution_live(ds)
+            ]
             self.clients = clients
             # Drop data sources that produced no client. The caller builds
             # `clients` via DataSourceService.construct_clients, which now 403s

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -135,6 +135,11 @@ class DataSourceReportSchema(BaseModel):
     owner_user_id: Optional[str] = None
     use_llm_sync: bool = False
 
+    # Publishing lifecycle — lets the client badge non-production agents
+    # (Development / Training) the same way the data source selector does.
+    publish_status: str = "published"
+    reliability_status: str = "training"
+
     # Connection info (multi-connection support)
     connections: List[ConnectionEmbedded] = []
 

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -332,6 +332,12 @@ class CompletionService:
 
             clients = {}
             for data_source in report.data_sources:
+                # The report's attachments are a creation-time snapshot — skip
+                # agents disabled/deactivated since, so they are neither
+                # queryable nor fed into the agent context (AgentV2 drops
+                # sources without a client).
+                if not self.data_source_service.is_execution_live(data_source):
+                    continue
                 try:
                     ds_clients = await self.data_source_service.construct_clients(db, data_source, current_user)
                     clients.update(ds_clients)
@@ -717,6 +723,10 @@ class CompletionService:
                     with tracer.start_as_current_span("completion.construct_clients") as clients_span:
                         clients = {}
                         for data_source in report.data_sources:
+                            # Skip agents disabled/deactivated after being
+                            # attached to the report (see foreground path).
+                            if not self.data_source_service.is_execution_live(data_source):
+                                continue
                             try:
                                 ds_clients = await self.data_source_service.construct_clients(db, data_source, current_user)
                                 clients.update(ds_clients)

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1933,6 +1933,61 @@ class DataSourceService:
             allowed = params
         return ClientClass(**allowed)
 
+    @staticmethod
+    def is_execution_live(ds) -> bool:
+        """User-independent lifecycle check for run-time consumers.
+
+        A report's attached data sources are a snapshot taken at creation;
+        an agent disabled (or deactivated) afterwards stays on the snapshot.
+        Execution paths — client construction, AI context — must skip those:
+        ``disabled`` means "excluded from normal use", not just hidden in
+        pickers. Draft/development agents remain runnable (their visibility
+        is a per-user concern handled by filter_live_data_sources).
+        """
+        if not getattr(ds, "is_active", True):
+            return False
+        return (getattr(ds, "publish_status", "published") or "published") != "disabled"
+
+    async def filter_live_data_sources(
+        self,
+        db: AsyncSession,
+        data_sources: list,
+        current_user: User | None,
+        organization: Organization | None,
+        visibility: tuple | None = None,
+    ) -> list:
+        """Keep only data sources that are live for this caller.
+
+        Mirrors the lifecycle rules of get_active_data_sources so a report's
+        attached data sources (a creation-time snapshot, serialized raw
+        otherwise) show the same set the selector would offer:
+          - inactive / ``disabled`` → dropped for everyone
+          - ``draft``               → managers only (governance / per-DS manage)
+          - ``development``         → agent admins only (manage_evals)
+
+        ``visibility`` optionally takes a precomputed ``_publish_visibility``
+        result so list endpoints can resolve permissions once across many
+        reports. With no current_user (system/scheduled contexts) only the
+        user-independent checks apply.
+        """
+        live = [ds for ds in (data_sources or []) if self.is_execution_live(ds)]
+        if current_user is None or organization is None:
+            return live
+        if visibility is None:
+            visibility = await self._publish_visibility(db, current_user, organization)
+        is_gov, manage_ids, resolved = visibility
+        out = []
+        for ds in live:
+            publish_status = getattr(ds, "publish_status", "published") or "published"
+            if publish_status == "draft" and not (is_gov or str(ds.id) in manage_ids):
+                continue
+            if self._development_hidden(
+                getattr(ds, "reliability_status", "training"), ds.id, is_gov, resolved
+            ):
+                continue
+            out.append(ds)
+        return out
+
     async def filter_user_visible_data_sources(
         self,
         db: AsyncSession,

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -341,6 +341,16 @@ class ReportService:
 
         user_schema = UserSchema.from_orm(report.user)
 
+        # Lifecycle-filter the attached data sources before serializing. The
+        # association is a creation-time snapshot, so agents disabled (or moved
+        # back to draft/development) afterwards would otherwise keep surfacing
+        # in the report's agent panel and prompt-box selection — places the
+        # active-agents selector would never offer them.
+        from app.services.data_source_service import DataSourceService
+        live_data_sources = await DataSourceService().filter_live_data_sources(
+            db, report.data_sources, current_user, organization
+        )
+
         # Detect app version for routing
         app_version = await self._detect_app_version(db, report.id)
 
@@ -355,7 +365,7 @@ class ReportService:
             created_at=report.created_at,
             updated_at=report.updated_at,
             app_version=app_version,
-            data_sources=report.data_sources,
+            data_sources=live_data_sources,
             external_platform=report.external_platform,
             theme_name=report.theme_name,
             theme_overrides=report.theme_overrides,
@@ -1514,11 +1524,21 @@ class ReportService:
                 active_sp_counts = {str(row[0]): row[1] for row in sp_result.all()}
 
             # Convert to schemas
+            # Lifecycle-filter each report's attached data sources (same rules
+            # as get_report); resolve the caller's publish visibility once for
+            # the whole page instead of per report.
+            from app.services.data_source_service import DataSourceService
+            ds_service = DataSourceService()
+            publish_visibility = await ds_service._publish_visibility(db, current_user, organization)
             report_schemas = []
             for report in reports:
                 report_schema = ReportSchema.from_orm(report)
                 report_schema.user = UserSchema.from_orm(report.user)
 
+                live_data_sources = await ds_service.filter_live_data_sources(
+                    db, report.data_sources, current_user, organization,
+                    visibility=publish_visibility,
+                )
                 # Manually build data_sources with type computed from connection
                 report_schema.data_sources = [
                     DataSourceReportSchema(
@@ -1534,10 +1554,12 @@ class ReportService:
                         is_public=ds.is_public,
                         owner_user_id=str(ds.owner_user_id) if ds.owner_user_id else None,
                         use_llm_sync=ds.use_llm_sync,
+                        publish_status=getattr(ds, "publish_status", "published") or "published",
+                        reliability_status=getattr(ds, "reliability_status", "training") or "training",
                         # Compute type from first connection
                         type=ds.connections[0].type if ds.connections else None,
                     )
-                    for ds in (report.data_sources or [])
+                    for ds in live_data_sources
                 ]
 
                 # Summary counts (from batched GROUP BY queries above)

--- a/backend/tests/unit/test_report_data_source_lifecycle.py
+++ b/backend/tests/unit/test_report_data_source_lifecycle.py
@@ -1,0 +1,95 @@
+"""Unit tests for the report data-source lifecycle filters.
+
+A report's attached data sources are a creation-time snapshot; agents
+disabled (or moved back to draft/development) afterwards stay on the
+snapshot. These filters keep such agents out of report serialization
+(``filter_live_data_sources``) and out of query execution / AI context
+(``is_execution_live``), mirroring the lifecycle rules of
+``get_active_data_sources``.
+"""
+import asyncio
+from types import SimpleNamespace
+
+from app.services.data_source_service import DataSourceService
+
+
+def _ds(ds_id, publish_status="published", reliability_status="ok", is_active=True):
+    return SimpleNamespace(
+        id=ds_id,
+        is_active=is_active,
+        publish_status=publish_status,
+        reliability_status=reliability_status,
+    )
+
+
+svc = DataSourceService()
+
+# Precomputed _publish_visibility results: (is_gov, manage_ids, resolved).
+NON_MANAGER = (False, set(), None)
+GOVERNANCE = (True, set(), None)
+
+USER = SimpleNamespace(id="user-1")
+ORG = SimpleNamespace(id="org-1")
+
+
+def _filter(data_sources, visibility, user=USER, org=ORG):
+    return asyncio.run(
+        svc.filter_live_data_sources(None, data_sources, user, org, visibility=visibility)
+    )
+
+
+class TestIsExecutionLive:
+    def test_published_active_is_live(self):
+        assert svc.is_execution_live(_ds("a"))
+
+    def test_disabled_is_not_live(self):
+        assert not svc.is_execution_live(_ds("a", publish_status="disabled"))
+
+    def test_inactive_is_not_live(self):
+        assert not svc.is_execution_live(_ds("a", is_active=False))
+
+    def test_draft_and_development_remain_runnable(self):
+        # Draft/development are per-user visibility concerns, not execution ones.
+        assert svc.is_execution_live(_ds("a", publish_status="draft"))
+        assert svc.is_execution_live(_ds("a", reliability_status="development"))
+
+    def test_missing_lifecycle_fields_default_to_live(self):
+        assert svc.is_execution_live(SimpleNamespace(id="a", is_active=True))
+
+
+class TestFilterLiveDataSources:
+    def test_disabled_dropped_for_everyone(self):
+        ds = [_ds("a"), _ds("b", publish_status="disabled")]
+        assert [d.id for d in _filter(ds, GOVERNANCE)] == ["a"]
+        assert [d.id for d in _filter(ds, NON_MANAGER)] == ["a"]
+
+    def test_draft_and_development_hidden_from_non_managers(self):
+        ds = [
+            _ds("a"),
+            _ds("b", publish_status="draft"),
+            _ds("c", reliability_status="development"),
+            _ds("d", reliability_status="training"),
+        ]
+        assert [d.id for d in _filter(ds, NON_MANAGER)] == ["a", "d"]
+
+    def test_managers_keep_their_drafts(self):
+        ds = [_ds("a"), _ds("b", publish_status="draft"), _ds("c", reliability_status="development")]
+        assert [d.id for d in _filter(ds, GOVERNANCE)] == ["a", "b", "c"]
+
+    def test_per_ds_manage_grant_unlocks_draft(self):
+        resolved = SimpleNamespace(
+            has_resource_permission=lambda rtype, rid, perm: False
+        )
+        visibility = (False, {"b"}, resolved)
+        ds = [_ds("a"), _ds("b", publish_status="draft")]
+        assert [d.id for d in _filter(ds, visibility)] == ["a", "b"]
+
+    def test_system_context_applies_only_user_independent_checks(self):
+        # No user (scheduled/system runs): drop disabled/inactive, keep the rest.
+        ds = [_ds("a"), _ds("b", publish_status="disabled"), _ds("c", publish_status="draft")]
+        result = asyncio.run(svc.filter_live_data_sources(None, ds, None, None))
+        assert [d.id for d in result] == ["a", "c"]
+
+    def test_empty_and_none_inputs(self):
+        assert _filter([], NON_MANAGER) == []
+        assert asyncio.run(svc.filter_live_data_sources(None, None, None, None)) == []

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -2,16 +2,20 @@
   <div class="h-full flex flex-col overflow-hidden">
     <!-- Agent selector dropdown -->
     <div class="px-4 pt-4 pb-2 flex-shrink-0 bg-gradient-to-b from-indigo-50/40 to-transparent dark:from-gray-900 dark:to-transparent">
-      <div v-if="agents.length === 0" class="text-xs text-gray-400 dark:text-gray-500 italic text-center py-4">
+      <div v-if="visibleAgents.length === 0" class="text-xs text-gray-400 dark:text-gray-500 italic text-center py-4">
         {{ $t('reportAgent.noAgents') }}
       </div>
-      <div v-else-if="agents.length === 1" class="flex items-center gap-2">
+      <div v-else-if="visibleAgents.length === 1" class="flex items-center gap-2">
         <button v-if="showClose" @click="$emit('close')" class="hover:bg-gray-100 dark:hover:bg-gray-800/70 p-1 rounded">
           <Icon name="heroicons:x-mark" class="w-4 h-4 text-gray-500 dark:text-gray-400" />
         </button>
-        <Icon v-if="(agents[0] as any).isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-        <DataSourceIcon v-else :type="agents[0].type || agents[0].connections?.[0]?.type" class="h-5 flex-shrink-0" />
-        <span class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ agents[0].name }}</span>
+        <Icon v-if="(visibleAgents[0] as any).isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+        <DataSourceIcon v-else :type="visibleAgents[0].type || visibleAgents[0].connections?.[0]?.type" class="h-5 flex-shrink-0" />
+        <span class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ visibleAgents[0].name }}</span>
+        <span
+          v-if="stageBadge(visibleAgents[0])"
+          :class="['flex-shrink-0 text-[10px] rounded border px-1 py-0.5', stageBadge(visibleAgents[0])?.badge]"
+        >{{ stageBadge(visibleAgents[0])?.label }}</span>
       </div>
       <div v-else class="flex items-center gap-2">
         <button v-if="showClose" @click="$emit('close')" class="hover:bg-gray-100 dark:hover:bg-gray-800/70 p-1 rounded flex-shrink-0">
@@ -39,7 +43,7 @@
         >
           <div v-if="dropdownOpen" class="absolute z-10 mt-1 w-full bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg shadow-lg overflow-hidden">
             <button
-              v-for="agent in agents"
+              v-for="agent in visibleAgents"
               :key="agent.id"
               @click="selectAgent(agent.id)"
               class="w-full flex items-center gap-2 px-3 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
@@ -48,6 +52,10 @@
               <Icon v-if="(agent as any).isGlobal" name="heroicons:globe-alt" class="w-4 h-4 text-gray-500 dark:text-gray-400 flex-shrink-0" />
               <DataSourceIcon v-else :type="agent.type || agent.connections?.[0]?.type" class="h-4 flex-shrink-0" />
               <span class="truncate flex-1 text-start font-medium">{{ agent.name }}</span>
+              <span
+                v-if="stageBadge(agent)"
+                :class="['flex-shrink-0 text-[10px] rounded border px-1 py-0.5', stageBadge(agent)?.badge]"
+              >{{ stageBadge(agent)?.label }}</span>
               <Icon v-if="selectedAgentId === agent.id" name="heroicons:check" class="w-3.5 h-3.5 text-indigo-600 flex-shrink-0" />
             </button>
           </div>
@@ -534,13 +542,28 @@ import BuildExplorerModal from '~/components/instructions/BuildExplorerModal.vue
 import InstructionTrackedChanges from '~/components/instructions/InstructionTrackedChanges.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
 import { useInstructionHelpers } from '~/composables/useInstructionHelpers'
+import { deriveStage, stageMeta } from '~/composables/useDataSourcePublishStatus'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  agents: Array<{ id: string; name: string; type?: string; connections?: any[] }>
+  agents: Array<{ id: string; name: string; type?: string; connections?: any[]; publish_status?: string; reliability_status?: string }>
   showClose?: boolean
 }>()
+
+// Lifecycle filter + badge, mirroring DataSourceSelector: disabled agents are
+// hidden (the home instructions modal feeds this panel from /data_sources,
+// which returns managers their disabled agents too), and non-production stages
+// (Development / Training) are flagged. The synthetic Global entry is exempt.
+const visibleAgents = computed(() =>
+  props.agents.filter((a: any) => a.isGlobal || deriveStage(a.publish_status, a.reliability_status) !== 'disabled')
+)
+
+function stageBadge(agent: any) {
+  if (agent?.isGlobal) return null
+  const stage = deriveStage(agent?.publish_status, agent?.reliability_status)
+  return stage === 'production' ? null : stageMeta(stage)
+}
 
 const emit = defineEmits(['close', 'starter-click', 'connected'])
 
@@ -776,16 +799,18 @@ const instructionsError = ref<string | null>(null)
 const queriesError = ref<string | null>(null)
 const evalsError = ref<string | null>(null)
 
-// Auto-select first agent
-watch(() => props.agents, (agents) => {
-  if (agents.length > 0 && !selectedAgentId.value) {
+// Auto-select first agent; also reselect when the current one drops out of
+// the visible list (e.g. it was disabled while the panel was open).
+watch(visibleAgents, (agents) => {
+  if (agents.length === 0) return
+  if (!selectedAgentId.value || !agents.some(a => a.id === selectedAgentId.value)) {
     selectedAgentId.value = agents[0].id
     if (agents[0].id === GLOBAL_AGENT_ID) activeTab.value = 'instructions'
   }
 }, { immediate: true })
 
 const selectedAgent = computed(() => {
-  return props.agents.find(a => a.id === selectedAgentId.value) || null
+  return visibleAgents.value.find(a => a.id === selectedAgentId.value) || null
 })
 
 // Tab definitions with counts (tables count managed by TablesSelector internally)

--- a/frontend/pages/dashboards/index.vue
+++ b/frontend/pages/dashboards/index.vue
@@ -72,11 +72,14 @@
                 <!-- Cards grid -->
                 <div v-else-if="reports.length > 0">
                     <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-6">
+                        <!-- view-mode="org" so cards open the dashboard view
+                             (/r/[id]) on both tabs — owners edit via the pencil
+                             (/reports/[id]). 'my' mode would link the editor. -->
                         <RecentReportCard
                             v-for="report in reports"
                             :key="report.id"
                             :report="report"
-                            :view-mode="activeFilter === 'shared' ? 'org' : 'my'"
+                            view-mode="org"
                             :is-owner="report.user?.id === (currentUser as any)?.id"
                         />
                     </div>


### PR DESCRIPTION
## Problem

**Disabled agents kept surfacing in reports.** A report's attached data sources are a creation-time snapshot (Auto mode pins every then-visible agent), and `GET /reports/{id}` serialized that snapshot raw. Agents disabled afterwards therefore:

- kept showing in the `ReportAgentPanel` dropdown and prompt-box selection — even though `DataSourceSelector` and the `/agents` page (both backed by `/data_sources/active`) would never offer them,
- were still **queried at completion time**: client construction and the AI context iterated `report.data_sources` with no lifecycle check.

Separately, cards on `/dashboards` (My Dashboards tab) linked to the report editor (`/reports/[id]`) instead of the dashboard view (`/r/[id]`).

## Changes

### Backend
- `DataSourceService.filter_live_data_sources()` — applies the same lifecycle rules as `get_active_data_sources` to a report's attachments: disabled/inactive dropped for everyone, `draft` visible to managers only, `development` to agent admins only. Accepts a precomputed visibility tuple so list endpoints resolve permissions once per page.
- `DataSourceService.is_execution_live()` — the user-independent subset (inactive/disabled only; draft/development stay runnable) for run-time consumers.
- `get_report` and the `get_reports` list serialization filter attachments through it. **Association rows are kept** — re-enabling an agent restores it on its reports.
- Completion client construction (foreground + background paths) and `AgentV2`'s context skip non-live sources, so disabled agents are neither queryable nor fed to the planner — including on scheduled runs.
- `DataSourceReportSchema` now carries `publish_status` / `reliability_status`.

### Frontend
- `ReportAgentPanel` hides disabled agents client-side (its home-page instructions modal feeder uses `/data_sources`, which returns managers their disabled agents) and badges non-production stages (Development / Training), mirroring `DataSourceSelector`. Selection recovers if the selected agent drops out of the list.
- `/dashboards` cards pass `view-mode="org"` on both tabs (My and Shared with me), so every card opens `/r/[id]`; owners still reach the editor via the pencil overlay. The home page's "My Reports" cards keep their editor links.

## Tests
- New `backend/tests/unit/test_report_data_source_lifecycle.py` (11 tests) covering `is_execution_live` and `filter_live_data_sources` across manager / non-manager / per-DS grant / system (no-user) contexts.
- Adjacent unit tests (`test_schema_section_agent_status`, `test_permission_resolver`, `test_data_preview_privacy`) still pass; `vue-tsc` shows no new errors in the edited components.

## Notes
- When a user submits a prompt on an old report, the client persists its (now-filtered) selection back to the report, dropping the disabled agent's association for that report. Re-enabling restores it only on reports untouched in the meantime.
- The underlying "Auto mode materializes as a frozen snapshot of all agents" design is out of scope here — worth a separate issue if we want auto resolved live at read/run time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBpxtYkRrP2tzdDDxd3SXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBpxtYkRrP2tzdDDxd3SXQ)_