### PR TITLE
Fix per-user OAuth tool calls running unauthenticated (X create_post 401)

### DIFF
--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -87,6 +87,12 @@ Do not use when:
         db = runtime_ctx.get("db")
         report = runtime_ctx.get("report")
         organization = runtime_ctx.get("organization")
+        # The run's user — needed so per-user OAuth connections (custom_api /
+        # mcp with auth_policy=user_required) resolve THIS user's access token
+        # instead of falling back to the connection's system credentials (which,
+        # for an oauth_app connection, carry no user token → the call goes out
+        # unauthenticated and X returns 401).
+        user = runtime_ctx.get("user") or runtime_ctx.get("current_user")
         if not db or not organization:
             yield ToolEndEvent(
                 type="tool.end",
@@ -189,9 +195,11 @@ Do not use when:
             )
 
             if result is None:
-                # Not an internal tool — call via MCP protocol over HTTP
+                # Not an internal tool — call via MCP protocol over HTTP.
+                # Pass the run's user so per-user OAuth credentials resolve to
+                # their token (system creds carry no user token for oauth_app).
                 service = ConnectionService()
-                client = await service.construct_client(db, connection)
+                client = await service.construct_client(db, connection, user)
                 logger.info(f"execute_mcp: Calling remote MCP: {getattr(client, 'server_url', '?')}")
                 result = await client.acall_tool(data.tool_name, data.arguments)
                 logger.info(f"execute_mcp: Remote call returned success={result.get('success')}, error={result.get('error')}")


### PR DESCRIPTION
## Summary

`create_post` on the **X (Write)** connector failed with `HTTP 401 {"title":"Unauthorized","detail":"Unauthorized"}` even though the user had a valid, non-expired per-user X token. Root cause: agent tool calls on per-user OAuth connections went out **unauthenticated**.

## Root cause

In `execute_mcp`, the external-tool path built the client with:

```python
client = await service.construct_client(db, connection)   # no current_user
```

For a connection with `auth_policy=user_required` (custom_api or mcp `oauth_app`), `resolve_credentials` with no user falls back to the connection's **system** credentials — which for an `oauth_app` connection are just the admin OAuth *client* (`client_id`/`client_secret`), carrying **no user access token**. `CustomApiClient` then sends no `Authorization` header, so `POST /2/tweets` reached X unauthenticated → X's generic `401`.

Diagnosed against production: the X (Write) connection shows `has_user_credentials: true`, `auth_mode: oauth`, `effective_auth: user`, `query_identity: self`, a non-expired token — i.e. a valid token existed and was selected, but the tool-execution path never passed the user to resolve it. A generic `401` (vs a `403` scope error) is exactly X's response to a missing bearer.

## Fix

Pass the run's user — `runtime_ctx["user"]` (the report owner, the same value already used elsewhere in this method and populated in `agent_v2`) — to `construct_client`, so per-user OAuth resolves the caller's token and attaches it as `Bearer`.

- System-only connections are unaffected (`resolve_credentials` ignores the user for them).
- A `user_required` connection with no user token now takes the correct "connect required" path instead of silently calling unauthenticated.

## Tests

- OAuth + MCP e2e suites pass (25) with no regression from threading the user through.
- Final confirmation is the live X post, which requires the deploy + interactive account (can't be driven from CI).

## Note

If, after this deploys, a post returns `403` (not `401`), that would indicate a *different* issue — the X app's User Authentication Settings lacking "Read and write" permission — which is an X-side config change (set write perms, then reconnect to mint a write-capable token). This PR fixes the `401` (no token attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvgAkrxxEpxKKjj5df9cY2)_