### PR TITLE
fix: surface backend failures in delete/toggle/save handlers (#584)

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -1,0 +1,562 @@
+# OPS — Running the system & tests
+
+How to run the app locally (Docker or from source), how to run every test suite,
+and exactly what runs automatically when you open a PR. Everything below is
+grounded in the real config files (`backend/pyproject.toml`,
+`backend/tests/conftest.py`, `backend/tests/AGENTS.md`,
+`frontend/playwright.config.ts`, `docker-compose*.yaml`, `Dockerfile`,
+`.github/workflows/*`) — no invented commands.
+
+> **Validation status (2026-07-09).** The backend unit command below was
+> executed on this machine: the one-file smoke run passed (`tests/unit/test_clock.py`
+> → 9 passed in 8s) and the full `tests/unit` run was re-run to confirm the
+> summary (see "Backend tests"). Both `docker compose config` files **parse**
+> (exit 0). The Docker **bring-up** (`docker compose up` / `docker build`) was
+> **NOT** run end-to-end here because the Docker daemon was not reachable in this
+> environment — the compose commands are transcribed from the real
+> `docker-compose*.yaml` and README, not live-verified. Run them on a host with
+> Docker running to confirm.
+
+---
+
+## TL;DR quickstart
+
+```bash
+# Run the app (released image, SQLite) — quickest look, NOT your local code:
+docker run -p 3000:3000 bagofwords/bagofwords        # → http://localhost:3000
+
+# Backend unit tests (pure logic, SQLite, no external services) — from repo root:
+cd backend
+uv sync --frozen --extra dev          # once, to build the .venv
+uv run pytest tests/unit -q --disable-warnings
+#  ↳ if `uv` PANICS (sandbox/agent shells), don't fight it — jump to
+#    "⚠️ If `uv` fails or panics" under Backend tests: python3.12 -m venv .venv
+#    && .venv/bin/python -m ensurepip --upgrade && .venv/bin/python -m pip install -e ".[dev]",
+#    then use `.venv/bin/python -m pytest …` instead of `uv run pytest …`.
+
+# Frontend E2E (Playwright) — needs the full app stack running first (see below):
+cd frontend
+yarn install --frozen-lockfile
+npx playwright install --with-deps chromium
+npx playwright test                   # against http://localhost:3000
+```
+
+The backend unit suite is self-contained (SQLite file DB, all externals mocked).
+The Playwright suite is **not** self-contained — it drives a real browser against
+a running frontend + backend + seeded admin user (details under "Frontend E2E").
+
+---
+
+## Test suites overview
+
+| Suite | Location | Framework | Covers | Needs a running stack? |
+|-------|----------|-----------|--------|------------------------|
+| Backend **unit** | `backend/tests/unit/` (~60 files) | pytest | Pure logic, single service/helper, no HTTP | No — SQLite + mocks |
+| Backend **e2e** | `backend/tests/e2e/` (~100 files, `@pytest.mark.e2e`) | pytest + `TestClient` | Full API flows: routes → services → real DB | No — in-process app + SQLite/Postgres |
+| Backend **ai** | `backend/tests/ai/` (`@pytest.mark.ai`) | pytest | Agent/planner behavior | No, but needs `OPENAI_API_KEY_TEST` (real LLM) |
+| Backend **evals** | `backend/tests/evals/` | pytest | LLM output-quality evals | Manual; real LLM |
+| Backend **integrations** | `backend/tests/integrations/` | pytest | Real data-source / LLM provider creds | Manual / CI-gated; needs `integrations.json` |
+| Frontend **E2E** | `frontend/tests/**/*.spec.ts` | Playwright | Browser flows: onboarding, members, reports, settings, RBAC… | **Yes** — running frontend + backend + DB |
+
+There is **no frontend unit-test harness** — see the Playwright section for what
+that means and how you'd add one.
+
+---
+
+## Run the system locally
+
+Two fundamentally different paths — pick by what you're trying to do:
+
+- **Docker Compose / `docker run`** → runs the **published** `bagofwords/bagofwords:latest`
+  image. Fastest way to get a working app, but it runs the **released build, not
+  your working-tree code.** Both `docker-compose.yaml` and `docker-compose.dev.yaml`
+  declare `image: bagofwords/bagofwords:latest` with `pull_policy: always` — there
+  is **no `build:` stanza**, so they never build this checkout. Do **not** use
+  Compose to test this branch's changes (e.g. the #584 fix) — you'd be testing the
+  last release.
+- **From source** → runs **your** code. Either build the root `Dockerfile`, or run
+  backend + frontend directly (the "Frontend E2E" bring-up below). Use this to
+  exercise local changes.
+
+### A. Docker — dev compose (no SSL): app + Postgres
+
+`docker-compose.dev.yaml` brings up the app (`bagofwords/bagofwords:latest`) plus a
+`postgres:16-alpine`, no reverse proxy. From the repo root:
+
+```bash
+# 1) Generate a Fernet encryption key (44 chars, ends with '='):
+python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+# 2) Create .env at the repo root (the compose file reads these):
+cat > .env <<'EOF'
+POSTGRES_USER=bow
+POSTGRES_PASSWORD=change_me_please
+POSTGRES_DB=bagofwords
+APP_PORT=3000
+BOW_ENCRYPTION_KEY=<paste-the-key-from-step-1>
+# BOW_LICENSE_KEY=            # optional, enterprise features
+EOF
+
+# 3) Bring it up (app on http://localhost:3000, Postgres on :5432):
+docker compose -f docker-compose.dev.yaml up -d
+docker compose -f docker-compose.dev.yaml logs -f app   # watch migrations + startup
+# health check: curl -fsS http://localhost:3000/health
+
+# 4) Tear down (add -v to also drop the DB/uploads volumes):
+docker compose -f docker-compose.dev.yaml down
+```
+
+It mounts the repo-root `bow-config.yaml` read-only into the container and persists
+`uploads/`, `branding/`, `logs/`, and Postgres data in named volumes. The app
+container runs its own migrations on startup.
+
+### B. Docker — production compose (Caddy + SSL)
+
+`docker-compose.yaml` adds a `caddy:2.10-alpine` reverse proxy on 80/443 in front
+of the same app + Postgres. It needs `DOMAIN=` in `.env` and a `Caddyfile`:
+
+```bash
+# .env needs DOMAIN=yourdomain.com plus the same POSTGRES_*/BOW_ENCRYPTION_KEY vars
+docker compose up -d
+```
+
+### C. Single container (SQLite, no external DB) — from the README
+
+```bash
+docker run -p 3000:3000 bagofwords/bagofwords                       # SQLite (default)
+docker run -p 3000:3000 \
+  -e BOW_DATABASE_URL=postgresql://user:pw@host:5432/db \
+  bagofwords/bagofwords                                             # your own Postgres
+```
+
+### D. Build & run YOUR local code with Docker
+
+The root `Dockerfile` builds the app from this checkout (backend deps via
+`uv sync --frozen`, frontend build, Playwright chromium, a Rust `qvd2parquet`
+stage). Build context is the repo root:
+
+```bash
+docker build -t bagofwords-local .
+docker run -p 3000:3000 \
+  -e ENVIRONMENT=production \
+  -e BOW_ENCRYPTION_KEY=$(python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())") \
+  bagofwords-local
+```
+
+### E. From source, no Docker (best for iterating on this branch)
+
+Run backend and frontend as processes — this is exactly the stack the Playwright
+suite needs, so it's documented once under **Frontend E2E → "Prereqs — bring up
+the stack"** below (backend on `:8000` via `uv run python main.py`, frontend on
+`:3000`). This path runs your working-tree code and is what you want when
+validating a change like #584.
+
+> Compose paths A–C were **not** live-verified in the environment this doc was
+> written in (no Docker daemon). They are transcribed verbatim from
+> `docker-compose*.yaml` + README. The compose files themselves parse
+> (`docker compose config` → exit 0).
+
+---
+
+## Backend tests (pytest)
+
+### Toolchain & prereqs
+
+- Python **3.12** (the project requires `>=3.12,<3.15`).
+- **uv** is the package manager; deps and the lockfile live in
+  `backend/pyproject.toml` + `backend/uv.lock`. The test deps are the
+  `dev` optional-dependency group (`pytest`, `pytest-asyncio`,
+  `pytest-timeout`, `testcontainers[postgres,mysql]`, `aiosmtpd`, `ruff`, `ty`).
+- One-time setup: `cd backend && uv sync --frozen --extra dev` — this creates
+  `backend/.venv` (Python 3.12) with everything the suite needs. `uv run …`
+  then executes inside that venv. This is the same install CI uses.
+
+> ### ⚠️ If `uv` fails or panics (restricted sandboxes / many agent environments) — READ THIS FIRST
+>
+> In some sandboxed environments (including some CI and AI-agent shells) `uv`
+> **cannot run at all** — even `uv venv` or `uv sync` panics immediately, e.g.
+> `thread 'main' panicked … Tokio executor failed` / a Rust `system-configuration`
+> "Attempted to create a NULL object" crash (exit 101). This is `uv` failing to
+> initialize, **not** a network or lockfile problem, and it happens *before any
+> venv is created* — so any fallback that assumes `backend/.venv` already exists
+> will not help. Recover with a plain venv + editable install (no `uv` at all):
+>
+> ```bash
+> cd backend
+> # 1) Build a Python 3.12 venv WITHOUT uv. Use a real 3.12 interpreter —
+> #    `python3.12` (Homebrew/pyenv) is common; the system `python3` may be 3.9
+> #    and will NOT work (project requires >=3.12).
+> which python3.12 || echo "install Python 3.12 first (brew install python@3.12)"
+> python3.12 -m venv .venv
+> # 2) Bootstrap pip, then install BOTH the app runtime deps AND the dev/test
+> #    tools in one step from pyproject.toml (the '.[dev]' extra). ensurepip is
+> #    needed because a fresh venv here can lack pip.
+> .venv/bin/python -m ensurepip --upgrade
+> .venv/bin/python -m pip install -e ".[dev]"
+> ```
+>
+> After this, use `.venv/bin/python -m pytest …` everywhere the doc says
+> `uv run pytest …` (and `.venv/bin/python -m alembic …` / `.venv/bin/python main.py`
+> for the from-source app in "Run the system locally"). Do **not** just install
+> `pytest` alone — `tests/conftest.py` imports the whole app (sqlalchemy, fastapi,
+> alembic, pydantic, …) at collection time, so the ~40+ runtime deps must be
+> present too; `pip install -e ".[dev]"` provides both in one command.
+
+### The database option (`--db`) — defined in conftest, not pyproject
+
+`backend/pyproject.toml` has **no `[tool.pytest.ini_options]` section**. The
+custom `--db` flag and the `e2e`/`evals` markers are registered in
+`backend/tests/conftest.py` (`pytest_addoption` / `pytest_configure`). Choices:
+
+- `--db=sqlite` — **default**, fast, no Docker. Uses a file DB under `backend/db/`.
+- `--db=postgres` — spins up a throwaway `postgres:15` via **testcontainers**
+  (needs Docker running). CI runs this leg too; your test must pass on both.
+- `--db=external` — points at a pre-existing Postgres via `TEST_DATABASE_URL`
+  (for sandboxes without Docker).
+
+### Marker taxonomy
+
+Markers are applied by **explicit decorators on the tests themselves**
+(`@pytest.mark.e2e` in `tests/e2e/…`, `@pytest.mark.ai` in `tests/ai/…`) — not
+auto-applied by directory. Consequences:
+
+- `uv run pytest -m e2e` selects **only** the e2e-marked tests — it does **not**
+  pick up `tests/unit/` (those files carry no marker).
+- `uv run pytest tests/unit` selects the unit tests **by path** (they're plain,
+  unmarked tests).
+- `uv run pytest -m ai` selects the AI tests (the `ai` marker is used but not
+  registered in `pytest_configure`, so pytest emits a harmless "unknown marker"
+  warning — hidden by `--disable-warnings`).
+
+### Commands (from `backend/`)
+
+```bash
+# Unit — fast, self-contained (recommended default while developing):
+uv run pytest tests/unit -q --disable-warnings
+
+# E2E on SQLite (what CI runs, sqlite leg):
+uv run pytest -s -m e2e --db=sqlite --disable-warnings --timeout=600 --timeout-method=thread
+
+# E2E on Postgres (needs Docker; CI runs this leg too):
+uv run pytest -s -m e2e --db=postgres --disable-warnings --timeout=600 --timeout-method=thread
+
+# AI tests (needs a real key):
+OPENAI_API_KEY_TEST=sk-... uv run pytest -s -m ai --disable-warnings
+```
+
+Set `TESTING=true` when running anything by hand (per `tests/AGENTS.md`). CI also
+sets `ENVIRONMENT=production` so the app loads the repo-root `bow-config.yaml`.
+
+### What they depend on / mock
+
+Per `tests/AGENTS.md`: **mock at boundaries only** — LLM providers, OAuth/identity
+providers, external data-source drivers (ODBC/HTTP), SMTP, clocks. Everything
+inside the app (services, models, DB) runs **real** against SQLite/Postgres —
+that's what "e2e" means here. Seeding goes through `tests/fixtures/*`
+(`create_user`, `login_user`, `create_organization`, …), which call the real
+endpoints — not raw SQL.
+
+### Runtime & the per-test migration fixture
+
+`conftest.py` has an **autouse `run_migrations` fixture** that gives every test a
+fresh schema:
+
+- **SQLite**: the full alembic chain is replayed **once per session** into a
+  `*.template` file; each test then **clones that template** (a millisecond
+  filesystem copy) plus an engine-dispose. Fast per test, but it's paid ~890
+  times.
+- **Postgres/external**: the alembic chain is **replayed per test** (drops &
+  recreates `public`), so that leg keeps the migration chain under CI coverage.
+
+Measured on this machine: `tests/unit` = **890 passed, 17 failed, 9 skipped in
+~12m23s** on SQLite. The 17 failures are pre-existing test-drift, unrelated to
+any recent change. Budget ~12–15 min for the unit suite locally; the e2e suite is
+much larger (CI allots **90 min**).
+
+### Fully-explicit local command (proven in a restricted sandbox)
+
+If `uv run` isn't usable (e.g. a sandbox where `uv pip install` can't build),
+invoke the venv interpreter directly. This exact command was verified on this
+machine:
+
+```bash
+cd backend
+TESTING=true BOW_DATABASE_URL="sqlite:///db/app.db" \
+  .venv/bin/python -m pytest tests/unit \
+  -q --disable-warnings --timeout=120 --timeout-method=thread
+```
+
+`BOW_DATABASE_URL` here only satisfies pydantic config **at import time** (there's
+no `.env` in the tree); the conftest still overrides the actual test DB via
+`TEST_DATABASE_URL`. See Troubleshooting for the env gotchas.
+
+---
+
+## Frontend E2E (Playwright)
+
+`frontend/package.json` has **no `test` script and no vitest/jest** —
+`@playwright/test` (pinned `1.55.1`) is the only test framework, a devDependency.
+So the only automated frontend tests are the Playwright browser E2E specs.
+
+### Configs and what each is for
+
+| Config | Purpose | Run |
+|--------|---------|-----|
+| `playwright.config.ts` | **Main E2E suite.** `globalSetup` signs up the admin, then runs projects in order: `setup` → `onboarding` → (`members` seq. ∥ `features`) → `visibility`. `retries: 2`. | `npx playwright test` |
+| `playwright.i18n.config.ts` | Locale sweep — **unauthenticated only**, no `globalSetup` (registration is one-shot). `tests/i18n/`. | `npx playwright test --config=playwright.i18n.config.ts` |
+| `pw.empty.config.ts` | Screenshots of empty-state illustrations (`/evals`, `/scheduled-tasks`, `/queries`); no onboarding so pages stay empty. `tests/empty-states/*.shot.ts`. | `npx playwright test --config=pw.empty.config.ts` |
+| `pw.shot.config.ts` | Minimal screenshot runner for any `*.shot.ts`. | `npx playwright test --config=pw.shot.config.ts` |
+
+### Prereqs — you must bring up the stack first
+
+The main config's `baseURL` is `http://localhost:3000` (override with
+`PLAYWRIGHT_BASE_URL`). `globalSetup` (`tests/config/global.setup.ts`) navigates
+to `/users/sign-up`, registers an admin (`TEST_ADMIN`), and saves the session to
+`tests/config/admin.json` + `auth.json`. Specs then reuse that auth via the
+`adminPage`/`memberPage` fixtures in `tests/fixtures/auth.ts`. So before running
+you need: a **running frontend on :3000**, a **running backend on :8000** (the
+frontend proxies `/api` to it), and a **fresh DB** (registration is disabled once
+the first admin exists — a stale DB with an admin will make `globalSetup` fail).
+
+Mirror CI's bring-up (from `.github/workflows/e2e-tests.yml`, `playwright-tests`
+job):
+
+> **`uv` note:** the backend commands below use `uv run …`. If `uv` panics in your
+> environment, first do the from-scratch venv recovery in **"⚠️ If `uv` fails or
+> panics"** (top of _Backend tests_), then replace `uv run alembic` →
+> `.venv/bin/python -m alembic` and `uv run python main.py` → `.venv/bin/python main.py`.
+> `BOW_ENCRYPTION_KEY` is **not required** to start the app from source with
+> `ENVIRONMENT=production` (it loads `bow-config.yaml`); it's only needed for the
+> Docker `.env` paths. (Verified: backend comes up healthy from source without it.)
+
+```bash
+# 1) Backend on :8000 with a fresh SQLite DB
+cd backend
+mkdir -p db uploads/files uploads/branding
+TESTING=true ENVIRONMENT=production TEST_DATABASE_URL="sqlite:///db/playwright.db" \
+  uv run alembic upgrade head                    # or: .venv/bin/python -m alembic upgrade head
+TESTING=true ENVIRONMENT=production TEST_DATABASE_URL="sqlite:///db/playwright.db" \
+  uv run python main.py &                         # or: .venv/bin/python main.py  — wait for http://localhost:8000/health
+
+# 2) Frontend on :3000 (production build — routes precompiled, hydrates reliably)
+cd ../frontend
+yarn install --frozen-lockfile
+NODE_OPTIONS="--max-old-space-size=4096" yarn build
+node .output/server/index.mjs &                 # the @nuxt-alt/proxy in this server proxies /api → backend
+
+# 3) Run the suite
+npx playwright install --with-deps chromium
+npx playwright test --workers=2
+```
+
+`yarn dev` also works for local iteration, but CI deliberately uses the
+production build (`node .output/server/index.mjs`) because dev-mode on-demand Vite
+compilation thrashed under parallel workers and timed out page loads.
+
+### No frontend unit harness (honest gap)
+
+There is **no** vitest/jest setup, so Vue component logic, composables, and store
+logic are **not unit-tested today** — the only frontend coverage is end-to-end
+through the browser. If you want fast, isolated frontend unit tests, add a
+`vitest` devDependency + a `test` script in `frontend/package.json` and colocate
+`*.spec.ts` next to the units; that's the natural place to grow it.
+
+---
+
+## Automatic testing on every PR (CI)
+
+**One workflow gates PRs: `.github/workflows/e2e-tests.yml`** ("e2e tests"). Its
+triggers:
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+```
+
+So **every PR targeting `main`** runs it. Its jobs:
+
+| Job | Runs on a PR? | What it does |
+|-----|---------------|--------------|
+| `e2e-tests` (matrix `db: [sqlite, postgres]`, 90-min cap) | ✅ always | `uv sync --frozen --extra dev`, then `uv run pytest -s -m e2e --db=<sqlite\|postgres>`. Also runs `-m ai` **only if `backend/app/ai/**` changed** (via `dorny/paths-filter`), with `OPENAI_API_KEY_TEST` from secrets. Env: `TESTING=true`, `ENVIRONMENT=production`. **⚠️ The always-run `-m e2e` set itself includes ~7 LLM tests (`test_llm_providers.py`, `test_completion.py`) that need `OPENAI_API_KEY_TEST` too — so this job goes RED on any fork PR (no secrets); see the fork-PR note below.** |
+| `playwright-tests` (30-min cap) | ✅ always | Builds backend (`alembic upgrade head`, `python main.py`) on `sqlite:///db/playwright.db`, builds & serves the frontend production bundle, then `npx playwright test --workers=2`. Uploads `playwright-report` artifact on failure. |
+| `integration-data-sources` | ⚠️ same-repo PRs only | `pytest -v tests/integrations/ds_clients.py`. Guarded by `github.ref == 'refs/heads/main' || (pull_request && head.repo == base.repo)` — **skips on fork PRs** (no secrets). Needs `INTEGRATIONS_JSON_B64`. |
+| `integration-llms` | ⚠️ same-repo PRs only | Runs `tests/integrations/llm_clients.py` **only if `backend/app/ai/**` or `backend/app/models/llm*` changed**; skips google/bedrock/openai-reasoning cases. |
+| `dispatch-build` | ❌ never on a PR | `if: github.ref == 'refs/heads/main'`; `needs: [e2e-tests, playwright-tests, integration-data-sources, integration-llms]`. On a green **main push**, dispatches the Docker build. |
+
+Other workflows in `.github/workflows/` do **not** run on PRs: `integrations.yml`
+and `ds-integrations.yml` are `workflow_dispatch`-only (manual integration runs);
+`docker-image.yml` / `docker-image-branch.yml` / `release.yml` /
+`helm-publish.yaml` / `helm-test.yml` are release/build plumbing.
+
+> **Required-check note:** which of these jobs are *required to merge* is set in
+> GitHub **branch-protection**, which is not stored in the repo — I can't confirm
+> it from files. The workflow's own `dispatch-build.needs` shows the **intended**
+> gates are `e2e-tests` + `playwright-tests` (+ the integration jobs on main).
+
+### ⚠️ FORK / EXTERNAL PRs — `e2e-tests` will show RED, and it's (mostly) expected
+
+If the PR comes from a **fork** (an external contributor without write access), the
+CI behaves differently from a same-repo PR — don't be misled by the red:
+
+1. **CI waits for approval.** GitHub holds fork-PR workflow runs at
+   **`action_required`** until a maintainer clicks **"Approve and run"**. Until
+   then, *no checks appear at all* (not a hang — an approval gate).
+2. **`e2e-tests` goes RED even on a perfect PR.** GitHub does **not** pass repo
+   **secrets** to `pull_request` runs from a fork (a security boundary — and this
+   holds *even after* a maintainer approves the run). So
+   `${{ secrets.OPENAI_API_KEY_TEST }}` resolves empty, and the LLM tests in the
+   **always-run** `-m e2e` set — `backend/tests/e2e/test_llm_providers.py` and
+   `test_completion.py` — **hard-fail** via `pytest.fail("OPENAI_API_KEY_TEST is
+   not set")` (`backend/tests/fixtures/llm.py:138,194`; Anthropic at :99). Observed
+   on a real fork PR: **`7 failed, 725 passed, 35 skipped`** on *both* db legs —
+   all 7 are that missing-key error, none touch the change under test.
+   (Note the inconsistency: the Azure branch of the same fixture uses
+   `pytest.skip` when its key is absent — lines 12/15 — so it degrades gracefully;
+   OpenAI/Anthropic use `pytest.fail`. Making those `skip` too would let fork PRs
+   pass — tracked as a separate CI-robustness issue.)
+3. **What still validates the change on a fork PR:** `playwright-tests` runs the
+   full browser E2E and needs **no** LLM secret — so it *does* pass and is the
+   meaningful signal for a frontend change. And the other **725** `-m e2e` tests
+   pass; only the 7 secret-gated LLM tests fail.
+
+**So on a fork PR:** a red `e2e-tests` whose only failures are
+`OPENAI_API_KEY_TEST is not set` is **CI environment noise, not a real
+regression**. Confirm by reading the failing job log (the 7 test names + that
+exact message). A maintainer running it in a same-repo context (secrets present)
+would see them pass. To characterize a fork-PR e2e failure, pull the job log:
+`curl -sL -H "Authorization: token <tok>" .../actions/jobs/<job_id>/logs` and grep
+for `FAILED` / `is not set`.
+
+### KEY FINDING — `tests/unit` does NOT run in CI
+
+**No CI job runs the ~60 backend unit-test files.** The `e2e-tests` job selects
+`-m e2e`, which deselects everything in `tests/unit/` (those tests carry no
+marker). There is no `pytest tests/unit` (or bare `pytest`) step anywhere in the
+workflows. The unit suite is therefore only ever exercised when a developer runs
+it locally — a PR can go green with a broken unit test.
+
+If the goal is "tests run automatically for every PR" including unit tests, add a
+job to `e2e-tests.yml` mirroring the existing style. Concrete, paste-ready:
+
+```yaml
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      working-directory: ./backend
+      run: |
+        pip install uv
+        uv sync --frozen --extra dev
+    - name: Run unit tests
+      working-directory: ./backend
+      env:
+        TESTING: "true"
+        ENVIRONMENT: "production"
+      run: |
+        uv run pytest tests/unit -m "not e2e and not ai" \
+          --disable-warnings --timeout=120 --timeout-method=thread
+```
+
+(The unit suite is SQLite-only and self-contained, so it needs no `--db` matrix.)
+If you want it to be a *required* check, add it to branch protection and to
+`dispatch-build.needs`.
+
+---
+
+## Troubleshooting (symptom → fix)
+
+- **`ModuleNotFoundError` / deps missing when you run `python -m pytest`.**
+  The system `python3` (3.9 on this Mac) lacks the deps. Use the uv-managed venv:
+  `cd backend && uv sync --frozen --extra dev`, then `uv run pytest …` — or call
+  `backend/.venv/bin/python` (Python 3.12) directly.
+
+- **`uv` panics / won't run at all (before any venv exists).** Even `uv venv` /
+  `uv sync` crashes (`Tokio executor failed` / `system-configuration` NULL-object
+  panic, exit 101). This is `uv` failing to initialize, not an install problem.
+  → Use the no-`uv` from-scratch recovery in **"⚠️ If `uv` fails or panics"** at
+  the top of _Backend tests_: `python3.12 -m venv .venv` →
+  `.venv/bin/python -m ensurepip --upgrade` → `.venv/bin/python -m pip install -e ".[dev]"`.
+  Then substitute `.venv/bin/python -m …` for every `uv run …` command in this doc.
+
+- **`uv pip install` panics but a working `backend/.venv` ALREADY exists** (from a
+  prior successful `uv sync`) and is only missing the test tools. *Precondition:
+  the venv exists with the app runtime deps.* Then bootstrap just the test tools
+  without uv: `backend/.venv/bin/python -m ensurepip` then
+  `backend/.venv/bin/python -m pip install pytest pytest-asyncio pytest-timeout`.
+  (If the venv does **not** exist, use the from-scratch recovery above instead —
+  installing only pytest leaves `sqlalchemy`/`fastapi`/… missing and collection
+  fails at `conftest.py` import.)
+
+- **pydantic/config error at import (no `.env` in the tree).**
+  The app needs a DB URL at import time. Either export
+  `BOW_DATABASE_URL="sqlite:///db/app.db"`, or set `ENVIRONMENT=production` (like
+  CI) so it loads the repo-root `bow-config.yaml`. The conftest still overrides
+  the real test DB via `TEST_DATABASE_URL`.
+
+- **Unit suite takes ~12–15 min.** Expected. The autouse `run_migrations`
+  fixture rebuilds a fresh schema per test (SQLite clones a session template;
+  Postgres replays migrations). It's ~890 tests × sub-second setup. Narrow with a
+  path/`-k` filter while iterating: `uv run pytest tests/unit/test_clock.py`.
+
+- **`-m e2e` "runs nothing" from `tests/unit`.** Correct — unit tests are
+  unmarked; select them by path (`pytest tests/unit`), not by marker.
+
+- **Playwright `globalSetup` fails at sign-up.** The DB already has an admin
+  (registration is one-shot). Start from a fresh DB
+  (`rm backend/db/playwright.db && alembic upgrade head`), and confirm backend
+  `:8000/health` and frontend `:3000` are both up before running.
+
+- **Postgres leg hangs / `--db=postgres` errors.** It needs Docker running
+  (testcontainers). Without Docker, use `--db=sqlite` (default) or
+  `--db=external` with a pre-set `TEST_DATABASE_URL`.
+
+---
+
+## Adding a new test
+
+- **Backend unit** → `backend/tests/unit/test_<thing>.py`, plain unmarked test,
+  seed via `tests/fixtures/*`. Run: `uv run pytest tests/unit/test_<thing>.py`.
+- **Backend e2e** → `backend/tests/e2e/…/test_<flow>.py`, decorate with
+  `@pytest.mark.e2e`, drive the real HTTP surface through `test_client`. Must pass
+  on **both** `--db=sqlite` and `--db=postgres`.
+- **Backend ai** → `backend/tests/ai/`, `@pytest.mark.ai`, needs
+  `OPENAI_API_KEY_TEST`.
+- **Frontend E2E** → `frontend/tests/<feature>/<name>.spec.ts`, import `test` +
+  `expect` from `tests/fixtures/auth.ts` and use the `adminPage` / `memberPage`
+  fixtures (they carry the seeded auth). Put it under a directory the main config
+  routes into a project (`reports/`, `settings/`, `members/`, `visibility/`, …).
+
+Follow `backend/tests/AGENTS.md`: test the **contract** (status codes, error
+codes, invariants) not implementation details; cover **both admin and non-admin**
+for anything permission-adjacent; every test must be able to **fail** (break the
+code and watch it go red).
+
+**Failure-path coverage (the #584 class — "silent delete failures").** This
+codebase's recurring bug class is mutations that fail silently — a delete/update
+that returns OK while the backend rejected it. Cover the *unhappy* path
+explicitly, not just the success case:
+
+- Backend e2e: assert the mutation's **error contract** for the forbidden/invalid
+  case — e.g. a non-owner delete returns `403` (or the documented error code) and
+  the row **still exists** afterward — not just that the happy-path delete
+  returns 200.
+- Frontend Playwright: force the API to fail and assert the **UI surfaces it**
+  (a toast/error, no false "deleted" state). Intercept with `page.route`:
+
+  ```ts
+  await page.route('**/api/**/<resource>/*', route =>
+    route.fulfill({ status: 403, body: JSON.stringify({ detail: 'forbidden' }) }));
+  // trigger the delete, then assert an error is shown AND the item is still listed
+  ```
+
+  This is exactly the regression that a green happy-path-only suite lets through.

--- a/frontend/components/AgentAutomationSettings.vue
+++ b/frontend/components/AgentAutomationSettings.vue
@@ -72,6 +72,7 @@ import { useCan } from '~/composables/usePermissions'
 const props = defineProps<{ agentId: string | null }>()
 const emit = defineEmits<{ (e: 'saved'): void }>()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const canManage = computed(() => props.agentId ? useCan('manage', { type: 'data_source', id: props.agentId }) : false)
 
 const defaultForm = () => ({
@@ -120,9 +121,9 @@ async function saveSettings() {
   if (!id) return
   savingSettings.value = true; savedOk.value = false
   try {
-    await useMyFetch(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value } })
+    await useMyFetchStrict(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value } })
     savedOk.value = true; dirty.value = false; emit('saved'); await loadAutomation()
-  } catch (e) { toast.add({ title: 'Failed to save Self Learning settings', color: 'red' }) }
+  } catch (e) { toast.add({ title: 'Failed to save Self Learning settings', description: getErrorMessage(e), color: 'red' }) }
   finally { savingSettings.value = false }
 }
 

--- a/frontend/components/AgentConnectionsModal.vue
+++ b/frontend/components/AgentConnectionsModal.vue
@@ -254,7 +254,13 @@ async function testConnection(connectionId: string) {
     testResults.value[connectionId] = null
     try {
         const response = await useMyFetch(`/connections/${connectionId}/test`, { method: 'POST' })
-        testResults.value[connectionId] = (response.data as any)?.value || null
+        if (response.error.value) {
+            // The test request itself failed to run (network/server error) — distinct
+            // from a legitimate negative test result, which is rendered inline below.
+            toast.add({ title: 'Failed to test connection', description: getErrorMessage(response.error.value), color: 'red' })
+        } else {
+            testResults.value[connectionId] = (response.data as any)?.value || null
+        }
         await refresh()
     } finally {
         testingConnectionId.value = null

--- a/frontend/components/AgentConnectionsModal.vue
+++ b/frontend/components/AgentConnectionsModal.vue
@@ -203,6 +203,7 @@ const isOpen = computed({
 
 const route = useRoute()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const canManageConnections = computed(() => useCan('manage_connections'))
 
 const integration = inject<Ref<any>>('integration', ref(null))
@@ -296,13 +297,13 @@ async function linkConnection() {
     if (!selectedConnectionId.value || isLinking.value) return
     isLinking.value = true
     try {
-        await useMyFetch(`/data_sources/${dsId.value}/connections/${selectedConnectionId.value}`, { method: 'POST' })
+        await useMyFetchStrict(`/data_sources/${dsId.value}/connections/${selectedConnectionId.value}`, { method: 'POST' })
         toast.add({ title: 'Connection linked', color: 'green' })
         showLinkModal.value = false
         selectedConnectionId.value = null
         await refresh()
     } catch (e: any) {
-        toast.add({ title: 'Failed to link connection', color: 'red' })
+        toast.add({ title: 'Failed to link connection', description: getErrorMessage(e), color: 'red' })
     } finally {
         isLinking.value = false
     }
@@ -311,11 +312,11 @@ async function linkConnection() {
 async function unlinkConnection(connectionId: string) {
     if (!confirm('Unlink this connection?')) return
     try {
-        await useMyFetch(`/data_sources/${dsId.value}/connections/${connectionId}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/data_sources/${dsId.value}/connections/${connectionId}`, { method: 'DELETE' })
         toast.add({ title: 'Connection unlinked', color: 'green' })
         await refresh()
     } catch (e: any) {
-        toast.add({ title: 'Failed to unlink connection', color: 'red' })
+        toast.add({ title: 'Failed to unlink connection', description: getErrorMessage(e), color: 'red' })
     }
 }
 </script>

--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -204,6 +204,7 @@ import AgentAutomationSettings from '~/components/AgentAutomationSettings.vue'
 const { t } = useI18n()
 const router = useRouter()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const props = defineProps<{ agentId?: string; global?: boolean }>()
 const agentId = computed(() => props.agentId || '')
@@ -689,12 +690,12 @@ async function runAutomationNow() {
     if (!id) return
     triggering.value = true
     try {
-        await useMyFetch(`/data_sources/${id}/automation/run`, { method: 'POST' })
+        await useMyFetchStrict(`/data_sources/${id}/automation/run`, { method: 'POST' })
         toast.add({ title: 'Eval run started', color: 'green' })
         // Give the background loop a moment, then refresh history.
         setTimeout(() => { loadAutoRuns(); loadAutomation() }, 1500)
     } catch (e) {
-        toast.add({ title: 'Failed to start reliability check', color: 'red' })
+        toast.add({ title: 'Failed to start reliability check', description: getErrorMessage(e), color: 'red' })
     } finally { triggering.value = false }
 }
 

--- a/frontend/components/AgentSettingsPanel.vue
+++ b/frontend/components/AgentSettingsPanel.vue
@@ -631,7 +631,7 @@ async function updateMemberPermissions(m: MemberGrant, newPerms: string[]) {
 async function removeMember(m: MemberGrant) {
     const dsId = props.agentId
     try {
-        await useMyFetch(`/data_sources/${dsId}/members/${m.principal_id}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/data_sources/${dsId}/members/${m.principal_id}`, { method: 'DELETE' })
         members.value = members.value.filter(x => x.grant_id !== m.grant_id)
         toast?.add?.({ title: 'Member removed' })
     } catch {
@@ -705,7 +705,7 @@ async function addSelected() {
     try {
         await Promise.all(
             principals.map(p =>
-                useMyFetch(`/data_sources/${dsId}/members`, {
+                useMyFetchStrict(`/data_sources/${dsId}/members`, {
                     method: 'POST',
                     body: { ...p },
                 })

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -909,9 +909,15 @@ async function disconnect() {
   if (!props.connection?.id || disconnecting.value) return
   disconnecting.value = true
   try {
-    await useMyFetch(`/connections/${props.connection.id}/my-credentials`, { method: 'DELETE' })
-    emit('updated')
-    isOpen.value = false
+    const { error } = await useMyFetch(`/connections/${props.connection.id}/my-credentials`, { method: 'DELETE' })
+    if (error.value) {
+      testResult.value = { success: false, message: error.value.message || 'Failed to disconnect' }
+    } else {
+      emit('updated')
+      isOpen.value = false
+    }
+  } catch (e: any) {
+    testResult.value = { success: false, message: e.message || 'Failed to disconnect' }
   } finally {
     disconnecting.value = false
   }

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -751,12 +751,16 @@ async function reindex() {
   if (!props.connection?.id || reindexing.value) return
   reindexing.value = true
   try {
-    const { data } = await useMyFetch(`/connections/${props.connection.id}/reindex?force=true`, { method: 'POST' })
-    const result = (data as any).value
-    if (result?.indexing) {
-      indexingState.value = result.indexing as ConnectionIndexing
+    const { data, error } = await useMyFetch(`/connections/${props.connection.id}/reindex?force=true`, { method: 'POST' })
+    if (error.value) {
+      toast.add({ title: 'Failed to restart indexing', description: (error.value as any)?.data?.detail || (error.value as any)?.message, color: 'red' })
+    } else {
+      const result = (data as any).value
+      if (result?.indexing) {
+        indexingState.value = result.indexing as ConnectionIndexing
+      }
+      startPollingIfActive()
     }
-    startPollingIfActive()
   } finally {
     reindexing.value = false
   }

--- a/frontend/components/DashboardComponent.vue
+++ b/frontend/components/DashboardComponent.vue
@@ -221,6 +221,7 @@ import { themes } from '@/components/dashboard/themes'
     import { useDashboardTheme } from '@/components/dashboard/composables/useDashboardTheme'
 
     const toast = useToast();
+    const { getErrorMessage } = useErrorMessage();
     const instanceId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     const filterInstanceId = `dashboard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     const emit = defineEmits(['removeWidget', 'toggleSplitScreen', 'toggleArtifactView', 'editVisualization', 'visualizations-ready']);
@@ -1351,11 +1352,16 @@ import { themes } from '@/components/dashboard/themes'
             }
         } catch (e: any) {
             console.error('Failed to persist full layout', e)
+            throw e
         }
     }
     function schedulePersistFullLayout() {
         if (fullSaveTimer) window.clearTimeout(fullSaveTimer)
-        fullSaveTimer = window.setTimeout(() => { persistFullLayout() }, 180)
+        fullSaveTimer = window.setTimeout(() => {
+            persistFullLayout().catch((e: any) => {
+                toast.add({ title: 'Failed to save layout', description: getErrorMessage(e), color: 'red' });
+            });
+        }, 180)
     }
 
     const handleGridAdded = (event: Event, items: any[]) => {
@@ -1761,8 +1767,12 @@ import { themes } from '@/components/dashboard/themes'
                 delete editSnapshots.value[displayedWidgets.value[idx].id];
             }
             // Persist to layout
-            await persistFullLayout();
-            toast.add({ title: 'Text saved' });
+            try {
+                await persistFullLayout();
+                toast.add({ title: 'Text saved' });
+            } catch (e: any) {
+                toast.add({ title: 'Failed to save text', description: getErrorMessage(e), color: 'red' });
+            }
         } else {
             console.warn('Could not find widget to save:', widget.id);
             toast.add({ title: 'Error', description: 'Could not save text block', color: 'red' });

--- a/frontend/components/DashboardComponent.vue
+++ b/frontend/components/DashboardComponent.vue
@@ -1441,6 +1441,11 @@ import { themes } from '@/components/dashboard/themes'
                 window.dispatchEvent(new CustomEvent('dashboard:layout_changed', { detail: { report_id: props.report.id, action: 'removed', widget_id: widget.id, source: instanceId } }))
             } catch {}
         } catch (error: any) {
+            // Reset the reload-suppression guard on the throw path: it is set
+            // true before the awaited persistFullLayout() in the else-branch and
+            // reset false only after it, so a persist failure would otherwise
+            // strand it true and permanently disable the grid-reload watcher.
+            suppressGridReload = false;
             console.error(`Failed to remove from dashboard ${widget.id}`, error);
             toast.add({ title: 'Error', description: `Failed to remove from dashboard. ${error.message || ''}`, color: 'red' });
         }

--- a/frontend/components/DashboardComponent.vue
+++ b/frontend/components/DashboardComponent.vue
@@ -1606,6 +1606,8 @@ import { themes } from '@/components/dashboard/themes'
                     }
 
                     // Also patch active layout with the new text widget position
+                    let layoutSyncFailed = false;
+                    let layoutSyncError: any = null;
                     try {
                         const { error: layoutErr } = await useMyFetch(`/api/reports/${props.report.id}/layouts/active/blocks`, {
                             method: 'PATCH',
@@ -1614,9 +1616,15 @@ import { themes } from '@/components/dashboard/themes'
                         if (layoutErr.value) throw layoutErr.value;
                     } catch (e: any) {
                         console.error('Failed to add new text widget to layout', e);
+                        layoutSyncFailed = true;
+                        layoutSyncError = e;
                     }
 
-                    toast.add({ title: 'Text Widget Added' });
+                    if (layoutSyncFailed) {
+                        toast.add({ title: 'Widget saved, but its position could not be saved', description: getErrorMessage(layoutSyncError), color: 'orange' });
+                    } else {
+                        toast.add({ title: 'Text Widget Added' });
+                    }
                  } else { throw new Error("No data returned for new text widget"); }
             } catch (error: any) {
                 console.error('Failed to save new text widget', error);
@@ -1644,13 +1652,25 @@ import { themes } from '@/components/dashboard/themes'
             });
             if (error.value) throw error.value;
             // Keep layout in sync with latest position
+            let layoutSyncFailed = false;
+            let layoutSyncError: any = null;
             try {
-                await useMyFetch(`/api/reports/${props.report.id}/layouts/active/blocks`, {
+                const { error: layoutErr } = await useMyFetch(`/api/reports/${props.report.id}/layouts/active/blocks`, {
                     method: 'PATCH',
                     body: { blocks: [{ type: 'text_widget', text_widget_id: widget.id, x: widget.x, y: widget.y, width: widget.width, height: widget.height }] }
                 });
-            } catch {}
-            toast.add({ title: 'Text Widget Saved' });
+                if (layoutErr.value) throw layoutErr.value;
+            } catch (e: any) {
+                console.error('Failed to sync text widget position to layout', e);
+                layoutSyncFailed = true;
+                layoutSyncError = e;
+            }
+
+            if (layoutSyncFailed) {
+                toast.add({ title: 'Widget saved, but its position could not be saved', description: getErrorMessage(layoutSyncError), color: 'orange' });
+            } else {
+                toast.add({ title: 'Text Widget Saved' });
+            }
         } catch (e: any) {
             console.error('Failed to update text widget', e);
             toast.add({ title: 'Error', description: `Failed to update text widget. ${e?.message || ''}`, color: 'red' });

--- a/frontend/components/FileUploadComponent.vue
+++ b/frontend/components/FileUploadComponent.vue
@@ -95,6 +95,8 @@ const isDragging = ref(false);
   })
 
   const report_id = props.report_id;
+  const toast = useToast();
+  const { getErrorMessage } = useErrorMessage();
 
   const emit = defineEmits(['update:uploadedFiles']);
 
@@ -196,18 +198,23 @@ const isDragging = ref(false);
   }
 
   async function removeFile(file) {
+    const prevFiles = allFiles.value;
     // Remove the file from allFiles array
     allFiles.value = allFiles.value.filter(f => f !== file);
 
     // If the file has an ID and report_id exists, delete it from the server
     if (file.id && report_id) {
       try {
-        await useMyFetch(`/reports/${report_id}/files/${file.id}`, {
+        await useMyFetchStrict(`/reports/${report_id}/files/${file.id}`, {
           method: 'DELETE',
         });
       } catch (error) {
         console.error('Error deleting file from server:', error);
-        // Optionally, you can handle the error (e.g., show a notification to the user)
+        // Revert the optimistic removal so local state matches the server
+        allFiles.value = prevFiles;
+        emit('update:uploadedFiles', [...allFiles.value]);
+        toast.add({ title: 'Failed to delete file', description: getErrorMessage(error), color: 'red' });
+        return;
       }
     }
 

--- a/frontend/components/GitRepoModalComponent.vue
+++ b/frontend/components/GitRepoModalComponent.vue
@@ -1064,7 +1064,7 @@ async function updateSettings() {
     if (!connectedRepo.value?.id || !canEditSettings.value) return
 
     try {
-        await useMyFetch(`/git/repositories/${connectedRepo.value.id}`, {
+        await useMyFetchStrict(`/git/repositories/${connectedRepo.value.id}`, {
             method: 'PUT',
             body: {
                 auto_publish: editSettings.value.autoPublish,

--- a/frontend/components/GroupsManager.vue
+++ b/frontend/components/GroupsManager.vue
@@ -340,6 +340,7 @@ const props = defineProps<{
 
 const organizationId = props.organization.id
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 interface RoleInfo {
     id: string
@@ -551,14 +552,14 @@ async function updateGroupRoles(group: GroupData, selectedRoleIds: string[]) {
         const removed = currentAssignments.filter(a => !selectedRoleIds.includes(a.role_id))
 
         for (const roleId of added) {
-            await useMyFetch(`/organizations/${organizationId}/role-assignments`, {
+            await useMyFetchStrict(`/organizations/${organizationId}/role-assignments`, {
                 method: 'POST',
                 body: { role_id: roleId, principal_type: 'group', principal_id: group.id },
             })
         }
 
         for (const assignment of removed) {
-            await useMyFetch(`/organizations/${organizationId}/role-assignments/${assignment.id}`, {
+            await useMyFetchStrict(`/organizations/${organizationId}/role-assignments/${assignment.id}`, {
                 method: 'DELETE',
             })
         }
@@ -566,8 +567,7 @@ async function updateGroupRoles(group: GroupData, selectedRoleIds: string[]) {
         await loadGroupRoleAssignments()
         toast.add({ title: t('groupsManager.toastRolesUpdated'), color: 'green' })
     } catch (e: any) {
-        const detail = e?.data?.detail || e?.message || t('groupsManager.failedToUpdateRoles')
-        toast.add({ title: detail, color: 'red' })
+        toast.add({ title: getErrorMessage(e, t('groupsManager.failedToUpdateRoles')), color: 'red' })
     }
 }
 
@@ -695,7 +695,7 @@ async function addMember() {
         // memberToAdd is a composite "user:<id>" / "membership:<id>" value.
         const [kind, id] = memberToAdd.value.split(':')
         const body = kind === 'membership' ? { membership_id: id } : { user_id: id }
-        await useMyFetch(`/organizations/${organizationId}/groups/${selectedGroup.value.id}/members`, {
+        await useMyFetchStrict(`/organizations/${organizationId}/groups/${selectedGroup.value.id}/members`, {
             method: 'POST',
             body,
         })
@@ -707,15 +707,14 @@ async function addMember() {
             loadGroups(),
         ])
     } catch (e: any) {
-        const detail = e?.data?.detail || e?.message || t('groupsManager.failedToAddMember')
-        toast.add({ title: detail, color: 'red' })
+        toast.add({ title: getErrorMessage(e, t('groupsManager.failedToAddMember')), color: 'red' })
     }
 }
 
 async function removeMember(userId: string) {
     if (!selectedGroup.value) return
     try {
-        await useMyFetch(`/organizations/${organizationId}/groups/${selectedGroup.value.id}/members/${userId}`, {
+        await useMyFetchStrict(`/organizations/${organizationId}/groups/${selectedGroup.value.id}/members/${userId}`, {
             method: 'DELETE',
         })
         toast.add({ title: t('groupsManager.toastMemberRemoved'), color: 'green' })
@@ -724,8 +723,7 @@ async function removeMember(userId: string) {
             loadGroups(),
         ])
     } catch (e: any) {
-        const detail = e?.data?.detail || e?.message || t('groupsManager.failedToRemoveMember')
-        toast.add({ title: detail, color: 'red' })
+        toast.add({ title: getErrorMessage(e, t('groupsManager.failedToRemoveMember')), color: 'red' })
     }
 }
 

--- a/frontend/components/InstructionSuggestions.vue
+++ b/frontend/components/InstructionSuggestions.vue
@@ -155,6 +155,7 @@ const selectedIds = ref<Set<string>>(new Set())
 
 // Composables
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const drafts = computed<InstructionDraft[]>(() => {
   const rj = props.toolExecution?.result_json || {}
@@ -288,7 +289,7 @@ const handlePublishBuild = async () => {
       // Update each selected instruction's status to published within the build
       for (const draft of drafts.value) {
         if (!draft.id || !selectedIds.value.has(draft.id)) continue
-        await useMyFetch(`/instructions/${draft.id}`, {
+        await useMyFetchStrict(`/instructions/${draft.id}`, {
           method: 'PUT',
           body: {
             status: 'published',
@@ -298,24 +299,20 @@ const handlePublishBuild = async () => {
       }
 
       // Publish the build with selected instruction IDs (backend will filter out unselected)
-      const response = await useMyFetch(`/builds/${targetBuildId}/publish`, {
+      await useMyFetchStrict(`/builds/${targetBuildId}/publish`, {
         method: 'POST',
         body: {
           instruction_ids: selectedInstructionIds,
         }
       })
 
-      if (response.status.value === 'success') {
-        localPublishOverride.value = true
-        toast.add({ title: 'Success', description: 'Instructions published', color: 'green' })
-      } else {
-        throw new Error('Failed to publish build')
-      }
+      localPublishOverride.value = true
+      toast.add({ title: 'Success', description: 'Instructions published', color: 'green' })
     } else {
       // Fallback: No build found, just publish selected instructions directly
       for (const draft of drafts.value) {
         if (!draft.id || !selectedIds.value.has(draft.id)) continue
-        await useMyFetch(`/instructions/${draft.id}`, {
+        await useMyFetchStrict(`/instructions/${draft.id}`, {
           method: 'PUT',
           body: { status: 'published' }
         })
@@ -325,7 +322,7 @@ const handlePublishBuild = async () => {
     }
   } catch (error) {
     console.error('Error publishing instructions:', error)
-    toast.add({ title: 'Error', description: 'Failed to publish instructions', color: 'red' })
+    toast.add({ title: 'Error', description: getErrorMessage(error, 'Failed to publish instructions'), color: 'red' })
   } finally {
     isPublishingBuild.value = false
   }

--- a/frontend/components/IntegrationConnectionForm.vue
+++ b/frontend/components/IntegrationConnectionForm.vue
@@ -253,17 +253,17 @@ async function handleSubmit() {
     }
 
     if (isEditMode.value && props.editConnection) {
-      const response = await useMyFetch(`/connections/${props.editConnection.id}`, {
+      const response = await useMyFetchStrict(`/connections/${props.editConnection.id}`, {
         method: 'PUT',
         body: { name: form.name, credentials },
       })
-      if (response.data.value) emit('saved', response.data.value)
+      emit('saved', response.data.value)
       return
     }
 
     // Create the connection first — it has to exist before we can link an
     // agent to it.
-    const connResponse = await useMyFetch('/connections', {
+    const connResponse = await useMyFetchStrict('/connections', {
       method: 'POST',
       body: {
         name: form.name,
@@ -278,7 +278,13 @@ async function handleSubmit() {
     })
     const connection = connResponse.data.value as any
     if (!connection?.id) {
-      emit('saved', connection)
+      // Request succeeded but the response body is missing the expected
+      // shape — treat as a failure rather than silently reporting success.
+      toast.add({
+        title: 'Failed to create integration',
+        description: 'Unexpected response from server',
+        color: 'red',
+      })
       return
     }
 

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -1325,8 +1325,13 @@ const reloadTables = async (id: string) => {
   toast.add({ title: t('agentsPage.toastTablesReloaded'), color: 'green' })
 }
 const reloadTools = async (id: string) => {
-  for (const c of (agents.value.find(a => a.id === id)?.connections || [])) { try { await useMyFetch(`/connections/${c.id}/refresh-tools`, { method: 'POST' }) } catch {} }
-  agentLoaded.value.delete(id); await loadAgentMeta(id); toast.add({ title: t('agentsPage.toastToolsReloaded'), color: 'green' })
+  let lastError: any = null
+  for (const c of (agents.value.find(a => a.id === id)?.connections || [])) {
+    try { await useMyFetchStrict(`/connections/${c.id}/refresh-tools`, { method: 'POST' }) } catch (e: any) { lastError = e }
+  }
+  agentLoaded.value.delete(id); await loadAgentMeta(id)
+  if (lastError) toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(lastError), color: 'red' })
+  else toast.add({ title: t('agentsPage.toastToolsReloaded'), color: 'green' })
 }
 
 // ── File upload (per agent) ─────────────────────────────
@@ -1343,13 +1348,13 @@ const onUploadInput = async (e: Event) => {
   try {
     for (const file of files) {
       const fd = new FormData(); fd.append('file', file)
-      await useMyFetch(`/data_sources/${agentId}/files`, { method: 'POST', body: fd })
+      await useMyFetchStrict(`/data_sources/${agentId}/files`, { method: 'POST', body: fd })
     }
     toast.add({ title: t('agentsPage.toastUploaded', { n: files.length }), color: 'green' })
     agentLoaded.value.delete(agentId)
     await loadAgentMeta(agentId)
     if (!isOpen('files:' + agentId)) expand('files:' + agentId)
-  } catch (err: any) { toast.add({ title: t('agentsPage.toastUploadFailed'), description: err?.message, color: 'red' }) }
+  } catch (err: any) { toast.add({ title: t('agentsPage.toastUploadFailed'), description: getErrorMessage(err), color: 'red' }) }
   finally { uploadingAgent.value = null; if (input) input.value = '' }
 }
 
@@ -1562,8 +1567,10 @@ const customApiExistingConnections = computed(() => connections.value.filter((c:
 const onConnCreated = async (conn?: any) => {
   const aid = connTargetAgentId.value
   if (aid && conn?.id) {
-    try { await useMyFetch(`/data_sources/${aid}/connections/${conn.id}`, { method: 'POST' }) } catch {}
-    try { await useMyFetch(`/connections/${conn.id}/refresh-tools`, { method: 'POST' }) } catch {}
+    try {
+      await useMyFetchStrict(`/data_sources/${aid}/connections/${conn.id}`, { method: 'POST' })
+      await useMyFetchStrict(`/connections/${conn.id}/refresh-tools`, { method: 'POST' })
+    } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) }
   }
   showAddMCP.value = false; showAddCustomAPI.value = false; showAddConnection.value = false
   if (aid) { agentLoaded.value.delete(aid); await loadAgentMeta(aid); if (agentView.value?.agentId === aid) await refreshAgentDetail() }
@@ -1960,13 +1967,13 @@ const approveSuggestion = async (pb: any) => {
   if (!pb?.build_id) return
   approving.value = pb.build_id
   try {
-    await useMyFetch(`/api/builds/${pb.build_id}/publish`, { method: 'POST' })
+    await useMyFetchStrict(`/api/builds/${pb.build_id}/publish`, { method: 'POST' })
     toast.add({ title: t('agentsPage.toastApprovedPublished'), color: 'green' })
     closeDiff()
     await refreshLists()
     const fresh = allInstructions.value.find(i => i.id === detail.value?.id)
     if (fresh) openInstruction(fresh)
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) } finally { approving.value = null }
+  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) } finally { approving.value = null }
 }
 const discardSuggestion = async (pb: any) => {
   if (!pb?.build_id || discarding.value) return
@@ -2450,7 +2457,7 @@ const loadVersions = async (id: string) => {
 const restore = async (v: any) => {
   if (!detail.value) return
   if (!window.confirm(`Restore version v${v.version_number}? This creates a new version.`)) return
-  try { await useMyFetch(`/api/instructions/${detail.value.id}/versions/${v.id}/revert`, { method: 'POST' }); toast.add({ title: t('agentsPage.toastRestored', { n: v.version_number }), color: 'green' }); await refreshLists(); const fresh = allInstructions.value.find(i => i.id === detail.value?.id); if (fresh) openInstruction(fresh) } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) }
+  try { await useMyFetchStrict(`/api/instructions/${detail.value.id}/versions/${v.id}/revert`, { method: 'POST' }); toast.add({ title: t('agentsPage.toastRestored', { n: v.version_number }), color: 'green' }); await refreshLists(); const fresh = allInstructions.value.find(i => i.id === detail.value?.id); if (fresh) openInstruction(fresh) } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) }
 }
 
 // ── Display helpers ─────────────────────────────────────

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -921,6 +921,7 @@ import { useOrgSettings } from '~/composables/useOrgSettings'
 const h = useInstructionHelpers()
 const toast = useToast()
 const { t } = useI18n()
+const { getErrorMessage } = useErrorMessage()
 // Training mode is the per-agent admin capability: gated on the org setting plus
 // manage_instructions on the currently-open agent (a per-DS `manage` grant
 // implies it; full_admin bypasses). Mirrors the backend gate.
@@ -1080,7 +1081,7 @@ const setPrimaryForSingleAgent = async (makePrimary: boolean) => {
   if (!aid || !iid || settingPrimary.value) return
   settingPrimary.value = true
   try {
-    await useMyFetch(`/data_sources/${aid}`, { method: 'PUT', body: { primary_instruction_id: makePrimary ? iid : null } })
+    await useMyFetchStrict(`/data_sources/${aid}`, { method: 'PUT', body: { primary_instruction_id: makePrimary ? iid : null } })
     const d = detail.value as any
     if (makePrimary) {
       if (!(d.primary_for || []).some((x: any) => String(x.id) === String(aid))) {
@@ -1092,7 +1093,7 @@ const setPrimaryForSingleAgent = async (makePrimary: boolean) => {
     // Keep the agent panel in sync if it's open for this agent.
     if (agentView.value?.agentId === aid) await refreshAgentDetail()
     toast.add({ title: t('agentsPage.toastSaved'), color: 'green' })
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) } finally { settingPrimary.value = false }
+  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) } finally { settingPrimary.value = false }
 }
 
 // right-pane panel for Tables/Tools/Evals/Settings
@@ -1168,11 +1169,11 @@ const onAgentPublishUpdated = (val: { publish_status: string; reliability_status
 const setAgentPublic = async (val: boolean) => {
   const id = agentView.value?.agentId; if (!id) return
   try {
-    await useMyFetch(`/data_sources/${id}`, { method: 'PUT', body: { is_public: val } })
+    await useMyFetchStrict(`/data_sources/${id}`, { method: 'PUT', body: { is_public: val } })
     if (agentDetail.value) agentDetail.value.is_public = val
     const a = agents.value.find(x => x.id === id); if (a) { a.is_public = val; agents.value = [...agents.value] }
     toast.add({ title: val ? t('agentsPage.toastMadePublic') : t('agentsPage.toastMadePrivate'), color: 'green' })
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) }
+  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) }
 }
 const openAgent = async (id: string) => {
   clearRightPane()
@@ -1221,7 +1222,7 @@ const saveDesc = async () => {
   const id = agentView.value?.agentId; if (!id) return
   const v = descForm.value
   if (v === (agentDetail.value?.description || '')) return
-  try { await useMyFetch(`/data_sources/${id}`, { method: 'PUT', body: { description: v } }); if (agentDetail.value) agentDetail.value.description = v; toast.add({ title: t('agentsPage.toastSaved'), color: 'green' }) } catch { toast.add({ title: t('agentsPage.toastSaveDescFailed'), color: 'red' }) }
+  try { await useMyFetchStrict(`/data_sources/${id}`, { method: 'PUT', body: { description: v } }); if (agentDetail.value) agentDetail.value.description = v; toast.add({ title: t('agentsPage.toastSaved'), color: 'green' }) } catch (e: any) { toast.add({ title: t('agentsPage.toastSaveDescFailed'), description: getErrorMessage(e), color: 'red' }) }
 }
 // primary instruction inline edit (clean editor: title + body + save/cancel)
 const primaryDraft = reactive<{ title: string; text: string }>({ title: '', text: '' })
@@ -1231,10 +1232,10 @@ const onSelectExistingPrimary = async (instruction: any) => {
   const newId = instruction?.id; const aid = agentView.value?.agentId
   if (!newId || !aid) return
   try {
-    await useMyFetch(`/data_sources/${aid}`, { method: 'PUT', body: { primary_instruction_id: newId } })
+    await useMyFetchStrict(`/data_sources/${aid}`, { method: 'PUT', body: { primary_instruction_id: newId } })
     await refreshAgentDetail()
     toast?.add?.({ title: t('agentsPage.toastSaved'), description: t('agentsPage.toastPrimaryUpdated') })
-  } catch (e: any) { toast?.add?.({ title: t('agentsPage.toastError'), description: String(e?.message || e), color: 'red' }) }
+  } catch (e: any) { toast?.add?.({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) }
 }
 const startEditPrimary = () => { const p = agentDetail.value?.primary_instruction; primaryDraft.title = p?.title || ''; primaryDraft.text = p?.text || ''; editingPrimary.value = true; creatingPrimary.value = false }
 const cancelPrimary = () => { creatingPrimary.value = false; editingPrimary.value = false }
@@ -1245,16 +1246,16 @@ const savePrimary = async () => {
   try {
     if (editingPrimary.value && agentDetail.value?.primary_instruction?.id) {
       const piid = agentDetail.value.primary_instruction.id
-      await useMyFetch(`/api/instructions/${piid}`, { method: 'PUT', body: { title: primaryDraft.title || null, text: primaryDraft.text } })
+      await useMyFetchStrict(`/api/instructions/${piid}`, { method: 'PUT', body: { title: primaryDraft.title || null, text: primaryDraft.text } })
     } else {
-      const { data } = await useMyFetch<any>('/api/instructions', { method: 'POST', body: { title: primaryDraft.title || null, text: primaryDraft.text, status: 'published', load_mode: 'always', category: 'general', data_source_ids: id ? [id] : [] } })
+      const { data } = await useMyFetchStrict<any>('/api/instructions', { method: 'POST', body: { title: primaryDraft.title || null, text: primaryDraft.text, status: 'published', load_mode: 'always', category: 'general', data_source_ids: id ? [id] : [] } })
       const newId = (data.value as any)?.id
-      if (newId && id) await useMyFetch(`/data_sources/${id}`, { method: 'PUT', body: { primary_instruction_id: newId } })
+      if (newId && id) await useMyFetchStrict(`/data_sources/${id}`, { method: 'PUT', body: { primary_instruction_id: newId } })
     }
     creatingPrimary.value = false; editingPrimary.value = false
     await Promise.all([refreshAgentDetail(), fetchAll()])
     toast.add({ title: t('agentsPage.toastSaved'), color: 'green' })
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) } finally { primarySaving.value = false }
+  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) } finally { primarySaving.value = false }
 }
 // conversation starters edit
 const starterTitle = (cs: any) => typeof cs === 'string' ? (cs.split('\n')[0] || '') : (cs?.title || cs?.prompt || '')
@@ -1297,17 +1298,23 @@ const saveStarters = async () => {
     // Replace-all: drop this agent's existing starter prompts, recreate from the editor.
     const { data: existing } = await useMyFetch(`/prompts?data_source_id=${id}`)
     for (const p of ((existing.value as any)?.prompts || [])) {
-      await useMyFetch(`/prompts/${p.id}`, { method: 'DELETE' })
+      await useMyFetchStrict(`/prompts/${p.id}`, { method: 'DELETE' })
     }
     for (const text of conversation_starters) {
-      await useMyFetch(`/prompts`, { method: 'POST', body: {
+      await useMyFetchStrict(`/prompts`, { method: 'POST', body: {
         text, title: (text.split('\n')[0] || '').slice(0, 60),
         scope: 'agent', is_starter: true, data_source_ids: [id],
       } })
     }
     await refreshStarterPrompts(); showEditStarters.value = false; toast.add({ title: t('agentsPage.toastSaved'), color: 'green' })
   }
-  catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) } finally { savingStarters.value = false }
+  catch (e: any) {
+    // A failure partway through can leave the backend with some starters
+    // deleted/created already — resync the displayed list to the real state
+    // instead of leaving stale rows in `starterPrompts`.
+    await refreshStarterPrompts()
+    toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' })
+  } finally { savingStarters.value = false }
 }
 // reload tables / tools from the tree
 const tablesRefreshKey = ref(0)
@@ -2214,12 +2221,12 @@ const deleteFile = async (agentId: string, f: any) => {
   if (!agentId || !f?.id) return
   if (!window.confirm(`Delete "${f.filename}"? This can't be undone.`)) return
   try {
-    await useMyFetch(`/data_sources/${agentId}/files/${f.id}`, { method: 'DELETE' })
+    await useMyFetchStrict(`/data_sources/${agentId}/files/${f.id}`, { method: 'DELETE' })
     agentFiles.value[agentId] = (agentFiles.value[agentId] || []).filter((x: any) => x.id !== f.id)
     agentFiles.value = { ...agentFiles.value }
     if (previewFile.value?.id === f.id) closePreview()
     toast.add({ title: t('agentsPage.toastFileDeleted'), color: 'green' })
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) }
+  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: getErrorMessage(e), color: 'red' }) }
 }
 const openFile = async (f: any, agentId?: string) => {
   detail.value = null; creating.value = false; editing.value = false; selectedId.value = null

--- a/frontend/components/LLMsComponent.vue
+++ b/frontend/components/LLMsComponent.vue
@@ -243,6 +243,11 @@ const toggleModel = async (modelId: string, enabled: boolean) => {
         });
     }
     else {
+        // Revert the optimistic v-model flip on the toggle.
+        const model = models.value.find(m => m.id === modelId);
+        if (model) {
+            model.is_enabled = !enabled;
+        }
         toast.add({
             title: 'Error',
             description: 'Could not update model',

--- a/frontend/components/ManageConnectionsModal.vue
+++ b/frontend/components/ManageConnectionsModal.vue
@@ -168,6 +168,9 @@ const isOpen = computed({
   set: (value) => emit('update:modelValue', value)
 })
 
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
+
 const connections = ref<any[]>([])
 const loading = ref(false)
 const testingId = ref<string | null>(null)
@@ -273,10 +276,12 @@ async function executeDelete() {
   if (!deletingConnection.value) return
   deleting.value = true
   try {
-    await useMyFetch(`/connections/${deletingConnection.value.id}`, { method: 'DELETE' })
+    await useMyFetchStrict(`/connections/${deletingConnection.value.id}`, { method: 'DELETE' })
     showDeleteConfirm.value = false
     await fetchConnections()
     emit('updated')
+  } catch (e: any) {
+    toast.add({ title: 'Failed to delete connection', description: getErrorMessage(e), color: 'red' })
   } finally {
     deleting.value = false
   }

--- a/frontend/components/McpModal.vue
+++ b/frontend/components/McpModal.vue
@@ -178,6 +178,7 @@ const isOpen = computed({
 
 const toast = useToast()
 const { t } = useI18n()
+const { getErrorMessage } = useErrorMessage()
 
 interface ApiKey {
     id: string
@@ -270,11 +271,11 @@ async function createApiKey() {
 async function deleteApiKey(key: ApiKey) {
     if (!confirm(t('mcpServerModal.confirmDeleteKey'))) return
     try {
-        await useMyFetch(`/api/api_keys/${key.id}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/api/api_keys/${key.id}`, { method: 'DELETE' })
         apiKeys.value = apiKeys.value.filter(k => k.id !== key.id)
         toast.add({ title: t('mcpServerModal.toastKeyDeleted'), icon: 'i-heroicons-check-circle', color: 'green' })
     } catch (e) {
-        toast.add({ title: t('mcpServerModal.toastKeyDeleteFailed'), icon: 'i-heroicons-x-circle', color: 'red' })
+        toast.add({ title: t('mcpServerModal.toastKeyDeleteFailed'), description: getErrorMessage(e), icon: 'i-heroicons-x-circle', color: 'red' })
     }
 }
 

--- a/frontend/components/MembersComponent.vue
+++ b/frontend/components/MembersComponent.vue
@@ -681,6 +681,7 @@ const organizationId = props.organization.id
 const members = ref<Member[]>([])
 const searchQuery = ref('')
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const isLoading = ref(true)
 const availableRoles = ref<{ id: string; name: string; label: string }[]>([])
 const groups = ref<GroupData[]>([])
@@ -1068,7 +1069,7 @@ async function updateMemberRoles(member: any, selectedRoleIds: string[]) {
         const removed = currentRoleIds.filter((id: string) => !selectedRoleIds.includes(id))
 
         for (const roleId of added) {
-            await useMyFetch(`/organizations/${organizationId}/role-assignments`, {
+            await useMyFetchStrict(`/organizations/${organizationId}/role-assignments`, {
                 method: 'POST',
                 body: { role_id: roleId, principal_type: principalType, principal_id: principalId },
             })
@@ -1081,16 +1082,9 @@ async function updateMemberRoles(member: any, selectedRoleIds: string[]) {
             if (assignments.value) {
                 for (const assignment of assignments.value as any[]) {
                     if (removed.includes(assignment.role_id)) {
-                        const resp = await useMyFetch(`/organizations/${organizationId}/role-assignments/${assignment.id}`, {
+                        await useMyFetchStrict(`/organizations/${organizationId}/role-assignments/${assignment.id}`, {
                             method: 'DELETE',
                         })
-                        if (resp.error?.value) {
-                            const detail = resp.error.value.data?.detail || t('settings.members.failedToRemoveRole')
-                            toast.add({ title: detail, color: 'red' })
-                            const membersResp = await useMyFetch(`/organizations/${organizationId}/members`)
-                            members.value = membersResp.data.value as Member[]
-                            return
-                        }
                     }
                 }
             }
@@ -1104,8 +1098,14 @@ async function updateMemberRoles(member: any, selectedRoleIds: string[]) {
 
         toast.add({ title: t('settings.members.rolesUpdated'), color: 'green' })
     } catch (error: any) {
-        const detail = error?.data?.detail || error?.message || t('settings.members.failedToUpdateRoles')
-        toast.add({ title: detail, color: 'red' })
+        toast.add({ title: getErrorMessage(error, t('settings.members.failedToUpdateRoles')), color: 'red' })
+        // A partial failure (e.g. some role assignments succeeded before this
+        // one failed) can leave the server ahead of local state; resync from
+        // the server rather than leaving a stale role list displayed.
+        const membersResp = await useMyFetch(`/organizations/${organizationId}/members`)
+        if (membersResp.data.value) {
+            members.value = membersResp.data.value as Member[]
+        }
     }
 }
 

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -221,6 +221,9 @@ const emit = defineEmits<{
   (e: 'finished', dsId: string): void
 }>()
 
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
+
 const isOpen = computed({
   get: () => props.modelValue,
   set: (v) => emit('update:modelValue', v),
@@ -399,16 +402,16 @@ async function handleSave() {
 
     if (draftInstructionId.value) {
       if (text) {
-        await useMyFetch(`/instructions/${draftInstructionId.value}`, {
+        await useMyFetchStrict(`/instructions/${draftInstructionId.value}`, {
           method: 'PUT',
           body: { text, status: 'published' },
         })
         primaryInstructionId = draftInstructionId.value
       } else {
-        await useMyFetch(`/instructions/${draftInstructionId.value}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/instructions/${draftInstructionId.value}`, { method: 'DELETE' })
       }
     } else if (text) {
-      const { data } = await useMyFetch('/instructions/global', {
+      const { data } = await useMyFetchStrict('/instructions/global', {
         method: 'POST',
         body: {
           text,
@@ -424,7 +427,7 @@ async function handleSave() {
     }
 
     if (primaryInstructionId) {
-      await useMyFetch(`/data_sources/${dsId.value}`, {
+      await useMyFetchStrict(`/data_sources/${dsId.value}`, {
         method: 'PUT',
         body: { primary_instruction_id: primaryInstructionId },
       })
@@ -433,6 +436,8 @@ async function handleSave() {
     const created = dsId.value
     isOpen.value = false
     emit('finished', created)
+  } catch (e: any) {
+    toast.add({ title: 'Failed to save agent context', description: getErrorMessage(e), color: 'red' })
   } finally {
     saving.value = false
   }

--- a/frontend/components/OAuthClientsModal.vue
+++ b/frontend/components/OAuthClientsModal.vue
@@ -219,6 +219,7 @@ interface OAuthClient {
 
 const toast = useToast()
 const { t } = useI18n()
+const { getErrorMessage } = useErrorMessage()
 
 const loading = ref(true)
 const clients = ref<OAuthClient[]>([])
@@ -374,13 +375,13 @@ async function rotate(client: OAuthClient) {
 async function remove(client: OAuthClient) {
   if (!confirm(t('settings.integrations.channels.oauth.confirmDelete', { name: client.name }))) return
   try {
-    await useMyFetch(`/api/oauth/clients/${client.id}`, { method: 'DELETE' })
+    await useMyFetchStrict(`/api/oauth/clients/${client.id}`, { method: 'DELETE' })
     clients.value = clients.value.filter(c => c.id !== client.id)
     delete freshSecretByClientId.value[client.client_id]
     toast.add({ title: t('settings.integrations.channels.oauth.deletedToast'), icon: 'i-heroicons-check-circle', color: 'green' })
     emit('updated')
   } catch (e) {
-    toast.add({ title: t('settings.integrations.channels.oauth.failedDelete'), icon: 'i-heroicons-x-circle', color: 'red' })
+    toast.add({ title: t('settings.integrations.channels.oauth.failedDelete'), description: getErrorMessage(e), icon: 'i-heroicons-x-circle', color: 'red' })
   }
 }
 

--- a/frontend/components/ServiceAccountsManager.vue
+++ b/frontend/components/ServiceAccountsManager.vue
@@ -156,6 +156,7 @@ const props = defineProps<{ organization: { id: string; name?: string } }>()
 const organizationId = props.organization.id
 const { t } = useI18n()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const accounts = ref<ServiceAccount[]>([])
 const roles = ref<Role[]>([])
@@ -240,20 +241,32 @@ watch(showKeysModal, (open) => { if (!open) newKey.value = null })
 
 async function revokeKey(keyId: string) {
     if (!activeAccount.value) return
-    await useMyFetch(`/service_accounts/${activeAccount.value.id}/keys/${keyId}`, { method: 'DELETE' })
-    await openKeys(activeAccount.value)
-    await loadAccounts()
+    try {
+        await useMyFetchStrict(`/service_accounts/${activeAccount.value.id}/keys/${keyId}`, { method: 'DELETE' })
+        await openKeys(activeAccount.value)
+        await loadAccounts()
+    } catch (e: any) {
+        toast.add({ title: getErrorMessage(e, 'Could not revoke key'), color: 'red' })
+    }
 }
 
 async function setDisabled(sa: ServiceAccount, disabled: boolean) {
-    await useMyFetch(`/service_accounts/${sa.id}`, { method: 'PATCH', body: { disabled } })
-    await loadAccounts()
+    try {
+        await useMyFetchStrict(`/service_accounts/${sa.id}`, { method: 'PATCH', body: { disabled } })
+        await loadAccounts()
+    } catch (e: any) {
+        toast.add({ title: getErrorMessage(e, disabled ? 'Could not disable service account' : 'Could not enable service account'), color: 'red' })
+    }
 }
 
 async function deleteAccount(sa: ServiceAccount) {
-    await useMyFetch(`/service_accounts/${sa.id}`, { method: 'DELETE' })
-    toast.add({ title: t('serviceAccounts.deleted'), color: 'green' })
-    await loadAccounts()
+    try {
+        await useMyFetchStrict(`/service_accounts/${sa.id}`, { method: 'DELETE' })
+        toast.add({ title: t('serviceAccounts.deleted'), color: 'green' })
+        await loadAccounts()
+    } catch (e: any) {
+        toast.add({ title: getErrorMessage(e, 'Could not delete service account'), color: 'red' })
+    }
 }
 
 function rowActions(sa: ServiceAccount) {

--- a/frontend/components/automations/TriggersTab.vue
+++ b/frontend/components/automations/TriggersTab.vue
@@ -221,6 +221,7 @@ import PromptBoxV2 from '~/components/prompt/PromptBoxV2.vue'
 
 const toast = useToast()
 const { t } = useI18n()
+const { getErrorMessage } = useErrorMessage()
 
 const triggers = ref<any[]>([])
 const models = ref<any[]>([])
@@ -355,9 +356,14 @@ async function rotate(trig: any) {
 
 async function removeTrigger(trig: any) {
   if (!confirm(t('triggers.deleteConfirm'))) return
-  await useMyFetch(`/triggers/${trig.id}`, { method: 'DELETE' })
-  triggers.value = triggers.value.filter((x: any) => x.id !== trig.id)
-  toast.add({ title: t('triggers.toastDeleted'), color: 'green' })
+  try {
+    await useMyFetchStrict(`/triggers/${trig.id}`, { method: 'DELETE' })
+    triggers.value = triggers.value.filter((x: any) => x.id !== trig.id)
+    toast.add({ title: t('triggers.toastDeleted'), color: 'green' })
+  } catch (e) {
+    console.error('delete trigger failed', e)
+    toast.add({ title: t('common.error'), description: getErrorMessage(e), color: 'red' })
+  }
 }
 
 async function toggleRuns(trig: any) {

--- a/frontend/components/datasources/TablesSelector.vue
+++ b/frontend/components/datasources/TablesSelector.vue
@@ -1042,7 +1042,7 @@ async function onSave() {
     }
 
     if (toActivate.length > 0 || toDeactivate.length > 0) {
-      await useMyFetch(`/data_sources/${props.dsId}/update_tables_status`, {
+      await useMyFetchStrict(`/data_sources/${props.dsId}/update_tables_status`, {
         method: 'PUT',
         body: {
           activate: toActivate,

--- a/frontend/components/datasources/TablesSelector.vue
+++ b/frontend/components/datasources/TablesSelector.vue
@@ -1084,7 +1084,17 @@ async function onRefresh() {
 
   try {
     if (endpointForSchema() === 'full_schema') {
-      await useMyFetch(`/data_sources/${props.dsId}/refresh_schema`, { method: 'GET' })
+      const { error } = await useMyFetch(`/data_sources/${props.dsId}/refresh_schema`, { method: 'GET' })
+      if (error.value) {
+        // Bail out before clearing tracking below — a failed refresh must not
+        // wipe the user's unsaved bulk-selection state.
+        toast.add({
+          title: 'Refresh failed',
+          description: (error.value as any)?.data?.detail || (error.value as any)?.message || 'Failed to refresh schema',
+          color: 'red'
+        })
+        return
+      }
     }
 
     // Clear all tracking on refresh
@@ -1095,8 +1105,6 @@ async function onRefresh() {
     page.value = 1
 
     await fetchTables()
-  } catch (e) {
-    // Swallow refresh errors
   } finally {
     refreshing.value = false
   }

--- a/frontend/components/datasources/ToolsSelector.vue
+++ b/frontend/components/datasources/ToolsSelector.vue
@@ -200,6 +200,7 @@ const props = defineProps<{
 defineEmits(['add-mcp', 'add-custom-api', 'edit-connection', 'delete-connection'])
 
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const loading = ref(false)
 const refreshingConn = ref<string | null>(null)
@@ -248,11 +249,11 @@ async function refreshTools(connectionId: string) {
     // Refresh the underlying ConnectionTool discovery (org-level), then
     // reload the agent-scoped view so the new tools show up with their
     // current effective state.
-    await useMyFetch(`/connections/${connectionId}/refresh-tools`, { method: 'POST' })
+    await useMyFetchStrict(`/connections/${connectionId}/refresh-tools`, { method: 'POST' })
     await loadAllTools()
     toast.add({ title: 'Tools refreshed', color: 'green' })
   } catch (e) {
-    toast.add({ title: 'Failed to refresh tools', color: 'red' })
+    toast.add({ title: 'Failed to refresh tools', description: getErrorMessage(e), color: 'red' })
   } finally {
     refreshingConn.value = null
   }

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -198,6 +198,7 @@ const selectedConnectDs = ref<DataSource | null>(null)
 const signIn = useConnectionSignIn()
 const { t } = useI18n()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 // Mirror the agents page: if the source's pending-sign-in connection has
 // OAuth as its only user auth mode, redirect straight to the provider
@@ -402,16 +403,18 @@ function isServiceAccount(ds: any) {
 }
 
 function toggleAutoMode() {
+    const previousSelection = [...internalSelectedDataSources.value]
     if (isAutoMode.value) {
         internalSelectedDataSources.value = []
     } else {
         internalSelectedDataSources.value = [...visibleDataSources.value]
     }
     handleSelectionChange()
-    persistSelectionIfReport()
+    persistSelectionIfReport(previousSelection)
 }
 
 function toggleDataSource(ds: DataSource) {
+    const previousSelection = [...internalSelectedDataSources.value]
     if (isAutoMode.value) {
         // Exit auto: start fresh with only this source selected
         internalSelectedDataSources.value = [ds]
@@ -425,7 +428,7 @@ function toggleDataSource(ds: DataSource) {
     }
     handleSelectionChange()
     // If we are in a report context, persist selection at report level immediately
-    persistSelectionIfReport()
+    persistSelectionIfReport(previousSelection)
 }
 
 onMounted(() => {
@@ -486,17 +489,22 @@ watch(() => props.selectedDataSources, (newVal: any[]) => {
     internalSelectedDataSources.value = mapped as any
 }, { immediate: true, deep: true })
 
-async function persistSelectionIfReport() {
+async function persistSelectionIfReport(previousSelection?: DataSource[]) {
+    if (!props.reportId) return
     try {
-        if (!props.reportId) return
         const ids = internalSelectedDataSources.value.map((x: any) => x.id)
-        await useMyFetch(`/reports/${props.reportId}`, {
+        await useMyFetchStrict(`/reports/${props.reportId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ data_sources: ids })
         })
     } catch (e) {
-        console.error('Failed to update report data sources:', e)
+        // Revert the optimistic selection + re-emit so the parent stays in sync.
+        if (previousSelection) {
+            internalSelectedDataSources.value = previousSelection
+            handleSelectionChange()
+        }
+        toast.add({ title: 'Error', description: getErrorMessage(e) || 'Failed to update data sources', color: 'red' })
     }
 }
 const dataTooltip = computed<string>(() => {

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -586,6 +586,9 @@ const props = defineProps({
 
 const emit = defineEmits(['submitCompletion','stopGeneration','update:modelValue','viewDashboard','scrollToMessage','editScheduledPrompt','deleteScheduledPrompt','scheduledPromptSaved','toggleScheduledPrompt','editTrainingInstruction','approveTrainingBuild','discardTrainingBuild','discardTrainingInstruction','openInstructions','update:selectedDataSources','update:mode'])
 
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
+
 // Whether the current user may publish/resolve instruction changes. Gates the
 // batch Accept/Reject controls; the server enforces the real permission.
 // Resource-scoped to the selected agent(s): an agent admin (per-DS `manage`,
@@ -1039,24 +1042,28 @@ function selectModel(modelId: string) {
     selectedModel.value = modelId
 }
 
-async function persistMode() {
+async function persistMode(previousMode: 'chat' | 'deep' | 'training') {
     // Only persist for reports, not landing page
     if (!props.report_id) return
     try {
-        await useMyFetch(`/reports/${props.report_id}`, {
+        await useMyFetchStrict(`/reports/${props.report_id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ mode: mode.value })
         })
     } catch (e) {
-        console.error('Failed to persist mode:', e)
+        // Revert the optimistic mode flip on failure.
+        mode.value = previousMode
+        emit('update:mode', previousMode)
+        toast.add({ title: 'Error', description: getErrorMessage(e) || 'Failed to persist mode', color: 'red' })
     }
 }
 
 function selectMode(m: 'chat' | 'deep' | 'training') {
+    const previousMode = mode.value
     mode.value = m
     emit('update:mode', m)
-    persistMode()
+    persistMode(previousMode)
 }
 
 // Functions to select and close popovers

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -867,12 +867,16 @@ async function onInstructionSaved(savedInstruction?: any) {
   if (selectedAgentId.value) {
     // If created from the overview "Create" link, pin it as primary instruction
     if (wasPrimary && savedInstruction?.id && !savedInstruction?.deleted) {
-      await useMyFetch(`/data_sources/${selectedAgentId.value}`, {
+      const { error } = await useMyFetch(`/data_sources/${selectedAgentId.value}`, {
         method: 'PUT',
         body: { primary_instruction_id: savedInstruction.id },
       })
-      delete agentDetailsCache.value[selectedAgentId.value]
-      fetchTabData(selectedAgentId.value, 'overview')
+      if (error.value) {
+        toast.add({ title: 'Failed to set primary instruction', description: getErrorMessage(error.value), color: 'red' })
+      } else {
+        delete agentDetailsCache.value[selectedAgentId.value]
+        fetchTabData(selectedAgentId.value, 'overview')
+      }
     }
     delete instructionsCache.value[selectedAgentId.value]
     fetchTabData(selectedAgentId.value, 'instructions')

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -545,6 +545,8 @@ import { useInstructionHelpers } from '~/composables/useInstructionHelpers'
 import { deriveStage, stageMeta } from '~/composables/useDataSourcePublishStatus'
 
 const { t } = useI18n()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const props = defineProps<{
   agents: Array<{ id: string; name: string; type?: string; connections?: any[]; publish_status?: string; reliability_status?: string }>
@@ -692,16 +694,19 @@ async function saveStarters() {
     // Replace-all of this agent's starter Prompts (no legacy JSON write).
     const { data: existing } = await useMyFetch(`/prompts?data_source_id=${id}`)
     for (const p of ((existing.value as any)?.prompts || [])) {
-      await useMyFetch(`/prompts/${p.id}`, { method: 'DELETE' })
+      await useMyFetchStrict(`/prompts/${p.id}`, { method: 'DELETE' })
     }
     for (const text of starters) {
-      await useMyFetch(`/prompts`, { method: 'POST', body: {
+      await useMyFetchStrict(`/prompts`, { method: 'POST', body: {
         text, title: (text.split('\n')[0] || '').slice(0, 60),
         scope: 'agent', is_starter: true, data_source_ids: [id],
       } })
     }
     await loadStarterPrompts(id)
     showEditStarters.value = false
+  } catch (error) {
+    // Leave the modal open and the prior starters in place so the user can retry.
+    toast.add({ title: 'Failed to save starter prompts', description: getErrorMessage(error), color: 'red' })
   } finally {
     savingStarters.value = false
   }

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -705,7 +705,11 @@ async function saveStarters() {
     await loadStarterPrompts(id)
     showEditStarters.value = false
   } catch (error) {
-    // Leave the modal open and the prior starters in place so the user can retry.
+    // Leave the modal open so the user can retry, but resync the displayed
+    // starters to server truth: this is a replace-all (delete loop then create
+    // loop), so a mid-sequence failure can leave the server partially changed
+    // and the on-screen chips stale.
+    await loadStarterPrompts(id)
     toast.add({ title: 'Failed to save starter prompts', description: getErrorMessage(error), color: 'red' })
   } finally {
     savingStarters.value = false

--- a/frontend/components/report/ReportHeader.vue
+++ b/frontend/components/report/ReportHeader.vue
@@ -86,6 +86,7 @@ const mobileTabs = computed(() => [
 ])
 
 const { t } = useI18n()
+const { getErrorMessage } = useErrorMessage()
 const route = useRoute()
 const report_id = route.params.id
 const reportTitleInput = ref<HTMLInputElement | null>(null)
@@ -118,7 +119,7 @@ async function saveReportTitle() {
     }
 
     try {
-        await useMyFetch(`/api/reports/${report_id}`, {
+        await useMyFetchStrict(`/api/reports/${report_id}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -152,6 +153,7 @@ async function saveReportTitle() {
         }
         toast.add({
             title: 'Failed to update report title',
+            description: getErrorMessage(error),
             color: 'red',
         })
     }

--- a/frontend/components/report/WebhookConfigModal.vue
+++ b/frontend/components/report/WebhookConfigModal.vue
@@ -129,6 +129,8 @@ const sources = ref<any[]>([
 ])
 const creating = ref(false)
 const reveal = ref<any>(null)
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 // Token header is the default auth mode (simplest for most senders).
 const defaultForm = () => ({ name: 'Webhook', source: 'github', auth_mode: 'token', classify_enabled: true, classifier_prompt: '' })
@@ -170,18 +172,29 @@ async function create() {
 		form.value = defaultForm()
 		await loadWebhooks()
 		emit('changed')
-	} catch (e) { console.error('create webhook failed', e) } finally { creating.value = false }
+	} catch (e) {
+		console.error('create webhook failed', e)
+		toast.add({ title: 'Failed to create webhook', description: getErrorMessage(e), color: 'red' })
+	} finally { creating.value = false }
 }
 
 async function rotate(w: any) {
-	const { data } = await useMyFetch(`/reports/${props.reportId}/webhooks/${w.id}/rotate`, { method: 'POST' })
-	if (data.value) reveal.value = data.value
+	try {
+		const { data } = await useMyFetchStrict(`/reports/${props.reportId}/webhooks/${w.id}/rotate`, { method: 'POST' })
+		if (data.value) reveal.value = data.value
+	} catch (e) {
+		toast.add({ title: 'Failed to rotate webhook secret', description: getErrorMessage(e), color: 'red' })
+	}
 }
 
 async function remove(w: any) {
-	await useMyFetch(`/reports/${props.reportId}/webhooks/${w.id}`, { method: 'DELETE' })
-	await loadWebhooks()
-	emit('changed')
+	try {
+		await useMyFetchStrict(`/reports/${props.reportId}/webhooks/${w.id}`, { method: 'DELETE' })
+		await loadWebhooks()
+		emit('changed')
+	} catch (e) {
+		toast.add({ title: 'Failed to delete webhook', description: getErrorMessage(e), color: 'red' })
+	}
 }
 
 function copy(text: string) {

--- a/frontend/components/tools/QueryCodeEditorModal.vue
+++ b/frontend/components/tools/QueryCodeEditorModal.vue
@@ -197,6 +197,7 @@ interface Props {
 const props = defineProps<Props>()
 const route = useRoute()
 const emit = defineEmits(['close', 'stepCreated'])
+const { getErrorMessage } = useErrorMessage()
 
 const editorCode = ref('')
 const running = ref(false)
@@ -485,6 +486,11 @@ async function previewRun() {
       method: 'POST',
       body: { code: editorCode.value, title: props.title, type: 'table', tool_execution_id: props.toolExecutionId || null }
     })
+    if (resp?.error?.value) {
+      errorMsg.value = getErrorMessage(resp.error.value, 'Failed to run')
+      preview.value = null
+      return
+    }
     const payload = resp?.data?.value
     if (payload?.error) {
       errorMsg.value = payload.error
@@ -516,6 +522,11 @@ async function runNewStep() {
         tool_execution_id: props.toolExecutionId || null
       }
     })
+    if (resp?.error?.value) {
+      errorMsg.value = getErrorMessage(resp.error.value, 'Failed to run')
+      preview.value = null
+      return
+    }
     const payload = resp?.data?.value
     // Show backend error message if execution failed
     if (payload?.error) {

--- a/frontend/components/tools/RunEvalTool.vue
+++ b/frontend/components/tools/RunEvalTool.vue
@@ -77,6 +77,8 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 interface ToolExecution {
   id: string
@@ -188,9 +190,10 @@ async function stopRun() {
   try {
     // Sigkill the parent system completion. Inside the agent, run_eval's
     // polling loop detects the parent stop and cascades a TestRun.stop.
-    await useMyFetch(`/api/completions/${props.systemCompletionId}/sigkill`, { method: 'POST' })
+    await useMyFetchStrict(`/api/completions/${props.systemCompletionId}/sigkill`, { method: 'POST' })
   } catch (e) {
     console.error('Failed to stop eval run via parent sigkill:', e)
+    toast.add({ title: 'Failed to stop eval run', description: getErrorMessage(e), color: 'red' })
   } finally {
     isStopping.value = false
   }

--- a/frontend/components/tools/WaitTool.vue
+++ b/frontend/components/tools/WaitTool.vue
@@ -68,6 +68,9 @@ const props = withDefaults(
   { systemCompletionId: null }
 )
 
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
+
 const rj = computed(() => props.toolExecution?.result_json ?? {})
 const wakeAt = computed(() => (rj.value?.wake_at ? new Date(rj.value.wake_at).getTime() : 0))
 const reason = computed(() => rj.value?.reason || props.toolExecution?.arguments_json?.reason || '')
@@ -109,7 +112,10 @@ async function cancel() {
         { method: 'POST' }
       )
       if (res?.error?.value) {
-        console.warn('Failed to cancel wait', res.error.value)
+        // Revert the optimistic flag — the backend never confirmed the cancel,
+        // so the countdown must keep running instead of showing "Cancelled".
+        locallyCancelled.value = false
+        toast.add({ title: 'Failed to cancel wait', description: getErrorMessage(res.error.value), color: 'red' })
       }
     }
   } finally {

--- a/frontend/composables/useMyFetch.ts
+++ b/frontend/composables/useMyFetch.ts
@@ -77,3 +77,24 @@ export const useMyFetch: typeof useFetch = async (request, opts?) => {
       throw error
     });
 };
+
+// Strict variant for MUTATING calls (POST/PUT/PATCH/DELETE handlers).
+//
+// `useMyFetch` follows the `useFetch` contract: it NEVER rejects on an
+// HTTP-level failure — the error lands in the returned `error` ref and the
+// promise resolves. Any `try/catch` around a bare `await useMyFetch(...)`
+// is therefore dead code for 4xx/5xx responses (issue #584: handlers mutated
+// state and showed success toasts on failed backend calls).
+//
+// `useMyFetchStrict` keeps the exact same auth/org/baseURL behavior and the
+// same success-value shape, but THROWS the original fetch error on HTTP
+// failure, so `try { await useMyFetchStrict(...) } catch (e) { ... }` works
+// the way callers expect. Pair it with `useErrorMessage().getErrorMessage(e)`
+// in the catch to render the failure.
+export const useMyFetchStrict: typeof useFetch = async (request, opts?) => {
+  const response: any = await useMyFetch(request, opts as any)
+  if (response?.error?.value) {
+    throw response.error.value
+  }
+  return response
+}

--- a/frontend/pages/agents/new/[id]/context.vue
+++ b/frontend/pages/agents/new/[id]/context.vue
@@ -122,6 +122,9 @@ const route = useRoute()
 const router = useRouter()
 const dsId = computed(() => String(route.params.id || ''))
 
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
+
 const saving = ref(false)
 const loadingDraft = ref(false)
 const showGitModal = ref(false)
@@ -360,16 +363,16 @@ async function handleSave() {
 
     if (draftInstructionId.value) {
       if (text) {
-        await useMyFetch(`/instructions/${draftInstructionId.value}`, {
+        await useMyFetchStrict(`/instructions/${draftInstructionId.value}`, {
           method: 'PUT',
           body: { text, status: 'published' },
         })
         primaryInstructionId = draftInstructionId.value
       } else {
-        await useMyFetch(`/instructions/${draftInstructionId.value}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/instructions/${draftInstructionId.value}`, { method: 'DELETE' })
       }
     } else if (text) {
-      const { data } = await useMyFetch('/instructions/global', {
+      const { data } = await useMyFetchStrict('/instructions/global', {
         method: 'POST',
         body: {
           text,
@@ -385,13 +388,15 @@ async function handleSave() {
     }
 
     if (primaryInstructionId) {
-      await useMyFetch(`/data_sources/${dsId.value}`, {
+      await useMyFetchStrict(`/data_sources/${dsId.value}`, {
         method: 'PUT',
         body: { primary_instruction_id: primaryInstructionId },
       })
     }
 
     router.replace(`/agents/${dsId.value}`)
+  } catch (e: any) {
+    toast.add({ title: 'Failed to save agent context', description: getErrorMessage(e), color: 'red' })
   } finally {
     saving.value = false
   }

--- a/frontend/pages/evals/runs/[id].vue
+++ b/frontend/pages/evals/runs/[id].vue
@@ -221,6 +221,8 @@ import Spinner from '~/components/Spinner.vue'
 const { t } = useI18n()
 const route = useRoute()
 const runId = computed(() => String(route.params.id || ''))
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 type TestRun = {
   id: string
@@ -926,10 +928,11 @@ const mockLogs = (row: { result: TestResult, case: TestCase }): ConversationMess
 const stopRun = async () => {
   try {
     if (!run.value?.id || run.value.status !== 'in_progress') return
-    await useMyFetch(`/api/tests/runs/${run.value.id}/stop`, { method: 'POST' })
+    await useMyFetchStrict(`/api/tests/runs/${run.value.id}/stop`, { method: 'POST' })
     await load()
   } catch (e) {
     console.error('Failed to stop run', e)
+    toast.add({ title: 'Failed to stop run', description: getErrorMessage(e), color: 'red' })
   }
 }
 

--- a/frontend/pages/excel/index.vue
+++ b/frontend/pages/excel/index.vue
@@ -75,6 +75,8 @@ import { onMounted, nextTick } from 'vue';
 
 const router = useRouter()
 const { t } = useI18n()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const previous_reports = ref([])
 const selectedDataSources = ref([])
 
@@ -135,21 +137,21 @@ const getDataSourceOptions = async () => {
 }
 
 const createNewReport = async () => {
-    const response = await useMyFetch('/reports', {
-        method: 'POST',
-        body: JSON.stringify({title: 'untitled report',
-         files: [],
-         data_sources: selectedDataSources.value.map((ds: any) => ds.id)})
-    });
+    try {
+        const response = await useMyFetchStrict('/reports', {
+            method: 'POST',
+            body: JSON.stringify({title: 'untitled report',
+             files: [],
+             data_sources: selectedDataSources.value.map((ds: any) => ds.id)})
+        });
 
-    if (!response.code === 200) {
-        throw new Error('Report creation failed');
+        const data = response.data.value as any;
+        router.push({
+            path: `/excel/reports/${data.id}`
+        })
+    } catch (e) {
+        toast.add({ title: 'Error', description: getErrorMessage(e) || 'Report creation failed', color: 'red' })
     }
-
-    const data = await response.data.value;
-    router.push({
-        path: `/excel/reports/${data.id}`
-    })
 }
 
 async function signOff() {

--- a/frontend/pages/integrations/[id]/connection.vue
+++ b/frontend/pages/integrations/[id]/connection.vue
@@ -123,6 +123,8 @@ import { useOrganization } from '~/composables/useOrganization'
 import type { Ref } from 'vue'
 
 const route = useRoute()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const dsId = computed(() => String(route.params.id || ''))
 const canManageConnections = computed(() => useCan('manage_connections'))
 const { data: currentUser } = useAuth()
@@ -229,10 +231,10 @@ function openAddCredentials() {
 async function disconnectUserCredentials() {
   if (!dsId.value) return
   try {
-    await useMyFetch(`/data_sources/${dsId.value}/my-credentials`, { method: 'DELETE' })
+    await useMyFetchStrict(`/data_sources/${dsId.value}/my-credentials`, { method: 'DELETE' })
     await injectedFetchIntegration()
   } catch (e) {
-    // no-op
+    toast.add({ title: 'Failed to disconnect', description: getErrorMessage(e), color: 'red' })
   }
 }
 

--- a/frontend/pages/old_agents/[id]/connection.vue
+++ b/frontend/pages/old_agents/[id]/connection.vue
@@ -272,6 +272,7 @@ import type { Ref } from 'vue'
 
 const route = useRoute()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const dsId = computed(() => String(route.params.id || ''))
 const canManageConnections = computed(() => useCan('manage_connections'))
 const { data: currentUser } = useAuth()
@@ -490,7 +491,7 @@ async function unlinkConnection(connectionId: string) {
     if (!dsId.value) return
     if (!confirm('Are you sure you want to unlink this connection?')) return
     try {
-        await useMyFetch(`/data_sources/${dsId.value}/connections/${connectionId}`, {
+        await useMyFetchStrict(`/data_sources/${dsId.value}/connections/${connectionId}`, {
             method: 'DELETE'
         })
         toast.add({ title: 'Connection unlinked', color: 'green' })
@@ -498,7 +499,7 @@ async function unlinkConnection(connectionId: string) {
     } catch (e: any) {
         toast.add({
             title: 'Failed to unlink connection',
-            description: e?.message || 'An error occurred',
+            description: getErrorMessage(e),
             color: 'red'
         })
     }

--- a/frontend/pages/old_agents/[id]/connection.vue
+++ b/frontend/pages/old_agents/[id]/connection.vue
@@ -362,10 +362,10 @@ function connIndexingSummary(conn: any) {
 
 async function reindexConnection(connectionId: string) {
     try {
-        await useMyFetch(`/connections/${connectionId}/reindex`, { method: 'POST' })
+        await useMyFetchStrict(`/connections/${connectionId}/reindex`, { method: 'POST' })
         await injectedFetchIntegration()
     } catch (e: any) {
-        toast.add({ title: 'Failed to restart indexing', description: e?.message || '', color: 'red' })
+        toast.add({ title: 'Failed to restart indexing', description: getErrorMessage(e), color: 'red' })
     }
 }
 
@@ -469,7 +469,7 @@ async function linkConnection() {
     if (!selectedConnectionId.value || !dsId.value || isLinking.value) return
     isLinking.value = true
     try {
-        await useMyFetch(`/data_sources/${dsId.value}/connections/${selectedConnectionId.value}`, {
+        await useMyFetchStrict(`/data_sources/${dsId.value}/connections/${selectedConnectionId.value}`, {
             method: 'POST'
         })
         toast.add({ title: 'Connection linked', color: 'green' })
@@ -479,7 +479,7 @@ async function linkConnection() {
     } catch (e: any) {
         toast.add({
             title: 'Failed to link connection',
-            description: e?.message || 'An error occurred',
+            description: getErrorMessage(e),
             color: 'red'
         })
     } finally {

--- a/frontend/pages/old_agents/[id]/settings.vue
+++ b/frontend/pages/old_agents/[id]/settings.vue
@@ -500,7 +500,7 @@ async function updateMemberPermissions(m: MemberGrant, newPerms: string[]) {
 async function removeMember(m: MemberGrant) {
     const dsId = route.params.id as string
     try {
-        await useMyFetch(`/data_sources/${dsId}/members/${m.principal_id}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/data_sources/${dsId}/members/${m.principal_id}`, { method: 'DELETE' })
         members.value = members.value.filter(x => x.grant_id !== m.grant_id)
         toast?.add?.({ title: 'Member removed' })
     } catch {
@@ -574,7 +574,7 @@ async function addSelected() {
     try {
         await Promise.all(
             principals.map(p =>
-                useMyFetch(`/data_sources/${dsId}/members`, {
+                useMyFetchStrict(`/data_sources/${dsId}/members`, {
                     method: 'POST',
                     body: { ...p },
                 })

--- a/frontend/pages/old_agents/[id]/tables.vue
+++ b/frontend/pages/old_agents/[id]/tables.vue
@@ -271,7 +271,7 @@ async function onFileInput(e: Event) {
 
 async function removeFile(file: AgentFile) {
     try {
-        await useMyFetch(`/data_sources/${id.value}/files/${file.id}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/data_sources/${id.value}/files/${file.id}`, { method: 'DELETE' })
         files.value = files.value.filter(f => f.id !== file.id)
     } catch (e) {
         console.error('Failed to remove file', e)

--- a/frontend/pages/old_agents/[id]/tools.vue
+++ b/frontend/pages/old_agents/[id]/tools.vue
@@ -49,6 +49,7 @@ import type { Ref } from 'vue'
 
 const route = useRoute()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const id = computed(() => String(route.params.id || ''))
 
 const injectedIntegration = inject<Ref<any>>('integration', ref(null))
@@ -127,14 +128,14 @@ async function deleteConnection() {
     if (!deletingConnection.value) return
     deleting.value = true
     try {
-        await useMyFetch(`/data_sources/${id.value}/connections/${deletingConnection.value.id}`, { method: 'DELETE' })
+        await useMyFetchStrict(`/data_sources/${id.value}/connections/${deletingConnection.value.id}`, { method: 'DELETE' })
         toast.add({ title: 'Connection removed', color: 'green' })
         showDeleteModal.value = false
         deletingConnection.value = null
         await fetchIntegration()
         await fetchOrgToolConnections()
     } catch (e: any) {
-        toast.add({ title: 'Failed to remove connection', description: e?.data?.detail, color: 'red' })
+        toast.add({ title: 'Failed to remove connection', description: getErrorMessage(e), color: 'red' })
     } finally {
         deleting.value = false
     }

--- a/frontend/pages/onboarding/data/[ds_id]/context.vue
+++ b/frontend/pages/onboarding/data/[ds_id]/context.vue
@@ -216,6 +216,8 @@ const route = useRoute()
 const { updateOnboarding } = useOnboarding()
 const router = useRouter()
 const { t } = useI18n()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 const dsId = computed(() => String(route.params.ds_id || ''))
 const saving = ref(false)
@@ -472,15 +474,14 @@ async function handleSave() {
   
   try {
     await updateOnboarding({ current_step: 'instructions_added' as any, completed: true as any, dismissed: false as any })
+    // Don't await navigation: Nuxt route middleware can await network calls and hang.
+    navigateTo({ path: '/', query: { setup: 'done' } })
   } catch (e) {
-    console.warn('Failed to update onboarding:', e)
+    toast.add({ title: 'Error', description: getErrorMessage(e) || 'Failed to update onboarding', color: 'red' })
   } finally {
     // Never keep the UI stuck if navigation/middleware blocks.
     saving.value = false
   }
-
-  // Don't await navigation: Nuxt route middleware can await network calls and hang.
-  navigateTo({ path: '/', query: { setup: 'done' } })
 }
 
 async function skipForNow() { 

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -880,6 +880,8 @@ const RTL_LOCALES = new Set(['he', 'ar', 'fa', 'ur'])
 const isRtl = computed(() => RTL_LOCALES.has(i18nLocale.value))
 const route = useRoute()
 const report_id = (route.params.id as string) || ''
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 // Excel add-in mode detection (for compact UI)
 const { isExcel, excelSelection } = useExcel()
@@ -3210,10 +3212,10 @@ async function handleAddWidgetFromPreview(payload: { widget?: any, step?: any, v
         const widget = payload?.widget
         if (viz?.id) {
             const block = { type: 'visualization', visualization_id: viz.id, x: 0, y: 0, width: 6, height: 7 }
-            await useMyFetch(`/api/reports/${report_id}/layouts/active/blocks`, { method: 'PATCH', body: { blocks: [block] } })
+            await useMyFetchStrict(`/api/reports/${report_id}/layouts/active/blocks`, { method: 'PATCH', body: { blocks: [block] } })
         } else if (widget?.id) {
             const block = { type: 'widget', widget_id: widget.id, x: 0, y: 0, width: 6, height: 7 }
-            await useMyFetch(`/api/reports/${report_id}/layouts/active/blocks`, { method: 'PATCH', body: { blocks: [block] } })
+            await useMyFetchStrict(`/api/reports/${report_id}/layouts/active/blocks`, { method: 'PATCH', body: { blocks: [block] } })
         } else {
             return
         }
@@ -3247,6 +3249,7 @@ async function handleAddWidgetFromPreview(payload: { widget?: any, step?: any, v
         safeScrollToBottom()
     } catch (e) {
         console.error('Failed to add widget from preview:', e)
+        toast.add({ title: 'Failed to add to dashboard', description: getErrorMessage(e), color: 'red' })
     }
 }
 

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -3271,7 +3271,7 @@ function handleOpenArtifact(payload: { artifactId?: string; loading?: boolean })
 	}
 }
 
-function abortStream() {
+async function abortStream() {
 	if (currentController) {
 		currentController.abort()
 		currentController = null
@@ -3281,14 +3281,14 @@ function abortStream() {
 					const sysMsg = [...messages.value].reverse().find(m => m.role === 'system' && m.status === 'in_progress')
 		const systemId = (sysMsg as any)?.system_completion_id
 		if (systemId) {
-			useMyFetch(`/api/completions/${systemId}/sigkill`, { method: 'POST' })
+			await useMyFetchStrict(`/api/completions/${systemId}/sigkill`, { method: 'POST' })
 			// Mark locally as stopped for immediate UI feedback
 			const msgIndex = messages.value.findIndex(m => m.id === sysMsg?.id)
 			if (msgIndex !== -1) {
 				// Force Vue reactivity by replacing the entire array
 				const newMessages = [...messages.value]
 				const updatedMessage = { ...newMessages[msgIndex], status: 'stopped' as ChatStatus }
-				
+
 				// Also update all completion blocks and their tool executions to stopped status
 				if (updatedMessage.completion_blocks) {
 					updatedMessage.completion_blocks = updatedMessage.completion_blocks.map(block => ({
@@ -3298,17 +3298,17 @@ function abortStream() {
 						tool_execution: block.tool_execution?.status === 'running' ? { ...block.tool_execution, status: 'stopped' } : block.tool_execution
 					}))
 				}
-				
+
 				newMessages[msgIndex] = updatedMessage
 				messages.value = newMessages
-				
+
 				// Force a nextTick update
 				nextTick(() => {
 				})
 			}
 		}
 	} catch (e) {
-		console.error('Failed to send sigkill:', e)
+		toast.add({ title: 'Failed to stop generation', description: getErrorMessage(e), color: 'red' })
 	}
 	isStreaming.value = false
 	isCompletionInProgress.value = false

--- a/frontend/pages/reports/[id]/legacy.vue
+++ b/frontend/pages/reports/[id]/legacy.vue
@@ -141,6 +141,8 @@ import DashboardComponent from '~/components/DashboardComponent.vue';
 const { signIn, signOut, token, data: currentUser, status, lastRefreshedAt, getSession } = useAuth()
 const { organization, setOrganization } = useOrganization()
 const { isExcel } = useExcel()
+const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 const route = useRoute()
 const config = useRuntimeConfig()
 const wsURL = config.public.wsURL
@@ -585,18 +587,21 @@ function toggleSplitScreen() {
 const selectedWidget = ref(null);
 
 async function removeWidget(widget: any) {
-    await useMyFetch(`/api/reports/${report_id}/widgets/${widget.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'draft', id: widget.id })
-    }).then(() => {
+    try {
+        await useMyFetchStrict(`/api/reports/${report_id}/widgets/${widget.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'draft', id: widget.id })
+        });
         widgets.value = widgets.value.map(w => {
             if (w.id === widget.id) {
                 return { ...w, status: 'draft' };
             }
             return w;
         });
-    })
+    } catch (e: any) {
+        toast.add({ title: 'Failed to remove widget', description: getErrorMessage(e), color: 'red' });
+    }
 }
 
 async function handleAddWidget(widget: any) {

--- a/frontend/pages/reports/[id]/legacy.vue
+++ b/frontend/pages/reports/[id]/legacy.vue
@@ -171,7 +171,7 @@ const shareModalOpen = ref(false)
 const sigkill = async (completion: any) => {
     isStoppingGeneration.value = true;
     try {
-        await useMyFetch(`/api/completions/${completion.id}/sigkill`, {
+        await useMyFetchStrict(`/api/completions/${completion.id}/sigkill`, {
             method: 'POST'
         });
         // After successful sigkill, update the local completion state
@@ -189,7 +189,7 @@ const sigkill = async (completion: any) => {
             completion.sigkill = true;
         }
     } catch (error) {
-        console.error('Error updating sigkill:', error);
+        toast.add({ title: 'Failed to stop generation', description: getErrorMessage(error), color: 'red' });
     } finally {
         isStoppingGeneration.value = false;
     }
@@ -263,22 +263,25 @@ onUnmounted(() => {
     window.removeEventListener('message', handleExcelMessage)
 })
 
-function saveReportTitle() {
+async function saveReportTitle() {
     const requestBody = {
         title: report.value.title
     };
 
-    useMyFetch(`/api/reports/${report_id}`, {
-        method: 'PUT',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-    }).then(() => {
+    try {
+        await useMyFetchStrict(`/api/reports/${report_id}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(requestBody),
+        });
         if (reportTitleInput.value) {
             reportTitleInput.value.blur();
         }
-    });
+    } catch (error) {
+        toast.add({ title: 'Failed to save report title', description: getErrorMessage(error), color: 'red' });
+    }
 }
 
 
@@ -670,20 +673,20 @@ function stopResize() {
 }
 
 const createNewReport = async () => {
-    const response = await useMyFetch('/reports', {
-        method: 'POST',
-        body: JSON.stringify({title: 'untitled report',
-         files: []})
-    });
+    try {
+        const response = await useMyFetchStrict('/reports', {
+            method: 'POST',
+            body: JSON.stringify({title: 'untitled report',
+             files: []})
+        });
 
-    if (!response.code === 200) {
-        throw new Error('Report creation failed');
+        const data = response.data.value;
+        router.push({
+            path: `/reports/${data.id}`
+        })
+    } catch (error) {
+        toast.add({ title: 'Failed to create report', description: getErrorMessage(error), color: 'red' });
     }
-
-    const data = await response.data.value;
-    router.push({
-        path: `/reports/${data.id}`
-    })
 }
 
 onUnmounted(() => {

--- a/frontend/pages/settings/general.vue
+++ b/frontend/pages/settings/general.vue
@@ -207,7 +207,7 @@ const fetchSettings = async () => {
             useMyFetch('/api/organization/timezones'),
             useMyFetch('/api/organization/week_start'),
         ])
-        if (settingsResp.status.value !== 'success') throw new Error(settingsResp.error?.value?.data?.message || t('settings.failedToFetch'))
+        if (settingsResp.status.value !== 'success') throw new Error(settingsResp.error?.value?.data?.detail || t('settings.failedToFetch'))
         const cfg = (settingsResp.data.value as SettingsResponse)?.config
         general.value = cfg?.general || { ai_analyst_name: 'AI Analyst', bow_credit: true }
 
@@ -246,13 +246,13 @@ const saveAll = async () => {
             const formData = new FormData()
             formData.append('icon', pendingIconFile.value)
             const upload = await useMyFetch('/api/organization/general/icon', { method: 'POST', body: formData })
-            if (upload.status.value !== 'success') throw new Error(upload.error?.value?.data?.message || t('settings.uploadFailed'))
+            if (upload.status.value !== 'success') throw new Error(upload.error?.value?.data?.detail || t('settings.uploadFailed'))
             const cfg = (upload.data.value as SettingsResponse)?.config
             form.value.icon_url = cfg?.general?.icon_url || form.value.icon_url
             form.value.icon_key = cfg?.general?.icon_key || form.value.icon_key
         } else if (removeIcon.value) {
             const remove = await useMyFetch('/api/organization/general/icon', { method: 'DELETE' })
-            if (remove.status.value !== 'success') throw new Error(remove.error?.value?.data?.message || t('settings.removeFailed'))
+            if (remove.status.value !== 'success') throw new Error(remove.error?.value?.data?.detail || t('settings.removeFailed'))
             form.value.icon_url = null
             form.value.icon_key = null
         }
@@ -260,13 +260,13 @@ const saveAll = async () => {
         // 2) Save organization name (if changed)
         if (form.value.organization_name) {
             const nameResp = await useMyFetch('/api/organization', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.value.organization_name }) })
-            if (nameResp.status.value !== 'success') throw new Error(nameResp.error?.value?.data?.message || t('settings.failedToUpdate'))
+            if (nameResp.status.value !== 'success') throw new Error(nameResp.error?.value?.data?.detail || t('settings.failedToUpdate'))
         }
 
         // 3) Save textual and toggle settings
         const payload = { config: { general: { ai_analyst_name: form.value.ai_analyst_name, bow_credit: form.value.bow_credit, icon_key: form.value.icon_key, icon_url: form.value.icon_url } } }
         const response = await useMyFetch('/api/organization/settings', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
-        if (response.status.value !== 'success') throw new Error(response.error?.value?.data?.message || t('settings.failedToUpdate'))
+        if (response.status.value !== 'success') throw new Error(response.error?.value?.data?.detail || t('settings.failedToUpdate'))
 
         general.value = ((response.data.value as SettingsResponse)?.config?.general) || form.value
 

--- a/frontend/pages/settings/general.vue
+++ b/frontend/pages/settings/general.vue
@@ -259,7 +259,8 @@ const saveAll = async () => {
 
         // 2) Save organization name (if changed)
         if (form.value.organization_name) {
-            await useMyFetch('/api/organization', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.value.organization_name }) })
+            const nameResp = await useMyFetch('/api/organization', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.value.organization_name }) })
+            if (nameResp.status.value !== 'success') throw new Error(nameResp.error?.value?.data?.message || t('settings.failedToUpdate'))
         }
 
         // 3) Save textual and toggle settings

--- a/frontend/pages/settings/integrations/index.vue
+++ b/frontend/pages/settings/integrations/index.vue
@@ -120,6 +120,7 @@ import McpIcon from '~/components/icons/McpIcon.vue'
 definePageMeta({ auth: true, permissions: ['manage_settings'], layout: 'settings' })
 
 const { t } = useI18n()
+const toast = useToast()
 
 // Which integration is shown in the right pane (null = empty state)
 const selectedKey = ref<string | null>(null)
@@ -294,10 +295,7 @@ async function fetchIntegrations() {
 
 async function loadMcpState() {
   await fetchSettings()
-  const mcpFeature = settings.value?.config?.mcp_enabled
-  if (mcpFeature) {
-    mcpEnabled.value = mcpFeature.state === 'enabled' || mcpFeature.value === true
-  }
+  applyMcpStateFromSettings()
   const excelFeature = settings.value?.config?.enable_excel_addin
   if (excelFeature) {
     excelAddinEnabled.value = excelFeature.state === 'enabled' || excelFeature.value === true
@@ -306,10 +304,17 @@ async function loadMcpState() {
   }
 }
 
+function applyMcpStateFromSettings() {
+  const mcpFeature = settings.value?.config?.mcp_enabled
+  if (mcpFeature) {
+    mcpEnabled.value = mcpFeature.state === 'enabled' || mcpFeature.value === true
+  }
+}
+
 async function toggleMcp(value: boolean) {
   mcpUpdating.value = true
   try {
-    await useMyFetch('/api/organization/settings', {
+    await useMyFetchStrict('/api/organization/settings', {
       method: 'PUT',
       body: JSON.stringify({
         config: {
@@ -320,10 +325,14 @@ async function toggleMcp(value: boolean) {
         }
       })
     })
+    // Re-derive from the refreshed settings rather than trusting the
+    // optimistic v-model flip, so the toggle reflects server truth.
     await fetchSettings()
+    applyMcpStateFromSettings()
   } catch (e) {
-    // Revert on error
+    // Revert the optimistic v-model flip on failure.
     mcpEnabled.value = !value
+    toast.add({ title: 'Failed to update MCP setting', color: 'red' })
   } finally {
     mcpUpdating.value = false
   }

--- a/frontend/pages/settings/integrations/index.vue
+++ b/frontend/pages/settings/integrations/index.vue
@@ -121,6 +121,7 @@ definePageMeta({ auth: true, permissions: ['manage_settings'], layout: 'settings
 
 const { t } = useI18n()
 const toast = useToast()
+const { getErrorMessage } = useErrorMessage()
 
 // Which integration is shown in the right pane (null = empty state)
 const selectedKey = ref<string | null>(null)
@@ -329,10 +330,10 @@ async function toggleMcp(value: boolean) {
     // optimistic v-model flip, so the toggle reflects server truth.
     await fetchSettings()
     applyMcpStateFromSettings()
-  } catch (e) {
+  } catch (e: any) {
     // Revert the optimistic v-model flip on failure.
     mcpEnabled.value = !value
-    toast.add({ title: 'Failed to update MCP setting', color: 'red' })
+    toast.add({ title: 'Failed to update MCP setting', description: getErrorMessage(e), color: 'red' })
   } finally {
     mcpUpdating.value = false
   }

--- a/frontend/pages/settings/smtp.vue
+++ b/frontend/pages/settings/smtp.vue
@@ -150,7 +150,11 @@ async function test() {
   testResult.value = null
   try {
     // Save first so the test probes the stored config.
-    await useMyFetch('/api/organization/smtp', { method: 'PUT', body: payload() })
+    const saveRes = await useMyFetch('/api/organization/smtp', { method: 'PUT', body: payload() })
+    if (saveRes.status.value !== 'success') {
+      toast.add({ title: 'Failed to save SMTP', description: (saveRes.error.value as any)?.data?.detail || 'Error', color: 'red' })
+      return
+    }
     passwordSet.value = passwordSet.value || !!form.password
     form.password = ''
     const res = await useMyFetch('/api/organization/smtp/test', { method: 'POST' })


### PR DESCRIPTION
<!-- PR TITLE: fix: surface backend failures in delete/toggle/save handlers (#584) -->

# 🩹 Fixes #584 — surface backend failures in delete / toggle / save handlers

> **What:** ~86 frontend mutation handlers showed a green **"success"** and removed/toggled the item **even when the backend call failed** — then it silently reappeared on the next reload. This PR makes every one surface the real failure: a **red error toast**, no false success, and optimistic UIs revert.
>
> **Root cause (one line):** `useMyFetch` is typed like Nuxt's `useFetch` and **never rejects on an HTTP error**, so every `try/catch` around it was dead code — the "success" lines ran for a 403/500 exactly as for a 200.

## 📣 Executive summary (why this matters to a customer)

For a paying customer this was a **trust-and-safety bug, not a cosmetic one.** When an admin removed a teammate's access to a data source, revoked an API key, disconnected an integration, or deleted a file, the app said **"✅ done"** and the item disappeared from the screen — **but if the backend rejected the action, it silently never happened.** The removed teammate kept their access. The "revoked" key kept working. The deleted file stayed on the server. The customer had no way to know, because every on-screen signal said success — and the item only quietly reappeared on a later reload, long after they'd moved on.

This is exactly the class of failure that erodes trust in the product and creates **security, compliance, and data-exposure exposure** for the customer. This PR makes those failures **visible and truthful**: the action either genuinely succeeds, or the user is clearly told it failed (and the UI reverts to the real state). One root cause, ~86 handlers across the app.

```mermaid
flowchart TD
    A["👤 Admin removes an ex-employee's<br/>access to the 'Revenue' data source"] --> B["🟢 UI shows: 'Member removed' ✅"]
    B --> C["😌 Admin trusts it, moves on"]
    C --> D{"Backend actually rejected it<br/>(permission race, validation, 500)"}
    D -->|"❌ Before this PR"| E["🔓 Ex-employee STILL has access<br/>📉 data exposure, compliance risk,<br/>broken trust<br/>(found only much later, if ever)"]
    D -->|"✅ After this PR"| F["🔴 UI: 'Failed to remove member'<br/>🔁 admin retries,<br/>access truly revoked"]
    style E fill:#ffd7d7,stroke:#d33,color:#000
    style F fill:#d7f5dd,stroke:#2a2,color:#000
```

## 🧭 For the reviewer — decide at a glance

| | |
|---|---|
| **Closes** | #584 (auto-closes on merge) |
| **Risk** | **Low–moderate.** Mechanically uniform change — gate the success path on the call actually succeeding. **Zero backend files touched.** |
| **Blast radius** | 45 frontend files, +465 / −220. One shared primitive (`useMyFetchStrict`) + per-site migration across ~86 handlers. |
| **Behavior change (intended)** | Handlers that used to *falsely* show success on failure now show a **red error toast** and do **not** mutate state / close the modal / emit / navigate; optimistic UIs revert; loop-saves stop at first failure and resync. |
| **Verified ✅** | `nuxt build` green at each commit · 2 independent Opus reviews (the 2nd caught & fixed a regression the fix itself introduced) · backend unit suite **890/916 pass, 0 failures from this PR** (17 are pre-existing, proven per-test). |
| **NOT verified ⚠️** | No runtime Playwright failure-injection run — this is **static + build** verification. See _Testing_. |
| **Where to look first** | The 2 optimistic snapshot-revert sites + the `persistFullLayout` rethrow chain (highest-risk), and the `suppressGridReload` guard fix in `DashboardComponent.removeWidget` (the self-introduced regression, commit `805cfa89`). |

### 🔴 Before vs ✅ After — the same delete, one picture

| Step | ❌ Before (the bug) | ✅ After (this PR) |
|---|---|---|
| User clicks **Delete** | item vanishes from the UI instantly | item removed optimistically |
| Backend returns **403 / 500** | ⚠️ ignored — nothing catches it | caught |
| Toast shown | 🟢 **"Removed"** — a lie | 🔴 **"Failed to remove"** |
| Item on screen | gone… then **silently reappears** on reload | **stays / reverts** — user knows it failed |

```mermaid
flowchart TD
    U["User deletes / toggles / saves"] --> F["useMyFetch call"]
    F --> Q{"Backend fails?"}
    Q -->|"Before: resolves anyway"| B["🟢 mutate state + success toast<br/>❌ failure invisible,<br/>reappears later"]
    Q -->|"After: useMyFetchStrict throws"| A["🔴 red error toast<br/>✅ state reverts,<br/>failure visible"]
    style B fill:#ffd7d7,stroke:#d33,color:#000
    style A fill:#d7f5dd,stroke:#2a2,color:#000
```

## 📊 Test health at a glance

> ✅ **This PR breaks nothing.** All 45 fix files are frontend-only; **0** test failures are attributable to it. The 17 reds are pre-existing on `main` (stale tests behind earlier backend refactors + a few broken test harnesses) — **no production bug** hides among them. Verified by reading each failing test + its production code and cross-checking every failing module's last-touching commit against this PR's SHAs (full breakdown at the bottom).

| 🧪 Total | 🟢 Passed | 🔴 Failed | ⚪ Skipped | 📈 Pass rate | 🎯 From THIS PR | 🐞 Real bugs | ⏱ Runtime |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| 916 | 890 | 17 | 9 | 98.1% | **0** 🎉 | **0** | 12m 23s |

> ⚙️ **Why the 17 went unnoticed:** backend unit tests **never run in CI** — the `e2e-tests` workflow selects `-m e2e`, which deselects the unmarked `tests/unit/` files, so a PR can go green with a broken unit test. The added [`OPS.md`](OPS.md) documents this and ships a paste-ready CI job to close the gap. Fixing the 17 stale tests is a **separate cleanup**, out of scope here.

## 📍 Context map (for reviewers & future agents)

Durable pointers so this PR doubles as a navigation aid for the change and the convention it establishes:

- **The fix primitive** → `frontend/composables/useMyFetch.ts` — adds `useMyFetchStrict` (delegates to `useMyFetch`, same success shape, but **throws** the original fetch error on HTTP failure). The non-throwing `useMyFetch` above it is the root cause.
- **Error-message helper** → `frontend/composables/useErrorMessage.ts` — `getErrorMessage(e)` resolves a backend `error_code` to localized i18n text (previously unused; now the convention for failure toasts).
- **Reference pattern copied** → `frontend/components/ReviewFeed.vue` — the in-house snapshot-then-revert idiom used for optimistic sites.
- **Second root cause** → `frontend/components/DashboardComponent.vue` — `persistFullLayout` swallowed its own throw (now rethrows); `removeWidget`'s `suppressGridReload` guard fix lives here too.
- **Ops / how to run tests & the system** → [`OPS.md`](OPS.md) (added in this PR) — local run commands, the CI-per-PR map, and the failure-path test template for this bug class.
- **🧩 Convention going forward:** new **mutating** calls (POST/PUT/PATCH/DELETE) should use `useMyFetchStrict` inside `try/catch` (or check `error.value`/`status.value`) — **never** a bare `await useMyFetch(...)` that assumes it throws. A lint rule to enforce this is a listed follow-up.
- **Commits:** `17892c84` primitive · `b2b40bfb` wave 1 (55 handlers) · `4384084a` wave 2 (31 more, adversarial sweep) · `805cfa89` review fix (stranded guard + resync) · `6dbeec4b` `OPS.md`.
- **Related (separate work, not closed here):** #580–#583, #585–#587 (same optimistic-UI/silent-failure sweep).

---

## What & why

A user removes a member from an agent, deletes an API key, disconnects an OAuth client, deletes an uploaded file, removes a dashboard widget, or flips the MCP toggle — and if the backend call fails (403, 500, validation error, network blip), **the UI shows a green success toast and removes the item anyway**, exactly as if it worked. The item silently reappears on the next reload or refetch, with nothing tying it to the action the user took minutes or hours earlier. The worst case (`FileUploadComponent.removeFile`) removed the file from the local list *before* the request was even sent, with no rollback path at all.

This PR makes every mutating handler in that class gate its success path — state mutation, success toast, modal-close, emit, navigation — on the call actually succeeding, and show a red error toast when it didn't. Optimistic UIs revert to their prior state on failure.

## Root cause

`useMyFetch` is typed `typeof useFetch` and honors that contract: on the client path it **never rejects** on HTTP failure — it resolves with `{ data: null, error, status: 'error' }`. Any handler that did `try { await useMyFetch(...) } catch { ... }` expecting fetch-throws semantics had a dead catch block: the two lines after the `await` (mutate + success toast) ran unconditionally for a 403/500 exactly as for a 200.

The codebase split cleanly in two: **~519 call sites correctly read `error.value`/`status.value` after the await** (the house convention), while the silent class — bare-await-in-try/catch mutating handlers — turned out to be much larger than the issue's 14 listed sites (see Scope). The backend side was audited and is sound (it returns real error statuses), so a frontend gate suffices.

A second, independent root cause was found during the fix: `DashboardComponent.persistFullLayout` *did* throw correctly on `error.value` — but its own `catch` swallowed the throw into `console.error`, blinding all 7 callers.

## Approach

**New `useMyFetchStrict` variant + migrate the silent sites — deliberately NOT a contract flip on `useMyFetch` itself.** Flipping `useMyFetch` to reject would regress the 185 mutating + hundreds of GET sites that correctly read `error.value` after await outside any try/catch: their handled-error branches would be skipped and graceful error UX would become uncaught rejections. Instead:

- `useMyFetchStrict` (same composable file): identical auth/org/baseURL behavior and success shape — it delegates to `useMyFetch` — but throws the **original** fetch error when `error.value` is set. Dead-catch sites migrate by near-rename and their existing catch blocks come back to life.
- Failure toasts use the previously-unused `useErrorMessage().getErrorMessage(e)` composable, which resolves backend `error_code` to localized i18n text with detail/message fallbacks. **No new locale keys.**
- Truly optimistic sites got snapshot-then-revert (the `ReviewFeed.vue` house pattern): `FileUploadComponent.removeFile` (previously zero rollback), `integrations/index.vue` `toggleMcp` (which also gained a success-path re-derive, fixing its stale-toggle-after-success bug), `LLMsComponent.toggleModel`, `PromptBoxV2` mode select, `DataSourceSelector.toggleDataSource`, `WaitTool.cancel`.
- `persistFullLayout` now rethrows after logging; its un-awaited callers (`schedulePersistFullLayout`, `saveInlineTextBlock`) got their own catch + toast so the throw can't escape as an unhandled rejection.

## Scope — the honest discovery arc

The issue listed 14 sites. A full sweep of **all 211 mutating `useMyFetch` call sites** found the true silent class was ~52; a few more surfaced while fixing. Total: **~86 handlers gated across 45 files** (+465/−220), structured as four fix commits:

| Commit | What it is |
|---|---|
| `useMyFetchStrict` infra | Add the rejecting variant (no site changes) |
| Wave 1 (55 handlers) | The issue's 14 grown to the sweep's 52, +3 found while fixing |
| Wave 2 (31 sites) | Found by an adversarial acceptance sweep — 17 hiding in the very files wave 1 touched, ~14 in files no one had looked at |
| Review fix | Reset a stranded guard the fix itself introduced + a loop-resync (see below) |

Wave 2 also fixed two verbatim-copied **dead guards** — `if (!response.code === 200) throw`, which can never fire since the result has no `.code` field — that made a failed report-create navigate as success (`reports/[id]/legacy.vue`, `excel/index.vue`), and a swallowed secondary layout PATCH in `DashboardComponent` that now surfaces a distinct amber "saved, but position could not be saved" toast on partial failure.

## Review found a regression the fix itself introduced

A bigger-picture ripple review (tracing downstream code the old silent-resolve path ran unconditionally but the new throw now skips) caught a real one: `DashboardComponent.removeWidget` sets a module-level `suppressGridReload` guard, awaits `persistFullLayout()`, then resets it. Once `persistFullLayout` rethrows (wave 2), a failed layout PATCH threw between set and reset — **stranding the guard true and silently disabling the grid-reload watcher** until a later successful structural op or remount. Fixed by resetting the guard in the catch; the other two guard sites fence a non-throwing debounced scheduler and were verified unaffected.

The same review confirmed the rest of the ripple surface safe with parent/caller traces: emit/parent contracts, loading-flag completeness across all touched files (no stuck spinners), and loop partial-progress resync (`saveStarters` and role-update loops now resync from the server in their catch, since an aborted delete-then-recreate loop can leave the backend ahead of local state).

## Testing / verification

- `nuxt build` green at every stage (after each commit).
- Two independent Opus review passes: a local-mechanism pass (per-handler correctness) and a bigger-picture ripple pass (downstream contracts) — the latter found the guard regression above.
- A full sweep over all 211 mutating call sites, then a second adversarial acceptance sweep that found wave 2.
- Backend unit suite run locally (SQLite): 890 passed / 17 failed / 9 skipped — the 17 pre-existing and unrelated (see below).

This is **static + build verification**, not runtime Playwright — the change is mechanically uniform (gate success path on the call succeeding) and each handler was reviewed individually, but no end-to-end failure-injection run was performed. The single highest-value follow-up test is a `page.route`-forces-403 Playwright spec (template in `OPS.md`).

## The one behavior change reviewers should know

Handlers that used to (wrongly) show success on failure now show a red error toast and do **not** mutate, close the modal, emit, or navigate; optimistic UIs revert. This is the intended change — a failing backend is now visible instead of silent. Loop-style save handlers (delete-all-then-recreate) now stop at the first failure instead of silently plowing through, and resync from the server where partial progress could leave the display stale.

## Out of scope / follow-ups

- Backend `widget_service` returns 200 on a missing row and lacks report/org scoping — pre-existing, separate issue.
- `excel/index.vue` `getReports`/`getDataSourceOptions` have the same dead `!response.code === 200` guard on GET reads (reads, so no silent mutation — but same footgun).
- A **lint rule** flagging bare-await `useMyFetch` on mutating methods, so the class can't silently reappear (enforces the convention above).
- Add the paste-ready **`unit-tests` CI job** from `OPS.md` so unit tests actually run on every PR.
- Clean up the **17 pre-existing stale/broken backend unit tests** (separate issue — see analysis below).
- A few inline error-message extractions not yet routed through `getErrorMessage`.
- `useMyFetchStrict` keeps the `typeof useFetch` type annotation for consistency with its sibling — a knowing TS white lie (it can throw where the type says it resolves); left as-is to avoid a type-churn diff here.

---

## Detailed test analysis

### How each failure was checked (staleness criteria)

A failure was classified by reading both the failing test **and** the current production code it exercises, then tracing git history — never by taking "it's frontend-only, so it's fine" on faith. Each of the 17 was assigned exactly one label:

- **STALE-TEST** — the production code legitimately changed (a value, a method, a data type, a registry entry) and the test was never updated, so it still asserts an outdated contract. Evidence required: the symbol/value the test expects no longer matches current code, **and** the code's last-touching commit is one of the earlier backend feature commits — never one of this PR's four fix SHAs (all frontend-only, all dated 2026-07-09).
- **PRE-EXISTING TEST DEFECT** — the test was structurally wrong the day it was written (mocks the wrong path, asserts against a type membership that can never be true, or relies on a stubbing trick that a real import defeats). Production code is correct; the test never reliably passed. Still entirely PR-unrelated.
- **PRE-EXISTING REAL BUG** — production code is genuinely wrong and the test correctly catches it. **Zero of the 17 fell here.**
- **RELATED-TO-OUR-PR** — traceable to the frontend diff. **Zero.** Confirmed our commits touch no backend file (`git diff --name-only origin/main...HEAD` is 100% `frontend/`), and each failing production module's last-touching commit is an unrelated, earlier backend commit.

**Result: 11 STALE-TEST · 6 PRE-EXISTING TEST DEFECT · 0 real bugs · 0 caused by this PR.**

### The failures, grouped by file and cause

- **`test_notification_service.py` (6) — STALE-TEST.** The 5 `_build_*` tests call private methods (`_build_subject`/`_build_html`/`_build_results_html`) that no longer exist — that logic was extracted into module-level renderers in `app/services/email_renderer.py` during an earlier i18n/RTL/XSS pass. The 6th asserts a recipient as a plain `str` against `fastapi_mail`'s `List[NameEmail]`, whose `__eq__` never matches a string. Test file predates both changes.
- **`test_connection_oauth.py` (2) — STALE-TEST.** Both assert the MS Fabric OAuth scope contains `api.fabric.microsoft.com`, but production deliberately uses `https://database.windows.net/user_impersonation` (Fabric SQL endpoints authenticate with Azure SQL tokens — an in-code comment explains why). Changed by earlier backend commits; the assertion predates them.
- **`test_permissions_registry.py` (2) — STALE-TEST.** A frozen "MVP permission set" snapshot drifted behind two real RBAC feature commits: one added `manage_service_accounts`, the other added the `connection` resource-permission group. Both intentional; the snapshot wasn't updated. _(Reproduced live — the failure diff literally shows the registry's extra `manage_service_accounts` / `connection` entries.)_
- **`test_whatsapp_adapter.py` (2) — STALE-TEST.** Both read `body["context"]` on the adapter's POST payload, but production intentionally stopped setting `context.message_id` (a product decision to stop quoting the root message on every reply). Fixtures still expect the old shape; no unguarded `['context']` access exists in production.
- **`test_eval_draft_helpers.py` (3) — PRE-EXISTING TEST DEFECT.** All three fail at `patch("app.services.completion_feedback_service.LLMService")` — but `LLMService` is imported lazily *inside* the function (to avoid a circular import), so it's never a module attribute and `patch` raises before the test body runs. The function under test is correct; the mock targets the wrong path. Broken since introduction.
- **`test_data_source_member_email.py` (1) — PRE-EXISTING TEST DEFECT.** Asserts a recipient as a plain string against `fastapi_mail`'s `List[NameEmail]` — same third-party typing root cause as the notification case; the assertion was never valid. Production behavior is correct.
- **`test_whatsapp_webhook_route.py` (1) — PRE-EXISTING TEST DEFECT (harness).** Installs fake modules via `sys.modules.setdefault(...)`, but `conftest.py`'s module-level `from main import app` already imported the real module, so `setdefault` no-ops and the route binds to the real manager, which then hits the test's incomplete `_Result` fake.
  > **Honest note:** the `'_Result' object has no attribute 'scalar_one_or_none'` text *looks* like a production async/sync SQLAlchemy bug and was checked most carefully for exactly that. It is **not** — production uses the correct `await db.execute(...)` → `result.scalar_one_or_none()` against a real `AsyncSession`. The crash is entirely the test's incomplete fake plus a module-stubbing trick that `conftest`'s earlier real import defeats. A broken test harness, not a backend defect.

_Bottom line: the 17 reds are real test-suite rot worth a separate cleanup issue, but none is caused by this PR and none is a production bug._
