### PR TITLE
Fix Custom API "Test Connection" showing 404 for per-user OAuth (keep auth_type)

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1374,8 +1374,14 @@ class ConnectionService:
             if credentials:
                 client_params.update(credentials)
 
-            # Strip meta keys, empty values, and oauth override keys (stored in credentials but not used by clients)
-            meta_keys = {"auth_type", "auth_policy", "allowed_user_auth_modes"}
+            # Strip meta keys, empty values, and oauth override keys (stored in credentials but not used by clients).
+            # Keep auth_type — the tool-provider clients (custom_api/mcp) switch on
+            # it (e.g. custom_api's per-user OAuth Bearer + its reachability test).
+            # This mirrors construct_client, which also keeps auth_type; stripping
+            # it here made the pre-save "Test Connection" build the client as
+            # auth_type="none", so an oauth_app API root 404 looked like a failure.
+            # Clients that don't accept auth_type drop it via the signature narrowing below.
+            meta_keys = {"auth_policy", "allowed_user_auth_modes"}
             client_params = {k: v for k, v in client_params.items() if v is not None and v != "" and k not in meta_keys and not k.startswith("oauth_")}
 
             # Narrow to constructor signature

--- a/backend/tests/unit/test_custom_api_oauth.py
+++ b/backend/tests/unit/test_custom_api_oauth.py
@@ -8,6 +8,7 @@ Covers:
 """
 from unittest.mock import MagicMock
 
+import pytest
 import httpx
 
 from app.data_sources.clients.custom_api_client import CustomApiClient
@@ -131,6 +132,50 @@ class TestConnectionReachability:
         _head_status(monkeypatch, 200)
         client = CustomApiClient(base_url="https://api.example.com", auth_type="bearer", token="t")
         assert client.test_connection()["success"] is True
+
+
+# --- Full Test-Connection path (test_connection_params) ----------------------
+
+class TestConnectionParamsPath:
+    """The pre-save 'Test Connection' button goes through
+    ConnectionService.test_connection_params -> _resolve_client_by_type, which
+    must preserve auth_type so an oauth_app API root 404 reads as reachable
+    (not the misleading 'HTTP 404 — check the base URL' failure)."""
+
+    def _cfg(self):
+        return {
+            "base_url": "https://api.x.com",
+            "auth_type": "oauth_app",
+            "headers": {},
+            "endpoints": [
+                {"name": "create_post", "method": "POST", "path": "/2/tweets",
+                 "parameters": [{"name": "text", "in": "body", "type": "string", "required": True}]},
+            ],
+        }
+
+    def test_resolve_client_preserves_auth_type(self):
+        from app.services.connection_service import ConnectionService
+        c = ConnectionService()._resolve_client_by_type("custom_api", self._cfg(), {"client_id": "x"})
+        assert c.auth_type == "oauth_app"
+
+    @pytest.mark.asyncio
+    async def test_test_params_oauth_app_root_404_is_success(self, monkeypatch):
+        import httpx
+        from app.services.connection_service import ConnectionService
+
+        def fake_head(self, url, **kw):
+            return httpx.Response(404, request=httpx.Request("HEAD", url))
+
+        monkeypatch.setattr(httpx.Client, "head", fake_head)
+        res = await ConnectionService().test_connection_params(
+            data_source_type="custom_api",
+            config=self._cfg(),
+            credentials={"client_id": "x", "client_secret": "y",
+                         "token_url": "https://api.x.com/2/oauth2/token"},
+        )
+        # Reachable → lists the configured endpoints as tools.
+        assert res["success"] is True
+        assert "404" not in res["message"]
 
 
 # --- get_oauth_params for custom_api ----------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #644. The X (Write) Custom API preset still showed `Reached https://api.x.com but it returned HTTP 404 — check the base URL...` on **Test Connection**, even with #644 deployed.

## Root cause

#644 made `CustomApiClient.test_connection()` treat a per-user OAuth (`oauth_app`/`oauth`) API root 404 as *reachable* — but that leniency keys on `self.auth_type`. There are two client-construction paths and they disagreed:

- OAuth **callback** (the real sign-in check) → `construct_client`, which **keeps** `auth_type`. #644 works here, so sign-in completes.
- Test Connection **button** / `test_connection_params` → `_resolve_client_by_type`, which **stripped** `auth_type` (it was in `meta_keys`). The client was built as `auth_type="none"`, so the oauth leniency never triggered and the 404 was reported as a failure.

Reproduced against production: `POST /api/connections/test-params` with the X Write config returned the 404 — and the *same* call reproduces locally on `main` (which already has #644), confirming this path, not deployment, was the gap.

## Fix

Remove `auth_type` from the strip-list in `_resolve_client_by_type`, matching `construct_client` (which already keeps it and documents why). The tool-provider clients (`custom_api`/`mcp`) switch on `auth_type`; clients that don't accept it drop it via the existing constructor-signature narrowing, so nothing else changes.

Result: the X (Write) test now returns `Connected successfully. Found N tool(s).` instead of the 404.

## Tests

- `_resolve_client_by_type` preserves `auth_type` for a custom_api oauth_app config.
- `test_connection_params` for a custom_api oauth_app root-404 returns success (no 404 message).
- Existing custom_api unit + e2e suites still pass (29 tests).

## Note

The user was right that prod is the new version — my earlier read of a prod `test-params` 404 as "not deployed" was wrong, because that path strips `auth_type` and returns 404 regardless. The sign-in fix from #644 is live; this closes the remaining Test-button gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2)_