### PR TITLE
Fix stale WhatsApp outbound tests and cover image sending

### DIFF
--- a/backend/tests/unit/test_whatsapp_adapter.py
+++ b/backend/tests/unit/test_whatsapp_adapter.py
@@ -260,7 +260,10 @@ async def test_send_response_posts_text(monkeypatch):
     assert body["to"] == "15551234567"
     assert body["type"] == "text"
     assert body["text"]["body"] == "hi there"
-    assert body["context"] == {"message_id": "wamid.AAA"}
+    # Outbound replies intentionally do NOT quote the inbound message: quoting
+    # the root prompt on every reply reads as repetitive clutter, and thread
+    # association is tracked server-side via Completion.external_thread_ts.
+    assert "context" not in body
 
 
 @pytest.mark.asyncio
@@ -333,7 +336,37 @@ async def test_send_file_in_thread_uploads_and_sends(monkeypatch, tmp_path):
     assert body["type"] == "document"
     assert body["document"]["id"] == "media-xyz"
     assert body["document"]["filename"] == "report.csv"
-    assert body["context"] == {"message_id": "wamid.AAA"}
+    # Media messages, like text replies, don't quote the root prompt.
+    assert "context" not in body
+
+
+@pytest.mark.asyncio
+async def test_send_image_in_dm_uploads_and_sends_image(monkeypatch, tmp_path):
+    f = tmp_path / "chart.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n")
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path.endswith("/media"):
+            return httpx.Response(200, json={"id": "media-img"})
+        return httpx.Response(200, json={"messages": [{"id": "wamid.I"}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mock_client(handler))
+    a = make_adapter()
+    ok = await a.send_image_in_dm("15551234567", str(f), "Revenue chart")
+    assert ok is True
+    # Two calls: upload then send
+    assert any(r.url.path.endswith("/media") for r in calls)
+    send_req = [r for r in calls if r.url.path.endswith("/messages")][-1]
+    body = json.loads(send_req.content.decode())
+    # Images are sent as the native WhatsApp `image` type (not `document`),
+    # carry a caption, and never include a `filename`.
+    assert body["type"] == "image"
+    assert body["image"]["id"] == "media-img"
+    assert body["image"]["caption"] == "Revenue chart"
+    assert "filename" not in body["image"]
+    assert "context" not in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The WhatsApp channel adapter already supports sending images outbound (mirroring the Slack connection): `send_image_in_dm` / `send_file_in_dm` upload the file to the WhatsApp `/media` endpoint and then send it, MIME-sniffing images into WhatsApp's native `image` message type (with caption) versus `document` for other files. Chart images flow through the shared notification pipeline (`create_plot` renders a `.png`, which is sent via `send_file_in_thread`), so no product code needed changing.

However, the branch's unit tests were out of sync with the implementation and the suite was red (`2 failed, 10 passed`). A prior change intentionally dropped `context.message_id` quoting on outbound messages — re-quoting the user's root prompt above every reply read as repetitive clutter, and thread association is tracked server-side via `Completion.external_thread_ts` — but two tests still asserted the old quoting behavior.

## Changes

- Update `test_send_response_posts_text` and `test_send_file_in_thread_uploads_and_sends` to assert outbound payloads carry **no** `context` field, matching the documented "no quoting" behavior in the adapter.
- Add `test_send_image_in_dm_uploads_and_sends_image` covering the image path that previously had no test: `send_image_in_dm` must upload media and send WhatsApp's native `image` message type with a caption and no `filename`, distinct from the `document` path used for other files.

## Testing

- `python -m pytest tests/unit/test_whatsapp_adapter.py` → **13 passed** (was 2 failed / 10 passed).
- Verified the end-to-end outbound chart path is WhatsApp-compatible: `create_plot` emits `.png` → `_upload_media` guesses `image/png` → adapter sends `type: "image"`.

## Notes

Scope is outbound only. WhatsApp *inbound* still accepts text only (`process_incoming_message` drops non-text messages) — that receive-side limitation is unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Hdmqk3L6Yd3gCBZ2KVRgs)_