### PR TITLE
Fix Custom API OAuth sign-in: treat per-user API root as reachable

### DIFF
--- a/backend/app/data_sources/clients/custom_api_client.py
+++ b/backend/app/data_sources/clients/custom_api_client.py
@@ -199,23 +199,50 @@ class CustomApiClient(ToolProviderClient):
             return "text"
         return "json"
 
+    # Auth types that sign in per user (X, …). For these the base URL is an API
+    # root that legitimately answers 4xx (404 no resource at "/", 401/403 auth
+    # required) and there's no user token at setup time — so reaching the host
+    # at all IS the only thing we can, and need to, verify.
+    _PER_USER_OAUTH_TYPES = ("oauth_app", "oauth")
+
     def test_connection(self) -> Dict[str, Any]:
         """Test connectivity by sending a HEAD request to the base URL.
 
-        A response is only a *success* when the API actually answers OK. An
-        error status (404 wrong base URL, 401/403 bad credentials, 5xx) means we
-        reached a host but the connection is not usable, so it must not be
-        reported as green/connected. 405 is treated as reachable because many
-        APIs reject HEAD on the base path while still being valid.
+        For a data API (none/bearer/api_key) a response is only a *success* when
+        the API answers OK — an error status (404 wrong base URL, 401/403 bad
+        credentials, 5xx) means we reached a host but the connection is not
+        usable. 405 is treated as reachable because many APIs reject HEAD on the
+        base path while still being valid.
+
+        For a per-user OAuth API (oauth_app/oauth) the base root commonly answers
+        4xx even when the API is perfectly usable, and the per-user token that
+        would make it 2xx doesn't exist until the user signs in. Getting any
+        (non-5xx) HTTP response there proves the host is reachable — which is the
+        real signal. Treating a root 404 as failure here would wrongly roll back
+        a valid token at the OAuth callback and block sign-in entirely.
         """
         import httpx
+
+        is_per_user_oauth = self.auth_type in self._PER_USER_OAUTH_TYPES
 
         try:
             headers = self._build_headers()
             with httpx.Client(timeout=10.0) as client:
                 response = client.head(self.base_url, headers=headers)
             status = response.status_code
-            if status < 400 or status == 405:
+            reachable = status < 400 or status == 405
+            if is_per_user_oauth and status < 500:
+                # Any answer from the host (incl. 401/403/404) = reachable.
+                reachable = True
+            if reachable:
+                if is_per_user_oauth:
+                    return {
+                        "success": True,
+                        "message": (
+                            f"Server reachable at {self.base_url} — sign-in required. "
+                            f"Tools run with each user's own token after they sign in."
+                        ),
+                    }
                 return {
                     "success": True,
                     "message": f"Connected to API at {self.base_url} (HTTP {status})",

--- a/backend/tests/unit/test_custom_api_oauth.py
+++ b/backend/tests/unit/test_custom_api_oauth.py
@@ -8,6 +8,8 @@ Covers:
 """
 from unittest.mock import MagicMock
 
+import httpx
+
 from app.data_sources.clients.custom_api_client import CustomApiClient
 from app.services.connection_oauth_service import get_oauth_params
 from app.schemas.data_source_registry import (
@@ -79,6 +81,56 @@ class TestWriteEndpointPolicy:
     def test_confirm_false_overrides_write_method(self):
         c = self._client_with([{"name": "safe_post", "method": "POST", "path": "/x", "confirm": False}])
         assert "default_policy" not in c.list_tools()[0]
+
+
+# --- test_connection reachability (the OAuth-callback rollback bug) ----------
+
+def _head_status(monkeypatch, status):
+    """Patch httpx.Client so a HEAD returns the given status."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status)
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.Client
+
+    class _Patched(original):
+        def __init__(self, *a, **kw):
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    monkeypatch.setattr(httpx, "Client", _Patched)
+
+
+class TestConnectionReachability:
+    def test_oauth_app_root_404_is_reachable(self, monkeypatch):
+        # X's api.x.com root 404s; the callback must NOT treat that as a failure
+        # (doing so rolled back a valid token and blocked sign-in).
+        _head_status(monkeypatch, 404)
+        client = CustomApiClient(base_url="https://api.x.com", auth_type="oauth_app")
+        res = client.test_connection()
+        assert res["success"] is True
+        assert "sign-in required" in res["message"].lower()
+
+    def test_oauth_app_401_is_reachable(self, monkeypatch):
+        _head_status(monkeypatch, 401)
+        client = CustomApiClient(base_url="https://api.x.com", auth_type="oauth_app")
+        assert client.test_connection()["success"] is True
+
+    def test_oauth_app_5xx_is_failure(self, monkeypatch):
+        _head_status(monkeypatch, 503)
+        client = CustomApiClient(base_url="https://api.x.com", auth_type="oauth_app")
+        assert client.test_connection()["success"] is False
+
+    def test_bearer_root_404_still_fails(self, monkeypatch):
+        # Strict behavior preserved for data APIs — a 404 root is a likely misconfig.
+        _head_status(monkeypatch, 404)
+        client = CustomApiClient(base_url="https://api.example.com", auth_type="bearer", token="t")
+        assert client.test_connection()["success"] is False
+
+    def test_bearer_200_succeeds(self, monkeypatch):
+        _head_status(monkeypatch, 200)
+        client = CustomApiClient(base_url="https://api.example.com", auth_type="bearer", token="t")
+        assert client.test_connection()["success"] is True
 
 
 # --- get_oauth_params for custom_api ----------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #636. The X (Write) Custom API connection could never complete sign-in: after authorizing on X, the OAuth callback discarded the valid token because a health-check probe hit a 404.

## The bug

The OAuth callback verifies a freshly-issued token via `test_user_connection` → `CustomApiClient.test_connection()`, which sends `HEAD <base_url>`. For X the base URL is `https://api.x.com`, whose **root answers 404** (there's no resource at `/`). The old check treated any non-OK status as "connection unusable", so the callback:

1. stored the valid token,
2. ran the probe → got 404 → marked the test failed,
3. **rolled back (deleted) the just-stored token** and redirected with `oauth=error`.

Sign-in succeeded on X's side but our own post-authorization health check threw the good token away, so the connection never completed. The same 404 also surfaced as a red error on the pre-save **Test Connection** button.

## Why the probe was wrong here

For a per-user OAuth API, the base URL is a root you never call directly — a 404/401/403 there means "host reachable, nothing at `/` and/or a token is required", **not** "broken". And at setup time there is no user token yet, so reaching the host at all is the only thing we can (and need to) verify.

## Fix

`CustomApiClient.test_connection()` now, for `oauth_app`/`oauth` auth types, treats any non-5xx response as reachable and reports "Server reachable — sign-in required". The strict behavior is preserved for data APIs (`none`/`bearer`/`api_key`), where a 404 root still indicates a likely misconfiguration.

Effect: the OAuth callback keeps the valid token and completes, and the pre-save Test button shows a positive "sign-in required" message instead of a 404.

## Tests

5 new unit tests: `oauth_app` root 404/401 → reachable, 5xx → failure; `bearer` 404 still fails, `bearer` 200 succeeds. The `test_custom_api_oauth.py` suite passes (22).

## Notes

This gap was missed by the automated tests in #636 because they didn't exercise the post-authorization callback path for a Custom API connection — only the live X sign-in flow surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2)_