### PR TITLE
Auto-detect RTL direction for free-form emails

### DIFF
--- a/backend/app/services/email_send_service.py
+++ b/backend/app/services/email_send_service.py
@@ -27,6 +27,63 @@ from app.ai.tools.schemas.send_email import (
 logger = logging.getLogger(__name__)
 
 
+# Strong right-to-left Unicode blocks: Hebrew, Arabic, Arabic Supplement,
+# Syriac, Thaana, NKo, Samaritan, Mandaic, plus the Hebrew/Arabic presentation
+# forms. A character in any of these ranges is "strong RTL" per the Unicode
+# bidi algorithm.
+_RTL_CHARS = re.compile(
+    "[֐-׿؀-ۿ܀-ݏݐ-ݿހ-޿"
+    "߀-߿ࠀ-࠿ࡀ-࡟ࢠ-ࣿ"
+    "יִ-ﭏﭐ-﷿ﹰ-﻿]"
+)
+# Strong left-to-right letters: Latin (incl. accented), plus Greek and Cyrillic
+# so a body in one of those isn't misread as neutral. Digits, whitespace, and
+# punctuation are bidi-neutral and deliberately excluded from the count.
+_LTR_CHARS = re.compile(
+    "[A-Za-zÀ-ɏͰ-ϿЀ-ӿ]"
+)
+# For HTML bodies we score the visible text only — tags, attribute values, and
+# entities are English-looking markup and would otherwise dilute the RTL ratio.
+_HTML_TAG = re.compile(r"<[^>]+>")
+_HTML_ENTITY = re.compile(r"&[#0-9A-Za-z]+;")
+
+# Any strong-RTL letters at or above this share of strong letters flips the body
+# to RTL. Kept low because pure/mostly-English bodies have *zero* RTL letters, so
+# the margin is wide; a Hebrew report peppered with English identifiers still
+# clears it comfortably.
+_RTL_THRESHOLD = 0.30
+
+# RIGHT-TO-LEFT MARK — an invisible strong-RTL character. Prefixed to a
+# plain-text body so clients that honour it anchor the base direction; harmless
+# in clients that ignore it.
+_RLM = "‏"
+
+
+def detect_text_direction(
+    text: str, *, is_html: bool = False, threshold: float = _RTL_THRESHOLD
+) -> str:
+    """Return ``"rtl"`` or ``"ltr"`` for ``text`` by scoring strong letters.
+
+    The body of a free-form email is written by the agent and carries no
+    direction hint, so we infer one: count strong-RTL vs strong-LTR letters and
+    call it RTL when RTL letters are at least ``threshold`` of the total. Bodies
+    with no RTL letters are always LTR. For ``is_html`` bodies the markup is
+    stripped first so tag/attribute text can't tip the balance.
+    """
+    if not text:
+        return "ltr"
+    if is_html:
+        text = _HTML_ENTITY.sub(" ", _HTML_TAG.sub(" ", text))
+    rtl = len(_RTL_CHARS.findall(text))
+    if rtl == 0:
+        return "ltr"
+    ltr = len(_LTR_CHARS.findall(text))
+    total = rtl + ltr
+    if total == 0:
+        return "ltr"
+    return "rtl" if (rtl / total) >= threshold else "ltr"
+
+
 # Default export format per ref_type when the caller doesn't specify one.
 _DEFAULT_FORMAT = {
     "visualization": "csv",
@@ -166,6 +223,11 @@ class EmailSendService:
                     new_root = make_message_id()
                     message_id = new_root
 
+            # Auto-detect the body's language direction and wrap RTL content so
+            # Hebrew/Arabic emails don't render left-to-right. Done before the
+            # report link is appended so the (LTR) URL stays outside the wrapper.
+            body = self._apply_direction(body, subtype)
+
             body = self._append_report_link(
                 body, subtype, report, can_reply=bool(integration and integration.get("inbound"))
             )
@@ -235,6 +297,26 @@ class EmailSendService:
             return {"inbound": bool(cfg.get("inbound_enabled"))}
         except Exception:  # noqa: BLE001
             return None
+
+    def _apply_direction(self, body: str, subtype: str) -> str:
+        """Wrap an RTL body so email clients render it right-to-left.
+
+        Detects direction from the body itself (see ``detect_text_direction``).
+        For HTML, an RTL body is wrapped in a ``dir="rtl"`` container — this sets
+        the base paragraph direction *and* flips table column / list-marker order
+        that clients otherwise lay out LTR. Runs of embedded English inside still
+        get their correct per-run direction from the client's bidi algorithm.
+        For plain text there is no markup to set, so we prefix a RIGHT-TO-LEFT
+        MARK. LTR bodies are returned unchanged. Called before the report-link
+        footer is appended, so the (LTR) deep-link URL stays outside the wrapper.
+        """
+        if not body:
+            return body
+        if detect_text_direction(body, is_html=(subtype == "html")) != "rtl":
+            return body
+        if subtype == "html":
+            return f'<div dir="rtl" style="text-align:right">{body}</div>'
+        return f"{_RLM}{body}"
 
     def _append_report_link(self, body: str, subtype: str, report: Any, can_reply: bool) -> str:
         """Append a report deep link (and reply hint) to the email body."""

--- a/backend/tests/unit/test_email_rtl_direction.py
+++ b/backend/tests/unit/test_email_rtl_direction.py
@@ -1,0 +1,162 @@
+"""Free-form emails must render right-to-left when their body is written in an
+RTL language (Hebrew, Arabic, ...).
+
+The templated share/schedule emails already resolve a locale and set ``dir`` in
+their Jinja layout, but the free-form ``send_email`` tool (and the MCP notify
+path) send whatever body the agent wrote verbatim. Email clients default to LTR
+when no direction is declared, so a Hebrew report rendered LTR: paragraphs
+left-aligned and, worst of all, table columns visually flipped.
+
+``EmailSendService`` now auto-detects the body's direction and, for RTL content,
+wraps an HTML body in ``<div dir="rtl">`` (and marks a plain-text body with a
+leading RLM). These tests assert the invariant — RTL in, RTL wrapper out; LTR in,
+no wrapper — not one specific reported string.
+"""
+import types
+
+import pytest
+
+from app.services.email_send_service import (
+    EmailSendService,
+    detect_text_direction,
+)
+
+
+# --- the detector: direction follows the dominant strong-directional script ---
+
+@pytest.mark.parametrize(
+    "text, is_html, expected",
+    [
+        ("Q2 revenue was $1.2M, up 14% QoQ.", False, "ltr"),
+        ("", False, "ltr"),
+        ("12345 — 67.8%", False, "ltr"),  # neutrals only -> ltr
+        ("דוח חריגים יומי — 09/07/2026", False, "rtl"),
+        ("שלום עולם", False, "rtl"),
+        ("مرحبا بالعالم", False, "rtl"),  # Arabic
+        # Mixed but Hebrew-dominant (the real report shape: Hebrew prose with
+        # scattered English identifiers like HasOverlap / StandardHours).
+        ("עובדים: תאיר פרץ (10.28 שעות) HasOverlap StandardHours", False, "rtl"),
+        # English-dominant with a stray Hebrew word stays LTR.
+        (
+            "This is a long English sentence about revenue and growth שלום",
+            False,
+            "ltr",
+        ),
+        # HTML tags/attributes/entities must not count as LTR letters and dilute
+        # the ratio: a Hebrew table wrapped in English markup is still RTL.
+        (
+            '<table><tr><td style="text-align:left">שעות לילה</td>'
+            "<td>אין חריגות</td></tr></table>",
+            True,
+            "rtl",
+        ),
+        # A pure-English HTML table stays LTR.
+        (
+            "<table><tr><td>Employee</td><td>Hours</td></tr></table>",
+            True,
+            "ltr",
+        ),
+    ],
+)
+def test_detect_text_direction(text, is_html, expected):
+    assert detect_text_direction(text, is_html=is_html) == expected
+
+
+# --- the send path applies the direction wrapper -----------------------------
+
+def _svc():
+    return EmailSendService()
+
+
+def test_apply_direction_wraps_rtl_html():
+    svc = _svc()
+    body = "<p>שלום, הנה הדוח היומי שלך.</p>"
+    out = svc._apply_direction(body, "html")
+    assert out.startswith('<div dir="rtl"')
+    assert body in out
+
+
+def test_apply_direction_leaves_ltr_html_untouched():
+    svc = _svc()
+    body = "<p>Hello, here is your daily report.</p>"
+    assert svc._apply_direction(body, "html") == body
+
+
+def test_apply_direction_marks_rtl_plaintext():
+    svc = _svc()
+    body = "שלום, הנה הדוח היומי שלך."
+    out = svc._apply_direction(body, "plain")
+    assert out.startswith("‏")  # RLM
+    assert "שלום" in out
+
+
+def test_apply_direction_leaves_ltr_plaintext_untouched():
+    svc = _svc()
+    body = "Hello, here is your daily report."
+    assert svc._apply_direction(body, "plain") == body
+
+
+# --- end-to-end through EmailSendService.send() ------------------------------
+
+@pytest.mark.asyncio
+async def test_send_wraps_hebrew_html_body(monkeypatch):
+    """A Hebrew HTML body handed to send() must reach the SMTP layer wrapped in
+    an RTL container, and the appended report-link footer must stay OUTSIDE it
+    (URLs render LTR)."""
+    captured = {}
+
+    async def _fake_send_custom_email(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(status="sent", error=None)
+
+    from app.services import notification_service as ns_mod
+    monkeypatch.setattr(
+        ns_mod.notification_service, "send_custom_email", _fake_send_custom_email
+    )
+
+    report = types.SimpleNamespace(id="report-123")
+    out = await EmailSendService().send(
+        db=None,
+        recipient="yochze@gmail.com",
+        subject="דוח חריגים יומי",
+        body="<p>שלום, הנה הדוח היומי שלך.</p><table><tr><td>שעות</td></tr></table>",
+        body_format="html",
+        report=report,
+        organization=None,
+        system_completion=None,
+    )
+
+    assert out.success is True
+    sent_body = captured["body"]
+    assert sent_body.startswith('<div dir="rtl"')
+    # The report link footer is appended after the RTL wrapper closes, so the
+    # deep-link URL is not trapped inside a right-to-left block.
+    assert "/reports/report-123" in sent_body
+    assert sent_body.index("</div>") < sent_body.index("/reports/report-123")
+
+
+@pytest.mark.asyncio
+async def test_send_leaves_english_html_body_unwrapped(monkeypatch):
+    captured = {}
+
+    async def _fake_send_custom_email(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(status="sent", error=None)
+
+    from app.services import notification_service as ns_mod
+    monkeypatch.setattr(
+        ns_mod.notification_service, "send_custom_email", _fake_send_custom_email
+    )
+
+    await EmailSendService().send(
+        db=None,
+        recipient="yochze@gmail.com",
+        subject="Your daily report",
+        body="<p>Hello, here is your daily report.</p>",
+        body_format="html",
+        report=None,
+        organization=None,
+        system_completion=None,
+    )
+
+    assert 'dir="rtl"' not in captured["body"]

--- a/docs/feedback-loops/hebrew-rtl-email-report.md
+++ b/docs/feedback-loops/hebrew-rtl-email-report.md
@@ -1,0 +1,105 @@
+# Feedback Loop — "send_email report is not RTL if hebrew"
+
+Reproduces the report: a Hebrew report delivered by the free-form `send_email`
+tool renders **left-to-right** in the mail client — paragraphs left-aligned and
+table columns visually flipped — because the outgoing HTML carries no direction
+hint. Validates that auto-detecting the body's direction and wrapping RTL
+content fixes it, without disturbing English (LTR) emails.
+
+## Root cause (validated)
+
+There are two email paths in the backend:
+
+- **Templated** share/schedule/scheduled-prompt emails resolve a locale and set
+  `dir` in their Jinja layout via `direction_for(locale)`
+  (`backend/app/services/email_strings.py:414-418`). These are already RTL-aware.
+- **Free-form** emails — the `send_email` agent tool and the MCP `notify` path —
+  send whatever body the model wrote, verbatim. Both funnel through
+  `EmailSendService.send()` (`backend/app/services/email_send_service.py:101`;
+  the MCP path reaches it via `notify_service._send_email`,
+  `backend/app/services/notify_service.py:300-312`). Before the fix, `send()`
+  appended a report link (`_append_report_link`) and handed the body straight to
+  `notification_service.send_custom_email` with **no direction handling**.
+
+Email clients default to LTR when no `dir` is declared, so a Hebrew body renders
+LTR. The `send_email` tool description even instructs the model to write simple
+HTML with "no wrapper divs" (`backend/app/ai/tools/implementations/send_email.py:54-62`),
+so the model never sets `dir` itself. This is the email in the report — the
+`_append_report_link` footer ("Open this in Bag of words:") is its signature.
+
+## Loop A — deterministic reproduction (no external services)
+
+`backend/tests/unit/test_email_rtl_direction.py` — pure detector cases plus an
+end-to-end `EmailSendService.send()` run with `send_custom_email` stubbed to
+capture the outgoing body.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"; mkdir -p db
+uv run pytest tests/unit/test_email_rtl_direction.py -q
+```
+
+Observed **FAIL** on pre-fix code — the send path has no direction hook, so the
+symbols the test asserts on don't exist:
+
+```
+ImportError: cannot import name 'detect_text_direction' from
+'app.services.email_send_service'
+```
+
+## Loop B — live confirmation (real LLM + real SMTP)
+
+`backend/.repro/rtl_email_e2e.py` (uncommitted; needs `ANTHROPIC_KEY`). A real
+model call writes the Hebrew report body — nothing hand-crafted for the assert —
+which flows through the real `EmailSendService.send()` → fastapi-mail → a local
+`aiosmtpd` sink, then the actual `text/html` MIME part is inspected.
+
+```bash
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+export ANTHROPIC_KEY=sk-ant-...        # env only; never commit
+uv run python .repro/rtl_email_e2e.py
+```
+
+Observed on the wire (post-fix), body generated live by the model:
+
+```
+First 200 chars of the text/html MIME part actually sent:
+<div dir="rtl" style="text-align:right"><p>שלום, להלן דוח החריגים היומי ...
+RTL wrapper present at start : True
+Report-link footer outside wrapper (LTR): True
+RESULT: PASS — real Hebrew email sent with dir="rtl".
+```
+
+## The fix
+
+`backend/app/services/email_send_service.py`:
+
+- `detect_text_direction(text, is_html=...)` — counts strong-RTL vs strong-LTR
+  letters (RTL Unicode blocks: Hebrew, Arabic, Syriac, Thaana, NKo, …; markup
+  stripped for HTML so tag/attribute text can't dilute the ratio). Returns
+  `"rtl"` when RTL letters are ≥ 30% of strong letters. Bodies with zero RTL
+  letters are always `"ltr"`, so English is never misdetected.
+- `EmailSendService._apply_direction(body, subtype)` — for an RTL HTML body,
+  wraps it in `<div dir="rtl" style="text-align:right">…</div>` (sets base
+  paragraph direction and flips table-column / list order; embedded English runs
+  keep their own per-run direction from the client's bidi algorithm). For plain
+  text, prefixes a RIGHT-TO-LEFT MARK. LTR bodies pass through untouched.
+- Called in `send()` **before** `_append_report_link`, so the LTR deep-link URL
+  stays outside the RTL wrapper.
+
+One change covers both the internal `send_email` tool and the MCP `notify` path.
+
+Re-run Loop A after the fix (**PASS**):
+
+```
+16 passed
+```
+
+## What this proves / regression notes
+
+The loop demonstrates the failure is a missing direction declaration on the
+free-form path, not a locale or data problem: RTL body in → `dir="rtl"` wrapper
+out; LTR body in → unchanged. The unit test asserts that invariant (not the one
+reported Hebrew string) and survives as a regression test. Existing email suites
+(`tests/unit/test_notification_email_retry.py`, `tests/e2e/test_email_integration.py`)
+still pass — the wrapper only appears for RTL-dominant bodies.


### PR DESCRIPTION
## Problem

Hebrew (and other RTL) reports sent by the free-form `send_email` tool render **left-to-right** in the mail client — paragraphs left-aligned and table columns visually flipped — because the outgoing HTML carries no direction hint.

Two email paths exist in the backend. The **templated** share/schedule/scheduled-prompt emails already resolve a locale and set `dir` in their Jinja layout (`direction_for(locale)` in `email_strings.py`). The **free-form** path — the `send_email` agent tool and the MCP `notify` path — sends whatever body the model wrote, verbatim, with no direction handling. The tool description even tells the model to write simple HTML with "no wrapper divs", so it never sets `dir` itself. Email clients default to LTR, so Hebrew renders LTR.

## Fix

`backend/app/services/email_send_service.py`:

- **`detect_text_direction(text, is_html=…)`** — scores strong-RTL vs strong-LTR letters (RTL Unicode blocks: Hebrew, Arabic, Syriac, Thaana, NKo, …; markup stripped for HTML so tag/attribute text can't dilute the ratio). Returns `"rtl"` when RTL letters are ≥ 30% of strong letters. Bodies with zero RTL letters are always `"ltr"`, so English is never misdetected.
- **`EmailSendService._apply_direction(body, subtype)`** — wraps an RTL HTML body in `<div dir="rtl" style="text-align:right">…</div>` (sets base paragraph direction and flips table-column / list order; embedded English runs keep their own per-run direction from the client's bidi algorithm); prefixes a plain-text body with a RIGHT-TO-LEFT MARK. LTR bodies pass through untouched.
- Called in `send()` **before** `_append_report_link`, so the LTR deep-link URL stays outside the RTL wrapper.

Both the internal `send_email` tool and the MCP `notify` path funnel through `EmailSendService.send()` (the MCP path via `notify_service._send_email`), so one change covers both.

## Verification

Followed the `sandbox-feedback-loop` skill — full writeup in `docs/feedback-loops/hebrew-rtl-email-report.md`.

- **Loop A (deterministic):** `backend/tests/unit/test_email_rtl_direction.py` — 16 cases (detector + end-to-end `send()` with the SMTP layer stubbed to capture the body). Went from FAIL (feature absent) to **16 passed** after the fix. Asserts the invariant (RTL in → `dir="rtl"` out; LTR in → unchanged), not one reported string, so it survives as a regression test.
- **Loop B (live end-to-end):** a real model call wrote the Hebrew report body, pushed through the real `send()` → fastapi-mail → a local `aiosmtpd` sink; the actual `text/html` MIME part on the wire came out `<div dir="rtl" style="text-align:right"><p>שלום, להלן דוח החריגים…` with the report-link footer outside the wrapper. (Harness needs a live API key, so it is not committed.)
- Existing email suites (`tests/unit/test_notification_email_retry.py`, `tests/e2e/test_email_integration.py`) still pass (10/10) — the wrapper only appears for RTL-dominant bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfGDurGC8EB5kS56NWbS31

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfGDurGC8EB5kS56NWbS31)_