### PR TITLE
RTL: align sidebar reports list to the start edge

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -188,7 +188,7 @@
           <ul class="font-normal text-[13px] !ps-0 space-y-0.5">
             <li v-for="report in recentReports" :key="report.id" class="relative group/report">
               <NuxtLink :to="`/reports/${report.id}`" :class="[
-                'flex items-center gap-2 px-2.5 py-1.5 pr-8 w-full rounded-md',
+                'flex items-center gap-2 px-2.5 py-1.5 pe-8 w-full rounded-md',
                 isRouteActive(`/reports/${report.id}`) ? 'text-gray-900 dark:text-white bg-gray-200/70 dark:bg-gray-800 font-medium' : 'text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/70'
               ]">
                 <UIcon :name="reportTypeIcon(report)" class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500" />
@@ -202,7 +202,7 @@
               <button
                 type="button"
                 @click.stop.prevent="openReportMenu($event, report)"
-                class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-6 h-6 rounded-full text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200/80 dark:hover:bg-gray-700 transition-opacity"
+                class="absolute end-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-6 h-6 rounded-full text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200/80 dark:hover:bg-gray-700 transition-opacity"
                 :class="reportMenuOpen && menuReport?.id === report.id ? 'opacity-100 bg-gray-200/80 dark:bg-gray-700' : 'opacity-0 group-hover/report:opacity-100'"
                 aria-label="Report actions"
               >


### PR DESCRIPTION
## Summary

In RTL (Hebrew), the recent-reports list in the sidebar/mobile drawer was inset from the start edge, so the report rows didn't line up with the nav items or the "דוחות" section header above them.

**Cause:** the report rows used physical utilities:
- `pr-8` on the row (reserving room on the right for the hover ellipsis menu), and
- the ellipsis menu button positioned at `right-1`.

Both are physical (right-anchored) and don't flip for RTL. Since the list's start edge in RTL is the right, `pr-8` padded the start side, pushing report titles inward and out of alignment.

**Fix:** switch to logical utilities — `pe-8` (padding-end) and `end-1`. The reserved space and the menu button now sit at the *end* edge in both directions.

- **LTR:** unchanged — `pe-8` ≡ `pr-8` and `end-1` ≡ `right-1`.
- **RTL:** report rows now align flush to the start (right) edge, matching the nav items and the section header.

## Testing
Reproduced locally with Playwright at 390px in Hebrew (RTL): opened the mobile drawer and confirmed the report row + its icon now share the same start edge as the nav labels (both right-aligned at the same x). Verified the change is a no-op for LTR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL5vMk8voqnHPgUAmCjSNc)_