### PR TITLE
Fix WhatsApp integration: deliver agent replies + correct verify UI

### DIFF
--- a/backend/app/models/completion.py
+++ b/backend/app/models/completion.py
@@ -241,12 +241,15 @@ def after_update_completion(mapper, connection, target):
         if target.step_id:
             data["step_id"] = str(target.step_id)
 
-        # Send completion blocks to Slack when completion finishes
+        # Send completion blocks to the chat platform when completion finishes.
+        # WhatsApp is driven through the same path as Slack (text answer + step
+        # data + eyes->checkmark reaction swap). Teams delivers via the
+        # per-block listeners in completion_block.py instead.
         if (target.status == "success" and
             target.role == "system" and
-            target.external_platform == "slack" and
+            target.external_platform in ("slack", "whatsapp") and
             target.external_user_id is not None):
-            
+
             logger.debug("SLACK_SENDER: Triggering completion blocks DM for completion %s", target.id)
             from app.models.completion_block import send_completion_blocks_to_slack
             asyncio.create_task(send_completion_blocks_to_slack(str(target.id)))

--- a/backend/app/models/completion_block.py
+++ b/backend/app/models/completion_block.py
@@ -72,8 +72,8 @@ async def send_completion_blocks_to_slack(completion_id: str):
             if not completion:
                 return
 
-            # Route only if originated from Slack
-            if not (completion.external_platform in ('slack', 'teams') and completion.external_user_id):
+            # Route only if originated from a supported chat platform
+            if not (completion.external_platform in ('slack', 'teams', 'whatsapp') and completion.external_user_id):
                 return
 
             # Get thread context from completion
@@ -196,8 +196,8 @@ async def _send_block_to_slack(block_id: str):
             if not completion:
                 return
 
-            # Route only if originated from Slack
-            if not (completion.external_platform in ('slack', 'teams') and completion.external_user_id):
+            # Route only if originated from a supported chat platform
+            if not (completion.external_platform in ('slack', 'teams', 'whatsapp') and completion.external_user_id):
                 return
 
             block_id_str = str(block_id)

--- a/backend/app/services/slack_notification_service.py
+++ b/backend/app/services/slack_notification_service.py
@@ -261,8 +261,8 @@ async def send_step_result_to_slack(step_id: str, external_user_id: str | None =
                 comp_result = await db.execute(comp_stmt)
                 completion = comp_result.scalar_one_or_none()
 
-                if not (completion and completion.external_platform in ("slack", "teams") and completion.external_user_id):
-                    logger.info("SLACK_NOTIFIER: No Slack-linked completion found for step %s. Caller should supply routing details.", step_id)
+                if not (completion and completion.external_platform in ("slack", "teams", "whatsapp") and completion.external_user_id):
+                    logger.info("SLACK_NOTIFIER: No chat-linked completion found for step %s. Caller should supply routing details.", step_id)
                     return
 
                 external_user_id = external_user_id or completion.external_user_id

--- a/frontend/pages/settings/integrations/verify/[verify_code].vue
+++ b/frontend/pages/settings/integrations/verify/[verify_code].vue
@@ -1,16 +1,23 @@
 <template>
   <div class="flex justify-center py-40 px-5 sm:px-0">
     <div class="w-full sm:w-1/3 bg-white dark:bg-gray-900 rounded-lg shadow p-8 flex flex-col items-center">
+      <!-- While verifying, show a neutral spinner so we never flash the wrong
+           platform's branding — platformType is only known after the API call. -->
+      <div v-if="loading" class="flex flex-col items-center">
+        <Icon name="heroicons:arrow-path" class="w-12 h-12 mb-4 text-blue-500 animate-spin" />
+        <div class="text-blue-500 font-medium">Verifying...</div>
+      </div>
+      <template v-else>
       <div class="mb-4">
         <img v-if="platformType === 'teams'" src="/icons/teams.png" alt="Teams" class="w-12 h-12" />
+        <img v-else-if="platformType === 'whatsapp'" src="/icons/whatsapp.png" alt="WhatsApp" class="w-12 h-12" />
         <img v-else src="/icons/slack.png" alt="Slack" class="w-12 h-12" />
       </div>
       <h1 class="font-bold text-lg mb-2">Verify your {{ platformLabel }} account</h1>
       <p class="mt-3 text-sm text-gray-700 dark:text-gray-300 text-center mb-6">
         Please follow the instructions below to activate your {{ platformLabel }} integration.
       </p>
-      <div v-if="loading" class="text-blue-500 font-medium">Verifying...</div>
-      <div v-else-if="success && alreadyVerified" class="text-blue-600 font-medium text-center">
+      <div v-if="success && alreadyVerified" class="text-blue-600 font-medium text-center">
         <Icon name="heroicons:information-circle" class="inline w-6 h-6 me-1" />
         {{ message || 'Your account is already verified.' }}
       </div>
@@ -22,6 +29,7 @@
         <Icon name="heroicons:x-circle" class="inline w-6 h-6 me-1" />
         Verification failed: {{ error }}
       </div>
+      </template>
     </div>
   </div>
 </template>
@@ -43,7 +51,7 @@ const error = ref('')
 const platformType = ref('slack')
 
 const platformLabel = computed(() => {
-  const labels = { slack: 'Slack', teams: 'Microsoft Teams' }
+  const labels = { slack: 'Slack', teams: 'Microsoft Teams', whatsapp: 'WhatsApp' }
   return labels[platformType.value] || 'Slack'
 })
 


### PR DESCRIPTION
## Summary

Two bugs surfaced while testing the WhatsApp integration end-to-end (inbound webhook now works after subscribing the app to the WABA). The transport layer was fine; these are code-level gaps in the outbound reply pipeline and the verification UI.

### Bug 1 — agent answers/data were never sent back to WhatsApp
The completion → chat-platform notification pipeline was gated to `slack`/`teams` only. WhatsApp inbound messages created a report and ran the agent, but nothing was delivered back to the user (and the 👀 processing reaction never cleared). The `WhatsAppAdapter` already implements the full Slack-style surface (`send_dm_in_thread`, `send_file_in_thread`, `add_reaction`/`remove_reaction`), so the fix is to add `"whatsapp"` to the routing allow-lists and drive it through the same path Slack uses (text answer + step data + eyes→checkmark swap):

- `backend/app/models/completion.py` — completion-level `after_update` trigger
- `backend/app/models/completion_block.py` — `send_completion_blocks_to_slack` and `_send_block_to_slack`
- `backend/app/services/slack_notification_service.py` — step-data discovery fallback

Routing degrades correctly for WhatsApp: `channel_type` is `im`, so the response channel resolves to `None` and the adapter sends by `wa_id` — same as a Slack DM. Both trigger paths share the existing `_sent_block_*` dedupe sets, identical to Slack today.

### Bug 2 — verification page showed Slack branding for non-Slack platforms
`frontend/pages/settings/integrations/verify/[verify_code].vue` defaulted `platformType` to `slack` and had no WhatsApp case, so WhatsApp users saw "Verify your Slack account" with the Slack logo (the backend already returns the correct `platform_type`). Added a WhatsApp icon + label, and gated all platform-specific branding behind a spinner while the verify request is in flight — this also removes the pre-existing Slack→Teams flash where the wrong logo showed for a moment before the API resolved.

## Changes
- `backend/app/models/completion.py`
- `backend/app/models/completion_block.py`
- `backend/app/services/slack_notification_service.py`
- `frontend/pages/settings/integrations/verify/[verify_code].vue`

## Testing
- `py_compile` passes on all edited backend files; the Vue template is well-formed.
- The full backend unit suite could not be run in the authoring environment (missing the project's runtime dependency set), so the changes were verified by static analysis. They add `"whatsapp"` to membership checks that already contain the working `"slack"`/`"teams"` entries.
- Recommended manual check after deploy: send a WhatsApp message to the connected number and confirm the agent's answer returns, the 👀 reaction flips to ✅, and the verification link page shows WhatsApp branding after a brief spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy4GM8DK4patwbCvD1pu1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uy4GM8DK4patwbCvD1pu1N)_