### PR TITLE
Stop content-indexing file sources during connection tests

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -97,6 +97,29 @@ def _looks_like_auth_challenge(message: str | None) -> bool:
     return any(marker in lowered for marker in _AUTH_CHALLENGE_MARKERS)
 
 
+async def _acount_files_for_validation(client) -> int | None:
+    """Metadata-only file count for validating a file source, or None for
+    non-file clients (callers fall through to get_schemas()).
+
+    File-source clients content-index inside get_schemas(): with the default
+    'content' index mode every PDF/Office document in the source is parsed for
+    keywords — minutes of sequential extraction on a directory full of PDFs —
+    and the connection test only uses len() of the result (real indexing
+    re-runs on save anyway). A plain listing proves connectivity and access
+    just as well. Gated on LIST_FILES-without-QUERY so a hybrid client that
+    also exposes a tabular schema still gets full schema validation.
+    """
+    import asyncio
+
+    from app.data_sources.clients.base import Capability
+
+    caps = getattr(client, "capabilities", None) or set()
+    if Capability.LIST_FILES not in caps or Capability.QUERY in caps:
+        return None
+    files = await asyncio.to_thread(client.list_files)
+    return sum(1 for f in files or [] if not f.get("is_folder"))
+
+
 def _connected_message(connection_type: str, table_count: int) -> str:
     """Build the success message after a connection test.
 
@@ -1399,6 +1422,14 @@ class ConnectionService:
     async def _avalidate_schema_access(self, client) -> dict:
         """Validate that we can read schema metadata (async, offloads to thread)."""
         try:
+            # File sources: count via a metadata-only listing instead of
+            # get_schemas(), which would content-extract every document just to
+            # be len()'d here. An empty-but-readable directory is a valid file
+            # connection (files can arrive later), so zero is a pass.
+            file_count = await _acount_files_for_validation(client)
+            if file_count is not None:
+                return {"success": True, "table_count": file_count}
+
             tables = None
             if hasattr(client, "aget_schemas"):
                 tables = await client.aget_schemas()

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1836,6 +1836,14 @@ class DataSourceService:
         Returns a dict with success status, table count, and optional error message.
         """
         try:
+            # File sources: count via a metadata-only listing instead of
+            # get_schemas(), which would content-extract every PDF/Office doc
+            # just to be len()'d here (real indexing re-runs on save).
+            from app.services.connection_service import _acount_files_for_validation
+            file_count = await _acount_files_for_validation(client)
+            if file_count is not None:
+                return {"success": True, "table_count": file_count}
+
             # Try aget_schemas first (most clients), fall back to get_tables
             tables = None
             if hasattr(client, "aget_schemas"):

--- a/backend/tests/unit/test_schema_validation_file_fast_path.py
+++ b/backend/tests/unit/test_schema_validation_file_fast_path.py
@@ -1,0 +1,95 @@
+"""Connection-test schema validation must not content-index file sources.
+
+The pre-save connection tests (test_new_data_source_connection /
+test_connection_params) validate "schema access" via _avalidate_schema_access.
+For file sources that used to mean get_schemas(), which with the default
+'content' index mode extracts text from every PDF/Office document in the
+directory — minutes of sequential pypdf work whose output the test discards
+after len(). These tests pin the fast path: a metadata-only listing counts the
+files, and no document extraction runs at all.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.data_sources.clients.base import Capability
+from app.data_sources.clients.network_dir_client import NetworkDirClient
+from app.services.connection_service import (
+    ConnectionService,
+    _acount_files_for_validation,
+)
+from app.services.data_source_service import DataSourceService
+
+
+@pytest.fixture()
+def pdf_dir(tmp_path: Path) -> Path:
+    (tmp_path / "report.pdf").write_bytes(b"%PDF-1.4 not a real pdf")
+    (tmp_path / "notes.txt").write_text("misc notes\n")
+    sub = tmp_path / "decks"
+    sub.mkdir()
+    (sub / "q3.pdf").write_bytes(b"%PDF-1.4 also fake")
+    return tmp_path
+
+
+@pytest.fixture()
+def forbid_extraction(monkeypatch):
+    """Any document-text extraction during the connection test is the bug."""
+    def _boom(*_a, **_k):
+        raise AssertionError("connection test must not extract document content")
+
+    monkeypatch.setattr(
+        "app.data_sources.clients.network_dir_client.extract_document_text", _boom
+    )
+
+
+def _client(pdf_dir: Path) -> NetworkDirClient:
+    # 'content' is the default index mode — the exact config that made the
+    # old path parse every PDF.
+    return NetworkDirClient(root_path=str(pdf_dir), index_mode="content")
+
+
+@pytest.mark.asyncio
+async def test_count_helper_lists_without_extraction(pdf_dir, forbid_extraction):
+    assert await _acount_files_for_validation(_client(pdf_dir)) == 3
+
+
+@pytest.mark.asyncio
+async def test_count_helper_skips_tabular_clients():
+    class FakeSQLClient:
+        capabilities = {Capability.QUERY}
+
+    assert await _acount_files_for_validation(FakeSQLClient()) is None
+
+
+@pytest.mark.asyncio
+async def test_count_helper_skips_hybrid_clients():
+    """A client with a tabular schema alongside files keeps full validation."""
+    class HybridClient:
+        capabilities = {Capability.QUERY, Capability.LIST_FILES}
+
+    assert await _acount_files_for_validation(HybridClient()) is None
+
+
+@pytest.mark.asyncio
+async def test_data_source_service_validates_via_listing(pdf_dir, forbid_extraction):
+    status = await DataSourceService()._avalidate_schema_access(_client(pdf_dir))
+    assert status == {"success": True, "table_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_connection_service_validates_via_listing(pdf_dir, forbid_extraction):
+    status = await ConnectionService()._avalidate_schema_access(_client(pdf_dir))
+    assert status == {"success": True, "table_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_empty_directory_is_a_valid_file_source(tmp_path):
+    """Files can arrive later — an empty-but-readable dir must not fail the
+    'no tables found' check meant for databases."""
+    status = await ConnectionService()._avalidate_schema_access(
+        NetworkDirClient(root_path=str(tmp_path))
+    )
+    assert status["success"] is True
+    assert status["table_count"] == 0


### PR DESCRIPTION
## Problem

Testing a new `network_dir` connection on a directory full of PDFs takes minutes. The pre-save test paths (`test_new_data_source_connection` and `ConnectionService.test_connection_params`) validate "schema access" via `_avalidate_schema_access` → `get_schemas()`. For file sources with the default `index_mode: "content"`, `get_schemas()` content-indexes the whole directory: every PDF/Word/PowerPoint/Excel file is parsed for keywords (`pypdf` extracts up to 200 pages per PDF, sequentially, one file at a time) — and the connection test then only calls `len()` on the result and throws the extraction away. The real indexing re-runs on save anyway, so all that work was pure waste.

## Fix

Both `_avalidate_schema_access` implementations (in `data_source_service.py` and `connection_service.py`) now take a fast path for file sources: a shared helper `_acount_files_for_validation` counts files via a metadata-only `list_files()` (stat-level walk / object listing, no content reads). The fast path is gated on `Capability.LIST_FILES` without `Capability.QUERY`, so a hybrid client that also exposes a tabular schema still gets full schema validation.

Applies to all pure file sources: `network_dir`, `s3`, SharePoint/OneDrive (Graph), Google Drive, Graph Mail.

## Behavior notes

- An empty-but-readable directory now **passes** the connection test with a count of 0 (files can arrive later; `NetworkDirClient.test_connection()` already treats it as success). Previously `ConnectionService._avalidate_schema_access` failed it with the database-oriented "Connected but no tables found" message.
- Testing an already-saved connection (`GET /data_sources/{id}/test_connection`) never indexed and is unchanged.

## Testing

- New unit suite `backend/tests/unit/test_schema_validation_file_fast_path.py` (6 tests): pins that the test path performs zero document extraction (monkeypatched extractor raises if called), that tabular/hybrid clients fall through to full schema validation, and that empty directories pass.
- Existing `test_network_dir_client.py`, `test_s3_client.py`, `test_mcp_presets.py`, `test_custom_api_oauth.py` all pass (103 tests).
- `ruff check` on the touched files matches the pre-change baseline (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsgtRVjcPvAREW1pPMCbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUsgtRVjcPvAREW1pPMCbT)_