### PR TITLE
fix(powerbi): unwrap Table[Column] DAX headers + live E2E feedback loop

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -1034,9 +1034,8 @@ class PowerBIClient(DataSourceClient):
         if not rows:
             return pd.DataFrame()
 
-        # Clean column names (remove brackets like [ColumnName])
         df = pd.DataFrame(rows)
-        df.columns = [col.strip("[]") for col in df.columns]
+        df.columns = self._clean_dax_columns(list(df.columns))
 
         if max_rows is not None and max_rows > 0 and len(df) > max_rows:
             df = df.head(max_rows)
@@ -1143,6 +1142,37 @@ TOPN(10,
     # ----------------------------
     # Internal helpers
     # ----------------------------
+
+    @staticmethod
+    def _clean_dax_columns(columns: List[str]) -> List[str]:
+        """
+        Unwrap executeQueries column names to bare column names.
+
+        The REST API returns '[Measure]' for measures/aliases and
+        'Table[Column]' for table columns. str.strip("[]") only handles the
+        first form — 'Sales[Region]' became 'Sales[Region'. Unwrap both forms,
+        but keep the qualified 'Table[Column]' name whenever unwrapping would
+        collide with another column in the same result set (e.g. both
+        Customers[Name] and Products[Name] selected).
+        """
+        unwrapped = []
+        for col in columns:
+            m = re.match(r"^(?:[^\[\]]*\[)?([^\[\]]+)\]$", col or "")
+            unwrapped.append(m.group(1) if m else col)
+
+        counts = {}
+        for name in unwrapped:
+            counts[name] = counts.get(name, 0) + 1
+
+        cleaned = []
+        for original, bare in zip(columns, unwrapped):
+            if counts[bare] > 1 and original != f"[{bare}]":
+                # Ambiguous bare name: keep the table-qualified form, just
+                # drop the trailing bracket noise ('Table[Column]' -> 'Table.Column').
+                cleaned.append(original.rstrip("]").replace("[", "."))
+            else:
+                cleaned.append(bare)
+        return cleaned
 
     def _build_headers(self) -> Dict[str, str]:
         if not self._access_token:

--- a/backend/tests/unit/test_powerbi_client.py
+++ b/backend/tests/unit/test_powerbi_client.py
@@ -337,3 +337,56 @@ class TestGetSchemasCache:
         c.get_schemas()
         c.get_schemas(force_refresh=True)
         assert c.list_workspaces.call_count == 2
+
+
+class TestCleanDaxColumns:
+    """executeQueries returns '[Measure]' and 'Table[Column]' headers; both
+    must unwrap to bare column names (the old str.strip("[]") left
+    'Sales[Region]' as 'Sales[Region')."""
+
+    def test_measure_alias_unwrapped(self):
+        assert PowerBIClient._clean_dax_columns(["[TotalRevenue]"]) == ["TotalRevenue"]
+
+    def test_table_qualified_column_unwrapped(self):
+        assert PowerBIClient._clean_dax_columns(
+            ["Sales[Region]", "Sales[Revenue]"]
+        ) == ["Region", "Revenue"]
+
+    def test_mixed_forms(self):
+        assert PowerBIClient._clean_dax_columns(
+            ["Sales[Region]", "[TotalRevenue]", "Month"]
+        ) == ["Region", "TotalRevenue", "Month"]
+
+    def test_table_name_with_spaces(self):
+        assert PowerBIClient._clean_dax_columns(
+            ["Order Details[Unit Price]"]
+        ) == ["Unit Price"]
+
+    def test_collision_keeps_qualified_names(self):
+        # Same bare column from two tables: unwrapping would create duplicate
+        # DataFrame columns, so keep them qualified (dot notation).
+        assert PowerBIClient._clean_dax_columns(
+            ["Customers[Name]", "Products[Name]"]
+        ) == ["Customers.Name", "Products.Name"]
+
+    def test_measure_wins_bare_name_on_collision_with_column(self):
+        assert PowerBIClient._clean_dax_columns(
+            ["[Name]", "Customers[Name]"]
+        ) == ["Name", "Customers.Name"]
+
+    def test_unbracketed_and_malformed_names_pass_through(self):
+        assert PowerBIClient._clean_dax_columns(
+            ["plain", "Sales[Region", ""]
+        ) == ["plain", "Sales[Region", ""]
+
+    def test_execute_dax_uses_cleaned_columns(self):
+        c = _mk_client()
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "results": [{"tables": [{"rows": [
+                {"Sales[Region]": "East", "[TotalRevenue]": 193327.0},
+            ]}]}]
+        }
+        c._request = MagicMock(return_value=resp)
+        df = c._execute_dax_internal("ws", "ds", "EVALUATE ...")
+        assert list(df.columns) == ["Region", "TotalRevenue"]

--- a/docs/feedback-loops/powerbi-live-e2e.md
+++ b/docs/feedback-loops/powerbi-live-e2e.md
@@ -1,0 +1,95 @@
+# Feedback Loop — Power BI connector, live end-to-end through the UI
+
+Validates the full Power BI path against a real Azure tenant: seed an empty
+tenant with data, connect via the product UI (service principal), index the
+schema, run real LLM completions, and confirm `inspect_data` / `create_data` /
+`create_artifact` execute real DAX and return correct numbers.
+
+This is a **Loop B** (live credentials) validation by design — the premise
+under test is the third-party integration itself. Secrets come from env vars
+only: `PBI_TENANT_ID`, `PBI_CLIENT_ID`, `PBI_CLIENT_SECRET`, `ANTHROPIC_API_KEY`.
+
+## Filling an empty tenant with data
+
+The connector discovers workspaces/datasets via the REST API and queries via
+`executeQueries` (DAX), so the tenant needs ≥1 workspace (SP as member/admin)
+containing ≥1 semantic model with rows. Both are scriptable with the same
+service principal — no portal clicks needed:
+
+1. `POST /v1.0/myorg/groups?workspaceV2=true` — create a workspace (the SP
+   becomes admin automatically), unless one already exists.
+2. Create a **push dataset** (`POST /groups/{ws}/datasets` with
+   `defaultMode: "Push"`, then `POST .../tables/{t}/rows`). Push datasets are
+   fully queryable through `executeQueries` — verified: `EVALUATE ROW(...)`,
+   `EVALUATE TOPN(...)`, and `SUMMARIZECOLUMNS(...)` all return data.
+   (Importing a sample PBIX via the Imports API also works but needs a PBIX
+   binary; the GitHub sample downloads are blocked in some sandboxes.)
+
+The validation run seeded dataset `SalesPush` with `Sales` (300 rows, seeded
+RNG so aggregates are reproducible) and `Customers` (40 rows).
+
+## The loop
+
+```bash
+tools/agent/boot_stack.sh
+cd backend && uv run python ../tools/agent/seed_org.py
+# LLM: POST /api/llm/providers with the model INLINE in `models` (see finding 1)
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+```
+
+UI flow (Playwright, `chromium.launch({ executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome' })`):
+
+1. Sign in → skip onboarding → `/agents/new`. With zero connections the
+   **Add Connection** modal auto-opens (don't click "Create new connection").
+2. Search "Power BI" → tile → fill `#tenant_id`, `#client_id`,
+   `#client_secret` → **Test Connection** → expect green
+   `Connected successfully. Found N tables.` → **Save and Continue**.
+3. Indexing step runs schema discovery (6 tables across 4 datasets in ~5s in
+   the validation run) → **Connect** → name the agent → **Save & Continue** →
+   **Select all** tables → context step → agent created. The LLM sync
+   generates the agent description/relationships/starters — first real
+   completions.
+4. New report → prompt for analysis (`.mention-input-field`, send button
+   `button.w-7.h-7.rounded-full:not([disabled])`) → poll
+   `/api/reports/{id}/completions` until the system completion is terminal.
+
+## Observed result (2026-07-14)
+
+- `test_connection`: success (probe DAX reached the engine).
+- Indexing: `connection_indexings.status = completed`, 6 tables catalogued
+  (`SalesPush/{Sales,Customers}`, `deals2/…Opportunities 1`,
+  `leads/…Leads 2`, 2 SharePoint-sourced `mySM/…` tables).
+- Run 1 (SalesPush revenue analysis): `create_note`, `inspect_data`,
+  `create_data`×3 → **all three widget outputs matched the seeded ground
+  truth to the dollar** (region / category / month aggregates). One
+  `create_data` errored on malformed generated Python (missing `except`) and
+  the agent retried the same widget successfully. It also self-created an
+  instruction about bracket-notation column names.
+- Run 2 (deals2+leads pipeline + dashboard): 4 `inspect_data` errors — all
+  LLM table-name mistakes (invented `SalesModel/…` prefix from the system
+  prompt's *example*, bare table name without dataset prefix, defensive
+  empty-DataFrame returns). Every error message correctly listed the known
+  schema tables and the agent converged: `create_data`×2 + `create_artifact`
+  (dashboard) all success.
+- Executed DAX (from `steps.code`): `SUMMARIZECOLUMNS` group-bys with
+  `ORDER BY`, full-table `EVALUATE Sales`, `COUNTA`/`COUNTROWS`/`SUM`
+  measures — all via `executeQueries` against both push and imported models.
+- 44 LLM calls, ~359K input / ~19K output tokens (Claude Haiku 4.5).
+- Backend log: no product errors (only sandbox thumbnail-browser noise).
+
+## Findings (pre-existing, not fixed here)
+
+1. **`POST /api/llm/models` is broken**: `app/routes/llm.py:130` calls
+   `llm_service.create_model(...)`, which doesn't exist on `LLMService`
+   (only `_create_models`). Standalone model creation 500s; the UI path works
+   because it passes `models` inline to `POST /api/llm/providers`
+   (`tools/agent/setup_haiku_llm.py` hits this bug).
+2. **Column-name mangling on whole-table DAX**: `powerbi_client.py`
+   `_execute_dax_internal` cleans headers with `col.strip("[]")`, which turns
+   `Sales[Region]` into `Sales[Region` (leading table prefix keeps the inner
+   bracket). Widgets built from `EVALUATE <Table>` show raw
+   `Table[Column`-style headers; the LLM copes but the UI looks wrong. A
+   regex like `re.sub(r"^.*\[(.+)\]$", r"\1", col)` would restore clean names.
+3. **LLM provider delete is soft**: recreating a provider with the same name
+   409s on the `llm_providers.organization_id+name` unique constraint even
+   after `DELETE` returns 200.

--- a/docs/feedback-loops/powerbi-live-e2e.md
+++ b/docs/feedback-loops/powerbi-live-e2e.md
@@ -84,12 +84,16 @@ UI flow (Playwright, `chromium.launch({ executablePath: '/opt/pw-browsers/chromi
    (only `_create_models`). Standalone model creation 500s; the UI path works
    because it passes `models` inline to `POST /api/llm/providers`
    (`tools/agent/setup_haiku_llm.py` hits this bug).
-2. **Column-name mangling on whole-table DAX**: `powerbi_client.py`
-   `_execute_dax_internal` cleans headers with `col.strip("[]")`, which turns
-   `Sales[Region]` into `Sales[Region` (leading table prefix keeps the inner
-   bracket). Widgets built from `EVALUATE <Table>` show raw
-   `Table[Column`-style headers; the LLM copes but the UI looks wrong. A
-   regex like `re.sub(r"^.*\[(.+)\]$", r"\1", col)` would restore clean names.
+2. **Column-name mangling on whole-table DAX** — FIXED on this branch.
+   `_execute_dax_internal` cleaned headers with `col.strip("[]")`, which turns
+   `Sales[Region]` into `Sales[Region` (the leading table prefix keeps the
+   inner bracket), so widgets built from `EVALUATE <Table>` showed raw
+   `Table[Column`-style headers. Now `_clean_dax_columns` unwraps both
+   `[Measure]` and `Table[Column]` forms, keeping a qualified `Table.Column`
+   name only when unwrapping would collide within one result set. Unit tests:
+   `tests/unit/test_powerbi_client.py::TestCleanDaxColumns`. Live re-run of the
+   top-5-sales prompt returned clean widget headers
+   (`OrderID, OrderDate, Region, Product, ...`).
 3. **LLM provider delete is soft**: recreating a provider with the same name
    409s on the `llm_providers.organization_id+name` unique constraint even
    after `DELETE` returns 200.


### PR DESCRIPTION
## What

Fixes Power BI DAX result column names and records a live end-to-end validation of the Power BI connector as a feedback-loop doc.

### The fix

`executeQueries` returns column names as `[Measure]` or `Table[Column]`. The old cleanup, `col.strip("[]")`, only handled the measure form — `Sales[Region]` came back as `Sales[Region` (trailing `]` stripped, table prefix and inner `[` kept), so any widget built from `EVALUATE <Table>`, `SUMMARIZECOLUMNS` group-by columns, `TOPN`, etc. showed `Table[Column`-style headers in the data grid, and the agent had to reference the mangled names in generated code.

`_clean_dax_columns` now unwraps both forms, with one guard: when two columns would unwrap to the same bare name in a single result set (e.g. `Customers[Name]` + `Products[Name]`), the qualified names are kept as `Customers.Name` / `Products.Name` instead of creating duplicate DataFrame columns.

### Testing

- 8 new unit tests (`TestCleanDaxColumns`) covering measure aliases, table-qualified columns, names with spaces, collisions, measure-vs-column collisions, and pass-through of malformed/plain names; full `test_powerbi_client.py` suite passes (36 tests).
- **Verified live** against a real Power BI tenant through the product UI: connected a service-principal data source, ran real completions (Claude Haiku 4.5), and confirmed the same top-N-sales prompt that previously produced `Sales[OrderID`-style widget headers now returns clean `OrderID, OrderDate, Region, Product, Category, Quantity, UnitPrice, Revenue` headers with correct row data.

### Feedback-loop doc

`docs/feedback-loops/powerbi-live-e2e.md` records the full runnable loop: seeding an empty tenant with a push dataset via the REST API, connecting through the UI (Playwright), running completions, and verifying `inspect_data`/`create_data`/`create_artifact` against ground-truth aggregates. It also documents two remaining pre-existing findings not fixed here:

1. `POST /api/llm/models` 500s — `routes/llm.py:130` calls `LLMService.create_model`, which doesn't exist (the UI path works because it passes `models` inline to `POST /api/llm/providers`).
2. LLM provider delete is soft, so recreating a provider with the same name hits the `organization_id+name` unique constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnrZgzFSZqqNP67z4N1jRG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnrZgzFSZqqNP67z4N1jRG)_