### PR TITLE
fix(icons): show connector brand icons across agent/connection/report surfaces

### DIFF
--- a/frontend/components/AgentConnectionsModal.vue
+++ b/frontend/components/AgentConnectionsModal.vue
@@ -38,7 +38,7 @@
                 >
                     <div class="flex items-center justify-between gap-3">
                         <div class="flex items-center gap-3 min-w-0">
-                            <DataSourceIcon :type="conn.type" class="h-7 flex-shrink-0" />
+                            <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-7 flex-shrink-0" />
                             <div class="min-w-0">
                                 <div class="text-sm font-medium text-gray-900 dark:text-white truncate">{{ conn.name }}</div>
                                 <div class="text-xs text-gray-400">{{ conn.type }}</div>
@@ -121,7 +121,7 @@
                     :class="{ 'border-blue-400 bg-blue-50 dark:bg-blue-950': selectedConnectionId === conn.id }"
                 >
                     <input type="radio" name="link-conn" :value="conn.id" v-model="selectedConnectionId" class="sr-only" />
-                    <DataSourceIcon :type="conn.type" class="h-5 flex-shrink-0" />
+                    <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-5 flex-shrink-0" />
                     <div class="min-w-0 flex-1">
                         <div class="text-sm font-medium text-gray-900 dark:text-white truncate">{{ conn.name }}</div>
                         <div class="text-xs text-gray-400">{{ conn.type }}</div>
@@ -147,7 +147,7 @@
             <template #header>
                 <div class="flex items-center justify-between">
                     <div class="flex items-center gap-2">
-                        <DataSourceIcon v-if="editingConnection" :type="editingConnection.type" class="h-5" />
+                        <DataSourceIcon v-if="editingConnection" :type="editingConnection.type" :connector-key="editingConnection.connector_key" class="h-5" />
                         <h3 class="text-sm font-semibold">Edit connection</h3>
                     </div>
                     <UButton color="gray" variant="ghost" size="xs" icon="i-heroicons-x-mark" @click="showEditModal = false" />

--- a/frontend/components/AgentFlyout.vue
+++ b/frontend/components/AgentFlyout.vue
@@ -44,6 +44,7 @@
                     v-for="conn in (agentDetails.connections || []).slice(0, 3)"
                     :key="conn.id"
                     :type="conn.type"
+                    :connector-key="conn.connector_key"
                     class="h-4 flex-shrink-0 ring-1 ring-white dark:ring-gray-900 rounded"
                   />
                 </div>

--- a/frontend/components/AgentSelector.vue
+++ b/frontend/components/AgentSelector.vue
@@ -56,7 +56,7 @@
         <template v-if="nav">
           <UTooltip v-if="collapsed" :text="navLabel" :popper="{ placement: 'right' }">
             <span class="relative flex items-center justify-center w-5 h-5">
-              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" class="w-[18px] h-[18px] rounded" />
+              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" class="w-[18px] h-[18px] rounded" />
               <DataSourceIcon v-else-if="navIconTypes.length" :type="navIconTypes[0]" class="w-[18px] h-[18px] rounded" />
               <UIcon v-else name="heroicons-cube" class="w-[18px] h-[18px]" />
               <span v-if="!navSelected && agents.length > 1" class="absolute -top-1.5 -right-1.5 min-w-[14px] h-3.5 px-1 rounded-full bg-gray-900 text-white text-[8px] font-semibold leading-none flex items-center justify-center">{{ agents.length > 9 ? '9+' : agents.length }}</span>
@@ -64,7 +64,7 @@
           </UTooltip>
           <template v-else>
             <span class="flex items-center justify-center">
-              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" class="w-[18px] h-[18px] rounded" />
+              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" class="w-[18px] h-[18px] rounded" />
               <span v-else-if="navIconTypes.length" class="flex -space-x-1.5 items-center">
                 <DataSourceIcon v-for="(t, i) in navIconTypes" :key="i" :type="t" class="w-[18px] h-[18px] ring-2 ring-white rounded-full bg-white" />
               </span>
@@ -136,6 +136,7 @@
                     <DataSourceIcon
                       v-if="a.connections?.[0]?.type"
                       :type="a.connections[0].type"
+                      :connector-key="a.connections[0].connector_key"
                       class="h-4 w-4 flex-shrink-0"
                     />
                     <UIcon v-else name="heroicons-circle-stack" class="w-4 h-4 text-gray-400 flex-shrink-0" />

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -428,7 +428,7 @@
       <template #header>
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <DataSourceIcon :type="connection?.type" class="h-5" />
+            <DataSourceIcon :type="connection?.type" :connector-key="connection?.connector_key" class="h-5" />
             <h3 class="text-lg font-semibold">{{ $t('data.editConnection') }}</h3>
           </div>
           <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark" @click="showEditModal = false" />

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -109,7 +109,7 @@
             <div v-if="searchResults.agents.length">
               <div class="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Agents</div>
               <button v-for="a in searchResults.agents" :key="a.id" type="button" class="w-full flex items-center gap-2 h-8 rounded-md text-[13px] text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/70 px-2" @click="onAgentClick(a)">
-                <DataSourceIcon :type="a.type" class="w-4 h-4 shrink-0" />
+                <DataSourceIcon :type="a.type" :connector-key="a.connector_key" class="w-4 h-4 shrink-0" />
                 <span class="flex-1 text-start truncate">{{ a.name }}</span>
               </button>
             </div>
@@ -231,7 +231,7 @@
           <div class="flex items-center gap-2 min-w-0 shrink-[9999] overflow-hidden py-1 -my-1 pe-1 -me-1">
             <UTooltip v-for="c in connections.slice(0, 4)" :key="c.id" :text="`${c.name} · ${c.type}`">
               <button type="button" class="relative inline-flex items-center justify-center w-6 h-6 rounded-md border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50" @click="openConnectionDetail(c)">
-                <DataSourceIcon :type="c.type" class="w-3.5 h-3.5" />
+                <DataSourceIcon :type="c.type" :connector-key="c.connector_key" class="w-3.5 h-3.5" />
                 <span class="absolute -bottom-0.5 -end-0.5 w-1.5 h-1.5 rounded-full" :class="c.is_active === false ? 'bg-gray-300' : 'bg-green-500'"></span>
               </button>
             </UTooltip>
@@ -341,7 +341,7 @@
             <!-- Connections / Connect -->
             <div class="flex flex-wrap items-center gap-1.5 mb-3">
               <button v-for="c in (agentDetail?.connections || [])" :key="c.id" class="inline-flex items-center gap-1.5 px-2 h-6 rounded-md border border-gray-200 dark:border-gray-800 text-gray-600 dark:text-gray-400 text-[11px] hover:bg-gray-50 dark:hover:bg-gray-800/50" @click="openConnectionDetail(c)">
-                <DataSourceIcon :type="c.type" class="w-3.5 h-3.5" />{{ c.name }}
+                <DataSourceIcon :type="c.type" :connector-key="c.connector_key" class="w-3.5 h-3.5" />{{ c.name }}
                 <span class="w-1.5 h-1.5 rounded-full" :class="c.is_active === false ? 'bg-gray-300' : 'bg-green-500'"></span>
               </button>
               <button v-if="agentDetail && needsSignIn(agentDetail)" class="inline-flex items-center gap-1.5 px-2.5 h-6 rounded-md bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/30 text-blue-600 dark:text-blue-400 text-[11px] font-medium hover:bg-blue-100 dark:hover:bg-blue-500/20" @click="openAgentTab(agentView.agentId)"><UIcon name="i-heroicons-key" class="w-3 h-3" />{{ $t('agentsPage.connect') }}</button>
@@ -678,7 +678,7 @@
                   <KSelect v-if="metaEditable" v-model="draft.data_source_ids" :options="agentOptsForDraft" multiple :placeholder="$t('agentsPage.allAgentsPlaceholder')" icon="i-heroicons-cube" @update:modelValue="onMetaChange" />
                   <template v-else>
                     <span v-if="(detail.data_sources || []).length === 0" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><UIcon name="i-heroicons-globe-alt" class="w-3 h-3 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.allAgentsPlaceholder') }}</span>
-                    <span v-for="ds in detail.data_sources" :key="ds.id" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><DataSourceIcon :type="ds.type" class="w-3 h-3" />{{ ds.name }}</span>
+                    <span v-for="ds in detail.data_sources" :key="ds.id" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" class="w-3 h-3" />{{ ds.name }}</span>
                   </template>
                   <!-- Primary: only when scoped to a single agent -->
                   <KSelect v-if="metaEditable && singleAgentId && !creating" v-model="primarySelectValue" :options="primaryOpts" icon="i-heroicons-star" />
@@ -813,7 +813,7 @@
         <div class="max-h-[60vh] overflow-auto -mx-1 px-1 space-y-0.5">
           <button v-for="c in connections" :key="c.id" type="button" class="w-full flex items-center gap-3 px-2.5 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 text-start transition-colors" @click="showConnectionsModal = false; openConnectionDetail(c)">
             <span class="relative inline-flex items-center justify-center w-8 h-8 rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shrink-0">
-              <DataSourceIcon :type="c.type" class="w-4 h-4" />
+              <DataSourceIcon :type="c.type" :connector-key="c.connector_key" class="w-4 h-4" />
               <span class="absolute -bottom-0.5 -end-0.5 w-2 h-2 rounded-full ring-2 ring-white dark:ring-gray-900" :class="c.is_active === false ? 'bg-gray-300' : 'bg-green-500'"></span>
             </span>
             <span class="min-w-0 flex-1">

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -10,7 +10,7 @@
           <Icon name="heroicons:x-mark" class="w-4 h-4 text-gray-500 dark:text-gray-400" />
         </button>
         <Icon v-if="(visibleAgents[0] as any).isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-        <DataSourceIcon v-else :type="visibleAgents[0].type || visibleAgents[0].connections?.[0]?.type" class="h-5 flex-shrink-0" />
+        <DataSourceIcon v-else :type="visibleAgents[0].type || visibleAgents[0].connections?.[0]?.type" :connector-key="(visibleAgents[0] as any).connector_key || visibleAgents[0].connections?.[0]?.connector_key" class="h-5 flex-shrink-0" />
         <span class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ visibleAgents[0].name }}</span>
         <span
           v-if="stageBadge(visibleAgents[0])"
@@ -27,7 +27,7 @@
           class="w-full flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-gray-800 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors bg-white/80 dark:bg-gray-900/80"
         >
           <Icon v-if="(selectedAgent as any)?.isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-          <DataSourceIcon v-else-if="selectedAgent" :type="selectedAgent.type || selectedAgent.connections?.[0]?.type" class="h-5 flex-shrink-0" />
+          <DataSourceIcon v-else-if="selectedAgent" :type="selectedAgent.type || selectedAgent.connections?.[0]?.type" :connector-key="(selectedAgent as any).connector_key || selectedAgent.connections?.[0]?.connector_key" class="h-5 flex-shrink-0" />
           <span class="truncate flex-1 text-start font-medium text-gray-900 dark:text-white">
             {{ selectedAgent?.name || $t('reportAgent.selectAgent') }}
           </span>
@@ -50,7 +50,7 @@
               :class="selectedAgentId === agent.id ? 'bg-indigo-50 text-indigo-700' : 'text-gray-700 dark:text-gray-300'"
             >
               <Icon v-if="(agent as any).isGlobal" name="heroicons:globe-alt" class="w-4 h-4 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-              <DataSourceIcon v-else :type="agent.type || agent.connections?.[0]?.type" class="h-4 flex-shrink-0" />
+              <DataSourceIcon v-else :type="agent.type || agent.connections?.[0]?.type" :connector-key="(agent as any).connector_key || agent.connections?.[0]?.connector_key" class="h-4 flex-shrink-0" />
               <span class="truncate flex-1 text-start font-medium">{{ agent.name }}</span>
               <span
                 v-if="stageBadge(agent)"

--- a/frontend/layouts/data.vue
+++ b/frontend/layouts/data.vue
@@ -67,7 +67,7 @@
                                         <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', statusDotClass(getEffectiveStatus(conn))]" />
                                         <UTooltip :text="conn.name + (getEffectiveStatus(conn) === 'indexing' ? ' · ' + indexingSummary(conn.indexing) : '')">
                                             <div class="flex items-center gap-1">
-                                                <DataSourceIcon :type="conn.type" class="h-3.5 opacity-70" />
+                                                <DataSourceIcon :type="conn.type" :connector-key="conn.connector_key" class="h-3.5 opacity-70" />
                                                 <span class="text-xs text-gray-500 dark:text-gray-400">{{ conn.name }}</span>
                                             </div>
                                         </UTooltip>


### PR DESCRIPTION
## Summary

Follow-up to #605. That PR added the connector brand icon (Monday, Notion, etc.) to the Create Data Agent modal, the `/agents/new` selector, and `ManageConnectionsModal` — but several other surfaces still rendered MCP connectors with the generic MCP paperclip icon because they passed only `:type` to `DataSourceIcon` and omitted `:connector-key`.

This threads `connector_key` through the remaining connection/agent/data-source icon spots, mirroring each existing `:type` binding (including its optional chaining).

## Surfaces fixed
- **KnowledgeExplorer** (the agents page): the "Connections" popover, the connection chips/tooltips, agent search results, the agent-detail connection chips, and instruction data-source chips
- **AgentConnectionsModal**: linked + available connection rows, and the edit header
- **ConnectionDetailModal**: edit header
- **AgentFlyout**: the agent connection icon stack
- **AgentSelector** (top nav): trigger (collapsed + expanded) and dropdown rows
- **ReportAgentPanel**: header, selector button, and dropdown rows (using the same `type || connections[0]` fallback the type binding already uses)
- **layouts/data.vue**: sidebar connection list

## Why this is safe
The data is already available — `ConnectionEmbedded` and the `/connections` list both carry `connector_key` (added in #605). Where a bound object happens to lack the field, the prop resolves to `undefined` and `DataSourceIcon` falls back exactly as it does today, so there's no regression.

## Deliberately out of scope
Bare-type-string spots — table/tool `connection_type`, aggregate icon stacks (`navIconTypes`), static demo/catalog tiles, and hard-coded DB types — are left as-is because they have no connection object to key off. Instruction-scoping selectors were also left out to keep this PR focused on the agent/connection/report surfaces; they can follow separately if desired.

## Testing
Frontend deps aren't installed in this environment, so no build/lint was run. Verified each edit against the bound object's schema (`ConnectionEmbedded` / `DataSourceListItemSchema` / the KnowledgeExplorer agent mapping all carry `connector_key`) and confirmed the diff only adds the prop without altering existing bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKvtLNCGV5suBAiaaMHbA8)_