### PR TITLE
Lower reindex interval minimum from 10 to 1 minute

### DIFF
--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -40,7 +40,7 @@ class Connection(BaseSchema):
     reindex_interval_hours = Column(Integer, nullable=True, default=None)
 
     # The schedule is EITHER a recurring interval OR a fixed time-of-day:
-    #   * mode == "interval": fire every `reindex_interval_minutes` (10m floor).
+    #   * mode == "interval": fire every `reindex_interval_minutes` (1m floor).
     #   * mode == "time":     fire once a day at `reindex_at_time` ("HH:MM"),
     #                         interpreted in the org's timezone (UTC fallback).
     # `reindex_interval_minutes` supersedes the legacy `reindex_interval_hours`
@@ -92,7 +92,7 @@ class Connection(BaseSchema):
     DEFAULT_REINDEX_INTERVAL_HOURS = 12
     DEFAULT_REINDEX_INTERVAL_MINUTES = 12 * 60
     # Hard floor on interval cadence — guards against runaway tight loops.
-    MIN_REINDEX_INTERVAL_MINUTES = 10
+    MIN_REINDEX_INTERVAL_MINUTES = 1
 
     @property
     def effective_reindex_interval_minutes(self) -> int:

--- a/backend/app/schemas/connection_schema.py
+++ b/backend/app/schemas/connection_schema.py
@@ -55,8 +55,8 @@ class ConnectionUpdate(BaseModel):
 
     @validator("reindex_interval_minutes")
     def _validate_minutes(cls, v):
-        if v is not None and v < 10:
-            raise ValueError("reindex_interval_minutes must be at least 10")
+        if v is not None and v < 1:
+            raise ValueError("reindex_interval_minutes must be at least 1")
         return v
 
     @validator("reindex_at_time")

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -372,12 +372,12 @@ class ConnectionService:
                     status_code=400,
                     detail="reindex_interval_hours must be between 1 and 168.",
                 )
-            # Interval minutes: 10 minute floor .. 7 days.
+            # Interval minutes: 1 minute floor .. 7 days.
             mins = updates.get("reindex_interval_minutes")
-            if mins is not None and (mins < 10 or mins > 24 * 7 * 60):
+            if mins is not None and (mins < 1 or mins > 24 * 7 * 60):
                 raise HTTPException(
                     status_code=400,
-                    detail="reindex_interval_minutes must be between 10 and 10080.",
+                    detail="reindex_interval_minutes must be between 1 and 10080.",
                 )
             mode = updates.get("reindex_schedule_mode")
             if mode is not None and mode not in ("interval", "time"):

--- a/backend/app/services/reindex_schedule.py
+++ b/backend/app/services/reindex_schedule.py
@@ -6,7 +6,7 @@ in exactly one place.
 
 A connection's schedule is EITHER:
 
-  * ``interval`` — fire every ``effective_reindex_interval_minutes`` (10m floor).
+  * ``interval`` — fire every ``effective_reindex_interval_minutes`` (1m floor).
   * ``time``     — fire once per day at ``reindex_at_time`` ("HH:MM"), interpreted
                    in the org's configured timezone (UTC if unset / invalid).
 

--- a/backend/app/services/scheduled_reindex.py
+++ b/backend/app/services/scheduled_reindex.py
@@ -71,7 +71,7 @@ def _is_due(connection, now: datetime, tz=None) -> bool:
 async def sweep_due_reindexes() -> None:
     """Scheduled entrypoint: re-index every connection whose schema is due.
 
-    Safe to register on a short APScheduler interval (e.g. every 10 minutes);
+    Safe to register on a short APScheduler interval (e.g. every 1 minute);
     the staleness gate keeps actual reindex work proportional to N / interval.
     """
     from app.core.scheduler import claim_scheduled_run

--- a/backend/main.py
+++ b/backend/main.py
@@ -466,14 +466,14 @@ async def startup_event():
             scheduler.add_job(
                 sweep_due_reindexes,
                 trigger="interval",
-                minutes=10,
+                minutes=1,
                 id="schema_reindex_sweep",
                 replace_existing=True,
                 coalesce=True,
                 max_instances=1,
-                misfire_grace_time=600,
+                misfire_grace_time=60,
             )
-            logger.info("Scheduled job: schema_reindex_sweep every 10 minutes")
+            logger.info("Scheduled job: schema_reindex_sweep every 1 minute")
         except Exception as e:
             logger.error(f"Failed to schedule schema reindex sweep job: {e}")
 

--- a/frontend/components/ConnectionDetailModal.vue
+++ b/frontend/components/ConnectionDetailModal.vue
@@ -130,7 +130,7 @@
             </div>
           </div>
 
-          <!-- Interval: number + unit (10 minute minimum) -->
+          <!-- Interval: number + unit (1 minute minimum) -->
           <div v-if="reindexMode === 'interval'" class="flex items-center justify-between">
             <span class="text-xs text-gray-500 dark:text-gray-400">{{ $t('data.autoReindexEvery') }}</span>
             <div class="flex items-center gap-1">
@@ -687,7 +687,7 @@ const autoReindexError = ref<string | null>(null)
 const savingAutoReindex = ref(false)
 
 // Schedule: either a recurring interval (value + unit) OR a fixed daily time.
-const MIN_INTERVAL_MINUTES = 10
+const MIN_INTERVAL_MINUTES = 1
 const reindexMode = ref<'interval' | 'time'>('interval')
 const intervalValue = ref<number>(12)
 const intervalUnit = ref<'minutes' | 'hours'>('hours')


### PR DESCRIPTION
## Summary

Allows connections to be scheduled for auto-reindex as frequently as **every 1 minute** (previously floored at 10).

## Changes

Lowered the minimum at every enforcement point:

- **`backend/app/models/connection.py`** — `MIN_REINDEX_INTERVAL_MINUTES` 10 → 1 (the model-level floor applied by `effective_reindex_interval_minutes`)
- **`backend/app/schemas/connection_schema.py`** — `ConnectionUpdate` validator (`< 10` → `< 1`)
- **`backend/app/services/connection_service.py`** — PUT bounds check + error message (`10..10080` → `1..10080`)
- **`frontend/components/ConnectionDetailModal.vue`** — `MIN_INTERVAL_MINUTES` 10 → 1

Additionally lowered the sweep cadence so a 1-minute interval can actually fire:

- **`backend/main.py`** — `schema_reindex_sweep` APScheduler job 10 → 1 minute (misfire grace 600s → 60s). Previously the sweep only polled every 10 minutes, which would have silently capped any shorter interval. The existing staleness gate keeps per-tick work proportional to N/interval, so the more frequent sweep adds no reindex load for connections on longer schedules.

## Notes

- Scheduled auto-reindex is enterprise-gated (`scheduled_reindex` feature), so the shorter cadence only applies where licensed.
- Verified the schema validator now accepts `1` and rejects `0`, and the effective-interval floor resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXATUMwDvkgMA6rowdJ8BW)_