### PR TITLE
Enhance report schedule modal with structured day/frequency builder

### DIFF
--- a/frontend/components/CronModal.vue
+++ b/frontend/components/CronModal.vue
@@ -19,11 +19,72 @@
             <div>
                 <div class="mt-4">
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Schedule Frequency</label>
-                    <select v-model="selectedSchedule" class="w-full rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm">
-                        <option v-for="option in cronOptions" :key="option.value" :value="option.value">
-                            {{ option.label }}
-                        </option>
-                    </select>
+
+                    <!-- Off / recurring toggle -->
+                    <div class="flex gap-0.5 p-0.5 bg-gray-100 dark:bg-gray-800 rounded w-fit mb-3">
+                        <button
+                            v-for="opt in enabledOptions"
+                            :key="String(opt.value)"
+                            type="button"
+                            class="px-2.5 py-0.5 text-[11px] rounded transition-colors"
+                            :class="scheduleEnabled === opt.value ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm font-medium' : 'text-gray-400 hover:text-gray-600'"
+                            @click="scheduleEnabled = opt.value"
+                        >
+                            {{ opt.label }}
+                        </button>
+                    </div>
+
+                    <!-- Structured recurring builder (mirrors the schedule-task modal) -->
+                    <div v-if="scheduleEnabled" class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 flex-wrap">
+                        <span>{{ $t('scheduledPrompt.every') }}</span>
+                        <template v-if="recurInterval === 'minutes' || recurInterval === 'hours'">
+                            <input v-model.number="recurEveryN" type="number" min="1" :max="recurInterval === 'minutes' ? 59 : 23"
+                                class="w-14 rounded border border-gray-200 dark:border-gray-700 px-1.5 py-1 text-sm text-center" />
+                        </template>
+                        <select v-model="recurInterval" class="rounded border border-gray-200 dark:border-gray-700 px-2 py-1 text-sm">
+                            <option value="minutes">{{ $t('scheduledPrompt.intervalMinutes') }}</option>
+                            <option value="hours">{{ $t('scheduledPrompt.intervalHours') }}</option>
+                            <option value="day">{{ $t('scheduledPrompt.intervalDay') }}</option>
+                            <option value="weekdays">{{ $t('scheduledPrompt.intervalWeekdays') }}</option>
+                            <option value="week">{{ $t('scheduledPrompt.intervalWeek') }}</option>
+                            <option value="month">{{ $t('scheduledPrompt.intervalMonth') }}</option>
+                        </select>
+                        <template v-if="recurInterval === 'day' || recurInterval === 'weekdays' || recurInterval === 'week' || recurInterval === 'month'">
+                            <span>{{ $t('scheduledPrompt.at') }}</span>
+                            <select v-model="recurHour" class="rounded border border-gray-200 dark:border-gray-700 px-2 py-1 text-sm">
+                                <option v-for="h in 24" :key="h - 1" :value="h - 1">{{ String(h - 1).padStart(2, '0') }}:00</option>
+                            </select>
+                        </template>
+                        <template v-if="recurInterval === 'week'">
+                            <span>{{ $t('scheduledPrompt.on') }}</span>
+                            <div class="flex items-center gap-1">
+                                <button
+                                    v-for="d in weekdays"
+                                    :key="d.value"
+                                    type="button"
+                                    @click="toggleRecurDay(d.value)"
+                                    :title="d.label"
+                                    :aria-pressed="recurDays.includes(d.value)"
+                                    class="flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-medium border transition-colors"
+                                    :class="recurDays.includes(d.value)
+                                        ? 'bg-blue-500 text-white border-blue-500'
+                                        : 'bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'"
+                                >
+                                    {{ d.short }}
+                                </button>
+                            </div>
+                        </template>
+                        <template v-if="recurInterval === 'month'">
+                            <span>{{ $t('scheduledPrompt.onDay') }}</span>
+                            <select v-model="recurDayOfMonth" class="rounded border border-gray-200 dark:border-gray-700 px-2 py-1 text-sm">
+                                <option v-for="d in 28" :key="d" :value="d">{{ d }}</option>
+                            </select>
+                        </template>
+                    </div>
+
+                    <p v-if="scheduleEnabled && scheduleLabel" class="mt-2 text-xs text-gray-400 dark:text-gray-600">
+                        {{ scheduleLabel }}
+                    </p>
                 </div>
 
                 <p v-if="report.last_run_at" class="mt-4 text-sm text-gray-500 dark:text-gray-400">
@@ -32,7 +93,7 @@
             </div>
 
             <!-- Notification subscribers (save-based, not send-now) -->
-            <div v-if="smtpEnabled && selectedSchedule !== 'None'" class="border-t border-gray-200 dark:border-gray-700 pt-4 mt-4">
+            <div v-if="smtpEnabled && scheduleEnabled" class="border-t border-gray-200 dark:border-gray-700 pt-4 mt-4">
                 <div class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <Icon name="heroicons:envelope" class="w-4 h-4" />
                     Notify after each run
@@ -95,6 +156,8 @@
 </template>
 
 <script lang="ts" setup>
+import { buildRecurringCron, parseRecurringCron, type RecurInterval } from '@/composables/useScheduleBuilder'
+
 const cronModalOpen = ref(false);
 const toast = useToast();
 const { smtpEnabled } = useAppSettings();
@@ -107,21 +170,72 @@ const isSaving = ref(false);
 
 const reportUrl = computed(() => `${window.location.origin}/r/${report.value.id}`);
 
-const selectedSchedule = ref(props.report.cron_schedule || 'None');
+const { t } = useI18n()
+const { getCronLabel } = useCronLabel()
 
 const _df = useFormatDate()
 function formatDate(date: string) {
     return _df.formatDateTime(date);
 }
 
-const cronOptions = ref([
-    { value: 'None', label: 'None' },
-    //{ value: '*/5 * * * * *', label: 'Every 5 Seconds' },
-    { value: '*/15 * * * *', label: 'Every 15 Minutes' },
-    { value: '0 * * * *', label: 'Hourly' },
-    { value: '0 0 * * *', label: 'Daily (Midnight)' },
-    { value: '0 0 * * 1', label: 'Weekly (Monday Midnight)' },
+// ---- Structured recurring schedule (shared builder with the task modal) ----
+
+const enabledOptions = computed(() => [
+    { value: false, label: t('scheduledPrompt.scheduleOff', 'Off') },
+    { value: true, label: t('scheduledPrompt.scheduleOn', 'On') },
 ]);
+
+const scheduleEnabled = ref(!!props.report.cron_schedule);
+
+const recurInterval = ref<RecurInterval>('day');
+const recurEveryN = ref(15);
+const recurHour = ref(8);
+const recurDays = ref<number[]>([1]);
+const recurDayOfMonth = ref(1);
+
+const weekdays = computed(() => [
+    { value: 0, label: t('scheduledPrompt.dowSun'), short: t('scheduledPrompt.dowSunShort') },
+    { value: 1, label: t('scheduledPrompt.dowMon'), short: t('scheduledPrompt.dowMonShort') },
+    { value: 2, label: t('scheduledPrompt.dowTue'), short: t('scheduledPrompt.dowTueShort') },
+    { value: 3, label: t('scheduledPrompt.dowWed'), short: t('scheduledPrompt.dowWedShort') },
+    { value: 4, label: t('scheduledPrompt.dowThu'), short: t('scheduledPrompt.dowThuShort') },
+    { value: 5, label: t('scheduledPrompt.dowFri'), short: t('scheduledPrompt.dowFriShort') },
+    { value: 6, label: t('scheduledPrompt.dowSat'), short: t('scheduledPrompt.dowSatShort') },
+]);
+
+function toggleRecurDay(value: number) {
+    const idx = recurDays.value.indexOf(value);
+    if (idx === -1) {
+        recurDays.value = [...recurDays.value, value].sort((a, b) => a - b);
+    } else if (recurDays.value.length > 1) {
+        // Keep at least one day selected so the cron stays valid.
+        recurDays.value = recurDays.value.filter((d) => d !== value);
+    }
+}
+
+function currentCron(): string {
+    return buildRecurringCron({
+        interval: recurInterval.value,
+        everyN: recurEveryN.value,
+        hour: recurHour.value,
+        days: recurDays.value,
+        dayOfMonth: recurDayOfMonth.value,
+    });
+}
+
+const scheduleLabel = computed(() => getCronLabel(currentCron()));
+
+// Hydrate the structured inputs from the report's saved cron on mount.
+if (props.report.cron_schedule) {
+    const patch = parseRecurringCron(props.report.cron_schedule);
+    if (patch) {
+        if (patch.interval !== undefined) recurInterval.value = patch.interval;
+        if (patch.everyN !== undefined) recurEveryN.value = patch.everyN;
+        if (patch.hour !== undefined) recurHour.value = patch.hour;
+        if (patch.days !== undefined) recurDays.value = patch.days;
+        if (patch.dayOfMonth !== undefined) recurDayOfMonth.value = patch.dayOfMonth;
+    }
+}
 
 // ---- Subscriber management ----
 
@@ -237,8 +351,8 @@ async function scheduleReport() {
         const response = await useMyFetch(`/api/reports/${report.value.id}/schedule`, {
             method: 'POST',
             body: {
-                cron_expression: selectedSchedule.value,
-                notification_subscribers: subscribers.value.length > 0 ? subscribers.value : null,
+                cron_expression: scheduleEnabled.value ? currentCron() : 'None',
+                notification_subscribers: scheduleEnabled.value && subscribers.value.length > 0 ? subscribers.value : null,
             },
         });
         if (response.data.value) {

--- a/frontend/components/ScheduledPromptModal.vue
+++ b/frontend/components/ScheduledPromptModal.vue
@@ -196,6 +196,7 @@
 <script lang="ts" setup>
 import Spinner from '@/components/Spinner.vue'
 import PromptBoxV2 from '@/components/prompt/PromptBoxV2.vue'
+import { buildRecurringCron, parseRecurringCron, type RecurInterval } from '@/composables/useScheduleBuilder'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -264,7 +265,6 @@ const delayAmount = ref(1)
 const delayUnit = ref<'minutes' | 'hours' | 'days'>('hours')
 
 // Recurring structured inputs
-type RecurInterval = 'minutes' | 'hours' | 'day' | 'weekdays' | 'week' | 'month'
 const recurInterval = ref<RecurInterval>('day')
 const recurEveryN = ref(15)
 const recurHour = ref(8)
@@ -291,36 +291,13 @@ function toggleRecurDay(value: number) {
 }
 
 function parseCronToStructured(cron: string) {
-    if (!cron) return
-    const parts = cron.split(' ')
-    if (parts.length < 5) return
-    const [min, hour, dom, , dow] = parts
-    if (min.startsWith('*/')) {
-        recurInterval.value = 'minutes'
-        recurEveryN.value = parseInt(min.slice(2)) || 15
-    } else if (hour.startsWith('*/')) {
-        recurInterval.value = 'hours'
-        recurEveryN.value = parseInt(hour.slice(2)) || 1
-    } else if (dow === '1-5') {
-        recurInterval.value = 'weekdays'
-        recurHour.value = parseInt(hour) || 0
-    } else if (dom !== '*' && dow === '*') {
-        recurInterval.value = 'month'
-        recurHour.value = parseInt(hour) || 0
-        recurDayOfMonth.value = parseInt(dom) || 1
-    } else if (dow !== '*') {
-        recurInterval.value = 'week'
-        recurHour.value = parseInt(hour) || 0
-        // Parse a comma list of days ("1,3,5" -> [1,3,5]). Guard NaN but keep 0
-        // (Sunday). Fall back to Monday if nothing valid parsed.
-        const parsedDays = dow.split(',')
-            .map((d) => parseInt(d, 10))
-            .filter((d) => !Number.isNaN(d) && d >= 0 && d <= 6)
-        recurDays.value = parsedDays.length > 0 ? [...new Set(parsedDays)].sort((a, b) => a - b) : [1]
-    } else {
-        recurInterval.value = 'day'
-        recurHour.value = parseInt(hour) || 0
-    }
+    const patch = parseRecurringCron(cron)
+    if (!patch) return
+    if (patch.interval !== undefined) recurInterval.value = patch.interval
+    if (patch.everyN !== undefined) recurEveryN.value = patch.everyN
+    if (patch.hour !== undefined) recurHour.value = patch.hour
+    if (patch.days !== undefined) recurDays.value = patch.days
+    if (patch.dayOfMonth !== undefined) recurDayOfMonth.value = patch.dayOfMonth
 }
 
 // Hydrate the schedule form from the existing cron on setup. The watch below is
@@ -422,15 +399,13 @@ function computeCronSchedule(): string {
         const target = new Date(now.getTime() + delayAmount.value * multiplier * 60_000)
         return `${target.getMinutes()} ${target.getHours()} ${target.getDate()} ${target.getMonth() + 1} *`
     }
-    if (recurInterval.value === 'minutes') return `*/${recurEveryN.value} * * * *`
-    if (recurInterval.value === 'hours') return `0 */${recurEveryN.value} * * *`
-    if (recurInterval.value === 'weekdays') return `0 ${recurHour.value} * * 1-5`
-    if (recurInterval.value === 'week') {
-        const days = [...recurDays.value].sort((a, b) => a - b)
-        return `0 ${recurHour.value} * * ${(days.length > 0 ? days : [1]).join(',')}`
-    }
-    if (recurInterval.value === 'month') return `0 ${recurHour.value} ${recurDayOfMonth.value} * *`
-    return `0 ${recurHour.value} * * *`
+    return buildRecurringCron({
+        interval: recurInterval.value,
+        everyN: recurEveryN.value,
+        hour: recurHour.value,
+        days: recurDays.value,
+        dayOfMonth: recurDayOfMonth.value,
+    })
 }
 
 function buildNotificationSubscribers(): Subscriber[] | null {

--- a/frontend/composables/useScheduleBuilder.ts
+++ b/frontend/composables/useScheduleBuilder.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared recurring-schedule builder.
+ *
+ * Single source of truth for converting between the structured schedule inputs
+ * used by the schedule UIs (interval + every-N + hour + weekdays + day-of-month)
+ * and a 5-field cron string. Both the report-refresh CronModal and the
+ * ScheduledPromptModal use these helpers so the two schedulers stay identical
+ * and can't drift.
+ *
+ * Cron conventions produced/parsed here:
+ *   minutes   -> `*​/N * * * *`
+ *   hours     -> `0 *​/N * * *`
+ *   weekdays  -> `0 H * * 1-5`
+ *   week      -> `0 H * * d1,d2,...`   (0=Sun .. 6=Sat)
+ *   month     -> `0 H DOM * *`
+ *   day       -> `0 H * * *`
+ */
+
+export type RecurInterval = 'minutes' | 'hours' | 'day' | 'weekdays' | 'week' | 'month'
+
+export interface RecurringSchedule {
+  interval: RecurInterval
+  everyN: number
+  hour: number
+  days: number[]
+  dayOfMonth: number
+}
+
+export function defaultRecurringSchedule(): RecurringSchedule {
+  return { interval: 'day', everyN: 15, hour: 8, days: [1], dayOfMonth: 1 }
+}
+
+/** Build a 5-field cron string from structured recurring inputs. */
+export function buildRecurringCron(s: RecurringSchedule): string {
+  if (s.interval === 'minutes') return `*/${s.everyN} * * * *`
+  if (s.interval === 'hours') return `0 */${s.everyN} * * *`
+  if (s.interval === 'weekdays') return `0 ${s.hour} * * 1-5`
+  if (s.interval === 'week') {
+    const days = [...s.days].sort((a, b) => a - b)
+    return `0 ${s.hour} * * ${(days.length > 0 ? days : [1]).join(',')}`
+  }
+  if (s.interval === 'month') return `0 ${s.hour} ${s.dayOfMonth} * *`
+  return `0 ${s.hour} * * *`
+}
+
+/**
+ * Parse a 5-field cron string into structured recurring inputs. Returns a
+ * partial patch (only the fields the cron determines); callers merge it over
+ * their current state. Returns null for crons we can't map to the builder.
+ */
+export function parseRecurringCron(cron?: string): Partial<RecurringSchedule> | null {
+  if (!cron) return null
+  const parts = cron.trim().split(/\s+/)
+  if (parts.length < 5) return null
+  const [min, hour, dom, , dow] = parts
+
+  if (min.startsWith('*/')) {
+    return { interval: 'minutes', everyN: parseInt(min.slice(2)) || 15 }
+  }
+  if (hour.startsWith('*/')) {
+    return { interval: 'hours', everyN: parseInt(hour.slice(2)) || 1 }
+  }
+  if (dow === '1-5') {
+    return { interval: 'weekdays', hour: parseInt(hour) || 0 }
+  }
+  if (dom !== '*' && dow === '*') {
+    return { interval: 'month', hour: parseInt(hour) || 0, dayOfMonth: parseInt(dom) || 1 }
+  }
+  if (dow !== '*') {
+    // Comma list of days ("1,3,5" -> [1,3,5]). Keep 0 (Sunday); fall back to Mon.
+    const parsedDays = dow.split(',')
+      .map((d) => parseInt(d, 10))
+      .filter((d) => !Number.isNaN(d) && d >= 0 && d <= 6)
+    return {
+      interval: 'week',
+      hour: parseInt(hour) || 0,
+      days: parsedDays.length > 0 ? [...new Set(parsedDays)].sort((a, b) => a - b) : [1],
+    }
+  }
+  return { interval: 'day', hour: parseInt(hour) || 0 }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -2944,6 +2944,8 @@
     "schedule": "Schedule",
     "typeOnce": "One-time",
     "typeRecurring": "Recurring",
+    "scheduleOff": "Off",
+    "scheduleOn": "On",
     "runIn": "Run in",
     "unitMinutes": "min",
     "unitHours": "hr",


### PR DESCRIPTION
## Summary

The report-refresh **Schedule modal** (clock icon → `CronModal.vue`) previously offered only a fixed dropdown — `None / Every 15 Minutes / Hourly / Daily / Weekly`. This replaces it with the same structured recurring builder used by the schedule-task modal, so users can select an interval, a time, specific weekdays, or a day of the month.

Motivation: a customer wanted to schedule a report data refresh every fifteen minutes but the picker was too coarse. The report `/schedule` backend already accepts arbitrary cron with no interval floor, so this is a UI-side enhancement that exposes that flexibility.

## What changed

- **`frontend/components/CronModal.vue`** — replaced the fixed frequency `<select>` with a structured builder:
  - Interval: **every N minutes / every N hours / day / weekdays / week / month**
  - Time-of-day selector for day/weekdays/week/month
  - Weekday chips (e.g. Mon/Wed/Fri) for the weekly option
  - Day-of-month selector for the monthly option
  - An **Off / On** toggle to schedule/unschedule
  - A small live human-readable schedule preview
  - Notification-recipients section now shows only when a schedule is enabled
- **`frontend/composables/useScheduleBuilder.ts`** (new) — single source of truth for converting between structured inputs and a 5-field cron (`buildRecurringCron` / `parseRecurringCron`).
- **`frontend/components/ScheduledPromptModal.vue`** — refactored to use the shared composable instead of its private copies of the same logic, so the report scheduler and the task scheduler stay identical and can't drift.
- **`locales/en.json`** — added `scheduledPrompt.scheduleOff` / `scheduleOn`; all other builder labels reuse existing `scheduledPrompt.*` keys (translations covered via `fallbackLocale: 'en'`).

## Verification

- Round-tripped the builder for every interval (e.g. every-15-min → `*/15 * * * *`, weekly → `0 17 * * 1,3,5`, monthly → `0 6 12 * *`) — structured → cron → structured is stable.
- The report `/schedule` endpoint (`report_service.set_report_schedule`) accepts these crons unchanged and APScheduler runs them, so 15-minute refresh works end to end.
- No stale references to the removed `selectedSchedule` / `cronOptions`.

## Note (out of scope)

The in-report **chat agent** path (`create_scheduled_task` / `edit_scheduled_task`) still enforces a deliberate, tested 1-hour minimum interval. If we also want sub-hourly schedules from chat, that floor is a separate decision — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYwViqUHYEFWzAXPzZnPpv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYwViqUHYEFWzAXPzZnPpv)_