### PR TITLE
feat(servicenow): per-user OAuth sign-in alongside basic auth

### DIFF
--- a/backend/app/data_sources/clients/servicenow_client.py
+++ b/backend/app/data_sources/clients/servicenow_client.py
@@ -104,8 +104,9 @@ class ServiceNowClient(DataSourceClient):
     def __init__(
         self,
         instance_url: str,
-        username: str,
-        password: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        access_token: Optional[str] = None,
         tables: Optional[str] = None,
         discover_all: bool = False,
         display_values: bool = True,
@@ -113,6 +114,11 @@ class ServiceNowClient(DataSourceClient):
         self.instance_url = (instance_url or "").rstrip("/")
         self.username = username
         self.password = password
+        # Per-user delegated OAuth: when present, requests authenticate with
+        # `Authorization: Bearer` instead of basic auth, so Table API ACLs
+        # apply as the signed-in user. Populated from user_connection_credentials
+        # (construct_client passes the token fields the signature accepts).
+        self.access_token = access_token
         self.tables = [t.strip() for t in tables.split(",") if t.strip()] if tables else None
         self.discover_all = discover_all
         self.display_values = display_values
@@ -121,9 +127,16 @@ class ServiceNowClient(DataSourceClient):
 
     @contextmanager
     def connect(self) -> Generator[requests.Session, None, None]:
+        if not self.access_token and not (self.username or self.password):
+            raise RuntimeError(
+                "ServiceNow client has no credentials: provide username/password or sign in with OAuth."
+            )
         session = requests.Session()
-        session.auth = (self.username, self.password)
         session.headers.update({"Accept": "application/json"})
+        if self.access_token:
+            session.headers["Authorization"] = f"Bearer {self.access_token}"
+        else:
+            session.auth = (self.username, self.password)
         try:
             yield session
         finally:
@@ -132,6 +145,11 @@ class ServiceNowClient(DataSourceClient):
     def _get(self, session: requests.Session, path: str, params: dict) -> dict:
         response = session.get(f"{self.instance_url}{path}", params=params, timeout=120)
         if response.status_code == 401:
+            if self.access_token:
+                raise RuntimeError(
+                    "ServiceNow authentication failed (401): the OAuth token was rejected "
+                    "(expired or revoked) — sign in again."
+                )
             raise RuntimeError("ServiceNow authentication failed (401): check username/password.")
         if response.status_code == 403:
             raise RuntimeError(

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -484,7 +484,14 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         description="Cloud platform for IT service management, operations, and workflows.",
         config_schema=ServiceNowConfig,
         credentials_auth=AuthOptions(default="userpass", by_auth={
+            # The userpass schema also carries optional oauth_client_id/secret
+            # (BigQuery pattern): the service account drives catalog indexing,
+            # the OAuth app fields power the per-user "oauth" sign-in below.
             "userpass": AuthVariant(title="Username / Password", schema=ServiceNowCredentials, scopes=["system", "user"]),
+            # Per-user delegated OAuth: authorization-code flow against the
+            # instance's /oauth_auth.do + /oauth_token.do; queries run as the
+            # signed-in user so Table API ACLs apply natively.
+            "oauth": AuthVariant(title="Sign in with ServiceNow", schema=OAuthDelegatedCredentials, scopes=["user"]),
         }),
         # Explicit path: dynamic resolution would derive "ServicenowClient" (lowercase n).
         client_path="app.data_sources.clients.servicenow_client.ServiceNowClient",

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -230,8 +230,27 @@ class SalesforceConfig(BaseModel):
 
 # ServiceNow
 class ServiceNowCredentials(BaseModel):
+    """Service-account basic auth, plus an optional OAuth client for per-user
+    sign-in (mirrors BigQueryCredentials). The username/password drive catalog
+    indexing and system-scope queries; the `oauth_*` fields — registered in the
+    instance under System OAuth → Application Registry — enable the "Sign in
+    with ServiceNow" per-user flow and are consumed only by the OAuth
+    authorize/token endpoints (construct_client strips `oauth_`-prefixed keys
+    before they reach the client)."""
     username: str = Field(..., title="Username", description="", json_schema_extra={"ui:type": "string"})
     password: str = Field(..., title="Password", description="", json_schema_extra={"ui:type": "password"})
+    oauth_client_id: Optional[str] = Field(
+        None,
+        title="OAuth Client ID",
+        description="Client ID of an OAuth app registered in ServiceNow (System OAuth → Application Registry) — enables per-user sign-in",
+        json_schema_extra={"ui:type": "string"}
+    )
+    oauth_client_secret: Optional[str] = Field(
+        None,
+        title="OAuth Client Secret",
+        description="Client Secret of the ServiceNow OAuth app",
+        json_schema_extra={"ui:type": "password"}
+    )
 
 
 class ServiceNowConfig(BaseModel):

--- a/backend/app/services/connection_oauth_service.py
+++ b/backend/app/services/connection_oauth_service.py
@@ -177,6 +177,44 @@ def get_oauth_params(connection: Connection) -> dict:
             "provider_name": "mcp",
         }
 
+    if conn_type == "servicenow":
+        # ServiceNow OAuth endpoints are instance-specific (unlike Google /
+        # Microsoft): {instance_url}/oauth_auth.do and /oauth_token.do. The
+        # instance URL lives in the connection *config*, not credentials.
+        import json as _json
+        config = connection.config
+        if isinstance(config, str):
+            try:
+                config = _json.loads(config)
+            except (TypeError, ValueError):
+                config = {}
+        instance_url = ((config or {}).get("instance_url") or "").rstrip("/")
+        if not instance_url:
+            raise ValueError(f"Connection {connection.id} missing instance_url in config for ServiceNow OAuth")
+
+        client_id = creds.get("oauth_client_id")
+        # Secret is optional: a ServiceNow OAuth app marked "public client"
+        # authenticates with PKCE only (no secret at the token endpoint).
+        client_secret = creds.get("oauth_client_secret")
+        if not client_id:
+            raise ValueError(
+                f"Connection {connection.id} missing oauth_client_id for ServiceNow OAuth. "
+                "Register an OAuth app in the instance (System OAuth → Application Registry) and save its "
+                "client ID (and secret, unless it's a public client) on the connection."
+            )
+
+        return {
+            "authorize_url": f"{instance_url}/oauth_auth.do",
+            "token_url": f"{instance_url}/oauth_token.do",
+            "client_id": client_id,
+            "client_secret": client_secret,  # None → public client (PKCE only)
+            # `useraccount` is ServiceNow's standard delegated scope: the token
+            # acts as the signing-in user. Refresh tokens are always issued
+            # (default ~100-day lifetime); no offline_access-style scope exists.
+            "scopes": "useraccount",
+            "provider_name": "servicenow",
+        }
+
     if conn_type == "bigquery":
         client_id = creds.get("oauth_client_id")
         client_secret = creds.get("oauth_client_secret")

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -198,6 +198,12 @@ class ConnectionService:
             from app.services.connection_oauth_service import ENTRA_OBO_CONNECTION_TYPES
             if type in ENTRA_OBO_CONNECTION_TYPES:
                 allowed_user_auth_modes = ["oauth"]
+            elif type == "servicenow" and (credentials or {}).get("oauth_client_id"):
+                # Admin supplied a ServiceNow OAuth app → enable per-user
+                # sign-in; keep userpass so users may bring their own
+                # username/password instead (matches the no-restriction
+                # behavior when modes are unset).
+                allowed_user_auth_modes = ["oauth", "userpass"]
             elif type == "MSSQL" and (config or {}).get("auth_type") == "kerberos":
                 # System auth is Kerberos → per-user auth means Kerberos SSO via
                 # constrained delegation (no per-user secret; UPN derived at
@@ -447,6 +453,16 @@ class ConnectionService:
             target_type = updates.get("type", connection.type)
             if target_type in ENTRA_OBO_CONNECTION_TYPES and not (connection.allowed_user_auth_modes or []):
                 updates["allowed_user_auth_modes"] = ["oauth"]
+            elif target_type == "servicenow" and not (connection.allowed_user_auth_modes or []):
+                # See create_connection: OAuth app configured → per-user sign-in.
+                creds = updates.get("credentials")
+                if not creds:
+                    try:
+                        creds = connection.decrypt_credentials() or {}
+                    except Exception:
+                        creds = {}
+                if (creds or {}).get("oauth_client_id"):
+                    updates["allowed_user_auth_modes"] = ["oauth", "userpass"]
             elif target_type == "MSSQL" and not (connection.allowed_user_auth_modes or []):
                 cfg = updates.get("config")
                 if cfg is None:

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -199,11 +199,11 @@ class ConnectionService:
             if type in ENTRA_OBO_CONNECTION_TYPES:
                 allowed_user_auth_modes = ["oauth"]
             elif type == "servicenow" and (credentials or {}).get("oauth_client_id"):
-                # Admin supplied a ServiceNow OAuth app → enable per-user
-                # sign-in; keep userpass so users may bring their own
-                # username/password instead (matches the no-restriction
-                # behavior when modes are unset).
-                allowed_user_auth_modes = ["oauth", "userpass"]
+                # Admin supplied a ServiceNow OAuth app → per-user auth means
+                # OAuth sign-in (Fabric-style). Without an OAuth app, modes
+                # stay unset so users may still bring their own
+                # username/password (basic-auth-only instances).
+                allowed_user_auth_modes = ["oauth"]
             elif type == "MSSQL" and (config or {}).get("auth_type") == "kerberos":
                 # System auth is Kerberos → per-user auth means Kerberos SSO via
                 # constrained delegation (no per-user secret; UPN derived at
@@ -462,7 +462,7 @@ class ConnectionService:
                     except Exception:
                         creds = {}
                 if (creds or {}).get("oauth_client_id"):
-                    updates["allowed_user_auth_modes"] = ["oauth", "userpass"]
+                    updates["allowed_user_auth_modes"] = ["oauth"]
             elif target_type == "MSSQL" and not (connection.allowed_user_auth_modes or []):
                 cfg = updates.get("config")
                 if cfg is None:

--- a/backend/tests/e2e/test_connection_oauth_flow.py
+++ b/backend/tests/e2e/test_connection_oauth_flow.py
@@ -217,6 +217,85 @@ class TestOAuthMultiProvider:
         assert "mock-oauth.test/google" in bq_resp.json()["authorization_url"]
 
 
+class TestServiceNowOAuthFlow:
+    """End-to-end ServiceNow per-user OAuth: mode defaulting → real authorize
+    URL built from the instance config → callback stores the user token."""
+
+    @pytest.mark.asyncio
+    async def test_full_flow(
+        self, test_client, login_user, create_connection, create_user, whoami
+    ):
+        user = create_user()
+        token = login_user(user["email"], user["password"])
+        me = whoami(token)
+        org_id = me["organizations"][0]["id"]
+        user_id = me["id"]
+
+        # No allowed_user_auth_modes passed: the backend must default to
+        # ["oauth"] because an OAuth client is configured (Fabric-style).
+        # The /authorize route 400s unless "oauth" is in the allowed modes,
+        # so step 1 succeeding proves the defaulting worked.
+        conn = create_connection(
+            name="Test ServiceNow OAuth",
+            type="servicenow",
+            config={"instance_url": "https://dev1234.service-now.test"},
+            credentials={
+                "username": "svc", "password": "pw",
+                "oauth_client_id": "snow_client", "oauth_client_secret": "snow_secret",
+            },
+            auth_policy="user_required",
+            user_token=token,
+            org_id=org_id,
+        )
+
+        # Step 1: authorize WITHOUT the oauth mock — exercises the real
+        # get_oauth_params servicenow branch (instance-specific endpoints).
+        auth_resp = test_client.get(
+            f"/api/connections/{conn['id']}/oauth/authorize",
+            headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+        )
+        assert auth_resp.status_code == 200, auth_resp.text
+        url = auth_resp.json()["authorization_url"]
+        assert url.startswith("https://dev1234.service-now.test/oauth_auth.do?")
+        assert "client_id=snow_client" in url
+        assert "code_challenge=" in url
+        assert "scope=useraccount" in url
+        state = _state_from_authorize(auth_resp)
+
+        # Step 2: callback with the token exchange mocked (no real instance).
+        with patch_oauth_for_tests() as mock:
+            callback_resp = test_client.get(
+                f"/api/connections/oauth/callback?code=snow_code&state={state}",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+                follow_redirects=False,
+            )
+        assert callback_resp.status_code in (302, 307)
+        assert "oauth=success" in callback_resp.headers.get("location", "")
+        assert mock.exchange_log[0]["code"] == "snow_code"
+
+        # Step 3: the user's token is stored encrypted and decrypts to what the
+        # provider issued — this is what construct_client hands to
+        # ServiceNowClient(access_token=...) at query time.
+        from app.dependencies import async_session_maker
+        from app.models.user_connection_credentials import UserConnectionCredentials
+        from sqlalchemy import select
+
+        async with async_session_maker() as db:
+            row = (await db.execute(
+                select(UserConnectionCredentials).where(
+                    UserConnectionCredentials.connection_id == conn["id"],
+                    UserConnectionCredentials.user_id == user_id,
+                    UserConnectionCredentials.is_active == True,
+                )
+            )).scalars().first()
+            assert row is not None, "callback did not store user credentials"
+            assert row.auth_mode == "oauth"
+            tokens = row.decrypt_credentials()
+
+        assert tokens["access_token"] == "access_token_v1"
+        assert tokens["refresh_token"]
+
+
 class TestOAuthReSignIn:
     """Test that re-signing in upserts (not duplicates) credentials."""
 

--- a/backend/tests/mocks/mock_oauth_provider.py
+++ b/backend/tests/mocks/mock_oauth_provider.py
@@ -53,6 +53,17 @@ class MockOAuthProvider:
             "scopes": "https://www.googleapis.com/auth/bigquery.readonly offline_access",
             "provider_name": "google",
         },
+        "servicenow": {
+            # Real endpoints are instance-specific ({instance_url}/oauth_auth.do);
+            # the mock mirrors the shape. client_secret=None models a ServiceNow
+            # "public client" app (PKCE only, no secret at the token endpoint).
+            "authorize_url": "https://mock-instance.service-now.test/oauth_auth.do",
+            "token_url": "https://mock-instance.service-now.test/oauth_token.do",
+            "client_id": "mock_snow_client_id",
+            "client_secret": None,
+            "scopes": "useraccount",
+            "provider_name": "servicenow",
+        },
     }
 
     def __init__(self):

--- a/backend/tests/unit/test_connection_oauth.py
+++ b/backend/tests/unit/test_connection_oauth.py
@@ -111,6 +111,47 @@ class TestGetOAuthParams:
         with pytest.raises(ValueError, match="oauth_client_id"):
             get_oauth_params(conn)
 
+    def test_servicenow(self):
+        conn = _make_connection(
+            type="servicenow",
+            credentials={
+                "username": "u", "password": "p",
+                "oauth_client_id": "sc1", "oauth_client_secret": "ss1",
+            },
+        )
+        conn.config = {"instance_url": "https://acme.service-now.com/"}
+        params = get_oauth_params(conn)
+        assert params["provider_name"] == "servicenow"
+        assert params["authorize_url"] == "https://acme.service-now.com/oauth_auth.do"
+        assert params["token_url"] == "https://acme.service-now.com/oauth_token.do"
+        assert params["client_id"] == "sc1"
+        assert params["client_secret"] == "ss1"
+        assert params["scopes"] == "useraccount"
+
+    def test_servicenow_config_stored_as_json_string(self):
+        conn = _make_connection(type="servicenow", credentials={"oauth_client_id": "sc1"})
+        conn.config = json.dumps({"instance_url": "https://acme.service-now.com"})
+        params = get_oauth_params(conn)
+        assert params["authorize_url"] == "https://acme.service-now.com/oauth_auth.do"
+
+    def test_servicenow_public_client_needs_no_secret(self):
+        conn = _make_connection(type="servicenow", credentials={"oauth_client_id": "sc1"})
+        conn.config = {"instance_url": "https://acme.service-now.com"}
+        params = get_oauth_params(conn)
+        assert params["client_secret"] is None
+
+    def test_servicenow_missing_client_id_raises(self):
+        conn = _make_connection(type="servicenow", credentials={"username": "u", "password": "p"})
+        conn.config = {"instance_url": "https://acme.service-now.com"}
+        with pytest.raises(ValueError, match="oauth_client_id"):
+            get_oauth_params(conn)
+
+    def test_servicenow_missing_instance_url_raises(self):
+        conn = _make_connection(type="servicenow", credentials={"oauth_client_id": "sc1"})
+        conn.config = {}
+        with pytest.raises(ValueError, match="instance_url"):
+            get_oauth_params(conn)
+
     def test_unsupported_type_raises(self):
         conn = _make_connection(type="postgres", credentials={})
         with pytest.raises(ValueError, match="not supported"):

--- a/backend/tests/unit/test_servicenow_client.py
+++ b/backend/tests/unit/test_servicenow_client.py
@@ -130,6 +130,38 @@ def test_connection_detects_silent_metadata_acl_failure(client):
     assert "sys_dictionary" in result["message"]
 
 
+# ── auth ─────────────────────────────────────────────────────────────────────
+
+def test_connect_uses_basic_auth_by_default(client):
+    c, session = client(metadata_responder)
+    c.test_connection()
+    assert session.auth == ("u", "p")
+    assert "Authorization" not in session.headers
+
+
+def test_connect_prefers_bearer_token_over_basic_auth(client):
+    """Per-user OAuth: access_token wins even when service-account
+    username/password are also present on the connection."""
+    c, session = client(metadata_responder, access_token="tok-123")
+    c.test_connection()
+    assert session.headers["Authorization"] == "Bearer tok-123"
+    assert session.auth is None
+
+
+def test_connect_without_any_credentials_raises():
+    c = ServiceNowClient(instance_url="https://example.service-now.com")
+    with pytest.raises(RuntimeError, match="no credentials"):
+        with c.connect():
+            pass
+
+
+def test_expired_oauth_token_message_mentions_sign_in(client):
+    c, _ = client(lambda path, params: FakeResponse({}, status_code=401), access_token="tok-123")
+    result = c.test_connection()
+    assert result["success"] is False
+    assert "sign in" in result["message"]
+
+
 # ── schema discovery ─────────────────────────────────────────────────────────
 
 def test_get_schemas_inherits_parent_fields(client):


### PR DESCRIPTION
## Summary

Adds delegated OAuth (authorization-code + PKCE) to the ServiceNow connector, reusing the existing connection OAuth machinery (authorize/callback routes, encrypted per-user token storage, automatic refresh). Basic auth is unchanged and remains the default — OAuth is opt-in per connection.

- **Client**: `ServiceNowClient` accepts an `access_token` and authenticates with `Authorization: Bearer` when present, falling back to basic auth; 401 messages distinguish an expired/revoked token from bad username/password.
- **Credentials**: `ServiceNowCredentials` gains optional `oauth_client_id` / `oauth_client_secret` (BigQuery pattern) — the service account keeps driving catalog indexing, the OAuth app powers per-user sign-in. Secret optional: ServiceNow "public client" apps work PKCE-only.
- **Registry**: new "Sign in with ServiceNow" user-scoped auth variant.
- **OAuth service**: `get_oauth_params` branch for ServiceNow's instance-specific `/oauth_auth.do` + `/oauth_token.do` endpoints, `useraccount` scope.
- **Connection service**: with an OAuth client configured, `user_required` connections default `allowed_user_auth_modes` to `["oauth"]` (Fabric pattern — the frontend then redirects straight to the provider). Without one, modes stay unrestricted so users on basic-auth-only instances can still bring their own credentials.

## Auth matrix after this change

| Setup | Catalog indexing | User queries |
|---|---|---|
| system_only + userpass (existing default) | service account | service account |
| user_required + OAuth client | service account | per-user OAuth token (native ACLs) |
| user_required, no OAuth client | service account | user's own username/password |

## Verification

- Unit tests: client Bearer/basic/no-credential paths, `get_oauth_params` (confidential + public client, JSON-string config, error cases).
- E2E test: full authorize → callback → token-storage flow through the real API with a mocked provider, including the mode-defaulting behavior.
- Live verification against a real ServiceNow PDI (`dev383284`): browser-equivalent sign-in (login → consent → code → token exchange at the real `/oauth_token.do`), token stored and auto-refresh wired, catalog indexed (11 curated tables), and a full agent completion answering "incidents by priority" with values that exactly match the instance's Stats API.
- Scale check against the same instance: 1,000-table schema discovery completes in ~73s (batched metadata reads, ~20 HTTP requests); single-table query latency ~1s regardless of catalog size.

## Notes

- No CHANGELOG entry included — entries appear to be added with release version bumps; suggested line: *"ServiceNow per-user OAuth — users can sign in with ServiceNow so queries run under their own ACLs; basic-auth service accounts unchanged."*
- Known follow-up (out of scope, per `documents/servicenow_connector_plan.md` Phase 2): server-side aggregation via ServiceNow's Aggregate API — today aggregations fetch rows (10k cap) and group in pandas, which undercounts on very large tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jyp5kiTWUigqYAhnobMnzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jyp5kiTWUigqYAhnobMnzH)_