### PR TITLE
fix(teams): stop sending duplicate table messages

### DIFF
--- a/backend/app/services/slack_notification_service.py
+++ b/backend/app/services/slack_notification_service.py
@@ -23,11 +23,13 @@ from app.services.platform_adapters.adapter_factory import PlatformAdapterFactor
 # standard module logger.
 logger = logging.getLogger(__name__)
 
-# Below this row count, we don't send the raw table data to Slack/Teams.
+# Below this row count, we don't send the raw table data to Slack/WhatsApp.
 # The agent's text answer already describes small results in prose (the
 # planner is instructed to do so for small datasets), so attaching a CSV
-# or markdown table on top is noise. Larger results still go through so
-# the user can scan/download them.
+# on top is noise. Larger results still go through so the user can
+# scan/download them. Teams skips table sends entirely (see
+# send_step_result_to_slack): the agent's text answer renders its own
+# markdown table there, so a second raw table is a duplicate.
 MIN_ROWS_TO_SEND = 10
 
 
@@ -163,42 +165,9 @@ def df_to_csv(data: dict) -> str:
         logger.warning("Error creating CSV file: %s", e)
         return None
 
-def _format_markdown_table(data: dict, title: str, max_rows: int = 20) -> str:
-    """Format step data as a markdown table for Teams."""
-    rows = data.get('rows', [])
-    columns = data.get('columns', [])
-    if not rows or not columns:
-        return None
-
-    headers = [col.get('headerName', col.get('field', '')) for col in columns]
-    fields = [col['field'] for col in columns]
-
-    lines = [f"**{title}**\n"]
-    # Header row
-    lines.append("| " + " | ".join(headers) + " |")
-    # Separator row
-    lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
-    # Data rows (cap to max_rows)
-    for row in rows[:max_rows]:
-        values = [str(row.get(field, '')) for field in fields]
-        lines.append("| " + " | ".join(values) + " |")
-
-    if len(rows) > max_rows:
-        lines.append(f"\n*Showing {max_rows} of {len(rows)} rows. See full data in the web report.*")
-
-    return "\n".join(lines)
-
-
-async def _handle_table_step_dm(adapter, external_user_id: str, step: 'Step', thread_ts: str = None, channel_id: str = None, platform_type: str = None):
-    """Handles sending table data, optionally in a thread."""
+async def _handle_table_step_dm(adapter, external_user_id: str, step: 'Step', thread_ts: str = None, channel_id: str = None):
+    """Handles sending table data as a CSV file, optionally in a thread."""
     title = step.title or "Table Data"
-
-    # Teams: send as markdown table text (Bot Connector doesn't support data: URLs for file uploads)
-    if platform_type == "teams":
-        md_table = _format_markdown_table(step.data, title)
-        if md_table:
-            return await adapter.send_dm_in_thread(external_user_id, md_table, thread_ts, channel_id=channel_id)
-        return False
 
     file_path = df_to_csv(step.data)
     if not file_path:
@@ -289,6 +258,18 @@ async def send_step_result_to_slack(step_id: str, external_user_id: str | None =
             success = False
             data_type = step.data_model.get('type')
 
+            # Teams: never send table data. The agent's final text answer
+            # renders its own (better-formatted) markdown table in Teams, so a
+            # separate raw table arrives as a duplicate. Slack/WhatsApp are
+            # unaffected — their data goes out as a CSV attachment, not a
+            # second table in the chat.
+            if data_type == "table" and platform_type == "teams":
+                logger.info(
+                    "SLACK_NOTIFIER: Skipping table send for step %s (Teams gets data via the text answer)",
+                    step_id,
+                )
+                return
+
             # Don't send small table results — the agent's text answer already
             # describes them. Charts (sent as images) and counts (scalar
             # answers) are unaffected.
@@ -300,7 +281,7 @@ async def send_step_result_to_slack(step_id: str, external_user_id: str | None =
                 return
 
             if data_type == "table":
-                success = await _handle_table_step_dm(adapter, external_user_id, step, thread_ts, channel_id, platform_type=platform_type)
+                success = await _handle_table_step_dm(adapter, external_user_id, step, thread_ts, channel_id)
             elif data_type == "count":
                 if step.data and 'rows' in step.data and step.data['rows'] and 'columns' in step.data and step.data['columns']:
                     count_value = step.data['rows'][0].get(step.data['columns'][0].get('field', ''))

--- a/backend/tests/unit/test_slack_notification_service.py
+++ b/backend/tests/unit/test_slack_notification_service.py
@@ -89,6 +89,31 @@ async def test_large_table_is_sent():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("n_rows", [5, 10, 50])
+async def test_teams_table_is_never_sent(n_rows):
+    # Teams gets the data via the agent's text answer (which renders its own
+    # markdown table), so the pipeline must not send a duplicate raw table —
+    # regardless of row count.
+    step = _make_step("table", n_rows)
+    platform = SimpleNamespace(platform_type="teams", organization_id="org-1")
+    adapter = AsyncMock()
+
+    with (
+        patch.object(svc, "create_async_session_factory", return_value=_patch_session_returning(step, platform)),
+        patch.object(svc.PlatformAdapterFactory, "create_adapter", return_value=adapter),
+    ):
+        await svc.send_step_result_to_slack(
+            step_id="step-1",
+            external_user_id="U1",
+            organization_id="org-1",
+            platform_type="teams",
+        )
+
+    adapter.send_dm_in_thread.assert_not_called()
+    adapter.send_file_in_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_small_count_is_still_sent():
     # Counts are scalar answers, not tabular data — the threshold must not apply.
     step = _make_step("count", 1)


### PR DESCRIPTION
## Problem

In Teams, table results showed up **twice**: the agent's final text answer renders its own markdown table (properly formatted — currency symbols, `14/07/2026` dates), and the notification pipeline then sent a second raw markdown table for the same step (unformatted `str()` values, `2026-07-14T00:00:00.000` timestamps).

The `MIN_ROWS_TO_SEND = 10` threshold was meant to prevent this — it assumed the agent only enumerates small (<10 row) results in its answer — but in practice the agent embeds tables for larger results too, so anything ≥10 rows arrived duplicated.

## Fix

Skip table sends entirely for Teams in `send_step_result_to_slack`. The agent's text answer carries the data inline, and the full result is always available in the linked web report.

Unchanged:
- **Slack / WhatsApp**: table data still goes out as a CSV attachment — that doesn't read as a duplicate table in the chat.
- **Teams charts** (web-report pointer message) and **counts** (one-line value).

Also removes the now-unused `_format_markdown_table` helper.

## Testing

Added `test_teams_table_is_never_sent` (parametrized over 5/10/50 rows) to `backend/tests/unit/test_slack_notification_service.py`; all 9 tests in the module pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThLC1D8Sxp2hPTq1a3LPVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThLC1D8Sxp2hPTq1a3LPVX)_