### PR TITLE
fix(mobile): prevent iOS focus-zoom on report prompt box

### DIFF
--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -4,6 +4,7 @@
       ref="inputRef"
       contenteditable="true"
       :dir="inputDir"
+      class="mention-input-field"
       :class="[
         'w-full outline-none resize-none bg-transparent text-gray-900 dark:text-white placeholder-gray-400 text-start',
         props.compact ? 'text-sm leading-[20px]' : 'text-sm min-h-[40px]'
@@ -1590,6 +1591,17 @@ function scrollSelectedIntoView() {
 
 [contenteditable]:focus {
   outline: none;
+}
+
+/* Mobile Safari auto-zooms the page when a focused editable element has a
+ * font-size below 16px. The prompt field is `text-sm` (14px), so tapping it
+ * on iOS zooms the report in. Pin it to 16px on small screens to suppress the
+ * focus-zoom; desktop keeps the 14px design. The `[contenteditable]` prefix
+ * raises specificity above Tailwind's `.text-sm` so this wins. */
+@media (max-width: 640px) {
+  [contenteditable].mention-input-field {
+    font-size: 16px;
+  }
 }
 
 /* Style mentions - Cursor-style minimal design */


### PR DESCRIPTION
## What & why

On mobile, opening a report (`/reports/[id]`) and tapping PromptBoxV2 zoomed the viewport into the prompt.

**Root cause:** Mobile Safari auto-zooms the viewport when a focused editable element has a computed `font-size` below 16px. The prompt field — the `contenteditable` in `MentionInput.vue` — renders at Tailwind `text-sm` (14px), which is under that threshold, so tapping it triggered the browser's built-in focus-zoom. The app uses Nuxt's default permissive viewport (no `maximum-scale`), so nothing suppressed it.

## Change

- Add a stable `mention-input-field` class to the `contenteditable` field.
- Add a `@media (max-width: 640px)` rule pinning the field to `16px`, using the `[contenteditable].mention-input-field` selector so it outranks Tailwind's `.text-sm`.

This suppresses the iOS focus-zoom on small screens while keeping the 14px design on desktop. It does **not** touch the viewport `<meta>`, so pinch-to-zoom remains available everywhere (no accessibility regression).

## Verification

Rendered the field in headless Chromium at two widths and read the computed `font-size`:

| viewport | font-size |
|----------|-----------|
| 375px (mobile) | 16px ✅ (no focus-zoom) |
| 800px (desktop) | 14px ✅ (design preserved) |

Note: the actual zoom is a Safari-specific heuristic and can't be reproduced in Chromium; the computed-font-size check verifies the exact condition (≥16px on focus) that prevents it. A tap-test on a real iPhone is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6JwKrpq7XvRM412B2nXp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6JwKrpq7XvRM412B2nXp7)_