### PR TITLE
Enforce org membership at all access chokepoints

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -28,7 +28,7 @@ from app.models.organization import Organization
 from app.models.membership import Membership
 
 from app.models.user import User
-from app.dependencies import get_user_db, get_async_db
+from app.dependencies import get_user_db, get_async_db, resolve_organization
 from app.models.oauth_account import OAuthAccount
 from fastapi.responses import RedirectResponse
 
@@ -1012,6 +1012,35 @@ async def current_user_optional(
         return await current_user(request, jwt_user, api_key, db)
     except HTTPException:
         return None
+
+
+async def get_current_organization(
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+    user: User = Depends(current_user),
+) -> Organization:
+    """Resolve the request's organization AND enforce that the caller still
+    belongs to it.
+
+    This is the single membership chokepoint for the HTTP surface: every route
+    that depends on it inherits the check, including the ~138 org-scoped routes
+    that carry no ``@requires_permission`` decorator. A user whose membership was
+    removed (directly, or via LDAP/OIDC/SCIM sync) is rejected with 403 the
+    moment they touch any org-scoped endpoint, instead of retaining access to
+    everything gated only on "public within the org".
+
+    Defined in core.auth (next to ``current_user``) rather than in dependencies
+    to avoid a circular import; ``app.dependencies`` re-exports it lazily so
+    ``from app.dependencies import get_current_organization`` keeps working.
+
+    Membership-bootstrap flows (invite acceptance, org creation) do not depend on
+    this — they establish the membership and so must run above the invariant.
+    """
+    from app.core.permission_resolver import assert_principal_belongs_to_org
+
+    org = await resolve_organization(request, db)
+    await assert_principal_belongs_to_org(db, user, org.id)
+    return org
 
 
 async def forbid_service_account_principal(user: User = Depends(current_user)) -> User:

--- a/backend/app/core/permission_resolver.py
+++ b/backend/app/core/permission_resolver.py
@@ -169,6 +169,20 @@ async def principal_belongs_to_org(db: AsyncSession, user, org_id: str) -> bool:
     return result.scalar_one_or_none() is not None
 
 
+async def assert_principal_belongs_to_org(db: AsyncSession, user, org_id: str) -> None:
+    """Raise 403 unless ``user`` is bound to ``org_id`` (member or service account).
+
+    The single membership invariant: whenever a user id and an org id both
+    exist for a request/job, the principal must still be bound to that org.
+    Enforced at every non-bootstrap entry point (HTTP org dependency, MCP auth,
+    completion creation, scheduled-prompt execution, external-platform messages)
+    so a removed member can't keep acting in the org via any surface that
+    bypasses ``@requires_permission``.
+    """
+    if not await principal_belongs_to_org(db, user, org_id):
+        raise HTTPException(status_code=403, detail="User is not a member of this organization")
+
+
 async def ensure_system_role_assignment(
     db: AsyncSession, org_id: str, user_id: str, role_name: str,
 ) -> None:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -96,8 +96,15 @@ async def get_user_db(session: AsyncSession = Depends(get_async_db)):
     # also lets release_request_db actually free the request's only connection.
     yield SQLAlchemyUserDatabase(session, User, OAuthAccount)
 
-async def get_current_organization(request: Request, db: AsyncSession = Depends(get_async_db)) -> Organization:
-    """Get organization from X-Organization-Id header or from API key."""
+async def resolve_organization(request: Request, db: AsyncSession) -> Organization:
+    """Resolve the request's organization from the X-Organization-Id header or
+    API key, WITHOUT enforcing that the caller belongs to it.
+
+    Callers that already establish the principal separately (e.g. MCP auth,
+    which returns (user, org) and enforces membership itself) use this. Regular
+    HTTP routes go through ``get_current_organization``, which layers the
+    membership check on top.
+    """
     organization_id: Optional[str] = request.headers.get("X-Organization-Id")
 
     if organization_id:
@@ -124,6 +131,23 @@ async def get_current_organization(request: Request, db: AsyncSession = Depends(
         raise AppError.unauthorized(ErrorCode.API_KEY_INVALID, "Invalid or expired API key")
 
     raise AppError.bad_request(ErrorCode.ORG_HEADER_REQUIRED, "Organization ID header missing")
+
+
+def __getattr__(name: str):
+    """Lazily expose the enforcing ``get_current_organization`` from core.auth.
+
+    The enforcing dependency needs ``current_user`` as a sub-dependency, which
+    lives in ``app.core.auth`` — and core.auth imports session providers from
+    this module, so importing it eagerly here would be a circular import at load
+    time. PEP 562 module ``__getattr__`` defers that import until the symbol is
+    actually looked up (route-registration time), by which point core.auth has
+    finished loading. Every ``from app.dependencies import get_current_organization``
+    keeps working unchanged.
+    """
+    if name == "get_current_organization":
+        from app.core.auth import get_current_organization
+        return get_current_organization
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _locale_from_org(organization: Optional[Organization]) -> Optional[str]:
@@ -153,9 +177,20 @@ async def get_current_locale(request: Request) -> str:
     return config.settings.bow_config.i18n.default_locale
 
 
+async def _resolve_organization_dep(
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+) -> Organization:
+    """Depends-compatible wrapper around ``resolve_organization`` (no membership
+    enforcement). Used by the locale/MCP-enabled read helpers below, which don't
+    gate access themselves — the route's own ``get_current_organization`` /
+    ``@requires_permission`` dependency enforces membership."""
+    return await resolve_organization(request, db)
+
+
 async def get_org_locale(
     request: Request,
-    organization: Organization = Depends(get_current_organization),
+    organization: Organization = Depends(_resolve_organization_dep),
 ) -> str:
     """Effective locale for authed requests: header override → org → default."""
     enabled = config.settings.bow_config.i18n.enabled_locales
@@ -169,7 +204,7 @@ async def get_org_locale(
 
 
 async def require_mcp_enabled(
-    organization: Organization = Depends(get_current_organization)
+    organization: Organization = Depends(_resolve_organization_dep)
 ) -> Organization:
     """Dependency to ensure MCP is enabled for the organization."""
     if not organization.settings:

--- a/backend/app/routes/mcp.py
+++ b/backend/app/routes/mcp.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
 from app.core.auth import current_user, _jwt_current_user, api_key_header
-from app.dependencies import get_async_db, require_mcp_enabled, get_current_organization
+from app.dependencies import get_async_db, require_mcp_enabled, get_current_organization, resolve_organization
 from app.models.user import User
 from app.models.organization import Organization
 from app.ai.tools.mcp import get_mcp_tool, list_mcp_tools
@@ -51,11 +51,20 @@ async def mcp_auth(
     Returns (user, organization). On failure, raises 401 with WWW-Authenticate
     header pointing to the OAuth protected resource metadata.
     """
+    async def _authed(user: User, org: Organization) -> Tuple[User, Organization]:
+        # Same membership invariant as the HTTP org dependency: a principal that
+        # is no longer bound to the org (removed member) can't act via MCP even
+        # with a still-valid JWT / API key / OAuth token. Service accounts pass
+        # via their ServiceAccount row.
+        from app.core.permission_resolver import assert_principal_belongs_to_org
+        await assert_principal_belongs_to_org(db, user, org.id)
+        return user, org
+
     # 1. Try JWT
     if jwt_user is not None:
         try:
-            org = await get_current_organization(request, db)
-            return jwt_user, org
+            org = await resolve_organization(request, db)
+            return await _authed(jwt_user, org)
         except HTTPException:
             pass
 
@@ -67,7 +76,7 @@ async def mcp_auth(
         if user:
             org = await svc.get_organization_by_api_key(db, api_key)
             if org:
-                return user, org
+                return await _authed(user, org)
 
     # 3. Try Bearer token from Authorization header
     auth_header = request.headers.get("Authorization", "")
@@ -82,7 +91,7 @@ async def mcp_auth(
             svc = OAuthServerService()
             result = await svc.validate_access_token(db, token)
             if result:
-                return result  # (user, organization)
+                return await _authed(result[0], result[1])  # (user, organization)
             logger.warning("OAuth token validation failed for token starting with: %s...", token[:16])
 
         # 3b. API key via Bearer
@@ -93,7 +102,7 @@ async def mcp_auth(
             if user:
                 org = await svc.get_organization_by_api_key(db, token)
                 if org:
-                    return user, org
+                    return await _authed(user, org)
 
     # No valid auth — return 401 with OAuth metadata
     resource_url = _resource_metadata_url(request)

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -483,6 +483,15 @@ class CompletionService:
         try:
             print("CompletionService: Starting create_completion (v2, non-stream)")
 
+            # Membership invariant: the acting user must still belong to the org.
+            # This is the service-layer chokepoint for callers that bypass the
+            # HTTP org dependency — external-platform webhooks (Teams/Slack/
+            # WhatsApp/email) and scheduled prompts both reach completion
+            # creation here without a request-time membership check.
+            if current_user is not None and organization is not None:
+                from app.core.permission_resolver import assert_principal_belongs_to_org
+                await assert_principal_belongs_to_org(db, current_user, organization.id)
+
             # Validate report exists
             result = await db.execute(select(Report).filter(Report.id == report_id))
             report = result.scalar_one_or_none()

--- a/backend/app/services/external_platform_manager.py
+++ b/backend/app/services/external_platform_manager.py
@@ -527,6 +527,24 @@ class ExternalPlatformManager:
         if not organization:
             return {"success": False, "error": "Organization not found"}
 
+        # Membership invariant: a verified external mapping is not a standing
+        # grant. If the linked user has since been removed from the org, stop
+        # honoring their messages — unverify the mapping (so the next message
+        # re-runs the link/verify flow) and tell them to ask their admin.
+        from app.core.permission_resolver import principal_belongs_to_org
+        if not await principal_belongs_to_org(db, user, str(organization.id)):
+            user_mapping.is_verified = False
+            await db.commit()
+            try:
+                await adapter.send_dm(
+                    user_mapping.external_user_id,
+                    "Your access to this workspace has been revoked. "
+                    "Ask your admin to re-invite you if this is a mistake.",
+                )
+            except Exception as e:
+                print(f"Failed to send access-revoked DM: {e}")
+            return {"success": False, "error": "User is not a member of this organization"}
+
         # Extract thread context from processed data
         thread_ts = processed_data.get("thread_ts")
         message_ts = processed_data.get("message_ts")

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -23,7 +23,7 @@ from app.models.user import User
 from typing import List
 from sqlalchemy.orm import selectinload
 from fastapi import HTTPException
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 from app.services.llm_service import LLMService
 from app.services.test_suite_service import TestSuiteService
 from app.settings.config import settings
@@ -485,6 +485,15 @@ class OrganizationService:
         if membership.user_id:
             # RBAC lockout prevention: ensure at least one user keeps full_admin_access
             await assert_full_admin_exists(db, organization_id, exclude_user_id=membership.user_id)
+            # Revoke the standing artifacts that would otherwise let the removed
+            # user keep acting in the org without a membership: verified external
+            # platform links (Teams/Slack/WhatsApp/email) and their scheduled
+            # prompts. The execution-time membership checks are the real gate;
+            # this proactively tears down convenience access at removal time and
+            # stops departed members' schedules from firing at all.
+            await self._revoke_departed_member_access(
+                db, organization_id, str(membership.user_id)
+            )
         else:
             # Pending invite: clean up any pre-assigned RBAC keyed by this
             # membership. Done explicitly (not via FK cascade) so it holds on
@@ -512,7 +521,71 @@ class OrganizationService:
 
         await db.execute(delete(Membership).where(Membership.id == membership_id))
         await db.commit()
-    
+
+    async def _revoke_departed_member_access(
+        self, db: AsyncSession, organization_id: str, user_id: str
+    ) -> None:
+        """Tear down a removed user's standing access artifacts in this org.
+
+        - Unverify their external-platform mappings (Teams/Slack/WhatsApp/email)
+          so an already-linked chat identity can no longer send queries; the
+          next message re-enters the verify flow, which will fail without a
+          membership.
+        - Deactivate their scheduled prompts on reports in this org and drop the
+          APScheduler jobs, so nothing keeps firing as the departed user.
+
+        Best-effort and self-contained: a failure here must not block the
+        membership removal itself (the execution-time checks still gate access).
+        """
+        from app.models.external_user_mapping import ExternalUserMapping
+        from app.models.scheduled_prompt import ScheduledPrompt
+        from app.models.report import Report
+
+        try:
+            await db.execute(
+                update(ExternalUserMapping)
+                .where(
+                    ExternalUserMapping.organization_id == organization_id,
+                    ExternalUserMapping.app_user_id == user_id,
+                )
+                .values(is_verified=False)
+            )
+        except Exception:
+            logger.warning("Failed to unverify external mappings for removed member", exc_info=True)
+
+        sp_ids: list[str] = []
+        try:
+            result = await db.execute(
+                select(ScheduledPrompt.id)
+                .join(Report, ScheduledPrompt.report_id == Report.id)
+                .where(
+                    Report.organization_id == organization_id,
+                    ScheduledPrompt.user_id == user_id,
+                    ScheduledPrompt.deleted_at == None,
+                    ScheduledPrompt.is_active == True,
+                )
+            )
+            sp_ids = [str(r) for r in result.scalars().all()]
+            if sp_ids:
+                await db.execute(
+                    update(ScheduledPrompt)
+                    .where(ScheduledPrompt.id.in_(sp_ids))
+                    .values(is_active=False)
+                )
+        except Exception:
+            logger.warning("Failed to deactivate scheduled prompts for removed member", exc_info=True)
+
+        await db.commit()
+
+        # Drop the cron jobs after the DB state is committed. Import locally to
+        # avoid a module-level dependency on the scheduler from org management.
+        for sp_id in sp_ids:
+            try:
+                from app.services.scheduled_prompt_service import scheduled_prompt_service
+                scheduled_prompt_service._remove_job(sp_id)
+            except Exception:
+                logger.warning(f"Failed to remove cron job for scheduled prompt {sp_id}", exc_info=True)
+
     async def update_member(self, db: AsyncSession, membership_id: str, organization_id: str, membership_data: MembershipUpdate, current_user: User, organization: Organization) -> MembershipSchema:
         from app.core.permission_resolver import assert_full_admin_exists
 

--- a/backend/app/services/scheduled_prompt_service.py
+++ b/backend/app/services/scheduled_prompt_service.py
@@ -284,6 +284,21 @@ class ScheduledPromptService:
                 logger.error(f"Scheduled prompt {sp.id}: organization not found")
                 return
 
+            # Membership invariant: don't keep running a departed member's
+            # schedule as them. If the owner is no longer bound to the org
+            # (removed directly or via LDAP/OIDC/SCIM sync), deactivate the
+            # schedule and drop its cron job instead of firing it.
+            from app.core.permission_resolver import principal_belongs_to_org
+            if not await principal_belongs_to_org(db, user, str(organization.id)):
+                logger.warning(
+                    f"Scheduled prompt {sp.id}: owner {sp.user_id} is no longer a "
+                    f"member of org {organization.id}; deactivating schedule."
+                )
+                sp.is_active = False
+                await db.commit()
+                self._remove_job(sp.id)
+                return
+
             # Routing: spawn_new_report = fresh dated report per run (clean
             # snapshot, no context growth), else run in the host report
             # (default — keeps cross-run memory for trend commentary).


### PR DESCRIPTION
## Problem

A removed member retained access through every surface that bypasses the `@requires_permission` decorator. Membership was enforced only by that one decorator, so anything not passing through it skipped the check:

- **~138 org-scoped HTTP routes** that carry no `@requires_permission` and gate only on "public within the org" (`data_sources/active`, `prompts`, `instructions`, `connections`, …) stayed accessible with a still-valid session.
- **External-platform webhooks** (Teams/Slack/WhatsApp/email) route through `ExternalPlatformManager` → `create_completion` directly, checking only a stored `is_verified` flag that is never revoked.
- **Scheduled prompts** fire via APScheduler and call `create_completion` as the owner, with no membership check — a departed member's daily prompt kept running.

The org itself is resolved from the `X-Organization-Id` header, which never verified the caller belonged to it; only the decorator tied the two together.

## Fix

Establish the invariant **"user id + org id present → principal must still be bound to the org"** at every non-bootstrap entry point, all sharing one predicate (`principal_belongs_to_org`, which still admits service accounts via their `ServiceAccount` row):

- **HTTP** — `get_current_organization` now resolves the org **and** asserts membership, so every route depending on it inherits the check (the ~138 undecorated ones included). Moved to `core.auth` next to `current_user` to avoid a circular import; `app.dependencies` re-exports it lazily via PEP 562 module `__getattr__` so all existing `from app.dependencies import get_current_organization` imports keep working. A pure `resolve_organization` (no enforcement) is split out for callers that establish the principal separately.
- **MCP** — `mcp_auth` asserts membership on every JWT / API-key / OAuth return path.
- **create_completion** — service-layer check covering the webhook + scheduled callers that bypass the HTTP dependency.
- **Scheduled prompts** — a run whose owner is no longer a member is skipped and the schedule auto-deactivated (its cron job dropped). Covers LDAP/OIDC/SCIM removals that never call `remove_member`.
- **External platform manager** — messages from a delinked member are rejected and the mapping unverified, so the next message re-enters the verify flow (which fails without a membership).
- **remove_member** — proactively unverifies the departed member's external mappings and deactivates their scheduled prompts at removal time.

Membership-bootstrap flows (invite acceptance, org creation) run *above* the invariant and are unaffected.

## Verification

Booted the backend against a scratch SQLite DB and drove the real HTTP API + live APScheduler; same flow run before and after:

- **Before**: removed member → `data_sources/active`, `prompts`, `instructions` all **200**; scheduled prompt fired after removal (`last_run_at` updated).
- **After**: same three routes **403** `"User is not a member of this organization"`; scheduled prompt `is_active=0`, never fired. Member-while-member stayed **200**; admin invite/remove unaffected.
- **Execution guard in isolation**: deleted the membership row directly (simulating a sync-path removal that bypasses `remove_member`) → next cron fire deactivated the schedule and did not run the completion.
- Confirmed no false positives for `create_completion` (automation/test-run paths resolve their actor to a real admin/member) and that imports resolve in all module load orders + the app boots clean.

Two guards were validated at the predicate/code level but not driven end-to-end: the external-platform manager (Teams webhook needs a valid Bot-Framework JWT signature) and the MCP path (needs MCP client setup). Both reuse the same `principal_belongs_to_org` primitive exercised above.

## Follow-up (not in this PR)

Departed members' scheduled prompts currently **auto-deactivate**. Transfer-to-admin or notifying subscribers is a deliberate product decision left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBFSzWSp1hV5KnqjkEskto

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBFSzWSp1hV5KnqjkEskto)_