### PR TITLE
fix(usage): buffer data-plane metering — removes 60s SQLite stall per create_data

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -29,7 +29,7 @@ from app.ai.http.safe_client import SafeHttpClient
 # already CPU-bound by the GIL, so wall-clock impact is negligible.
 _STDOUT_REDIRECT_LOCK = threading.Lock()
 from app.schemas.organization_settings_schema import OrganizationSettingsConfig, FeatureState
-from app.services.usage_policy_service import UsageLimitContext, usage_policy_service
+from app.services.usage_policy_service import UsageLimitContext
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.ai.context.builders.code_context_builder import CodeContextBuilder
@@ -481,6 +481,16 @@ class QueryCapturingClientWrapper:
         return holder.get("value")
 
     def _consume_query_quota(self, query: str) -> None:
+        """Enforce, then buffer — never write to the DB from the sandbox thread.
+
+        The old shape ran the counter+event WRITE synchronously here; on SQLite
+        it queued behind the agent's writer lock, waited out busy_timeout (30s)
+        and got skipped — +30s per query with the metering lost anyway (see
+        docs/feedback-loops/agent-latency-deep-dive.md). Enforcement is now a
+        cached READ (`check_data_query`, WAL-safe, in-memory after first load);
+        the usage event is buffered on the context and persisted by the same
+        end-of-run flush() the token/cost buffers use.
+        """
         context = self._usage_context
         if context is None or context.session_maker is None:
             return
@@ -489,22 +499,16 @@ class QueryCapturingClientWrapper:
             return
         metadata = self._usage_metadata(query)
         try:
-            context.run_blocking(
-                usage_policy_service.consume_data_query_with_context(
-                    context,
-                    connection_id=str(connection_id),
-                    metadata=metadata,
-                )
-            )
+            # Raises UsageLimitExceeded when over quota — propagates, same as before.
+            context.run_blocking(context.check_data_query(str(connection_id)))
         except OperationalError as e:
-            # SQLite-only: the agent's long-lived session can hold the single
-            # write lock while model code runs, making this bookkeeping write
-            # time out. Metering is best-effort there (same policy as the LLM
-            # usage recorder); enforcement raises UsageLimitExceeded, which is
-            # not an OperationalError and still propagates.
+            # SQLite-only: the rare cache-refresh READ can still lose to a
+            # locked DB in exotic states. Enforcement is best-effort there;
+            # UsageLimitExceeded is not an OperationalError and still propagates.
             if not _is_sqlite_lock_error(e):
                 raise
-            logger.debug("Skipping data-query quota write; SQLite is locked")
+            logger.debug("Skipping data-query quota check; SQLite is locked")
+        context.add_data_query(str(connection_id), metadata)
 
     def _consume_data_bytes_quota(self, query: str, result_bytes: int, rows: Optional[int]) -> None:
         context = self._usage_context
@@ -519,18 +523,12 @@ class QueryCapturingClientWrapper:
             "result_bytes": result_bytes,
         }
         try:
-            context.run_blocking(
-                usage_policy_service.consume_data_bytes_with_context(
-                    context,
-                    connection_id=str(connection_id),
-                    amount=result_bytes,
-                    metadata=metadata,
-                )
-            )
+            context.run_blocking(context.check_data_bytes(str(connection_id), result_bytes))
         except OperationalError as e:
             if not _is_sqlite_lock_error(e):
                 raise
-            logger.debug("Skipping data-bytes quota write; SQLite is locked")
+            logger.debug("Skipping data-bytes quota check; SQLite is locked")
+        context.add_data_bytes(str(connection_id), result_bytes, metadata)
 
     def _connection_id(self) -> Optional[str]:
         connection_id = getattr(self._original, "_bow_connection_id", None)

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -731,28 +731,45 @@ class LLM:
         attribution = get_usage_attribution()
 
         async def _record_usage():
-            try:
-                async with session_maker() as session:
-                    recorder = LLMUsageRecorderService(session)
-                    await recorder.record(
-                        scope=scope,
-                        scope_ref_id=scope_ref_id,
-                        llm_model=self.model,
-                        prompt_tokens=prompt_tokens or 0,
-                        completion_tokens=completion_tokens or 0,
-                        cache_read_tokens=cache_read_tokens or 0,
-                        cache_creation_tokens=cache_creation_tokens or 0,
-                        organization_id=attribution.get("organization_id"),
-                        user_id=attribution.get("user_id"),
-                        report_id=attribution.get("report_id"),
-                        data_source_id=attribution.get("data_source_id"),
-                    )
-                    await session.commit()
-            except Exception as exc:
-                if self._is_sqlite_lock_error(exc):
-                    logger.debug("Skipping LLM usage record because SQLite is locked: scope=%s", scope)
+            # SQLite: the agent's writer transaction can hold the lock while a
+            # tool/code execution is in flight, so the first attempt may lose.
+            # This is a background task — a few spaced retries recover nearly
+            # every record instead of silently dropping it (these rows back
+            # /monitoring and cost accounting; the drop was measurable — see
+            # docs/feedback-loops/agent-latency-deep-dive.md).
+            delays = (0.0, 0.5, 2.0, 5.0)
+            for attempt, delay in enumerate(delays, start=1):
+                if delay:
+                    await asyncio.sleep(delay)
+                try:
+                    async with session_maker() as session:
+                        recorder = LLMUsageRecorderService(session)
+                        await recorder.record(
+                            scope=scope,
+                            scope_ref_id=scope_ref_id,
+                            llm_model=self.model,
+                            prompt_tokens=prompt_tokens or 0,
+                            completion_tokens=completion_tokens or 0,
+                            cache_read_tokens=cache_read_tokens or 0,
+                            cache_creation_tokens=cache_creation_tokens or 0,
+                            organization_id=attribution.get("organization_id"),
+                            user_id=attribution.get("user_id"),
+                            report_id=attribution.get("report_id"),
+                            data_source_id=attribution.get("data_source_id"),
+                        )
+                        await session.commit()
                     return
-                logger.warning("Skipping LLM usage record after unexpected failure: %s", exc)
+                except Exception as exc:
+                    if self._is_sqlite_lock_error(exc):
+                        if attempt < len(delays):
+                            continue
+                        logger.warning(
+                            "Dropping LLM usage record after %d lock retries: scope=%s",
+                            attempt, scope,
+                        )
+                        return
+                    logger.warning("Skipping LLM usage record after unexpected failure: %s", exc)
+                    return
 
         global _MAIN_LOOP
         try:

--- a/backend/app/ai/tools/mcp/create_data.py
+++ b/backend/app/ai/tools/mcp/create_data.py
@@ -227,7 +227,14 @@ class CreateDataMCPTool(MCPTool):
                 full_log = e["payload"].get("execution_log")
                 if full_log and len(full_log) > len(output_log):
                     output_log = full_log
-        
+
+        # Persist buffered data-plane metering (queries/bytes are enqueued by
+        # the execute_query wrapper, not written synchronously).
+        try:
+            await usage_ctx.flush()
+        except Exception:
+            _logger.debug("mcp.create_data usage flush failed", exc_info=True)
+
         # Check for execution failure
         if generated_code is None or exec_df is None:
             error_msg = "Code execution failed"

--- a/backend/app/ai/tools/mcp/inspect_data.py
+++ b/backend/app/ai/tools/mcp/inspect_data.py
@@ -260,6 +260,13 @@ class InspectDataMCPTool(MCPTool):
                 if full_log and len(full_log) > len(output_log):
                     output_log = full_log
 
+        # Persist buffered data-plane metering (queries/bytes are enqueued by
+        # the execute_query wrapper, not written synchronously).
+        try:
+            await usage_ctx.flush()
+        except Exception:
+            _logger.debug("mcp.inspect_data usage flush failed", exc_info=True)
+
         # Audit: success or failure
         try:
             from app.ee.audit.service import audit_service

--- a/backend/app/services/query_service.py
+++ b/backend/app/services/query_service.py
@@ -289,6 +289,13 @@ class QueryService:
             db.add(step)
             await db.commit()
             await db.refresh(step)
+            # Persist buffered data-plane metering (queries/bytes are enqueued
+            # by the execute_query wrapper, not written synchronously).
+            if usage_context is not None:
+                try:
+                    await usage_context.flush()
+                except Exception:
+                    pass
 
         # If this save originated from a tool execution, update it to point to the latest step
         try:
@@ -425,6 +432,14 @@ class QueryService:
         except Exception as e:
             # Surface error to client for preview display
             return {"preview": None, "error": str(e)}
+        finally:
+            # Persist buffered data-plane metering (queries/bytes are enqueued
+            # by the execute_query wrapper, not written synchronously).
+            if usage_context is not None:
+                try:
+                    await usage_context.flush()
+                except Exception:
+                    pass
 
     def _usage_context(
         self,

--- a/backend/app/services/usage_policy_service.py
+++ b/backend/app/services/usage_policy_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -191,9 +192,34 @@ class UsageLimitContext:
     _cache_loaded_at: float = field(default=-1.0, init=False, repr=False)
     _CACHE_TTL_SECONDS: float = field(default=30.0, init=False, repr=False)
     _cache_lock: Optional[asyncio.Lock] = field(default=None, init=False, repr=False)
+    # Buffered data-plane metering (queries / bytes), mirroring the token/cost
+    # buffers above. Events are appended from sandboxed code-exec worker
+    # THREADS (see TrackedClient in code_execution.py), so unlike the int
+    # buffers these need an explicit threading.Lock. Each event:
+    # {metric, connection_id, amount, source, source_ref_id, metadata}.
+    _pending_data_events: List[dict] = field(default_factory=list, init=False, repr=False)
+    _data_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    # Per-(metric, connection_id) enforcement cache: {"limit", "used", "loaded_at"}.
+    # Same TTL/refresh-then-raise discipline as the token cache.
+    _data_cache: Dict[tuple, dict] = field(default_factory=dict, init=False, repr=False)
+    # Set on contexts created via for_source(): buffered amounts/events and
+    # quota checks delegate to the root context so one end-of-run flush covers
+    # everything added under any derived label.
+    _parent: Optional["UsageLimitContext"] = field(default=None, init=False, repr=False)
+
+    def _root(self) -> "UsageLimitContext":
+        ctx = self
+        while ctx._parent is not None:
+            ctx = ctx._parent
+        return ctx
 
     def for_source(self, source: str, source_ref_id: Optional[str] = None) -> "UsageLimitContext":
-        return UsageLimitContext(
+        """Derive a child context that relabels `source` but shares the
+        parent's accumulation buffers and quota caches (via `_parent`
+        delegation). Without the delegation, usage added through a derived
+        context (e.g. the coder's tokens inside a create_data tool call) sat
+        in the child's own buffers, which nothing ever flushed."""
+        child = UsageLimitContext(
             organization_id=self.organization_id,
             user_id=self.user_id,
             source=source,
@@ -201,6 +227,8 @@ class UsageLimitContext:
             session_maker=self.session_maker,
             loop=self.loop,
         )
+        child._parent = self
+        return child
 
     def add_tokens(self, amount: int, metadata: Optional[dict] = None) -> None:
         """Buffer tokens for a later flush. Cheap, no IO, no lock.
@@ -213,9 +241,10 @@ class UsageLimitContext:
             return
         if not has_feature("usage_limits"):
             return
-        self._pending_tokens += int(amount)
+        root = self._root()
+        root._pending_tokens += int(amount)
         if metadata is not None:
-            self._last_metadata = metadata
+            root._last_metadata = metadata
 
     def add_cost(self, amount_micro_usd: int, metadata: Optional[dict] = None) -> None:
         """Buffer LLM spend (in micro-USD) for a later flush. Mirrors add_tokens."""
@@ -223,9 +252,10 @@ class UsageLimitContext:
             return
         if not has_feature("usage_limits"):
             return
-        self._pending_cost_micro += int(amount_micro_usd)
+        root = self._root()
+        root._pending_cost_micro += int(amount_micro_usd)
         if metadata is not None:
-            self._last_cost_metadata = metadata
+            root._last_cost_metadata = metadata
 
     @property
     def pending_tokens(self) -> int:
@@ -277,6 +307,9 @@ class UsageLimitContext:
         Enforces both the monthly token cap and the monthly USD spend cap.
         Raises UsageLimitExceeded if the call would push us over either.
         """
+        if self._parent is not None:
+            # Derived contexts share the root's cache and pending buffers.
+            return await self._root().check_tokens(requested_tokens)
         if not has_feature("usage_limits") or self.session_maker is None:
             return
         if requested_tokens <= 0:
@@ -351,11 +384,17 @@ class UsageLimitContext:
             )
 
     async def flush(self) -> None:
-        """Persist any buffered tokens and spend. Called by the agent at end of run."""
+        """Persist any buffered tokens, spend, and data-plane usage events.
+        Called by the agent at end of run (and by non-agent owners of a
+        context after their execution finishes)."""
+        if self._parent is not None:
+            # Buffers live on the root; flush there.
+            return await self._root().flush()
         if self.session_maker is None:
             return
         await self._flush_tokens()
         await self._flush_cost()
+        await self._flush_data_events()
 
     async def _flush_tokens(self) -> None:
         if self._pending_tokens <= 0:
@@ -391,6 +430,144 @@ class UsageLimitContext:
             if meta is not None:
                 self._last_cost_metadata = meta
             raise
+
+    # ── Data-plane metering (queries / bytes) — buffered like tokens/cost ──
+    #
+    # Rationale (docs/feedback-loops/agent-latency-deep-dive.md): the previous
+    # shape did a synchronous counter+event WRITE around every sandboxed
+    # execute_query. On SQLite those writes queue behind the agent's writer
+    # lock, wait out busy_timeout (30s) twice per query, then get skipped —
+    # +60s per execution and the metering lost anyway. Now: enforcement is a
+    # cached READ (WAL-safe), recording is buffered here and persisted by the
+    # same end-of-run flush() the token/cost buffers already use.
+
+    def _add_data_event(self, metric: str, connection_id: str, amount: int,
+                        metadata: Optional[dict]) -> None:
+        if amount <= 0 or not has_feature("usage_limits"):
+            return
+        # Source labeling comes from THIS context; storage lives on the root
+        # so a single end-of-run flush covers derived (for_source) contexts.
+        event = {
+            "metric": metric,
+            "connection_id": str(connection_id or ""),
+            "amount": int(amount),
+            "source": self.source,
+            "source_ref_id": self.source_ref_id,
+            "metadata": metadata,
+        }
+        root = self._root()
+        with root._data_lock:
+            root._pending_data_events.append(event)
+            entry = root._data_cache.get((metric, event["connection_id"]))
+            if entry is not None:
+                entry["pending"] = entry.get("pending", 0) + int(amount)
+
+    def add_data_query(self, connection_id: str, metadata: Optional[dict] = None) -> None:
+        """Buffer one data-query usage event. Cheap, no IO, thread-safe."""
+        self._add_data_event(METRIC_DATA_QUERIES, connection_id, 1, metadata)
+
+    def add_data_bytes(self, connection_id: str, amount: int, metadata: Optional[dict] = None) -> None:
+        """Buffer a data-bytes usage event. Cheap, no IO, thread-safe."""
+        self._add_data_event(METRIC_DATA_BYTES, connection_id, int(amount), metadata)
+
+    async def _refresh_data_cache_entry(self, metric: str, connection_id: str) -> dict:
+        """Load the effective limit + current counter for one (metric, connection)."""
+        limit = None
+        used = 0
+        if self.session_maker is not None:
+            async with self.session_maker() as db:
+                limits = await usage_policy_service.resolve_effective_limits(
+                    db, self.organization_id, self.user_id
+                )
+                if metric == METRIC_DATA_QUERIES:
+                    limit = limits.query_limit_for_connection(connection_id)
+                else:
+                    limit = limits.data_bytes_limit_for_connection(connection_id)
+                if limit is not None:
+                    used = await usage_policy_service._get_counter_used(
+                        db,
+                        org_id=self.organization_id,
+                        user_id=self.user_id,
+                        metric=metric,
+                        scope_type=SCOPE_CONNECTION,
+                        scope_ref_id=connection_id,
+                    )
+        import time as _time
+        with self._data_lock:
+            prior = self._data_cache.get((metric, connection_id)) or {}
+            entry = {
+                "limit": limit,
+                "used": used,
+                "loaded_at": _time.monotonic(),
+                # keep unflushed local usage in the projection
+                "pending": prior.get("pending", 0),
+            }
+            self._data_cache[(metric, connection_id)] = entry
+        return entry
+
+    async def _check_data(self, metric: str, connection_id: str, amount: int) -> None:
+        """Pre-query quota check. In-memory against the cached limit/counter
+        (refreshed at most once per TTL); force-refresh before raising so a
+        stale-low cache can't produce a false rejection. Same one-call grace
+        window the token cap tolerates."""
+        if not has_feature("usage_limits") or self.session_maker is None:
+            return
+        connection_id = str(connection_id or "")
+        import time as _time
+        entry = self._data_cache.get((metric, connection_id))
+        if entry is None or (_time.monotonic() - entry["loaded_at"]) >= self._CACHE_TTL_SECONDS:
+            if self._cache_lock is None:
+                self._cache_lock = asyncio.Lock()
+            async with self._cache_lock:
+                entry = self._data_cache.get((metric, connection_id))
+                if entry is None or (_time.monotonic() - entry["loaded_at"]) >= self._CACHE_TTL_SECONDS:
+                    entry = await self._refresh_data_cache_entry(metric, connection_id)
+        if entry["limit"] is None:
+            return
+        projected = entry["used"] + entry.get("pending", 0) + int(amount)
+        if projected <= entry["limit"]:
+            return
+        # Might be stale low — refresh and re-check before raising.
+        entry = await self._refresh_data_cache_entry(metric, connection_id)
+        if entry["limit"] is None:
+            return
+        projected = entry["used"] + entry.get("pending", 0) + int(amount)
+        if projected > entry["limit"]:
+            raise UsageLimitExceeded(
+                "Monthly usage quota exceeded.",
+                metric=metric,
+                limit=entry["limit"],
+                used=entry["used"] + entry.get("pending", 0),
+                requested=int(amount),
+            )
+
+    async def check_data_query(self, connection_id: str) -> None:
+        await self._root()._check_data(METRIC_DATA_QUERIES, connection_id, 1)
+
+    async def check_data_bytes(self, connection_id: str, amount: int) -> None:
+        await self._root()._check_data(METRIC_DATA_BYTES, connection_id, int(amount))
+
+    async def _flush_data_events(self) -> None:
+        with self._data_lock:
+            if not self._pending_data_events:
+                return
+            events = self._pending_data_events
+            self._pending_data_events = []
+        try:
+            await usage_policy_service.record_data_usage_with_context(self, events)
+        except Exception:
+            # Best-effort. Re-credit so a future flush retries.
+            with self._data_lock:
+                self._pending_data_events = events + self._pending_data_events
+            raise
+        # Move the flushed amounts from "pending" into "used" so checks
+        # stay accurate without a DB refresh.
+        with self._data_lock:
+            for event in events:
+                entry = self._data_cache.get((event["metric"], event["connection_id"]))
+                if entry is not None:
+                    entry["pending"] = max(entry.get("pending", 0) - event["amount"], 0)
+                    entry["used"] = entry.get("used", 0) + event["amount"]
 
     def run_blocking(self, coroutine):
         if self.loop and self.loop.is_running():
@@ -986,6 +1163,69 @@ class UsagePolicyService:
                 metadata=metadata,
             )
             await db.commit()
+
+    async def record_data_usage_with_context(
+        self,
+        context: UsageLimitContext,
+        events: List[dict],
+    ) -> None:
+        """Persist buffered data-plane usage events (queries / bytes) in one
+        session+commit. Counters are aggregated per (metric, connection);
+        enforcement never happens here — it already ran at check time, and a
+        bookkeeping flush must not raise quota errors."""
+        if not context.session_maker or not events:
+            return
+        async with context.session_maker() as db:
+            await self.record_data_usage(
+                db,
+                org_id=context.organization_id,
+                user_id=context.user_id,
+                events=events,
+            )
+            await db.commit()
+
+    async def record_data_usage(
+        self,
+        db: AsyncSession,
+        *,
+        org_id: str,
+        user_id: str,
+        events: List[dict],
+    ) -> None:
+        if not has_feature("usage_limits") or not events:
+            return
+        limits = await self.resolve_effective_limits(db, org_id, user_id)
+        policy_id = limits.policy_ids[0] if limits.policy_ids else None
+        totals: Dict[tuple, int] = {}
+        for event in events:
+            key = (event["metric"], event.get("connection_id") or "")
+            totals[key] = totals.get(key, 0) + int(event.get("amount") or 0)
+        for (metric, connection_id), amount in totals.items():
+            await self._increment_counter(
+                db,
+                org_id=org_id,
+                user_id=user_id,
+                metric=metric,
+                scope_type=SCOPE_CONNECTION,
+                scope_ref_id=connection_id,
+                amount=amount,
+                limit=None,
+                enforce_limit=False,
+            )
+        for event in events:
+            self._add_event(
+                db,
+                org_id=org_id,
+                user_id=user_id,
+                policy_id=policy_id,
+                metric=event["metric"],
+                amount=int(event.get("amount") or 0),
+                scope_type=SCOPE_CONNECTION,
+                scope_ref_id=event.get("connection_id") or "",
+                source=event.get("source"),
+                source_ref_id=event.get("source_ref_id"),
+                metadata=event.get("metadata"),
+            )
 
     async def consume_data_bytes_with_context(
         self,

--- a/backend/tests/e2e/test_usage_limits.py
+++ b/backend/tests/e2e/test_usage_limits.py
@@ -897,6 +897,10 @@ def generate_df(ds_clients, excel_files):
     with pytest.raises(UsageLimitExceeded):
         _run(executor.execute_code_async(code=code, ds_clients={"main": client}, excel_files=[]))
     assert client.calls == 1
+    # Recording is buffered on the context and persisted by flush() (the agent
+    # flushes at end of run); only the query that actually ran is recorded —
+    # the blocked one was rejected before being buffered.
+    _run(usage_ctx.flush())
     assert _run(_counter_used(
         org_id,
         user_id,
@@ -1014,6 +1018,10 @@ def generate_df(ds_clients, excel_files):
         _run(executor.execute_code_async(code=code, ds_clients={"main": client}, excel_files=[]))
     assert exc_info.value.metric == METRIC_DATA_BYTES
     assert client.calls == 2
+    # Recording is buffered on the context and persisted by flush(): both
+    # executed queries are recorded, but only the small result's bytes — the
+    # big result was rejected by the check before being buffered.
+    _run(usage_ctx.flush())
     assert _run(_counter_used(
         org_id,
         user_id,

--- a/backend/tests/unit/test_usage_metering_buffer.py
+++ b/backend/tests/unit/test_usage_metering_buffer.py
@@ -1,0 +1,275 @@
+"""Buffered data-plane usage metering (queries / bytes).
+
+Contract under test (see docs/feedback-loops/agent-latency-deep-dive.md):
+sandboxed `execute_query` must never issue a blocking DB write from the
+code-exec worker thread. Enforcement is a cached read; the usage record is
+buffered on the UsageLimitContext and persisted by `flush()`. Previously each
+query paid up to 2 x 30s of SQLite busy_timeout on metering writes that were
+then skipped anyway.
+
+Covers:
+- execute_query returns promptly while another connection holds the SQLite
+  writer lock (the 60s-stall regression), and the usage event is buffered
+- flush() persists usage_events + aggregated usage_counters
+- quota enforcement raises when over the limit (including buffered pending)
+- derived contexts (for_source) route buffers to the root, keeping their label
+- a failed flush re-credits the buffer so a later flush can retry
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import time
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+import app.services.usage_policy_service as ups
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.usage_policy import UsageCounter, UsageEvent
+from app.models.user import User
+from app.services.usage_policy_service import (
+    METRIC_DATA_BYTES,
+    METRIC_DATA_QUERIES,
+    UsageLimitContext,
+    UsageLimitExceeded,
+)
+
+
+async def _seed_org_user(db):
+    org = Organization(name=f"Org-{uuid.uuid4().hex[:8]}")
+    db.add(org)
+    await db.flush()
+    user = User(
+        name="U",
+        email=f"metering-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    ids = (str(org.id), str(user.id))
+    await db.commit()
+    return ids
+
+
+def _ctx(org_id: str, user_id: str, loop=None) -> UsageLimitContext:
+    ctx = UsageLimitContext(
+        organization_id=org_id,
+        user_id=user_id,
+        source="agent",
+        source_ref_id="run-1",
+        session_maker=async_session_maker,
+    )
+    ctx.loop = loop
+    return ctx
+
+
+@pytest.fixture(autouse=True)
+def _usage_limits_on(monkeypatch):
+    # Buffering is gated on the usage_limits feature; force it on so the
+    # tests exercise the metering path regardless of the test license.
+    monkeypatch.setattr(ups, "has_feature", lambda name: True)
+    yield
+
+
+class _StubClient:
+    """Stands in for a data-source client behind TrackedClient."""
+
+    def __init__(self):
+        self._bow_connection_id = str(uuid.uuid4())
+        self._bow_client_key = "stub:1"
+        self._bow_connection_name = "Stub"
+        self._bow_data_source_id = None
+        self._bow_data_source_name = None
+
+    def execute_query(self, query, *args, **kwargs):
+        return [{"a": 1}, {"a": 2}]
+
+
+def _tracked(client, ctx):
+    from app.ai.code_execution.code_execution import QueryCapturingClientWrapper
+
+    return QueryCapturingClientWrapper(client, [], [], usage_context=ctx, client_key="stub:1")
+
+
+@pytest.mark.asyncio
+async def test_execute_query_buffers_without_blocking_on_writer_lock():
+    """The 60s-stall regression: with the SQLite writer lock held by another
+    connection, a metered execute_query must still return promptly (it only
+    reads + buffers), and the usage event must be waiting in the buffer."""
+    test_url = os.environ.get("TEST_DATABASE_URL", "")
+    if not test_url.startswith("sqlite"):
+        pytest.skip("writer-lock stall is SQLite-specific")
+    db_path = test_url.replace("sqlite:///", "")
+
+    async with async_session_maker() as db:
+        org_id, user_id = await _seed_org_user(db)
+
+    ctx = _ctx(org_id, user_id, loop=asyncio.get_running_loop())
+    tracked = _tracked(_StubClient(), ctx)
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("PRAGMA busy_timeout = 100")
+        raw.execute("BEGIN IMMEDIATE")  # hold the writer lock
+
+        start = time.monotonic()
+        # Same shape as production: the sandbox runs execute_query on a
+        # worker thread while the event loop stays free.
+        result = await asyncio.to_thread(tracked.execute_query, "select 1")
+        elapsed = time.monotonic() - start
+    finally:
+        raw.rollback()
+        raw.close()
+
+    assert result == [{"a": 1}, {"a": 2}]
+    # Old behavior waited out busy_timeout (30s per metering write). Generous
+    # bound: anything near seconds means a write leaked back into this path.
+    assert elapsed < 5.0, f"metered query stalled {elapsed:.1f}s with writer lock held"
+    assert len(ctx._pending_data_events) == 2  # query event + bytes event
+    metrics = {e["metric"] for e in ctx._pending_data_events}
+    assert metrics == {METRIC_DATA_QUERIES, METRIC_DATA_BYTES}
+
+
+@pytest.mark.asyncio
+async def test_flush_persists_buffered_events_and_counters():
+    async with async_session_maker() as db:
+        org_id, user_id = await _seed_org_user(db)
+
+    ctx = _ctx(org_id, user_id)
+    conn_id = str(uuid.uuid4())
+    ctx.add_data_query(conn_id, {"sql": "select 1"})
+    ctx.add_data_query(conn_id, {"sql": "select 2"})
+    ctx.add_data_bytes(conn_id, 512, {"rows": 4})
+
+    await ctx.flush()
+    assert ctx._pending_data_events == []
+
+    async with async_session_maker() as db:
+        events = (
+            await db.execute(
+                select(UsageEvent).where(UsageEvent.organization_id == org_id)
+            )
+        ).scalars().all()
+        by_metric = {}
+        for e in events:
+            by_metric.setdefault(e.metric, []).append(e)
+        assert len(by_metric[METRIC_DATA_QUERIES]) == 2
+        assert len(by_metric[METRIC_DATA_BYTES]) == 1
+        assert by_metric[METRIC_DATA_BYTES][0].amount == 512
+        assert all(e.scope_ref_id == conn_id for e in events)
+
+        counters = (
+            await db.execute(
+                select(UsageCounter).where(UsageCounter.organization_id == org_id)
+            )
+        ).scalars().all()
+        used = {c.metric: c.used for c in counters}
+        assert used[METRIC_DATA_QUERIES] == 2
+        assert used[METRIC_DATA_BYTES] == 512
+
+
+@pytest.mark.asyncio
+async def test_check_data_query_enforces_limit(monkeypatch):
+    async with async_session_maker() as db:
+        org_id, user_id = await _seed_org_user(db)
+
+    class _Limits:
+        policy_ids = []
+
+        def query_limit_for_connection(self, connection_id):
+            return 2
+
+        def data_bytes_limit_for_connection(self, connection_id):
+            return None
+
+    async def _fake_resolve(db, o, u):
+        return _Limits()
+
+    used = {"value": 0}
+
+    async def _fake_counter_used(db, **kw):
+        return used["value"]
+
+    monkeypatch.setattr(ups.usage_policy_service, "resolve_effective_limits", _fake_resolve)
+    monkeypatch.setattr(ups.usage_policy_service, "_get_counter_used", _fake_counter_used)
+
+    ctx = _ctx(org_id, user_id)
+    conn_id = str(uuid.uuid4())
+
+    # Under the limit: passes.
+    await ctx.check_data_query(conn_id)
+
+    # At the limit in the DB counter: the next query would exceed -> raises.
+    used["value"] = 2
+    ctx._data_cache.clear()  # force a fresh load of the new counter value
+    with pytest.raises(UsageLimitExceeded):
+        await ctx.check_data_query(conn_id)
+
+    # Buffered-but-unflushed usage counts toward the projection too.
+    used["value"] = 1
+    ctx._data_cache.clear()
+    ctx.add_data_query(conn_id, None)  # no cache entry yet -> event only
+    await ctx.check_data_query(conn_id)  # 1 used + 1 = 2 <= 2 passes (pending not yet cached)
+    ctx.add_data_query(conn_id, None)  # cache entry exists now -> pending=1
+    with pytest.raises(UsageLimitExceeded):
+        await ctx.check_data_query(conn_id)  # 1 used + 1 pending + 1 = 3 > 2
+
+
+@pytest.mark.asyncio
+async def test_derived_context_routes_buffers_to_root():
+    async with async_session_maker() as db:
+        org_id, user_id = await _seed_org_user(db)
+
+    root = _ctx(org_id, user_id)
+    child = root.for_source("create_data", "tool-call-9")
+
+    conn_id = str(uuid.uuid4())
+    child.add_data_query(conn_id, None)
+    child.add_tokens(123, {"model": "m"})
+
+    # Buffers live on the root; the child's source labels the event.
+    assert len(root._pending_data_events) == 1
+    assert root._pending_data_events[0]["source"] == "create_data"
+    assert child._pending_data_events == []
+    assert root.pending_tokens == 123
+
+    await root.flush()
+    async with async_session_maker() as db:
+        event = (
+            await db.execute(
+                select(UsageEvent).where(
+                    UsageEvent.organization_id == org_id,
+                    UsageEvent.metric == METRIC_DATA_QUERIES,
+                )
+            )
+        ).scalars().one()
+        assert event.source == "create_data"
+        assert event.source_ref_id == "tool-call-9"
+
+
+@pytest.mark.asyncio
+async def test_failed_flush_recredits_buffer(monkeypatch):
+    async with async_session_maker() as db:
+        org_id, user_id = await _seed_org_user(db)
+
+    ctx = _ctx(org_id, user_id)
+    ctx.add_data_query(str(uuid.uuid4()), None)
+
+    async def _boom(context, events):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(ups.usage_policy_service, "record_data_usage_with_context", _boom)
+    with pytest.raises(RuntimeError):
+        await ctx.flush()
+    # Event re-credited; a later flush (with the DB back) persists it.
+    assert len(ctx._pending_data_events) == 1
+    monkeypatch.undo()
+    await ctx.flush()
+    assert ctx._pending_data_events == []


### PR DESCRIPTION
## Problem

Every sandboxed `execute_query()` ran **two synchronous usage-metering writes** (`consume_data_query` / `consume_data_bytes`) from the code-exec worker thread via `run_blocking`. On SQLite each write queues behind the agent's single-writer lock, waits out `PRAGMA busy_timeout = 30000` (30s), then fails and is skipped — **+60.2s on every `create_data` execution, with the metering silently lost anyway**. The same contention also dropped LLM usage records (cost accounting undercounts on SQLite).

Diagnosed with persisted `sub_timings_json`, py-spy thread dumps, and a SQLite↔Postgres differential — full write-up in `docs/feedback-loops/agent-latency-deep-dive.md` on the `claude/prometheus-integration-plan-9xm1dx` branch (PR #595). The py-spy dump caught the sandbox thread frozen in `_consume_query_quota → run_blocking → Future.result()` for ~30s, twice per query, on every run.

## Fix

Mirrors the buffer-and-flush pattern the context already uses for tokens/cost:

- **Enforcement is a cached read**: `check_data_query` / `check_data_bytes` on `UsageLimitContext` — per-(metric, connection) cache with the same TTL + refresh-then-raise discipline as `check_tokens`. WAL-safe, in-memory after first load. `UsageLimitExceeded` propagates exactly as before (same one-call grace window the token cap tolerates).
- **Recording is buffered**: `add_data_query` / `add_data_bytes` append thread-safely (the sandbox thread never touches the DB); the existing end-of-run `flush()` persists them in one session with counters aggregated (`record_data_usage`), never re-raising quota errors at flush time.
- **`for_source()` children delegate to the root context** — usage added under derived labels (the coder inside `create_data`, per-tool contexts) previously sat in child buffers that nothing ever flushed; now one end-of-run flush covers everything, with per-event source labels preserved.
- **Non-agent owners flush after execution**: query run/preview (`query_service`), MCP `create_data` / `inspect_data`.
- **LLM usage recorder retries on SQLite lock** (bounded backoff in its existing background task) instead of dropping the record.

## Measured (same live prompt, Prometheus source, claude-haiku)

| | before | after |
|---|---:|---:|
| SQLite `create_data` | 64.7s | **4.2s** |
| SQLite `executing_code` | 60,196 ms | **95 ms** |
| SQLite query metering | silently dropped | **recorded** |
| Postgres `executing_code` | ~155 ms | ~180 ms (unchanged) |

## Tests

`tests/unit/test_usage_metering_buffer.py` (5 tests):
- **Regression**: with the SQLite writer lock held by another connection, a metered `execute_query` returns in ms and buffers its events — verified FAIL→PASS (on pre-fix code this test stalls 60s+ and fails)
- flush persists `usage_events` + aggregated `usage_counters`
- quota enforcement raises when over (including buffered pending usage)
- derived contexts route buffers to the root, keeping their source label
- a failed flush re-credits the buffer for retry

Full unit suite run: no new failures (the handful of failing tests — whatsapp/notifications/oauth/permissions — reproduce identically on clean `main` in this environment).

## Trade-off

Data-query/bytes quota enforcement moves from check-on-write to cached-read + buffered write — a counter can lag by one agent run, the same documented trade-off the token/spend caps already accept ("acceptable for monthly quotas; not for hard rate limits"). On SQLite, enforcement previously didn't work under load at all (the writes were dropped), so this is strictly more accurate there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyRCuJgL3TrqYEEaiLNBLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyRCuJgL3TrqYEEaiLNBLg)_