### PR TITLE
Show selected model provider icon in PromptBoxV2 LLM selector button

### DIFF
--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -448,7 +448,8 @@
                     <UPopover :key="'model-' + (props.popoverOffset || 0)" :popper="popperLegacy">
                         <UTooltip :text="selectedModelLabel" :popper="{ strategy: 'fixed', placement: 'top' }">
                             <button class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-md px-2 py-1 text-xs flex items-center max-w-[180px]">
-                                <Icon name="heroicons-cpu-chip" class="w-4 h-4 flex-shrink-0" />
+                                <LLMProviderIcon v-if="selectedModelProvider" :provider="selectedModelProvider" :icon="true" class="w-4 h-4 flex-shrink-0" />
+                                <Icon v-else name="heroicons-cpu-chip" class="w-4 h-4 flex-shrink-0" />
                                 <span v-if="!isCompactPrompt" class="ms-1 truncate">{{ selectedModelLabel }}</span>
                             </button>
                         </UTooltip>
@@ -935,6 +936,10 @@ const selectedModel = ref<string>('')
 const selectedModelLabel = computed(() => {
     const model = models.value.find(m => m.id === selectedModel.value)
     return model?.name || t('prompt.selectModel')
+})
+const selectedModelProvider = computed(() => {
+    const model = models.value.find(m => m.id === selectedModel.value)
+    return model?.provider?.provider_type || null
 })
 
 // Legacy popper (for current Nuxt UI stable)


### PR DESCRIPTION
## Summary

In PromptBoxV2's LLM selector, the button previously always displayed a generic `heroicons-cpu-chip` icon. This updates it to show the **selected model's provider icon** instead — the same `LLMProviderIcon` already rendered for each option in the dropdown list — so the button visually reflects the currently selected model.

## Changes

- Added a `selectedModelProvider` computed that resolves the selected model's `provider.provider_type`.
- Updated the selector button to render `<LLMProviderIcon>` for the selected provider, falling back to the `heroicons-cpu-chip` icon only when no model is selected.

Single file changed: `frontend/components/prompt/PromptBoxV2.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjTmyxiR5TjKWPx2gxFKKM)_