### PR TITLE
Give sandbox violations a feedback loop so codegen can self-correct

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -13,8 +13,23 @@ from app.schemas.organization_settings_schema import OrganizationSettingsConfig
 from app.ai.schemas.codegen import CodeGenContext
 from app.services.usage_policy_service import UsageLimitContext
 from app.core.otel import get_tracer
+from app.ai.code_execution.code_execution import FORBIDDEN_BUILTINS, FORBIDDEN_MODULES
 
 tracer = get_tracer(__name__)
+
+
+def _sandbox_rules_section() -> str:
+    """Sandbox constraints for codegen prompts, derived from the validator's
+    own lists so the prompt can never drift from what execute_code enforces."""
+    builtins_list = ", ".join(sorted(FORBIDDEN_BUILTINS))
+    modules_list = ", ".join(sorted(FORBIDDEN_MODULES))
+    return f"""**Sandbox rules — the code is AST-validated BEFORE it runs; ANY of these constructs rejects the whole attempt:**
+        - Forbidden function calls (never call these, in any context): {builtins_list}.
+          * Use plain dot access instead of getattr/hasattr — fields on provided objects (e.g. `excel_files[N].path`, FetchedPage fields) always exist; check truthiness, not presence.
+          * For messy or mixed-type Excel column labels, normalize with `str(col).strip()` — never `getattr(col, 'strip', ...)`.
+        - Forbidden imports: {modules_list}.
+        - Never access dunder attributes (e.g. `obj.__class__`, `obj.__dict__`).
+        - SQL strings must be read-only — no INSERT / UPDATE / DELETE / DROP / CREATE / ALTER / TRUNCATE / GRANT."""
 
 class Coder:
     def __init__(
@@ -404,6 +419,49 @@ class Coder:
             )
         return ""
 
+    @staticmethod
+    def _render_error_feedback(code_and_error_messages, limit: int = 2) -> str:
+        """Render the failing (code, error) pairs of THIS request's earlier
+        attempts for prompt inclusion, so a retry can actually correct the
+        failure instead of re-rolling blind. Bounded to the most recent
+        `limit` attempts to keep the prompt small."""
+        if not code_and_error_messages:
+            return "None"
+        parts = []
+        for code, error in code_and_error_messages[-limit:]:
+            parts.append(
+                f"<failed_attempt>\n<code>\n{code or ''}\n</code>\n<error>\n{error or ''}\n</error>\n</failed_attempt>"
+            )
+        return "\n".join(parts)
+
+    @staticmethod
+    def _render_last_failed_observation(last_observation) -> str:
+        """When the previous tool call failed (e.g. the planner re-invoked
+        inspect_data after a sandbox violation), surface that failure so the
+        fresh codegen doesn't repeat it. Successful observations return ""
+        — a prior success is noise for a quick inspection."""
+        if not isinstance(last_observation, dict):
+            return ""
+        obs = last_observation.get("observation") or {}
+        if not isinstance(obs, dict) or obs.get("success") is not False:
+            return ""
+        err = obs.get("error")
+        if isinstance(err, dict):
+            err_text = err.get("detail") or err.get("message") or ""
+        else:
+            err_text = str(err or "")
+        err_text = err_text or obs.get("summary") or ""
+        if not err_text:
+            return ""
+        section = (
+            "- The previous attempt at this task FAILED — do not repeat its mistake:\n"
+            f"<previous_failed_attempt>\n<error>\n{err_text}\n</error>"
+        )
+        code = obs.get("code") or ""
+        if code:
+            section += f"\n<code>\n{str(code)[:1500]}\n</code>"
+        return section + "\n</previous_failed_attempt>"
+
     async def generate_code(
         self,
         data_model,  # kept for signature compatibility; ignored
@@ -541,10 +599,17 @@ class Coder:
             - Last Observation:
             <last_observation>{json.dumps(last_observation) if last_observation else 'None'}</last_observation>
 
+            - Previous code attempts for THIS request that FAILED (retry #{retries}; fix these errors, do not repeat them):
+            <code_and_error_messages>
+            {self._render_error_feedback(code_and_error_messages)}
+            </code_and_error_messages>
+
             - Similar successful code snippets (for reference on what is working):
             <similar_successful_code_snippets>
             {similar_successful_code_snippets}
             </similar_successful_code_snippets>
+
+            {_sandbox_rules_section()}
 
             **Guidelines and Requirements**:
 
@@ -619,9 +684,10 @@ class Coder:
                - Do not use tables/cols that exist in instructions but are not in the provided schemas.
 
             4. **Handling Previous Code and Errors**:
-               - If `retries` ≥ 1, review the code_and_error_messages:
-                 * Understand the error.
+               - If the <code_and_error_messages> section above is not "None", review each failed attempt:
+                 * Understand the error and write code that cannot fail the same way.
                  * If it's related to a missing column or invalid query, fix it by removing or correcting that column/query.
+                 * If it's a "Security violation" from the sandbox, rewrite the code without the forbidden construct (see the sandbox rules above).
                - If `retries` ≥ 2 and still failing due to a specific column or measure, remove that problematic part and return a reduced but valid DataFrame.
                - Ensure you produce some output even if reduced.
                - If the error is related to size of the query, try to use partitions when available in context/metadata resources.
@@ -715,6 +781,12 @@ class Coder:
             excel_files_description.append(f"{index}: {file.description}")
         excel_files_section = "\n".join(excel_files_description)
 
+        # Cross-call memory: when the planner re-invokes inspection after a
+        # failed attempt, surface that failure instead of regenerating blind.
+        prev_failure_section = self._render_last_failed_observation(
+            context.last_observation if context is not None else None
+        )
+
         text = f"""
         Role: data investigator doing a quick hypothesis validation.
 
@@ -742,6 +814,15 @@ class Coder:
 
         - Excel Files (available via `excel_files` list):
         {excel_files_section}
+
+        {prev_failure_section}
+
+        - Previous code attempts for THIS request that FAILED (retry #{retries}; fix the error, do not repeat it):
+        <code_and_error_messages>
+        {self._render_error_feedback(code_and_error_messages)}
+        </code_and_error_messages>
+
+        {_sandbox_rules_section()}
 
         **Excel File Access**: Use `pd.read_excel(excel_files[INDEX].path, sheet_name=0)` to read Excel files.
         - `excel_files` is a list of File objects with `.path` attribute (NOT a dict, use `.path` not `['path']`)

--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -1256,7 +1256,16 @@ class StreamingCodeExecutor:
                 code_and_error_messages.append((final_code, msg))
                 yield {"type": "security_violation", "payload": {"violation_type": violation_type, "message": str(e), "code_snippet": final_code[:500]}}
                 yield {"type": "stdout", "payload": msg}
-                # Security violations are not retryable
+                if violation_type == "unsafe_python":
+                    # AST validation runs BEFORE exec() — nothing has executed,
+                    # so this is a correctable style problem (e.g. the coder
+                    # used getattr()). Feed the violation back and regenerate.
+                    retries += 1
+                    if retries < max_retries:
+                        yield {"type": "progress", "payload": {"stage": "retry", "attempt": retries, "timing": False}}
+                    continue
+                # unsafe_sql fires mid-execution (a write query reached a real
+                # client wrapper), so the attempt is not safely repeatable.
                 break
             except Exception as e:
                 msg = f"Execution error: {str(e)}"

--- a/backend/app/ai/tools/implementations/inspect_data.py
+++ b/backend/app/ai/tools/implementations/inspect_data.py
@@ -191,9 +191,10 @@ Queries are subject to a per-connection timeout.
         execution_start = time.monotonic()
         raw_errors: List[Any] = []
 
-        # No retries by default for inspection to keep it fast, unless it crashes hard
+        # One retry: with error feedback wired into the prompt a second attempt
+        # can self-correct (e.g. after a sandbox violation) while staying fast.
         async for e in streamer.generate_and_execute_stream_v2(
-            request=CodeGenRequest(context=codegen_context, retries=1),
+            request=CodeGenRequest(context=codegen_context, retries=2),
             ds_clients=runtime_ctx.get("ds_clients", {}),
             excel_files=runtime_ctx.get("excel_files", []),
             code_generator_fn=_inspection_generator_fn,

--- a/backend/app/ai/tools/mcp/inspect_data.py
+++ b/backend/app/ai/tools/mcp/inspect_data.py
@@ -213,8 +213,10 @@ class InspectDataMCPTool(MCPTool):
 
         sigkill_event = asyncio.Event()
 
+        # One retry: error feedback in the prompt lets a second attempt
+        # self-correct (e.g. after a sandbox violation).
         async for e in streamer.generate_and_execute_stream_v2(
-            request=CodeGenRequest(context=codegen_context, retries=1),
+            request=CodeGenRequest(context=codegen_context, retries=2),
             ds_clients=rich_ctx.ds_clients,
             excel_files=[],
             code_generator_fn=_inspection_generator_fn,

--- a/backend/tests/unit/test_sandbox_feedback_loop.py
+++ b/backend/tests/unit/test_sandbox_feedback_loop.py
@@ -1,0 +1,257 @@
+"""Sandbox feedback loop for code-security violations.
+
+Contract under test: when generated Python trips the AST validator
+(`unsafe_python`, e.g. a `getattr()` call), the executor must treat it as a
+correctable codegen failure — retry within the attempt budget — and the next
+code-generation prompt must actually contain the previous code + error so the
+coder can self-correct instead of re-rolling blind.
+
+Born as the reproduction for: xls inspection failing repeatedly with
+"Security violation (unsafe_python): Forbidden function call: 'getattr()'".
+"""
+
+import asyncio
+
+import pandas as pd
+
+from app.ai.agents.coder.coder import Coder
+from app.ai.code_execution.code_execution import (
+    FORBIDDEN_BUILTINS,
+    StreamingCodeExecutor,
+)
+from app.ai.llm.types import TextDeltaEvent
+from app.ai.schemas.codegen import CodeGenContext, CodeGenRequest
+
+
+GETATTR_CODE = (
+    "def generate_df(ds_clients, excel_files):\n"
+    "    import pandas as pd\n"
+    "    path = getattr(excel_files, 'path', None)\n"
+    "    return pd.DataFrame({'a': [1]})\n"
+)
+
+CLEAN_CODE = (
+    "def generate_df(ds_clients, excel_files):\n"
+    "    import pandas as pd\n"
+    "    return pd.DataFrame({'a': [1]})\n"
+)
+
+VIOLATION_MSG = (
+    "Security violation (unsafe_python): Code contains forbidden constructs: "
+    "Forbidden function call: 'getattr()'"
+)
+
+
+def _capturing_coder(code_sequence):
+    """code_generator_fn stub that records the kwargs of every call."""
+    calls = []
+
+    async def _gen(**kwargs):
+        calls.append(kwargs)
+        i = min(len(calls) - 1, len(code_sequence) - 1)
+        return code_sequence[i]
+
+    return _gen, calls
+
+
+def _drive(executor, generator_fn, retries=2):
+    events = []
+
+    async def go():
+        async for ev in executor.generate_and_execute_stream_v2(
+            request=CodeGenRequest(
+                context=CodeGenContext(user_prompt="x", schemas_excerpt=""),
+                retries=retries,
+            ),
+            ds_clients={},
+            excel_files=[],
+            code_generator_fn=generator_fn,
+        ):
+            events.append(ev)
+
+    asyncio.run(go())
+    return events
+
+
+class TestUnsafePythonIsRetryable:
+    def test_violation_then_clean_code_succeeds(self):
+        """An unsafe_python violation must consume a retry, not end the run."""
+        gen, calls = _capturing_coder([GETATTR_CODE, CLEAN_CODE])
+        events = _drive(StreamingCodeExecutor(), gen, retries=2)
+
+        done = [e for e in events if e["type"] == "done"][-1]["payload"]
+        assert len(calls) == 2, "executor must regenerate after an unsafe_python violation"
+        df = done["df"]
+        assert df is not None and list(df.columns) == ["a"]
+        # The violation is still recorded for the caller/audit trail.
+        assert any("unsafe_python" in (err or "") for _, err in done["errors"])
+
+    def test_violation_still_emits_security_event(self):
+        """Retrying must not silence the audit event."""
+        gen, _ = _capturing_coder([GETATTR_CODE, CLEAN_CODE])
+        events = _drive(StreamingCodeExecutor(), gen, retries=2)
+
+        sec = [e for e in events if e["type"] == "security_violation"]
+        assert len(sec) == 1
+        assert sec[0]["payload"]["violation_type"] == "unsafe_python"
+
+    def test_retry_receives_violation_feedback(self):
+        """The 2nd codegen call must see the offending code and the violation."""
+        gen, calls = _capturing_coder([GETATTR_CODE, CLEAN_CODE])
+        _drive(StreamingCodeExecutor(), gen, retries=2)
+
+        assert len(calls) == 2
+        feedback = calls[1]["code_and_error_messages"]
+        assert feedback, "previous attempt must be fed back to the coder"
+        prev_code, prev_error = feedback[-1]
+        assert "getattr" in prev_code
+        assert "unsafe_python" in prev_error
+
+    def test_budget_still_bounds_violations(self):
+        """A coder that always emits violations must stop at the retry budget."""
+        gen, calls = _capturing_coder([GETATTR_CODE])
+        events = _drive(StreamingCodeExecutor(), gen, retries=2)
+
+        done = [e for e in events if e["type"] == "done"][-1]["payload"]
+        assert len(calls) == 2, "must not loop beyond the configured budget"
+        assert done["df"] is None
+        assert len(done["errors"]) == 2
+
+
+class _PromptCapturingLLM:
+    """Stands in for Coder.llm — records the rendered prompt."""
+
+    def __init__(self):
+        self.prompts = []
+
+    async def inference_stream_v2(self, messages, **kwargs):
+        self.prompts.append(messages[0].content)
+        yield TextDeltaEvent(text=CLEAN_CODE)
+
+
+def _bare_coder():
+    coder = Coder.__new__(Coder)  # skip __init__: it needs a live LLM provider
+    coder.llm = _PromptCapturingLLM()
+    coder.organization_settings = None
+    coder.enable_llm_see_data = True
+    coder.instruction_context_builder = None
+    coder.context_hub = None
+    return coder
+
+
+def _ctx(**overrides):
+    base = dict(user_prompt="inspect the excel file", schemas_excerpt="")
+    base.update(overrides)
+    return CodeGenContext(**base)
+
+
+class TestErrorFeedbackReachesPrompts:
+    """The prompt templates must render code_and_error_messages, not drop them."""
+
+    def _feedback(self):
+        return [(GETATTR_CODE, VIOLATION_MSG)]
+
+    def test_inspection_prompt_contains_previous_error(self):
+        coder = _bare_coder()
+        asyncio.run(
+            coder.generate_inspection_code(
+                prompt="p", schemas="", ds_clients={}, excel_files=[],
+                code_and_error_messages=self._feedback(),
+                memories="", previous_messages="", retries=1,
+                context=_ctx(),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        assert VIOLATION_MSG in prompt
+        assert "getattr(excel_files, 'path', None)" in prompt
+
+    def test_create_data_prompt_contains_previous_error(self):
+        coder = _bare_coder()
+        asyncio.run(
+            coder.generate_code(
+                data_model={}, prompt="p", interpreted_prompt="p", schemas="",
+                ds_clients={}, excel_files=[],
+                code_and_error_messages=self._feedback(),
+                memories="", previous_messages="", retries=1,
+                context=_ctx(),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        assert VIOLATION_MSG in prompt
+        assert "getattr(excel_files, 'path', None)" in prompt
+
+
+class TestSandboxRulesInPrompts:
+    """Both codegen prompts must state the sandbox's forbidden builtins,
+    kept in sync with the validator's own list."""
+
+    def test_inspection_prompt_lists_forbidden_builtins(self):
+        coder = _bare_coder()
+        asyncio.run(
+            coder.generate_inspection_code(
+                prompt="p", schemas="", ds_clients={}, excel_files=[],
+                code_and_error_messages=[], memories="", previous_messages="",
+                retries=0, context=_ctx(),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        missing = sorted(b for b in FORBIDDEN_BUILTINS if b not in prompt)
+        assert not missing, f"inspection prompt missing sandbox rules for: {missing}"
+
+    def test_create_data_prompt_lists_forbidden_builtins(self):
+        coder = _bare_coder()
+        asyncio.run(
+            coder.generate_code(
+                data_model={}, prompt="p", interpreted_prompt="p", schemas="",
+                ds_clients={}, excel_files=[],
+                code_and_error_messages=[], memories="", previous_messages="",
+                retries=0, context=_ctx(),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        missing = sorted(b for b in FORBIDDEN_BUILTINS if b not in prompt)
+        assert not missing, f"create_data prompt missing sandbox rules for: {missing}"
+
+
+class TestInspectionPromptSeesLastFailedObservation:
+    """When the planner re-invokes inspect_data after a failed attempt, the
+    inspection prompt must surface the previous failure from last_observation."""
+
+    def test_failed_last_observation_rendered(self):
+        coder = _bare_coder()
+        last_obs = {
+            "tool_name": "inspect_data",
+            "tool_input": {"user_prompt": "count DMCH rows"},
+            "observation": {
+                "success": False,
+                "summary": "Inspection failed for: count DMCH rows",
+                "error": {"type": "execution_failure", "message": VIOLATION_MSG},
+                "code": GETATTR_CODE,
+            },
+        }
+        asyncio.run(
+            coder.generate_inspection_code(
+                prompt="p", schemas="", ds_clients={}, excel_files=[],
+                code_and_error_messages=[], memories="", previous_messages="",
+                retries=0, context=_ctx(last_observation=last_obs),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        assert VIOLATION_MSG in prompt
+
+    def test_successful_last_observation_not_dumped(self):
+        """A prior success is noise for a quick inspection — don't inject it."""
+        coder = _bare_coder()
+        last_obs = {
+            "tool_name": "create_data",
+            "observation": {"success": True, "summary": "built Customer Sales"},
+        }
+        asyncio.run(
+            coder.generate_inspection_code(
+                prompt="p", schemas="", ds_clients={}, excel_files=[],
+                code_and_error_messages=[], memories="", previous_messages="",
+                retries=0, context=_ctx(last_observation=last_obs),
+            )
+        )
+        prompt = coder.llm.prompts[0]
+        assert "built Customer Sales" not in prompt

--- a/docs/feedback-loops/sandbox-violation-feedback.md
+++ b/docs/feedback-loops/sandbox-violation-feedback.md
@@ -1,0 +1,124 @@
+# Feedback Loop — xls inspection dies repeatedly with "Security violation (unsafe_python): Forbidden function call: 'getattr()'"
+
+Reported (mobile screenshot, July 2026): inspecting an uploaded Excel file made
+`inspect_data` fail three times in a row, every attempt showing
+`Security violation (unsafe_python): Code contains forbidden constructs:
+Forbidden function call: 'getattr()'` — the second attempt contained *three*
+`getattr()` calls instead of one. The claim validated here: the violation is
+recorded everywhere **except** the one prompt that could fix it, so the coder
+can never self-correct.
+
+## Root cause (validated)
+
+Four stacked gaps, all confirmed by reading code and by the live reproduction
+below:
+
+1. **The ban itself is correct.** `FORBIDDEN_BUILTINS`
+   (`backend/app/ai/code_execution/code_execution.py`) rejects any `getattr`/
+   `hasattr` call at AST level, because dynamic attribute lookup would bypass
+   the dunder-attribute blocklist (`getattr(df, '__cl' + 'ass__')`). Not the bug.
+2. **The coder was never told.** The inspection codegen prompt
+   (`Coder.generate_inspection_code`) mentioned the `getattr` ban only inside
+   the HTTP/`FetchedPage` bullet — invisible for an Excel task. Excel is also
+   exactly where models reach for `getattr(col, 'strip', None)`-style defensive
+   code (messy mixed-type headers, `header=None` reads).
+3. **Violations were terminal.** `generate_and_execute_stream_v2` `break`s on
+   any `CodeSecurityError`, even though `unsafe_python` fires **before**
+   `exec()` — nothing has run, so there is no safety reason not to retry.
+4. **Feedback was dropped at the last step.** The violation *is* recorded in
+   the planner's observations and even plumbed into `CodeGenContext`
+   (`past_observations` / `last_observation`), and the executor passes
+   `code_and_error_messages` into every codegen call — but neither
+   `generate_inspection_code` nor the v2 `generate_code` prompt template ever
+   interpolated them (`generate_code` section 4 told the model to "review the
+   code_and_error_messages" that were not in the prompt). Each regeneration was
+   a blind re-roll, so the same idiom came back.
+
+## Loop A — deterministic reproduction (no external services)
+
+`backend/tests/unit/test_sandbox_feedback_loop.py` drives the real executor
+with a stubbed `code_generator_fn` (LLM is the only stubbed boundary):
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"; mkdir -p db
+TESTING=true uv run pytest tests/unit/test_sandbox_feedback_loop.py -q
+```
+
+Observed on pre-fix code — 8 FAIL / 2 pass:
+
+- `test_violation_then_clean_code_succeeds` — executor stopped after one
+  attempt (`calls == 1`), `df is None`.
+- `test_retry_receives_violation_feedback` — no second codegen call existed.
+- `test_inspection_prompt_contains_previous_error` /
+  `test_create_data_prompt_contains_previous_error` — the violation text never
+  appeared in the rendered prompt.
+- `test_*_prompt_lists_forbidden_builtins` — prompts did not state the
+  sandbox's forbidden-builtin list.
+- `test_failed_last_observation_rendered` — a failed previous tool run was not
+  surfaced to the next inspection prompt.
+
+## Loop B — live confirmation (real Anthropic key, full stack)
+
+Stack via `tools/agent/boot_stack.sh` + `tools/agent/seed_org.py`; Anthropic
+provider registered through `POST /api/llm/providers` with the key from the
+environment (env var only, never committed). A messy two-sheet
+`clients_ledger.xlsx` (banner rows, mixed-type header labels: str/int/float/
+datetime/None, a `DMCH` client-code column) is uploaded through
+`POST /api/files`, attached to a report, and a real completion is run.
+
+Pre-fix, a prompt steering the coder toward the `getattr` convention produced
+exactly the reported failure, recorded in SQLite (`db/agent.db`):
+
+- `tool_executions`: `inspect_data` row with `status=error`, `success=0`,
+  `error_message = Security violation (unsafe_python): … 'getattr()'`, and the
+  generated code containing `file_path = getattr(excel_file, 'path', None)`.
+- `audit_logs`: `security.unsafe_code_blocked` + `tool.data_query_failed`.
+- One attempt only (`retries=1` at the time); the planner had to route around
+  the tool.
+
+## The fix
+
+- `backend/app/ai/code_execution/code_execution.py` — `unsafe_python`
+  violations now consume a retry (with the violation appended to
+  `code_and_error_messages`) instead of ending the run; the
+  `security_violation` audit event is still emitted. `unsafe_sql` stays
+  terminal: it fires mid-execution, so the attempt is not safely repeatable.
+- `backend/app/ai/agents/coder/coder.py` —
+  - `_sandbox_rules_section()` renders the forbidden builtins/modules into both
+    v2 codegen prompts, **derived from the validator's own frozensets** so
+    prompt and enforcement cannot drift, with the Excel-specific substitute
+    (`str(col).strip()`, never `getattr(col, 'strip', …)`).
+  - `_render_error_feedback()` interpolates the last failed (code, error)
+    pairs into both `generate_code` and `generate_inspection_code` — the
+    phantom "review the code_and_error_messages" instruction now has real
+    content behind it.
+  - `_render_last_failed_observation()` surfaces a failed previous tool run
+    (from `context.last_observation`) in the inspection prompt, covering the
+    planner-re-invokes-the-tool loop from the report.
+- `backend/app/ai/tools/implementations/inspect_data.py` +
+  `backend/app/ai/tools/mcp/inspect_data.py` — `retries` 1 → 2; a retry is no
+  longer a blind re-roll, so the extra attempt buys a correction.
+
+Re-running Loop A: **10 passed**. Re-running Loop B with the same
+getattr-steering prompt: `inspect_data` `success=1`, final code free of
+`getattr`, correct DMCH output, and **no** `security.unsafe_code_blocked`
+audit row — the prompt rules prevent the idiom at generation time, and the
+executor retry stands behind it if a model still emits one.
+
+## What this proves / regression notes
+
+- Prevention layer: both codegen prompts now state the sandbox rules, kept in
+  sync with the validator by construction (test fails if a builtin is added to
+  the validator but missing from the prompt).
+- Correction layer: a violation feeds the exact code + error back into the
+  next attempt within the same tool call; budget still bounds the loop
+  (`test_budget_still_bounds_violations`).
+- Audit behavior unchanged (`security.unsafe_code_blocked` still logged per
+  violation).
+- `tests/e2e/test_loadables.py` (16 tests over the same executor loop) passes
+  unchanged.
+- Live note: on the deliberately messy sheet, inspection can still fail for
+  ordinary data reasons (e.g. `KeyError: 'Client Code'` twice) — it now
+  retries with feedback and the planner falls back to another tool; that is
+  the intended failure economics, not this bug.


### PR DESCRIPTION
Inspecting an uploaded Excel file could fail repeatedly with "Security
violation (unsafe_python): Forbidden function call: 'getattr()'": the coder
naturally writes defensive getattr()/hasattr() code for messy spreadsheet
headers, the AST validator (correctly) rejects it, and nothing ever told the
next generation attempt what went wrong — violations were terminal in the
executor, and neither v2 codegen prompt interpolated code_and_error_messages
despite instructing the model to review them.

- code_execution: unsafe_python violations now consume a retry instead of
  ending the run — AST validation fires before exec(), so nothing has
  executed and regenerating is safe. unsafe_sql stays terminal (fires
  mid-execution). The security_violation audit event is still emitted.
- coder: both generate_code and generate_inspection_code now render the
  failed (code, error) pairs of earlier attempts, plus a sandbox-rules
  section derived from the validator's own FORBIDDEN_BUILTINS/MODULES so
  prompt and enforcement cannot drift. The inspection prompt also surfaces
  the last failed tool observation for planner re-invocations.
- inspect_data (tool + MCP variant): retries 1 -> 2; a retry is no longer a
  blind re-roll, so the extra attempt can actually correct the failure.

Reproduced and verified end-to-end against a live stack with a messy-header
XLSX (docs/feedback-loops/sandbox-violation-feedback.md); the new unit tests
pin the executor retry semantics and the prompt-feedback contract.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VfAFNSGcTjd869kA7TEEUq