### PR TITLE
Render artifact/doc/excel/MCP/report tools in the shared conversation view

### DIFF
--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -229,6 +229,19 @@ import GrepFilesTool from '~/components/tools/GrepFilesTool.vue'
 import ListFilesTool from '~/components/tools/ListFilesTool.vue'
 import ReadFileTool from '~/components/tools/ReadFileTool.vue'
 import AttachFileTool from '~/components/tools/AttachFileTool.vue'
+import CreateArtifactTool from '~/components/tools/CreateArtifactTool.vue'
+import EditArtifactTool from '~/components/tools/EditArtifactTool.vue'
+import ReadArtifactTool from '~/components/tools/ReadArtifactTool.vue'
+import CreateDocTool from '~/components/tools/CreateDocTool.vue'
+import EditDocTool from '~/components/tools/EditDocTool.vue'
+import WriteCsvTool from '~/components/tools/WriteCsvTool.vue'
+import WriteToExcelTool from '~/components/tools/WriteToExcelTool.vue'
+import ReadExcelRangeTool from '~/components/tools/ReadExcelRangeTool.vue'
+import ReadExcelAsCsvTool from '~/components/tools/ReadExcelAsCsvTool.vue'
+import WriteOfficeJsCodeTool from '~/components/tools/WriteOfficeJsCodeTool.vue'
+import MCPTool from '~/components/tools/MCPTool.vue'
+import SearchReportsTool from '~/components/tools/SearchReportsTool.vue'
+import ReadReportTool from '~/components/tools/ReadReportTool.vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 
 const route = useRoute()
@@ -369,6 +382,33 @@ function getToolComponent(toolName: string) {
             return ReadFileTool
         case 'attach_file':
             return AttachFileTool
+        case 'create_artifact':
+            return CreateArtifactTool
+        case 'edit_artifact':
+            return EditArtifactTool
+        case 'read_artifact':
+            return ReadArtifactTool
+        case 'create_doc':
+            return CreateDocTool
+        case 'edit_doc':
+            return EditDocTool
+        case 'write_csv':
+            return WriteCsvTool
+        case 'write_to_excel':
+            return WriteToExcelTool
+        case 'read_excel_range':
+            return ReadExcelRangeTool
+        case 'read_excel_as_csv':
+            return ReadExcelAsCsvTool
+        case 'write_officejs_code':
+            return WriteOfficeJsCodeTool
+        case 'search_mcps':
+        case 'execute_mcp':
+            return MCPTool
+        case 'search_reports':
+            return SearchReportsTool
+        case 'read_report':
+            return ReadReportTool
         case 'execute_code':
         case 'execute_sql':
         case 'create_and_execute_code':


### PR DESCRIPTION
## Summary

The shared conversation view (`/c/[token]`) maintains its own tool-component dispatcher, separate from the report view. It mapped far fewer tools, so when a shared link contained artifacts, docs, CSV/Excel outputs, MCP calls, or report references, those rendered as a bare `tool_name (status)` text fallback instead of their real cards.

This wires the following tools into the shared dispatcher (readonly), matching the report view:

- `create_artifact` / `edit_artifact` / `read_artifact`
- `create_doc` / `edit_doc`
- `write_csv` / `write_to_excel` / `read_excel_range` / `read_excel_as_csv` / `write_officejs_code`
- `search_mcps` / `execute_mcp`
- `search_reports` / `read_report`

## Changes

- `frontend/pages/c/[token]/index.vue` — added the component imports and `getToolComponent()` switch cases for the tools above. No other behavior changed.

## Safety in the readonly share

All added components take only `tool-execution` (+ optional `readonly`); the report-view-only props (`data-sources`, `system-completion-id`) and event handlers are optional. Their interactive paths never activate on a completed shared conversation:

- **CreateArtifactTool** — the confirmation card only renders while `status === 'running'`.
- **MCPTool** — `showApprovalCard` requires a running status; `respond()` early-returns without `systemCompletionId` (not passed by the share view).
- Unhandled emits (`openArtifact`, `toggleSplitScreen`, `editQuery`) are harmless no-ops.

## Testing

Manual code review against the report-view dispatcher. Frontend dependencies aren't installed in this environment, so no build/typecheck was run; the change is additive and mirrors the existing working report-view mapping. A local dev-server smoke of a shared link is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oyNwd2TUHz62CFGMoHZqD)_