### PR TITLE
Collapse file-tool results by default in the report tool-call view

### DIFF
--- a/frontend/components/tools/GrepFilesTool.vue
+++ b/frontend/components/tools/GrepFilesTool.vue
@@ -9,7 +9,14 @@
             <template v-else>Grepping files for {{ patternLabel }}…</template>
           </span>
         </span>
-        <span v-else class="text-gray-700 dark:text-gray-300 flex items-center flex-wrap">
+        <span
+          v-else
+          class="text-gray-700 dark:text-gray-300 flex items-center flex-wrap"
+          :class="matches.length ? 'cursor-pointer' : ''"
+          @click="matches.length && (expanded = !expanded)"
+          :aria-expanded="matches.length ? expanded : undefined"
+        >
+          <Icon v-if="matches.length" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 rtl-flip" />
           <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
           <span class="align-middle">{{ modelTitle || ('Grepped files for ' + patternLabel) }}</span>
           <span v-if="rj.success" class="ms-2 text-gray-400">
@@ -26,7 +33,7 @@
     </Transition>
 
     <Transition name="fade" appear>
-      <div v-if="matches.length" class="text-xs text-gray-600 dark:text-gray-400">
+      <div v-if="matches.length && expanded" class="text-xs text-gray-600 dark:text-gray-400">
         <ul class="ms-1 space-y-1 leading-snug">
           <li v-for="(m, idx) in matches.slice(0, 10)" :key="idx">
             <div
@@ -97,6 +104,8 @@ const skipReasons = computed(() => {
   return Object.entries(counts).map(([r, n]) => `${n} ${r}`).join(', ')
 })
 const errorMessage = computed(() => rj.value.error || '')
+
+const expanded = ref(false)
 
 const expandedItems = ref<Set<number>>(new Set())
 function toggleItem(i: number) {

--- a/frontend/components/tools/ListFilesTool.vue
+++ b/frontend/components/tools/ListFilesTool.vue
@@ -6,7 +6,14 @@
           <Spinner class="w-3 h-3 me-1.5 shrink-0 text-gray-400" />
           <span class="tool-shimmer">{{ modelTitle ? modelTitle + '…' : 'Listing files…' }}</span>
         </span>
-        <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
+        <span
+          v-else
+          class="text-gray-700 dark:text-gray-300 flex items-center"
+          :class="files.length ? 'cursor-pointer' : ''"
+          @click="files.length && (expanded = !expanded)"
+          :aria-expanded="files.length ? expanded : undefined"
+        >
+          <Icon v-if="files.length" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500 rtl-flip" />
           <Icon name="heroicons-folder" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500" />
           <span>{{ modelTitle || 'Listed files' }}</span>
           <span v-if="files.length" class="ms-2 text-gray-400 dark:text-gray-500">({{ files.length }}{{ truncated ? '+' : '' }})</span>
@@ -15,7 +22,7 @@
     </Transition>
 
     <Transition name="fade" appear>
-      <div v-if="files.length" class="text-xs text-gray-600 dark:text-gray-400">
+      <div v-if="files.length && expanded" class="text-xs text-gray-600 dark:text-gray-400">
         <ul class="ms-1 space-y-1 leading-snug">
           <li v-for="(f, idx) in files.slice(0, 10)" :key="f.id || idx">
             <div
@@ -78,6 +85,8 @@ const files = computed<any[]>(() => {
 })
 const truncated = computed(() => !!props.toolExecution?.result_json?.truncated)
 const errorMessage = computed(() => props.toolExecution?.result_json?.error || '')
+
+const expanded = ref(false)
 
 const expandedItems = ref<Set<number>>(new Set())
 function toggleItem(i: number) {

--- a/frontend/components/tools/ListFilesTool.vue
+++ b/frontend/components/tools/ListFilesTool.vue
@@ -16,7 +16,7 @@
           <Icon v-if="files.length" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500 rtl-flip" />
           <Icon name="heroicons-folder" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500" />
           <span>{{ modelTitle || 'Listed files' }}</span>
-          <span v-if="files.length" class="ms-2 text-gray-400 dark:text-gray-500">({{ files.length }}{{ truncated ? '+' : '' }})</span>
+          <span v-if="files.length" class="ms-2 text-gray-400 dark:text-gray-500">{{ files.length }}{{ truncated ? '+' : '' }} {{ files.length === 1 ? 'file' : 'files' }}</span>
         </span>
       </div>
     </Transition>

--- a/frontend/components/tools/SearchFilesTool.vue
+++ b/frontend/components/tools/SearchFilesTool.vue
@@ -9,25 +9,32 @@
             <template v-else>Searching files for {{ queryLabel }}…</template>
           </span>
         </span>
-        <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
+        <span
+          v-else
+          class="text-gray-700 dark:text-gray-300 flex items-center"
+          :class="files.length ? 'cursor-pointer' : ''"
+          @click="files.length && (expanded = !expanded)"
+          :aria-expanded="files.length ? expanded : undefined"
+        >
+          <Icon v-if="files.length" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 rtl-flip" />
           <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
           <template v-if="modelTitle">
             <span class="align-middle">{{ modelTitle }}</span>
-            <span v-if="files.length" class="ms-2 text-gray-400">( {{ files.length }})</span>
+            <span v-if="files.length" class="ms-2 text-gray-400">{{ files.length }} {{ files.length === 1 ? 'file' : 'files' }}</span>
           </template>
           <template v-else>
             <span class="align-middle">Searched files for&nbsp;</span>
             <Transition name="fade-in" mode="out-in">
               <span :key="queryLabel || ''" class="align-middle">{{ queryLabel }}</span>
             </Transition>
-            <span v-if="files.length" class="ms-2 text-gray-400">( {{ files.length }})</span>
+            <span v-if="files.length" class="ms-2 text-gray-400">{{ files.length }} {{ files.length === 1 ? 'file' : 'files' }}</span>
           </template>
         </span>
       </div>
     </Transition>
 
     <Transition name="fade" appear>
-      <div v-if="files.length" class="text-xs text-gray-600 dark:text-gray-400">
+      <div v-if="files.length && expanded" class="text-xs text-gray-600 dark:text-gray-400">
         <ul class="ms-1 space-y-1 leading-snug">
           <li v-for="(f, idx) in files.slice(0, 10)" :key="f.id || idx">
             <div
@@ -99,6 +106,8 @@ const files = computed<any[]>(() => {
 })
 
 const errorMessage = computed(() => props.toolExecution?.result_json?.error || '')
+
+const expanded = ref(false)
 
 const expandedItems = ref<Set<number>>(new Set())
 function toggleItem(i: number) {


### PR DESCRIPTION
## Summary

In the report view (`/reports/[id]`), the file-browsing tools (`list_files`, `search_files`, `grep_files`) rendered their full result list expanded by default, which pushed the conversation around whenever the agent browsed files. This makes them collapsed by default — matching the existing collapsed-by-default "Preview" pattern in `read_file` — and surfaces the total result count in the header row so you can see how much was returned at a glance without expanding.

## Changes

- **`ListFilesTool.vue`** — File list is collapsed by default. The header row (folder icon + title) is now a clickable toggle with a chevron. Total shown as an explicit `N files` label (e.g. `12 files`, `12+ files` when capped, `1 file` singular).
- **`GrepFilesTool.vue`** — Match list collapsed by default; header row (pattern + the existing `N matches in X/Y files` count) becomes the toggle.
- **`SearchFilesTool.vue`** — Result list collapsed by default; header toggle added and the count normalized to the same `N files` label.

Per-item expansion inside each list is unchanged. The toggle only activates when there are results; empty/error/running states are untouched.

## Testing

Manual review of the Vue template/state changes. No backend changes — the count fields consumed already exist in each tool's `result_json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oyNwd2TUHz62CFGMoHZqD)_