### PR TITLE
Add release-notes skill for version bump + changelog

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: release-notes
+description: Bump the version and write a CHANGELOG.md release-notes entry after a user-facing change ships. Use when asked to "bump the version", "cut a release", "add a changelog entry", or "write release notes". Produces one minimal, user-facing, technical bullet per change.
+---
+
+# Release notes & version bump
+
+Two files, one commit. `VERSION` drives the release; `CHANGELOG.md` is the
+human-readable history.
+
+- **`VERSION`** — a single line, `MAJOR.MINOR.PATCH` (e.g. `0.0.448`). The
+  Release workflow (`.github/workflows/release.yml`) reads it, tags `vX.Y.Z`,
+  and extracts the matching `CHANGELOG.md` section as the GitHub release body.
+- **`CHANGELOG.md`** — newest version first. Served to users at `/changelog`
+  (parsed by `backend/app/routes/changelog.py`), so the format is load-bearing.
+
+## Steps
+
+1. **Bump `VERSION`.** Increment the **patch** by one (`0.0.448` → `0.0.449`)
+   unless told otherwise. No leading spaces, no trailing newline changes —
+   just the number.
+2. **Add a section at the top of `CHANGELOG.md`**, directly under
+   `# Release Notes`:
+   ```
+   ## Version <new-version> (<Month DD, YYYY>)
+   - **<Title> (#<PR>)** — <one-line description>.
+   ```
+   Use today's date, format `July 12, 2026`. One bullet per user-facing
+   change; group the whole release under this single version heading.
+3. **Commit both files together**: `Bump version to <X.Y.Z> with changelog entry`.
+
+## How to write a bullet
+
+Format: `- **Title (#PR)** — description.`
+
+- **Bold title** — a short noun phrase for the feature/fix (`**Elasticsearch
+  connector**`, `**Fix SSO login for mismatched email casing**`). Prefix fixes
+  with `Fix`.
+- **`(#PR)`** — the pull request number, if known. Omit the parens entirely if
+  there's no PR.
+- **` — ` (em-dash + spaces)** separates title from description.
+- **Description** — what the user can now do, or what stopped being broken.
+  Technical but plain. Name the real thing (`PromQL`, `SSE`, `.xlsx`, the org
+  setting, the env var). One sentence. End with a period.
+
+### Rules
+
+- **Minimal.** One line per change. If it needs two sentences, the second adds
+  a concrete knob (default value, env var, setting name) — not narration.
+- **User-facing only.** Skip pure refactors, test-only changes, CI, and
+  dependency bumps. If a user can't observe it, it's not a release note.
+- **Present tense, user's point of view.** "Charts export to Excel" — not
+  "Added the ability to export" or "We changed the exporter".
+- **No filler.** Drop "now", "the ability to", "support for", "improved",
+  "various", "enhancements". State the capability directly.
+- **Be specific, not vague.** "caps requests per minute/hour/day, enforced as
+  a hard block" beats "better rate limiting".
+
+## Examples
+
+Feature:
+```
+- **Prometheus connector (#595)** — query metrics with PromQL over the Prometheus HTTP API; each metric becomes a table.
+```
+
+Feature with a knob:
+```
+- **Concurrent multi-tool execution (#598)** — one planner decision can run its tool calls in parallel, controlled by the `ai_tool_concurrency` org setting (defaults to 4; set to 1 for serial).
+```
+
+Fix:
+```
+- **Fix iOS focus-zoom on the report prompt box (#600)** — the mobile prompt field is pinned to 16px so tapping it no longer zooms the viewport.
+```
+
+Fix with cause:
+```
+- **Fix profile Usage tab never updating (#576)** — usage counters now record without a hard cap configured, and the tab refreshes the session on open instead of showing stale zeros.
+```
+
+Config/model change (no PR):
+```
+- **OpenAI model presets** — add GPT-5.6 Sol, Terra, and Luna; make Terra the default and retire the GPT-5.4/5.2 presets.
+```
+
+A full release section:
+```
+## Version 0.0.438 (July 7, 2026)
+- **Triggers (#562)** — user-owned webhooks that spawn agent sessions, plus report-per-run routing for scheduled tasks, under a new Automations page.
+- **QVD indexing progress (#564)** — real per-file indexing progress with stop, file size, and duration.
+- **WhatsApp fixes (#565)** — agent replies (text + data) are delivered back to WhatsApp, and the verification page shows WhatsApp branding instead of Slack.
+```

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -55,6 +55,9 @@ Format: `- **Title (#PR)** — description.`
   "various", "enhancements". State the capability directly.
 - **Be specific, not vague.** "caps requests per minute/hour/day, enforced as
   a hard block" beats "better rate limiting".
+- **Never real data.** No customer/org names, account identifiers, emails,
+  tokens, connection strings, or any PII — release notes are public. Use
+  generic placeholders (`<name>`, `acme`) if an example needs one.
 
 ## Examples
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ one of these tasks:
   credentials schemas, registry entry, tests) with verification steps.
 - **add-llm-provider-or-model** — extend the LLM catalog; model id, pricing,
   and context window must be verified against official docs first.
+- **release-notes** — bump `VERSION` and write a minimal, user-facing
+  `CHANGELOG.md` entry after a user-facing change ships.
 
 Shared setup scripts (usable by humans too): `tools/agent/boot_stack.sh`
 (run the full stack like CI), `tools/agent/seed_org.py` (seed org/users/demo


### PR DESCRIPTION
## What

Adds a new agent skill at `.agents/skills/release-notes/SKILL.md` that codifies the version-bump + release-notes procedure, and registers it in the root `AGENTS.md` skill index.

## Why

The bump/changelog flow is load-bearing but undocumented: the Release workflow reads `VERSION`, tags `vX.Y.Z`, and extracts the matching `CHANGELOG.md` section as the GitHub release body, while `/changelog` (`backend/app/routes/changelog.py`) parses the same markdown for users. The skill captures that format so entries stay consistent.

## What the skill covers

- **Bump `VERSION`** — patch by default (`0.0.448` → `0.0.449`).
- **Prepend a `## Version X.Y.Z (Month DD, YYYY)` section** to `CHANGELOG.md`.
- **Commit both files** as `Bump version to X.Y.Z with changelog entry`.
- **Writing rules** for minimal, user-facing, technical bullets — `- **Title (#PR)** — description.` — with filler words banned and user-observable changes only.
- **Examples**: feature, feature-with-knob, fix, fix-with-cause, config/model change without a PR, and a full multi-bullet release section — all drawn from the existing changelog's style.

## Files

- `.agents/skills/release-notes/SKILL.md` (new)
- `AGENTS.md` — added the skill to the skills index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012rjZmRm13miab6FaXPzjeA)_