### PR TITLE
Add persistent uploads volume to the Helm chart

### DIFF
--- a/k8s/AGENTS.md
+++ b/k8s/AGENTS.md
@@ -58,6 +58,12 @@ Concise overview of `@k8s/` with emphasis on the Helm chart layout, how values m
     sync, optional auto-provisioning. Bind password is Secret-only.
 - **ServiceAccount**
   - `serviceAccount.annotations`: Arbitrary annotations map.
+- **Persistence**
+  - `persistence.uploads.enabled`: PVC mounted at `/app/backend/uploads` so
+    uploaded files survive pod restarts/rollouts (default `false` — uploads
+    are ephemeral otherwise). `existingClaim`, `size`, `storageClass`,
+    `accessModes` configure the claim; `ReadWriteOnce` requires a single
+    replica and forces the `Recreate` strategy.
 - **Scheduling**
   - Node selectors/affinity/tolerations can be set (example in README shows `postgresql.primary.nodeSelector`).
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -268,6 +268,45 @@ The bind password is never accepted via `values.yaml` — it must be set as
 `BOW_LDAP_BIND_PASSWORD` in the Secret referenced by `config.secretRef`.
 
 
+### Persistent storage for uploaded files
+
+By default the chart does **not** persist user uploads (CSV/Excel files,
+branding logos, avatars): they live on the pod's ephemeral filesystem under
+`/app/backend/uploads` and are lost on every pod restart or rollout, while
+their database records survive — later reads then fail with
+`No such file or directory`. To keep them, enable the uploads volume:
+
+```bash
+--set persistence.uploads.enabled=true
+```
+
+or in `values.yaml`:
+
+```yaml
+persistence:
+  uploads:
+    enabled: true
+    size: 10Gi
+    storageClass: ""        # empty = cluster default
+    # existingClaim: my-uploads-pvc   # use a pre-created PVC instead
+```
+
+Notes:
+
+- The default `ReadWriteOnce` access mode means the volume attaches to a
+  single pod: the chart requires `replicaCount: 1` with autoscaling disabled
+  (rendering fails otherwise) and defaults the deployment strategy to
+  `Recreate` so upgrades don't deadlock waiting for the volume. To run
+  multiple replicas, use a `ReadWriteMany`-capable storage class (EFS, NFS,
+  Azure Files, …) and set `persistence.uploads.accessModes={ReadWriteMany}`.
+- The created PVC is annotated `helm.sh/resource-policy: keep`, so
+  `helm uninstall` leaves it (and your files) in place. Delete it manually if
+  you really want the data gone.
+- An init container seeds the empty volume with the directory layout the app
+  expects and hands ownership to the app user. It runs as root; if your
+  cluster's pod security policy forbids that, pre-provision a writable PVC
+  and pass it via `persistence.uploads.existingClaim`.
+
 ### Service Account annotations
 For adding a SA annotation pass the following flag during `helm install` command
 `--set serviceAccount.annotations.foo=bar`

--- a/k8s/chart/CHANGELOG.md
+++ b/k8s/chart/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.1.0
+
+### Added: persistent storage for uploaded files
+
+Previously the chart mounted no volume for `/app/backend/uploads`, so user
+uploads (CSV/Excel files, branding logos, avatars) lived on the pod's
+ephemeral filesystem and were lost on every pod restart or rollout — while
+their database records survived, causing later reads to fail with
+`No such file or directory`.
+
+- New `persistence.uploads` values: `enabled` (default `false`),
+  `existingClaim`, `size`, `storageClass`, `accessModes`, `annotations`.
+- When enabled, the chart creates a PVC (or uses `existingClaim`) mounted at
+  `/app/backend/uploads`, and an init container seeds the expected
+  `files/branding/avatars` subdirectories with `app`-user ownership.
+- With the default `ReadWriteOnce` access mode, the deployment strategy
+  defaults to `Recreate` (unless `strategy` is set explicitly) so upgrades
+  don't deadlock on the volume attachment, and rendering fails if
+  `replicaCount > 1` or `autoscaling.enabled=true`. Use a `ReadWriteMany`
+  storage class for multi-replica setups.
+- The created PVC carries `helm.sh/resource-policy: keep` by default so
+  `helm uninstall` does not delete uploaded files.
+- `NOTES.txt` now warns that uploads are ephemeral when persistence is off.
+
 ## 2.0.0 — Breaking change
 
 ### ⚠ Breaking: Deployment selector labels changed

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bagofwords
 description: Bag of words - a new ai data tool
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: 1.0.1
 dependencies:
   - name: postgresql

--- a/k8s/chart/README.md
+++ b/k8s/chart/README.md
@@ -1,6 +1,6 @@
 # bagofwords
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 Bag of words - a new ai data tool
 
@@ -107,6 +107,13 @@ Bag of words - a new ai data tool
 | networkPolicy.enabled | bool | `false` |  |
 | networkPolicy.ingress | list | `[]` |  |
 | nodeSelector | object | `{}` | Node selector for the app pod. Does NOT affect the bundled PostgreSQL pod (use postgresql.primary.nodeSelector for that). |
+| persistence | object | `{"uploads":{"accessModes":["ReadWriteOnce"],"annotations":{"helm.sh/resource-policy":"keep"},"enabled":false,"existingClaim":"","size":"10Gi","storageClass":""}}` | Persistent storage for user-uploaded content (`/app/backend/uploads`: file uploads, branding logos, user avatars). When disabled, uploads live on the pod's ephemeral filesystem and are LOST on every pod restart or rollout, while their database records survive — later reads then fail with "No such file or directory". |
+| persistence.uploads.accessModes | list | `["ReadWriteOnce"]` | Access modes for the created PVC. Use `ReadWriteMany` (on storage that supports it, e.g. EFS/NFS) to allow multiple replicas or autoscaling. |
+| persistence.uploads.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Annotations for the created PVC. `helm.sh/resource-policy: keep` prevents `helm uninstall` from deleting uploaded files; remove it if the PVC should be removed with the release. |
+| persistence.uploads.enabled | bool | `false` | Create a PersistentVolumeClaim and mount it at `/app/backend/uploads`. With the default `ReadWriteOnce` access mode the volume cannot be shared across pods: rendering fails unless `replicaCount` is 1 and `autoscaling.enabled` is false, and the deployment strategy defaults to `Recreate` so upgrades don't deadlock on the volume attachment. |
+| persistence.uploads.existingClaim | string | `""` | Name of an existing PVC to use instead of creating one. Must exist in the release namespace. The app runs as the non-root `app` user, so the volume must be writable by it (the chart's init container handles this). |
+| persistence.uploads.size | string | `"10Gi"` | Requested storage size for the created PVC. |
+| persistence.uploads.storageClass | string | `""` | StorageClass for the created PVC. Leave empty for the cluster default. |
 | podAnnotations | object | `{}` | Annotations added to every pod (not the Deployment metadata). |
 | podDisruptionBudget.enabled | bool | `false` |  |
 | podDisruptionBudget.minAvailable | string | `"50%"` |  |

--- a/k8s/chart/templates/NOTES.txt
+++ b/k8s/chart/templates/NOTES.txt
@@ -56,6 +56,16 @@ WARNING: plaintext sensitive values detected in values:
   ...with a Secret named "bowapp-secrets" containing key BOW_GOOGLE_CLIENT_SECRET.
 {{- end }}
 
+{{- if not .Values.persistence.uploads.enabled }}
+
+NOTE: uploaded files are not persisted.
+  persistence.uploads.enabled is false, so user uploads (CSV/Excel files,
+  branding logos, avatars) live on the pod's ephemeral filesystem and are
+  lost on every pod restart or rollout — their database records survive, so
+  later reads of those files fail. To keep them:
+    --set persistence.uploads.enabled=true
+{{- end }}
+
 {{- if .Values.config.ldap.enabled }}
 
 LDAP is enabled. Make sure config.secretRef points to a Secret containing

--- a/k8s/chart/templates/deployment.yaml
+++ b/k8s/chart/templates/deployment.yaml
@@ -1,3 +1,10 @@
+{{- $uploads := .Values.persistence.uploads -}}
+{{- $uploadsRWX := has "ReadWriteMany" $uploads.accessModes -}}
+{{- if and $uploads.enabled (not $uploadsRWX) }}
+{{- if or (gt (int .Values.replicaCount) 1) .Values.autoscaling.enabled }}
+{{- fail "persistence.uploads: a ReadWriteOnce uploads volume cannot be shared across pods. Set replicaCount=1 and autoscaling.enabled=false, or use a ReadWriteMany-capable storageClass and set persistence.uploads.accessModes=[ReadWriteMany]." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,9 +18,14 @@ spec:
   selector:
     matchLabels:
       {{- include "bowapp.selectorLabels" . | nindent 6 }}
-  {{- with .Values.strategy }}
+  {{- if .Values.strategy }}
   strategy:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- else if and $uploads.enabled (not $uploadsRWX) }}
+  # A ReadWriteOnce uploads volume can't be attached to old and new pods at
+  # once during a rolling update, so replace the pod instead.
+  strategy:
+    type: Recreate
   {{- end }}
   template:
     metadata:
@@ -48,9 +60,28 @@ spec:
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- with .Values.initContainers }}
+      {{- if or $uploads.enabled .Values.initContainers }}
       initContainers:
+        {{- if $uploads.enabled }}
+        # A fresh PVC mounts empty and root-owned, but the app runs as the
+        # non-root "app" user and expects the uploads/* layout baked into the
+        # image (hidden by the mount). Seed it before the app starts.
+        - name: init-uploads
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - mkdir -p /uploads/files /uploads/branding /uploads/avatars && chown app:app /uploads /uploads/files /uploads/branding /uploads/avatars
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: uploads
+              mountPath: /uploads
+        {{- end }}
+        {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ include "bowapp.name" . }}
@@ -100,6 +131,10 @@ spec:
             - name: bow-config
               mountPath: /app/bow-config.yaml
               subPath: bowConfig
+            {{- if $uploads.enabled }}
+            - name: uploads
+              mountPath: /app/backend/uploads
+            {{- end }}
             {{- if .Values.database.auth.sslRootCert.secretName }}
             - name: db-ca-cert
               mountPath: /app/certs
@@ -115,6 +150,11 @@ spec:
         - name: bow-config
           configMap:
             name: {{ include "bowapp.name" . }}
+        {{- if $uploads.enabled }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ $uploads.existingClaim | default (printf "%s-uploads" (include "bowapp.name" .)) }}
+        {{- end }}
         {{- if .Values.database.auth.sslRootCert.secretName }}
         - name: db-ca-cert
           secret:

--- a/k8s/chart/templates/pvc.yaml
+++ b/k8s/chart/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.uploads.enabled (not .Values.persistence.uploads.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "bowapp.name" . }}-uploads
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bowapp.labels" . | nindent 4 }}
+  {{- with .Values.persistence.uploads.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.uploads.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.uploads.size }}
+  {{- with .Values.persistence.uploads.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/k8s/chart/tests/deployment_test.yaml
+++ b/k8s/chart/tests/deployment_test.yaml
@@ -49,3 +49,109 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 500m
+
+  - it: has no uploads volume or init container by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.strategy
+
+  - it: mounts the uploads volume when persistence is enabled
+    set:
+      persistence.uploads.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uploads
+            persistentVolumeClaim:
+              claimName: test-release-uploads
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: uploads
+            mountPath: /app/backend/uploads
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-uploads
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: uses an existing claim when provided
+    set:
+      persistence.uploads.enabled: true
+      persistence.uploads.existingClaim: my-uploads
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uploads
+            persistentVolumeClaim:
+              claimName: my-uploads
+
+  - it: keeps an explicit strategy over the Recreate default
+    set:
+      persistence.uploads.enabled: true
+      strategy.type: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: does not force Recreate for a ReadWriteMany volume
+    set:
+      persistence.uploads.enabled: true
+      persistence.uploads.accessModes:
+        - ReadWriteMany
+    asserts:
+      - notExists:
+          path: spec.strategy
+
+  - it: keeps user initContainers alongside the uploads init container
+    set:
+      persistence.uploads.enabled: true
+      initContainers:
+        - name: my-init
+          image: busybox
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-uploads
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: my-init
+
+  - it: fails with multiple replicas on a ReadWriteOnce volume
+    set:
+      persistence.uploads.enabled: true
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot be shared across pods"
+
+  - it: fails with autoscaling on a ReadWriteOnce volume
+    set:
+      persistence.uploads.enabled: true
+      autoscaling.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot be shared across pods"
+
+  - it: allows multiple replicas with a ReadWriteMany volume
+    set:
+      persistence.uploads.enabled: true
+      persistence.uploads.accessModes:
+        - ReadWriteMany
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/k8s/chart/tests/pvc_test.yaml
+++ b/k8s/chart/tests/pvc_test.yaml
@@ -1,0 +1,66 @@
+suite: test pvc
+templates:
+  - pvc.yaml
+release:
+  name: test-release
+chart:
+  appVersion: 0.0.1-test
+set:
+  postgresql.auth.username: test
+  postgresql.auth.password: test
+  postgresql.auth.database: testdb
+tests:
+  - it: is absent by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when enabled
+    set:
+      persistence.uploads.enabled: true
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-release-uploads
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: test-release
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+      - notExists:
+          path: spec.storageClassName
+
+  - it: honors size, storageClass and accessModes
+    set:
+      persistence.uploads.enabled: true
+      persistence.uploads.size: 50Gi
+      persistence.uploads.storageClass: efs-sc
+      persistence.uploads.accessModes:
+        - ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+      - equal:
+          path: spec.storageClassName
+          value: efs-sc
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany
+
+  - it: is absent when an existing claim is provided
+    set:
+      persistence.uploads.enabled: true
+      persistence.uploads.existingClaim: my-uploads
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/k8s/chart/values.schema.json
+++ b/k8s/chart/values.schema.json
@@ -219,6 +219,28 @@
         "ingress": { "type": "array" },
         "egress": { "type": "array" }
       }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uploads": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "size": { "type": "string" },
+            "storageClass": { "type": "string" },
+            "accessModes": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "annotations": { "type": "object", "additionalProperties": true }
+          }
+        }
+      }
     }
   }
 }

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -393,3 +393,37 @@ networkPolicy:
   #       port: 3000
   egress: []
 
+##########################################################
+# Persistence
+##########################################################
+# -- Persistent storage for user-uploaded content (`/app/backend/uploads`:
+# file uploads, branding logos, user avatars). When disabled, uploads live on
+# the pod's ephemeral filesystem and are LOST on every pod restart or rollout,
+# while their database records survive — later reads then fail with
+# "No such file or directory".
+persistence:
+  uploads:
+    # -- Create a PersistentVolumeClaim and mount it at `/app/backend/uploads`.
+    # With the default `ReadWriteOnce` access mode the volume cannot be shared
+    # across pods: rendering fails unless `replicaCount` is 1 and
+    # `autoscaling.enabled` is false, and the deployment strategy defaults to
+    # `Recreate` so upgrades don't deadlock on the volume attachment.
+    enabled: false
+    # -- Name of an existing PVC to use instead of creating one. Must exist in
+    # the release namespace. The app runs as the non-root `app` user, so the
+    # volume must be writable by it (the chart's init container handles this).
+    existingClaim: ""
+    # -- Requested storage size for the created PVC.
+    size: 10Gi
+    # -- StorageClass for the created PVC. Leave empty for the cluster default.
+    storageClass: ""
+    # -- Access modes for the created PVC. Use `ReadWriteMany` (on storage that
+    # supports it, e.g. EFS/NFS) to allow multiple replicas or autoscaling.
+    accessModes:
+      - ReadWriteOnce
+    # -- Annotations for the created PVC. `helm.sh/resource-policy: keep`
+    # prevents `helm uninstall` from deleting uploaded files; remove it if the
+    # PVC should be removed with the release.
+    annotations:
+      helm.sh/resource-policy: keep
+


### PR DESCRIPTION
The chart mounted no volume for /app/backend/uploads, so user uploads
(CSV/Excel files, branding logos, avatars) lived on the pod's ephemeral
filesystem and were lost on every pod restart or rollout — while their
database records survived, causing later reads to fail with
"No such file or directory".

New persistence.uploads values (disabled by default) create a PVC — or
use an existing claim — mounted at /app/backend/uploads. An init
container seeds the empty volume with the files/branding/avatars layout
the backend expects and hands ownership to the non-root app user, since
the main upload path does not create directories itself.

With the default ReadWriteOnce access mode the volume cannot be shared
across pods, so the chart fails rendering when replicaCount > 1 or
autoscaling is enabled, and defaults the deployment strategy to
Recreate so upgrades don't deadlock on the volume attachment. A
ReadWriteMany access mode lifts both restrictions. The created PVC
carries helm.sh/resource-policy: keep so helm uninstall doesn't delete
uploaded files, and NOTES.txt now warns when uploads are ephemeral.

Chart version 2.0.0 -> 2.1.0.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DeDpQWVhRkPQf741ndwjPD