### PR TITLE
Reduce Oracle ORA-12704 charset-mismatch loops in generated SQL

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -427,6 +427,52 @@ def validate_sql_query(query: str) -> None:
 
 
 # =============================================================================
+# Known DB-error remediation hints
+# =============================================================================
+
+# Some database errors are cryptic enough that the raw message alone doesn't
+# tell the coder how to fix them, so it keeps regenerating the same broken
+# query across retries. Each entry maps a case-insensitive signature found in
+# the error text to an actionable hint appended to the retry feedback. Keep
+# this list SHORT and high-signal — only errors where the fix is unambiguous.
+_DB_ERROR_HINTS: List[Tuple[str, str]] = [
+    (
+        "ORA-12704",
+        # Oracle character set mismatch: an expression combines national-charset
+        # text (NVARCHAR2/NCHAR/NCLOB) with database-charset text (VARCHAR2/CHAR/
+        # CLOB/a plain literal), usually across a UNION/UNION ALL, CASE/DECODE/
+        # COALESCE/NVL, concatenation, or comparison.
+        "Hint: ORA-12704 means the query combines text of two different Oracle "
+        "character sets — a national-charset column (NVARCHAR2/NCHAR/NCLOB) mixed "
+        "with a database-charset value (VARCHAR2/CHAR/CLOB or a plain 'literal'). "
+        "This usually happens across a UNION/UNION ALL, CASE/DECODE/COALESCE/NVL, "
+        "string concatenation (||), or comparison. Fix it by normalizing every "
+        "text branch to ONE character set: wrap each NVARCHAR2/NCHAR column (and "
+        "any mismatched literal) in TO_CHAR(...) so all branches share the "
+        "database charset — e.g. SELECT TO_CHAR(a) ... UNION ALL SELECT TO_CHAR(b) ... "
+        "Apply the conversion to EVERY branch of the offending expression, then retry."
+    ),
+]
+
+
+def augment_db_error_hint(error_text: str) -> str:
+    """Append a remediation hint when the error matches a known signature.
+
+    Returns the error text unchanged when nothing matches. Reactive companion
+    to the proactive guidance in each client's `description`: the hint rides
+    the actual failure into the retry feedback, right next to the failing
+    code, regardless of how the query was generated.
+    """
+    if not isinstance(error_text, str) or not error_text:
+        return error_text
+    haystack = error_text.upper()
+    hints = [hint for signature, hint in _DB_ERROR_HINTS if signature.upper() in haystack]
+    if not hints:
+        return error_text
+    return error_text + "\n" + "\n".join(hints)
+
+
+# =============================================================================
 # Query Capturing Wrapper (captures queries passed to execute_query)
 # =============================================================================
 
@@ -1201,7 +1247,7 @@ class StreamingCodeExecutor:
                 executed_successfully = True
                 break
             except Exception as e:
-                msg = f"Execution error: {str(e)}"
+                msg = augment_db_error_hint(f"Execution error: {str(e)}")
                 code_and_error_messages.append((final_code, msg))
                 yield {"type": "stdout", "payload": msg}
                 retries += 1
@@ -1423,7 +1469,7 @@ class StreamingCodeExecutor:
                 # client wrapper), so the attempt is not safely repeatable.
                 break
             except Exception as e:
-                msg = f"Execution error: {str(e)}"
+                msg = augment_db_error_hint(f"Execution error: {str(e)}")
                 code_and_error_messages.append((final_code, msg))
                 yield {"type": "stdout", "payload": msg}
                 retries += 1

--- a/backend/app/data_sources/clients/oracledb_client.py
+++ b/backend/app/data_sources/clients/oracledb_client.py
@@ -270,7 +270,7 @@ class OracledbClient(DataSourceClient):
     def description(self):
         system_prompt = """
         You can call the execute_query method to run SQL queries.
-        
+
         The below are examples for how to use the execute_query method. Note that the actual SQL will vary based on the schema.
         Notice only the SQL syntax and instructions on how to use the execute_query method, not the actual SQL queries.
 
@@ -281,6 +281,30 @@ class OracledbClient(DataSourceClient):
         ```python
         df = client.execute_query("SELECT * FROM HR.EMPLOYEES WHERE SALARY > 100000")
         ```
+
+        Character set mismatch (ORA-12704):
+        Oracle raises "ORA-12704: character set mismatch" when a single expression
+        combines text values of different character sets — a national-charset column
+        (NVARCHAR2 / NCHAR / NCLOB) mixed with a database-charset value (VARCHAR2 /
+        CHAR / CLOB / a plain 'literal'). Watch the column types in the schema: a
+        column typed NVARCHAR2 or NCHAR is national charset.
+        This happens most often in:
+          - UNION / UNION ALL where one branch's text column is NVARCHAR2 and the
+            matching column in another branch is VARCHAR2 (or a plain string literal).
+          - CASE / DECODE / COALESCE / NVL whose branches mix NVARCHAR2 and VARCHAR2.
+          - String concatenation (||) or comparison across the two charsets.
+        To avoid it, normalize every text branch to ONE charset. The simplest, most
+        reliable fix is to wrap each text column and literal in TO_CHAR(...) so all
+        branches share the database charset:
+          - TO_CHAR(nvarchar2_col)  -- national -> database charset
+          - Use TO_CHAR('literal') or just a plain 'literal' consistently.
+        Example (fixes a UNION across a VARCHAR2 and an NVARCHAR2 column):
+          SELECT TO_CHAR(status) AS status FROM DWH.WF_PROC_INSTS
+          UNION ALL
+          SELECT TO_CHAR(state)  AS status FROM DWH.WF_MANUAL_WORKITEMS
+        Alternatively bring everything to the national charset with TO_NCHAR(...),
+        but pick one direction and apply it to every branch — do not leave a raw
+        NVARCHAR2 column next to a VARCHAR2 one.
         """
         description = f"Oracle database service '{self.service_name}' at {self.host}:{self.port}\n\n"
         description += system_prompt

--- a/backend/tests/unit/test_db_error_hints.py
+++ b/backend/tests/unit/test_db_error_hints.py
@@ -1,0 +1,128 @@
+"""Reactive DB-error remediation hints in the code-execution retry loop.
+
+Some database errors are too cryptic for the coder to fix from the raw
+message alone, so it re-rolls the same broken query every retry. The
+executor augments known error signatures with an actionable hint before
+feeding them back. This is the reactive companion to the proactive guidance
+carried in each client's `description`.
+
+Born as the reproduction for: Oracle DWH queries looping on
+"ORA-12704: character set mismatch" across attempts 1-3.
+"""
+
+import asyncio
+
+import pandas as pd
+
+from app.ai.code_execution.code_execution import (
+    StreamingCodeExecutor,
+    augment_db_error_hint,
+)
+from app.ai.schemas.codegen import CodeGenContext, CodeGenRequest
+
+
+# ---------------------------------------------------------------------------
+# augment_db_error_hint (pure helper)
+# ---------------------------------------------------------------------------
+
+class TestAugmentDbErrorHint:
+    def test_ora_12704_gets_charset_hint(self):
+        err = "Execution error: (oracledb.exceptions.DatabaseError) ORA-12704: character set mismatch"
+        out = augment_db_error_hint(err)
+        assert out.startswith(err), "original error text must be preserved verbatim"
+        assert "ORA-12704" in out
+        assert "TO_CHAR" in out
+        assert "NVARCHAR2" in out and "VARCHAR2" in out
+        assert "UNION" in out
+
+    def test_signature_match_is_case_insensitive(self):
+        out = augment_db_error_hint("boom ora-12704 character set mismatch")
+        assert "TO_CHAR" in out
+
+    def test_unknown_error_is_returned_unchanged(self):
+        err = "Execution error: ORA-00942: table or view does not exist"
+        assert augment_db_error_hint(err) == err
+
+    def test_non_string_input_is_passed_through(self):
+        assert augment_db_error_hint(None) is None
+        assert augment_db_error_hint("") == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the hint must reach the coder's retry feedback
+# ---------------------------------------------------------------------------
+
+class _RaisingClient:
+    """Minimal ds_client whose execute_query always raises ORA-12704."""
+
+    description = "oracle stub"
+
+    def execute_query(self, query, *args, **kwargs):
+        raise RuntimeError(
+            "(oracledb.exceptions.DatabaseError) ORA-12704: character set mismatch"
+        )
+
+
+ORA_CODE = (
+    "def generate_df(ds_clients, excel_files):\n"
+    "    import pandas as pd\n"
+    "    key = list(ds_clients.keys())[0]\n"
+    "    return ds_clients[key].execute_query('SELECT 1 FROM DUAL')\n"
+)
+
+CLEAN_CODE = (
+    "def generate_df(ds_clients, excel_files):\n"
+    "    import pandas as pd\n"
+    "    return pd.DataFrame({'a': [1]})\n"
+)
+
+
+def _capturing_coder(code_sequence):
+    calls = []
+
+    async def _gen(**kwargs):
+        calls.append(kwargs)
+        i = min(len(calls) - 1, len(code_sequence) - 1)
+        return code_sequence[i]
+
+    return _gen, calls
+
+
+def _drive(executor, generator_fn, ds_clients, retries=2):
+    events = []
+
+    async def go():
+        async for ev in executor.generate_and_execute_stream_v2(
+            request=CodeGenRequest(
+                context=CodeGenContext(user_prompt="x", schemas_excerpt=""),
+                retries=retries,
+            ),
+            ds_clients=ds_clients,
+            excel_files=[],
+            code_generator_fn=generator_fn,
+        ):
+            events.append(ev)
+
+    asyncio.run(go())
+    return events
+
+
+class TestHintReachesRetryFeedback:
+    def test_ora_12704_hint_is_fed_back_to_the_coder(self):
+        """After an ORA-12704 failure, the 2nd codegen call must see the hint
+        alongside the failing code — not just the bare error."""
+        gen, calls = _capturing_coder([ORA_CODE, CLEAN_CODE])
+        ds_clients = {"DWH:oracle-1": _RaisingClient()}
+        events = _drive(StreamingCodeExecutor(), gen, ds_clients, retries=2)
+
+        assert len(calls) == 2, "an ORA-12704 failure must consume a retry"
+        feedback = calls[1]["code_and_error_messages"]
+        assert feedback, "previous attempt must be fed back to the coder"
+        _, prev_error = feedback[-1]
+        assert "ORA-12704" in prev_error
+        assert "TO_CHAR" in prev_error, "the actionable hint must ride the retry feedback"
+
+        # And the run recovers on the clean retry.
+        done = [e for e in events if e["type"] == "done"][-1]["payload"]
+        df = done["df"]
+        assert isinstance(df, pd.DataFrame) and list(df.columns) == ["a"]

--- a/backend/tests/unit/test_oracledb_thick_mode.py
+++ b/backend/tests/unit/test_oracledb_thick_mode.py
@@ -73,3 +73,19 @@ def test_tcps_without_verification_omits_ssl_context_in_thick_mode(monkeypatch):
     args = _client(use_tcps=True, verify_ssl=False)._connect_args()
     assert args["ssl_server_dn_match"] is False
     assert "ssl_context" not in args
+
+
+# ---------------------------------------------------------------------------
+# Coder-facing description
+# ---------------------------------------------------------------------------
+
+def test_description_warns_about_charset_mismatch():
+    """The description feeds the coder's <connection_clients> prompt, so it must
+    teach how to avoid the recurring ORA-12704 character set mismatch."""
+    desc = _client().description
+    assert "ORA-12704" in desc
+    assert "character set mismatch" in desc.lower()
+    # Names the offending types and the concrete fix so the model can act on it.
+    assert "NVARCHAR2" in desc
+    assert "VARCHAR2" in desc
+    assert "TO_CHAR" in desc


### PR DESCRIPTION
## Problem

Oracle data queries were looping on `ORA-12704: character set mismatch` across retries (observed on a `DWH.WF_*` UNION). This is a **server-side** Oracle error: it fires when a single expression combines text of two different character sets — a national-charset column (`NVARCHAR2`/`NCHAR`/`NCLOB`) mixed with a database-charset value (`VARCHAR2`/`CHAR`/`CLOB` or a plain literal), typically across a `UNION`/`UNION ALL`, `CASE`/`DECODE`/`COALESCE`/`NVL`, `||`, or comparison.

The generated-SQL coder had no guidance connecting the column types it already sees in the schema to this error, and the raw `ORA-12704` string fed back on retry wasn't actionable enough for it to self-correct — so it re-rolled the same charset-mixing SQL each attempt.

## Changes

Two complementary fixes:

1. **Proactive guidance** (`oracledb_client.py`): the Oracle client's `description` flows into the coder's `<connection_clients>` prompt section. Added a concise explanation of what causes ORA-12704, which column types are national vs database charset, the common triggers, and the fix — normalize every text branch to one charset (e.g. wrap each `NVARCHAR2` column/literal in `TO_CHAR(...)`), with a worked `UNION ALL` example.

2. **Reactive hint** (`code_execution.py`): a small, high-signal `signature → hint` table (`augment_db_error_hint`) that, when a known DB-error signature appears in an execution error, appends the concrete fix to the retry feedback. The hint rides the actual failure into the next codegen prompt — right next to the failing code — regardless of how the query was generated or whether the description made it into context. Wired into both the v1 and v2 `generate_and_execute` streams.

## Tests

- `test_oracledb_thick_mode.py`: asserts the ORA-12704 guidance is present in the client description.
- `test_db_error_hints.py`: unit tests for `augment_db_error_hint` (match, case-insensitivity, unknown-error passthrough, non-string input) plus an end-to-end test that drives the executor with a client raising ORA-12704 and confirms the hint reaches the coder's retry feedback and the run recovers.

All new and adjacent tests pass locally.

## Scope / honesty

These are prompt-guidance mitigations that steer the LLM — they should meaningfully reduce the ORA-12704 retry loop but are **not** a hard guarantee of valid Oracle SQL, since the architecture generates and executes model-written SQL. A deterministic fix would require intercepting and rewriting the generated SQL, which is intentionally out of scope here. Not validated against a live Oracle instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMQaipQJCePyX2nYeMPb2e)_