### PR TITLE
Perf: fix /agents page slowness with many connections (N+1s, MB payloads, review-hunks)

### DIFF
--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -9,7 +9,7 @@ from sqlalchemy import select, func
 from typing import List
 
 from app.ee.audit.service import audit_service
-from app.dependencies import get_async_db
+from app.dependencies import get_async_db, release_request_db
 from app.models.user import User
 from app.core.auth import current_user
 from app.models.organization import Organization
@@ -61,9 +61,14 @@ def _iso_utc(dt) -> "str | None":
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def _indexing_to_progress(row) -> "ConnectionIndexingProgress | None":
+def _indexing_to_progress(row, include_events: bool = True) -> "ConnectionIndexingProgress | None":
     """Adapt a ConnectionIndexing ORM row to the polling payload. Returns None
     when no row is provided.
+
+    ``include_events=False`` leaves the event log out (and must be paired with
+    a row loaded with ``events_json`` deferred, so the log is never fetched) —
+    used by the list endpoint, where 50 connections × 200 log entries made the
+    response megabytes for a pane that never shows the log.
     """
     if row is None:
         return None
@@ -78,7 +83,7 @@ def _indexing_to_progress(row) -> "ConnectionIndexingProgress | None":
         finished_at=_iso_utc(row.finished_at),
         error=row.error,
         stats=row.stats_json,
-        events=row.events_json or [],
+        events=(row.events_json or []) if include_events else [],
     )
 
 
@@ -153,39 +158,95 @@ async def list_connections(
 
         connections = [c for c in connections if _conn_visible(c)]
 
+    # ── Batched lookups (one grouped query each, instead of 2-4 queries per
+    # connection — with ~50 connections the per-row loop was 100-200 round
+    # trips per page load) ────────────────────────────────────────────────
+    from sqlalchemy.orm import defer
+    from app.models.connection_indexing import ConnectionIndexing
+    from app.schemas.data_source_registry import tool_provider_types
+    _TOOL_PROVIDER_TYPES = tool_provider_types()
+
+    conn_ids = [str(c.id) for c in connections]
+
+    # Catalog table count per connection (all available tables in the database).
+    catalog_count_by_conn: dict = {}
+    if conn_ids:
+        count_rows = await db.execute(
+            select(ConnectionTable.connection_id, func.count(ConnectionTable.id))
+            .where(ConnectionTable.connection_id.in_(conn_ids))
+            .group_by(ConnectionTable.connection_id)
+        )
+        catalog_count_by_conn = {str(cid): (n or 0) for cid, n in count_rows.all()}
+
+    # Fallback for legacy connections with an empty catalog: count from
+    # DataSourceTable (existing domains using this connection), grouped per
+    # data source and summed per connection below.
+    legacy_ds_ids = {
+        str(ds.id)
+        for c in connections
+        if catalog_count_by_conn.get(str(c.id), 0) == 0
+        for ds in (c.data_sources or [])
+    }
+    legacy_count_by_ds: dict = {}
+    if legacy_ds_ids:
+        legacy_rows = await db.execute(
+            select(DataSourceTable.datasource_id, func.count(DataSourceTable.id))
+            .where(DataSourceTable.datasource_id.in_(legacy_ds_ids))
+            .group_by(DataSourceTable.datasource_id)
+        )
+        legacy_count_by_ds = {str(dsid): (n or 0) for dsid, n in legacy_rows.all()}
+
+    # Latest indexing row per connection (portable MAX(created_at) join), with
+    # the event log deferred — the list payload doesn't include it.
+    indexing_by_conn: dict = {}
+    if conn_ids:
+        latest_subq = (
+            select(
+                ConnectionIndexing.connection_id,
+                func.max(ConnectionIndexing.created_at).label("max_created"),
+            )
+            .where(ConnectionIndexing.connection_id.in_(conn_ids))
+            .group_by(ConnectionIndexing.connection_id)
+            .subquery()
+        )
+        idx_rows = await db.execute(
+            select(ConnectionIndexing)
+            .options(defer(ConnectionIndexing.events_json))
+            .join(
+                latest_subq,
+                (ConnectionIndexing.connection_id == latest_subq.c.connection_id)
+                & (ConnectionIndexing.created_at == latest_subq.c.max_created),
+            )
+        )
+        for idx in idx_rows.scalars().all():
+            indexing_by_conn[str(idx.connection_id)] = idx
+
+    # Tool count per tool-provider connection.
+    tool_count_by_conn: dict = {}
+    tool_conn_ids = [str(c.id) for c in connections if c.type in _TOOL_PROVIDER_TYPES]
+    if tool_conn_ids:
+        tool_rows = await db.execute(
+            select(ConnectionTool.connection_id, func.count(ConnectionTool.id))
+            .where(ConnectionTool.connection_id.in_(tool_conn_ids))
+            .group_by(ConnectionTool.connection_id)
+        )
+        tool_count_by_conn = {str(cid): (n or 0) for cid, n in tool_rows.all()}
+
     result = []
     for conn in connections:
-        # Count tables from ConnectionTable (all available tables in the database)
-        count_result = await db.execute(
-            select(func.count(ConnectionTable.id))
-            .where(ConnectionTable.connection_id == str(conn.id))
-        )
-        table_count = count_result.scalar() or 0
-
-        # Fallback for legacy connections: if ConnectionTable is empty,
-        # count from DataSourceTable (existing domains using this connection)
+        table_count = catalog_count_by_conn.get(str(conn.id), 0)
         if table_count == 0 and conn.data_sources:
-            ds_ids = [str(ds.id) for ds in conn.data_sources]
-            if ds_ids:
-                fallback_result = await db.execute(
-                    select(func.count(DataSourceTable.id))
-                    .where(DataSourceTable.datasource_id.in_(ds_ids))
-                )
-                table_count = fallback_result.scalar() or 0
-
-        # Inline latest indexing for the dot status / polling.
-        indexing_row = await indexing_service.get_latest(db, str(conn.id))
-        indexing_payload = _indexing_to_progress(indexing_row)
-
-        from app.schemas.data_source_registry import tool_provider_types; _TOOL_PROVIDER_TYPES = tool_provider_types()
-        if conn.type in _TOOL_PROVIDER_TYPES:
-            tool_count_result = await db.execute(
-                select(func.count(ConnectionTool.id))
-                .where(ConnectionTool.connection_id == str(conn.id))
+            table_count = sum(
+                legacy_count_by_ds.get(str(ds.id), 0) for ds in conn.data_sources
             )
-            tool_count = tool_count_result.scalar() or 0
-        else:
-            tool_count = 0
+
+        # Inline latest indexing for the dot status / polling (no event log —
+        # the detail modal fetches GET /connections/{id}/indexing for that).
+        indexing_payload = _indexing_to_progress(
+            indexing_by_conn.get(str(conn.id)), include_events=False
+        )
+
+        tool_count = tool_count_by_conn.get(str(conn.id), 0) if conn.type in _TOOL_PROVIDER_TYPES else 0
 
         # Per-user auth status (so the UI can show Connected/Disconnect vs Connect
         # for user_required connections). Cached (live_test=False) — cheap.
@@ -245,6 +306,7 @@ async def list_connections(
             indexing=indexing_payload.model_dump() if indexing_payload else None,
             user_status=user_status_payload,
         ))
+    await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
     return result
 
 

--- a/backend/app/routes/data_source.py
+++ b/backend/app/routes/data_source.py
@@ -52,7 +52,9 @@ async def get_data_sources(
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization)
 ):
-    return await data_source_service.get_data_sources(db, current_user, organization, show_all=show_all)
+    result = await data_source_service.get_data_sources(db, current_user, organization, show_all=show_all)
+    await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
+    return result
 
 @router.get("/data_sources/active", response_model=list[DataSourceListItemSchema])
 async def get_active_data_sources(

--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -832,7 +832,10 @@ async def get_instruction_review_hunks(
     """Server-authoritative tracked changes for an instruction: every pending
     suggestion as word-level hunks diffed against current main (rejected hunks
     filtered out). The unit of accept/reject is the hunk."""
-    existing = await instruction_service.get_instruction(db, instruction_id, organization, current_user)
+    # Light access check (row + attached data-source ids) — the review pane
+    # calls this endpoint per instruction and re-calls it after every hunk
+    # action, so it must not pay get_instruction's full detail eager graph.
+    existing = await instruction_service.get_instruction_access_view(db, instruction_id, organization)
     if existing is None:
         raise AppError.not_found(ErrorCode.INSTRUCTION_NOT_FOUND, "Instruction not found")
     if not await instruction_service.user_can_view_instruction(db, existing, current_user, organization):
@@ -840,6 +843,7 @@ async def get_instruction_review_hunks(
     result = await instruction_service.review_hunks(db, instruction_id, organization=organization, current_user=current_user)
     if result is None:
         raise AppError.not_found(ErrorCode.INSTRUCTION_NOT_FOUND, "Instruction not found")
+    await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
     return result
 
 

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -99,7 +99,9 @@ class DataSourceService:
     def __init__(self):
         pass
 
-    async def _bulk_connection_aux(self, db: AsyncSession, data_sources: list):
+    async def _bulk_connection_aux(
+        self, db: AsyncSession, data_sources: list, *, defer_indexing_events: bool = False
+    ):
         """Precompute the per-connection indexing rows and table counts for MANY
         data sources in a handful of grouped queries.
 
@@ -109,9 +111,16 @@ class DataSourceService:
         per data source plus one (or two) table-count queries per connection —
         an N+1 whose cost grows with the number of agents, which is exactly what
         makes "show all" slow. This batches all of it into three queries and
-        returns maps keyed by connection id / data source id for
-        ``_build_connections_list`` to read.
+        returns maps keyed by (data source id, connection id) / data source id
+        for ``_build_connections_list`` to read.
+
+        ``defer_indexing_events`` skips loading each indexing row's
+        ``events_json`` (up to 200 log entries per connection) — pass it from
+        list callers that also pass ``include_indexing_events=False`` to
+        ``_build_connections_list``, so the event logs are neither fetched nor
+        serialized.
         """
+        from sqlalchemy.orm import defer
         from app.models.connection_indexing import ConnectionIndexing
         from app.models.connection_table import ConnectionTable
 
@@ -134,22 +143,29 @@ class DataSourceService:
                 .group_by(ConnectionIndexing.connection_id)
                 .subquery()
             )
-            rows = await db.execute(
-                select(ConnectionIndexing).join(
-                    latest_subq,
-                    (ConnectionIndexing.connection_id == latest_subq.c.connection_id)
-                    & (ConnectionIndexing.created_at == latest_subq.c.max_created),
-                )
+            latest_stmt = select(ConnectionIndexing).join(
+                latest_subq,
+                (ConnectionIndexing.connection_id == latest_subq.c.connection_id)
+                & (ConnectionIndexing.created_at == latest_subq.c.max_created),
             )
+            if defer_indexing_events:
+                latest_stmt = latest_stmt.options(defer(ConnectionIndexing.events_json))
+            rows = await db.execute(latest_stmt)
             for idx in rows.scalars().all():
                 indexing_by_conn[str(idx.connection_id)] = idx
         except Exception:
             logger.exception("indexing.bulk_lookup_failed_multi")
 
-        # Active table count grouped by connection — one query for all connections.
+        # Active table count grouped by (data source, connection) — one query
+        # for all connections. Keyed by the pair so a connection shared by two
+        # selected agents doesn't report the sum of both agents' tables.
         try:
             count_rows = await db.execute(
-                select(ConnectionTable.connection_id, func.count(DataSourceTable.id))
+                select(
+                    DataSourceTable.datasource_id,
+                    ConnectionTable.connection_id,
+                    func.count(DataSourceTable.id),
+                )
                 .select_from(DataSourceTable)
                 .join(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
                 .where(
@@ -157,10 +173,10 @@ class DataSourceService:
                     DataSourceTable.is_active == True,
                     ConnectionTable.connection_id.in_(conn_ids),
                 )
-                .group_by(ConnectionTable.connection_id)
+                .group_by(DataSourceTable.datasource_id, ConnectionTable.connection_id)
             )
-            for cid, cnt in count_rows.all():
-                table_count_by_conn[str(cid)] = cnt or 0
+            for dsid, cid, cnt in count_rows.all():
+                table_count_by_conn[(str(dsid), str(cid))] = cnt or 0
         except Exception:
             logger.exception("table_count.bulk_lookup_failed")
 
@@ -191,6 +207,7 @@ class DataSourceService:
         indexing_by_conn: dict | None = None,
         table_count_by_conn: dict | None = None,
         legacy_count_by_ds: dict | None = None,
+        include_indexing_events: bool = True,
     ) -> List[ConnectionEmbedded]:
         """
         Build list of ConnectionEmbedded from all connections of a DataSource.
@@ -203,6 +220,13 @@ class DataSourceService:
         the whole list instead of run per-connection — avoiding an N+1 that
         scales with the agent count. Single-data-source callers omit them and
         keep the original per-call queries.
+
+        ``include_indexing_events=False`` drops the indexing event log (up to
+        200 entries per connection) from the payload. List endpoints pass it:
+        nothing on the /agents page renders the log from a list response, and
+        with ~50 connections the logs alone are megabytes per request. The
+        single-data-source detail keeps events (the connections modal shows
+        live logs from it while indexing runs).
         """
         if not data_source.connections:
             return []
@@ -269,7 +293,9 @@ class DataSourceService:
             # When the caller supplied batched maps, read the counts from them
             # instead of issuing per-connection queries (avoids the N+1).
             if table_count_by_conn is not None:
-                table_count = table_count_by_conn.get(str(conn.id), 0)
+                table_count = table_count_by_conn.get(
+                    (str(data_source.id), str(conn.id)), 0
+                )
                 # Fallback to legacy (connection_table_id IS NULL) tables, mirroring
                 # the per-connection path below.
                 if table_count == 0 and legacy_count_by_ds is not None:
@@ -356,7 +382,7 @@ class DataSourceService:
                     "finished_at": indexing_row.finished_at.isoformat() if indexing_row.finished_at else None,
                     "error": indexing_row.error,
                     "stats": indexing_row.stats_json,
-                    "events": indexing_row.events_json or [],
+                    "events": (indexing_row.events_json or []) if include_indexing_events else [],
                 }
 
             connections_list.append(ConnectionEmbedded(
@@ -1018,12 +1044,22 @@ class DataSourceService:
                 pass
 
         # Build connections list - always use cached status (live_test=False)
-        # since we already tested if needed above
+        # since we already tested if needed above. Batch the indexing +
+        # table-count lookups: this endpoint is polled every ~2s while an
+        # indexing run is live, and per-connection COUNTs made each poll issue
+        # 2×N queries for agents with many connections. Events stay included —
+        # the connections modal renders the live indexing log from this payload.
+        indexing_by_conn, table_count_by_conn, legacy_count_by_ds = (
+            await self._bulk_connection_aux(db, [data_source])
+        )
         connections_list = await self._build_connections_list(
             db=db,
             data_source=data_source,
             current_user=current_user,
-            live_test=False
+            live_test=False,
+            indexing_by_conn=indexing_by_conn,
+            table_count_by_conn=table_count_by_conn,
+            legacy_count_by_ds=legacy_count_by_ds,
         )
 
         # Get first connection for legacy fields
@@ -1199,6 +1235,14 @@ class DataSourceService:
         data_sources = result.scalars().all()
         # Non-published agents (draft/disabled) are only visible to managers.
         is_gov, manage_ids, resolved = await self._publish_visibility(db, current_user, organization)
+        # Batch the per-connection indexing + table-count lookups across the
+        # whole list (same as get_active_data_sources) — without this, an org
+        # with many connections per agent pays one COUNT round-trip per
+        # connection per agent, which is what made GET /data_sources take tens
+        # of seconds on large deployments.
+        indexing_by_conn, table_count_by_conn, legacy_count_by_ds = (
+            await self._bulk_connection_aux(db, data_sources, defer_indexing_events=True)
+        )
         # Build list with connection info (no live test for list to keep it fast)
         schemas: list[DataSourceListItemSchema] = []
         for d in data_sources:
@@ -1215,7 +1259,11 @@ class DataSourceService:
                 db=db,
                 data_source=d,
                 current_user=current_user,
-                live_test=False
+                live_test=False,
+                indexing_by_conn=indexing_by_conn,
+                table_count_by_conn=table_count_by_conn,
+                legacy_count_by_ds=legacy_count_by_ds,
+                include_indexing_events=False,
             )
             conn = d.connections[0] if d.connections else None
 
@@ -1307,7 +1355,7 @@ class DataSourceService:
         # whole list so building N agents doesn't issue N×(queries) — the N+1
         # that made the admin "show all" view slow as the org's agent count grew.
         indexing_by_conn, table_count_by_conn, legacy_count_by_ds = (
-            await self._bulk_connection_aux(db, data_sources)
+            await self._bulk_connection_aux(db, data_sources, defer_indexing_events=True)
         )
 
         # Compute once whether the current user has admin-level access to data sources
@@ -1372,6 +1420,7 @@ class DataSourceService:
                 indexing_by_conn=indexing_by_conn,
                 table_count_by_conn=table_count_by_conn,
                 legacy_count_by_ds=legacy_count_by_ds,
+                include_indexing_events=False,
             )
             conn = d.connections[0] if d.connections else None
 
@@ -1446,7 +1495,7 @@ class DataSourceService:
 
         # Batch per-connection indexing + table-count lookups (avoid N+1).
         indexing_by_conn, table_count_by_conn, legacy_count_by_ds = (
-            await self._bulk_connection_aux(db, data_sources)
+            await self._bulk_connection_aux(db, data_sources, defer_indexing_events=True)
         )
 
         items: list[DataSourceListItemSchema] = []
@@ -1469,6 +1518,7 @@ class DataSourceService:
                 indexing_by_conn=indexing_by_conn,
                 table_count_by_conn=table_count_by_conn,
                 legacy_count_by_ds=legacy_count_by_ds,
+                include_indexing_events=False,
             )
 
             s = DataSourceListItemSchema(

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -885,6 +885,34 @@ class InstructionService:
             db, instruction, organization=organization, current_user=current_user
         )
 
+    async def get_instruction_access_view(
+        self,
+        db: AsyncSession,
+        instruction_id: str,
+        organization: Organization,
+    ) -> Optional[Instruction]:
+        """Instruction row + attached data-source ids only — just enough for
+        ``user_can_view_instruction``. Read endpoints that don't return the
+        detail schema (e.g. review-hunks) use this instead of
+        ``get_instruction``, whose eager graph (memberships, git repo, every
+        agent's connections, references, labels) is wasted on an access check.
+        """
+        result = await db.execute(
+            select(Instruction)
+            .options(
+                lazyload("*"),
+                selectinload(Instruction.data_sources).options(lazyload("*")),
+            )
+            .where(
+                and_(
+                    Instruction.id == instruction_id,
+                    Instruction.organization_id == organization.id,
+                    Instruction.deleted_at == None
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def user_can_view_instruction(
         self,
         db: AsyncSession,
@@ -1350,15 +1378,69 @@ class InstructionService:
         rendered against current main so the UI overlays it on live text."""
         from app.services.text_hunks import rebased_hunks_against_main
         from app.models.agent_execution import AgentExecution
+        from app.models.build_content import BuildContent
+        from app.models.instruction_version import InstructionVersion as _IV
         instruction = await self._get_instruction_by_id(db, instruction_id, organization)
         if not instruction:
             return None
         main_text, main_vid, _meta = await self._main_text_of(db, instruction)
         rows = await self._pending_suggestion_builds(db, instruction_id, organization)
-        suggestions = []
+
+        # A build snapshots EVERY instruction, so most pending builds contain
+        # this instruction only as an unchanged carry-over of their base. The
+        # old path paid one base-text query + a word-level diff per build —
+        # O(all pending builds in the org) — which is what made review-hunks
+        # take seconds once suggestion builds accumulated. Bulk-load every
+        # build's base version/text for this instruction in ONE query, then
+        # skip carry-overs (proposed version == base version: no intended
+        # change, zero hunks by construction) before any diff work. Same rule
+        # as the batched get_pending_change_instruction_ids sweep.
+        base_ids = {
+            str(b.base_build_id) for b, _t, _v in rows
+            if getattr(b, "base_build_id", None)
+        }
+        base_vid_by_build: dict = {}
+        base_text_by_build: dict = {}
+        if base_ids:
+            for bid, vid, txt in (await db.execute(
+                select(BuildContent.build_id, BuildContent.instruction_version_id, _IV.text)
+                .join(_IV, _IV.id == BuildContent.instruction_version_id)
+                .where(
+                    BuildContent.build_id.in_(base_ids),
+                    BuildContent.instruction_id == str(instruction_id),
+                )
+            )).all():
+                base_vid_by_build[str(bid)] = str(vid)
+                base_text_by_build[str(bid)] = txt or ""
+
+        live_rows = []
         for build, proposed_text, proposed_vid in rows:
+            base_id = str(build.base_build_id) if getattr(build, "base_build_id", None) else None
+            if base_id and base_vid_by_build.get(base_id) == str(proposed_vid):
+                continue
+            base_text = base_text_by_build.get(base_id, "") if base_id else ""
+            live_rows.append((build, proposed_text, proposed_vid, base_text))
+
+        # Agent-execution traces for the surviving builds — one query, not one
+        # per build.
+        exec_ids = {
+            str(b.agent_execution_id) for b, _t, _v, _bt in live_rows
+            if getattr(b, "agent_execution_id", None)
+        }
+        trace_by_exec: dict = {}
+        if exec_ids:
+            for eid, rid, cid in (await db.execute(
+                select(AgentExecution.id, AgentExecution.report_id, AgentExecution.completion_id)
+                .where(AgentExecution.id.in_(exec_ids))
+            )).all():
+                trace_by_exec[str(eid)] = {
+                    "report_id": str(rid) if rid else None,
+                    "completion_id": str(cid) if cid else None,
+                }
+
+        suggestions = []
+        for build, proposed_text, proposed_vid, base_text in live_rows:
             rejected = self._rejected_keys(build, instruction_id)
-            base_text = await self._build_base_text(db, build, instruction_id)
             # Lenient: rebase the suggestion's intent onto current main so a STALE
             # suggestion (forked from an older main) still surfaces reviewable
             # hunks instead of collapsing to nothing. Identical to the strict
@@ -1369,12 +1451,7 @@ class InstructionService:
                 continue
             trace = None
             if getattr(build, "agent_execution_id", None):
-                ex = (await db.execute(
-                    select(AgentExecution.report_id, AgentExecution.completion_id)
-                    .where(AgentExecution.id == str(build.agent_execution_id))
-                )).first()
-                if ex:
-                    trace = {"report_id": str(ex[0]) if ex[0] else None, "completion_id": str(ex[1]) if ex[1] else None}
+                trace = trace_by_exec.get(str(build.agent_execution_id))
             creator = getattr(build, "created_by_user", None)
             suggestions.append({
                 "build_id": str(build.id),

--- a/backend/scripts/profile_agents_page.py
+++ b/backend/scripts/profile_agents_page.py
@@ -1,0 +1,122 @@
+"""Profile the /agents page's heavy service calls: wall time, SQL statement
+count, and serialized payload size for each.
+
+Covers:
+  * DataSourceService.get_data_sources         (GET /api/data_sources)
+  * DataSourceService.get_active_data_sources  (GET /api/data_sources/active)
+  * DataSourceService.get_data_source          (GET /api/data_sources/{id} — 2s poll)
+  * ConnectionService list overview             (GET /api/connections)
+  * InstructionService.review_hunks             (GET /instructions/{id}/review-hunks)
+  * InstructionService.get_instruction_counts   (GET /api/instructions/counts)
+
+Seed first with scripts/seed_agents_page_perf.py (+ seed_review_hunks_perf.py).
+
+Usage: python scripts/profile_agents_page.py
+"""
+import os, time, json, asyncio
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, m, _ in pkgutil.iter_modules(app.models.__path__):
+    if m != "application":
+        importlib.import_module(f"app.models.{m}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.instruction import Instruction
+
+
+def _payload_bytes(result) -> int:
+    def enc(o):
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
+        if hasattr(o, "isoformat"):
+            return o.isoformat()
+        if isinstance(o, set):
+            return sorted(o)
+        return str(o)
+    try:
+        return len(json.dumps(result, default=enc))
+    except Exception:
+        return -1
+
+
+async def main():
+    engine = create_async_engine("sqlite+aiosqlite:///db/app.db", future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    counter = {"n": 0}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, params, context, executemany):
+        counter["n"] += 1
+
+    async def bench(name, fn):
+        # Fresh session per benchmark so identity-map caching doesn't help one
+        # call at the expense of another.
+        async with Session() as db:
+            counter["n"] = 0
+            t0 = time.perf_counter()
+            result = await fn(db)
+            dt = time.perf_counter() - t0
+        size = _payload_bytes(result)
+        n_items = len(result) if isinstance(result, (list, tuple)) else 1
+        print(f"{name:34s} {dt:8.2f}s   {counter['n']:5d} SQL   "
+              f"{size/1024:9.1f} KB   ({n_items} items)")
+        return result
+
+    async with Session() as db:
+        user = (await db.execute(select(User).where(User.email == "sandbox@bow.dev"))).scalars().first()
+        org = (await db.execute(select(Organization))).scalars().first()
+        perf_ds_id = (await db.execute(
+            select(DataSource.id).where(DataSource.name.like("Perf Agent 0%")).limit(1)
+        )).scalar()
+        hot_instr_id = (await db.execute(
+            select(Instruction.id).where(Instruction.title == "Rule 0").limit(1)
+        )).scalar()
+
+    from app.services.data_source_service import DataSourceService
+    from app.services.connection_service import ConnectionService
+    from app.services.instruction_service import InstructionService
+    ds_svc = DataSourceService()
+    conn_svc = ConnectionService()
+    instr_svc = InstructionService()
+
+    print(f"{'endpoint (service call)':34s} {'wall':>9s}   {'stmts':>5s}   {'payload':>12s}")
+
+    await bench("GET /data_sources",
+                lambda db: ds_svc.get_data_sources(db, user, org))
+    await bench("GET /data_sources/active",
+                lambda db: ds_svc.get_active_data_sources(db, org, user, include_unconnected=True))
+    if perf_ds_id:
+        await bench("GET /data_sources/{id} (2s poll)",
+                    lambda db: ds_svc.get_data_source(db, str(perf_ds_id), org, user))
+
+    # GET /api/connections — the route loop lives in the route before the fix
+    # and in ConnectionService after it; call whichever exists so this script
+    # runs on both sides of the change.
+    if hasattr(conn_svc, "get_connections_overview"):
+        await bench("GET /connections (list)",
+                    lambda db: conn_svc.get_connections_overview(db, org, user))
+    else:
+        from app.routes.connection import list_connections  # route fn, pre-fix
+        await bench("GET /connections (list)",
+                    lambda db: list_connections(current_user=user, db=db, organization=org))
+
+    if hot_instr_id:
+        await bench("GET .../review-hunks (hot instr)",
+                    lambda db: instr_svc.review_hunks(db, str(hot_instr_id), organization=org, current_user=user))
+    await bench("GET /instructions/counts",
+                lambda db: instr_svc.get_instruction_counts(db, org, user))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/seed_agents_page_perf.py
+++ b/backend/scripts/seed_agents_page_perf.py
@@ -1,0 +1,158 @@
+"""Seed the /agents page perf shape: many connections × many tables × few agents.
+
+Reproduces the reported deployment (~50 connections, ~1,500 tables each,
+3 agents) that makes the agents page take 40s+:
+
+  * N_CONN system_only connections, each with N_TABLES ConnectionTable rows
+  * one COMPLETED ConnectionIndexing row per connection carrying N_EVENTS
+    event-log entries (what the list endpoints serialize per connection)
+  * N_AGENTS data sources; connections are distributed round-robin across
+    them, and every agent gets an ACTIVE DataSourceTable row mirroring each
+    table of each of its connections (what refresh_schema's domain sync does)
+  * the sandbox admin (sandbox@bow.dev) is a member of every agent
+
+Usage:
+  python scripts/seed_agents_page_perf.py [n_conn] [n_tables] [n_agents]
+
+Defaults: 50 connections × 1500 tables × 3 agents. Idempotent-ish: re-running
+adds a fresh batch (names are suffixed with a run nonce).
+"""
+import os
+import sys
+import uuid
+import asyncio
+from datetime import datetime, timedelta
+
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select, insert
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.data_source_membership import DataSourceMembership
+from app.models.connection import Connection
+from app.models.connection_table import ConnectionTable
+from app.models.connection_indexing import ConnectionIndexing
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+
+N_EVENTS = 200  # matches ConnectionIndexingService._EVENT_LOG_MAX
+
+
+def _columns():
+    return [{"name": f"col_{i}", "dtype": "varchar"} for i in range(8)]
+
+
+def _events(n=N_EVENTS):
+    base = datetime.utcnow() - timedelta(hours=1)
+    return [
+        {
+            "ts": (base + timedelta(seconds=i)).isoformat() + "Z",
+            "level": "info",
+            "phase": "schema",
+            "message": f"Discovered table dbo.some_table_{i} (8 columns)",
+            "done": i,
+            "total": n,
+        }
+        for i in range(n)
+    ]
+
+
+async def main():
+    n_conn = int(sys.argv[1]) if len(sys.argv) > 1 else 50
+    n_tables = int(sys.argv[2]) if len(sys.argv) > 2 else 1500
+    n_agents = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+    nonce = uuid.uuid4().hex[:6]
+
+    _u = os.environ["BOW_DATABASE_URL"]
+    _u = (_u.replace("postgresql://", "postgresql+asyncpg://", 1) if _u.startswith("postgresql://")
+          else _u.replace("sqlite:///", "sqlite+aiosqlite:///", 1) if _u.startswith("sqlite:///") else _u)
+    engine = create_async_engine(_u, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as db:
+        user = (await db.execute(select(User).where(User.email == "sandbox@bow.dev"))).scalars().first()
+        org = (await db.execute(select(Organization))).scalars().first()
+        assert user and org, "run signup first (sandbox@bow.dev) so user+org exist"
+        org_id = str(org.id)
+        now = datetime.utcnow()
+
+        # Agents
+        agent_ids = []
+        for a in range(n_agents):
+            ds = DataSource(id=str(uuid.uuid4()), name=f"Perf Agent {a} {nonce}",
+                            is_active=True, is_public=False, organization_id=org_id)
+            db.add(ds)
+            await db.flush()
+            db.add(DataSourceMembership(id=str(uuid.uuid4()), data_source_id=str(ds.id),
+                                        principal_type="user", principal_id=str(user.id)))
+            agent_ids.append(str(ds.id))
+        await db.commit()
+
+        for c in range(n_conn):
+            conn_id = str(uuid.uuid4())
+            db.add(Connection(
+                id=conn_id, name=f"Hotel DB {c:02d} {nonce}", type="postgres",
+                config={"host": "db.example.com", "port": 5432, "database": f"hotel_{c}"},
+                credentials=None, is_active=True, auth_policy="system_only",
+                last_synced_at=now, last_connection_status="success",
+                last_connection_checked_at=now, organization_id=org_id,
+            ))
+            await db.flush()
+
+            # Completed indexing run with a full event log (what lists serialize).
+            db.add(ConnectionIndexing(
+                id=str(uuid.uuid4()), connection_id=conn_id, status="completed",
+                progress_done=n_tables, progress_total=n_tables,
+                started_at=now - timedelta(minutes=5), finished_at=now,
+                stats_json={"table_count": n_tables, "synced_domains": 1, "elapsed_s": 38.9},
+                events_json=_events(),
+            ))
+
+            # Catalog tables for this connection (bulk insert).
+            ct_rows = [
+                {
+                    "id": str(uuid.uuid4()), "name": f"dbo.table_{c:02d}_{t}",
+                    "connection_id": conn_id, "columns": _columns(),
+                    "pks": [], "fks": [], "no_rows": 0,
+                    "created_at": now, "updated_at": now,
+                }
+                for t in range(n_tables)
+            ]
+            await db.execute(insert(ConnectionTable), ct_rows)
+
+            # Link to one agent (round-robin) and mirror every table as an
+            # ACTIVE DataSourceTable — what sync_domain_tables_from_connection
+            # produces after each reindex.
+            ds_id = agent_ids[c % n_agents]
+            await db.execute(insert(domain_connection).values(
+                data_source_id=ds_id, connection_id=conn_id))
+            dst_rows = [
+                {
+                    "id": str(uuid.uuid4()), "name": r["name"],
+                    "datasource_id": ds_id, "connection_table_id": r["id"],
+                    "is_active": True, "created_at": now, "updated_at": now,
+                }
+                for r in ct_rows
+            ]
+            await db.execute(insert(DataSourceTable), dst_rows)
+            await db.commit()
+            if (c + 1) % 10 == 0:
+                print(f"  ...{c+1}/{n_conn} connections")
+
+        print(f"seeded {n_conn} connections × {n_tables} tables, {n_agents} agents")
+        print(f"org={org_id} agents={agent_ids}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/seed_review_hunks_perf.py
+++ b/backend/scripts/seed_review_hunks_perf.py
@@ -1,0 +1,159 @@
+"""Seed the review-hunks perf shape: suggestion builds that SNAPSHOT every
+instruction (copy_from_main), so each instruction appears in every pending
+build as an unchanged carry-over row.
+
+This is the shape a long-lived org accumulates: every hunk-accept creates a
+fresh copy_from_main build, and self-learning keeps adding suggestion builds.
+`GET /instructions/{id}/review-hunks` then finds the instruction in EVERY
+pending build and (before the fix) pays a base-text query + word diff per
+build even though only one build actually changed it.
+
+Usage:
+  python scripts/seed_review_hunks_perf.py [n_instructions] [n_builds]
+
+Defaults: 40 instructions, 60 pending suggestion builds. Each build carries
+all N instructions; build i changes instruction (i % N) and carries the rest
+over unchanged.
+"""
+import os
+import sys
+import uuid
+import asyncio
+import hashlib
+
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select, insert
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.data_source_membership import DataSourceMembership
+from app.models.instruction import Instruction, instruction_data_source_association
+from app.models.instruction_version import InstructionVersion
+from app.models.instruction_build import InstructionBuild
+from app.models.build_content import BuildContent
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+async def main():
+    n_instr = int(sys.argv[1]) if len(sys.argv) > 1 else 40
+    n_builds = int(sys.argv[2]) if len(sys.argv) > 2 else 60
+
+    _u = os.environ["BOW_DATABASE_URL"]
+    _u = (_u.replace("postgresql://", "postgresql+asyncpg://", 1) if _u.startswith("postgresql://")
+          else _u.replace("sqlite:///", "sqlite+aiosqlite:///", 1) if _u.startswith("sqlite:///") else _u)
+    engine = create_async_engine(_u, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as db:
+        user = (await db.execute(select(User).where(User.email == "sandbox@bow.dev"))).scalars().first()
+        org = (await db.execute(select(Organization))).scalars().first()
+        assert user and org, "run signup first (sandbox@bow.dev) so user+org exist"
+        org_id = str(org.id)
+
+        ds = (await db.execute(
+            select(DataSource).where(DataSource.organization_id == org_id,
+                                     DataSource.name == "Review Perf Agent")
+        )).scalars().first()
+        if ds is None:
+            ds = DataSource(id=str(uuid.uuid4()), name="Review Perf Agent",
+                            is_active=True, organization_id=org_id)
+            db.add(ds)
+            await db.flush()
+            db.add(DataSourceMembership(id=str(uuid.uuid4()), data_source_id=str(ds.id),
+                                        principal_type="user", principal_id=str(user.id)))
+        ds_id = str(ds.id)
+
+        main_build = (await db.execute(
+            select(InstructionBuild).where(
+                InstructionBuild.organization_id == org_id, InstructionBuild.is_main == True  # noqa: E712
+            )
+        )).scalars().first()
+        next_bn = ((await db.execute(
+            select(InstructionBuild.build_number).where(InstructionBuild.organization_id == org_id)
+            .order_by(InstructionBuild.build_number.desc()).limit(1)
+        )).scalar() or 0) + 1
+        if main_build is None:
+            main_build = InstructionBuild(id=str(uuid.uuid4()), build_number=next_bn, status="approved",
+                                          source="user", is_main=True, organization_id=org_id,
+                                          created_by_user_id=str(user.id))
+            db.add(main_build)
+            await db.flush()
+            next_bn += 1
+        main_build_id = str(main_build.id)
+
+        # Instructions with a live v1 in main.
+        instr_ids, v1_ids = [], []
+        for i in range(n_instr):
+            iid = str(uuid.uuid4())
+            text = (f"Rule {i}: compute occupancy from confirmed reservations only; "
+                    f"exclude no-shows and same-day cancellations from the denominator.")
+            db.add(Instruction(id=iid, text=text, title=f"Rule {i}", status="published",
+                               category="general", kind="instruction", user_id=str(user.id),
+                               organization_id=org_id, source_type="user", load_mode="always",
+                               thumbs_up=0, is_seen=True, can_user_toggle=True))
+            await db.flush()
+            await db.execute(instruction_data_source_association.insert().values(
+                instruction_id=iid, data_source_id=ds_id))
+            v1 = InstructionVersion(id=str(uuid.uuid4()), instruction_id=iid, version_number=1,
+                                    text=text, title=f"Rule {i}", status="published",
+                                    load_mode="always", content_hash=_hash(text),
+                                    created_by_user_id=str(user.id))
+            db.add(v1)
+            await db.flush()
+            db.add(BuildContent(id=str(uuid.uuid4()), build_id=main_build_id,
+                                instruction_id=iid, instruction_version_id=str(v1.id)))
+            instr_ids.append(iid)
+            v1_ids.append(str(v1.id))
+        await db.commit()
+
+        # Pending suggestion builds, each snapshotting ALL instructions
+        # (copy_from_main carry-over) and actually changing exactly one.
+        for b in range(n_builds):
+            changed = b % n_instr
+            sug = InstructionBuild(id=str(uuid.uuid4()), build_number=next_bn, status="draft",
+                                   source="ai", is_main=False, organization_id=org_id,
+                                   base_build_id=main_build_id, created_by_user_id=str(user.id),
+                                   description=f"AI suggestion batch {b}")
+            next_bn += 1
+            db.add(sug)
+            await db.flush()
+
+            v2_text = (f"Rule {changed}: compute occupancy from confirmed reservations only; "
+                       f"exclude no-shows, same-day cancellations AND overbookings (rev {b}).")
+            v2 = InstructionVersion(id=str(uuid.uuid4()), instruction_id=instr_ids[changed],
+                                    version_number=2 + b, text=v2_text, title=f"Rule {changed}",
+                                    status="published", load_mode="always",
+                                    content_hash=_hash(v2_text), created_by_user_id=str(user.id))
+            db.add(v2)
+            await db.flush()
+
+            rows = []
+            for i, iid in enumerate(instr_ids):
+                rows.append({
+                    "id": str(uuid.uuid4()), "build_id": str(sug.id), "instruction_id": iid,
+                    "instruction_version_id": (str(v2.id) if i == changed else v1_ids[i]),
+                })
+            await db.execute(insert(BuildContent), rows)
+            await db.commit()
+
+        print(f"seeded {n_instr} instructions, {n_builds} pending builds "
+              f"({n_builds * n_instr} build-content rows)")
+        print(f"hot instruction (in every build, changed by ~{n_builds // n_instr} of them): {instr_ids[0]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/feedback-loops/agents-page-connections-perf.md
+++ b/docs/feedback-loops/agents-page-connections-perf.md
@@ -1,0 +1,90 @@
+# Sandbox Feedback Loop — `/agents` page slow with many connections × tables
+
+Reproduces the reported deployment: **50 connections × ~1,500 tables each,
+3 agents**, where the agents page took 40s+ to load (`GET /api/data_sources`
+alone measured at 43.7s server wait in production DevTools) and each
+`review-hunks` call took ~14s.
+
+## Root causes (validated, fixed)
+
+1. **`GET /api/data_sources` per-connection COUNT N+1** —
+   `DataSourceService.get_data_sources` built each agent's connection list
+   without the batched maps `get_active_data_sources` already used: one COUNT
+   join per connection per agent (+ a legacy-fallback COUNT and a per-agent
+   latest-indexing query). Same N+1 in `get_data_source` (polled every ~2s
+   while indexing runs) and, route-level, in `GET /api/connections`.
+2. **Megabyte list payloads** — every list endpoint inlined each connection's
+   latest `indexing.events` (up to 200 log entries × 50 connections ≈ 1.5 MB
+   per response) that nothing in a list view renders. Serialized on the event
+   loop, delaying every concurrent request; the pooled DB connection was held
+   through serialization on the unfixed routes.
+3. **`review-hunks` O(all pending builds)** — a build snapshots every
+   instruction, so `_pending_suggestion_builds` returns every pending build in
+   the org for any instruction; the endpoint paid one base-text query + a word
+   diff per build even for carry-over rows with no actual change, plus the
+   heavy `get_instruction` detail graph just for the access check.
+4. **Frontend double-fetch** — the layout and the command palette both fired
+   `GET /data_sources` on every page load.
+
+## Repro / benchmark loop
+
+Backend sandbox (same setup as `agents-instructions-perf.md`): fresh SQLite DB,
+`alembic upgrade head`, run `main.py`, register `sandbox@bow.dev`. Then:
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db" BOW_SMTP_PASSWORD=dummy ANTHROPIC_API_KEY=dummy
+uv run python scripts/seed_agents_page_perf.py 50 1500 3   # connections × tables × agents
+uv run python scripts/seed_review_hunks_perf.py 40 60      # instructions × pending builds
+uv run python scripts/profile_agents_page.py               # wall + SQL count + payload
+```
+
+## Measured (local SQLite, zero network latency)
+
+| endpoint | before | after |
+|---|---|---|
+| `GET /data_sources` | 2.66s · **59 SQL** · 1,644 KB | 0.30s · **9 SQL** · 53 KB |
+| `GET /data_sources/active` | 0.31s · 9 SQL · 1,644 KB | 0.26s · 9 SQL · 53 KB |
+| `GET /data_sources/{id}` (2s poll) | 0.82s · **22 SQL** · 560 KB | 0.11s · **7 SQL** · 560 KB* |
+| `GET /connections` | 0.18s · **105 SQL** · 1,628 KB | 0.06s · **7 SQL** · 37 KB |
+| `GET .../review-hunks` (60 pending builds) | 0.09s · **67 SQL** · 1.7 KB | 0.03s · **8 SQL** · 1.7 KB |
+
+\* the single-agent detail keeps `indexing.events` — the connections modal
+renders the live indexing log from it.
+
+HTTP end-to-end (`curl`, same sandbox): `/api/data_sources` 2.76s → 0.29s;
+`/api/connections` 0.46s → 0.23s; review-hunks 0.18s → 0.03s with a
+byte-identical response body.
+
+On production Postgres the win is larger than the local wall times suggest:
+the removed statements each paid network RTT, and the COUNT scans ran against
+a `datasource_tables` heap continuously rewritten (bloated) by the reindex
+sweeper — that multiplication is what stretched 59 queries into 43s.
+
+## Fix summary
+
+- `_bulk_connection_aux` now keys table counts by *(data source, connection)*
+  (a shared connection no longer reports the sum of both agents' tables) and
+  can defer `events_json`; wired into `get_data_sources`, `get_data_source`,
+  and both active-list paths. Lists pass `include_indexing_events=False`.
+- `GET /connections` list route batched to 4 grouped queries (catalog counts,
+  legacy fallback, latest indexing with deferred events, tool counts).
+- `review_hunks` bulk-loads base versions/texts and agent-execution traces,
+  and skips carry-over rows (`proposed version == base version`) before
+  diffing — the same rule the batched pending sweep applies. The route uses a
+  light instruction+agent-ids fetch (`get_instruction_access_view`) for the
+  visibility check.
+- `release_request_db` added to `GET /data_sources`, `GET /connections`, and
+  review-hunks so pooled connections are freed before serialization.
+- Frontend: `useAgent.initAgent()` dedupes concurrent callers (shared
+  in-flight promise + 10s freshness window, `{ force: true }` to bypass); the
+  command palette reuses the shared list instead of its own
+  `GET /data_sources`.
+
+## Repro artifacts
+
+- `backend/scripts/seed_agents_page_perf.py` — connections/tables/agents shape.
+- `backend/scripts/seed_review_hunks_perf.py` — copy-from-main suggestion
+  builds with carry-over rows.
+- `backend/scripts/profile_agents_page.py` — wall time + SQL statement count +
+  payload size per endpoint; runs on both pre- and post-fix code.

--- a/frontend/components/CommandPalette.vue
+++ b/frontend/components/CommandPalette.vue
@@ -113,8 +113,10 @@ async function fetchPrompts(q: string) {
 
 async function fetchAgents() {
   try {
-    const res: any = await useMyFetch('/data_sources', { method: 'GET' })
-    const list = res?.data?.value ?? []
+    // Reuse the shared agent list (deduped/cached in useAgent) instead of
+    // firing another GET /data_sources — the layout already loads it.
+    await initAgent()
+    const list: any[] = (sharedAgents.value as any[]) ?? []
     // newest first for the "recent" default view
     agentItemsRaw.value = [...list].sort((a: any, b: any) =>
       new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
@@ -293,7 +295,7 @@ function onPromptParamsConfirm(values: Record<string, any>) {
 }
 
 // --- actions ---
-const { initAgent, selectedAgentObjects } = useAgent()
+const { initAgent, selectedAgentObjects, agents: sharedAgents } = useAgent()
 const creatingReport = ref(false)
 async function createReport(initialPrompt: string, mentions: any[] = []) {
   if (creatingReport.value) return
@@ -343,5 +345,4 @@ function onInstructionSaved() {
   showInstructionModal.value = false
 }
 
-onMounted(() => { initAgent() })
 </script>

--- a/frontend/composables/useAgent.ts
+++ b/frontend/composables/useAgent.ts
@@ -70,6 +70,13 @@ const agents = ref<Agent[]>([])
 const loading = ref(false)
 let watcherInitialized = false
 let agentsWatcherInitialized = false
+// initAgent dedupe: one in-flight GET /data_sources shared by all callers,
+// and a short freshness window so the burst of mounts on a page load doesn't
+// refetch. Kept short (seconds) so a just-created agent still shows up in
+// selectors on the next navigation.
+let inflightInit: Promise<void> | null = null
+let lastInitAt = 0
+const INIT_CACHE_TTL_MS = 10_000
 
 export function useAgent() {
   // Set up watcher to persist selection changes (only once)
@@ -189,18 +196,37 @@ export function useAgent() {
     return selectedAgents.value.includes(agentId)
   }
 
-  // Initialize agents by fetching from API
-  async function initAgent() {
-    loading.value = true
-    try {
-      const { data } = await useMyFetch<Agent[]>('/data_sources', { method: 'GET' })
-      if (data.value) {
-        agents.value = data.value
+  // Initialize agents by fetching from API.
+  //
+  // GET /data_sources is one of the heavier list endpoints and several
+  // always-mounted components (layout, command palette, agent selector) call
+  // initAgent() around the same time, so the page used to fire it 2-3× per
+  // load. Dedupe: callers share one in-flight request, and a result fresher
+  // than the TTL is reused instead of refetched. Pass { force: true } to
+  // bypass (e.g. right after creating/deleting an agent).
+  async function initAgent(opts: { force?: boolean } = {}) {
+    if (!opts.force) {
+      if (inflightInit) return inflightInit
+      if (agents.value.length > 0 && Date.now() - lastInitAt < INIT_CACHE_TTL_MS) return
+    }
+    inflightInit = (async () => {
+      loading.value = true
+      try {
+        const { data } = await useMyFetch<Agent[]>('/data_sources', { method: 'GET' })
+        if (data.value) {
+          agents.value = data.value
+          lastInitAt = Date.now()
+        }
+      } catch (error) {
+        console.error('Failed to fetch agents:', error)
+      } finally {
+        loading.value = false
       }
-    } catch (error) {
-      console.error('Failed to fetch agents:', error)
+    })()
+    try {
+      await inflightInit
     } finally {
-      loading.value = false
+      inflightInit = null
     }
   }
 


### PR DESCRIPTION
# Summary

On a deployment with **50 connections × ~1,500 tables each and 3 agents**, the /agents page took 40s+ to load — `GET /api/data_sources` alone measured **43.7s** server wait in DevTools, and each `review-hunks` call took ~14s. Root causes were per-connection query N+1s, megabyte list payloads (inlined indexing event logs), an O(all-pending-builds) review-hunks path, and a duplicated frontend fetch.

## Backend

- **`GET /data_sources` + `GET /data_sources/{id}` (2s poll) batched** — both now use the `_bulk_connection_aux` maps that `get_active_data_sources` already had: one grouped COUNT + one latest-indexing query for the whole list instead of 2 COUNTs per connection per agent. Counts are keyed by *(data source, connection)*, which also fixes a shared connection reporting the sum of both agents' tables.
- **`GET /connections` list route batched** — 4 grouped queries (catalog counts, legacy fallback, latest indexing, tool counts) instead of 2–4 queries per connection.
- **List payloads drop `indexing.events`** — up to 200 log entries × 50 connections ≈ 1.5 MB per response that no list view renders. `events_json` is deferred at the SQL level so it's never fetched. The event log stays in the single-agent detail and `GET /connections/{id}/indexing`, which the connections modal uses.
- **`review_hunks` batched** — bulk-loads base versions/texts and agent-execution traces (2 queries), and skips carry-over rows (`proposed version == base version`) before diffing — the same rule as the batched pending sweep. Cost is now proportional to builds that actually changed the instruction, not all pending builds in the org. Its route uses a light instruction+agent-ids fetch (`get_instruction_access_view`) for the visibility check instead of the full detail eager graph.
- **`release_request_db`** added to `GET /data_sources`, `GET /connections`, and review-hunks so pooled connections are freed before response serialization.

## Frontend

- `useAgent.initAgent()` dedupes concurrent callers (shared in-flight promise + 10s freshness window; `{ force: true }` bypasses).
- The command palette reuses the shared agent list instead of firing its own `GET /data_sources` on mount — the page no longer loads that endpoint twice.

## Benchmarks

Seeded sandbox with the reported shape (50 conns × 1,500 tables × 3 agents; 60 pending suggestion builds), local SQLite:

| endpoint | before | after |
|---|---|---|
| `GET /data_sources` | 2.66s · **59 SQL** · 1.6 MB | 0.30s · **9 SQL** · 53 KB |
| `GET /data_sources/active` | 0.31s · 9 SQL · 1.6 MB | 0.26s · 9 SQL · 53 KB |
| `GET /data_sources/{id}` (2s poll) | 0.82s · **22 SQL** | 0.11s · **7 SQL** |
| `GET /connections` | 0.46s · **105 SQL** · 1.5 MB | 0.23s · **7 SQL** · 37 KB |
| `GET .../review-hunks` (60 builds) | 0.18s · **67 SQL** | 0.03s · **8 SQL** |

review-hunks response body is byte-identical before/after; list payloads verified to carry correct per-connection table counts and indexing status. On production Postgres the win is larger than local wall times suggest: each removed statement paid network RTT, and the COUNTs scanned a `datasource_tables` heap continuously rewritten by the reindex sweeper.

Repro artifacts committed: `backend/scripts/seed_agents_page_perf.py`, `seed_review_hunks_perf.py`, `profile_agents_page.py`, with the full loop documented in `docs/feedback-loops/agents-page-connections-perf.md`.

## Tests

`pytest -m e2e --db=sqlite` on `test_data_source.py`, `test_connection.py`, `test_domains.py`, `test_instruction.py`, `test_connection_indexing.py`, `test_channel_availability.py` — **56 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjKkNiiJWRaTg1j7x5jXxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjKkNiiJWRaTg1j7x5jXxN)_