### PR TITLE
chore(docs): add issue + PR authoring standards under .claude/templates

### DIFF
--- a/.claude/templates/PR_DESCRIPTION_STANDARD.md
+++ b/.claude/templates/PR_DESCRIPTION_STANDARD.md
@@ -1,0 +1,80 @@
+# PR Description Standard — the generative logic
+
+A PR description is a **dual-audience artifact**, and every requirement below falls out of that one fact:
+
+1. **A human reviewer** must be able to *decide* (merge / request-changes) and know *what to check* — from the top of the page, without scrolling into the diff.
+2. **A future agent or engineer** (including Claude Code) must be able to *navigate the change and follow the convention it set* months later — so the description doubles as a durable context/routing map.
+
+Write for both. If a section serves neither, cut it. If either audience is missing something to do their job, it's incomplete.
+
+---
+
+## The 9 required elements (each states WHAT it must contain and the DONE test)
+
+Order them top-to-bottom as listed — that ordering *is* the progressive-disclosure requirement (decide → see → trust → navigate → deep-detail). A reader stops at any depth with a coherent, correct picture.
+
+### 1. Title + issue link
+- **What:** `type(scope): outcome-in-imperative (#NNN)`, and a closing keyword (`Fixes #NNN` / `Closes #NNN`) in the body so the issue auto-links and auto-closes.
+- **Done when:** the title says the *outcome*, not the file list; the issue number is one click away.
+
+### 2. Two-line orientation (what + why)
+- **What:** one line on *what changed* and one line on *the root cause / why it existed*, before any other prose.
+- **Done when:** a reader who reads only these two lines can say what the PR does and why it was needed.
+
+### 3. Executive summary — at CUSTOMER / product altitude
+- **What:** the impact stated for a **paying customer / end user** in plain language: what breaks for them, and why it matters (trust, safety, money, data-exposure, compliance) — *not* the code mechanism.
+- **The question it answers:** "If I never open the diff, why do I care?"
+- **Done when:** a non-engineer stakeholder (PM, support, exec) understands the stakes.
+
+### 4. Two visuals at two altitudes
+- **4a. Product/UX-impact visual** — the *harm* (or *benefit*) as the **customer experiences it**: the journey of the bug damaging (or the fix protecting) a real user. Before-vs-after.
+- **4b. Technical-mechanism visual** — the *code/data flow* of the bug vs the fix.
+- **What:** rendered diagrams (Mermaid) or tight before/after tables. Color the bad path red, the good path green.
+- **Done when:** a customer-side reader gets 4a; an engineer gets 4b; neither has to read prose to grasp the shape.
+
+### 5. Reviewer decision box
+- **What:** a compact table a reviewer scans to decide: **Risk · Blast radius · Behavior change (intended) · Verified ✅ · NOT verified ⚠️ · Where to look first.**
+- **Done when:** a reviewer can make a merge/no-merge call from this box alone, and knows the riskiest lines to inspect.
+
+### 6. Evidence / KPI table
+- **What:** verification quantified at a glance — build status, tests (total/pass/fail/skip), review passes — **including an honest "failures/impact attributable to THIS PR" cut** that separates your change from pre-existing noise.
+- **Done when:** the numbers are *observed* (you ran it), and the "caused by this PR" line is explicit.
+- **When the KPI shows pre-existing failures you're attributing *away* from this PR**, include a **per-failure attribution appendix** (near the end): each failure labeled — `stale-test` / `pre-existing-defect` / `real-bug` / `caused-by-this-PR` — with the *evidence* that assigns the label (the symbol that changed + the failing code's last-touching commit vs this PR's SHAs). A bare "N are pre-existing" without the per-item proof is an assertion, not evidence — see #589's "Detailed test analysis." Omit the appendix when there is no pre-existing noise to separate out (per Smallest Structure).
+
+### 7. Context map — durable references
+- **What:** the pointers a future reader/agent needs to navigate: **key files** (repo-relative paths, agent-openable), **the convention this PR establishes** (what future code should now do), **commits by role**, **related issues**, and **follow-ups**.
+- **Done when:** someone landing here in 6 months can find the primitive, copy the pattern, and knows what was deliberately left for later.
+
+### 8. Deep detail (progressive) + radical honesty
+- **What:** root cause, approach (and the roads *not* taken + why), scope, review findings (including any regression the change *itself* introduced and how it was caught), testing, and out-of-scope/follow-ups.
+- **Honesty requirements (non-negotiable):** state what is **NOT** verified; label **intended** behavior changes as intended; **disclose self-introduced issues** found and fixed; **never claim a green you didn't observe**.
+- **Done when:** the deep reader trusts the PR *because* it volunteers its own limits, not despite hiding them.
+
+### 9. Resolve automated review before "done"
+- **What:** a PR isn't finished when the description is written — it's finished when the automated review (Copilot / bots) is **resolved**. Fetch every automated-reviewer comment and **validate each against the actual code** — neither rubber-stamp nor reflexively dismiss (judge in context, trace the call graph). **Integrate** the genuine ones; **dismiss** the false positives *with the evidence* that proves them false; reply on each thread so the resolution is visible, and mark it resolved.
+- **Reflect it in the description** — in the decision box's *Verified* line or a short "Automated review — addressed" note (e.g. "automated review: 2 integrated, 1 dismissed-with-reason").
+- **Watch for the widened bug:** an automated reviewer flags an *instance*, not always the *class*. When you confirm one is real, sweep for the same pattern elsewhere before fixing — a single flagged line turned out to be a 5-site bug in #589. Fix the class, not just the line.
+- **Done when:** every automated-review thread is either integrated (with the commit) or dismissed (with proof), none left dangling, and the description records the outcome.
+
+---
+
+## The generative questions (fill each section by answering these)
+
+| Section | The question the author answers |
+|---|---|
+| Executive summary | "How does this hurt/help a paying customer, in one paragraph?" |
+| Product visual (4a) | "Draw the moment the user is harmed (or protected). Before vs after." |
+| Technical visual (4b) | "Draw the code path that fails vs the one that now works." |
+| Decision box | "What does a reviewer need to say yes/no and know what to inspect?" |
+| KPI table | "What did I actually run, and what of the result is *mine* vs pre-existing?" |
+| Context map | "If an agent had to extend this in 6 months, what paths + convention + follow-ups do they need?" |
+| Deep detail | "What would a skeptical senior engineer challenge — and what am I hiding?" |
+| Resolve automated review | "Is every Copilot/bot comment integrated (real) or dismissed with proof (false), none dangling — and did I check whether a flagged *line* is actually a *class*?" |
+
+---
+
+## Enforcement
+
+- **`.github/pull_request_template.md`** — a skeleton with these headings, so every new PR starts pre-shaped (humans fill it in; GitHub auto-populates it).
+- **CLAUDE.md / agent instructions** — a rule that Claude-authored PRs must satisfy this standard, so agent-generated descriptions carry it by default.
+- **The test for a good PR description:** would a reviewer merge from the first screen, and could a future agent navigate the change from the bottom? If either fails, it's not done.

--- a/.claude/templates/issue_schema.md
+++ b/.claude/templates/issue_schema.md
@@ -1,0 +1,161 @@
+# Issue Schema — how to open a GitHub issue in bagofwords
+
+An issue is a **dual-audience artifact**, and every requirement below falls out of that one fact:
+
+1. **A maintainer** must be able to *decide* — is this real, how bad, do we fix it now — from the top of the issue, without reading the code themselves.
+2. **A future fixer** (human or agent, often months later) must be able to *reproduce it, find the exact lines, and know what "right" looks like* — so the issue doubles as a durable repair map.
+
+Write for both. This is the sibling of `PR_DESCRIPTION_STANDARD.md`: a **PR proposes a change**; an **issue reports a problem** (and optionally proposes the fix). Where they overlap — product-altitude-first, evidence-not-assertion, radical honesty about scope — they agree by design.
+
+Everything here is grounded in the CLAUDE.md cornerstones, restated for issues:
+- **Evidence over assertion** (the "verify FACTS" carve-out): quote real output, cite `file:line`, trace the hop — never "I think it probably…". A claim a reader can't check is not evidence.
+- **Concrete & self-explaining**: name the persona, the action, the exact file — no bare codes, no "the thing breaks."
+- **Product altitude before mechanism**: lead with how it hurts a paying customer in plain language; the code comes second.
+- **No severity-by-vibe** (No-Scores cornerstone): the bracket tag is a *judgment stated in words in the body*, not a number pulled from feeling. Justify it with the impact, don't inflate it.
+- **Candor about scope**: say what is NOT affected, what is NOT in scope, and — for a bug surfaced by a PR — that it is NOT caused by that PR.
+
+---
+
+## 1. Title — `[Severity] area: precise outcome`
+
+The convention the real issues use (#580–#587):
+
+- **`[Severity]`** in brackets, first: `[Low]`, `[Low-Medium]`, `[Medium]`, `[Medium-High]`, `[High]`. Compound tags are fine when the call is genuinely between two levels — that honesty beats false precision.
+- **For infra/CI/tooling**, replace the bracket with a domain prefix: `CI: …` (#640), `chore: …`, `test: …`. Same idea — the reader knows the class at a glance.
+- **`area: precise outcome`** — the *outcome*, not the file. Include the **scope count** when the bug repeats (`…across 11 frontend sites`) and the **intended behavior** in a parenthetical when it clarifies (`…hard-fail on missing OPENAI_API_KEY_TEST (should skip)`). **Keep the count consistent with the enumerated Affected list** — #584's title says "11 sites" but its body lists 14; don't do that.
+
+**Done test:** a maintainer scanning the issues list knows the severity, the area, and what actually goes wrong — without opening it.
+
+**Good**
+```
+[Medium] Delete/remove/toggle actions silently no-op on backend failure across 11 frontend sites
+[High] Monitoring tab silently shows an empty dashboard instead of an error for scoped users
+CI: fork/external PRs can never pass `e2e-tests` — LLM tests hard-fail on missing OPENAI_API_KEY_TEST (should skip)
+```
+**Bad**
+```
+Bug in members panel            # no severity, no mechanism, vague area
+Fix useMyFetch                  # a proposed fix as a title; states no problem
+[Critical] everything is broken # severity-by-vibe, no outcome
+```
+
+Choosing the severity (in words, then tag it): **[High]** = silent data/security/billing wrongness a user acts on (a scoped user concludes "all fine" while 403s hide everything — #582; a "sent" notification that never sends — #585). **[Medium]** = a real failure the user is misled about but the blast radius is bounded (silent delete no-op — #584). **[Low]** = a hidden-affordance or cosmetic-but-real correctness gap (an unregistered permission string hides a debug button — #583). If you're between two, write the compound tag; don't round up to look urgent.
+
+---
+
+## 2. Required sections (each with its one-line "done test")
+
+Order them as listed — that ordering *is* the progressive-disclosure requirement (feel the harm → trust it's real → find the lines → know the fix). A reader stops at any depth with a correct picture.
+
+### `## Summary / Impact` — FIRST, always, at the altitude the harm actually lives
+- **What it must contain:** lead where the harm is *real* — don't force a screen or a persona onto a bug that has neither.
+  - **For a bug a user SEES** (UX / frontend): a **named persona** (data analyst, org admin, contractor with single-data-source access) doing a **concrete action** ("clicks Save changes on the training-instructions pill"), **what they see** ("the pill reverts to exactly how it looked before — bit-for-bit identical"), and **why it hurts** in product terms (they believe their approved fix is live; it isn't). No code here. Inline before/after ASCII is encouraged (see #580, #581, #582, #587).
+  - **For an infra / CI / backend / test bug with no screen** (e.g. #640): a plain **Summary** of what is broken, then **who is structurally affected** ("external contributors can never get a green `e2e-tests`"). Do **not** invent a persona or a screen that isn't there.
+- **Done test:** the reader who matches the altitude — a non-engineer for a UX bug, a maintainer for an infra bug — grasps the stakes from this section alone, without a fabricated user or screen.
+
+### `## Root cause` (or `## Technical detail`) — the single mechanism, with `file:line`
+- **What it must contain:** the **one mechanism** behind the symptom(s) where honest to collapse them — #584 titles it "Root cause (single mechanism behind all 11 sites)" and points at `frontend/composables/useMyFetch.ts (~L48-69)`. Every claim carries a **`repo-relative-path:line`** citation.
+- **Done test:** a fixer can open the named line and see the cause with their own eyes — no further hunting to locate it.
+
+### Evidence — quoted real output, never a paraphrase
+- **What it must contain:** the **actual observed artifact** — a pasted test log (#640: `7 failed, 725 passed, 35 skipped, 1091 deselected` / `FAILED …test_llm_providers - Failed: OPENAI_API_KEY_TEST is not set`), a traced call chain "confirmed hop-by-hop (file + line)" (#582), the real error string the user sees (#581: `column "revenu" does not exist`). If you ran it, quote it; if you traced it, show the hops.
+- **Done test:** nothing load-bearing rests on "I think" or "probably" — a skeptic can re-run or re-trace every factual claim.
+
+### The "tell" — the proof it's a real bug, not intended behavior *(when one exists)*
+- **What it must contain:** the **internal inconsistency** that rules out "working as designed." #640's tell: the *Azure* branch of the same fixture `pytest.skip`s when its key is absent while OpenAI/Anthropic `pytest.fail` — "Azure clearly shows the intended pattern is skip-when-absent; the others hard-fail — almost certainly an oversight." A correct sibling in the same file is the strongest tell.
+- **Done test:** a maintainer inclined to say "that's just how it works" is answered by the issue itself.
+
+### Scope & who's affected — enumerated, and honestly bounded
+- **What it must contain:** the **full affected list** with `file:line` and the handler/symbol name (#584 lists all 14 sites), **who is hit** (#640: "external contributors are structurally locked out of a green `e2e-tests`"), and — the candor requirement — **what was checked and is NOT affected** (#584: "~15 other delete/toggle handlers … were checked and confirmed to already correctly gate on `error.value` — a real, bounded pattern … not a codebase-wide problem").
+- **Call out the worst instance** when the affected sites differ in severity — #584 flags `FileUploadComponent` as the worst ("no rollback path exists at all"). It drives fix prioritization.
+- **Done test:** the reader knows the exact blast radius and trusts it because the boundary is stated, not implied.
+
+### A correct reference pattern — what "right" already looks like in-repo *(when one exists)*
+- **What it must contain:** the **existing in-house template** the fix should copy — #584 points to `frontend/components/ReviewFeed.vue`'s snapshot-then-revert (`items.value = prev`); #640 points to the Azure skip branch. This turns "someone should fix this" into "copy that."
+- **Done test:** the fixer has a concrete pattern to mirror, not a blank page.
+
+### `## Proposed fix` — minimal first, then fuller/optional
+- **What it must contain:** the **smallest correct change** first (#640: "change the three `pytest.fail(…)` → `pytest.skip(…)` at lines ~99, 138, 194"), then optionally a **fuller/root-cause option with its tradeoff named** (#584: fix the composable = kills the whole footgun vs. patch 14 sites = smaller blast radius but error-prone), and any **guardrail so it can't silently return** (a lint rule / review-checklist item). Defer a big design exploration to a follow-up comment rather than bloating the issue (#640 does exactly this) — and give that comment a shape: the options with their tradeoffs named, a single **worded recommendation** ("ship this"), and a **why-it's-safe** paragraph (see #640's follow-up comment).
+- **Done test:** a fixer could start today from the minimal option; the tradeoffs of going further are explicit, not left to guess.
+
+### Provenance footer — how it was found, and its relations
+- **What it must contain:** an italic footer stating **how it surfaced** and **related issues/PRs**, including the real-bug-vs-artifact distinction. #584: "_Surfaced during a dedicated sweep for optimistic-UI/fire-and-forget silent failures…_". #640: "_Found while validating PR #589 (issue #584 fix). **Not caused by that PR — surfaced by it.**_"
+- **Done test:** a reader knows whether this is a fresh regression, a pre-existing latent bug, a sweep finding, or test-rot — and which PR/issue it relates to.
+
+### Reconstructed wireframe / before-after visual — **when, and only when, it's a UX or visual bug**
+- **When warranted:** the bug is something a user *sees* on a screen — a silent no-op, a misleading toast, an empty-state that masks a 403, a reverting pill, a hidden button. Then include a **code-derived** wireframe like #584/#582: dated, stating the exact files+lines it was reconstructed from, with **Level 1 (where it sits on the real screen)** and **Level 2 (before / immediately-after / next-reload)** so the *invisibility* of the failure is legible.
+- **When NOT warranted:** a CI/test/backend-logic/permission-registry bug with no distinct on-screen state (#640 has none; #583 is UX-adjacent but a one-line registry fix — a small ASCII suffices). Don't manufacture a wireframe where there's nothing visual to show.
+- **The visual must be code-derived, not imagined:** cite the component and the template line-range, **and paste the ~5–15 line handler itself, annotated with the one line where the bug lives** — as #584 pastes `removeMember` and points at the dead `catch` that never fires. An invented mock is an assertion, not evidence.
+- **If the bug repeats across N sites, say the one wireframe stands in for all N** (they share the identical shape), so fixing the shape once fixes all — as #584's "Same shape, 13 more sites" closer does; this is what justifies a root-cause fix over per-site patching.
+- **Done test:** for a visual bug, a reader who never opens the app can see *why the user can't tell success from failure*; for a non-visual bug, no visual is forced in.
+
+---
+
+## 3. The generative questions (fill each section by answering these)
+
+| Section | The question the author answers |
+|---|---|
+| Summary / Impact | UX bug: "Which real user, doing what, sees what — and why does it hurt (trust / money / security / data)?" · Infra/CI/backend bug: "What is broken, and who is structurally affected?" |
+| Root cause | "What is the *one* mechanism, and at which `file:line` can I point to it?" |
+| Evidence | "What did I actually observe or trace — quoted, not paraphrased?" |
+| The tell | "What inconsistency proves this is a bug and not intended behavior?" |
+| Scope | "Exactly what is affected, who is hit, and what did I check and rule OUT?" |
+| Correct reference | "Where does the right pattern already live in this repo?" |
+| Proposed fix | "What's the smallest correct change, and what does going further buy or cost?" |
+| Provenance | "How was this found, is it caused-by or merely surfaced-by a PR, and what's related?" |
+| Wireframe | "Is this something a user *sees*? If yes, draw the before/after from the code. If no, skip it." |
+
+---
+
+## 4. Paste-ready skeleton
+
+```markdown
+# [Severity] area: precise outcome (scope count if it repeats)
+
+## User experience impact
+
+<Named persona> doing <concrete action> sees <exactly what appears on screen>.
+Why it hurts: <trust / money / security / data, in plain language — no code>.
+
+<optional inline before/after ASCII for a UX bug>
+
+## Root cause  <!-- single mechanism where honest -->
+
+<the one mechanism>, at `path/to/file.ext:LINE`.
+
+**Evidence:**
+```
+<pasted real log / error string / traced hop-by-hop file:line — not a paraphrase>
+```
+
+**The tell:** <the internal inconsistency proving it's a bug, e.g. a correct sibling in the same file>.  <!-- omit if none -->
+
+**Affected (N confirmed):**
+- `path/one.ext:LINE` — <handler/symbol>
+- `path/two.ext:LINE` — <handler/symbol>
+
+**NOT affected / already correct:** <what you checked and ruled out — bound the blast radius>.
+
+**Correct reference pattern (already in-repo):** `path/to/good.ext` — <what it does right>.  <!-- omit if none -->
+
+## Proposed fix
+
+1. **Minimal:** <smallest correct change, with exact file:line>.
+2. **Fuller (optional):** <root-cause option> — tradeoff: <what it buys vs costs>.
+3. **Guardrail:** <lint rule / review-checklist item so it can't silently return>.
+
+<!-- UX/visual bugs only: a dated, code-derived wireframe (Level 1 where-on-screen, Level 2 before/after/reload), citing the files+lines it was reconstructed from. Omit entirely for CI/backend/logic bugs. -->
+
+---
+_Provenance: <how found>. <caused-by vs surfaced-by which PR>. Related: #NNN, #NNN._
+```
+
+---
+
+## 5. Where this belongs & how to enforce
+
+Consistent with what already exists in this repo — **no issue standard exists today** (checked: root `AGENTS.md` + `frontend`/`backend` sub-guides reference skills and a commit-guidelines doc but say nothing about issues; global CLAUDE.md governs commits, not issues; auto-memory has no issue memory), and there is **no `.github/ISSUE_TEMPLATE/`** yet. Mirror how the PR standard proposes to enforce itself:
+
+- **`.github/ISSUE_TEMPLATE/bug_report.md`** — the section 4 skeleton as a GitHub-native template, so every human-opened issue starts pre-shaped and GitHub auto-populates it. (A second `feature_request.md` can follow later; this schema is bug/finding-shaped, which is what the real corpus is.)
+- **A reference from `AGENTS.md`** (and/or the docs standard set alongside the commit-guidelines doc) so **agent-authored** issues — the bulk of the #580–#640 corpus — carry this by default, the same way commits carry the commit-message guidelines.
+- **The test for a good issue:** could a maintainer decide (real? how bad? fix now?) from the first screen, and could a future fixer reproduce it, find the exact lines, and copy the right pattern — without help? If either fails, it's not done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,27 @@
 See `frontend/AGENTS.md` and `backend/AGENTS.md` for the per-side guides, and
 `backend/tests/AGENTS.md` before writing or changing any backend test.
 
+### Issues & PRs — read the authoring standard first
+
+Before you **open a GitHub issue** or **write a PR description**, read the
+matching standard **in full** and follow it. These are dual-audience artifacts
+(a maintainer must be able to *decide* from the top; a future fixer/agent must
+be able to *navigate and reproduce*), distilled from this repo's own issues/PRs:
+
+- **`.claude/templates/issue_schema.md`** — how to open an issue: title
+  `[Severity] area: precise outcome`, **user-impact first** (a named persona,
+  what they see, why it hurts), a single **root cause with `file:line`**,
+  **quoted evidence** (never "I think"), the **"tell"** that proves it's a real
+  bug vs intended, honestly-**bounded scope** (what's NOT affected), an in-repo
+  **correct-reference pattern**, a **minimal→fuller proposed fix**, and a
+  code-derived **wireframe only for visual bugs**. Severity is a worded judgment,
+  not a score.
+- **`.claude/templates/PR_DESCRIPTION_STANDARD.md`** — the PR body shape:
+  reviewer **decision box**, a product/customer **executive summary**, both a
+  **product-impact and a technical visual**, an **evidence KPI**, and a
+  **context map** — ordered so a reviewer can decide from the first screen and a
+  future agent can navigate the change from the bottom.
+
 ### Agent skills
 
 Reusable agent procedures live in `.agents/skills/<name>/SKILL.md`


### PR DESCRIPTION
## 📣 Executive summary — why this matters to the team's velocity

Today every issue and every PR in this repo is a **fresh reinvention of "what good looks like."** When one comes out under-specified, the cost doesn't land on the author — it lands on the whole team: a maintainer burns triage time deciding whether a vague issue is even *real* and *how bad*, a fixer re-discovers the same `file:line` and reproduction from scratch, and a reviewer bounces a thin PR back asking for the evidence that should have been there. Multiply that by a corpus that is **mostly agent-authored** and the drag is continuous.

These two standards move quality to the **start** of the loop instead of the end: an issue arrives **decision-ready** (impact → evidence → `file:line` → reproduction → the correct in-repo pattern to copy), and a PR arrives **reviewable in one pass** (a decision box, honest verification, a context map). The impact is on the **development lifecycle itself** — faster triage, fewer round-trips, less rework, and consistent output from the agents that write most of these artifacts. It's the same "make the failure/insight visible up front" instinct behind the #584 fix, applied to how we *communicate* work rather than how the app behaves.

```mermaid
flowchart TD
    ISSUE["🐛 Issue opened"] -->|"guided by<br/>issue_schema.md"| DECIDE["⚡ Maintainer decides in ONE read:<br/>is it real? how bad? fix now?"]
    DECIDE --> FIX["🔧 Fixer starts with file:line,<br/>a reproduction, bounded scope,<br/>and the correct in-repo pattern"]
    FIX -->|"guided by<br/>PR_DESCRIPTION_STANDARD.md"| REVIEW["⚡ Reviewer decides<br/>from the FIRST screen"]
    REVIEW --> MERGE["✅ One-pass merge,<br/>less back-and-forth, less rework"]
    style DECIDE fill:#d7f5dd,stroke:#2a2,color:#000
    style REVIEW fill:#d7f5dd,stroke:#2a2,color:#000
    style MERGE fill:#d7f5dd,stroke:#2a2,color:#000
```

## What & why

Adds two **authoring standards** — one for opening issues, one for writing PR descriptions — under `.claude/templates/`, plus a reference from `AGENTS.md` so humans and agents read them before opening an issue / writing a PR. They exist because the repo had **no** issue- or PR-authoring guidance (checked: global CLAUDE.md governs commits only; `AGENTS.md` references skills + the commit guidelines but nothing about issues/PRs; no `.github/ISSUE_TEMPLATE/`). Both are **distilled from this repo's own best issues/PRs** (#584, #640, #589) — not invented — so the next issue/PR is as good as those without the author reverse-engineering the shape.

## How each template speeds the lifecycle up

- **`issue_schema.md` — cuts the triage-to-fix time.** A maintainer decides *real? / how bad? / fix now?* from the top **without reading code** (Summary/Impact-first, worded severity, the "tell" that pre-answers "isn't that just how it works?"). The fixer then starts with the exact **`file:line`**, a **reproduction**, the **bounded scope** (what's *not* affected, worst instance flagged), and the **correct in-repo pattern to copy** — instead of re-deriving all of it. Net: less time spent deciding whether to act, and less spent finding where to act.
- **`PR_DESCRIPTION_STANDARD.md` — cuts review time and rework.** The reviewer decides **from the first screen** (decision box: risk / blast radius / what's verified / what to check + an evidence KPI). The honest **"NOT verified"** line and the **per-failure attribution appendix** pre-empt the usual review round-trips ("did you check X?", "are these failures yours?"). The **context map** lets a future agent extend the change months later without re-deriving it. Net: fewer review cycles, faster merges, and a description that stays useful as `git blame` context.

## 🧭 For the reviewer — decide at a glance

| | |
|---|---|
| **Risk** | **Minimal** — docs/tooling only, **zero code**, additive markdown. Nothing runs it; nothing breaks. |
| **Blast radius** | 3 files, +255 lines: two templates + a reference section in `AGENTS.md`. |
| **Behavior change** | None at runtime. It changes how future *issues and PRs are written*, not the product. |
| **Verified** | Both templates were **validated against the real #584 / #640 / #589** — an independent pass checked that following them reproduces those artifacts' quality, and they were corrected for the gaps found (notably: the issue schema now handles **non-visual bugs** like CI/backend, not just UX). |
| **What to check** | Are the templates *accurate to this repo's conventions* (the `[Severity]` title style, `AGENTS.md` reference placement, No-Scores worded severity), and is anything over-prescribed? |
| **Automated review** | None flagged as of this writing (0 Copilot comments). Any that arrive will be resolved per the standard's own new element 9 — validate each against the code, integrate real / dismiss false-with-proof — before merge. |

## What it adds

- **`.claude/templates/issue_schema.md`** — `[Severity] area: precise outcome` title; **Summary/Impact first at the altitude the harm lives** (named persona + on-screen consequence for a UX bug; plain summary + who's-affected for a CI/backend bug); single **root cause with `file:line`**; **quoted evidence** (never "I think"); the **"tell"**; honestly-**bounded scope**; an in-repo **correct-reference pattern**; a **minimal→fuller proposed fix**; a code-derived **wireframe only for visual bugs**; provenance footer.
- **`.claude/templates/PR_DESCRIPTION_STANDARD.md`** — the dual-audience PR body shape (this PR follows it): decision box, executive summary, product + technical visuals *when warranted*, evidence KPI (+ conditional per-failure attribution appendix), context map, and a **"resolve automated review before done"** step (element 9 — fetch each Copilot/bot comment, validate against the code, integrate the real / dismiss the false-with-proof, and watch for a flagged *line* that's really a *class*).
- **`AGENTS.md`** — a new "Issues & PRs — read the authoring standard first" section pointing to both.

## Context map

- **Where they live:** `.claude/templates/` — repo-local tooling, siblings to the commit-message guidelines.
- **How they're enforced:** referenced from `AGENTS.md` so agent-authored issues/PRs pick them up; a `.github/ISSUE_TEMPLATE/bug_report.md` install is a suggested follow-up (not done here) to auto-populate human-opened issues.
- **How they were validated:** compared section-by-section against #584 (fixed UX bug + reconstructed wireframe), #640 (CI bug + quoted-log evidence + deferred-design comment), and #589 (dual-altitude description), then edited for the gaps found.

## Out of scope / deliberately not here

- **Not** part of the #584 product-fix PR (#589) — orthogonal meta-tooling, on its own branch on purpose.
- **No** `.github/ISSUE_TEMPLATE/` install yet (proposed follow-up).
- **No** `feature_request.md` — the real corpus is entirely bug/finding-shaped; a feature template would be speculation with no examples to distill from.

> _Note on calibration: this PR's description deliberately carries an executive summary + a lifecycle visual (the impact is on developer velocity, not an end customer) but **no** fabricated product/customer diagram or test KPI — a 3-file docs change has neither. That's the standard applied honestly, per "build the smallest structure that reaches the goal."_
