### PR TITLE
Refine connection management permissions for agents

### DIFF
--- a/backend/app/routes/data_source.py
+++ b/backend/app/routes/data_source.py
@@ -497,16 +497,19 @@ async def add_connection_to_domain(
 ):
     """Add a connection to an agent (M:N relationship).
 
-    The `data_source:manage` decorator proves the caller can manage this agent.
-    We additionally require that they have access to the connection they're
-    attaching — mirroring the picker's `GET /connections` filtering — so the
-    endpoint can't be used to attach a connection the caller can't see by
-    passing its id directly.
+    Two independent capabilities are required, matching the "build an agent on a
+    connection" model:
+      - The `data_source:manage` decorator proves the caller owns/manages this
+        agent.
+      - Per-connection `create_data_sources` proves they may build agents on the
+        connection being attached — the SAME check `create_data_source` runs when
+        an agent is created directly on a connection. Connection admins /
+        `manage_connections` pass via implication.
     """
-    from app.services.connection_service import ConnectionService
-    from app.routes.connection import _ensure_can_read_connection
-    connection = await ConnectionService().get_connection(db, connection_id, organization)
-    await _ensure_can_read_connection(db, organization, current_user, connection)
+    await check_resource_permissions(
+        db, str(current_user.id), str(organization.id),
+        "connection", [connection_id], "create_data_sources",
+    )
 
     result = await data_source_service.add_connection_to_domain(
         db=db,

--- a/backend/app/routes/data_source.py
+++ b/backend/app/routes/data_source.py
@@ -495,7 +495,19 @@ async def add_connection_to_domain(
     organization: Organization = Depends(get_current_organization),
     current_user: User = Depends(current_user)
 ):
-    """Add a connection to an agent (M:N relationship)."""
+    """Add a connection to an agent (M:N relationship).
+
+    The `data_source:manage` decorator proves the caller can manage this agent.
+    We additionally require that they have access to the connection they're
+    attaching — mirroring the picker's `GET /connections` filtering — so the
+    endpoint can't be used to attach a connection the caller can't see by
+    passing its id directly.
+    """
+    from app.services.connection_service import ConnectionService
+    from app.routes.connection import _ensure_can_read_connection
+    connection = await ConnectionService().get_connection(db, connection_id, organization)
+    await _ensure_can_read_connection(db, organization, current_user, connection)
+
     result = await data_source_service.add_connection_to_domain(
         db=db,
         data_source_id=data_source_id,

--- a/frontend/components/AgentConnectionsModal.vue
+++ b/frontend/components/AgentConnectionsModal.vue
@@ -111,7 +111,7 @@
                 <Spinner class="w-5 h-5" />
             </div>
             <div v-else-if="availableConnections.length === 0" class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
-                All connections are already linked to this agent.
+                No connections available to link.
             </div>
             <div v-else class="space-y-2 max-h-64 overflow-y-auto">
                 <label
@@ -245,9 +245,15 @@ const loadingOrgConnections = ref(false)
 const orgConnections = ref<any[]>([])
 const isLinking = ref(false)
 
+// Offer only connections the caller (a) hasn't already linked and (b) may build
+// agents on — per-connection `create_data_sources`, the same permission the link
+// API enforces. Keeps the picker in sync with what the backend will accept.
 const availableConnections = computed(() => {
     const linked = new Set(connections.value.map((c: any) => c.id))
-    return orgConnections.value.filter((c) => !linked.has(c.id))
+    return orgConnections.value.filter((c) =>
+        !linked.has(c.id) &&
+        useCan('create_data_sources', { type: 'connection', id: c.id })
+    )
 })
 
 function getConnectionEffective(conn: any) {

--- a/frontend/components/AgentConnectionsModal.vue
+++ b/frontend/components/AgentConnectionsModal.vue
@@ -6,7 +6,7 @@
                     <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Connections</h3>
                     <div class="flex items-center gap-2">
                         <UButton
-                            v-if="canManageConnections"
+                            v-if="canLinkConnections"
                             color="blue"
                             variant="soft"
                             size="xs"
@@ -25,7 +25,7 @@
             <div v-else-if="connections.length === 0" class="py-8 text-center">
                 <UIcon name="heroicons-link" class="w-8 h-8 mx-auto mb-2 text-gray-300 dark:text-gray-600" />
                 <p class="text-sm text-gray-500 dark:text-gray-400">No connections linked to this agent.</p>
-                <UButton v-if="canManageConnections" color="blue" variant="soft" size="sm" class="mt-3" @click="openLinkModal">
+                <UButton v-if="canLinkConnections" color="blue" variant="soft" size="sm" class="mt-3" @click="openLinkModal">
                     Link a connection
                 </UButton>
             </div>
@@ -49,7 +49,7 @@
                                 {{ getStatusLabel(conn) }}
                             </span>
                             <button
-                                v-if="canManageConnections"
+                                v-if="canManageConnection(conn)"
                                 @click="testConnection(conn.id)"
                                 :disabled="testingConnectionId === conn.id"
                                 class="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
@@ -59,14 +59,14 @@
                                 <UIcon v-else name="heroicons-arrow-path" class="w-4 h-4 text-gray-400" />
                             </button>
                             <UButton
-                                v-if="canManageConnections"
+                                v-if="canManageConnection(conn)"
                                 color="gray" variant="ghost" size="xs"
                                 @click="openEditModal(conn)"
                             >
                                 <UIcon name="heroicons-pencil" class="w-4 h-4" />
                             </UButton>
                             <UButton
-                                v-if="canManageConnections && connections.length > 1"
+                                v-if="canLinkConnections && connections.length > 1"
                                 color="red" variant="ghost" size="xs"
                                 @click="unlinkConnection(conn.id)"
                                 title="Unlink"
@@ -86,7 +86,7 @@
                     <!-- Indexing progress -->
                     <div v-if="conn.indexing" class="mt-2 ms-10">
                         <ConnectionIndexingProgress :indexing="conn.indexing" :show-logs="true" />
-                        <div v-if="conn.indexing.status === 'failed' && canManageConnections" class="mt-2">
+                        <div v-if="conn.indexing.status === 'failed' && canManageConnection(conn)" class="mt-2">
                             <UButton size="xs" color="amber" variant="soft" @click="reindexConnection(conn.id)">
                                 Retry
                             </UButton>
@@ -203,7 +203,6 @@ const isOpen = computed({
 
 const route = useRoute()
 const toast = useToast()
-const canManageConnections = computed(() => useCan('manage_connections'))
 
 const integration = inject<Ref<any>>('integration', ref(null))
 const fetchIntegration = inject<() => Promise<void>>('fetchIntegration', async () => {})
@@ -212,6 +211,23 @@ const fetchIntegration = inject<() => Promise<void>>('fetchIntegration', async (
 const dsId = computed(() => props.dsId ?? String(route.params.id || ''))
 const connections = computed(() => props.connections ?? (integration.value?.connections || []))
 const ready = computed(() => props.dsId != null || !!integration.value)
+
+// Linking/unlinking a connection to THIS agent is an agent-management action:
+// anyone who can manage the agent may attach connections they have access to
+// (the picker only lists connections the caller can see, and the API enforces
+// per-connection read access on link). This is distinct from managing the
+// shared connection object below.
+const canLinkConnections = computed(() =>
+    useCan('manage', { type: 'data_source', id: dsId.value })
+)
+
+// Editing / testing / reindexing mutates the SHARED connection (config,
+// credentials, catalog) used by every agent it backs, so it stays gated by the
+// per-connection `manage_connection` permission (org `manage_connections` and
+// full_admin imply it) rather than agent-management.
+function canManageConnection(conn: any) {
+    return useCan('manage_connection', { type: 'connection', id: conn.id })
+}
 
 // Refresh both the legacy layout (via inject) and the standalone parent (via emit).
 async function refresh() {

--- a/frontend/pages/old_agents/[id]/connection.vue
+++ b/frontend/pages/old_agents/[id]/connection.vue
@@ -206,7 +206,7 @@
                 <!-- No connections available -->
                 <div v-else class="text-center py-4 text-gray-500">
                     <p class="text-sm">No available connections to link.</p>
-                    <p class="text-xs mt-1">All organization connections are already linked to this agent.</p>
+                    <p class="text-xs mt-1">Connections you can build agents on and that aren't already linked will appear here.</p>
                 </div>
             </div>
 
@@ -320,10 +320,15 @@ const isAdmin = computed(() => {
   return org?.role === 'admin'
 })
 
-// Available connections (org connections not already linked)
+// Available connections: not already linked, and ones the caller may build
+// agents on (per-connection `create_data_sources` — the same permission the
+// link API enforces). See AgentConnectionsModal.vue.
 const availableConnections = computed(() => {
   const linkedIds = new Set(connections.value.map((c: any) => c.id))
-  return orgConnections.value.filter(c => !linkedIds.has(c.id))
+  return orgConnections.value.filter(c =>
+    !linkedIds.has(c.id) &&
+    useCan('create_data_sources', { type: 'connection', id: c.id })
+  )
 })
 
 // Status helpers — derived from the shared state machine.

--- a/frontend/pages/old_agents/[id]/connection.vue
+++ b/frontend/pages/old_agents/[id]/connection.vue
@@ -9,7 +9,7 @@
             <!-- Main content -->
             <div v-else>
                 <!-- Header with Add button -->
-                <div class="flex items-center justify-between mb-4" v-if="canManageConnections">
+                <div class="flex items-center justify-between mb-4" v-if="canLinkConnections">
                     <h2 class="text-sm font-medium text-gray-700 dark:text-gray-300">Connections</h2>
                     <UButton
                         color="blue"
@@ -48,7 +48,7 @@
                                 </span>
                                 <!-- Test button (admin only) -->
                                 <button
-                                    v-if="canManageConnections"
+                                    v-if="canManageConnection(conn)"
                                     @click="testConnection(conn.id)"
                                     :disabled="testingConnectionId === conn.id"
                                     class="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
@@ -59,7 +59,7 @@
                                 </button>
                                 <!-- Edit button -->
                                 <UButton
-                                    v-if="canManageConnections"
+                                    v-if="canManageConnection(conn)"
                                     color="gray"
                                     variant="ghost"
                                     size="xs"
@@ -69,7 +69,7 @@
                                 </UButton>
                                 <!-- Unlink button (only if more than 1 connection) -->
                                 <UButton
-                                    v-if="canManageConnections && connections.length > 1"
+                                    v-if="canLinkConnections && connections.length > 1"
                                     color="red"
                                     variant="ghost"
                                     size="xs"
@@ -84,7 +84,7 @@
                         <!-- Indexing progress / completion / failure (shared component, with logs toggle) -->
                         <div v-if="conn.indexing" class="mt-3 ms-11">
                             <ConnectionIndexingProgress :indexing="conn.indexing" :show-logs="true" />
-                            <div v-if="conn.indexing.status === 'failed' && canManageConnections" class="mt-2">
+                            <div v-if="conn.indexing.status === 'failed' && canManageConnection(conn)" class="mt-2">
                                 <UButton size="xs" color="amber" variant="soft" @click="reindexConnection(conn.id)">
                                     Retry
                                 </UButton>
@@ -142,7 +142,7 @@
                         <UIcon name="heroicons-link" class="w-8 h-8 mx-auto mb-2 text-gray-400" />
                         <p class="text-sm">No connections linked to this agent.</p>
                         <UButton
-                            v-if="canManageConnections"
+                            v-if="canLinkConnections"
                             color="blue"
                             variant="soft"
                             size="sm"
@@ -273,7 +273,15 @@ import type { Ref } from 'vue'
 const route = useRoute()
 const toast = useToast()
 const dsId = computed(() => String(route.params.id || ''))
-const canManageConnections = computed(() => useCan('manage_connections'))
+// Linking/unlinking a connection to this agent is an agent-management action;
+// editing/testing/reindexing mutates the shared connection and stays gated by
+// per-connection `manage_connection`. See AgentConnectionsModal.vue.
+const canLinkConnections = computed(() =>
+    useCan('manage', { type: 'data_source', id: dsId.value })
+)
+function canManageConnection(conn: any) {
+    return useCan('manage_connection', { type: 'connection', id: conn.id })
+}
 const { data: currentUser } = useAuth()
 const { organization } = useOrganization()
 


### PR DESCRIPTION
## Summary
This PR refines the permission model for managing agent connections, distinguishing between two separate capabilities:
1. **Linking/unlinking connections to an agent** — requires agent management permission
2. **Editing/testing/reindexing shared connection objects** — requires per-connection management permission

## Key Changes

- **Permission separation**: Replaced the blanket `canManageConnections` check with two distinct permissions:
  - `canLinkConnections`: Uses `manage` permission on the data_source (agent), allowing users who manage an agent to attach connections they have access to
  - `canManageConnection(conn)`: Uses per-connection `manage_connection` permission for operations that mutate shared connection state (edit, test, reindex)

- **Frontend updates** (AgentConnectionsModal.vue and connection.vue):
  - Link/unlink buttons now check `canLinkConnections` instead of `canManageConnections`
  - Test, edit, and reindex buttons now check `canManageConnection(conn)` per-connection
  - Updated available connections filter to only show connections where the user has `create_data_sources` permission (matching backend enforcement)
  - Improved empty state messaging to clarify what connections are available

- **Backend enforcement** (data_source.py):
  - Added explicit permission check in `add_connection_to_domain` endpoint
  - Validates that the caller has `create_data_sources` permission on the connection being linked
  - Added detailed docstring explaining the two-capability model

## Implementation Details

The permission model now aligns with the "build an agent on a connection" paradigm:
- Linking a connection to an agent requires the same `create_data_sources` permission that creating an agent directly on a connection requires
- This ensures the frontend picker only shows connections the backend will accept
- Connection admins and users with `manage_connections` implicitly have `create_data_sources` on all connections

https://claude.ai/code/session_01CRqaxeJjVnvwcbntTMnjJH