### PR TITLE
Add "new"/חדש command to start a fresh report on Teams and WhatsApp

### DIFF
--- a/backend/app/services/external_platform_manager.py
+++ b/backend/app/services/external_platform_manager.py
@@ -13,6 +13,15 @@ from app.services.data_source_service import DataSourceService
 from app.settings.config import settings
 
 
+# Sending one of these words — and nothing else — starts a fresh conversation
+# report instead of continuing the current one. Matched case-insensitively after
+# trimming surrounding whitespace, so "new", "New" and "  new  " all qualify but
+# "new report" / "retry new" do not. Only platforms that reuse a report across
+# messages (Teams 1:1, WhatsApp) honour it; see _is_new_conversation_command.
+NEW_REPORT_COMMANDS = {"new", "חדש"}
+NEW_REPORT_COMMAND_PLATFORMS = {"teams", "whatsapp"}
+
+
 class ExternalPlatformManager:
     """Manages external platform interactions"""
     
@@ -283,6 +292,55 @@ class ExternalPlatformManager:
             token
         )
 
+    @staticmethod
+    def _is_new_conversation_command(platform_type: str, text: str) -> bool:
+        """Return True when the whole message is a single "start fresh" keyword.
+
+        Only the exact word (e.g. "new" / "חדש") counts — "new report" or
+        "retry new" are ordinary prompts, not commands — and only on platforms
+        that otherwise reuse a report across messages (Teams 1:1, WhatsApp),
+        where the user has no other way to break out of the running report.
+        """
+        if platform_type not in NEW_REPORT_COMMAND_PLATFORMS:
+            return False
+        if not text:
+            return False
+        return text.strip().lower() in NEW_REPORT_COMMANDS
+
+    async def _find_recent_platform_report(
+        self,
+        db: AsyncSession,
+        organization_id: str,
+        user_id: str,
+        platform_id: str,
+        max_age_days: int,
+    ) -> Optional[Any]:
+        """Return the user's most recent report for a platform within the window.
+
+        Report-level (rather than completion-level) lookup, so a freshly created
+        report with no completions yet — e.g. one started by a "new" command —
+        is still picked up by the next message.
+        """
+        from app.models.report import Report
+        from sqlalchemy import select, and_
+        import datetime
+
+        cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=max_age_days)
+        result = await db.execute(
+            select(Report)
+            .filter(
+                and_(
+                    Report.external_platform_id == platform_id,
+                    Report.organization_id == organization_id,
+                    Report.user_id == user_id,
+                    Report.created_at >= cutoff,
+                )
+            )
+            .order_by(Report.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
     async def _get_or_create_conversation_report(
         self,
         db: AsyncSession,
@@ -290,6 +348,7 @@ class ExternalPlatformManager:
         user: Any,
         user_mapping: ExternalUserMapping,
         channel_type: str = None,
+        force_new: bool = False,
     ) -> Tuple[Any, bool]:
         """
         Get a report for a user if one from the platform exists from the last 24 hours,
@@ -319,7 +378,7 @@ class ExternalPlatformManager:
         # the user's most recent report from the last 24h (mirrors Teams'
         # per-conversation reuse). Other platforms mint a fresh report per
         # top-level message and rely on thread replies for continuation.
-        if user_mapping.platform_type == "whatsapp":
+        if user_mapping.platform_type == "whatsapp" and not force_new:
             result = await db.execute(
                 select(Report)
                 .filter(
@@ -449,22 +508,53 @@ class ExternalPlatformManager:
         created = False
 
         platform_type = processed_data.get("platform_type", "slack")
+        message_text = processed_data.get("message_text") or ""
 
-        if is_thread_reply and thread_ts and platform_type != "whatsapp":
+        # A lone "new"/"חדש" message is a command to start a fresh report, not a
+        # prompt — only on platforms that otherwise keep reusing one report
+        # (Teams 1:1, WhatsApp), where the user has no other way out. Force-create
+        # the report, confirm it, and stop: there's no question to answer yet, so
+        # we don't create a completion. The next message reuses this fresh report.
+        if self._is_new_conversation_command(platform_type, message_text):
+            report, _ = await self._get_or_create_conversation_report(
+                db, organization, user, user_mapping, channel_type, force_new=True
+            )
+            report_url = f"{settings.bow_config.base_url}/reports/{report.id}"
+            if platform_type == "teams":
+                report_link = f"[{report.title}]({report_url})"
+            else:  # whatsapp
+                report_link = f"{report.title} ({report_url})"
+            await adapter.send_dm_in_thread(
+                user_mapping.external_user_id,
+                f"> I've started a new conversation report for you: {report_link}",
+                thread_ts,
+                channel_id=channel_id,
+            )
+            return {
+                "success": True,
+                "action": "new_conversation_started",
+                "user_id": user_mapping.app_user_id,
+                "report_id": str(report.id),
+                "thread_ts": thread_ts,
+            }
+
+        if platform_type == "teams" and channel_type == "personal":
+            # Teams 1:1 chats have no threading, so reuse the user's most recent
+            # Teams report within a 5-day window (older ones start fresh). This is
+            # report-level rather than keyed on a completion's thread_ts, so a
+            # report just started by a "new" command — which has no completion
+            # yet — is still the one this next message continues.
+            report = await self._find_recent_platform_report(
+                db, organization.id, user.id, user_mapping.platform_id,
+                max_age_days=5,
+            )
+        elif is_thread_reply and thread_ts and platform_type != "whatsapp":
             # This is a reply in an existing thread - find the associated report.
             # WhatsApp is excluded: its thread_ts is the (per-message) inbound id,
             # not a stable conversation key, so it reuses by 24h window instead.
             report = await self._find_report_by_thread_ts(
                 db, organization.id, user.id, thread_ts,
                 platform_type=platform_type,
-            )
-        elif platform_type == "teams" and channel_type == "personal" and thread_ts:
-            # Teams 1:1 chats have no threading — reuse report by conversation ID
-            # within a 5-day window so old conversations start fresh
-            report = await self._find_report_by_thread_ts(
-                db, organization.id, user.id, thread_ts,
-                platform_type=platform_type,
-                max_age_days=5,
             )
 
         if not report:

--- a/backend/tests/unit/test_new_report_command.py
+++ b/backend/tests/unit/test_new_report_command.py
@@ -1,0 +1,169 @@
+"""Unit tests for the "new"/"חדש" start-a-fresh-report command.
+
+Exercises ExternalPlatformManager._process_verified_message with mocked
+services/DB so the report-selection branches are tested in isolation (no DB
+fixtures needed). A lone "new" (Teams 1:1 / WhatsApp only) must force-create a
+report, confirm it, and create no completion; the next message must then
+continue that fresh report.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.external_platform_manager import ExternalPlatformManager
+
+
+def _make_manager():
+    m = ExternalPlatformManager()
+    m.mapping_service.get_user_by_id = AsyncMock(
+        return_value=SimpleNamespace(id="u1", name="Alice")
+    )
+    m.organization_service.get_organization = AsyncMock(
+        return_value=SimpleNamespace(id="org1")
+    )
+    m.completion_service.create_completion = AsyncMock()
+    return m
+
+
+def _data(text, platform="teams", channel_type="personal", is_thread_reply=False):
+    return {
+        "platform_type": platform,
+        "message_text": text,
+        "thread_ts": "conv-123",
+        "message_ts": "msg-1",
+        "channel_id": "conv-123",
+        "channel_type": channel_type,
+        "is_thread_reply": is_thread_reply,
+    }
+
+
+def _mapping(platform="teams"):
+    return SimpleNamespace(
+        app_user_id="u1",
+        organization_id="org1",
+        external_user_id="ext-user-1",
+        platform_type=platform,
+        platform_id="plat-1",
+    )
+
+
+def _adapter():
+    return SimpleNamespace(add_reaction=AsyncMock(), send_dm_in_thread=AsyncMock())
+
+
+def _db():
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.mark.parametrize(
+    "platform,text,expected",
+    [
+        ("teams", "new", True),
+        ("teams", "New", True),
+        ("teams", "  new  ", True),
+        ("teams", "חדש", True),
+        ("teams", "  חדש ", True),
+        ("whatsapp", "new", True),
+        ("whatsapp", "חדש", True),
+        # Only the lone keyword counts.
+        ("teams", "new report", False),
+        ("teams", "retry new", False),
+        ("teams", "create a new dashboard", False),
+        ("teams", "newer", False),
+        ("whatsapp", "new.", False),
+        ("teams", "", False),
+        ("teams", None, False),
+        # Platforms without cross-message report reuse never treat it as a command.
+        ("slack", "new", False),
+        ("email", "new", False),
+    ],
+)
+def test_is_new_conversation_command(platform, text, expected):
+    assert (
+        ExternalPlatformManager._is_new_conversation_command(platform, text) is expected
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ["teams", "whatsapp"])
+async def test_new_command_forces_report_and_skips_completion(platform):
+    m = _make_manager()
+    adapter = _adapter()
+    fresh = SimpleNamespace(id="R_NEW", title="Chat with Alice")
+    keyword = "new" if platform == "teams" else "חדש"
+
+    with patch.object(
+        m, "_get_or_create_conversation_report", new=AsyncMock(return_value=(fresh, True))
+    ) as goc, patch.object(
+        m, "_find_recent_platform_report", new=AsyncMock()
+    ) as frp, patch.object(
+        m, "_find_report_by_thread_ts", new=AsyncMock()
+    ) as fbt:
+        res = await m._process_verified_message(
+            _db(), adapter, _data(keyword, platform=platform), _mapping(platform)
+        )
+
+    assert res["action"] == "new_conversation_started"
+    # Reuse is bypassed and a brand-new report is forced.
+    assert goc.call_args.kwargs.get("force_new") is True
+    assert frp.await_count == 0 and fbt.await_count == 0
+    # The user is told a fresh report started, but no prompt is dispatched.
+    assert adapter.send_dm_in_thread.await_count == 1
+    assert m.completion_service.create_completion.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_teams_followup_continues_fresh_report():
+    """After "new", the next Teams 1:1 message reuses the fresh (completion-less)
+    report via report-level lookup, and its completion lands in that report."""
+    m = _make_manager()
+    fresh = SimpleNamespace(id="R_NEW", title="Chat with Alice")
+
+    with patch.object(
+        m, "_find_recent_platform_report", new=AsyncMock(return_value=fresh)
+    ) as frp, patch.object(
+        m, "_get_or_create_conversation_report", new=AsyncMock()
+    ) as goc, patch(
+        "app.services.report_service.ReportService"
+    ) as RS:
+        RS.return_value.set_data_sources_for_report = AsyncMock()
+        m.data_source_service.get_active_data_sources = AsyncMock(return_value=[])
+        res = await m._process_verified_message(
+            _db(), _adapter(), _data("show me sales"), _mapping()
+        )
+
+    assert res["action"] == "message_processed"
+    assert frp.await_count == 1          # report-level reuse used
+    assert goc.await_count == 0          # no new report created
+    assert m.completion_service.create_completion.await_count == 1
+    assert (
+        m.completion_service.create_completion.await_args.kwargs.get("report_id")
+        == "R_NEW"
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_report_phrase_is_a_normal_prompt():
+    """"new report" is a question, not the command — it must reach a completion."""
+    m = _make_manager()
+    fresh = SimpleNamespace(id="R_X", title="Chat with Alice")
+
+    with patch.object(
+        m, "_find_recent_platform_report", new=AsyncMock(return_value=fresh)
+    ), patch.object(
+        m, "_get_or_create_conversation_report", new=AsyncMock()
+    ), patch(
+        "app.services.report_service.ReportService"
+    ) as RS:
+        RS.return_value.set_data_sources_for_report = AsyncMock()
+        m.data_source_service.get_active_data_sources = AsyncMock(return_value=[])
+        res = await m._process_verified_message(
+            _db(), _adapter(), _data("new report"), _mapping()
+        )
+
+    assert res["action"] == "message_processed"
+    assert m.completion_service.create_completion.await_count == 1


### PR DESCRIPTION
## Summary

On Teams 1:1 and WhatsApp, incoming messages reuse a single conversation report within a time window (5 days for Teams, 24h for WhatsApp), so a user had no way to explicitly start over mid-conversation. This adds a lightweight command: a message that is **exactly** `new` or `חדש` now forces a brand-new report.

## Behavior

- **Whole-message exact match only** — case-insensitive, whitespace-trimmed. `new` / `New` / `  new  ` / `חדש` trigger it; `new report`, `retry new`, `newer`, `new.` stay ordinary prompts.
- **Restricted to reuse platforms** — Teams 1:1 and WhatsApp only. Slack/email are unaffected (they already mint a fresh report per top-level message).
- On the command: force-create the report, confirm it to the user (`> I've started a new conversation report for you: …`), and **skip completion creation** — there is no question to answer yet. The next message flows into the fresh report.

## Implementation

- `backend/app/services/external_platform_manager.py`
  - `NEW_REPORT_COMMANDS` / `NEW_REPORT_COMMAND_PLATFORMS` constants + `_is_new_conversation_command()` matcher.
  - `force_new` flag on `_get_or_create_conversation_report()` to bypass the WhatsApp 24h reuse.
  - Command branch in `_process_verified_message()` that force-creates, confirms, and returns without a completion.
  - Teams 1:1 reuse switched to a **report-level** lookup (`_find_recent_platform_report`) instead of a completion-`thread_ts` lookup. This is required: the freshly created report has no completions yet, so a `thread_ts` lookup would miss it and re-select the *old* report, silently defeating the command. A side benefit is the 5-day cap now applies uniformly to Teams 1:1.

## Testing

- New `backend/tests/unit/test_new_report_command.py` (20 cases): the matcher across 16 inputs, force-create + confirm + no-completion for both platforms, the Teams follow-up correctly continuing the fresh report, and `new report` remaining a normal prompt. All pass.
- Existing WhatsApp-webhook unit tests unaffected (the one failing test, `test_post_valid_text_message_dispatches`, fails identically on the base commit — pre-existing, unrelated).

## Notes

The command word and confirmation text are hardcoded English/Hebrew. Localizing them per user locale or making the keyword set configurable would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QbiBDVT8uCoxs8RkfYQxy

---
_Generated by [Claude Code](https://claude.ai/code/session_019QbiBDVT8uCoxs8RkfYQxy)_