### PR TITLE
Fix write_csv: distinct filenames and per-call widget previews

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -131,7 +131,11 @@ _PARALLEL_SAFE_TOOLS = frozenset({"inspect_data", "create_data"})
 # Tools that start a fresh created-objects scope: each invocation gets an
 # empty ToolInvocationState instead of inheriting the previous tool's
 # query/step/visualization (mirrors the old per-action self.current_* reset).
-_INVOCATION_RESET_TOOLS = frozenset({"create_widget", "create_data", "describe_entity"})
+# write_csv belongs here too: it produces its own Step/Query/Visualization via
+# the data_model_type_determined event. Without a fresh scope it inherits the
+# previous data tool's step, the step-creation guard (`not cur_step`) skips, and
+# every write_csv in a session renders the same stale widget preview.
+_INVOCATION_RESET_TOOLS = frozenset({"create_widget", "create_data", "describe_entity", "write_csv"})
 
 
 class ToolInvocationState:

--- a/backend/app/ai/tools/implementations/write_csv.py
+++ b/backend/app/ai/tools/implementations/write_csv.py
@@ -1,4 +1,5 @@
 import csv
+import re
 import time
 import logging
 import uuid
@@ -19,6 +20,31 @@ from app.ee.audit.tool_audit import log_tool_audit
 from app.dependencies import async_session_maker
 
 logger = logging.getLogger(__name__)
+
+# Fallback display name when no usable title is provided.
+_DEFAULT_CSV_FILENAME = "write_csv_output.csv"
+
+
+def _derive_csv_filename(title: str | None) -> str:
+    """Turn an LLM-provided title into a safe, readable ``*.csv`` display name.
+
+    Sanitizes to a filename-safe slug so the value cannot contain path
+    separators or other unexpected characters, and falls back to the default
+    when the title is missing or slugs to nothing.
+    """
+    if not title:
+        return _DEFAULT_CSV_FILENAME
+
+    # Keep alphanumerics, dashes and underscores; collapse everything else.
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", title.strip())
+    slug = re.sub(r"_+", "_", slug).strip("._-")
+    # Drop any extension the slug may carry so we control the suffix.
+    slug = re.sub(r"\.csv$", "", slug, flags=re.IGNORECASE)
+    slug = slug[:100].strip("._-")
+
+    if not slug:
+        return _DEFAULT_CSV_FILENAME
+    return f"{slug}.csv"
 
 
 class WriteCsvTool(Tool):
@@ -263,15 +289,18 @@ Do not use when:
         info = formatted.get("info", {})
         data_preview = full_df.head(5).to_string() if not full_df.empty else ""
 
+        # Derive a readable display filename from the LLM-provided title.
+        display_filename = _derive_csv_filename(data.title)
+
         # Generate preview
         preview = None
         try:
-            preview = _preview_csv(dest_path, "write_csv_output.csv")
+            preview = _preview_csv(dest_path, display_filename)
         except Exception:
             pass
 
         file = File(
-            filename="write_csv_output.csv",
+            filename=display_filename,
             path=dest_path,
             content_type="text/csv",
             preview=preview,

--- a/backend/app/ai/tools/schemas/write_csv.py
+++ b/backend/app/ai/tools/schemas/write_csv.py
@@ -9,7 +9,7 @@ class WriteCsvInput(BaseModel):
     )
     title: Optional[str] = Field(
         default=None,
-        description="Title for the generated data visualization. If not provided, a default title will be used."
+        description="Title for the generated data visualization. Also used to name the saved CSV file, so prefer a short, descriptive title (e.g. 'Software Houses Income Tax 2025'). If not provided, a default title and filename will be used."
     )
     tables_by_source: Optional[List[Dict[str, Any]]] = Field(
         default=None,

--- a/backend/tests/unit/test_write_csv_filename.py
+++ b/backend/tests/unit/test_write_csv_filename.py
@@ -1,0 +1,47 @@
+"""write_csv display-filename derivation.
+
+The saved CSV's display name is derived from the LLM-provided ``title`` so
+files read as e.g. ``Software_Houses_Income_Tax_2025.csv`` instead of the
+generic ``write_csv_output.csv``. Derivation must stay filename-safe (no path
+separators leaking through) and fall back to the default when the title is
+missing or slugs to nothing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.ai.tools.implementations.write_csv import (
+    _DEFAULT_CSV_FILENAME,
+    _derive_csv_filename,
+)
+
+
+@pytest.mark.parametrize(
+    "title, expected",
+    [
+        ("Software Houses Income Tax 2025", "Software_Houses_Income_Tax_2025.csv"),
+        ("Sales — Q1/Q2 (2025)!!!", "Sales_Q1_Q2_2025.csv"),
+        ("report.csv", "report.csv"),  # existing extension is normalized, not doubled
+    ],
+)
+def test_derives_readable_name(title, expected):
+    assert _derive_csv_filename(title) == expected
+
+
+@pytest.mark.parametrize("title", [None, "", "   ", "....", "///"])
+def test_falls_back_to_default(title):
+    assert _derive_csv_filename(title) == _DEFAULT_CSV_FILENAME
+
+
+def test_strips_path_separators():
+    result = _derive_csv_filename("../../etc/passwd")
+    assert "/" not in result and "\\" not in result
+    assert ".." not in result
+    assert result == "etc_passwd.csv"
+
+
+def test_caps_length():
+    result = _derive_csv_filename("x" * 500)
+    # 100-char slug budget + ".csv"
+    assert len(result) <= 104
+    assert result.endswith(".csv")


### PR DESCRIPTION
## Summary

Two related fixes for `write_csv` when it is called multiple times in a session.

### 1. Distinct display filenames
Every `write_csv` output was saved as the generic `write_csv_output.csv`, so multiple files in a session were visually indistinguishable in the file picker. The display filename is now derived from the LLM-provided `title` (sanitized to a filename-safe slug, e.g. `Software_Houses_Income_Tax_2025.csv`), falling back to the old default when no usable title is given. On-disk paths were already unique via a UUID prefix — only the display name changed.

### 2. Per-call widget previews (stale-preview bug)
`write_csv` produces its own Step/Query/Visualization via the `data_model_type_determined` event, but it was missing from `_INVOCATION_RESET_TOOLS`. As a result each `write_csv` invocation inherited the previous data tool's `current_step`; the step-creation guard (`not cur_step`) then skipped, so no new Step/Query/Visualization was created and the execution was linked to a stale step. The symptom: multiple `write_csv` cards in a report all rendered the *same* widget preview (e.g. a prior `create_data` query's data), even though each call produced different data.

Adding `write_csv` to the reset set gives each call an empty invocation state, so its own step is created and the post-batch reset fires, preventing state from leaking into the next call.

## Changes
- `backend/app/ai/tools/implementations/write_csv.py` — add `_derive_csv_filename()` helper; use the derived name for the `File` record and CSV preview label.
- `backend/app/ai/tools/schemas/write_csv.py` — note in the `title` field description that it also names the saved file.
- `backend/app/ai/agent_v2.py` — add `write_csv` to `_INVOCATION_RESET_TOOLS`.
- `backend/tests/unit/test_write_csv_filename.py` — unit tests for filename derivation (readable names, default fallback, path-separator stripping, length cap).

## Notes
- The distinct `File` records were always created correctly per call; the preview bug was purely in Step/Query/Visualization wiring, so no CSV data was lost.
- This is a **forward-only** fix: already-persisted reports keep their stale `created_step_id`/`query_id` and won't self-heal. Their underlying CSV files remain available in the file list.
- Verified via code-path analysis and a standalone check of the filename logic; the full backend stack wasn't runnable in the authoring environment, so an end-to-end run with two `write_csv` calls is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q2Z6GKQpjEymQqSeS6e3k

---
_Generated by [Claude Code](https://claude.ai/code/session_011q2Z6GKQpjEymQqSeS6e3k)_