### PR TITLE
fix(powerbi): make dataset GUIDs available to the agent at query time

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -301,6 +301,7 @@ class Coder:
              * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
            - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
            - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
+           - **Power BI connections**: `execute_query` needs the target semantic model — pass the schema table name (format `Dataset/Table`, exactly as shown in the schema) as the SECOND argument: `execute_query("EVALUATE Customers", "SalesModel/Customers")`. Alternatively pass `dataset_id=`/`workspace_id=` from the table's `<powerbi .../>` metadata. Never ask the user for these IDs.
            - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
            {data_preview_instruction}
            - For SQL data sources, "SOME QUERY" should be SQL code that matches the schema column names exactly.
@@ -725,6 +726,7 @@ class Coder:
                  * Example: `ds_clients["Sales Analytics:snowflake_prod"].execute_query("SELECT * FROM orders")`
                - **Connection-Table Mapping**: Each client_key corresponds to a specific database connection. The `<connection name="...">` tags in <ground_truth_schemas> show which tables belong to which connection. Match the connection name to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
                - **Cross-Connection Queries**: Tables from different connections cannot be joined in SQL. Query each connection separately and merge the results in Python using pandas (e.g., `pd.merge(df1, df2, on="shared_key")`).
+               - **Power BI connections**: `execute_query` needs the target semantic model — pass the schema table name (format `Dataset/Table`, exactly as shown in the schema) as the SECOND argument: `execute_query("EVALUATE Customers", "SalesModel/Customers")`. Alternatively pass `dataset_id=`/`workspace_id=` from the table's `<powerbi .../>` metadata. Never ask the user for these IDs.
                - After each query or DataFrame creation, print its info using: print("df Info:", df.info())
                {data_preview_instruction}
                - For SQL data sources, "SOME QUERY" should be SQL code that matches the schema column names exactly.
@@ -904,6 +906,7 @@ class Coder:
         3. **Joins within one connection are fine**, but cross-connection joins do not work in SQL. If tables are under different `<connection>` tags, query each connection separately.
         4. **Connection-Table Mapping**: Match `<connection name="...">` in schemas to the client_key suffix (e.g., `<connection name="postgresql-1">` → `ds_clients["...:postgresql-1"]`). Only query tables listed under that connection.
         5. **Do not query information_schema** — schemas are already provided above.
+        6. **Power BI connections**: pass the schema table name (`Dataset/Table`, exactly as shown) as the SECOND argument to `execute_query`, or `dataset_id=`/`workspace_id=` from the `<powerbi .../>` metadata. Never ask the user for these IDs.
 
         **What to validate**:
         - Sample rows to see data structure

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -66,6 +66,30 @@ class FileScopeItem(BaseModel):
     enforces_scope: bool = True
 
 
+def _render_powerbi_cloud_metadata_xml(t: PromptTable) -> str:
+    """Render the `powerbi` (cloud) metadata block for a table, if present.
+
+    Emits datasetId/workspaceId/datasetName/tableName as attributes so the
+    agent can execute DAX with explicit IDs (executeQueries is addressed by
+    dataset GUID) or with the exact schema table name.
+    """
+    try:
+        meta = t.metadata_json if isinstance(t.metadata_json, dict) else None
+        pbi = (meta or {}).get("powerbi")
+        if not isinstance(pbi, dict):
+            return ""
+        attrs = {}
+        for k in ("datasetId", "workspaceId", "datasetName", "tableName"):
+            v = pbi.get(k)
+            if v is not None and v != "":
+                attrs[k] = str(v)
+        if not attrs:
+            return ""
+        return xml_tag("powerbi", "", attrs)
+    except Exception:
+        return ""
+
+
 class TablesSchemaContext(ContextSection):
     tag_name: ClassVar[str] = "data_sources"
 
@@ -179,7 +203,7 @@ class TablesSchemaContext(ContextSection):
                 pbi = (t.metadata_json or {}).get("powerbi_report_server") if isinstance(t.metadata_json, dict) else None
                 if isinstance(pbi, dict):
                     pbi_attrs = {}
-                    for k in ("queryable", "report_type", "upstream_source"):
+                    for k in ("queryable", "report_type", "upstream_source", "report_id", "dataset_id"):
                         v = pbi.get(k)
                         if v is not None and v != "":
                             pbi_attrs[k] = str(v).lower() if isinstance(v, bool) else str(v)
@@ -189,12 +213,17 @@ class TablesSchemaContext(ContextSection):
                         pbi_xml = xml_tag("powerbi_report_server", pbi_inner, pbi_attrs)
             except Exception:
                 pbi_xml = ""
+            # Power BI (cloud) metadata — the executeQueries endpoint is addressed
+            # by dataset GUID, so the agent needs datasetId/workspaceId (or the
+            # exact schema table name) to run DAX. Without these it has no way to
+            # resolve the dataset and ends up asking the user for the GUID.
+            pbi_cloud_xml = _render_powerbi_cloud_metadata_xml(t)
             # Add query instructions for semantic views
             is_semantic_view = isinstance(t.metadata_json, dict) and t.metadata_json.get("type") == "semantic_view"
             note_xml = ""
             if is_semantic_view:
                 note_xml = xml_tag("note", "Snowflake Semantic View: query with SELECT * FROM SEMANTIC_VIEW(view_name DIMENSIONS dim1, dim2 METRICS metric1, metric2 WHERE condition). Use DIMENSIONS for role=dimension columns, METRICS for role=measure/metric columns.")
-            inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), metadata_xml, pbi_xml, metrics_xml]))
+            inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), metadata_xml, pbi_xml, pbi_cloud_xml, metrics_xml]))
             table_attrs = {"name": t.name}
             # Mark semantic views
             if is_semantic_view:
@@ -493,7 +522,7 @@ class TablesSchemaContext(ContextSection):
                     pbi = (t.metadata_json or {}).get("powerbi_report_server") if isinstance(getattr(t, 'metadata_json', None), dict) else None
                     if isinstance(pbi, dict):
                         pbi_attrs = {}
-                        for k in ("queryable", "report_type", "upstream_source"):
+                        for k in ("queryable", "report_type", "upstream_source", "report_id", "dataset_id"):
                             v = pbi.get(k)
                             if v is not None and v != "":
                                 pbi_attrs[k] = str(v).lower() if isinstance(v, bool) else str(v)
@@ -503,7 +532,8 @@ class TablesSchemaContext(ContextSection):
                             pbi_xml = xml_tag("powerbi_report_server", pbi_inner, pbi_attrs)
                 except Exception:
                     pbi_xml = ""
-                inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), xml_tag("pks", pks) if pks else "", xml_tag("fks", fks) if fks else "", pbi_xml]))
+                pbi_cloud_xml = _render_powerbi_cloud_metadata_xml(t)
+                inner = "\n".join(filter(None, [note_xml, xml_tag("columns", cols), xml_tag("pks", pks) if pks else "", xml_tag("fks", fks) if fks else "", pbi_xml, pbi_cloud_xml]))
                 return xml_tag("table", inner, attrs)
 
             if has_multi_connection:

--- a/backend/app/ai/prompt_formatters.py
+++ b/backend/app/ai/prompt_formatters.py
@@ -253,6 +253,19 @@ class ServiceFormatter:
             except Exception:
                 pass
             try:
+                # Power BI (cloud): executeQueries is addressed by dataset GUID —
+                # surface it so the agent can query without asking the user.
+                pbic = table.metadata_json.get("powerbi", {})
+                kv = []
+                for k in ["datasetId", "workspaceId", "datasetName", "tableName"]:
+                    v = pbic.get(k)
+                    if v is not None and v != "":
+                        kv.append(f"{k}={v}")
+                if kv:
+                    table_strs.append(f"meta: {'; '.join(kv)}")
+            except Exception:
+                pass
+            try:
                 pbi = table.metadata_json.get("powerbi_report_server", {})
                 if pbi:
                     kv = []
@@ -302,8 +315,10 @@ class TableFormatter:
             and table.metadata_json.get("type") == "semantic_view"
         )
         pbi_meta = None
+        pbi_cloud_meta = None
         if isinstance(table.metadata_json, dict):
             pbi_meta = table.metadata_json.get("powerbi_report_server")
+            pbi_cloud_meta = table.metadata_json.get("powerbi")
         table_fmt = []
         table_name = table.name
         for col in table.columns or []:
@@ -374,6 +389,15 @@ class TableFormatter:
                 create_tbl = f"-- Snowflake Semantic View\nCREATE SEMANTIC VIEW {table_name}"
             else:
                 create_tbl = f"CREATE TABLE {table_name}"
+
+        if isinstance(pbi_cloud_meta, dict):
+            kv = []
+            for k in ("datasetId", "workspaceId", "datasetName", "tableName"):
+                v = pbi_cloud_meta.get(k)
+                if v is not None and v != "":
+                    kv.append(f"{k}={v}")
+            if kv:
+                create_tbl = f"-- Power BI: {'; '.join(kv)}\n" + create_tbl
 
         if pbi_meta:
             lines = [f"-- Power BI Report Server entry: {table_name}"]

--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -85,6 +85,59 @@ class PowerBIClient(DataSourceClient):
         self._access_token: Optional[str] = access_token
         self._http: Optional[requests.Session] = None
 
+        # Persisted schema metadata injected via attach_table_metadata():
+        # schema table name ("Dataset/Table") -> the table's `powerbi` metadata
+        # dict ({datasetId, workspaceId, ...}). Lets execute_query resolve the
+        # dataset GUID as a dict lookup instead of re-crawling the tenant.
+        self._table_metadata_map: Dict[str, Dict] = {}
+        # Live-discovery cache: get_schemas() is a full tenant crawl (workspaces,
+        # datasets, admin scan, COLUMNSTATISTICS) — run it at most once per
+        # client instance.
+        self._schemas_cache: Optional[List[Table]] = None
+
+    def attach_table_metadata(self, tables: List[Dict]) -> None:
+        """Inject persisted table metadata (from the indexed schema catalog).
+
+        `tables` is a list of {"name": <schema table name>, "metadata_json": {...}}
+        entries. Only entries carrying `powerbi.datasetId` are kept. Called by
+        DataSourceService.construct_clients so query-time table_name resolution
+        needs zero API calls.
+        """
+        mapping: Dict[str, Dict] = {}
+        for t in tables or []:
+            try:
+                name = (t.get("name") or "").strip()
+                meta = t.get("metadata_json") or {}
+                pbi = meta.get("powerbi") if isinstance(meta, dict) else None
+                if name and isinstance(pbi, dict) and pbi.get("datasetId"):
+                    mapping[name] = pbi
+            except Exception:
+                continue
+        self._table_metadata_map = mapping
+
+    def _resolve_ids_from_metadata(self, table_name: str) -> Optional[Dict]:
+        """Resolve a table reference to its `powerbi` metadata using the
+        attached map. Matches the exact schema name first, then falls back to
+        case-insensitive and tableName/datasetName/datasetId matches."""
+        if not table_name or not self._table_metadata_map:
+            return None
+        pbi = self._table_metadata_map.get(table_name)
+        if pbi:
+            return pbi
+        lowered = table_name.strip().lower()
+        for name, meta in self._table_metadata_map.items():
+            if name.strip().lower() == lowered:
+                return meta
+        for meta in self._table_metadata_map.values():
+            candidates = (
+                str(meta.get("tableName") or "").strip().lower(),
+                str(meta.get("datasetName") or "").strip().lower(),
+                str(meta.get("datasetId") or "").strip().lower(),
+            )
+            if lowered in candidates and lowered:
+                return meta
+        return None
+
     def connect(self):
         """
         Authenticate with Azure AD and obtain an access token for Power BI API.
@@ -647,10 +700,14 @@ class PowerBIClient(DataSourceClient):
 
         return results
 
-    def get_schemas(self) -> List[Table]:
+    def get_schemas(self, force_refresh: bool = False) -> List[Table]:
         """
         Build Table objects representing all internal tables across all datasets.
         Each internal Power BI table becomes one BOW Table named "{Dataset}/{Table}".
+
+        The result is cached on the instance: this is a full tenant crawl
+        (workspaces, datasets, admin scan, COLUMNSTATISTICS fallbacks), far too
+        expensive to repeat per query. Pass force_refresh=True to re-discover.
 
         Strategy:
         1. Fetch datasets and reports for all workspaces in parallel
@@ -659,6 +716,9 @@ class PowerBIClient(DataSourceClient):
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
         import logging
+
+        if self._schemas_cache is not None and not force_refresh:
+            return self._schemas_cache
 
         workspaces = self.list_workspaces()
         tables: List[Table] = []
@@ -830,6 +890,7 @@ class PowerBIClient(DataSourceClient):
                     metadata_json=metadata_json,
                 ))
 
+        self._schemas_cache = tables
         return tables
 
     def get_schema(self, table_name: str) -> Table:
@@ -890,18 +951,45 @@ class PowerBIClient(DataSourceClient):
         if not query:
             raise ValueError("DAX query is required")
 
-        # If table_name provided (but not dataset_id), look up the IDs
+        # If table_name provided (but not dataset_id), resolve the IDs:
+        # 1. From the attached persisted metadata map — zero API calls.
+        # 2. Fallback: live discovery (cached on the instance after first use).
+        lookup_error: Optional[str] = None
         if table_name and not dataset_id:
-            try:
-                table = self.get_schema(table_name)
-                pbi = (table.metadata_json or {}).get("powerbi") or {}
-                dataset_id = pbi.get("datasetId")
-                workspace_id = workspace_id or pbi.get("workspaceId")
-            except Exception:
-                pass
+            meta = self._resolve_ids_from_metadata(table_name)
+            if meta:
+                dataset_id = meta.get("datasetId")
+                workspace_id = workspace_id or meta.get("workspaceId")
+            else:
+                try:
+                    table = self.get_schema(table_name)
+                    pbi = (table.metadata_json or {}).get("powerbi") or {}
+                    dataset_id = pbi.get("datasetId")
+                    workspace_id = workspace_id or pbi.get("workspaceId")
+                except Exception as e:
+                    lookup_error = str(e)
 
         if not dataset_id:
-            raise ValueError("dataset_id is required (pass table_name or dataset_id)")
+            known = sorted(self._table_metadata_map.keys())
+            hint = (
+                f" Known schema tables include: {', '.join(known[:10])}"
+                f"{', ...' if len(known) > 10 else ''}."
+                if known else ""
+            )
+            if table_name:
+                detail = f" Lookup failed: {lookup_error}" if lookup_error else ""
+                raise ValueError(
+                    f"Could not resolve Power BI dataset for table '{table_name}'.{detail} "
+                    "Pass the schema table name EXACTLY as shown in the schema context "
+                    "(format 'Dataset/Table'), or pass explicit dataset_id=/workspace_id= "
+                    f"from the table's powerbi metadata.{hint}"
+                )
+            raise ValueError(
+                "execute_query needs a target dataset: pass the schema table name as the "
+                "second argument (format 'Dataset/Table', exactly as shown in the schema "
+                "context), or explicit dataset_id=/workspace_id= from the table's powerbi "
+                f"metadata. Do not ask the user for these IDs.{hint}"
+            )
 
         return self._execute_dax_internal(workspace_id, dataset_id, query, max_rows=max_rows)
 
@@ -997,7 +1085,16 @@ df = db_clients['powerbi'].execute_query(
     "EVALUATE Customers",           # DAX uses the table name (after /)
     "SalesModel/Customers"          # Schema table name (REQUIRED)
 )
+
+# Or with explicit IDs from the table's <powerbi datasetId=... workspaceId=.../> metadata:
+df = db_clients['powerbi'].execute_query(
+    "EVALUATE Customers",
+    dataset_id="<datasetId>",
+    workspace_id="<workspaceId>",
+)
 ```
+
+Every table's `datasetId`/`workspaceId` are shown in the schema context — NEVER ask the user for them.
 
 ### DAX Query Pattern
 

--- a/backend/app/data_sources/clients/powerbi_report_server_client.py
+++ b/backend/app/data_sources/clients/powerbi_report_server_client.py
@@ -199,6 +199,10 @@ class PowerBIReportServerClient(DataSourceClient):
         self.enable_pbix_query = enable_pbix_query
 
         self._session: Optional[requests.Session] = None
+        # Catalog-discovery cache: get_schema() is called per execute_query
+        # (table_name → report/dataset ID resolution), so avoid re-enumerating
+        # the whole catalog on every query within one client lifetime.
+        self._schemas_cache: Optional[List[Table]] = None
 
     # ------------------------------------------------------------------
     # URL / auth plumbing
@@ -905,6 +909,11 @@ class PowerBIReportServerClient(DataSourceClient):
           - Each shared dataset (.rsd) — one Table with schema columns and CommandText
           - Each KPI — one Table representing the metric (for LLM awareness)
         """
+        # Serve from cache only for internal (no-callback) calls — indexing
+        # passes a progress_callback and must always re-discover.
+        if progress_callback is None and self._schemas_cache is not None:
+            return self._schemas_cache
+
         reporter = make_reporter(progress_callback)
         reporter.phase("listing")
         self.connect()
@@ -1151,7 +1160,7 @@ class PowerBIReportServerClient(DataSourceClient):
                                 "path": r.get("Path"),
                                 "parse_error": str(e),
                                 "queryable": True,
-                                "query_note": "Execute via execute_query(report_id=..., format='CSV').",
+                                "query_note": "Execute via execute_query(table_name=<this schema table name>) — the report_id is resolved from metadata (or pass report_id=... explicitly, format='CSV').",
                             }},
                         ))
                         continue
@@ -1186,7 +1195,7 @@ class PowerBIReportServerClient(DataSourceClient):
                                 "report_parameters": report_params,
                                 "report_data_sources": report_sources,
                                 "queryable": True,
-                                "query_note": "Execute via execute_query(report_id=..., format='CSV'). Single dataset per execution — RDL export returns full rendered report data.",
+                                "query_note": "Execute via execute_query(table_name=<this schema table name>) — the report_id is resolved from metadata (or pass report_id=... explicitly, format='CSV'). Single dataset per execution — RDL export returns full rendered report data.",
                             }
                         }
                         tables.append(Table(
@@ -1213,7 +1222,7 @@ class PowerBIReportServerClient(DataSourceClient):
                                 "report_name": rname,
                                 "path": r.get("Path"),
                                 "queryable": True,
-                                "query_note": "Execute via execute_query(report_id=..., format='CSV').",
+                                "query_note": "Execute via execute_query(table_name=<this schema table name>) — the report_id is resolved from metadata (or pass report_id=... explicitly, format='CSV').",
                             }},
                         ))
 
@@ -1297,7 +1306,7 @@ class PowerBIReportServerClient(DataSourceClient):
                             for p in params.get(did, [])
                         ],
                         "queryable": True,
-                        "query_note": "Execute via execute_query(dataset_id=...). Uses Model.GetData action. Supports parameters via the parameters kwarg.",
+                        "query_note": "Execute via execute_query(table_name=<this schema table name>) — the dataset_id is resolved from metadata (or pass dataset_id=... explicitly). Uses Model.GetData action. Supports parameters via the parameters kwarg.",
                     }
                 }
                 tables.append(Table(
@@ -1342,6 +1351,7 @@ class PowerBIReportServerClient(DataSourceClient):
             ))
 
         reporter.done()
+        self._schemas_cache = tables
         return tables
 
     def get_schema(self, table_name: str) -> Table:

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2173,6 +2173,7 @@ class DataSourceService:
 
             client = ClientClass(**allowed)
             self._attach_client_quota_metadata(client, data_source, conn, key)
+            await self._attach_stored_table_metadata(db, client, data_source, conn)
             clients[key] = client
 
         # Backward compatibility: add legacy key aliases for single-connection domains
@@ -2182,6 +2183,48 @@ class DataSourceService:
             clients[data_source.name] = first_client
 
         return clients
+
+    async def _attach_stored_table_metadata(self, db: AsyncSession, client, data_source: DataSource, connection) -> None:
+        """Inject the persisted (indexed) table metadata into clients that
+        resolve query targets from it.
+
+        Some connectors address queries by opaque IDs rather than names — e.g.
+        Power BI's executeQueries endpoint needs the dataset GUID. Those GUIDs
+        are captured at indexing time in DataSourceTable.metadata_json, but the
+        client itself is constructed from connection config/credentials only and
+        has no DB access at query time. Without this hook its only fallback is a
+        live catalog re-crawl on every query. Clients opt in by exposing
+        `attach_table_metadata(tables)`.
+        """
+        if not hasattr(client, "attach_table_metadata"):
+            return
+        try:
+            from app.models.datasource_table import DataSourceTable
+            from app.models.connection_table import ConnectionTable
+
+            rows = (await db.execute(
+                select(DataSourceTable.name, DataSourceTable.metadata_json)
+                .join(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
+                .where(
+                    DataSourceTable.datasource_id == str(data_source.id),
+                    DataSourceTable.is_active == True,
+                    ConnectionTable.connection_id == str(connection.id),
+                )
+            )).all()
+            if not rows:
+                # Legacy rows indexed before the connection_table link existed
+                rows = (await db.execute(
+                    select(DataSourceTable.name, DataSourceTable.metadata_json).where(
+                        DataSourceTable.datasource_id == str(data_source.id),
+                        DataSourceTable.is_active == True,
+                    )
+                )).all()
+            client.attach_table_metadata(
+                [{"name": name, "metadata_json": metadata_json} for name, metadata_json in rows]
+            )
+        except Exception:
+            # Non-fatal: the client falls back to live discovery.
+            logger.debug("attach_stored_table_metadata failed", exc_info=True)
 
     def _attach_client_quota_metadata(self, client, data_source: DataSource, connection, client_key: str) -> None:
         try:

--- a/backend/tests/unit/test_powerbi_client.py
+++ b/backend/tests/unit/test_powerbi_client.py
@@ -215,3 +215,125 @@ class TestRequestRetry:
         out = c._request("POST", "https://api.powerbi.com/x")
         assert out.status_code == 400
         assert c._http.request.call_count == 1
+
+
+# ---------- execute_query dataset resolution ---------- #
+
+
+PBI_META = {
+    "powerbi": {
+        "datasetId": "ds-guid-1",
+        "workspaceId": "ws-guid-1",
+        "workspaceName": "Sales",
+        "datasetName": "SalesModel",
+        "tableName": "Customers",
+    }
+}
+
+
+class TestExecuteQueryResolution:
+    """table_name -> (dataset_id, workspace_id) must resolve from the attached
+    persisted metadata (a dict lookup) — NOT a live tenant re-crawl — and the
+    failure message must steer the model to the schema table name, never to
+    asking the user for a GUID."""
+
+    def _client_with_map(self):
+        c = _mk_client()
+        c.attach_table_metadata([
+            {"name": "SalesModel/Customers", "metadata_json": PBI_META},
+            {"name": "SalesModel/Orders", "metadata_json": {
+                "powerbi": {**PBI_META["powerbi"], "tableName": "Orders"}
+            }},
+            # Rows without powerbi metadata (e.g. other connectors) are ignored
+            {"name": "other", "metadata_json": {"schema": "public"}},
+        ])
+        return c
+
+    def test_resolves_from_attached_metadata_without_discovery(self):
+        c = self._client_with_map()
+        c.get_schemas = MagicMock(side_effect=AssertionError("live discovery must not run"))
+        c._execute_dax_internal = MagicMock(return_value="df")
+        out = c.execute_query("EVALUATE Customers", "SalesModel/Customers")
+        assert out == "df"
+        c._execute_dax_internal.assert_called_once_with(
+            "ws-guid-1", "ds-guid-1", "EVALUATE Customers", max_rows=None
+        )
+
+    def test_resolution_is_case_insensitive(self):
+        c = self._client_with_map()
+        c.get_schemas = MagicMock(side_effect=AssertionError("live discovery must not run"))
+        c._execute_dax_internal = MagicMock(return_value="df")
+        c.execute_query("EVALUATE Customers", "salesmodel/customers")
+        c._execute_dax_internal.assert_called_once()
+
+    def test_resolves_by_internal_table_name(self):
+        c = self._client_with_map()
+        c.get_schemas = MagicMock(side_effect=AssertionError("live discovery must not run"))
+        c._execute_dax_internal = MagicMock(return_value="df")
+        c.execute_query("EVALUATE Orders", "Orders")
+        args = c._execute_dax_internal.call_args[0]
+        assert args[1] == "ds-guid-1"
+
+    def test_explicit_ids_bypass_all_lookup(self):
+        c = _mk_client()
+        c.get_schemas = MagicMock(side_effect=AssertionError("live discovery must not run"))
+        c._execute_dax_internal = MagicMock(return_value="df")
+        c.execute_query("EVALUATE T", dataset_id="d-x", workspace_id="w-x")
+        c._execute_dax_internal.assert_called_once_with("w-x", "d-x", "EVALUATE T", max_rows=None)
+
+    def test_explicit_workspace_kept_when_table_name_resolves(self):
+        c = self._client_with_map()
+        c._execute_dax_internal = MagicMock(return_value="df")
+        c.execute_query("EVALUATE Customers", "SalesModel/Customers", workspace_id="override-ws")
+        args = c._execute_dax_internal.call_args[0]
+        assert args[0] == "override-ws"
+
+    def test_falls_back_to_live_discovery_when_not_in_map(self):
+        c = self._client_with_map()
+        from app.ai.prompt_formatters import Table
+        live = Table(name="NewModel/Things", columns=[], pks=[], fks=[], is_active=True,
+                     metadata_json={"powerbi": {"datasetId": "live-ds", "workspaceId": "live-ws"}})
+        c.get_schemas = MagicMock(return_value=[live])
+        c._execute_dax_internal = MagicMock(return_value="df")
+        c.execute_query("EVALUATE Things", "NewModel/Things")
+        args = c._execute_dax_internal.call_args[0]
+        assert (args[0], args[1]) == ("live-ws", "live-ds")
+
+    def test_unresolvable_table_error_names_table_and_known_tables(self):
+        c = self._client_with_map()
+        c.get_schemas = MagicMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(ValueError) as ei:
+            c.execute_query("EVALUATE X", "Nope/Nothing")
+        msg = str(ei.value)
+        assert "Nope/Nothing" in msg
+        assert "SalesModel/Customers" in msg          # known-tables hint
+        assert "dataset_id is required" not in msg    # the old GUID-demanding message
+
+    def test_missing_target_error_forbids_asking_user(self):
+        c = self._client_with_map()
+        with pytest.raises(ValueError) as ei:
+            c.execute_query("EVALUATE X")
+        msg = str(ei.value)
+        assert "Do not ask the user" in msg
+        assert "dataset_id is required" not in msg
+
+    def test_empty_query_still_rejected(self):
+        c = self._client_with_map()
+        with pytest.raises(ValueError):
+            c.execute_query("", "SalesModel/Customers")
+
+
+class TestGetSchemasCache:
+    def test_get_schemas_cached_per_instance(self):
+        c = _mk_client()
+        c.list_workspaces = MagicMock(return_value=[])
+        assert c.get_schemas() == []
+        assert c.get_schemas() == []
+        c.list_workspaces.assert_called_once()
+
+    def test_force_refresh_re_discovers(self):
+        c = _mk_client()
+        c.list_workspaces = MagicMock(return_value=[])
+        c.get_schemas()
+        c.get_schemas(force_refresh=True)
+        assert c.list_workspaces.call_count == 2

--- a/backend/tests/unit/test_powerbi_context_rendering.py
+++ b/backend/tests/unit/test_powerbi_context_rendering.py
@@ -1,0 +1,86 @@
+"""Power BI (cloud) metadata must be rendered into the agent's schema context.
+
+The executeQueries endpoint is addressed by dataset GUID, so the agent needs
+each table's datasetId/workspaceId (or the exact schema table name) at query
+time. These GUIDs are captured at indexing time in metadata_json.powerbi, but
+were historically stripped by every renderer — leaving the agent no way to
+resolve a dataset and prompting it to ask the user for the GUID.
+"""
+from app.ai.context.sections.tables_schema_section import TablesSchemaContext
+from app.schemas.data_source_schema import DataSourceSummarySchema
+from app.ai.prompt_formatters import Table, TableColumn, ServiceFormatter, TableFormatter
+
+
+PBI_META = {
+    "powerbi": {
+        "datasetId": "11111111-aaaa-bbbb-cccc-000000000001",
+        "workspaceId": "22222222-aaaa-bbbb-cccc-000000000002",
+        "workspaceName": "Sales WS",
+        "datasetName": "SalesModel",
+        "tableName": "Customers",
+        "reports": [],
+    }
+}
+
+PBIRS_META = {
+    "powerbi_report_server": {
+        "report_type": "Dataset",
+        "dataset_id": "33333333-aaaa-bbbb-cccc-000000000003",
+        "queryable": True,
+        "query_note": "Execute via execute_query(table_name=...).",
+    }
+}
+
+
+def _pbi_table(name="SalesModel/Customers", meta=PBI_META):
+    return Table(
+        name=name,
+        columns=[TableColumn(name="id", dtype="int")],
+        pks=[], fks=[], is_active=True,
+        metadata_json=meta,
+    )
+
+
+def _ctx(tables):
+    return TablesSchemaContext(data_sources=[
+        TablesSchemaContext.DataSource(
+            info=DataSourceSummarySchema(id="1", name="PBI", type="powerbi"),
+            tables=tables,
+        )
+    ])
+
+
+def test_full_render_includes_dataset_and_workspace_guids():
+    out = _ctx([_pbi_table()]).render("full")
+    assert '<powerbi ' in out
+    assert 'datasetId="11111111-aaaa-bbbb-cccc-000000000001"' in out
+    assert 'workspaceId="22222222-aaaa-bbbb-cccc-000000000002"' in out
+    assert 'datasetName="SalesModel"' in out
+
+
+def test_combined_render_includes_dataset_and_workspace_guids():
+    out = _ctx([_pbi_table()]).render_combined(top_k_per_ds=10, index_limit=200)
+    assert 'datasetId="11111111-aaaa-bbbb-cccc-000000000001"' in out
+    assert 'workspaceId="22222222-aaaa-bbbb-cccc-000000000002"' in out
+
+
+def test_no_powerbi_block_for_other_sources():
+    out = _ctx([_pbi_table(name="orders", meta={"schema": "public"})]).render("full")
+    assert '<powerbi ' not in out
+
+
+def test_pbirs_render_includes_report_and_dataset_ids():
+    out = _ctx([_pbi_table(name="dataset:Sales", meta=PBIRS_META)]).render("full")
+    assert 'dataset_id="33333333-aaaa-bbbb-cccc-000000000003"' in out
+
+
+def test_service_formatter_includes_guids():
+    out = ServiceFormatter([_pbi_table()]).table_str
+    assert "datasetId=11111111-aaaa-bbbb-cccc-000000000001" in out
+    assert "workspaceId=22222222-aaaa-bbbb-cccc-000000000002" in out
+
+
+def test_table_formatter_includes_guids():
+    out = TableFormatter([_pbi_table()]).table_str
+    assert "datasetId=11111111-aaaa-bbbb-cccc-000000000001" in out
+    assert "workspaceId=22222222-aaaa-bbbb-cccc-000000000002" in out

--- a/docs/feedback-loops/powerbi-dataset-id-resolution.md
+++ b/docs/feedback-loops/powerbi-dataset-id-resolution.md
@@ -1,0 +1,135 @@
+# Feedback Loop — "Power BI loads the semantic models, but the dataset ID/GUID is never available to the agent when querying — it always asks the user to provide that GUID"
+
+The Power BI (cloud) connector indexes semantic models correctly, but at query
+time the agent cannot resolve which dataset GUID to execute DAX against, fails
+with `dataset_id is required (pass table_name or dataset_id)`, and — since no
+GUID exists anywhere in its context — asks the user to supply one. This loop
+validates the root cause and proves the fix.
+
+## Root cause (validated)
+
+Power BI's `executeQueries` REST endpoint is addressed by dataset GUID
+(`POST .../datasets/{dataset_id}/executeQueries`) — unlike SQL connectors,
+where the query string itself names the table. Four compounding defects:
+
+1. **GUIDs stripped from the agent's context.** Indexing stores
+   `metadata_json.powerbi.{datasetId, workspaceId}` on every table
+   (`powerbi_client.py`, `get_schemas`), and the schema builder loads it into
+   `PromptTable.metadata_json` — but every renderer only had branches for
+   `tableau` and `powerbi_report_server`, never `powerbi`
+   (`tables_schema_section.py` `_render_table_xml` / `_render_topk_tables_full`,
+   `prompt_formatters.py`). The GUIDs never reached the prompt.
+2. **Query-time `table_name` resolution re-crawled the tenant.** Clients are
+   constructed from connection config + credentials only
+   (`data_source_service.py` `construct_clients`) with no DB access, so
+   `execute_query(dax, table_name)` resolved the GUID via
+   `get_schema()` → `get_schemas()` — a full live discovery (list workspaces,
+   list datasets/reports per workspace, admin scan with polling sleeps,
+   per-dataset `COLUMNSTATISTICS`) on **every query**, uncached, inside the
+   60-second sandbox query timeout (`code_execution.py`,
+   `DEFAULT_QUERY_TIMEOUT_SECONDS`).
+3. **Failures swallowed into a GUID-demanding error.** The lookup was wrapped
+   in `except Exception: pass`; any failure degraded to
+   `ValueError("dataset_id is required (pass table_name or dataset_id)")` —
+   the message that trains the model to ask the user for a GUID it cannot know.
+4. **Generic coder guidance contradicted the convention.** `coder.py` showed
+   single-arg `execute_query("SOME QUERY")` examples; the Power BI two-argument
+   rule lived only in the client description blob.
+
+## Loop A — deterministic reproduction (no external services)
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+uv run pytest tests/unit/test_powerbi_context_rendering.py \
+              tests/unit/test_powerbi_client.py -q
+```
+
+Observed on pre-fix code (`git stash push -- backend/app` to reproduce):
+
+```
+FAILED tests/unit/test_powerbi_context_rendering.py::test_full_render_includes_dataset_and_workspace_guids
+FAILED tests/unit/test_powerbi_context_rendering.py::test_combined_render_includes_dataset_and_workspace_guids
+FAILED tests/unit/test_powerbi_context_rendering.py::test_pbirs_render_includes_report_and_dataset_ids
+FAILED tests/unit/test_powerbi_context_rendering.py::test_service_formatter_includes_guids
+FAILED tests/unit/test_powerbi_context_rendering.py::test_table_formatter_includes_guids
+FAILED tests/unit/test_powerbi_client.py::TestExecuteQueryResolution::* (8 tests,
+       incl. test_unresolvable_table_error_names_table_and_known_tables — the
+       pre-fix error is exactly "dataset_id is required")
+FAILED tests/unit/test_powerbi_client.py::TestGetSchemasCache::* (2 tests)
+```
+
+## Loop B — live confirmation (real tenant, optional)
+
+Credentials via env vars only (`PBI_TENANT_ID`, `PBI_CLIENT_ID`,
+`PBI_CLIENT_SECRET` — a service principal with workspace access). Run the
+harness from a scratch directory (it is intentionally not committed):
+authenticate → `get_schemas()` → render context → `attach_table_metadata` →
+`execute_query(dax, table_name)` with an HTTP-call counter.
+
+Observed against a live tenant (2 workspaces, 3 datasets, 4 model tables):
+
+- **Old path** (no attached metadata, per-query fallback):
+  `execute_query` made **9 REST calls** (plus admin-scan traffic not routed
+  through `_request`) and took **4.0s** — for ONE query, repeated per query
+  since nothing was cached. On real tenants this scales with workspace/dataset
+  count and routinely exceeded the 60s sandbox budget.
+- **New path** (metadata attached, as `construct_clients` now does):
+  **exactly 1 REST call** (`executeQueries`), 3 rows returned.
+- Warm-cache fallback (2nd query, same instance): 1 call, 0.3s.
+- Rendered context (`render("full")`, `render_combined()`, `ServiceFormatter`)
+  now contains `<powerbi datasetId="..." workspaceId="..."/>` for every table.
+- Unresolvable table → `Could not resolve Power BI dataset for table
+  'Bogus/Nothing'. ... Pass the schema table name EXACTLY as shown in the
+  schema context ... Known schema tables include: ...` (the old
+  `dataset_id is required` message is gone).
+
+## The fix
+
+1. `app/ai/context/sections/tables_schema_section.py` — new
+   `_render_powerbi_cloud_metadata_xml()` emits
+   `<powerbi datasetId= workspaceId= datasetName= tableName=/>` in both
+   `_render_table_xml` (full render) and `_render_topk_tables_full`
+   (combined render); `powerbi_report_server` blocks now also emit
+   `report_id`/`dataset_id`.
+2. `app/ai/prompt_formatters.py` — `ServiceFormatter.format_table` and
+   `TableFormatter.format_table` emit the same GUID metadata.
+3. `app/data_sources/clients/powerbi_client.py` —
+   `attach_table_metadata()` accepts the persisted catalog
+   (name → `powerbi` metadata); `execute_query` resolves `table_name` from it
+   first (zero API calls), falls back to live discovery **cached per instance**
+   (`get_schemas(force_refresh=False)`), and raises an actionable error naming
+   the table and known schema names instead of `dataset_id is required`.
+   The client `system_prompt` documents the explicit-ID form and forbids
+   asking the user for IDs.
+4. `app/services/data_source_service.py` — `construct_clients` injects the
+   persisted `DataSourceTable.metadata_json` into any client exposing
+   `attach_table_metadata` (`_attach_stored_table_metadata`).
+5. `app/ai/agents/coder/coder.py` — the three generic `execute_query`
+   instruction blocks now state the Power BI two-argument / explicit-ID
+   convention and forbid asking the user for IDs.
+6. `app/data_sources/clients/powerbi_report_server_client.py` — same-family
+   hardening: `get_schemas()` cached per instance (indexing calls with a
+   progress callback still re-discover), `query_note` strings recommend
+   `table_name=` first.
+
+Re-run Loop A after the fix:
+
+```
+78 passed (test_powerbi_client.py, test_powerbi_context_rendering.py,
+           test_powerbi_report_server_client.py)
+```
+
+## What this proves / regression notes
+
+- The agent's context now carries every Power BI table's dataset/workspace
+  GUID, so DAX execution needs no user-supplied identifiers — validated
+  end-to-end against a live tenant (auth → discovery → render → 1-call query).
+- Query-time `table_name` resolution is a dict lookup; the per-query tenant
+  crawl (the timeout/throttling source) is gone, with a cached live fallback
+  for tables indexed after the catalog snapshot.
+- Adjacent suites (`test_schema_section_agent_status.py`,
+  `test_attach_and_index.py`, `test_powerbi_report_server_client.py`,
+  `test_file_tools.py`) pass unchanged — except
+  `test_file_tools.py::TestResolveFileClientIdResolution::test_rejects_unrelated_id_with_helpful_error`,
+  which fails identically with this change stashed (pre-existing, unrelated).


### PR DESCRIPTION
The Power BI cloud connector indexed semantic models correctly, but the
agent could never resolve which dataset GUID to run DAX against: the
GUIDs captured in metadata_json.powerbi were stripped by every context
renderer, query-time table_name resolution re-crawled the whole tenant
via live REST on every query (uncached, inside the 60s sandbox budget),
and any lookup failure was swallowed into "dataset_id is required" —
which trained the agent to ask the user for a GUID it had no way to know.

- Render <powerbi datasetId/workspaceId/datasetName/tableName> in the
  schema context (full + combined renders) and in Service/TableFormatter;
  PBIRS blocks now also emit report_id/dataset_id.
- construct_clients injects the persisted DataSourceTable.metadata_json
  into clients exposing attach_table_metadata(); PowerBIClient resolves
  table_name -> (datasetId, workspaceId) as a dict lookup (zero API
  calls), with live discovery as fallback, now cached per instance.
- Replace the swallowed-exception "dataset_id is required" path with an
  actionable error naming the table and known schema names.
- Coder prompts document the Power BI two-arg / explicit-ID convention.
- PBIRS: cache get_schemas() per instance; query_notes recommend
  table_name= first.

Verified live (docs/feedback-loops/powerbi-dataset-id-resolution.md):
one executeQueries call per query (was 9+ REST calls + admin scan, 4s,
per query on a 2-workspace tenant).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ghCKhaUNGb7qjDyVyf4j2