### PR TITLE
Improve mobile readability and tab styling in reports

### DIFF
--- a/frontend/components/report/ReportHeader.vue
+++ b/frontend/components/report/ReportHeader.vue
@@ -44,13 +44,15 @@
                 v-for="tab in mobileTabs"
                 :key="tab.value"
                 @click="$emit('update:mobileView', tab.value)"
-                class="flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium rounded-md transition-colors"
+                class="flex items-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors"
                 :class="mobileView === tab.value
-                    ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800'
-                    : 'text-gray-400 hover:text-gray-600'"
+                    ? 'px-3 text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800'
+                    : 'px-2.5 text-gray-400 hover:text-gray-600'"
+                :aria-label="tab.label"
+                :title="tab.label"
             >
-                <Icon :name="tab.icon" class="w-3 h-3" />
-                {{ tab.label }}
+                <Icon :name="tab.icon" class="w-4 h-4 flex-shrink-0" />
+                <span v-if="mobileView === tab.value">{{ tab.label }}</span>
             </button>
             <button
                 v-if="mobileView !== 'chat'"

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -85,7 +85,7 @@
 		/>
 
 		<!-- Messages -->
-		<div class="flex-1 overflow-y-auto mt-4 pb-4" :class="{ 'compact-messages': isExcel }" ref="scrollContainer">
+		<div class="flex-1 overflow-y-auto mt-4 pb-4 chat-messages" :class="{ 'compact-messages': isExcel }" ref="scrollContainer">
 			<div class="ps-3 pe-3 sm:ps-4 sm:pe-2 pb-[3px] max-w-2xl w-full mx-auto">
 
 				<!-- Forked queries panel (shown for forked reports) -->
@@ -134,7 +134,7 @@
 							<div v-if="isScheduledExpanded(m.id)" class="flex rounded-lg p-1 justify-end">
 								<div class="flex items-start gap-2 max-w-xl w-full mb-4">
 									<div class="flex-1 flex justify-end">
-										<div class="inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start" dir="auto">
+										<div class="user-bubble inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start" dir="auto">
 											<div v-if="m.prompt?.content" class="pt-1">
 												<InstructionText
 													:text="m.prompt.content"
@@ -185,7 +185,7 @@
 									<div class="flex items-start gap-2 w-full">
 										<!-- User message bubble -->
 										<div class="flex-1 flex justify-end">
-											<div class="inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start" dir="auto">
+											<div class="user-bubble inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start" dir="auto">
 												<div v-if="m.prompt?.content" class="pt-1">
 													<InstructionText
 														:text="m.prompt.content"
@@ -4234,6 +4234,35 @@ onMounted(async () => {
 }
 .compact-messages li {
 	font-size: 13px;
+}
+
+/* Mobile — larger reading text (excludes Excel compact mode, which can also be narrow) */
+@media (max-width: 767px) {
+	.chat-messages:not(.compact-messages) .block-content {
+		font-size: 15px;
+	}
+	.chat-messages:not(.compact-messages) .markdown-wrapper :deep(.markdown-content) {
+		font-size: 15px;
+	}
+	.chat-messages:not(.compact-messages) .markdown-wrapper :deep(.markdown-content pre code),
+	.chat-messages:not(.compact-messages) .markdown-wrapper :deep(.markdown-content code) {
+		font-size: 13px;
+	}
+	/* User message bubbles (InstructionText renders at 13px by default) */
+	.chat-messages:not(.compact-messages) .user-bubble :deep(.instruction-prose),
+	.chat-messages:not(.compact-messages) .user-bubble :deep(.whitespace-pre-wrap) {
+		font-size: 15px;
+	}
+	/* Collapsible reasoning stays secondary, but readable */
+	.chat-messages:not(.compact-messages) .thinking-header {
+		font-size: 13px;
+	}
+	.chat-messages:not(.compact-messages) .thinking-content,
+	.chat-messages:not(.compact-messages) .thinking-content :deep(*),
+	.chat-messages:not(.compact-messages) .thinking-content :deep(.markdown-content),
+	.chat-messages:not(.compact-messages) .thinking-content :deep(p) {
+		font-size: 13px !important;
+	}
 }
 
 @keyframes simple-ellipsis { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }


### PR DESCRIPTION
## Summary
This PR enhances the mobile experience in the reports page by improving text readability on smaller screens and refining the mobile tab navigation styling.

## Key Changes

### Mobile Text Readability (reports/[id]/index.vue)
- Added `chat-messages` class to the messages container for better CSS targeting
- Introduced comprehensive mobile media query styles (`@media (max-width: 767px)`) that increase font sizes for better readability on mobile devices:
  - Main content blocks: increased from default to 15px
  - Markdown content: increased to 15px (code blocks remain at 13px for compactness)
  - User message bubbles: increased to 15px for better legibility
  - Thinking/reasoning sections: kept at 13px as secondary content
- Styles exclude Excel compact mode to maintain its intended narrow layout
- Added `user-bubble` class to user message elements for targeted styling

### Mobile Tab Navigation (ReportHeader.vue)
- Updated tab button styling for better mobile UX:
  - Increased padding and text size (`text-xs` instead of `text-[11px]`)
  - Improved spacing between icon and label (`gap-1.5`)
  - Increased icon size from 3x3 to 4x4 for better touch targets
  - Dynamic padding: active tabs get `px-3`, inactive tabs get `px-2.5`
- Enhanced accessibility:
  - Added `aria-label` and `title` attributes to tab buttons
  - Tab labels now only display when the tab is active, reducing visual clutter on mobile
  - Icon is marked as `flex-shrink-0` to maintain consistent sizing

## Implementation Details
- The mobile readability improvements use CSS media queries to avoid affecting desktop or Excel compact views
- Tab styling uses conditional classes to provide visual feedback while maintaining a cleaner mobile interface
- All changes are backward compatible and don't affect existing functionality

https://claude.ai/code/session_01Mq1JqVYFar7zG68F2eysC7