### PR TITLE
Fix file attachment UI overflow: scrollable files modal and capped inline chips

### DIFF
--- a/frontend/components/FileUploadComponent.vue
+++ b/frontend/components/FileUploadComponent.vue
@@ -10,7 +10,7 @@
         </span>
       </button>
       <UModal v-model="isFilesOpen">
-        <div class="p-4 h-72">
+        <div class="p-4 min-h-72 flex flex-col">
           <h2 class="text-md font-semibold pb-2">Upload files</h2>
           <hr />
 
@@ -43,7 +43,7 @@
           </div>
           <ul
             v-if="allFiles.length > 0"
-            class="w-full mt-4"
+            class="w-full mt-4 max-h-64 overflow-y-auto"
             @dragover.prevent="isDragging = true"
             @dragenter.prevent="isDragging = true"
             @dragleave.prevent="isDragging = false"
@@ -52,30 +52,34 @@
               v-for="(file, index) in allFiles" 
               :key="file.id" 
               class="text-xs py-2 text-gray-600 dark:text-gray-400 flex items-center justify-between border-b border-gray-100 dark:border-gray-800 last:border-b-0">
-              <div class="flex items-center gap-1.5">
+              <div class="flex items-center gap-1.5 min-w-0 flex-1">
                 <Spinner v-if="file.status === 'processing'" class="w-3 h-3 text-blue-500 flex-shrink-0" />
                 <Icon v-else-if="file.status === 'uploaded'" name="heroicons-check-circle" class="text-blue-500 w-4 h-4 flex-shrink-0" />
                 <Icon v-else-if="file.status === 'error'" name="heroicons-x-circle" class="text-red-500 w-4 h-4 flex-shrink-0" />
 
                 <span class="truncate">{{ file.filename }}</span>
               </div>
-              <div>
+              <div class="flex-shrink-0 ps-2">
               <button @click="removeFile(file)" class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full ms-auto items-center justify-center">
                 <Icon name="heroicons-x-mark" class="w-4 h-4" />
               </button>
             </div>
             </li>
-            <li 
-              :class="['text-center items-center py-4 mt-3 rounded-lg transition-all cursor-pointer',
-                isDragging ? 'bg-blue-50 dark:bg-blue-950 border-1 border-dashed border-blue-400' : 'border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:bg-blue-50/50 dark:hover:bg-blue-950']"
-              v-if="allFiles.length > 0"
-              @click="$refs.fileInput.click()">
-              <div class="text-sm text-blue-500 flex items-center justify-center gap-2 w-full">
-                <Icon name="heroicons-cloud-arrow-up" class="w-5 h-5" />
-                {{ isDragging ? 'Drop files here' : 'Click or drag to upload more' }}
-              </div>
-            </li>
           </ul>
+          <div
+            :class="['text-center items-center py-4 mt-3 rounded-lg transition-all cursor-pointer',
+              isDragging ? 'bg-blue-50 dark:bg-blue-950 border-1 border-dashed border-blue-400' : 'border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:bg-blue-50/50 dark:hover:bg-blue-950']"
+            v-if="allFiles.length > 0"
+            @dragover.prevent="isDragging = true"
+            @dragenter.prevent="isDragging = true"
+            @dragleave.prevent="isDragging = false"
+            @drop.prevent="handleDrop"
+            @click="$refs.fileInput.click()">
+            <div class="text-sm text-blue-500 flex items-center justify-center gap-2 w-full">
+              <Icon name="heroicons-cloud-arrow-up" class="w-5 h-5" />
+              {{ isDragging ? 'Drop files here' : 'Click or drag to upload more' }}
+            </div>
+          </div>
         </div>
       </UModal>
     </div>

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -225,7 +225,7 @@
             <div v-if="uploadedFiles.length > 0" class="px-3 pb-2 flex flex-wrap gap-2">
                 <!-- Image files - show thumbnail preview -->
                 <div
-                    v-for="file in uploadedFiles.filter(f => isImageFile(f))"
+                    v-for="file in visibleInlineFiles.filter(f => isImageFile(f))"
                     :key="file.id"
                     class="relative group"
                 >
@@ -270,14 +270,14 @@
 
                 <!-- Non-image files - show chip style -->
                 <div
-                    v-for="file in uploadedFiles.filter(f => !isImageFile(f))"
+                    v-for="file in visibleInlineFiles.filter(f => !isImageFile(f))"
                     :key="file.id"
                     class="inline-flex items-center gap-1.5 px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded-lg text-xs text-gray-700 dark:text-gray-300 group"
                 >
                     <Spinner v-if="file.status === 'processing'" class="w-3 h-3 text-blue-500 flex-shrink-0" />
                     <Icon v-else-if="file.status === 'error'" name="heroicons-exclamation-circle" class="w-3.5 h-3.5 text-red-500 flex-shrink-0" />
                     <Icon v-else name="heroicons-document" class="w-3.5 h-3.5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-                    <span class="truncate max-w-[150px]">{{ file.filename }}</span>
+                    <span class="truncate max-w-[110px]">{{ file.filename }}</span>
                     <button
                         @click="removeInlineFile(file)"
                         class="ms-0.5 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
@@ -286,6 +286,15 @@
                         <Icon name="heroicons-x-mark" class="w-3 h-3" />
                     </button>
                 </div>
+
+                <!-- Overflow: remaining files are managed via the files modal -->
+                <button
+                    v-if="hiddenInlineFileCount > 0"
+                    @click="openFilesModal"
+                    class="inline-flex items-center px-2 py-1 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+                >
+                    {{ $t('prompt.moreFiles', { count: hiddenInlineFileCount }) }}
+                </button>
             </div>
 
             <!-- Bottom controls -->
@@ -1173,6 +1182,21 @@ function submit() {
 
 function onFilesUploaded(files: any[]) {
     uploadedFiles.value = files || []
+}
+
+// Cap inline chips to one row's worth; the rest live behind a "+N more"
+// chip that opens the files modal. Images sort first to match display order,
+// so the hidden tail is always the last chips visually.
+const MAX_INLINE_FILES = 4
+const orderedInlineFiles = computed(() => {
+    const files = uploadedFiles.value
+    return [...files.filter(f => isImageFile(f)), ...files.filter(f => !isImageFile(f))]
+})
+const visibleInlineFiles = computed(() => orderedInlineFiles.value.slice(0, MAX_INLINE_FILES))
+const hiddenInlineFileCount = computed(() => Math.max(0, orderedInlineFiles.value.length - MAX_INLINE_FILES))
+
+function openFilesModal() {
+    fileUploadRef.value?.open?.()
 }
 
 // Helper to check if a file is an image

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -1187,7 +1187,7 @@ function onFilesUploaded(files: any[]) {
 // Cap inline chips to one row's worth; the rest live behind a "+N more"
 // chip that opens the files modal. Images sort first to match display order,
 // so the hidden tail is always the last chips visually.
-const MAX_INLINE_FILES = 4
+const MAX_INLINE_FILES = 2
 const orderedInlineFiles = computed(() => {
     const files = uploadedFiles.value
     return [...files.filter(f => isImageFile(f)), ...files.filter(f => !isImageFile(f))]

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -403,6 +403,7 @@
     "connectLLM": "اربط نموذج اللغة أولًا",
     "connectDataOrFile": "اربط بيانات أو ارفع ملفًا",
     "waitingForFiles": "بانتظار اكتمال رفع الملفات…",
+    "moreFiles": "+{count} أخرى",
     "enterMessage": "اكتب رسالة",
     "estimatingContext": "جارٍ تقدير السياق المُستخدَم…",
     "contextSizeUnavailable": "حجم السياق غير متاح",

--- a/locales/de.json
+++ b/locales/de.json
@@ -403,6 +403,7 @@
     "connectLLM": "Verbinden Sie zuerst ein LLM",
     "connectDataOrFile": "Verbinden Sie Daten oder laden Sie eine Datei hoch",
     "waitingForFiles": "Warten auf Datei-Uploads …",
+    "moreFiles": "+{count} weitere",
     "enterMessage": "Nachricht eingeben",
     "estimatingContext": "Geschätzter verwendeter Kontext …",
     "contextSizeUnavailable": "Kontextgröße nicht verfügbar",

--- a/locales/en.json
+++ b/locales/en.json
@@ -435,6 +435,7 @@
     "connectLLM": "First connect LLM",
     "connectDataOrFile": "Connect data or upload a file",
     "waitingForFiles": "Waiting for files to upload…",
+    "moreFiles": "+{count} more",
     "enterMessage": "Enter a message",
     "estimatingContext": "Estimating context used…",
     "contextSizeUnavailable": "Context size unavailable",

--- a/locales/es.json
+++ b/locales/es.json
@@ -418,6 +418,7 @@
     "connectLLM": "Conecte primero un LLM",
     "connectDataOrFile": "Conecte datos o suba un archivo",
     "waitingForFiles": "Esperando a que terminen las subidas…",
+    "moreFiles": "+{count} más",
     "enterMessage": "Escriba un mensaje",
     "estimatingContext": "Estimando contexto usado…",
     "contextSizeUnavailable": "Tamaño de contexto no disponible",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -403,6 +403,7 @@
     "connectLLM": "Connectez d'abord un LLM",
     "connectDataOrFile": "Connectez des données ou téléversez un fichier",
     "waitingForFiles": "En attente du téléversement des fichiers…",
+    "moreFiles": "+{count} autres",
     "enterMessage": "Saisissez un message",
     "estimatingContext": "Estimation du contexte utilisé…",
     "contextSizeUnavailable": "Taille du contexte indisponible",

--- a/locales/he.json
+++ b/locales/he.json
@@ -418,6 +418,7 @@
     "connectLLM": "חברו קודם LLM",
     "connectDataOrFile": "חברו נתונים או העלו קובץ",
     "waitingForFiles": "ממתין לסיום העלאת קבצים…",
+    "moreFiles": "+{count} נוספים",
     "enterMessage": "הקלידו הודעה",
     "estimatingContext": "מעריך שימוש בקונטקסט…",
     "contextSizeUnavailable": "גודל הקונטקסט אינו זמין",

--- a/locales/it.json
+++ b/locales/it.json
@@ -403,6 +403,7 @@
     "connectLLM": "Collega prima un LLM",
     "connectDataOrFile": "Collega dati o carica un file",
     "waitingForFiles": "In attesa del caricamento dei file…",
+    "moreFiles": "+{count} altri",
     "enterMessage": "Scrivi un messaggio",
     "estimatingContext": "Stima del contesto utilizzato…",
     "contextSizeUnavailable": "Dimensione del contesto non disponibile",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -403,6 +403,7 @@
     "connectLLM": "Conecte primeiro um LLM",
     "connectDataOrFile": "Conecte dados ou faça upload de um arquivo",
     "waitingForFiles": "Aguardando o upload dos arquivos…",
+    "moreFiles": "+{count} mais",
     "enterMessage": "Digite uma mensagem",
     "estimatingContext": "Estimando contexto utilizado…",
     "contextSizeUnavailable": "Tamanho do contexto indisponível",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -403,6 +403,7 @@
     "connectLLM": "Сначала подключите LLM",
     "connectDataOrFile": "Подключите данные или загрузите файл",
     "waitingForFiles": "Ожидание загрузки файлов…",
+    "moreFiles": "ещё {count}",
     "enterMessage": "Введите сообщение",
     "estimatingContext": "Оценка использованного контекста…",
     "contextSizeUnavailable": "Размер контекста недоступен",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -403,6 +403,7 @@
     "connectLLM": "Anslut först LLM",
     "connectDataOrFile": "Anslut data eller ladda upp en fil",
     "waitingForFiles": "Väntar på att filerna ska laddas upp…",
+    "moreFiles": "+{count} till",
     "enterMessage": "Skriv ett meddelande",
     "estimatingContext": "Uppskattar använd kontext…",
     "contextSizeUnavailable": "Kontextstorlek ej tillgänglig",


### PR DESCRIPTION
## Summary

Two related UI fixes for file attachments in the prompt area:

**Upload files modal (`FileUploadComponent.vue`)**
- The modal body had a fixed `h-72` height with no overflow handling, so with more than a few files the list rows spilled past the modal's bottom edge.
- The file list now scrolls within a max height (`max-h-64 overflow-y-auto`), and the "Click or drag to upload more" drop zone moved out of the list so it stays pinned and reachable below the scroll area (it keeps its own drag-and-drop handlers).
- Long filenames now truncate properly (`min-w-0 flex-1` on the filename cell) instead of pushing the remove button outside the modal.

**Inline file chips in the prompt box (`PromptBoxV2.vue`)**
- With several files attached, inline chips wrapped into multiple rows and ate a big chunk of the prompt box.
- Chips are now capped at 2 (`MAX_INLINE_FILES`), with the rest collapsed into a "+N more" chip that opens the files modal for full review/removal. Image thumbnails sort first to match display order, so the hidden tail is always the last chips visually.
- Chip filename truncation tightened from 150px to 110px so more chips fit per row.
- Adds a `prompt.moreFiles` ("+{count} more") i18n key to all 10 locales.

## Verification

Mounted the real components in a Vite + Playwright harness (Nuxt-specific bits stubbed) and drove them with 10 uploaded files:

| | Before | After |
|---|---|---|
| Files modal | rows spill ~200px past the modal bottom; long filenames overflow horizontally | all content contained, list scrolls, filenames truncate |
| Prompt box chips | chips wrap into multiple rows | single row: 2 chips + "+8 more" |

Also verified clicking "+N more" opens the Upload files modal listing all attached files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MnpR7hitPWVAcf3egfY4A

---
_Generated by [Claude Code](https://claude.ai/code/session_015MnpR7hitPWVAcf3egfY4A)_