### PR TITLE
Add current-time context to Coder codegen prompts

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -10,6 +10,7 @@ from app.models.llm_model import LLMModel
 import re
 import json
 from app.schemas.organization_settings_schema import OrganizationSettingsConfig
+from app.ai.agents.planner.clock import current_time_str
 from app.ai.schemas.codegen import CodeGenContext
 from app.services.usage_policy_service import UsageLimitContext
 from app.core.otel import get_tracer
@@ -32,6 +33,21 @@ class Coder:
         # Back-compat: accept either legacy builder or new context hub
         self.instruction_context_builder = instruction_context_builder
         self.context_hub = context_hub
+
+    def _time_context(self) -> str:
+        """Current-time line for codegen prompts, same clock the planner sees.
+
+        Rendered in the org's timezone/week-start/locale settings so relative
+        date phrases ("today", "last week") resolve consistently between the
+        planner and the generated code; server-local time when unset.
+        """
+        def _get(key):
+            try:
+                value = self.organization_settings.get_config(key)
+            except Exception:
+                value = getattr(self.organization_settings, key, None)
+            return value if isinstance(value, str) else None
+        return current_time_str(_get("timezone"), _get("week_start"), _get("locale"))
 
     async def execute(self, schemas, persona, prompt, memories, previous_messages):
         # Implementation left out as not requested.
@@ -188,6 +204,9 @@ class Coder:
         {instructions_context}
 
         **Context and Inputs**:
+        - Current Time: {self._time_context()}
+          Resolve relative date expressions ("today", "last week", "this month") against this time, not the database server's clock.
+
         - Data Model (newly generated):
         <data_model>
         {data_model}
@@ -495,11 +514,14 @@ class Coder:
             {instructions_context}
 
             **Context and Inputs**:
+            - Current Time: {self._time_context()}
+              Resolve relative date expressions ("today", "last week", "this month") against this time, not the database server's clock.
+
             - User Prompt:
             <user_prompt>
             {prompt}
             </user_prompt>
-            
+
             - Interpreted Prompt:
             <interpreted_prompt>
             {interpreted_prompt}
@@ -722,6 +744,8 @@ class Coder:
         This is not for generating insights — insights come from create_data. This is just a quick peek.
 
         **Context and Inputs**:
+        - Current Time: {self._time_context()}
+
         - User Prompt (Validation Goal):
         <user_prompt>
         {prompt}

--- a/backend/tests/unit/test_coder_time_context.py
+++ b/backend/tests/unit/test_coder_time_context.py
@@ -1,0 +1,154 @@
+"""Unit tests for the Coder's per-prompt current-time injection.
+
+The planner prompts already carry a "Time:" line rendered by
+app.ai.agents.planner.clock in the org's timezone/week-start settings. The
+Coder's three codegen prompts (data_model_to_code, generate_code,
+generate_inspection_code) must carry the same clock so relative date phrases
+("today", "last week") resolve consistently between planning and the
+generated code.
+"""
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.ai.agents.coder.coder import Coder
+from app.ai.schemas.codegen import CodeGenContext
+from app.schemas.organization_settings_schema import OrganizationSettingsConfig
+
+
+class _StubSettings:
+    """Mimics the OrganizationSettings DB model's get_config lookup."""
+
+    def __init__(self, config=None):
+        self._config = config or {}
+
+    def get_config(self, key, default=None):
+        return self._config.get(key, default)
+
+
+class _StubLLM:
+    """Captures the prompt text instead of calling a provider."""
+
+    def __init__(self):
+        self.prompts = []
+
+    def inference(self, text, **kwargs):
+        self.prompts.append(text)
+        return "def generate_df(ds_clients, excel_files):\n    return df"
+
+    async def inference_stream_v2(self, messages, **kwargs):
+        self.prompts.append(messages[0].content)
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+
+class _StubCodeContextBuilder:
+    async def get_top_successful_snippets_for_data_model(self, data_model):
+        return ""
+
+    async def get_top_failed_snippets_for_data_model(self, data_model):
+        return ""
+
+
+def _make_coder(settings) -> Coder:
+    coder = Coder.__new__(Coder)
+    coder.llm = _StubLLM()
+    coder.organization_settings = settings
+    coder.enable_llm_see_data = True
+    coder.instruction_context_builder = None
+    coder.context_hub = None
+    return coder
+
+
+def _codegen_context(**kwargs) -> CodeGenContext:
+    base = {"user_prompt": "total sales last week", "schemas_excerpt": "<schemas/>"}
+    base.update(kwargs)
+    return CodeGenContext(**base)
+
+
+def test_time_context_uses_org_timezone_and_week_start():
+    coder = _make_coder(
+        _StubSettings({"timezone": "Asia/Jerusalem", "week_start": "sunday"})
+    )
+    rendered = coder._time_context()
+    today = datetime.now(ZoneInfo("Asia/Jerusalem")).strftime("%Y-%m-%d")
+    assert today in rendered
+    assert "timezone: Asia/Jerusalem" in rendered
+    assert "week starts on Sunday" in rendered
+
+
+def test_time_context_falls_back_to_server_local_when_unset():
+    rendered = _make_coder(_StubSettings())._time_context()
+    local_today = datetime.now().astimezone().strftime("%Y-%m-%d")
+    assert local_today in rendered
+    assert "week starts on" in rendered
+
+
+def test_time_context_reads_plain_schema_attributes():
+    """Settings objects without get_config (the pydantic schema) still work."""
+    settings = OrganizationSettingsConfig(timezone="America/New_York")
+    rendered = _make_coder(settings)._time_context()
+    assert "timezone: America/New_York" in rendered
+
+
+@pytest.mark.asyncio
+async def test_generate_code_prompt_includes_current_time():
+    coder = _make_coder(_StubSettings({"timezone": "Asia/Jerusalem"}))
+    await coder.generate_code(
+        data_model=None,
+        prompt="total sales last week",
+        interpreted_prompt="sum sales for the last 7 days",
+        schemas="<schemas/>",
+        ds_clients={},
+        excel_files=[],
+        code_and_error_messages=[],
+        memories="",
+        previous_messages=[],
+        retries=0,
+        context=_codegen_context(),
+    )
+    prompt = coder.llm.prompts[0]
+    assert "Current Time:" in prompt
+    assert datetime.now(ZoneInfo("Asia/Jerusalem")).strftime("%Y-%m-%d") in prompt
+    assert "Resolve relative date expressions" in prompt
+
+
+@pytest.mark.asyncio
+async def test_data_model_to_code_prompt_includes_current_time():
+    coder = _make_coder(_StubSettings({"timezone": "Asia/Jerusalem"}))
+    await coder.data_model_to_code(
+        data_model={"columns": []},
+        prompt="total sales last week",
+        schemas="<schemas/>",
+        ds_clients={},
+        excel_files=[],
+        code_and_error_messages=[],
+        memories="",
+        previous_messages=[],
+        retries=0,
+        prev_data_model_code_pair=None,
+        code_context_builder=_StubCodeContextBuilder(),
+    )
+    prompt = coder.llm.prompts[0]
+    assert "Current Time:" in prompt
+    assert datetime.now(ZoneInfo("Asia/Jerusalem")).strftime("%Y-%m-%d") in prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_inspection_code_prompt_includes_current_time():
+    coder = _make_coder(_StubSettings({"timezone": "Asia/Jerusalem"}))
+    await coder.generate_inspection_code(
+        prompt="check date ranges",
+        schemas="<schemas/>",
+        ds_clients={},
+        excel_files=[],
+        code_and_error_messages=[],
+        memories="",
+        previous_messages=[],
+        retries=0,
+        context=_codegen_context(),
+    )
+    prompt = coder.llm.prompts[0]
+    assert "Current Time:" in prompt
+    assert datetime.now(ZoneInfo("Asia/Jerusalem")).strftime("%Y-%m-%d") in prompt


### PR DESCRIPTION
## Summary

The planner prompts already carry a per-turn timestamp (org timezone, weekday, and week-start convention via `planner/clock.py`), but the Coder's code-generation prompts had no clock at all — generated SQL/pandas code had to trust that every relative date phrase ("today", "last week", "this month") was pre-resolved upstream, and had no basis to avoid leaning on the database server's clock.

This PR injects the same current-time line into all three Coder prompts:

- Added a `_time_context()` helper on `Coder` that renders the current time via the shared `clock.current_time_str`, reading `timezone` / `week_start` / `locale` from the org settings the Coder already holds (falls back to attribute access and server-local time when unset).
- Added a `- Current Time: ...` line under **Context and Inputs** in `data_model_to_code`, `generate_code`, and `generate_inspection_code`, with guidance to resolve relative date expressions against this time rather than the database server's clock. Example rendering: `2026-07-07 06:39:45, Tuesday; timezone: Asia/Jerusalem; week starts on Sunday; this week: 2026-07-05 (Sun) to 2026-07-11 (Sat)`.

Unlike prompt_builder_v3 (which places the timestamp below the cache breakpoint), the time is rendered inline in each prompt body: the Coder sends a single uncached user message per call, so there is no cached prefix to invalidate.

## Testing

- New unit tests in `backend/tests/unit/test_coder_time_context.py` (6 tests): stub the LLM to capture the rendered prompts and assert the timestamp lands in all three prompts, that org timezone/week-start settings are honored, and that both the DB-model (`get_config`) and plain pydantic-schema settings shapes work.
- Existing `test_clock.py` and `test_prompt_builder_v3_user_profile.py` suites still pass (15 tests).
- Ruff clean on the new test file; remaining `coder.py` findings are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9LNrwS6yuQssnFfUqz5fX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9LNrwS6yuQssnFfUqz5fX)_