### PR TITLE
Incremental network_dir indexing: skip unchanged files, report progress

### DIFF
--- a/backend/app/data_sources/clients/base.py
+++ b/backend/app/data_sources/clients/base.py
@@ -36,18 +36,18 @@ class Capability(str, Enum):
     WRITE_FILE = "write_file"
 
 
-def _accepts_progress_callback(fn) -> bool:
-    """Inspect a `get_schemas`-like method to see if it accepts a
-    `progress_callback` kwarg. Used by the async wrapper so we don't catch a
-    bare `TypeError` raised from inside the call (which would mask real bugs
-    inside the client).
+def _accepts_kwarg(fn, name: str) -> bool:
+    """Inspect a `get_schemas`-like method to see if it accepts the given
+    kwarg (`progress_callback`, `prior_catalog`, …). Used by the async wrapper
+    so we don't catch a bare `TypeError` raised from inside the call (which
+    would mask real bugs inside the client).
     """
     try:
         sig = inspect.signature(fn)
     except (TypeError, ValueError):
         return False
     params = sig.parameters
-    if "progress_callback" in params:
+    if name in params:
         return True
     # Accept anything with **kwargs since it'll silently ignore the kwarg.
     return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
@@ -114,17 +114,29 @@ class DataSourceClient(ABC):
     async def atest_connection(self):
         return await asyncio.to_thread(self.test_connection)
 
-    async def aget_schemas(self, progress_callback: Optional[ProgressCallback] = None):
-        """Forwards `progress_callback` to the sync `get_schemas` only if it
-        accepts the kwarg, determined by signature introspection.
+    async def aget_schemas(
+        self,
+        progress_callback: Optional[ProgressCallback] = None,
+        prior_catalog: "dict | None" = None,
+    ):
+        """Forwards `progress_callback` / `prior_catalog` to the sync
+        `get_schemas` only if it accepts each kwarg, determined by signature
+        introspection. `prior_catalog` is the previous run's
+        `{table_name: metadata_json}` — file-source clients use it to skip
+        re-extracting unchanged files (incremental indexing).
 
         We do NOT catch a bare `TypeError` from the call: a real `TypeError`
         from inside `get_schemas` (e.g. a bug in a client) should surface,
         not be silently retried without progress.
         """
-        if progress_callback is None or not _accepts_progress_callback(self.get_schemas):
+        kwargs = {}
+        if progress_callback is not None and _accepts_kwarg(self.get_schemas, "progress_callback"):
+            kwargs["progress_callback"] = progress_callback
+        if prior_catalog and _accepts_kwarg(self.get_schemas, "prior_catalog"):
+            kwargs["prior_catalog"] = prior_catalog
+        if not kwargs:
             return await asyncio.to_thread(self.get_schemas)
-        return await asyncio.to_thread(self.get_schemas, progress_callback=progress_callback)
+        return await asyncio.to_thread(self.get_schemas, **kwargs)
 
     async def aget_schema(self, table_name):
         return await asyncio.to_thread(self.get_schema, table_name)

--- a/backend/app/data_sources/clients/network_dir_client.py
+++ b/backend/app/data_sources/clients/network_dir_client.py
@@ -656,7 +656,17 @@ class NetworkDirClient(DataSourceClient):
         except Exception as e:
             return {"success": False, "message": str(e)}
 
-    def get_schemas(self, progress_callback=None) -> List[Table]:
+    @staticmethod
+    def _prior_meta(prior_catalog: dict[str, Any] | None, name: str) -> dict:
+        """The previous run's `network_dir` metadata for a catalog row, or {}."""
+        entry = (prior_catalog or {}).get(name)
+        if isinstance(entry, dict):
+            meta = entry.get("network_dir")
+            if isinstance(meta, dict):
+                return meta
+        return {}
+
+    def get_schemas(self, progress_callback=None, prior_catalog=None) -> List[Table]:
         """Index the directory into catalog rows per the connection's index tier:
 
         - `none`     → no catalog at all (listing/search go live at the tool
@@ -664,13 +674,27 @@ class NetworkDirClient(DataSourceClient):
         - `metadata` → one row per file with name/size/mtime, NO content read.
         - `content`  → metadata + extracted keywords/hash so search_files can
                        match by topic without re-parsing every file.
+
+        `prior_catalog` ({table_name: metadata_json} from the previous index
+        run) makes content indexing INCREMENTAL: a file whose size+mtime match
+        its prior row reuses the stored keywords/hash instead of re-extracting
+        — so a scheduled reindex of an unchanged PDF archive is a stat-only
+        walk, not hours of pypdf. `progress_callback` gets a per-file tick,
+        which doubles as the cancellation checkpoint (the indexing runner's
+        callback raises IndexingCancelled once a cancel is requested).
         """
+        from app.data_sources.clients.progress import make_reporter
+
         if self.index_mode == INDEX_NONE:
             # Live mode: nothing is cached; the tool layer lists/reads directly.
             return []
         root = self._root()
+        files = self.list_files(recursive=self.recursive)
+        reporter = make_reporter(progress_callback)
+        reporter.phase("indexing files", total=len(files))
         tables: List[Table] = []
-        for f in self.list_files(recursive=self.recursive):
+        for f in files:
+            name = f["path"] or f["name"]
             meta = {
                 "file_id": f["id"],
                 "mime_type": f.get("mime_type"),
@@ -682,26 +706,42 @@ class NetworkDirClient(DataSourceClient):
                 f"File '{f['name']}' (type: {f.get('mime_type') or _ext(f['name']) or 'unknown'})."
             )
             if self.index_content:
-                try:
-                    path = root / f["id"]
-                    text = self._file_text(path)
-                    meta["keywords"] = extract_keywords(text, f["name"], self.max_keywords)
-                    meta["content_hash"] = hashlib.sha1(
-                        (text or "").encode("utf-8", "ignore")
-                    ).hexdigest() if text else None
+                prior = self._prior_meta(prior_catalog, name)
+                if (
+                    prior.get("indexed")
+                    and prior.get("size") == f.get("size")
+                    and prior.get("modified_at") == f.get("modified_at")
+                ):
+                    # Unchanged since the last run — reuse the stored keywords
+                    # and hash instead of re-reading/re-parsing the file.
+                    meta["keywords"] = prior.get("keywords") or []
+                    meta["content_hash"] = prior.get("content_hash")
                     meta["indexed"] = True
-                    if meta["keywords"]:
-                        description += " Keywords: " + ", ".join(meta["keywords"][:15]) + "."
-                except Exception:
-                    meta["indexed"] = False
+                else:
+                    try:
+                        path = root / f["id"]
+                        text = self._file_text(path)
+                        meta["keywords"] = extract_keywords(text, f["name"], self.max_keywords)
+                        meta["content_hash"] = hashlib.sha1(
+                            (text or "").encode("utf-8", "ignore")
+                        ).hexdigest() if text else None
+                        meta["indexed"] = True
+                    except Exception:
+                        meta["indexed"] = False
+                if meta.get("keywords"):
+                    description += " Keywords: " + ", ".join(meta["keywords"][:15]) + "."
             tables.append(Table(
-                name=f["path"] or f["name"],
+                name=name,
                 description=description,
                 columns=[],
                 pks=[],
                 fks=[],
                 metadata_json={"network_dir": meta},
             ))
+            # Per-file progress tick — also the cancel checkpoint: the runner's
+            # callback raises IndexingCancelled here once a cancel is requested.
+            reporter.tick(f["id"])
+        reporter.done()
         if self._last_walk_truncated:
             import logging
             logging.getLogger(__name__).warning(

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload, lazyload
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
+from app.data_sources.clients.progress import IndexingCancelled
 from app.models.connection import Connection
 from app.models.connection_table import ConnectionTable
 from app.models.connection_tool import ConnectionTool
@@ -1013,11 +1014,27 @@ class ConnectionService:
                     return []
 
             client = await self.construct_client(db, connection, current_user)
+
+            # Load the existing catalog up front: it powers BOTH the upsert diff
+            # below AND incremental indexing — file-source clients whose
+            # get_schemas accepts `prior_catalog` reuse stored keywords/hashes
+            # for unchanged files instead of re-extracting every document
+            # (base.aget_schemas only forwards the kwarg to clients that take it).
+            connection_id_str = str(connection.id)
+            existing_q = await db.execute(
+                select(ConnectionTable)
+                .filter(ConnectionTable.connection_id == connection_id_str)
+            )
+            existing_tables = {t.name: t for t in existing_q.scalars().all()}
+            prior_catalog = {
+                name: t.metadata_json for name, t in existing_tables.items()
+                if t.metadata_json
+            }
+
             logger.info(f"refresh_schema: Client constructed successfully, calling get_schemas()...")
-            if progress_callback is not None:
-                fresh_tables = await client.aget_schemas(progress_callback=progress_callback)
-            else:
-                fresh_tables = await client.aget_schemas()
+            fresh_tables = await client.aget_schemas(
+                progress_callback=progress_callback, prior_catalog=prior_catalog
+            )
 
             logger.info(f"refresh_schema: Got {len(fresh_tables) if fresh_tables else 0} tables from database")
             if fresh_tables and len(fresh_tables) > 0:
@@ -1071,15 +1088,8 @@ class ConnectionService:
                         "metadata_json": getattr(t, "metadata_json", None),
                     }
 
-            # Get existing tables - ensure connection_id is string
-            connection_id_str = str(connection.id)
-            logger.info(f"refresh_schema: Looking for existing tables with connection_id={connection_id_str}")
-
-            existing_q = await db.execute(
-                select(ConnectionTable)
-                .filter(ConnectionTable.connection_id == connection_id_str)
-            )
-            existing_tables = {t.name: t for t in existing_q.scalars().all()}
+            # Existing tables were loaded before schema discovery (they also
+            # feed `prior_catalog` for incremental file indexing).
             logger.info(f"refresh_schema: Found {len(existing_tables)} existing ConnectionTable records")
 
             # Upsert tables
@@ -1155,6 +1165,11 @@ class ConnectionService:
 
             return final_tables
 
+        except IndexingCancelled:
+            # Cancellation is control flow, not a failure: let it reach the
+            # indexing runner so the run is finalized as `cancelled` — wrapping
+            # it in the generic 500 below would mark the run failed instead.
+            raise
         except Exception as e:
             logger.error(f"Error refreshing schema for connection {connection.id}: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to refresh schema: {e}")

--- a/backend/scripts/bench_network_dir_indexing.py
+++ b/backend/scripts/bench_network_dir_indexing.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+"""Benchmark network_dir content indexing: cold index vs re-index of an
+UNCHANGED directory, with and without the incremental `prior_catalog` skip.
+
+Generates a corpus of REAL multi-page PDFs (matplotlib PDF backend — selectable
+text, so pypdf extraction does real work) plus some txt/csv, then measures:
+
+  run 1  cold index (every file extracted)
+  run 2  re-index without a prior catalog — the pre-incremental behavior,
+         which re-extracted everything on every scheduled reindex
+  run 3  re-index WITH the prior catalog — what refresh_schema passes now;
+         unchanged files reuse stored keywords/hashes (stat-only walk)
+
+and asserts run 3 produces a catalog identical to run 1 (same files, same
+keywords, same content hashes).
+
+Usage:
+    cd backend
+    uv run python scripts/bench_network_dir_indexing.py /tmp/bench_corpus --pdfs 200
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import textwrap
+import time
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+from app.data_sources.clients.network_dir_client import NetworkDirClient
+
+VENDORS = ["Acme Corp", "Globex", "Initech", "Umbrella", "Soylent",
+           "Stark Industries", "Wayne Enterprises", "Cyberdyne"]
+CLAUSES = ["indemnity", "auto-renewal", "arbitration", "force majeure",
+           "limitation of liability", "data protection"]
+LOREM = (
+    "The parties acknowledge that continued performance under this agreement "
+    "requires timely delivery of services, quarterly reconciliation of invoices, "
+    "and adherence to the governing service levels. "
+)
+
+
+def _make_pdf(path: Path, title: str, pages: int, rng: random.Random) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(path) as pdf:
+        for p in range(pages):
+            fig = plt.figure(figsize=(8.5, 11))
+            fig.text(0.08, 0.94, f"{title} — page {p + 1}", fontsize=14, weight="bold")
+            body = [
+                f"Section {p + 1}.{i + 1}: {rng.choice(CLAUSES)} clause. "
+                f"Contract value ${rng.randint(50_000, 5_000_000):,}. " + LOREM
+                for i in range(6)
+            ]
+            fig.text(0.08, 0.88, "\n".join(textwrap.fill(t, width=95) for t in body),
+                     fontsize=9, va="top")
+            pdf.savefig(fig)
+            plt.close(fig)
+
+
+def generate_corpus(root: Path, pdfs: int, pages: int, others: int) -> int:
+    rng = random.Random(1234)
+    for i in range(pdfs):
+        vendor = VENDORS[i % len(VENDORS)]
+        slug = vendor.lower().replace(" ", "_")
+        _make_pdf(root / f"contracts/{i // 200:02d}" / f"msa_{slug}_{i:04d}.pdf",
+                  f"Master Services Agreement — {vendor} #{i:04d}", pages, rng)
+        if (i + 1) % 100 == 0:
+            print(f"  corpus: {i + 1}/{pdfs} PDFs")
+    for i in range(others):
+        if i % 2 == 0:
+            p = root / "notes" / f"note_{i:03d}.txt"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(f"Meeting notes {i}: renewal pipeline review. " + LOREM * 3)
+        else:
+            p = root / "invoices" / f"invoice_{i:03d}.csv"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            with open(p, "w", newline="") as fh:
+                w = csv.writer(fh)
+                w.writerow(["invoice_id", "vendor", "amount"])
+                for r in range(50):
+                    w.writerow([f"INV-{i:03d}-{r:03d}", rng.choice(VENDORS),
+                                rng.randint(100, 99999)])
+    return sum(1 for f in root.rglob("*") if f.is_file())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("root")
+    ap.add_argument("--pdfs", type=int, default=200)
+    ap.add_argument("--pages", type=int, default=3)
+    ap.add_argument("--others", type=int, default=50)
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if root.exists() and any(root.rglob("*.pdf")):
+        print(f"reusing existing corpus under {root}")
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+        n = generate_corpus(root, args.pdfs, args.pages, args.others)
+        print(f"corpus ready: {n} files under {root}")
+
+    client = NetworkDirClient(root_path=str(root), index_mode="content")
+
+    t0 = time.perf_counter()
+    tables1 = client.get_schemas()
+    t1 = time.perf_counter() - t0
+    print(f"run 1 (cold index):                    {t1:8.2f}s  files={len(tables1)}")
+
+    t0 = time.perf_counter()
+    client.get_schemas()
+    t2 = time.perf_counter() - t0
+    print(f"run 2 (unchanged, NO prior catalog):   {t2:8.2f}s   <- old behavior, every reindex")
+
+    prior = {t.name: t.metadata_json for t in tables1}
+    t0 = time.perf_counter()
+    tables3 = client.get_schemas(prior_catalog=prior)
+    t3 = time.perf_counter() - t0
+    print(f"run 3 (unchanged, WITH prior catalog): {t3:8.2f}s   <- new behavior")
+    if t3 > 0:
+        print(f"speedup vs old rerun: {t2 / t3:,.1f}x")
+
+    m1 = {t.name: (t.metadata_json or {}).get("network_dir", {}) for t in tables1}
+    m3 = {t.name: (t.metadata_json or {}).get("network_dir", {}) for t in tables3}
+    assert set(m1) == set(m3), "file sets differ"
+    assert not [n for n in m1 if m1[n].get("keywords") != m3[n].get("keywords")], "keywords differ"
+    assert not [n for n in m1 if m1[n].get("content_hash") != m3[n].get("content_hash")], "hashes differ"
+    print("catalog equivalence: OK (same files, same keywords, same hashes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/e2e/test_network_dir_incremental_e2e.py
+++ b/backend/tests/e2e/test_network_dir_incremental_e2e.py
@@ -1,0 +1,133 @@
+"""E2E: reindexing an UNCHANGED network_dir must not re-extract file content.
+
+Drives the real stack — POST /connections (kicks background indexing) →
+ConnectionIndexingService runner → ConnectionService.refresh_schema →
+NetworkDirClient.get_schemas — and asserts the second run (POST /reindex on an
+unchanged directory) reuses the stored keywords via the `prior_catalog` skip
+instead of re-reading every file. Before the incremental fix the second run
+re-extracted everything, which on a PDF-heavy share meant hours of pypdf per
+scheduled reindex.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from app.data_sources.clients.network_dir_client import NetworkDirClient
+
+
+def _poll_until_terminal(test_client, connection_id, headers, *, timeout_s: float = 15.0):
+    deadline = time.perf_counter() + timeout_s
+    last = None
+    while time.perf_counter() < deadline:
+        r = test_client.get(f"/api/connections/{connection_id}/indexing", headers=headers)
+        if r.status_code == 404:
+            time.sleep(0.05)
+            continue
+        assert r.status_code == 200, r.text
+        last = r.json()
+        if last["status"] in ("completed", "failed", "cancelled"):
+            return last
+        time.sleep(0.1)
+    pytest.fail(f"Indexing did not reach terminal state within {timeout_s}s; last={last!r}")
+
+
+async def _catalog_meta(conn_id: str) -> dict:
+    from sqlalchemy import select
+
+    from app.dependencies import async_session_maker
+    from app.models.connection_table import ConnectionTable
+
+    async with async_session_maker() as db:
+        rows = (await db.execute(
+            select(ConnectionTable).where(ConnectionTable.connection_id == str(conn_id))
+        )).scalars().all()
+        return {r.name: (r.metadata_json or {}).get("network_dir", {}) for r in rows}
+
+
+@pytest.mark.e2e
+def test_reindex_unchanged_dir_skips_extraction(
+    create_connection,
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+    tmp_path: Path,
+    monkeypatch,
+):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "alpha.txt").write_text("alpha renewal clause budget\n")
+    (tmp_path / "docs" / "beta.txt").write_text("beta indemnity headcount\n")
+    (tmp_path / "gamma.md").write_text("# gamma\narbitration forecast\n")
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    connection = create_connection(
+        name="Incremental Share",
+        type="network_dir",
+        config={"root_path": str(tmp_path), "index_mode": "content"},
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    conn_id = connection["id"]
+
+    first = _poll_until_terminal(test_client, conn_id, headers)
+    assert first["status"] == "completed", first
+    # get_schemas now ticks per file, so the indexing row shows real progress
+    # (3 files) instead of the 0/0 it reported before.
+    assert first["progress_total"] == 3, first
+    assert first["progress_done"] == 3, first
+
+    meta1 = asyncio.run(_catalog_meta(conn_id))
+    assert len(meta1) == 3
+    assert all(m.get("keywords") for m in meta1.values()), meta1
+
+    # From here on, count real content extractions. The indexing runner lives
+    # on a daemon thread in this same process, so the patch reaches it.
+    calls: list[str] = []
+    original = NetworkDirClient._file_text
+
+    def counting(self, path, max_chars=200_000):
+        calls.append(Path(path).name)
+        return original(self, path, max_chars)
+
+    monkeypatch.setattr(NetworkDirClient, "_file_text", counting)
+
+    r = test_client.post(f"/api/connections/{conn_id}/reindex", headers=headers)
+    assert r.status_code == 200, r.text
+    second = _poll_until_terminal(test_client, conn_id, headers)
+    assert second["status"] == "completed", second
+
+    # The whole point: an unchanged directory re-indexes without reading a
+    # single file's content...
+    assert calls == [], f"reindex re-extracted {calls}"
+    # ...and the catalog keeps its keywords/hashes.
+    meta2 = asyncio.run(_catalog_meta(conn_id))
+    assert {n: m.get("keywords") for n, m in meta2.items()} == \
+           {n: m.get("keywords") for n, m in meta1.items()}
+    assert {n: m.get("content_hash") for n, m in meta2.items()} == \
+           {n: m.get("content_hash") for n, m in meta1.items()}
+
+    # A changed file IS re-extracted on the next reindex — and only that file.
+    import os
+    target = tmp_path / "docs" / "alpha.txt"
+    target.write_text("alpha totally different retention wording\n")
+    st = target.stat()
+    os.utime(target, (st.st_atime, st.st_mtime + 5))
+
+    r = test_client.post(f"/api/connections/{conn_id}/reindex", headers=headers)
+    assert r.status_code == 200, r.text
+    third = _poll_until_terminal(test_client, conn_id, headers)
+    assert third["status"] == "completed", third
+    assert calls == ["alpha.txt"], calls
+
+    meta3 = asyncio.run(_catalog_meta(conn_id))
+    assert "retention" in (meta3["docs/alpha.txt"].get("keywords") or [])
+    assert meta3["docs/alpha.txt"]["content_hash"] != meta1["docs/alpha.txt"]["content_hash"]

--- a/backend/tests/unit/test_network_dir_incremental_index.py
+++ b/backend/tests/unit/test_network_dir_incremental_index.py
@@ -1,0 +1,218 @@
+"""Incremental content indexing + progress/cancel for network_dir.
+
+Before this feature, every `get_schemas()` run re-extracted text from EVERY
+file (pypdf over every PDF, pandas over every workbook) even when nothing had
+changed — a scheduled reindex of a static archive repaid the full multi-hour
+extraction cost every interval, and the run reported no progress and could not
+be cancelled. These tests pin the new contract:
+
+  * a file whose size+mtime match its prior catalog row reuses the stored
+    keywords/hash (no extraction);
+  * changed / new / prior-unindexed files are (re)extracted;
+  * `progress_callback` ticks per file and doubles as the cancel checkpoint
+    (raising IndexingCancelled aborts the walk);
+  * base.aget_schemas forwards `prior_catalog` only to clients that accept it.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app.data_sources.clients.network_dir_client import NetworkDirClient
+from app.data_sources.clients.progress import IndexingCancelled
+
+
+@pytest.fixture()
+def tree(tmp_path: Path) -> Path:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "alpha.txt").write_text("alpha renewal clause budget\n")
+    (tmp_path / "docs" / "beta.txt").write_text("beta indemnity headcount\n")
+    (tmp_path / "gamma.md").write_text("# gamma\narbitration forecast\n")
+    return tmp_path
+
+
+def _client(root: Path) -> NetworkDirClient:
+    return NetworkDirClient(root_path=str(root), index_mode="content")
+
+
+@pytest.fixture()
+def count_extractions(monkeypatch):
+    """Count real content-extraction calls without changing behavior."""
+    calls: list[str] = []
+    original = NetworkDirClient._file_text
+
+    def counting(self, path, max_chars=200_000):
+        calls.append(Path(path).name)
+        return original(self, path, max_chars)
+
+    monkeypatch.setattr(NetworkDirClient, "_file_text", counting)
+    return calls
+
+
+def _prior(tables) -> dict:
+    return {t.name: t.metadata_json for t in tables}
+
+
+class TestIncrementalIndexing:
+    def test_unchanged_files_reuse_prior_keywords(self, tree, count_extractions):
+        client = _client(tree)
+        run1 = client.get_schemas()
+        assert len(count_extractions) == 3
+
+        run2 = client.get_schemas(prior_catalog=_prior(run1))
+        # No new extraction — everything matched size+mtime.
+        assert len(count_extractions) == 3
+        m1 = {t.name: t.metadata_json["network_dir"] for t in run1}
+        m2 = {t.name: t.metadata_json["network_dir"] for t in run2}
+        assert m1.keys() == m2.keys()
+        for name in m1:
+            assert m2[name]["keywords"] == m1[name]["keywords"]
+            assert m2[name]["content_hash"] == m1[name]["content_hash"]
+            assert m2[name]["indexed"] is True
+        # Keyword description survives the reuse path (search context uses it).
+        by_name = {t.name: t for t in run2}
+        assert "alpha" in by_name["docs/alpha.txt"].description
+        assert "Keywords:" in by_name["docs/alpha.txt"].description
+
+    def test_changed_file_is_reextracted(self, tree, count_extractions):
+        client = _client(tree)
+        run1 = client.get_schemas()
+        count_extractions.clear()
+
+        target = tree / "docs" / "alpha.txt"
+        target.write_text("alpha totally different retention wording\n")
+        # Force an mtime change even on coarse-granularity filesystems.
+        st = target.stat()
+        os.utime(target, (st.st_atime, st.st_mtime + 5))
+
+        run2 = client.get_schemas(prior_catalog=_prior(run1))
+        assert count_extractions == ["alpha.txt"]
+        meta = {t.name: t.metadata_json["network_dir"] for t in run2}
+        assert "retention" in meta["docs/alpha.txt"]["keywords"]
+        old = {t.name: t.metadata_json["network_dir"] for t in run1}
+        assert meta["docs/alpha.txt"]["content_hash"] != old["docs/alpha.txt"]["content_hash"]
+
+    def test_same_mtime_different_size_is_reextracted(self, tree, count_extractions):
+        client = _client(tree)
+        run1 = client.get_schemas()
+        count_extractions.clear()
+
+        target = tree / "gamma.md"
+        st = target.stat()
+        target.write_text("# gamma\narbitration forecast plus appended text\n")
+        os.utime(target, (st.st_atime, st.st_mtime))  # keep mtime identical
+
+        client.get_schemas(prior_catalog=_prior(run1))
+        assert count_extractions == ["gamma.md"]
+
+    def test_new_and_deleted_files(self, tree, count_extractions):
+        client = _client(tree)
+        run1 = client.get_schemas()
+        count_extractions.clear()
+
+        (tree / "docs" / "delta.txt").write_text("delta severance matrix\n")
+        (tree / "gamma.md").unlink()
+
+        run2 = client.get_schemas(prior_catalog=_prior(run1))
+        assert count_extractions == ["delta.txt"]
+        names = {t.name for t in run2}
+        assert "docs/delta.txt" in names
+        assert "gamma.md" not in names
+
+    def test_prior_row_without_indexed_flag_is_extracted(self, tree, count_extractions):
+        """A prior row from a metadata-only run (or a failed extraction) must
+        not satisfy the skip check — content still needs to be extracted."""
+        meta_client = NetworkDirClient(root_path=str(tree), index_mode="metadata")
+        run_meta = meta_client.get_schemas()
+        count_extractions.clear()
+
+        client = _client(tree)
+        client.get_schemas(prior_catalog=_prior(run_meta))
+        assert len(count_extractions) == 3
+
+    def test_malformed_prior_entries_are_ignored(self, tree, count_extractions):
+        client = _client(tree)
+        prior = {
+            "docs/alpha.txt": None,
+            "docs/beta.txt": {"network_dir": "not-a-dict"},
+            "gamma.md": "garbage",
+        }
+        tables = client.get_schemas(prior_catalog=prior)
+        assert len(count_extractions) == 3
+        assert all(t.metadata_json["network_dir"]["indexed"] for t in tables)
+
+
+class TestProgressAndCancel:
+    def test_progress_ticks_per_file(self, tree):
+        events = []
+
+        def cb(phase, item, done, total):
+            events.append((phase, item, done, total))
+
+        client = _client(tree)
+        client.get_schemas(progress_callback=cb)
+        assert events[0] == ("indexing files", None, 0, 3)
+        item_events = [e for e in events if e[1] is not None]
+        assert len(item_events) == 3
+        assert events[-1][2] == events[-1][3] == 3
+
+    def test_cancel_via_callback_aborts_walk(self, tree):
+        seen = []
+
+        def cb(phase, item, done, total):
+            if item is not None:
+                seen.append(item)
+            if len(seen) >= 2:
+                raise IndexingCancelled()
+
+        client = _client(tree)
+        with pytest.raises(IndexingCancelled):
+            client.get_schemas(progress_callback=cb)
+        assert len(seen) == 2  # aborted promptly, not after the full walk
+
+    def test_metadata_mode_still_reports_progress(self, tree):
+        events = []
+        meta_client = NetworkDirClient(root_path=str(tree), index_mode="metadata")
+        meta_client.get_schemas(progress_callback=lambda *a: events.append(a))
+        assert events and events[-1][2] == 3
+
+
+class TestBaseForwarding:
+    @pytest.mark.asyncio
+    async def test_prior_catalog_forwarded_when_accepted(self, tree):
+        client = _client(tree)
+        run1 = await client.aget_schemas()
+        run2 = await client.aget_schemas(prior_catalog=_prior(run1))
+        m1 = {t.name: t.metadata_json["network_dir"]["content_hash"] for t in run1}
+        m2 = {t.name: t.metadata_json["network_dir"]["content_hash"] for t in run2}
+        assert m1 == m2
+
+    @pytest.mark.asyncio
+    async def test_prior_catalog_not_forwarded_to_legacy_clients(self):
+        """A client whose get_schemas takes no kwargs must not receive them."""
+        from app.data_sources.clients.base import DataSourceClient
+
+        class LegacyClient(DataSourceClient):
+            description = "legacy"
+
+            def test_connection(self):
+                return {"success": True}
+
+            def get_schemas(self):
+                return ["t1"]
+
+            def get_schema(self, table_name):
+                return None
+
+            def prompt_schema(self):
+                return ""
+
+            def execute_query(self, **kwargs):
+                return None
+
+        client = LegacyClient()
+        assert await client.aget_schemas(
+            progress_callback=lambda *a: None, prior_catalog={"x": {}}
+        ) == ["t1"]

--- a/docs/feedback-loops/network-dir-incremental-indexing.md
+++ b/docs/feedback-loops/network-dir-incremental-indexing.md
@@ -1,0 +1,115 @@
+# Feedback Loop — "indexing a network_dir with thousands of PDFs re-extracts everything, every time"
+
+A `network_dir` connection with the default `index_mode: "content"` extracts
+text from every PDF/Office document on **every** index run — including the
+scheduled reindex (default every 12h) of a directory where nothing changed.
+On a PDF-heavy share that is minutes-to-hours of sequential pypdf work whose
+output already sits, byte-identical, in the catalog rows. The run also
+reported no per-file progress and could not be cancelled. This loop proves
+the cost, then proves the fix: reindexing an unchanged directory becomes a
+stat-only walk that reuses the stored keywords/hashes.
+
+## Root cause (validated)
+
+- `NetworkDirClient.get_schemas()` (`backend/app/data_sources/clients/network_dir_client.py`)
+  called `_file_text()` → `extract_document_text()` (pypdf, up to 200 pages /
+  200k chars per file) for **every** file on **every** run. Each catalog row
+  already stored `size`, `modified_at`, and `content_hash` — none of it was
+  consulted to skip unchanged files.
+- The scheduled sweeper (`backend/app/services/scheduled_reindex.py`) re-runs
+  `refresh_schema` per connection on its interval (default 12h,
+  `Connection.DEFAULT_REINDEX_INTERVAL_MINUTES`), so the full extraction cost
+  recurred forever on static archives.
+- `get_schemas(progress_callback=...)` accepted the callback but never invoked
+  it, so the indexing UI showed 0/0 and the runner's cancel checkpoint (the
+  callback raising `IndexingCancelled`) never fired.
+- `ConnectionService.refresh_schema` wrapped every exception in a generic 500
+  (`connection_service.py`), which would have converted `IndexingCancelled`
+  into a *failed* run instead of a *cancelled* one.
+
+## Loop A — deterministic reproduction (no external services)
+
+```bash
+cd backend
+pip install uv
+uv sync --frozen --extra dev
+export ENVIRONMENT=development BOW_DATABASE_URL="sqlite:///db/app.db"
+mkdir -p db
+
+# Benchmark: generates a corpus of REAL multi-page PDFs (matplotlib backend,
+# selectable text — pypdf does real extraction work), then times three runs.
+uv run python scripts/bench_network_dir_indexing.py /tmp/bench_corpus --pdfs 1000 --pages 3
+```
+
+Observed BEFORE the fix (1,000 three-page PDFs + 100 txt/csv, local SSD —
+a real SMB/NFS mount and messier real-world PDFs are substantially slower):
+
+```
+run 1 (cold index):                      102.68s  files=1100
+run 2 (unchanged, NO prior catalog):     104.93s   <- every scheduled reindex paid this
+```
+
+Observed AFTER the fix (same corpus, same process):
+
+```
+run 3 (unchanged, WITH prior catalog):     0.14s
+speedup vs old rerun: 775.2x
+catalog equivalence: OK (same files, same keywords, same hashes)
+```
+
+Regression tests (all deterministic, tmp-dir fixtures):
+
+```bash
+uv run pytest tests/unit/test_network_dir_incremental_index.py -q   # 11 tests
+uv run pytest tests/e2e/test_network_dir_incremental_e2e.py -q      # full-stack reindex loop
+```
+
+The e2e test drives the real stack — `POST /connections` → background
+`ConnectionIndexingService` runner → `refresh_schema` →
+`NetworkDirClient.get_schemas` — and asserts that `POST /reindex` on an
+unchanged directory performs **zero** content extractions (counted by
+patching `_file_text`), that a changed file re-extracts exactly that file,
+and that the indexing row now reports real per-file progress (3/3).
+
+## The fix
+
+- `NetworkDirClient.get_schemas(progress_callback=None, prior_catalog=None)`
+  (`network_dir_client.py`): a file whose `size` + `modified_at` match its
+  prior catalog row (and whose prior row was successfully content-indexed)
+  reuses the stored keywords/`content_hash` instead of re-extracting. A
+  per-file `reporter.tick()` reports progress and doubles as the cancel
+  checkpoint.
+- `DataSourceClient.aget_schemas` (`base.py`): forwards `prior_catalog` (like
+  `progress_callback`) only to clients whose `get_schemas` accepts it —
+  legacy clients are untouched.
+- `ConnectionService.refresh_schema` (`connection_service.py`): loads the
+  existing `ConnectionTable` rows *before* schema discovery (they already fed
+  the upsert diff afterwards) and passes `{table_name: metadata_json}` as the
+  prior catalog; re-raises `IndexingCancelled` so the runner finalizes the
+  run as `cancelled`, not `failed`.
+
+Skip-check correctness notes:
+
+- `modified_at` is the full-precision UTC isoformat of `st_mtime`, and size is
+  compared too, so a same-mtime-different-size edit still re-extracts
+  (covered by `test_same_mtime_different_size_is_reextracted`).
+- A prior row from a metadata-only run or a failed extraction has no
+  `indexed: true` flag and never satisfies the skip.
+- New files extract, deleted files drop out (the walk is still live).
+
+## What this proves / regression notes
+
+- Steady-state scheduled reindexing of an unchanged directory is now O(stat)
+  instead of O(full pypdf re-extraction): 104.93s → 0.14s on the 1,100-file
+  corpus, with a byte-identical catalog.
+- Related suites pass: `tests/unit/test_network_dir_client.py`,
+  `test_s3_client.py`, `test_schema_validation_file_fast_path.py`,
+  `test_attach_and_index.py`, `test_grep_files.py` (110 tests) and
+  `tests/e2e/test_connection_indexing.py` (6 tests, incl. cancel endpoint).
+- Pre-existing, unrelated: `tests/e2e/test_network_dir_e2e.py`'s two tests
+  fail identically with this change stashed (deep-search assertion), so they
+  are not regressions from this loop.
+- First-time indexing of a huge archive is unchanged (still sequential
+  extraction) — by design; it happens once, in the background, and now shows
+  progress and honors cancel. S3 has the same incremental opportunity
+  (ETag-keyed) and can adopt the same `prior_catalog` kwarg later.


### PR DESCRIPTION
## Problem

`network_dir` content indexing re-extracted text from **every** PDF/Office document on **every** run — including the scheduled reindex (default every 12h) of a directory where nothing changed. Each catalog row already stored `size`, `modified_at`, and `content_hash`, but none of it was consulted. On a PDF-heavy share that meant minutes-to-hours of sequential pypdf work per run, repaid forever on static archives. The run also reported no per-file progress (the `progress_callback` param was accepted but never invoked) and could not be cancelled mid-walk.

## Fix

- **Incremental indexing** — `NetworkDirClient.get_schemas` now accepts `prior_catalog` (`{table_name: metadata_json}` from the previous run). A file whose `size` + `modified_at` match its prior content-indexed row reuses the stored keywords/`content_hash` instead of re-extracting. `ConnectionService.refresh_schema` loads the existing `ConnectionTable` rows *before* schema discovery (it already needed them for the upsert diff afterwards) and passes them through; `base.aget_schemas` forwards the kwarg only to clients whose `get_schemas` accepts it, so all other connectors are untouched.
- **Progress + cancellation** — `get_schemas` ticks the progress reporter per file, so the indexing UI shows real progress (`indexing files`, N/N) and the runner's cancel checkpoint fires (the callback raises `IndexingCancelled`). `refresh_schema` re-raises `IndexingCancelled` instead of wrapping it in the generic 500, so a cancelled run finalizes as `cancelled` rather than `failed`.

Skip-check correctness: size is compared alongside full-precision mtime (a same-mtime-different-size edit still re-extracts); prior rows from metadata-only runs or failed extractions never satisfy the skip; new files extract; deleted files drop out.

## Benchmark (real mock files, large corpus)

`scripts/bench_network_dir_indexing.py` generates 1,000 three-page PDFs with real selectable text (matplotlib PDF backend, so pypdf does genuine extraction work) + 100 txt/csv, then times three runs in one process:

```
run 1 (cold index):                      102.68s  files=1100
run 2 (unchanged, NO prior catalog):     104.93s   <- old behavior, every scheduled reindex
run 3 (unchanged, WITH prior catalog):     0.14s   <- new behavior
speedup vs old rerun: 775.2x
catalog equivalence: OK (same files, same keywords, same hashes)
```

Local SSD + clean PDFs is the *favorable* case for the old code — real SMB/NFS mounts and messier PDFs are substantially slower per file, so the absolute win is larger in production.

## Testing

- `tests/unit/test_network_dir_incremental_index.py` (11 tests): unchanged-reuse, changed/new/deleted re-extraction, same-mtime-different-size, metadata-only prior rows, malformed prior entries, per-file progress ticks, cancel-aborts-walk, and `aget_schemas` kwarg forwarding (including legacy clients that must not receive it).
- `tests/e2e/test_network_dir_incremental_e2e.py`: drives the real stack — `POST /connections` → background indexing runner → `POST /reindex` — asserting **zero** content extractions on the unchanged pass (counted via patched `_file_text`), exactly-one re-extraction after a file edit, identical keywords/hashes, and real progress (3/3) on the indexing row.
- Adjacent suites pass: `test_network_dir_client`, `test_s3_client`, `test_schema_validation_file_fast_path`, `test_attach_and_index`, `test_grep_files` (110 tests) and `tests/e2e/test_connection_indexing.py` (6 tests, incl. the cancel endpoint).
- Pre-existing, unrelated: 2 failures in `tests/e2e/test_network_dir_e2e.py` (deep-search assertion) reproduce identically with this change stashed.
- `ruff` on the touched files matches the pre-change baseline.

Feedback-loop doc (re-executable repro → fix → verify, per the `sandbox-feedback-loop` skill): `docs/feedback-loops/network-dir-incremental-indexing.md`.

Follow-up candidate: S3 has the same incremental opportunity (ETag-keyed) and can adopt the same `prior_catalog` kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsgtRVjcPvAREW1pPMCbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUsgtRVjcPvAREW1pPMCbT)_