### PR TITLE
OpenSearch: mark non-aggregatable full-text fields in the prompt schema

### DIFF
--- a/backend/app/data_sources/clients/opensearch_client.py
+++ b/backend/app/data_sources/clients/opensearch_client.py
@@ -36,6 +36,12 @@ class OpenSearchClient(DataSourceClient):
     # timeout just above the 60s query timeout sent to the engine.
     TIMEOUTS = (5, 65)
 
+    # Analyzed full-text types: never valid in terms aggs / sort. Without a
+    # `.keyword` subfield (log-style templates often omit it) the schema must
+    # say so, or the coder writes aggregations that 400. Mirrors the
+    # Elasticsearch client (fork parity).
+    _ANALYZED_TEXT_TYPES = {"text", "match_only_text", "search_as_you_type"}
+
     def __init__(
         self,
         host: str,
@@ -142,6 +148,14 @@ class OpenSearchClient(DataSourceClient):
                     columns.extend(self._flatten_properties(child_props, f"{full}[]", raw_types))
                 continue
             dtype = self._dtype_for(mtype or "object")
+            if mtype in self._ANALYZED_TEXT_TYPES:
+                kw = next(
+                    (f"{full}.{sub}" for sub, sub_defn in (defn.get("fields") or {}).items()
+                     if (sub_defn or {}).get("type") == "keyword"),
+                    None,
+                )
+                dtype = (f"string (full-text; aggregate/sort on {kw})" if kw
+                         else "string (full-text; NOT aggregatable/sortable)")
             columns.append(TableColumn(name=full, dtype=dtype))
             if raw_types is not None and mtype:
                 raw_types[full] = mtype
@@ -469,7 +483,10 @@ CRITICAL RULES:
 2. Use valid JSON: true/false/null (NOT Python True/False/None)
 3. Aggregate, sort and filter exactly on KEYWORD fields, never on "text" fields.
    When the schema shows both "title" (string) and "title.keyword", use
-   "title.keyword" for terms aggs / sorting and "title" for full-text "match"
+   "title.keyword" for terms aggs / sorting and "title" for full-text "match".
+   Fields marked "NOT aggregatable/sortable" (full-text with no keyword
+   subfield) can NEVER appear in terms aggs or sort — aggregate on a keyword
+   field instead (e.g. an error-type or code field rather than the message)
 4. Fields marked "array" with children under "name[]" are NESTED - queries on
    them must be wrapped: {{"nested": {{"path": "items", "query": {{...}}}}}}
 5. When only aggregations matter, "size" defaults to 0 automatically

--- a/backend/tests/unit/test_opensearch_client.py
+++ b/backend/tests/unit/test_opensearch_client.py
@@ -158,8 +158,9 @@ class TestGetTables:
         assert cols["order_id"] == "string"
         assert cols["total"] == "number"
         assert cols["created_at"] == "datetime"
-        # object recursion -> dot paths
-        assert cols["customer.name"] == "string"
+        # object recursion -> dot paths; analyzed text with no keyword
+        # subfield is flagged non-aggregatable
+        assert cols["customer.name"] == "string (full-text; NOT aggregatable/sortable)"
         assert cols["customer.tier"] == "string"
         # nested -> array column + [] children
         assert cols["items"] == "array"
@@ -169,6 +170,15 @@ class TestGetTables:
         assert cols["title.keyword"] == "string"
         # pk convention
         assert [p.name for p in tables[0].pks] == ["_id"]
+
+    def test_analyzed_text_dtype_points_at_keyword_subfield(self, transport):
+        # A text field WITH a keyword subfield routes aggs/sort to the
+        # subfield; one WITHOUT is flagged. Mirrors the Elasticsearch client.
+        transport(self._routes())
+        cols = {c.name: c.dtype for c in OpenSearchClient(host="h").get_tables()[0].columns}
+        assert cols["title"] == "string (full-text; aggregate/sort on title.keyword)"
+        assert cols["title.keyword"] == "string"
+        assert cols["customer.name"] == "string (full-text; NOT aggregatable/sortable)"
 
     def test_raw_types_metadata_kept(self, transport):
         transport(self._routes())


### PR DESCRIPTION
## What

Fork-parity follow-up to #662: the analyzed-text dtype annotation added to the Elasticsearch client is now applied to `opensearch_client.py` too.

Analyzed full-text fields (`text` / `match_only_text` / `search_as_you_type`) can never be used in terms aggregations or sort — the schema now says so instead of showing them as plain `string`:

- `title` (text with a `.keyword` subfield) → `string (full-text; aggregate/sort on title.keyword)`
- `customer.name` (text with no keyword subfield) → `string (full-text; NOT aggregatable/sortable)`

The client's prompt rule is extended to cover the no-keyword-subfield case. Unlike the Elasticsearch variant, it deliberately does **not** recommend `runtime_mappings` — OpenSearch's `_search` doesn't accept it (and it isn't in this client's envelope pass-through) — pointing at keyword-field alternatives instead.

The failure mode is rarer on OpenSearch than on Elastic serverless (dynamic mappings usually create `.keyword` multifields), but log-style templates that omit keyword subfields hit exactly the same 400, and keeping the two forked clients in lockstep is the design-doc contract.

## Test plan
- `cd backend && uv run pytest tests/unit/test_opensearch_client.py tests/unit/test_elasticsearch_client.py` — 65 passed
- New: `test_analyzed_text_dtype_points_at_keyword_subfield` (both annotation variants); existing flattening test updated for the flagged dtype

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RYeg2f8tH8XWWQpEkEW57

---
_Generated by [Claude Code](https://claude.ai/code/session_013RYeg2f8tH8XWWQpEkEW57)_