### PR TITLE
Add manual per-model vision toggle with durable override

### DIFF
--- a/backend/alembic/versions/v1s2v3o4t5g6_add_supports_vision_override_to_llm_models.py
+++ b/backend/alembic/versions/v1s2v3o4t5g6_add_supports_vision_override_to_llm_models.py
@@ -1,0 +1,33 @@
+"""add supports_vision_override to llm_models
+
+Revision ID: v1s2v3o4t5g6
+Revises: dsicon0001
+Create Date: 2026-07-12 12:00:00.000000
+
+Adds a nullable supports_vision_override column to llm_models so admins can
+manually toggle image support per model. NULL means "follow the catalog"
+(LLM_MODEL_DETAILS); True/False is an explicit override that survives catalog
+re-syncs. The existing supports_vision column stays the resolved value read at
+inference time.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'v1s2v3o4t5g6'
+down_revision: Union[str, None] = 'dsicon0001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('llm_models', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('supports_vision_override', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('llm_models', schema=None) as batch_op:
+        batch_op.drop_column('supports_vision_override')

--- a/backend/app/core/permissions_decorator.py
+++ b/backend/app/core/permissions_decorator.py
@@ -168,6 +168,8 @@ def requires_permission(permission, model=None, owner_only=False, allow_public=F
                 raise HTTPException(status_code=403, detail="Permission denied")
 
             return await func(*args, **kwargs)
+        # Expose the required permission for introspection (tests, tooling).
+        wrapper._required_permission = permission
         return wrapper
     return decorator
 

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -205,7 +205,10 @@ class LLMModel(BaseSchema):
     is_default = Column(Boolean, default=False, nullable=False)  # If True, this is the default model for the organization
     is_small_default = Column(Boolean, default=False, nullable=False)  # Optional small default model per organization
     is_restricted = Column(Boolean, default=False, nullable=False)  # If True, usable only by granted principals (plus admins/org defaults). EE feature.
-    supports_vision = Column(Boolean, default=False, nullable=False)  # Whether model accepts image inputs
+    supports_vision = Column(Boolean, default=False, nullable=False)  # Effective flag: whether model accepts image inputs
+    # Manual admin override for vision. NULL = follow the catalog (LLM_MODEL_DETAILS); True/False = admin-set,
+    # persisted across catalog re-syncs. `supports_vision` above is the resolved value inference reads.
+    supports_vision_override = Column(Boolean, nullable=True)
     # Token limits
     context_window_tokens = Column(Integer, nullable=True)  # Max prompt+completion tokens
     max_output_tokens = Column(Integer, nullable=True)  # Max model output tokens

--- a/backend/app/routes/llm.py
+++ b/backend/app/routes/llm.py
@@ -208,6 +208,18 @@ async def toggle_model(
     """Enable/disable a model"""
     return await llm_service.toggle_model(db, organization, current_user, model_id, enabled)
 
+@router.post("/llm/models/{model_id}/toggle_vision")
+@requires_permission('manage_llm')
+async def toggle_model_vision(
+    model_id: str,
+    enabled: bool,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization)
+):
+    """Manually enable/disable image (vision) support for a model."""
+    return await llm_service.toggle_vision(db, organization, current_user, model_id, enabled)
+
 @router.post("/llm/models/{model_id}/set_default")
 @requires_permission('manage_llm')
 async def set_default_model(

--- a/backend/app/schemas/llm_schema.py
+++ b/backend/app/schemas/llm_schema.py
@@ -171,6 +171,8 @@ class LLMModelBase(BaseModel):
     is_default: bool = False
     is_small_default: bool = False
     supports_vision: bool = False
+    # Manual admin override for vision. None = follow the catalog; True/False = explicit, survives catalog re-syncs.
+    supports_vision_override: Optional[bool] = None
     context_window_tokens: Optional[int] = None
     max_output_tokens: Optional[int] = None
     input_cost_per_million_tokens_usd: Optional[float] = None

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -742,7 +742,53 @@ class LLMService:
             pass
 
         return {"success": True}
-    
+
+    async def toggle_vision(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        model_id: str,
+        enabled: bool
+    ):
+        """Manually enable/disable image (vision) support for a model.
+
+        Sets an explicit override so the choice survives catalog re-syncs, and
+        updates the effective `supports_vision` flag that inference reads.
+        """
+        model = await db.execute(
+            select(LLMModel).join(LLMProvider).filter(
+                LLMModel.id == model_id,
+                LLMProvider.organization_id == organization.id
+            )
+        )
+        model = model.scalar_one_or_none()
+
+        if not model:
+            raise HTTPException(status_code=404, detail="Model not found")
+
+        model.supports_vision_override = enabled
+        model.supports_vision = enabled
+        await db.commit()
+
+        logger.info("LLM model vision toggled: id=%s, name=%s, model_id=%s, supports_vision=%s, org_id=%s", model.id, model.name, model.model_id, enabled, organization.id)
+
+        # Audit log
+        try:
+            await audit_service.log(
+                db=db,
+                organization_id=str(organization.id),
+                action="llm_model.vision_toggled",
+                user_id=str(current_user.id),
+                resource_type="llm_model",
+                resource_id=str(model.id),
+                details={"name": model.name, "model_id": model.model_id, "supports_vision": enabled},
+            )
+        except Exception:
+            pass
+
+        return {"success": True}
+
     async def _create_models(
         self, 
         db: AsyncSession,
@@ -852,6 +898,9 @@ class LLMService:
             # Set context_window_tokens, pricing, and supports_vision
             # For preset models: use values from LLM_MODEL_DETAILS
             # For custom models: use values from model dict if provided (already set via LLMModel(**model_dict))
+            # A non-null supports_vision_override always wins over the catalog default (see _resolve_supports_vision).
+            vision_override = model.get("supports_vision_override")
+            db_model.supports_vision_override = vision_override
             if model_details and not db_model.is_custom:
                 if model_details.get("context_window_tokens") is not None:
                     db_model.context_window_tokens = model_details["context_window_tokens"]
@@ -861,7 +910,9 @@ class LLMService:
                     db_model.input_cost_per_million_tokens_usd = model_details["input_cost_per_million_tokens_usd"]
                 if model_details.get("output_cost_per_million_tokens_usd") is not None:
                     db_model.output_cost_per_million_tokens_usd = model_details["output_cost_per_million_tokens_usd"]
-                db_model.supports_vision = model_details.get("supports_vision", False)
+                db_model.supports_vision = self._resolve_supports_vision(
+                    vision_override, model_details.get("supports_vision", False)
+                )
             elif db_model.is_custom:
                 # Inherit catalog fields when model_id+provider_type match; user values take precedence.
                 if model_details:
@@ -875,12 +926,16 @@ class LLMService:
                         db_model.input_cost_per_million_tokens_usd = model_details["input_cost_per_million_tokens_usd"]
                     if db_model.output_cost_per_million_tokens_usd is None and model_details.get("output_cost_per_million_tokens_usd") is not None:
                         db_model.output_cost_per_million_tokens_usd = model_details["output_cost_per_million_tokens_usd"]
-                    if not model.get("supports_vision"):
-                        db_model.supports_vision = model_details.get("supports_vision", False)
-                    else:
-                        db_model.supports_vision = True
+                    base_vision = bool(model.get("supports_vision")) or model_details.get("supports_vision", False)
+                    db_model.supports_vision = self._resolve_supports_vision(vision_override, base_vision)
                 else:
-                    db_model.supports_vision = model.get("supports_vision", False)
+                    db_model.supports_vision = self._resolve_supports_vision(
+                        vision_override, model.get("supports_vision", False)
+                    )
+            else:
+                db_model.supports_vision = self._resolve_supports_vision(
+                    vision_override, db_model.supports_vision
+                )
 
             db.add(db_model)
 
@@ -1049,6 +1104,9 @@ class LLMService:
                     (m for m in LLM_MODEL_DETAILS if m["model_id"] == db_model.model_id and m["provider_type"] == provider.provider_type),
                     None
                 )
+                # A non-null vision override from the client is honored for both preset and custom models.
+                if getattr(model, "supports_vision_override", None) is not None:
+                    db_model.supports_vision_override = model.supports_vision_override
                 if db_model.is_preset:
                     if catalog:
                         if catalog.get("context_window_tokens") is not None:
@@ -1059,7 +1117,10 @@ class LLMService:
                             db_model.input_cost_per_million_tokens_usd = catalog["input_cost_per_million_tokens_usd"]
                         if catalog.get("output_cost_per_million_tokens_usd") is not None:
                             db_model.output_cost_per_million_tokens_usd = catalog["output_cost_per_million_tokens_usd"]
-                        db_model.supports_vision = catalog.get("supports_vision", False)
+                    catalog_vision = catalog.get("supports_vision", False) if catalog else db_model.supports_vision
+                    db_model.supports_vision = self._resolve_supports_vision(
+                        db_model.supports_vision_override, catalog_vision
+                    )
                 else:
                     # Custom models: user values take precedence; fall back to catalog when model_id+provider_type match.
                     if getattr(model, "context_window_tokens", None) is not None:
@@ -1078,12 +1139,12 @@ class LLMService:
                         db_model.output_cost_per_million_tokens_usd = model.output_cost_per_million_tokens_usd
                     elif catalog and catalog.get("output_cost_per_million_tokens_usd") is not None:
                         db_model.output_cost_per_million_tokens_usd = catalog["output_cost_per_million_tokens_usd"]
-                    if getattr(model, "supports_vision", False):
-                        db_model.supports_vision = True
-                    elif catalog:
-                        db_model.supports_vision = catalog.get("supports_vision", False)
-                    else:
-                        db_model.supports_vision = False
+                    base_vision = bool(getattr(model, "supports_vision", False)) or (
+                        catalog.get("supports_vision", False) if catalog else False
+                    )
+                    db_model.supports_vision = self._resolve_supports_vision(
+                        db_model.supports_vision_override, base_vision
+                    )
                 
                 db.add(db_model)
             else:
@@ -1119,6 +1180,10 @@ class LLMService:
                     output_cost = getattr(model, "output_cost_per_million_tokens_usd", None) or (catalog.get("output_cost_per_million_tokens_usd") if catalog else None)
                     supports_vision = getattr(model, "supports_vision", False) or (catalog.get("supports_vision", False) if catalog else False)
 
+                # A non-null vision override from the client wins over the catalog default.
+                supports_vision_override = getattr(model, "supports_vision_override", None)
+                supports_vision = self._resolve_supports_vision(supports_vision_override, supports_vision)
+
                 # Set as default if org has no default and this model is enabled
                 should_be_default = not has_default_model and model.is_enabled
                 should_be_small_default = not has_small_default_model and model.is_enabled
@@ -1134,6 +1199,7 @@ class LLMService:
                     is_default=should_be_default,
                     is_small_default=should_be_small_default,
                     supports_vision=supports_vision,
+                    supports_vision_override=supports_vision_override,
                     context_window_tokens=context_window_tokens,
                     max_output_tokens=max_output_tokens,
                     input_cost_per_million_tokens_usd=input_cost,
@@ -1407,12 +1473,23 @@ class LLMService:
         await db.commit()
         
     @staticmethod
+    def _resolve_supports_vision(override, catalog_value) -> bool:
+        """Effective vision flag: a non-null admin override always wins over the catalog."""
+        if override is not None:
+            return bool(override)
+        return bool(catalog_value)
+
+    @staticmethod
     def _apply_catalog_model_details(model: LLMModel, model_data: dict, *, sync_enabled: bool = False) -> None:
         model.name = model_data["name"]
         model.is_preset = model_data.get("is_preset", True)
         if sync_enabled:
             model.is_enabled = model_data.get("is_enabled", True)
-        model.supports_vision = model_data.get("supports_vision", False)
+        # Respect an admin's manual vision override so it survives catalog re-syncs.
+        model.supports_vision = LLMService._resolve_supports_vision(
+            getattr(model, "supports_vision_override", None),
+            model_data.get("supports_vision", False),
+        )
         model.context_window_tokens = model_data.get("context_window_tokens")
         if "max_output_tokens" in model_data:
             model.max_output_tokens = model_data.get("max_output_tokens")

--- a/backend/tests/e2e/test_llm_vision_toggle.py
+++ b/backend/tests/e2e/test_llm_vision_toggle.py
@@ -1,0 +1,139 @@
+"""Feedback loop — manual per-model vision toggle.
+
+Proves the admin `toggle_vision` control:
+  * flips the effective `supports_vision` flag read at inference time,
+  * persists as an explicit override that SURVIVES catalog re-sync
+    (the bug this feature closes: without the override, GET /llm/models
+    re-syncs preset models from LLM_MODEL_DETAILS and reverts the choice),
+  * gates image inputs in the LLM abstraction accordingly.
+
+Loop A is fully self-contained: the provider is seeded directly in the DB
+(no external LLM calls) and every assertion goes through the real
+route -> service -> DB stack. The live-credentials leg lives in the
+feedback-loop doc (Loop B).
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.llm_model import LLMModel
+from app.models.llm_provider import LLMProvider
+from app.ai.llm.llm import LLM
+from app.ai.llm.types import ImageInput
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed_anthropic_preset(org_id):
+    """Seed a preset Anthropic provider with a vision-capable catalog model.
+
+    claude-sonnet-4-6 is `supports_vision=True` in LLM_MODEL_DETAILS, so this is
+    exactly the case that regressed before the override existed.
+    """
+    async with async_session_maker() as db:
+        provider = LLMProvider(
+            organization_id=org_id,
+            name="Anthropic",
+            provider_type="anthropic",
+            is_preset=True,
+            is_enabled=True,
+            use_preset_credentials=True,
+        )
+        db.add(provider)
+        await db.flush()
+
+        db.add(
+            LLMModel(
+                organization_id=org_id,
+                provider_id=provider.id,
+                name="Claude 4.6 Sonnet",
+                model_id="claude-sonnet-4-6",
+                is_preset=True,
+                is_enabled=True,
+                is_default=True,
+                supports_vision=True,
+            )
+        )
+        await db.commit()
+        return str(provider.id)
+
+
+def _find(models, model_id):
+    return next(m for m in models if m["model_id"] == model_id)
+
+
+@pytest.mark.e2e
+def test_vision_toggle_persists_across_catalog_resync(
+    create_user, login_user, whoami, get_models, test_client
+):
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    _run(_seed_anthropic_preset(org_id))
+
+    # Baseline: catalog says this model is vision-capable.
+    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    assert model["supports_vision"] is True
+    assert model["supports_vision_override"] in (None, False, True)
+    model_id = model["id"]
+
+    # Admin turns vision OFF.
+    resp = test_client.post(
+        f"/api/llm/models/{model_id}/toggle_vision", params={"enabled": False}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    # GET re-syncs preset providers from the catalog. The override must win:
+    # effective flag stays OFF even though the catalog says True.
+    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    assert model["supports_vision"] is False, "override was clobbered by catalog re-sync"
+    assert model["supports_vision_override"] is False
+
+    # Admin turns vision back ON; still survives another re-sync.
+    resp = test_client.post(
+        f"/api/llm/models/{model_id}/toggle_vision", params={"enabled": True}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    assert model["supports_vision"] is True
+    assert model["supports_vision_override"] is True
+
+
+@pytest.mark.e2e
+def test_toggle_vision_route_is_permission_gated():
+    """The endpoint carries the same manage_llm gate as every other LLM route."""
+    from app.routes import llm as llm_routes
+
+    route = next(
+        r for r in llm_routes.router.routes
+        if getattr(r, "path", "").endswith("/llm/models/{model_id}/toggle_vision")
+    )
+    # @requires_permission('manage_llm') wraps the handler; the permission name
+    # is recorded on the endpoint by the decorator.
+    perm = getattr(route.endpoint, "_required_permission", None) or getattr(
+        route.endpoint, "required_permission", None
+    )
+    assert perm == "manage_llm", f"expected manage_llm gate, got {perm!r}"
+
+
+@pytest.mark.e2e
+def test_inference_gate_reads_supports_vision():
+    """The image gate in the LLM abstraction keys off model.supports_vision."""
+    image = ImageInput(data="Zm9v", media_type="image/png", source_type="base64")
+
+    off = SimpleNamespace(model=SimpleNamespace(supports_vision=False), model_id="m")
+    with pytest.raises(ValueError, match="does not support images"):
+        LLM._validate_vision_support(off, [image])
+
+    on = SimpleNamespace(model=SimpleNamespace(supports_vision=True), model_id="m")
+    # Should not raise.
+    LLM._validate_vision_support(on, [image])
+
+    # No images -> never gated, regardless of flag.
+    LLM._validate_vision_support(off, None)

--- a/docs/feedback-loops/llm-vision-toggle.md
+++ b/docs/feedback-loops/llm-vision-toggle.md
@@ -1,0 +1,158 @@
+# Feedback Loop — "manually manage LLM model and toggle vision on/off"
+
+Admins want to turn a model's image (vision) support on or off by hand, and have
+that choice **stick** — including for preset models like Claude, whose flags are
+otherwise re-synced from the hardcoded catalog on every settings load.
+
+The vision plumbing already existed end-to-end on the backend (`supports_vision`
+column → enforced at inference by `_validate_vision_support`). What was missing
+was (a) a durable way to override the catalog per model and (b) any UI to do it.
+This loop validates the new manual override.
+
+## Root cause (validated)
+
+Before this change there was **no** manual control, and the catalog would clobber
+any direct edit to a preset model. `LLMService.get_models` calls
+`_sync_provider_with_latest_models` for preset providers on every read, and that
+sync funnels through `_apply_catalog_model_details`
+(`backend/app/services/llm_service.py:1415`), which unconditionally did:
+
+```python
+model.supports_vision = model_data.get("supports_vision", False)
+```
+
+So setting `supports_vision` directly on a preset row would revert to the catalog
+value on the next `GET /llm/models`. There was also no `create_model`/`update_model`
+service method behind the `PATCH /llm/models/{id}` route (those routes are dead),
+so widening `LLMModelUpdate` was a non-starter — the durable primitive had to be a
+new toggle plus an override column.
+
+## The fix
+
+- **New column** `llm_models.supports_vision_override` (nullable): `NULL` = follow
+  the catalog; `True`/`False` = explicit admin choice. Migration
+  `v1s2v3o4t5g6_add_supports_vision_override_to_llm_models.py`.
+  `supports_vision` stays the *resolved* value inference reads.
+- **Resolution helper** `LLMService._resolve_supports_vision(override, catalog)` —
+  a non-null override always wins. Applied everywhere the effective flag is set:
+  `_apply_catalog_model_details` (the sync), `_create_models`, `_update_models`.
+  This is what makes preset overrides survive re-sync.
+- **New endpoint** `POST /llm/models/{id}/toggle_vision?enabled=<bool>` +
+  `LLMService.toggle_vision` (mirrors the existing `toggle_model`), gated by
+  `@requires_permission('manage_llm')`. It sets the override and the effective flag,
+  and writes an audit log (`llm_model.vision_toggled`).
+- **Schema** `LLMModelBase.supports_vision_override` so the flag round-trips through
+  the provider create/update payloads and the model/provider responses.
+- **Frontend**: a Vision toggle column in `LLMsComponent.vue` (settings table,
+  calls `toggle_vision`) and a per-model Vision toggle in
+  `LLMProviderModalComponent.vue` (Integrate Models modal, threads
+  `supports_vision_override`). Both gated on `manage_llm_settings`. i18n keys under
+  `settings.llms.*`.
+
+## Loop A — deterministic reproduction (no external services)
+
+`backend/tests/e2e/test_llm_vision_toggle.py`. Seeds a preset Anthropic provider
+with `claude-sonnet-4-6` (catalog `supports_vision=True`) directly in the DB, then
+drives the real route → service → DB stack. No LLM calls.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run pytest tests/e2e/test_llm_vision_toggle.py -q
+```
+
+Observed:
+
+```
+3 passed
+```
+
+- `test_vision_toggle_persists_across_catalog_resync` — turns vision OFF via the
+  endpoint, then re-reads (which re-syncs from the catalog). **Before the override:
+  `supports_vision` reverted to `True`.** After: it stays `False`
+  (`supports_vision_override == False`), and toggling back ON survives another
+  re-sync. This is the regression the feature closes.
+- `test_toggle_vision_route_is_permission_gated` — asserts the endpoint carries the
+  `manage_llm` gate (via the introspectable `_required_permission` the decorator now
+  records).
+- `test_inference_gate_reads_supports_vision` — `LLM._validate_vision_support`
+  raises `"does not support images"` when `supports_vision` is False and passes when
+  True, proving the manual flag actually governs inference.
+
+Reproducing the *pre-fix* clobber: stash the `_resolve_supports_vision` change (so
+`_apply_catalog_model_details` sets `supports_vision` straight from the catalog) and
+the first test fails on `assert model["supports_vision"] is False` after the re-sync
+— the override is ignored and the catalog wins.
+
+## Loop B — live confirmation (real ANTHROPIC credentials)
+
+Proves the toggle governs a **real** provider call, not just a DB flag. Secrets come
+from `ANTHROPIC_KEY` in the environment (never committed); the Anthropic SDK routes
+through `ANTHROPIC_BASE_URL`. Save as `backend/loopb_vision.py` and run from
+`backend/`:
+
+```python
+import base64, io, os
+from PIL import Image
+import main  # noqa: F401 -- registers every ORM model so mappers configure
+from app.models.llm_model import LLMModel
+from app.models.llm_provider import LLMProvider
+from app.ai.llm.llm import LLM
+from app.ai.llm.types import ImageInput
+
+def image():
+    img = Image.new("RGB", (96, 96), (30, 120, 220))  # solid blue
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    return ImageInput(data=base64.b64encode(buf.getvalue()).decode(),
+                      media_type="image/png", source_type="base64")
+
+def llm(supports_vision):
+    p = LLMProvider(name="A", provider_type="anthropic", organization_id="o",
+                    is_preset=True, is_enabled=True)
+    p.encrypt_credentials(os.environ["ANTHROPIC_KEY"], None)
+    m = LLMModel(name="Haiku", model_id="claude-haiku-4-5-20251001",
+                 organization_id="o", provider=p, is_preset=True, is_enabled=True,
+                 supports_vision=supports_vision, supports_vision_override=supports_vision)
+    return LLM(m)
+
+img = image()
+try:
+    llm(False).inference("What color?", images=[img], should_record=False)
+    print("FAIL: gate did not fire")
+except ValueError as e:
+    print("OFF -> gated:", e)
+out = llm(True).inference("What color is this image? One word.", images=[img], should_record=False)
+print("ON  -> live response:", out.strip())
+assert "blue" in out.lower()
+```
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run python loopb_vision.py
+```
+
+Observed (real `POST https://api.anthropic.com/v1/messages "200 OK"`):
+
+```
+OFF -> gated: Model 'claude-haiku-4-5-20251001' does not support images. ...
+ON  -> live response: Blue
+```
+
+Vision OFF is refused before any network call; vision ON reaches Anthropic and the
+model correctly reads the blue image. The manual flag drives real behavior.
+
+## What this proves / regression notes
+
+- The override is the single source of manual truth and **survives catalog re-sync**
+  for preset models — the core requirement.
+- Custom/Bedrock models were never synced from a catalog, so their vision value was
+  already user-owned; the override makes them consistent and lets the same UI toggle
+  govern them.
+- The inference gate is unchanged and already keyed off `supports_vision`; no client
+  code needed touching.
+- Pre-existing unrelated failures in `tests/e2e/test_llm_providers.py` come from
+  `OPENAI_API_KEY_TEST`/`ANTHROPIC_API_KEY_TEST` not being set in this sandbox
+  (the fixtures `pytest.fail` without them) — they reproduce with this change stashed.
+  The catalog-sync test that does not need a key
+  (`test_preset_openai_sync_migrates_to_gpt_56_models`) passes.

--- a/frontend/components/LLMProviderModalComponent.vue
+++ b/frontend/components/LLMProviderModalComponent.vue
@@ -174,6 +174,12 @@
                                         <div class="text-sm font-medium text-gray-900 dark:text-white">{{ model.name }}</div>
                                         <div class="text-xs text-gray-500 dark:text-gray-400">Model ID: {{ model.model_id }}</div>
                                     </div>
+                                    <UTooltip :text="$t('settings.llms.visionTooltip')">
+                                        <label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
+                                            <UToggle size="xs" v-model="model.supports_vision" @change="onVisionChange(model)" />
+                                            <span>{{ $t('settings.llms.colVision') }}</span>
+                                        </label>
+                                    </UTooltip>
                                     <button
                                         v-if="model.is_custom"
                                         type="button"
@@ -195,6 +201,12 @@
                                             class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 w-full focus:outline-none focus:border-blue-500"
                                         />
                                     </div>
+                                    <UTooltip :text="$t('settings.llms.visionTooltip')">
+                                        <label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
+                                            <UToggle size="xs" v-model="customModel.supports_vision" />
+                                            <span>{{ $t('settings.llms.colVision') }}</span>
+                                        </label>
+                                    </UTooltip>
                                     <button
                                         type="button"
                                         @click="removeExistingProviderCustomModel(index)"
@@ -362,6 +374,12 @@
                                             <div class="text-sm font-medium text-gray-900 dark:text-white">{{ model.name }}</div>
                                             <div class="text-xs text-gray-500 dark:text-gray-400">Model ID: {{ model.model_id }}</div>
                                         </div>
+                                        <UTooltip :text="$t('settings.llms.visionTooltip')">
+                                            <label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
+                                                <UToggle size="xs" v-model="model.supports_vision" @change="onVisionChange(model)" />
+                                                <span>{{ $t('settings.llms.colVision') }}</span>
+                                            </label>
+                                        </UTooltip>
                                     </div>
                                 </template>
                                 <template v-else>
@@ -379,6 +397,12 @@
                                             class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 w-full focus:outline-none focus:border-blue-500"
                                         />
                                     </div>
+                                    <UTooltip :text="$t('settings.llms.visionTooltip')">
+                                        <label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
+                                            <UToggle size="xs" v-model="customModel.supports_vision" />
+                                            <span>{{ $t('settings.llms.colVision') }}</span>
+                                        </label>
+                                    </UTooltip>
                                     <button
                                         type="button"
                                         @click="removeCustomModel(index)"
@@ -467,7 +491,7 @@ type OrgProvider = {
   models: any[];
 };
 type AvailableProvider = { type: string; name: string; credentials?: { properties?: Record<string, { title: string; description?: string }>} };
-type AvailableModel = { id?: string; name: string; model_id: string; provider_type: string; is_preset?: boolean; is_enabled?: boolean; selected?: boolean };
+type AvailableModel = { id?: string; name: string; model_id: string; provider_type: string; is_preset?: boolean; is_enabled?: boolean; selected?: boolean; supports_vision?: boolean; supports_vision_override?: boolean | null };
 
 type CredentialField = { key: string; title: string; description?: string; required?: boolean };
 const providers = ref<AvailableProvider[]>([]);
@@ -495,8 +519,15 @@ onMounted(async () => {
 
 const selectedProvider = ref<any | null>(null);
 const selectedModel = ref<any | null>(null);
-const customModels = ref<{ model_id: string; is_enabled: boolean }[]>([]);
-const existingProviderCustomModels = ref<{ model_id: string; is_enabled: boolean }[]>([]);
+const customModels = ref<{ model_id: string; is_enabled: boolean; supports_vision: boolean }[]>([]);
+const existingProviderCustomModels = ref<{ model_id: string; is_enabled: boolean; supports_vision: boolean }[]>([]);
+
+// A model's vision toggle in the modal is an explicit admin override: mirror the
+// current supports_vision into supports_vision_override so it persists across
+// catalog re-syncs. Untouched models keep their existing (usually null) override.
+function onVisionChange(model: any) {
+    model.supports_vision_override = !!model.supports_vision;
+}
 const providerForm = ref<{ name: string; provider_type: string; credentials: Record<string, any>; models?: any[]}>({
     name: '',
     provider_type: '',
@@ -795,7 +826,10 @@ async function createProvider() {
             name: model.name,
             is_custom: false,
             is_enabled: true,
-            is_preset: true
+            is_preset: true,
+            supports_vision: !!model.supports_vision,
+            // Only send an explicit override when the admin toggled vision for this model.
+            supports_vision_override: model.supports_vision_override ?? null
         }));
 
     // Gather selected custom models
@@ -806,7 +840,9 @@ async function createProvider() {
             name: model.model_id, // Use model_id as the name for custom models
             is_custom: true,
             is_enabled: true,
-            is_preset: false
+            is_preset: false,
+            supports_vision: !!model.supports_vision,
+            supports_vision_override: !!model.supports_vision
         }));
 
     // Combine all selected models
@@ -841,13 +877,15 @@ async function updateProvider() {
     // Prepare new custom models for creation (no ID means create new)
     const newCustomModels = existingProviderCustomModels.value
         .filter((model: { model_id: string; is_enabled: boolean }) => model.is_enabled && model.model_id.trim() !== '')
-        .map((model: { model_id: string; is_enabled: boolean }) => ({
+        .map((model: { model_id: string; is_enabled: boolean; supports_vision: boolean }) => ({
             // No id field - this signals to backend to create new model
             model_id: model.model_id,
             name: model.model_id,
             is_custom: true,
             is_enabled: true,
-            is_preset: false
+            is_preset: false,
+            supports_vision: !!model.supports_vision,
+            supports_vision_override: !!model.supports_vision
         }));
 
     // Existing models keep their IDs for updates
@@ -858,7 +896,10 @@ async function updateProvider() {
         name: model.name,
         is_custom: model.is_custom,
         is_enabled: model.is_enabled,
-        is_preset: model.is_preset
+        is_preset: model.is_preset,
+        supports_vision: !!model.supports_vision,
+        // Preserve any existing override; onVisionChange sets it when the admin toggles vision.
+        supports_vision_override: model.supports_vision_override ?? null
     }));
 
     // Prepare update payload with existing models + new custom models
@@ -1005,7 +1046,8 @@ async function deleteProvider(providerId: string) {
 function addCustomModel() {
     customModels.value.push({
         model_id: '',
-        is_enabled: true
+        is_enabled: true,
+        supports_vision: false
     });
 }
 
@@ -1016,7 +1058,8 @@ function removeCustomModel(index: number) {
 function addExistingProviderCustomModel() {
     existingProviderCustomModels.value.push({
         model_id: '',
-        is_enabled: true
+        is_enabled: true,
+        supports_vision: false
     });
 }
 

--- a/frontend/components/LLMsComponent.vue
+++ b/frontend/components/LLMsComponent.vue
@@ -27,6 +27,9 @@
                         <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('settings.llms.colModel') }}</th>
                         <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('settings.llms.colProvider') }}</th>
                         <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ $t('settings.llms.colStatus') }}</th>
+                        <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                            <UTooltip :text="$t('settings.llms.visionTooltip')">{{ $t('settings.llms.colVision') }}</UTooltip>
+                        </th>
                         <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" v-if="canManageAccess">Access</th>
                         <th class="px-6 py-3 text-start text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" v-if="useCan('manage_llm_settings')">{{ $t('settings.llms.colActions') }}</th>
                     </tr>
@@ -63,6 +66,15 @@
                                 @change="toggleModel(model.id, $event)"
                                 :disabled="!useCan('manage_llm_settings') || model.is_default || model.is_small_default"
                             />
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                            <UTooltip :text="$t('settings.llms.visionTooltip')">
+                                <UToggle
+                                    v-model="model.supports_vision"
+                                    @change="toggleVision(model.id, $event)"
+                                    :disabled="!useCan('manage_llm_settings')"
+                                />
+                            </UTooltip>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" v-if="canManageAccess">
                             <button
@@ -142,6 +154,8 @@ type Model = {
   is_default: boolean;
   is_small_default: boolean;
   is_enabled: boolean;
+  supports_vision: boolean;
+  supports_vision_override?: boolean | null;
   is_restricted?: boolean;
   provider: Provider;
 };
@@ -246,6 +260,31 @@ const toggleModel = async (modelId: string, enabled: boolean) => {
         toast.add({
             title: 'Error',
             description: 'Could not update model',
+            color: 'red'
+        });
+    }
+};
+
+const toggleVision = async (modelId: string, enabled: boolean) => {
+    const response = await useMyFetch(`/llm/models/${modelId}/toggle_vision`, {
+        method: 'POST',
+        query: { enabled }
+    });
+    if (response.status.value === 'success') {
+        await getModels();
+        toast.add({
+            title: 'Model updated',
+            description: enabled ? 'Vision enabled for this model' : 'Vision disabled for this model',
+            color: 'green'
+        });
+    }
+    else {
+        // Revert optimistic toggle on failure
+        const model = models.value.find(m => m.id === modelId);
+        if (model) model.supports_vision = !enabled;
+        toast.add({
+            title: 'Error',
+            description: 'Could not update vision setting',
             color: 'red'
         });
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1858,15 +1858,18 @@
       "colModel": "Model",
       "colProvider": "Provider",
       "colStatus": "Status",
+      "colVision": "Vision",
       "colActions": "Actions",
       "badgeDefault": "Default",
       "badgeSmallDefault": "Small default",
+      "badgeVision": "Vision",
       "emptyTitle": "No LLMs Integrated",
       "emptyHint": "Get started by integrating your LLM provider and models",
       "makeDefault": "Make Default",
       "makeSmallDefault": "Make Small Default",
       "manageProvider": "Manage Provider",
       "smallDefaultTooltip": "Used for LLM Judge, tests, and other small tasks",
+      "visionTooltip": "Whether this model accepts image inputs. Controls what the app sends to the provider — it does not change the model's real capability.",
       "modelIdLabel": "Model ID"
     },
     "licensePage": {


### PR DESCRIPTION
## Summary

Admins can now manually turn a model's image (vision) support on/off, and the choice **sticks** — including for preset models like Claude, whose flags are otherwise re-synced from the hardcoded catalog on every settings load.

The vision plumbing already existed end-to-end on the backend (`supports_vision` column → enforced at inference by `_validate_vision_support`). What was missing was a durable way to override the catalog per model, plus any UI to do it.

### The core problem
`get_models` re-syncs preset providers on every read via `_apply_catalog_model_details`, which unconditionally set `supports_vision` from `LLM_MODEL_DETAILS`. So a naive edit to a preset model reverted on the next page load. The fix stores the manual choice as a nullable **override** rather than mutating the effective value directly.

## Changes

**Backend**
- New nullable column `llm_models.supports_vision_override` (`NULL` = follow catalog; `True`/`False` = explicit admin choice) + Alembic migration. `supports_vision` remains the resolved value read at inference.
- `LLMService._resolve_supports_vision(override, catalog)` — a non-null override always wins. Applied in the catalog sync (`_apply_catalog_model_details`), `_create_models`, and `_update_models`.
- New endpoint `POST /llm/models/{id}/toggle_vision?enabled=<bool>` + `LLMService.toggle_vision` (mirrors the existing `toggle_model`), gated by `@requires_permission('manage_llm')`, with a `llm_model.vision_toggled` audit log.
- `supports_vision_override` added to `LLMModelBase` so it round-trips through provider create/update payloads and responses.
- `requires_permission` now records the required permission on the wrapper for introspection.

**Frontend**
- Vision toggle column in the settings table (`LLMsComponent.vue`) calling `toggle_vision`.
- Per-model Vision toggle in the Integrate Models modal (`LLMProviderModalComponent.vue`) threading `supports_vision_override`.
- Both gated on `manage_llm_settings`; i18n keys under `settings.llms.*` with a tooltip clarifying it controls what the app *sends*, not the model's real capability.

## Verification

Documented as a runnable feedback loop in `docs/feedback-loops/llm-vision-toggle.md`.

- **Loop A** (deterministic, `backend/tests/e2e/test_llm_vision_toggle.py`, 3 passing): the override **persists across catalog re-sync** (the regression this closes), the route is permission-gated, and the inference gate reads the flag.
- **Loop B** (live Anthropic credentials): vision OFF is refused with `ValueError` before any network call; vision ON reaches `POST /v1/messages` `200 OK` and the model correctly reads the image.

## Notes

- **Bedrock**: works unchanged — Bedrock models are custom (never catalog-synced), so their vision value was already user-owned; the same toggle now governs them consistently.
- Pre-existing failures in `tests/e2e/test_llm_providers.py` are from `OPENAI_API_KEY_TEST`/`ANTHROPIC_API_KEY_TEST` not being set in the sandbox (fixtures `pytest.fail` without them) — unrelated to this change. The key-free catalog-sync test passes.
- Frontend wasn't typechecked in the sandbox (no `node_modules`); changes mirror existing `UToggle`/`UTooltip`/`UCheckbox` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8f3kQvjnm78qKqaFvPbxv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8f3kQvjnm78qKqaFvPbxv)_