### PR TITLE
WhatsApp: reuse report per 24h, drop repetitive quoting and report URL

### DIFF
--- a/backend/app/services/external_platform_manager.py
+++ b/backend/app/services/external_platform_manager.py
@@ -315,25 +315,27 @@ class ExternalPlatformManager:
         # Find a recent report for this user from the same platform
         platform_name = user_mapping.platform_type.capitalize()
 
-        # this will neer work, need to be re-written to use completion reports and by that to find the relevant one
-        result = await db.execute(
-            select(Report)
-            .filter(
-                and_(
-                    Report.external_platform_id == user_mapping.platform_id,
-                    Report.organization_id == organization.id,
-                    Report.user_id == user.id,
-                    Report.created_at >= twenty_four_hours_ago
+        # WhatsApp has no native threading or a stable conversation id, so reuse
+        # the user's most recent report from the last 24h (mirrors Teams'
+        # per-conversation reuse). Other platforms mint a fresh report per
+        # top-level message and rely on thread replies for continuation.
+        if user_mapping.platform_type == "whatsapp":
+            result = await db.execute(
+                select(Report)
+                .filter(
+                    and_(
+                        Report.external_platform_id == user_mapping.platform_id,
+                        Report.organization_id == organization.id,
+                        Report.user_id == user.id,
+                        Report.created_at >= twenty_four_hours_ago
+                    )
                 )
+                .order_by(Report.created_at.desc())
+                .limit(1)
             )
-            .order_by(Report.created_at.desc())
-            .limit(1)
-        )
-        report = result.scalar_one_or_none()
-        report = None
-
-        if report:
-            return report, False
+            report = result.scalar_one_or_none()
+            if report:
+                return report, False
 
         # If no recent report, create a new one
         # For channel mentions, only use public data sources (visible to everyone in the channel)
@@ -448,8 +450,10 @@ class ExternalPlatformManager:
 
         platform_type = processed_data.get("platform_type", "slack")
 
-        if is_thread_reply and thread_ts:
-            # This is a reply in an existing thread - find the associated report
+        if is_thread_reply and thread_ts and platform_type != "whatsapp":
+            # This is a reply in an existing thread - find the associated report.
+            # WhatsApp is excluded: its thread_ts is the (per-message) inbound id,
+            # not a stable conversation key, so it reuses by 24h window instead.
             report = await self._find_report_by_thread_ts(
                 db, organization.id, user.id, thread_ts,
                 platform_type=platform_type,
@@ -472,7 +476,10 @@ class ExternalPlatformManager:
                 db, organization, user, user_mapping, channel_type
             )
 
-            if created:
+            if created and platform_type != "whatsapp":
+                # WhatsApp intentionally skips the "new report" announcement — with
+                # 24h report reuse it would only fire on the first message of a
+                # window, and the URL adds noise to a 1:1 chat.
                 report_url = f"{settings.bow_config.base_url}/reports/{report.id}"
                 # Send the "new report" message in the thread
                 # For channel mentions, respond in the channel; for DMs, open a DM
@@ -504,10 +511,11 @@ class ExternalPlatformManager:
         # a reused report can outlive changes to the user's data-source access:
         # grants made after creation wouldn't appear, and revocations would still
         # be queryable from the stale snapshot. Re-sync the report's attached
-        # sources to the user's current set on each message — but only for Teams
-        # (Slack DMs/channels mint a fresh report per top-level message) and only
-        # when reusing an existing report (a freshly created one is already current).
-        if platform_type == "teams" and report is not None and not created:
+        # sources to the user's current set on each message — for Teams and
+        # WhatsApp, both of which reuse a report across messages (Slack DMs/
+        # channels mint a fresh report per top-level message) and only when
+        # reusing an existing report (a freshly created one is already current).
+        if platform_type in ("teams", "whatsapp") and report is not None and not created:
             from app.services.report_service import ReportService
             if channel_type == "channel":
                 fresh = await self.data_source_service.get_public_data_sources(db, organization, channel=platform_type)

--- a/backend/app/services/platform_adapters/whatsapp_adapter.py
+++ b/backend/app/services/platform_adapters/whatsapp_adapter.py
@@ -153,9 +153,12 @@ class WhatsAppAdapter(PlatformAdapter):
             "type": "text",
             "text": {"body": text[:4096], "preview_url": False},
         }
-        thread_ts = message_data.get("thread_ts")
-        if thread_ts:
-            payload["context"] = {"message_id": thread_ts}
+        # Intentionally NOT setting `context.message_id`: quoting the root inbound
+        # message on every outbound reply made WhatsApp re-quote the user's
+        # original prompt above each of the (multiple) reply messages, which reads
+        # as repetitive clutter. Report/thread association is tracked server-side
+        # via Completion.external_thread_ts, not via the WhatsApp quote, so
+        # dropping the quote is purely cosmetic.
         return await self._post_message(payload)
 
     async def get_user_info(self, external_user_id: str, conversation_id: Optional[str] = None) -> Dict[str, Any]:
@@ -302,8 +305,8 @@ class WhatsAppAdapter(PlatformAdapter):
             "type": msg_type,
             msg_type: media_obj,
         }
-        if thread_ts:
-            payload["context"] = {"message_id": thread_ts}
+        # Don't quote the root prompt (see send_response) — avoids repetitive
+        # quoted-reply clutter when several messages/files are sent per answer.
         return await self._post_message(payload)
 
     async def send_image_in_dm(self, user_id: str, image_path: str, title: str) -> bool:


### PR DESCRIPTION
## Summary

Follow-up polish to the WhatsApp integration after live testing (the reply-delivery fix from #565 works — answers now come back). Three small behavior fixes, all scoped to WhatsApp so Slack/Teams/email are untouched.

### 1. One report per 24h (like Teams), not one per prompt
Each inbound prompt was creating a brand-new report. WhatsApp has no native threading or stable conversation id (its `thread_ts` is the per-message inbound id), so reuse can't key on the thread the way Teams keys on its conversation id. Instead we reuse the user's most recent report from the last 24h:
- `_get_or_create_conversation_report`: enable the previously dead-coded 24h lookup, scoped to `whatsapp` only.
- `_process_verified_message`: route WhatsApp past the per-message thread lookup so it always resolves via the 24h window.
- Extend the Teams-style data-source re-sync to WhatsApp, so a reused report reflects the user's current data-source access on each message (grants/revocations don't leak through a stale snapshot).

### 2. Stop re-quoting the original prompt on every reply
The adapter set `context.message_id` (a quoted reply) on every outbound message, so WhatsApp re-quoted the user's original prompt above each of the multiple reply messages — repetitive clutter. The quote is purely cosmetic (thread association is tracked via `Completion.external_thread_ts` server-side), so it's dropped for both text (`send_response`) and file (`send_file_in_thread`) sends.

### 3. Don't send the "new report" URL announcement for WhatsApp
`"I've started a new conversation report for you: <url>"` is suppressed for WhatsApp — with 24h reuse it would only fire on the first message of a window anyway, and the URL is noise in a 1:1 chat.

### (Not in this PR) eyes → checkmark
The 👀→✅ swap already works through the notification path enabled in #565 (`send_completion_blocks_to_slack`), so no code change was needed. Flagged for live confirmation on the next test.

## Changes
- `backend/app/services/external_platform_manager.py`
- `backend/app/services/platform_adapters/whatsapp_adapter.py`

## Testing
- `py_compile` passes on both edited files.
- The full backend unit suite could not be run in the authoring environment (missing the project's runtime dependency set); changes were verified by static analysis and are WhatsApp-scoped.
- Recommended manual check after deploy: send several WhatsApp messages within 24h and confirm they land in one report, replies are not quoted, no report-URL message is sent, and 👀 flips to ✅ when the answer completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy4GM8DK4patwbCvD1pu1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uy4GM8DK4patwbCvD1pu1N)_