### PR TITLE
fix(connections): connector icons, inline create errors, and tool counts in agent selectors

### DIFF
--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -164,6 +164,7 @@ async def list_connections(
     from sqlalchemy.orm import defer
     from app.models.connection_indexing import ConnectionIndexing
     from app.schemas.data_source_registry import tool_provider_types
+    from app.services.data_source_service import _conn_connector_key
     _TOOL_PROVIDER_TYPES = tool_provider_types()
 
     conn_ids = [str(c.id) for c in connections]
@@ -305,6 +306,7 @@ async def list_connections(
             agent_names=[ds.name for ds in conn.data_sources] if conn.data_sources else [],
             indexing=indexing_payload.model_dump() if indexing_payload else None,
             user_status=user_status_payload,
+            connector_key=_conn_connector_key(conn),
         ))
     await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
     return result
@@ -334,6 +336,7 @@ async def create_connection(
     # Inline the latest indexing run so the modal can show progress
     # immediately without a second roundtrip.
     from app.schemas.data_source_registry import tool_provider_types; _TOOL_PROVIDER_TYPES = tool_provider_types()
+    from app.services.data_source_service import _conn_connector_key
     indexing_row = await indexing_service.get_latest(db, str(connection.id))
     indexing_payload = _indexing_to_progress(indexing_row)
     return ConnectionSchema(
@@ -348,6 +351,7 @@ async def create_connection(
         tool_count=len(connection.connection_tools) if connection.type in _TOOL_PROVIDER_TYPES and connection.connection_tools else 0,
         agent_count=len(connection.data_sources) if connection.data_sources else 0,
         indexing=indexing_payload.model_dump() if indexing_payload else None,
+        connector_key=_conn_connector_key(connection),
     )
 
 

--- a/backend/app/schemas/connection_schema.py
+++ b/backend/app/schemas/connection_schema.py
@@ -93,6 +93,10 @@ class ConnectionSchema(BaseModel):
     # Per-user auth status for the requesting user (user_required connections):
     # has_user_credentials / effective_auth / uses_fallback / connection.
     user_status: Optional[Dict[str, Any]] = None
+    # Catalog key for a known connector (e.g. "notion", "monday") so the UI can
+    # render the provider's brand icon even though `type` is just "mcp". None for
+    # generic connections.
+    connector_key: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/frontend/components/CustomAPIConnectionForm.vue
+++ b/frontend/components/CustomAPIConnectionForm.vue
@@ -154,6 +154,10 @@
         <div v-if="testResult" :class="['text-xs px-3 py-2 rounded', testResult.success ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700']">
           {{ testResult.message }}
         </div>
+
+        <div v-if="submitError" class="text-xs px-3 py-2 rounded bg-red-50 dark:bg-red-950 text-red-700">
+          {{ submitError }}
+        </div>
       </template>
 
       <div class="flex items-center justify-between pt-2">
@@ -185,7 +189,6 @@ const emit = defineEmits<{
   (e: 'cancel'): void
 }>()
 
-const toast = useToast()
 const selectedExisting = ref<any>(null)
 const existingConnections = computed(() => props.existingConnections || [])
 const existingConnectionOptions = computed(() =>
@@ -314,6 +317,16 @@ watch(() => props.editConnection, async (conn) => {
 const testing = ref(false)
 const submitting = ref(false)
 const testResult = ref<{ success: boolean; message: string } | null>(null)
+const submitError = ref<string | null>(null)
+
+// Extract a human-readable message from a useMyFetch error (FetchError) or a
+// thrown exception. `detail` is what FastAPI returns for HTTPException.
+function errorMessage(err: any, fallback: string): string {
+  return err?.data?.detail || err?.message || fallback
+}
+
+// Clear the inline submit error as soon as the user edits any field.
+watch(() => ({ ...form }), () => { submitError.value = null })
 
 const endpointsError = computed(() => {
   if (rawMode.value) {
@@ -385,25 +398,35 @@ async function handleSubmit() {
 
   if (endpointsError.value) return
   submitting.value = true
+  submitError.value = null
+  const fallback = isEditMode.value ? 'Failed to update connection' : 'Failed to create connection'
   try {
     const config = buildConfig()
     const credentials = buildCredentials()
 
+    let response: any
     if (isEditMode.value && props.editConnection) {
-      const response = await useMyFetch(`/connections/${props.editConnection.id}`, {
+      response = await useMyFetch(`/connections/${props.editConnection.id}`, {
         method: 'PUT',
         body: { name: form.name, config, credentials },
       })
-      if (response.data.value) emit('saved', response.data.value)
     } else {
-      const response = await useMyFetch('/connections', {
+      response = await useMyFetch('/connections', {
         method: 'POST',
         body: { name: form.name, type: 'custom_api', config, credentials, auth_policy: 'system_only' },
       })
-      if (response.data.value) emit('saved', response.data.value)
     }
+
+    // useMyFetch resolves (never throws) on HTTP errors — a non-2xx response
+    // surfaces via response.error, so surface it inline instead of silently
+    // doing nothing (e.g. a duplicate connection name → 409).
+    if (response.error?.value) {
+      submitError.value = errorMessage(response.error.value, fallback)
+      return
+    }
+    if (response.data.value) emit('saved', response.data.value)
   } catch (e: any) {
-    toast.add({ title: isEditMode.value ? 'Failed to update' : 'Failed to create connection', description: e?.data?.detail, color: 'red' })
+    submitError.value = errorMessage(e, fallback)
   } finally {
     submitting.value = false
   }

--- a/frontend/components/MCPConnectionForm.vue
+++ b/frontend/components/MCPConnectionForm.vue
@@ -104,6 +104,10 @@
         <div v-if="testResult" :class="['text-xs px-3 py-2 rounded', testResult.success ? 'bg-green-50 dark:bg-green-950 text-green-700' : 'bg-red-50 dark:bg-red-950 text-red-700']">
           {{ testResult.message }}
         </div>
+
+        <div v-if="submitError" class="text-xs px-3 py-2 rounded bg-red-50 dark:bg-red-950 text-red-700">
+          {{ submitError }}
+        </div>
       </template>
 
       <div class="flex items-center justify-between pt-2">
@@ -138,7 +142,6 @@ const emit = defineEmits<{
   (e: 'cancel'): void
 }>()
 
-const toast = useToast()
 const selectedExisting = ref<any>(null)
 const existingConnections = computed(() => props.existingConnections || [])
 const existingConnectionOptions = computed(() =>
@@ -209,6 +212,16 @@ watch(() => props.prefill, (p) => {
 const testing = ref(false)
 const submitting = ref(false)
 const testResult = ref<{ success: boolean; message: string } | null>(null)
+const submitError = ref<string | null>(null)
+
+// Extract a human-readable message from a useMyFetch error (FetchError) or a
+// thrown exception. `detail` is what FastAPI returns for HTTPException.
+function errorMessage(err: any, fallback: string): string {
+  return err?.data?.detail || err?.message || fallback
+}
+
+// Clear the inline submit error as soon as the user edits any field.
+watch(() => ({ ...form }), () => { submitError.value = null })
 
 function buildCredentials(): Record<string, any> | undefined {
   if (form.auth_type === 'bearer' && form.token) return { token: form.token }
@@ -261,32 +274,42 @@ async function handleSubmit() {
   }
 
   submitting.value = true
+  submitError.value = null
+  const fallback = isEditMode.value ? t('settings.mcpModal.failedUpdate') : t('settings.mcpModal.failedConnect')
   try {
     const config = { server_url: form.server_url, transport: form.transport, auth_type: form.auth_type }
     const credentials = buildCredentials()
 
+    let response: any
     if (isEditMode.value && props.editConnection) {
       const body: Record<string, any> = { name: form.name, config, credentials, auth_policy: authPolicy.value }
       if (allowedUserAuthModes.value) body.allowed_user_auth_modes = allowedUserAuthModes.value
-      const response = await useMyFetch(`/connections/${props.editConnection.id}`, {
+      response = await useMyFetch(`/connections/${props.editConnection.id}`, {
         method: 'PUT',
         body,
       })
-      if (response.data.value) emit('saved', response.data.value)
     } else {
       const body: Record<string, any> = {
         name: form.name, type: 'mcp', config, credentials,
         auth_policy: authPolicy.value,
       }
       if (allowedUserAuthModes.value) body.allowed_user_auth_modes = allowedUserAuthModes.value
-      const response = await useMyFetch('/connections', {
+      response = await useMyFetch('/connections', {
         method: 'POST',
         body,
       })
-      if (response.data.value) emit('saved', response.data.value)
     }
+
+    // useMyFetch resolves (never throws) on HTTP errors — a non-2xx response
+    // surfaces via response.error, so surface it inline instead of silently
+    // doing nothing (e.g. a duplicate connection name → 409).
+    if (response.error?.value) {
+      submitError.value = errorMessage(response.error.value, fallback)
+      return
+    }
+    if (response.data.value) emit('saved', response.data.value)
   } catch (e: any) {
-    toast.add({ title: isEditMode.value ? t('settings.mcpModal.failedUpdate') : t('settings.mcpModal.failedConnect'), description: e?.data?.detail, color: 'red' })
+    submitError.value = errorMessage(e, fallback)
   } finally {
     submitting.value = false
   }

--- a/frontend/components/ManageConnectionsModal.vue
+++ b/frontend/components/ManageConnectionsModal.vue
@@ -33,7 +33,7 @@
           >
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3">
-                <DataSourceIcon :type="conn.type" class="h-6" />
+                <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-6" />
                 <div>
                   <div class="font-medium text-gray-900 dark:text-white">{{ conn.name }}</div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">
@@ -96,7 +96,7 @@
       <template #header>
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <DataSourceIcon v-if="editingConnection" :type="editingConnection.type" class="h-5" />
+            <DataSourceIcon v-if="editingConnection" :type="editingConnection.type" :connector-key="editingConnection.connector_key" class="h-5" />
             <h3 class="text-lg font-semibold">Edit Connection</h3>
           </div>
           <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark" @click="showEditModal = false" />

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -70,7 +70,7 @@
                 <div v-if="selectedConnections.length > 0" class="flex items-center gap-1.5 flex-wrap">
                   <template v-for="conn in selectedConnections" :key="conn.id">
                     <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded px-1.5 py-0.5">
-                      <DataSourceIcon :type="conn.type" class="h-3.5 flex-shrink-0" />
+                      <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-3.5 flex-shrink-0" />
                       <span class="text-xs truncate max-w-[100px]">{{ conn.name }}</span>
                     </div>
                   </template>
@@ -79,7 +79,7 @@
               </template>
               <template #option="{ option }">
                 <div class="flex items-center gap-2 w-full">
-                  <DataSourceIcon :type="option.type" class="h-4 flex-shrink-0" />
+                  <DataSourceIcon :type="option.type" :connector-key="option.connector_key" class="h-4 flex-shrink-0" />
                   <div class="flex-1 min-w-0">
                     <div class="font-medium truncate">{{ option.name }}</div>
                     <div class="text-[10px] text-gray-400 dark:text-gray-500">
@@ -268,6 +268,7 @@ interface Connection {
   id: string
   name: string
   type: string
+  connector_key?: string | null
   table_count?: number
   agent_count?: number
 }

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -83,7 +83,7 @@
                   <div class="flex-1 min-w-0">
                     <div class="font-medium truncate">{{ option.name }}</div>
                     <div class="text-[10px] text-gray-400 dark:text-gray-500">
-                      {{ option.table_count || 0 }} tables · {{ option.agent_count || 0 }} agents
+                      {{ connectionCountLabel(option) }} · {{ option.agent_count || 0 }} agents
                     </div>
                   </div>
                 </div>
@@ -270,7 +270,20 @@ interface Connection {
   type: string
   connector_key?: string | null
   table_count?: number
+  tool_count?: number
   agent_count?: number
+}
+
+// Tool-provider connections (MCP / custom API) expose tools, not tables, so
+// their catalog count is meaningless — show the tool count instead.
+const TOOL_PROVIDER_TYPES = ['mcp', 'custom_api']
+function connectionCountLabel(conn: Connection): string {
+  if (TOOL_PROVIDER_TYPES.includes(conn.type)) {
+    const n = conn.tool_count || 0
+    return `${n} tool${n === 1 ? '' : 's'}`
+  }
+  const n = conn.table_count || 0
+  return `${n} table${n === 1 ? '' : 's'}`
 }
 
 const connections = ref<Connection[]>([])

--- a/frontend/pages/agents/new/index.vue
+++ b/frontend/pages/agents/new/index.vue
@@ -50,7 +50,7 @@
               <div v-if="selectedConnections.length > 0" class="flex items-center gap-1.5 flex-wrap">
                 <template v-for="conn in selectedConnections" :key="conn.id">
                   <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded px-1.5 py-0.5">
-                    <DataSourceIcon :type="conn.type" class="h-3.5 flex-shrink-0" />
+                    <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-3.5 flex-shrink-0" />
                     <span class="text-xs truncate max-w-[100px]">{{ conn.name }}</span>
                   </div>
                 </template>
@@ -59,7 +59,7 @@
             </template>
             <template #option="{ option }">
               <div class="flex items-center gap-2 w-full">
-                <DataSourceIcon :type="option.type" class="h-4 flex-shrink-0" />
+                <DataSourceIcon :type="option.type" :connector-key="option.connector_key" class="h-4 flex-shrink-0" />
                 <div class="flex-1 min-w-0">
                   <div class="font-medium truncate">{{ option.name }}</div>
                   <div class="text-[10px] text-gray-400">
@@ -134,6 +134,7 @@ interface Connection {
   id: string
   name: string
   type: string
+  connector_key?: string | null
   table_count?: number
   agent_count?: number
 }

--- a/frontend/pages/agents/new/index.vue
+++ b/frontend/pages/agents/new/index.vue
@@ -63,7 +63,7 @@
                 <div class="flex-1 min-w-0">
                   <div class="font-medium truncate">{{ option.name }}</div>
                   <div class="text-[10px] text-gray-400">
-                    {{ option.table_count || 0 }} tables · {{ option.agent_count || 0 }} agents
+                    {{ connectionCountLabel(option) }} · {{ option.agent_count || 0 }} agents
                   </div>
                 </div>
               </div>
@@ -136,7 +136,20 @@ interface Connection {
   type: string
   connector_key?: string | null
   table_count?: number
+  tool_count?: number
   agent_count?: number
+}
+
+// Tool-provider connections (MCP / custom API) expose tools, not tables, so
+// their catalog count is meaningless — show the tool count instead.
+const TOOL_PROVIDER_TYPES = ['mcp', 'custom_api']
+function connectionCountLabel(conn: Connection): string {
+  if (TOOL_PROVIDER_TYPES.includes(conn.type)) {
+    const n = conn.tool_count || 0
+    return `${n} tool${n === 1 ? '' : 's'}`
+  }
+  const n = conn.table_count || 0
+  return `${n} table${n === 1 ? '' : 's'}`
 }
 
 const connections = ref<Connection[]>([])


### PR DESCRIPTION
## Summary

Fixes three small bugs around connections in the **Create Data Agent** flow and MCP/custom-API connection creation.

### 1. Wrong data-source icon for MCP connectors
MCP connections have `type == "mcp"`, so `DataSourceIcon` needs a `connector_key` to render the provider's brand icon. The `/connections` list response never carried that key, so connectors like Monday showed the generic MCP paperclip icon instead of their brand icon.

- Added `connector_key` to `ConnectionSchema` and populated it via the existing `_conn_connector_key()` helper (resolves from `config.catalog_key`, else matches `config.server_url` against the MCP presets) in the list and create routes.
- Passed `:connector-key` through `DataSourceIcon` in `NewAgentWizardModal`, the `/agents/new` selector, and `ManageConnectionsModal`.

Connectors that match a known preset (e.g. Monday) now render their brand icon; custom MCP servers with no matching preset keep the generic MCP icon.

### 2. Silent failure when creating a connection with a duplicate name
The backend returns a `409` with a clear message, but `useMyFetch` resolves (rather than throws) on non-2xx responses — so the error landed in `response.error` and the old `catch`-based toast never fired. The modal appeared to do nothing.

- Surface `response.error` inline in `MCPConnectionForm` and `CustomAPIConnectionForm`, clearing it when the user edits the form.

### 3. Tool-provider connections showed "0 tables" instead of their tool count
MCP/custom-API connections always have 0 tables by design, hiding the meaningful number — their tool count, which the `/connections` response already carries as `tool_count`.

- Added a type-based `connectionCountLabel()` helper so `mcp`/`custom_api` connections read "X tools" while database connections keep "X tables", in both the Create Data Agent modal and the `/agents/new` selector.

## Notes
- Backend change is limited to adding/populating `connector_key`; tool counts required no backend change.
- A freshly-added MCP connection will briefly show "0 tools" until its tool refresh completes.

## Testing
Verified Python syntax and confirmed the reused helper's resolution paths, that `monday` is a real MCP preset, and that the backend's tool-provider types are exactly `mcp` and `custom_api` (matching the frontend constant). Frontend/backend dependencies aren't installed in this environment, so no build/lint was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKvtLNCGV5suBAiaaMHbA8)_