### PR TITLE
Clarify that read_artifact reads docs (markdown), not just dashboards

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -290,7 +290,7 @@ Two cases — handle them differently:
 Artifact tool selection:
   - `create_artifact` — brand-new dashboard, rebuild, or large change. **First check past_observations for existing viz_ids. If they cover the ask, go straight here without calling create_data.** Only call create_data first when a needed column genuinely isn't in any existing viz.
   - `edit_artifact` — small/focused change to current dashboard. Needs an `artifact_id`.
-  - `read_artifact` — when the next step depends on what the artifact code currently says.
+  - `read_artifact` — when the next step depends on the artifact's current content. Works on ALL artifact modes: dashboards/slides (returns the JSX code) AND docs (returns the document's markdown in the same `code` field).
   - Edit that needs new data: call `create_data` first, then `edit_artifact` with the new viz_id.
   - `create_doc` / `edit_doc` — WRITTEN documents (see DOCUMENT DELIVERABLES below), not dashboards.
 
@@ -310,7 +310,7 @@ Authoring documents:
   - Deep-dive report: Executive summary (3-5 bullets, numbers inline) → Findings (one section per finding: chart + prose + citation) → Methodology (tables used, definitions, caveats) → Next questions.
   - Executive memo: the answer first, one supporting viz, caveats footnoted. Brevity is the feature.
   - Data audit: Scope → Checks performed → Issues found (each with evidence) → Severity and recommended fixes.
-- Editing: prefer `edit_doc` with surgical `edits` (find/replace; each `find` must match exactly once — quote exact text from the doc). Full `markdown` rewrite only for restructures. Edits are additive by default; preserve title and sections unless asked.
+- Editing: prefer `edit_doc` with surgical `edits` (find/replace; each `find` must match exactly once — quote exact text from the doc). Unless the doc's full current markdown is already in context, call `read_artifact` with the doc's artifact_id first — it returns the markdown, so your `find` strings match. Full `markdown` rewrite only for restructures. Edits are additive by default; preserve title and sections unless asked.
 - Write the doc in the user's language.
 
 ANALYTICAL STANDARDS

--- a/backend/app/ai/tools/implementations/edit_doc.py
+++ b/backend/app/ai/tools/implementations/edit_doc.py
@@ -42,7 +42,10 @@ class EditDocTool(Tool):
         return ToolMetadata(
             name="edit_doc",
             description=(
-                "Edit an existing document created with create_doc. PREFER surgical `edits` "
+                "Edit an existing document created with create_doc. Unless the doc's current markdown "
+                "is already fully visible in context, call read_artifact first (it returns a doc's "
+                "markdown in the `code` field) so your `find` strings quote the exact current text. "
+                "PREFER surgical `edits` "
                 "(find/replace ops — each `find` must match the current markdown exactly once; all ops "
                 "apply atomically). For restructures too large for surgical edits, pass full `markdown` "
                 "instead. Embedded {{viz:<uuid>}} placeholders are re-validated after the edit. "

--- a/backend/app/ai/tools/implementations/read_artifact.py
+++ b/backend/app/ai/tools/implementations/read_artifact.py
@@ -37,8 +37,10 @@ class ReadArtifactTool(Tool):
         return ToolMetadata(
             name="read_artifact",
             description=(
-                "Read an existing dashboard, slides, and artifact's code and metadata from the current report. "
-                "Use this to load previous artifact code into context before modifying with edit_artifact (or create_artifact) or when the user wants to inspect or analyze an existing artifact. "
+                "Read an existing artifact's content and metadata from the current report — dashboards, slides, AND documents (mode='doc'). "
+                "For dashboards/slides the `code` field contains the JSX code; for docs it contains the document's full markdown. "
+                "Use this to load previous artifact content into context before modifying with edit_artifact/create_artifact (dashboards) or edit_doc (documents), or when the user wants to inspect or analyze an existing artifact. "
+                "ALWAYS use this before edit_doc so you can quote exact text for its find/replace edits. "
                 "Use this also if the user is saying something is not working like filters or UI elements are not showing up - to check the existing code and visualizations for debugging. "
                 "ALWAYS use this before editing an artifact (edit_artifact) to have a full view of the existing code, visualizations, and layout. "
                 "If the user refers to a specific version of an artifact, ALWAYS load that version with this tool to have the correct code context for the edit. "


### PR DESCRIPTION
## Summary

`read_artifact` already handles doc artifacts (`mode='doc'`) — it returns the document's markdown in the `code` field — but the tool description and planner prompt only mentioned dashboards/slides, and the `edit_doc` guidance told the planner to quote exact text from the doc without ever saying how to load it. This PR makes the doc path explicit so the planner reliably reads a doc before editing it.

## Changes

- **`read_artifact` tool description**: now states it works on all artifact modes including docs (markdown returned in the `code` field) and to always use it before `edit_doc` to quote exact text for find/replace edits.
- **`edit_doc` tool description**: now instructs calling `read_artifact` first (unless the doc's current markdown is already fully in context) so `find` strings match the current text.
- **v3 planner prompt** (`prompt_builder_v3.py`): the artifact tool-selection list notes `read_artifact` covers docs, and the doc-editing bullet spells out the `read_artifact`-first loading step.

Prompt/description wording only — no behavior change in the tools themselves. The v1 `prompt_builder.py` has no doc-artifact flow, so it's untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVuuYrhqxeLKWmXaCHbNkh

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVuuYrhqxeLKWmXaCHbNkh)_