### PR TITLE
Fix /agents slowness for many-connection agents: cached status + background sweep + paginated tree fetch

### DIFF
--- a/backend/app/services/connection_status_sweep.py
+++ b/backend/app/services/connection_status_sweep.py
@@ -1,0 +1,144 @@
+"""Background connection-status refresher.
+
+Keeps ``last_connection_status`` / ``last_connection_checked_at`` fresh so
+read endpoints can serve the cached status without ever dialing a warehouse.
+This replaces the old read-path behavior where ``GET /data_sources/{id}``
+live-tested every connection whose cached status was older than 5 minutes —
+sequentially, inside the request, with no connect timeout — which stalled the
+agent detail view for minutes on many-connection agents and pinned pooled DB
+connections for the whole sweep (see
+docs/feedback-loops/agents-hub-agent-many-connections.md).
+
+Design mirrors ``scheduled_reindex.sweep_due_reindexes``:
+
+  * Frequent, cheap tick claimed via ``claim_scheduled_run`` — one
+    worker/replica per fire.
+  * Own staleness TTL, decoupled from per-connection reindex schedules (those
+    run daily/weekly; status wants minutes). Only connections whose last check
+    is older than the TTL are tested, oldest first, bounded per tick.
+  * Tests run concurrently under a semaphore, each on its own short-lived
+    session (``test_connection`` commits), so a slow warehouse never blocks a
+    request or holds a request-scoped pool slot.
+  * ``system_only`` connections only: per-user (``user_required``) status is
+    resolved per user at read time and a system-side probe would test the
+    wrong identity. Inactive connections ARE swept — a successful test is what
+    reactivates an auto-deactivated ``system_only`` connection.
+
+Unlike the reindex sweeper this is NOT enterprise-gated: with the read-path
+retest gone, this is the only thing keeping status badges honest.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
+
+SWEEP_JOB_ID = "connection_status_sweep"
+
+# How old a cached test may get before the sweeper re-tests it. Matches the
+# TTL the read path used to enforce.
+_DEFAULT_TTL_SECONDS = 300
+
+# Max connections tested per tick (oldest-checked first; the rest roll over).
+_DEFAULT_BATCH = 200
+
+# Concurrent tests. Each test occupies a thread from the shared
+# ``asyncio.to_thread`` pool for its full dial time, so keep this well below
+# the pool size (~32) — query execution shares that pool.
+_DEFAULT_CONCURRENCY = 8
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.environ.get(name, default)))
+    except (TypeError, ValueError):
+        return default
+
+
+async def sweep_stale_connection_status() -> None:
+    """Scheduled entrypoint: re-test every system_only connection whose cached
+    status is stale past the TTL. Safe on a short APScheduler interval."""
+    from app.core.scheduler import claim_scheduled_run
+
+    if not await asyncio.to_thread(claim_scheduled_run, SWEEP_JOB_ID):
+        return
+
+    from app.dependencies import async_session_maker
+    from app.models.connection import Connection
+    from app.models.organization import Organization
+    from app.services.connection_service import ConnectionService
+
+    ttl = _env_int("BOW_CONN_STATUS_TTL", _DEFAULT_TTL_SECONDS)
+    batch = _env_int("BOW_CONN_STATUS_SWEEP_BATCH", _DEFAULT_BATCH)
+    concurrency = _env_int("BOW_CONN_STATUS_SWEEP_CONCURRENCY", _DEFAULT_CONCURRENCY)
+    cutoff = datetime.utcnow() - timedelta(seconds=ttl)
+    t0 = time.perf_counter()
+
+    async with async_session_maker() as db:
+        rows = (
+            await db.execute(
+                select(Connection.id, Connection.organization_id)
+                .where(
+                    Connection.deleted_at.is_(None),
+                    Connection.auth_policy == "system_only",
+                    (Connection.last_connection_checked_at.is_(None))
+                    | (Connection.last_connection_checked_at <= cutoff),
+                )
+                .order_by(Connection.last_connection_checked_at.asc().nullsfirst())
+                .limit(batch)
+            )
+        ).all()
+        if not rows:
+            return
+        org_ids = {str(oid) for _, oid in rows}
+        orgs = {
+            str(o.id): o
+            for o in (
+                await db.execute(select(Organization).where(Organization.id.in_(org_ids)))
+            ).scalars().all()
+        }
+
+    svc = ConnectionService()
+    sem = asyncio.Semaphore(concurrency)
+    results = {"ok": 0, "failed": 0, "errored": 0}
+
+    async def _test_one(conn_id: str, org_id: str) -> None:
+        org = orgs.get(org_id)
+        if org is None:
+            return
+        async with sem:
+            # Own session per test: test_connection commits, and a slow dial
+            # must not hold a shared session/pool slot for its neighbors.
+            async with async_session_maker() as sdb:
+                try:
+                    status = await svc.test_connection(
+                        db=sdb,
+                        connection_id=str(conn_id),
+                        organization=org,
+                    )
+                    ok = bool(status.get("success")) if isinstance(status, dict) else bool(status)
+                    results["ok" if ok else "failed"] += 1
+                except Exception as exc:
+                    results["errored"] += 1
+                    logger.warning(
+                        "connection_status_sweep.test_failed",
+                        extra={"connection_id": str(conn_id), "error": str(exc)},
+                    )
+
+    await asyncio.gather(*(_test_one(str(cid), str(oid)) for cid, oid in rows))
+
+    logger.info(
+        "connection_status_sweep.done",
+        extra={
+            "swept": len(rows),
+            **results,
+            "ttl_s": ttl,
+            "elapsed_s": round(time.perf_counter() - t0, 3),
+        },
+    )

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -964,12 +964,7 @@ class DataSourceService:
 
         return result
 
-    # TTL for connection test cache (5 minutes)
-    CONNECTION_TEST_TTL_SECONDS = 300
-
     async def get_data_source(self, db: AsyncSession, data_source_id: str, organization: Organization, current_user: User = None) -> DataSourceSchema:
-        from datetime import datetime, timezone
-
         # lazyload("*") suppresses the model-level lazy="selectin" cascade
         # (reports → widgets/queries/completions/…). The detail schema does
         # surface git_repository and memberships, so keep those eager. We
@@ -994,61 +989,18 @@ class DataSourceService:
         if not data_source:
             raise HTTPException(status_code=404, detail="Data source not found")
 
-        # Check if any connection needs retesting (cache expired or never tested)
-        from app.services.connection_service import ConnectionService
-        conn_service = ConnectionService()
-        stale_connections = []
-        for conn in (data_source.connections or []):
-            needs_retest = True
-            if conn.last_connection_checked_at:
-                last_checked = conn.last_connection_checked_at
-                if last_checked.tzinfo is None:
-                    last_checked = last_checked.replace(tzinfo=timezone.utc)
-                age = (datetime.now(timezone.utc) - last_checked).total_seconds()
-                needs_retest = age > self.CONNECTION_TEST_TTL_SECONDS
-            if needs_retest:
-                stale_connections.append(conn)
-
-        # Retest stale connections
-        if stale_connections:
-            try:
-                for conn in stale_connections:
-                    try:
-                        await conn_service.test_connection(
-                            db=db,
-                            connection_id=str(conn.id),
-                            organization=organization,
-                            current_user=current_user or User(),
-                        )
-                    except Exception:
-                        pass
-                # After commits in tests, relationships may be expired; reload with eager options
-                try:
-                    stmt = (
-                        select(DataSource)
-                        .options(
-                            lazyload("*"),
-                            selectinload(DataSource.git_repository),
-                            selectinload(DataSource.data_source_memberships),
-                            selectinload(DataSource.connections).options(lazyload("*")),
-                            selectinload(DataSource.primary_instruction).selectinload(InstructionModel.references),
-                        )
-                        .where(DataSource.id == data_source.id)
-                    )
-                    refreshed_res = await db.execute(stmt)
-                    data_source = refreshed_res.scalar_one()
-                except Exception:
-                    pass
-            except Exception:
-                # Non-fatal: keep serving the resource even if the live check fails
-                pass
-
-        # Build connections list - always use cached status (live_test=False)
-        # since we already tested if needed above. Batch the indexing +
-        # table-count lookups: this endpoint is polled every ~2s while an
-        # indexing run is live, and per-connection COUNTs made each poll issue
-        # 2×N queries for agents with many connections. Events stay included —
-        # the connections modal renders the live indexing log from this payload.
+        # Build connections list from CACHED status only (live_test=False).
+        # This endpoint used to live-test every connection whose cached status
+        # was older than 5 minutes — sequentially, inside the request, with no
+        # connect timeout — so an agent with 50 connections stalled for minutes
+        # (and pinned its pooled DB connection the whole time) every TTL window.
+        # Freshness is now owned by the background sweeper
+        # (connection_status_sweep.sweep_stale_connection_status); reads never
+        # dial a warehouse. Batch the indexing + table-count lookups: this
+        # endpoint is polled every ~2s while an indexing run is live, and
+        # per-connection COUNTs made each poll issue 2×N queries for agents
+        # with many connections. Events stay included — the connections modal
+        # renders the live indexing log from this payload.
         indexing_by_conn, table_count_by_conn, legacy_count_by_ds = (
             await self._bulk_connection_aux(db, [data_source])
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ from app.services.maintenance_service import purge_step_payloads_keep_latest_per
 from app.data_sources.clients.qvd_client import warm_all_qvd_caches
 from app.data_sources.clients.powerbi_report_server_client import warm_all_pbirs_caches
 from app.services.scheduled_reindex import sweep_due_reindexes
+from app.services.connection_status_sweep import sweep_stale_connection_status
 from app.core.otel import setup_telemetry, instrument_app
 from app.ee.audit.tool_audit import start_tool_audit_worker, stop_tool_audit_worker
 
@@ -475,6 +476,26 @@ async def startup_event():
             logger.info("Scheduled job: schema_reindex_sweep every 10 minutes")
         except Exception as e:
             logger.error(f"Failed to schedule schema reindex sweep job: {e}")
+
+    # Background connection-status refresher: re-tests system_only connections
+    # whose cached status is stale past the TTL (~5 min). Read endpoints serve
+    # the cached status and never live-test — this job is what keeps the
+    # badges honest, so it runs on every install (not enterprise-gated).
+    if is_scheduler_leader:
+        try:
+            scheduler.add_job(
+                sweep_stale_connection_status,
+                trigger="interval",
+                minutes=5,
+                id="connection_status_sweep",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+                misfire_grace_time=300,
+            )
+            logger.info("Scheduled job: connection_status_sweep every 5 minutes")
+        except Exception as e:
+            logger.error(f"Failed to schedule connection status sweep job: {e}")
 
     # Register LDAP group sync job if configured AND licensed (sync is enterprise-only)
     if is_scheduler_leader and settings.bow_config.ldap.enabled and has_feature("ldap"):

--- a/backend/scripts/seed_one_agent_many_conns.py
+++ b/backend/scripts/seed_one_agent_many_conns.py
@@ -1,0 +1,176 @@
+"""Seed the "one agent owns every connection" shape: N connections × N tables
+all attached to a SINGLE agent, plus one empty agent. Only a handful of tables
+are ACTIVE (selected); the rest are the unselected catalog.
+
+Reproduces the reported deployment (50 connections × ~3,000 tables each on ONE
+agent — ~150k DataSourceTable rows — with only ~100 tables active across all
+50 connections; a second agent unused) where /agents takes forever and the
+whole system degrades. Differs from seed_agents_page_perf.py in four ways that
+matter for this loop:
+
+  * every connection joins the SAME data source (no round-robin), so the
+    per-agent volumes (50 connections, 75k DataSourceTable rows) match the
+    report;
+  * connections are seeded with type="postgresql" (the registry name) and a
+    config pointing at HOST:PORT (default 127.0.0.1:55445 — run
+    scripts/slow_tcp_stub.py there), so ConnectionService.test_connection
+    builds a real PostgresqlClient and actually dials the address — required
+    to reproduce the stale-connection retest sweep in
+    DataSourceService.get_data_source;
+  * DataSourceTable rows carry `columns` (like the rows
+    sync_domain_tables_from_connection writes in production), so the
+    /full_schema legacy path serializes full Table objects instead of
+    crashing on `columns=None`;
+  * only N_ACTIVE tables per connection get is_active=True — the reported org
+    has ~100 active tables across 50 connections, yet the row-volume costs are
+    driven by the ~150k INACTIVE catalog rows.
+
+Usage:
+  python scripts/seed_one_agent_many_conns.py [n_conn] [n_tables] [n_active_per_conn] [host] [port]
+
+Defaults: 50 connections × 3000 tables, 2 active per connection (=100 org-wide),
+stub at 127.0.0.1:55445. Requires the sandbox admin (sandbox@bow.dev) to exist.
+Re-running adds a fresh batch.
+"""
+import os
+import sys
+import uuid
+import asyncio
+from datetime import datetime, timedelta
+
+os.environ.setdefault("BOW_DATABASE_URL", "sqlite:///db/app.db")
+os.environ.setdefault("BOW_SMTP_PASSWORD", "dummy")
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy")
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select, insert
+
+import app.models  # noqa
+import pkgutil, importlib
+for _, modname, _ in pkgutil.iter_modules(app.models.__path__):
+    if modname == "application":
+        continue
+    importlib.import_module(f"app.models.{modname}")
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.data_source import DataSource
+from app.models.data_source_membership import DataSourceMembership
+from app.models.connection import Connection
+from app.models.connection_table import ConnectionTable
+from app.models.connection_indexing import ConnectionIndexing
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+
+N_EVENTS = 200  # matches ConnectionIndexingService._EVENT_LOG_MAX
+
+
+def _columns():
+    return [{"name": f"col_{i}", "dtype": "varchar"} for i in range(8)]
+
+
+def _events(n=N_EVENTS):
+    base = datetime.utcnow() - timedelta(hours=1)
+    return [
+        {
+            "ts": (base + timedelta(seconds=i)).isoformat() + "Z",
+            "level": "info",
+            "phase": "schema",
+            "message": f"Discovered table dbo.some_table_{i} (8 columns)",
+            "done": i,
+            "total": n,
+        }
+        for i in range(n)
+    ]
+
+
+async def main():
+    n_conn = int(sys.argv[1]) if len(sys.argv) > 1 else 50
+    n_tables = int(sys.argv[2]) if len(sys.argv) > 2 else 3000
+    n_active = int(sys.argv[3]) if len(sys.argv) > 3 else 2
+    host = sys.argv[4] if len(sys.argv) > 4 else "127.0.0.1"
+    port = int(sys.argv[5]) if len(sys.argv) > 5 else 55445
+    nonce = uuid.uuid4().hex[:6]
+
+    _u = os.environ["BOW_DATABASE_URL"]
+    _u = (_u.replace("postgresql://", "postgresql+asyncpg://", 1) if _u.startswith("postgresql://")
+          else _u.replace("sqlite:///", "sqlite+aiosqlite:///", 1) if _u.startswith("sqlite:///") else _u)
+    engine = create_async_engine(_u, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as db:
+        user = (await db.execute(select(User).where(User.email == "sandbox@bow.dev"))).scalars().first()
+        org = (await db.execute(select(Organization))).scalars().first()
+        assert user and org, "run signup first (sandbox@bow.dev) so user+org exist"
+        org_id = str(org.id)
+        now = datetime.utcnow()
+
+        # Agent 0 gets every connection; agent 1 stays empty.
+        agent_ids = []
+        for name in (f"Hub Agent {nonce}", f"Empty Agent {nonce}"):
+            ds = DataSource(id=str(uuid.uuid4()), name=name,
+                            is_active=True, is_public=False, organization_id=org_id)
+            db.add(ds)
+            await db.flush()
+            db.add(DataSourceMembership(id=str(uuid.uuid4()), data_source_id=str(ds.id),
+                                        principal_type="user", principal_id=str(user.id)))
+            agent_ids.append(str(ds.id))
+        await db.commit()
+        hub_id = agent_ids[0]
+
+        for c in range(n_conn):
+            conn_id = str(uuid.uuid4())
+            db.add(Connection(
+                id=conn_id, name=f"Hotel DB {c:02d} {nonce}", type="postgresql",
+                config={"host": host, "port": port, "database": f"hotel_{c}", "user": "bow"},
+                credentials=None, is_active=True, auth_policy="system_only",
+                last_synced_at=now, last_connection_status="success",
+                last_connection_checked_at=now, organization_id=org_id,
+            ))
+            await db.flush()
+
+            db.add(ConnectionIndexing(
+                id=str(uuid.uuid4()), connection_id=conn_id, status="completed",
+                progress_done=n_tables, progress_total=n_tables,
+                started_at=now - timedelta(minutes=5), finished_at=now,
+                stats_json={"table_count": n_tables, "synced_domains": 1, "elapsed_s": 38.9},
+                events_json=_events(),
+            ))
+
+            ct_rows = [
+                {
+                    "id": str(uuid.uuid4()), "name": f"dbo.table_{c:02d}_{t}",
+                    "connection_id": conn_id, "columns": _columns(),
+                    "pks": [], "fks": [], "no_rows": 0,
+                    "created_at": now, "updated_at": now,
+                }
+                for t in range(n_tables)
+            ]
+            await db.execute(insert(ConnectionTable), ct_rows)
+
+            await db.execute(insert(domain_connection).values(
+                data_source_id=hub_id, connection_id=conn_id))
+            # Mirror what sync_domain_tables_from_connection writes: rows WITH
+            # columns/pks/fks (/full_schema serializes these fields). Only the
+            # first n_active per connection are selected (is_active=True); the
+            # rest are the unselected catalog the org never uses.
+            dst_rows = [
+                {
+                    "id": str(uuid.uuid4()), "name": r["name"],
+                    "datasource_id": hub_id, "connection_table_id": r["id"],
+                    "columns": r["columns"], "pks": [], "fks": [],
+                    "is_active": t < n_active, "created_at": now, "updated_at": now,
+                }
+                for t, r in enumerate(ct_rows)
+            ]
+            await db.execute(insert(DataSourceTable), dst_rows)
+            await db.commit()
+            if (c + 1) % 10 == 0:
+                print(f"  ...{c+1}/{n_conn} connections")
+
+        print(f"seeded {n_conn} connections × {n_tables} tables "
+              f"({n_active} active each → {n_conn * n_active} org-wide) → 1 hub agent (+1 empty)")
+        print(f"org={org_id} hub_agent={hub_id} empty_agent={agent_ids[1]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/slow_tcp_stub.py
+++ b/backend/scripts/slow_tcp_stub.py
@@ -1,0 +1,39 @@
+"""A TCP endpoint that accepts and then stalls: models a slow / dropping
+database server for connection-test repros without real credentials.
+
+psycopg2 connects, sends its startup packet, and blocks waiting for the
+server's reply; after DELAY seconds the stub closes the socket and the client
+errors out. Each test therefore costs ~DELAY seconds — a *deterministic,
+optimistic* stand-in for a slow or unreachable warehouse (a firewalled host
+with no RST is far worse: psycopg2 has no connect_timeout here, so it waits
+the OS TCP timeout, ~2 minutes).
+
+Usage: python scripts/slow_tcp_stub.py [delay_seconds] [port]
+Defaults: 1.0s on 127.0.0.1:55445.
+"""
+import socket
+import sys
+import threading
+import time
+
+DELAY = float(sys.argv[1]) if len(sys.argv) > 1 else 1.0
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 55445
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", PORT))
+s.listen(100)
+print(f"slow stub on 127.0.0.1:{PORT} delay={DELAY}s", flush=True)
+
+
+def handle(conn):
+    try:
+        time.sleep(DELAY)
+        conn.close()
+    except Exception:
+        pass
+
+
+while True:
+    c, _ = s.accept()
+    threading.Thread(target=handle, args=(c,), daemon=True).start()

--- a/docs/feedback-loops/agents-hub-agent-many-connections.md
+++ b/docs/feedback-loops/agents-hub-agent-many-connections.md
@@ -1,0 +1,254 @@
+# Feedback Loop — one agent with 50 connections: `/agents` "takes forever", "the entire system is extremely slow"
+
+Reproduces the reported deployment: **50 connections × ~3,000 tables each all
+attached to ONE agent** (~150k `DataSourceTable` rows, only ~100 tables active
+across the 50 connections), plus a second unused agent. The `/agents` page
+takes forever to load and the whole system degrades. This is a follow-up to
+`agents-page-connections-perf.md` / `agents-page-contention.md` — those fixes
+are merged and hold (the *list* endpoints stay fast below); the remaining
+slowness lives on three different paths that all scale with a single agent's
+connection/table volume.
+
+**Status: reproduced, root causes isolated. No fix implemented (investigation
+only).**
+
+## Root causes (validated)
+
+### A. Opening the agent fires a synchronous live-test of all 50 connections — sequentially, with no timeout
+
+`GET /api/data_sources/{id}` embeds a stale-connection retest sweep:
+`DataSourceService.get_data_source` collects every connection whose cached
+test is older than `CONNECTION_TEST_TTL_SECONDS = 300`
+(`backend/app/services/data_source_service.py:968`) and live-tests each one
+**in a sequential loop inside the request**
+(`data_source_service.py:1012-1024`). Each iteration runs
+`ConnectionService.test_connection`
+(`backend/app/services/connection_service.py:666-728`): build a client, dial
+the warehouse, and `await db.commit()` — on the request's own session.
+
+Three amplifiers:
+
+- **No connect timeout.** `PostgresqlClient.connect` is
+  `sqlalchemy.create_engine(uri).connect()` with no `connect_timeout`
+  (`backend/app/data_sources/clients/postgresql_client.py:42-64`), so a
+  firewalled/blackholed host waits the OS TCP timeout (~2 minutes) — verified
+  below. 50 unreachable connections ≈ **100+ minutes** for one detail request.
+- **The sweep re-arms every 5 minutes** (TTL 300s) and fires from more than
+  the /agents page: the agents tree fetches the detail on every agent click
+  (`frontend/components/KnowledgeExplorer.vue:1156`, via `openAgent`
+  at `:1177-1181`) and the report/chat page's agent panel fetches the same
+  endpoint (`frontend/components/report/ReportAgentPanel.vue:936`).
+- **No dedup across requests.** Two concurrent detail requests each ran their
+  own 50-test sweep (measured: 60.4s and 59.6s side by side, tests
+  interleaved in the log).
+
+The request holds its pooled DB connection for the sweep's entire wall time
+(`get_async_db` yields the session for the request lifetime,
+`backend/app/dependencies.py:48-61`; this endpoint never calls
+`release_request_db`). On production Postgres the pool is
+`pool_size=20 + max_overflow=20` per worker
+(`backend/app/settings/database.py:256-258`), so a handful of users sitting
+on /agents or report pages pins the pool for minutes at a time —
+`agents-page-contention.md` already showed the whole API collapses once
+in-flight requests exceed the pool. That is the "entire system is extremely
+slow" mechanism: every endpoint queues behind a pool starved by sweeping
+detail requests.
+
+Side effect (correctness, not just perf): each failed test flips the
+connection to `is_active = False` for `system_only` connections
+(`connection_service.py:699-706`). A transient network blip while a user has
+/agents open silently deactivates connections org-wide — observed below
+(`50 × is_active=0` after one sweep).
+
+### B. The agent tree loads the FULL 150k-row catalog unpaginated (~200 MB)
+
+Clicking the agent also calls `loadAgentMeta` →
+`GET /data_sources/{id}/full_schema` **without pagination params**
+(`frontend/components/KnowledgeExplorer.vue:2191`). The route treats
+missing `page`/`page_size` as the legacy path
+(`backend/app/routes/data_source.py:199,233-236`) →
+`get_data_source_schema(include_inactive=True)`
+(`backend/app/services/data_source_service.py:2528`) →
+`DataSource.get_schemas` (`backend/app/models/data_source.py:246-375`), which
+`selectinload`s **every** `DataSourceTable` row with its
+`connection_table → connection` chain (`data_source.py:258-264`) and builds a
+`Table` object per row. For this shape that is 150,000 rows → measured **36.1s
+and a 199.4 MB JSON response** (ORM hydration dominates: 21.1s / 166 SQL at
+the 75k-row scale, serialization adds the rest). The browser then parses
+~200 MB and maps it (`items.map` in `loadAgentMeta`) — the tab freezes too.
+
+The same data through the paginated branch of the same route takes **0.58s /
+90 KB** (that's what `TablesSelector.vue` uses). Only `KnowledgeExplorer`
+still uses the unpaginated call.
+
+Because hydration/serialization run on the event loop between awaits, one
+`full_schema` request stalls **every** request on the process: a 2-3ms
+`/api/settings` probe measured **4.0s / 8.7s / 3.4s** while it was in flight.
+Second "entire system" mechanism.
+
+### C. `/schema` (chat @-mentions, agent flyout) hydrates 150k rows to return 100
+
+`GET /data_sources/{id}/schema` returns only *active* tables (~100, 132 KB) —
+but `DataSource.get_schemas` does the `is_active` filtering **in Python after
+loading every row** (`backend/app/models/data_source.py:282-284`; only
+`include_inactive` differs from path B). Measured: **22.9s to return 132 KB.**
+This endpoint fires from the chat prompt's mention autocomplete
+(`frontend/components/prompt/MentionInput.vue:1242`) and the agent flyout
+(`frontend/components/AgentFlyout.vue:528`) — i.e. from ordinary chat usage,
+not just /agents. Contrast: `SchemaContextBuilder` (the completion path)
+pushes the same filter into SQL
+(`backend/app/ai/context/builders/schema_context_builder.py:85-87`) and is
+fine; `DataSource.prompt_schema` (`data_source_service.py:4016-4018`) still
+goes through the Python-filtered `get_schemas`.
+
+## Loop A — deterministic reproduction (no external services)
+
+Fresh sandbox, Python 3.12, SQLite:
+
+```bash
+cd backend
+pip install uv && uv sync --frozen --extra dev
+export BOW_DATABASE_URL="sqlite:///db/app.db" BOW_SMTP_PASSWORD=dummy ANTHROPIC_API_KEY=dummy
+mkdir -p db && rm -f db/app.db db/app.db-wal db/app.db-shm
+uv run alembic upgrade head
+uv run python main.py &                      # backend :8000
+uv run python scripts/slow_tcp_stub.py 1.0 & # "slow warehouse" on 127.0.0.1:55445
+```
+
+Register the sandbox admin and capture credentials:
+
+```bash
+B=http://localhost:8000
+curl -s -X POST $B/api/auth/register -H "Content-Type: application/json" \
+  -d '{"email":"sandbox@bow.dev","password":"Sandbox123!","name":"Sandbox Admin"}'
+TOK=$(curl -s -X POST $B/api/auth/jwt/login -d "username=sandbox@bow.dev&password=Sandbox123!" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+ORG=$(curl -s $B/api/organizations -H "Authorization: Bearer $TOK" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)[0]['id'])")
+```
+
+Seed the customer shape — 50 connections × 3,000 tables, 2 active per
+connection (100 org-wide), ALL on one "hub" agent plus one empty agent
+(prints the hub agent id):
+
+```bash
+uv run python scripts/seed_one_agent_many_conns.py 50 3000 2
+HUB=<hub_agent id printed by the seed>
+H1="Authorization: Bearer $TOK"; H2="X-Organization-Id: $ORG"
+```
+
+**B + C — catalog hydration** (fires on agent click / chat mention):
+
+```bash
+curl -s -o /dev/null -w "full_schema (KnowledgeExplorer): %{time_total}s %{size_download}B\n" \
+  -H "$H1" -H "$H2" "$B/api/data_sources/$HUB/full_schema"
+curl -s -o /dev/null -w "full_schema (paginated):         %{time_total}s %{size_download}B\n" \
+  -H "$H1" -H "$H2" "$B/api/data_sources/$HUB/full_schema?page=1&page_size=100"
+curl -s -o /dev/null -w "schema (mentions/flyout):        %{time_total}s %{size_download}B\n" \
+  -H "$H1" -H "$H2" "$B/api/data_sources/$HUB/schema"
+# while full_schema is in flight, probe any cheap endpoint from another shell:
+curl -s -o /dev/null -w "%{time_total}s\n" -H "$H1" -H "$H2" $B/api/settings
+```
+
+**A — the stale-connection sweep** (backdate the 5-minute TTL, then open the
+agent twice concurrently):
+
+```bash
+python3 - <<'EOF'
+import sqlite3
+db = sqlite3.connect("db/app.db")
+db.execute("UPDATE connections SET last_connection_checked_at=datetime('now','-1 hour')")
+db.commit()
+EOF
+curl -s -o /dev/null -w "detail 1st: %{time_total}s\n" -H "$H1" -H "$H2" "$B/api/data_sources/$HUB" &
+sleep 3
+curl -s -o /dev/null -w "detail 2nd: %{time_total}s\n" -H "$H1" -H "$H2" "$B/api/data_sources/$HUB"
+```
+
+**No-connect-timeout evidence** (why 1s/test is the *optimistic* case):
+
+```bash
+timeout 20 uv run python -c "
+import sqlalchemy; sqlalchemy.create_engine('postgresql://u:p@10.255.255.1:5432/x').connect()" \
+  || echo "still connecting after 20s — OS TCP timeout (~2min) is the only bound"
+```
+
+### Observed (local SQLite, zero network latency, 1s/test stub)
+
+| call | wall | payload | notes |
+|---|---|---|---|
+| `GET /data_sources` (list) | 0.05s | 49 KB | earlier fixes hold |
+| `GET /connections` (list) | 0.36s | 35 KB | earlier fixes hold |
+| `GET /data_sources/{empty agent}` | 0.01s | 1 KB | contrast |
+| `GET /data_sources/{hub}` within TTL | 0.06s | **1.5 MB** | indexing events × 50 conns |
+| `GET /data_sources/{hub}` after TTL (sweep) | **60.4s** | 1.5 MB | 50 × ~1.1s sequential tests |
+| `GET /data_sources/{hub}` 2nd, concurrent | **59.6s** | 1.5 MB | no dedup — its own sweep |
+| `GET .../full_schema` (as KnowledgeExplorer calls it) | **36.1s** | **199.4 MB** | 150k rows hydrated + serialized |
+| `GET .../full_schema?page=1&page_size=100` | 0.58s | 90 KB | same data, paginated branch |
+| `GET .../schema` (mentions/flyout) | **22.9s** | 132 KB | 150k rows loaded → 100 returned |
+| `/api/settings` idle | 0.002s | — | baseline |
+| `/api/settings` during `full_schema` | **4.0s / 8.7s / 3.4s** | — | event loop blocked |
+
+After one sweep against the stub:
+`SELECT last_connection_status, is_active FROM connections` →
+`('not_connected', 0) × 50` — **all 50 connections silently deactivated** by
+a transient failure (`connection_service.py:699-706`).
+
+The blackhole check confirms `psycopg2` is still waiting at 20s: with no
+`connect_timeout`, each unreachable connection costs ~2 minutes of OS TCP
+timeout, so the production sweep is bounded at ~50 × 2min ≈ **100 minutes**,
+re-armed every 5 minutes — "takes forever" is literal.
+
+### Why the *whole* system degrades
+
+1. **Event loop stalls**: hydrating/serializing 150k ORM rows (B, C) blocks
+   the process between awaits — measured 8.7s stalls on a 2ms endpoint. Every
+   user on that worker feels it, on every page.
+2. **Pool pinning**: a sweeping detail request (A) holds its pooled DB
+   connection for its full 60s–minutes wall time
+   (`dependencies.py:48-61`; no `release_request_db` on this path). With
+   `pool_size+overflow = 40` per worker (`settings/database.py:256-258`), a
+   few open /agents or report tabs starve the pool and every other endpoint
+   times out — the collapse mechanism already demonstrated in
+   `agents-page-contention.md`.
+3. **Triggered from everywhere**: the sweep and the catalog loads fire not
+   only from `/agents` (`KnowledgeExplorer.vue:1156,2191`) but from report
+   pages (`ReportAgentPanel.vue:936`) and the chat prompt's mention
+   autocomplete (`MentionInput.vue:1242`), so ordinary chat usage keeps
+   re-detonating them.
+
+## Candidate fixes (not implemented — investigation only)
+
+- **A:** take the live retest out of the read path (background refresher or
+  fire-and-forget task), test connections concurrently with a bounded gather,
+  set explicit connect timeouts on clients (e.g. `connect_args={"connect_timeout": 5}`),
+  dedupe concurrent sweeps per connection, and don't auto-deactivate on a
+  single failed probe.
+- **B:** make `KnowledgeExplorer.loadAgentMeta` use the paginated
+  `full_schema` branch (the tree only renders names/active flags), or add a
+  slim projection endpoint.
+- **C:** push the `is_active` filter into SQL in `DataSource.get_schemas`
+  (as `SchemaContextBuilder.build` already does) so `/schema` and
+  `prompt_schema` stop hydrating the inactive catalog.
+- Detail payload: drop `indexing.events` from `GET /data_sources/{id}` unless
+  an indexing run is live (1.5 MB per fetch with 50 connections).
+
+## What this proves / regression notes
+
+- The earlier list-endpoint fixes (`agents-page-connections-perf.md`) hold at
+  this scale; the remaining slowness is on the detail/catalog paths above.
+- All three causes scale with *per-agent* connection/table volume, which is
+  why concentrating 50 connections on one agent (vs round-robin across 3)
+  regressed the page after the earlier fixes.
+- The seed initially wrote `type="postgres"` (registry name is
+  `postgresql`) which made every test fail in ~3ms with "Unknown data source
+  type" — masking cause A entirely. `scripts/seed_one_agent_many_conns.py`
+  seeds the registry name and real dialable configs; if you fork the loop,
+  keep that, or the sweep looks cheap.
+
+## Repro artifacts
+
+- `backend/scripts/seed_one_agent_many_conns.py` — the customer shape:
+  N connections × N tables (N active) all on one agent, + one empty agent.
+- `backend/scripts/slow_tcp_stub.py` — deterministic "slow warehouse":
+  accepts TCP, stalls, closes; each connection test costs ~DELAY seconds.

--- a/docs/feedback-loops/agents-hub-agent-many-connections.md
+++ b/docs/feedback-loops/agents-hub-agent-many-connections.md
@@ -9,8 +9,9 @@ are merged and hold (the *list* endpoints stay fast below); the remaining
 slowness lives on three different paths that all scale with a single agent's
 connection/table volume.
 
-**Status: reproduced, root causes isolated. No fix implemented (investigation
-only).**
+**Status: reproduced, root causes isolated; causes A and B fixed (see "The
+fix" below). Cause C (`/schema` Python-side filtering) is documented but not
+yet fixed.**
 
 ## Root causes (validated)
 
@@ -217,19 +218,73 @@ re-armed every 5 minutes — "takes forever" is literal.
    autocomplete (`MentionInput.vue:1242`), so ordinary chat usage keeps
    re-detonating them.
 
-## Candidate fixes (not implemented — investigation only)
+## The fix (A and B applied)
 
-- **A:** take the live retest out of the read path (background refresher or
-  fire-and-forget task), test connections concurrently with a bounded gather,
-  set explicit connect timeouts on clients (e.g. `connect_args={"connect_timeout": 5}`),
-  dedupe concurrent sweeps per connection, and don't auto-deactivate on a
-  single failed probe.
-- **B:** make `KnowledgeExplorer.loadAgentMeta` use the paginated
-  `full_schema` branch (the tree only renders names/active flags), or add a
-  slim projection endpoint.
+- **A — reads never dial.** The stale-retest block is deleted from
+  `DataSourceService.get_data_source`; the endpoint serves the cached
+  `last_connection_status` unconditionally. Freshness moved to a background
+  sweeper, `backend/app/services/connection_status_sweep.py`
+  (`sweep_stale_connection_status`), registered in `main.py` every 5 minutes.
+  It reuses the `scheduled_reindex` machinery (`claim_scheduled_run`, one
+  worker per fire) but with its **own TTL** (`BOW_CONN_STATUS_TTL`, default
+  300s) decoupled from per-connection reindex schedules — reindex cadence is
+  daily/weekly, status wants minutes, and reactivation of an auto-deactivated
+  connection rides on the next successful test. Tests run concurrently
+  (semaphore, `BOW_CONN_STATUS_SWEEP_CONCURRENCY`, default 8), each on its own
+  short-lived session, bounded per tick (`BOW_CONN_STATUS_SWEEP_BATCH`,
+  default 200), `system_only` connections only (per-user status is resolved
+  per user at read time). Not enterprise-gated — with the read-path retest
+  gone this is what keeps badges honest on every install.
+- **B — the tree fetches one selected-only page.**
+  `KnowledgeExplorer.loadAgentMeta` now calls
+  `full_schema?page=1&page_size=500&selected_state=selected` (the paginated
+  branch pushes `is_active` into SQL) and reads `tables`/`total` from
+  `PaginatedTablesResponse`. A new `agentTableTotals` map backs the tree and
+  overview counts so they don't depend on the capped page length. Note the
+  overview "N tables" badge now counts **active** tables (previously the full
+  catalog including unselected rows).
+
+Deliberately NOT included (agreed scope): client connect timeouts (a dead
+host still costs ~2 min per dial — now only inside the background sweep) and
+the single-failure auto-deactivation guard (a blip still flips
+`is_active=False`, healing on the next successful sweep within one TTL).
+
+### Re-run — observed after the fix (same seed, same stub)
+
+| call | before | after |
+|---|---|---|
+| `GET /data_sources/{hub}`, all 50 connections stale | **60.4s** | **0.09s** |
+| `GET .../full_schema` as KnowledgeExplorer calls it | **36.1s / 199.4 MB** | **0.52s / 89 KB** (100 active tables, `total_tables=150000` intact) |
+| `/api/settings` while the above run | up to **8.7s** | **~0.003s** (flat) |
+| status refresh for 50 stale connections | in-request, sequential | background sweep, all 50 refreshed in one pass (~23s vs 60s in-request), zero requests impacted |
+
+Trigger the sweep manually to verify (the scheduled job does the same thing
+every 5 minutes):
+
+```bash
+uv run python - <<'EOF'
+import asyncio
+import app.models, pkgutil, importlib
+for _, m, _ in pkgutil.iter_modules(app.models.__path__):
+    if m != "application": importlib.import_module(f"app.models.{m}")
+from app.services.connection_status_sweep import sweep_stale_connection_status
+asyncio.run(sweep_stale_connection_status())
+EOF
+# then: SELECT count(*) FROM connections
+#       WHERE last_connection_checked_at <= datetime('now','-300 seconds')  → 0
+```
+
+## Remaining candidate fixes (not implemented)
+
 - **C:** push the `is_active` filter into SQL in `DataSource.get_schemas`
-  (as `SchemaContextBuilder.build` already does) so `/schema` and
+  (as `SchemaContextBuilder.build` already does) so `/schema` (mention
+  autocomplete, agent flyout — still **22.9s** at this shape) and
   `prompt_schema` stop hydrating the inactive catalog.
+- Client connect timeouts (e.g. `connect_args={"connect_timeout": 5}`) so the
+  background sweep isn't bounded by the ~2-minute OS TCP timeout per dead
+  host.
+- Auto-deactivation guard: require consecutive failures before flipping
+  `is_active=False` on `system_only` connections.
 - Detail payload: drop `indexing.events` from `GET /data_sources/{id}` unless
   an indexing run is live (1.5 MB per fetch with 50 connections).
 

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -159,7 +159,7 @@
             <TreeGroup :label="agent.name" :count="agentCount(agent.id) || undefined" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? $t('agentsPage.signInBadge') : (agent.publish_status === 'disabled' ? $t('agentsPage.disabledBadge') : (agent.is_connector ? $t('agentsPage.connectorBadge') : ''))" :disabled="needsSignIn(agent)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
               <template #icon><DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" class="w-4 h-4 shrink-0" /></template>
 
-              <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id] ? (activeTables(agent.id).length || undefined) : undefined" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
+              <TreeGroup :label="$t('agentsPage.tables')" icon="i-heroicons-table-cells" :count="agentTables[agent.id] ? ((agentTableTotals[agent.id] ?? activeTables(agent.id).length) || undefined) : undefined" :indent="1" reloadable :active="panelView?.kind === 'tables' && panelView?.agentId === agent.id" :open="isOpen('tables:' + agent.id)" @toggle="onPanelRowClick('tables', agent.id)" @reload="reloadTables(agent.id)">
                 <TreeGroup v-for="t in activeTables(agent.id)" :key="t.id" :label="t.name" icon="i-heroicons-table-cells" :count="listForTable(agent.id, t.id).length || undefined" mono addable :indent="2" :open="isOpen('table:' + agent.id + ':' + t.id)" @toggle="expand('table:' + agent.id + ':' + t.id)" @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })">
                   <InstrLeaf v-for="ins in listForTable(agent.id, t.id)" :key="ins.id" :ins="ins" :indent="3" />
                   <EmptyHint v-if="loadedGroups.has(agent.id) && listForTable(agent.id, t.id).length === 0" :text="$t('agentsPage.noRulesAttached')" add @add="openCreate({ agentId: agent.id, tableId: t.id, tableName: t.name })" :pad="62" />
@@ -352,7 +352,7 @@
 
             <!-- Counts (clean) -->
             <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400 mb-6 pb-5 border-b border-gray-100 dark:border-gray-800">
-              <span class="inline-flex items-center gap-1"><UIcon name="i-heroicons-table-cells" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.countTables', { n: agentTables[agentView.agentId]?.length ?? '–' }) }}</span>
+              <span class="inline-flex items-center gap-1"><UIcon name="i-heroicons-table-cells" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.countTables', { n: agentTableTotals[agentView.agentId] ?? agentTables[agentView.agentId]?.length ?? '–' }) }}</span>
               <span class="inline-flex items-center gap-1"><UIcon name="i-heroicons-wrench-screwdriver" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.countTools', { n: agentTools[agentView.agentId]?.length ?? '–' }) }}</span>
               <span class="inline-flex items-center gap-1"><UIcon name="i-heroicons-paper-clip" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.countFiles', { n: agentFiles[agentView.agentId]?.length ?? '–' }) }}</span>
               <span class="inline-flex items-center gap-1"><UIcon name="i-heroicons-document-text" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.countInstructions', { n: agentCount(agentView.agentId) }) }}</span>
@@ -985,6 +985,9 @@ const fStatus = ref<string[]>([]); const fLoad = ref<string[]>([]); const fSourc
 
 const expanded = ref<Set<string>>(new Set())
 const agentTables = ref<Record<string, { id: string; name: string; is_active: boolean }[]>>({})
+// Active-table totals from the paginated response — the fetched rows are
+// capped at one page, so counts must not rely on array length.
+const agentTableTotals = ref<Record<string, number>>({})
 const agentTools = ref<Record<string, any[]>>({})
 const agentFiles = ref<Record<string, any[]>>({})
 const agentLoaded = ref<Set<string>>(new Set())
@@ -2188,7 +2191,16 @@ const onGitChanged = () => { fetchGitStatus(); fetchAll() }
 const loadAgentMeta = async (id: string) => {
   if (agentLoaded.value.has(id)) return
   agentLoaded.value.add(id)
-  try { const { data } = await useMyFetch<any>(`/data_sources/${id}/full_schema`, { method: 'GET' }); const items = Array.isArray(data.value) ? data.value : (data.value?.items || []); agentTables.value[id] = items.map((t: any) => ({ id: String(t.id ?? t.name), name: t.name, is_active: t.is_active !== false })) } catch { agentTables.value[id] = [] }
+  try {
+    // Paginated + selected-only: the tree renders active tables only, and the
+    // unpaginated legacy branch hydrates the ENTIRE catalog (150k rows / ~200MB
+    // on a 50-connection agent — see docs/feedback-loops/agents-hub-agent-many-connections.md).
+    const { data } = await useMyFetch<any>(`/data_sources/${id}/full_schema?page=1&page_size=500&selected_state=selected&sort_by=name&sort_dir=asc`, { method: 'GET' })
+    const v: any = data.value
+    const items = Array.isArray(v) ? v : (v?.tables || v?.items || [])
+    agentTables.value[id] = items.map((t: any) => ({ id: String(t.id ?? t.name), name: t.name, is_active: t.is_active !== false }))
+    agentTableTotals.value[id] = typeof v?.total === 'number' ? v.total : agentTables.value[id].length
+  } catch { agentTables.value[id] = []; delete agentTableTotals.value[id] }
   try { const { data } = await useMyFetch<any[]>(`/data_sources/${id}/tools`, { method: 'GET' }); agentTools.value[id] = data.value || [] } catch { agentTools.value[id] = [] }
   try { const { data } = await useMyFetch<any[]>(`/data_sources/${id}/files`, { method: 'GET' }); agentFiles.value[id] = data.value || [] } catch { agentFiles.value[id] = [] }
   agentTables.value = { ...agentTables.value }; agentTools.value = { ...agentTools.value }; agentFiles.value = { ...agentFiles.value }


### PR DESCRIPTION
# Why

A customer deployment — **50 connections (~3k tables each) all attached to ONE agent**, ~100 tables active org-wide, a second agent unused — made `/agents` take forever and degraded the entire system. The earlier list-endpoint fixes (`agents-page-connections-perf.md`) hold at this scale; the remaining slowness lives on the detail/catalog paths, which all scale with a *single agent's* connection/table volume.

Reproduced in a fresh sandbox (runnable loop in `docs/feedback-loops/agents-hub-agent-many-connections.md`):

| call | measured (before) |
|---|---|
| `GET /data_sources/{id}` with 50 stale connections | **60.4s** (sequential live tests, 1s/dial stub; unreachable hosts → ~2min each, ~100min bound) |
| same, second concurrent request | **59.6s** (no dedup — runs its own sweep) |
| `GET .../full_schema` as the /agents tree called it | **36.1s / 199.4 MB** (150k rows hydrated + serialized) |
| `/api/settings` (2ms baseline) while the above ran | **up to 8.7s** (event loop blocked) |

Each in-flight sweep also pinned a pooled DB connection for its full wall time, and a transient failure silently flipped all 50 connections to `is_active=false`.

# What

**A. Reads never dial** — deleted the stale-connection retest sweep from `DataSourceService.get_data_source`; the endpoint always serves cached `last_connection_status`.

**A′. Background status refresher** — new `connection_status_sweep.sweep_stale_connection_status`, registered in `main.py` every 5 minutes. Mirrors the `scheduled_reindex` machinery (`claim_scheduled_run`, one worker per fire) with its **own TTL** (`BOW_CONN_STATUS_TTL`, default 300s), bounded concurrency (`BOW_CONN_STATUS_SWEEP_CONCURRENCY`, default 8), per-tick batch cap, one short-lived session per test, `system_only` connections only. Not enterprise-gated — with the read-path retest gone this is the only status refresher. Reactivation of an auto-deactivated connection rides on its next successful test, as before.

**B. Paginated tree fetch** — `KnowledgeExplorer.loadAgentMeta` now requests `full_schema?page=1&page_size=500&selected_state=selected` (the paginated branch filters `is_active` in SQL) and reads `tables`/`total` from `PaginatedTablesResponse`. New `agentTableTotals` map backs the tree and overview counts so they don't depend on the capped page length. Note: the overview "N tables" badge now counts **active** tables (previously the raw catalog including unselected rows).

Also includes the repro artifacts: `scripts/seed_one_agent_many_conns.py` (the customer shape) and `scripts/slow_tcp_stub.py` (deterministic slow-warehouse stand-in), plus the feedback-loop doc.

# Measured after (same seed, same stub)

| call | before | after |
|---|---|---|
| `GET /data_sources/{id}`, 50 stale connections | 60.4s | **0.09s** |
| `GET .../full_schema` (tree) | 36.1s / 199.4 MB | **0.52s / 89 KB** |
| `/api/settings` during the above | up to 8.7s | **~0.003s (flat)** |
| status refresh of 50 stale connections | in-request, sequential | background, one pass, zero request impact |

# Deliberately out of scope (documented in the feedback loop)

- Cause C: `GET /data_sources/{id}/schema` (chat mention autocomplete / agent flyout) still filters `is_active` in Python after hydrating the full catalog — ~23s at this shape.
- Client connect timeouts (a dead host still costs ~2min per dial, now confined to the background sweep).
- Auto-deactivation guard (single failed probe still flips `is_active`; heals on next successful sweep).

# Testing

- `tests/e2e/test_connection.py` + `tests/e2e/test_domains.py`: 22 passed.
- Full before/after loop re-run in the sandbox; sweep verified both by direct invocation (all 50 stale connections refreshed in one pass, API probes flat at ~3ms throughout) and via the registered APScheduler job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jeUWT82z5Gw2nqUwnbT5P

---
_Generated by [Claude Code](https://claude.ai/code/session_019jeUWT82z5Gw2nqUwnbT5P)_