### PR TITLE
Add thinking indicator with live duration above prompt box

### DIFF
--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -1558,6 +1558,10 @@ async function createReport() {
     color: transparent;
     animation: thinking-shimmer 2s linear infinite;
 }
+/* RTL locales (he/ar): sweep the shine in reading direction, right to left. */
+[dir="rtl"] .thinking-shimmer {
+    animation-direction: reverse;
+}
 @keyframes thinking-shimmer {
     0% { background-position: -100% 0; }
     100% { background-position: 100% 0; }

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -176,7 +176,7 @@
                 aria-live="polite"
             >
                 <Spinner class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" />
-                <span class="thinking-shimmer">{{ $t('prompt.thinking', 'Thinking') }}</span>
+                <span class="thinking-shimmer">{{ thinkingLabel }}</span>
                 <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ thinkingElapsedLabel }}</span>
             </div>
         </Transition>
@@ -746,6 +746,15 @@ const thinkingElapsedLabel = computed(() => {
     const s = thinkingElapsedSeconds.value
     if (s < 60) return `${s}s`
     return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+})
+
+// "Thinking" until the completion streams its first visible output (the parent
+// passes hasFirstToken on latestInProgressCompletion), then "Working".
+const thinkingLabel = computed(() => {
+    const completion: any = props.latestInProgressCompletion
+    return completion?.hasFirstToken
+        ? t('prompt.working', 'Working')
+        : t('prompt.thinking', 'Thinking')
 })
 
 // Excel selection hint

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -168,6 +168,19 @@
             </button>
         </div>
 
+        <!-- Thinking indicator (visible while a completion is running) -->
+        <Transition name="thinking-fade">
+            <div
+                v-if="isThinking"
+                class="mb-2 px-1 flex items-center gap-2 text-xs select-none"
+                aria-live="polite"
+            >
+                <Spinner class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" />
+                <span class="thinking-shimmer">{{ $t('prompt.thinking', 'Thinking') }}</span>
+                <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ thinkingElapsedLabel }}</span>
+            </div>
+        </Transition>
+
         <!-- Minimalist prompt container -->
         <div
             class="border rounded-xl bg-white dark:bg-gray-900 transition-colors relative"
@@ -702,6 +715,38 @@ function ordSuffix(n: number): string {
     return r === 1 ? 'st' : r === 2 ? 'nd' : r === 3 ? 'rd' : 'th'
 }
 let dragCounter = 0 // Track enter/leave for nested elements
+
+// Thinking indicator: covers the whole run, from the moment the user submits
+// (isSubmitting) through the in-progress completion reported by the parent.
+const isThinking = computed(() => isSubmitting.value || !!props.latestInProgressCompletion)
+const thinkingStartedAt = ref<number | null>(null)
+const thinkingElapsedSeconds = ref(0)
+let thinkingTimer: ReturnType<typeof setInterval> | null = null
+
+// immediate: also starts the timer when the component mounts mid-run
+// (e.g. page refresh while a completion is streaming).
+watch(isThinking, (active) => {
+    if (active) {
+        if (thinkingTimer) return // submit → in-progress handoff: keep counting
+        thinkingStartedAt.value = Date.now()
+        thinkingElapsedSeconds.value = 0
+        thinkingTimer = setInterval(() => {
+            if (thinkingStartedAt.value !== null) {
+                thinkingElapsedSeconds.value = Math.floor((Date.now() - thinkingStartedAt.value) / 1000)
+            }
+        }, 1000)
+    } else {
+        if (thinkingTimer) { clearInterval(thinkingTimer); thinkingTimer = null }
+        thinkingStartedAt.value = null
+        thinkingElapsedSeconds.value = 0
+    }
+}, { immediate: true })
+
+const thinkingElapsedLabel = computed(() => {
+    const s = thinkingElapsedSeconds.value
+    if (s < 60) return `${s}s`
+    return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+})
 
 // Excel selection hint
 const { isExcel, excelSelection } = useExcel()
@@ -1358,6 +1403,7 @@ onBeforeUnmount(() => {
     window.removeEventListener('prompt:prefill', handlePromptPrefill)
     window.removeEventListener('keydown', handleEscKey)
     if (compactRO) { compactRO.disconnect(); compactRO = null }
+    if (thinkingTimer) { clearInterval(thinkingTimer); thinkingTimer = null }
 })
 
 watch(() => props.report_id, async (newId, oldId) => {
@@ -1493,4 +1539,20 @@ async function createReport() {
 
 <style scoped>
 .placeholder-gray-400::placeholder { color: #9ca3af; }
+
+/* Shining "Thinking" label, à la Codex */
+.thinking-shimmer {
+    background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: thinking-shimmer 2s linear infinite;
+}
+@keyframes thinking-shimmer {
+    0% { background-position: -100% 0; }
+    100% { background-position: 100% 0; }
+}
+.thinking-fade-enter-active, .thinking-fade-leave-active { transition: opacity 0.2s ease, transform 0.2s ease; }
+.thinking-fade-enter-from, .thinking-fade-leave-to { opacity: 0; transform: translateY(2px); }
 </style>

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -168,19 +168,6 @@
             </button>
         </div>
 
-        <!-- Thinking indicator (visible while a completion is running) -->
-        <Transition name="thinking-fade">
-            <div
-                v-if="isThinking"
-                class="mb-2 px-1 flex items-center gap-2 text-xs select-none"
-                aria-live="polite"
-            >
-                <Spinner class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" />
-                <span class="thinking-shimmer">{{ $t('prompt.thinking', 'Thinking') }}</span>
-                <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ thinkingElapsedLabel }}</span>
-            </div>
-        </Transition>
-
         <!-- Minimalist prompt container -->
         <div
             class="border rounded-xl bg-white dark:bg-gray-900 transition-colors relative"
@@ -715,38 +702,6 @@ function ordSuffix(n: number): string {
     return r === 1 ? 'st' : r === 2 ? 'nd' : r === 3 ? 'rd' : 'th'
 }
 let dragCounter = 0 // Track enter/leave for nested elements
-
-// Thinking indicator: covers the whole run, from the moment the user submits
-// (isSubmitting) through the in-progress completion reported by the parent.
-const isThinking = computed(() => isSubmitting.value || !!props.latestInProgressCompletion)
-const thinkingStartedAt = ref<number | null>(null)
-const thinkingElapsedSeconds = ref(0)
-let thinkingTimer: ReturnType<typeof setInterval> | null = null
-
-// immediate: also starts the timer when the component mounts mid-run
-// (e.g. page refresh while a completion is streaming).
-watch(isThinking, (active) => {
-    if (active) {
-        if (thinkingTimer) return // submit → in-progress handoff: keep counting
-        thinkingStartedAt.value = Date.now()
-        thinkingElapsedSeconds.value = 0
-        thinkingTimer = setInterval(() => {
-            if (thinkingStartedAt.value !== null) {
-                thinkingElapsedSeconds.value = Math.floor((Date.now() - thinkingStartedAt.value) / 1000)
-            }
-        }, 1000)
-    } else {
-        if (thinkingTimer) { clearInterval(thinkingTimer); thinkingTimer = null }
-        thinkingStartedAt.value = null
-        thinkingElapsedSeconds.value = 0
-    }
-}, { immediate: true })
-
-const thinkingElapsedLabel = computed(() => {
-    const s = thinkingElapsedSeconds.value
-    if (s < 60) return `${s}s`
-    return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
-})
 
 // Excel selection hint
 const { isExcel, excelSelection } = useExcel()
@@ -1403,7 +1358,6 @@ onBeforeUnmount(() => {
     window.removeEventListener('prompt:prefill', handlePromptPrefill)
     window.removeEventListener('keydown', handleEscKey)
     if (compactRO) { compactRO.disconnect(); compactRO = null }
-    if (thinkingTimer) { clearInterval(thinkingTimer); thinkingTimer = null }
 })
 
 watch(() => props.report_id, async (newId, oldId) => {
@@ -1539,20 +1493,4 @@ async function createReport() {
 
 <style scoped>
 .placeholder-gray-400::placeholder { color: #9ca3af; }
-
-/* Shining "Thinking" label, à la Codex */
-.thinking-shimmer {
-    background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
-    background-size: 200% 100%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    animation: thinking-shimmer 2s linear infinite;
-}
-@keyframes thinking-shimmer {
-    0% { background-position: -100% 0; }
-    100% { background-position: 100% 0; }
-}
-.thinking-fade-enter-active, .thinking-fade-leave-active { transition: opacity 0.2s ease, transform 0.2s ease; }
-.thinking-fade-enter-from, .thinking-fade-leave-to { opacity: 0; transform: translateY(2px); }
 </style>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -343,9 +343,11 @@
 											@published="() => loadCompletions({ skipEstimate: true })"
 										/>
 
-										<!-- Thinking dots when system is working but no visible progress - moved to end -->
-										<div v-if="shouldShowWorkingDots(m)" class="mt-2">
-											<div class="simple-dots"></div>
+										<!-- Thinking indicator (spinner + shimmer + live elapsed) while the completion runs -->
+										<div v-if="shouldShowThinkingIndicator(m)" class="mt-2 flex items-center gap-2 text-xs select-none" aria-live="polite">
+											<Spinner class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" />
+											<span class="thinking-shimmer">{{ $t('prompt.thinking', 'Thinking') }}</span>
+											<span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ thinkingElapsedLabel(m) }}</span>
 										</div>
 									</div>
 
@@ -987,6 +989,19 @@ const isCompletionInProgress = ref<boolean>(false)
 const hasInProgressCompletion = computed(() =>
 	messages.value.some(m => m.role === 'system' && m.status === 'in_progress')
 )
+// 1s heartbeat for the thinking indicator's live elapsed counter; only runs
+// while a completion is in progress.
+const thinkingNowTick = ref<number>(Date.now())
+let thinkingTickTimer: ReturnType<typeof setInterval> | null = null
+watch(hasInProgressCompletion, (active) => {
+	if (active && !thinkingTickTimer) {
+		thinkingNowTick.value = Date.now()
+		thinkingTickTimer = setInterval(() => { thinkingNowTick.value = Date.now() }, 1000)
+	} else if (!active && thinkingTickTimer) {
+		clearInterval(thinkingTickTimer)
+		thinkingTickTimer = null
+	}
+}, { immediate: true })
 const copiedMessageId = ref<string | null>(null)
 let currentController: AbortController | null = null
 const scrollContainer = ref<HTMLElement | null>(null)
@@ -1709,66 +1724,29 @@ function shouldShowToolWidgetPreview(toolExecution: ToolCall | undefined): boole
 	       (toolExecution.created_widget || toolExecution.created_step)
 }
 
-function shouldShowWorkingDots(message: ChatMessage): boolean {
-	// Only show for system messages that are in progress
-	if (message.role !== 'system' || message.status !== 'in_progress') {
-		return false
-	}
-	
-	// Don't show dots if the message was killed (sigkill timestamp exists)
-	if (message.sigkill) {
-		return false
-	}
-	
-	// CASE 1: No blocks yet - show dots (initial startup phase)
-	if (!message.completion_blocks || message.completion_blocks.length === 0) {
-		return true
-	}
-	
-	// CASE 2: Blocks exist but no meaningful content yet (early startup)
-	const hasAnyMeaningfulContent = message.completion_blocks.some(block => 
-		block.plan_decision?.reasoning || 
-		block.reasoning || 
-		block.content ||
-		block.tool_execution
-	)
-	
-	// If no meaningful content yet, show dots
-	if (!hasAnyMeaningfulContent) {
-		return true
-	}
-	
-	// CASE 3: Check if we're in a "gap" between blocks during streaming
-	const lastBlock = message.completion_blocks[message.completion_blocks.length - 1]
-	
-	// If the last block has final_answer and analysis_complete, we're truly done
-	if (lastBlock?.plan_decision?.analysis_complete === true) {
-		return false
-	}
-	
-	// Check if the last block has finished its main content but no tools are running
-	const lastBlockHasContent = lastBlock && (
-		lastBlock.content ||
-		lastBlock.plan_decision?.final_answer
-	)
-	
-	// Check if tools are actively running
-	const hasActiveTools = message.completion_blocks.some(block => 
-		block.tool_execution?.status === 'running' || 
-		block.status === 'in_progress'
-	)
-	
-	// Check if any block is actively streaming text (has reasoning but no assistant yet)
-	const hasStreamingContent = message.completion_blocks.some(block => 
-		(block.plan_decision?.reasoning && !block.content) ||
-		(block.reasoning && !block.content)
-	)
-	
-	// Show dots when:
-	// 1. System is in progress AND
-	// 2. No active tools/streaming AND
-	// 3. Last block has content but system continues (preparing next block)
-	return !hasActiveTools && !hasStreamingContent && (!!lastBlockHasContent && message.status === 'in_progress')
+// Thinking indicator: unlike the old "working dots" (which only filled the gaps
+// between blocks), this stays visible for the entire run so the live elapsed
+// counter never blinks out mid-completion.
+function shouldShowThinkingIndicator(message: ChatMessage): boolean {
+	return message.role === 'system' && message.status === 'in_progress' && !message.sigkill
+}
+
+// Backend timestamps are naive UTC (models/base.py: datetime.utcnow) — append
+// 'Z' when no timezone marker is present so Date.parse doesn't read them as
+// local time. Client-generated placeholders use toISOString(), which has 'Z'.
+function parseUtcTimestamp(value?: string): number | null {
+	if (!value) return null
+	const iso = /(Z|[+-]\d{2}:?\d{2})$/.test(value) ? value : value + 'Z'
+	const t = Date.parse(iso)
+	return Number.isNaN(t) ? null : t
+}
+
+function thinkingElapsedLabel(message: ChatMessage): string {
+	const started = parseUtcTimestamp(message.created_at)
+	if (started === null) return ''
+	const s = Math.max(0, Math.floor((thinkingNowTick.value - started) / 1000))
+	if (s < 60) return `${s}s`
+	return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
 }
 
 function getThoughtProcessLabel(block: CompletionBlock): string {
@@ -3332,6 +3310,7 @@ onUnmounted(() => {
 	stopScheduledCompletionsPoll()
 	stopWatchStream()
 	stopKickoffWatchdog()
+	if (thinkingTickTimer) { clearInterval(thinkingTickTimer); thinkingTickTimer = null }
 	document.removeEventListener('visibilitychange', onStreamVisibilityChange)
 	markdownAutoDir.value?.stop()
 	// Clear reasoning refs
@@ -3548,6 +3527,9 @@ function onSubmitCompletion(data: { text: string, mentions: any[]; mode?: string
 		role: 'system',
 		status: 'in_progress',
 		model: data.model_id || undefined,
+		// Anchors the thinking indicator's elapsed counter until the server
+		// message (with its own created_at) replaces this placeholder.
+		created_at: new Date().toISOString(),
 		completion_blocks: []
 	}
 	messages.value.push(sysMsg)
@@ -4354,8 +4336,16 @@ onMounted(async () => {
 	}
 }
 
-@keyframes simple-ellipsis { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }
-.simple-dots::after { content: '.'; display: inline-block; margin-top: 5px; animation: simple-ellipsis 1.5s infinite; font-weight: 400; font-size: 14px; color: #888; }
+/* Shining "Thinking" label for the in-progress indicator, à la Codex */
+.thinking-shimmer {
+	background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
+	background-size: 200% 100%;
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+	animation: shimmer 2s linear infinite;
+	font-weight: 400;
+}
 
 @keyframes shimmer {
 	0% { background-position: -100% 0; }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -343,11 +343,9 @@
 											@published="() => loadCompletions({ skipEstimate: true })"
 										/>
 
-										<!-- Thinking indicator (spinner + shimmer + live elapsed) while the completion runs -->
-										<div v-if="shouldShowThinkingIndicator(m)" class="mt-2 flex items-center gap-2 text-xs select-none" aria-live="polite">
-											<Spinner class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" />
-											<span class="thinking-shimmer">{{ $t('prompt.thinking', 'Thinking') }}</span>
-											<span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ thinkingElapsedLabel(m) }}</span>
+										<!-- Thinking dots when system is working but no visible progress - moved to end -->
+										<div v-if="shouldShowWorkingDots(m)" class="mt-2">
+											<div class="simple-dots"></div>
 										</div>
 									</div>
 
@@ -989,19 +987,6 @@ const isCompletionInProgress = ref<boolean>(false)
 const hasInProgressCompletion = computed(() =>
 	messages.value.some(m => m.role === 'system' && m.status === 'in_progress')
 )
-// 1s heartbeat for the thinking indicator's live elapsed counter; only runs
-// while a completion is in progress.
-const thinkingNowTick = ref<number>(Date.now())
-let thinkingTickTimer: ReturnType<typeof setInterval> | null = null
-watch(hasInProgressCompletion, (active) => {
-	if (active && !thinkingTickTimer) {
-		thinkingNowTick.value = Date.now()
-		thinkingTickTimer = setInterval(() => { thinkingNowTick.value = Date.now() }, 1000)
-	} else if (!active && thinkingTickTimer) {
-		clearInterval(thinkingTickTimer)
-		thinkingTickTimer = null
-	}
-}, { immediate: true })
 const copiedMessageId = ref<string | null>(null)
 let currentController: AbortController | null = null
 const scrollContainer = ref<HTMLElement | null>(null)
@@ -1724,29 +1709,66 @@ function shouldShowToolWidgetPreview(toolExecution: ToolCall | undefined): boole
 	       (toolExecution.created_widget || toolExecution.created_step)
 }
 
-// Thinking indicator: unlike the old "working dots" (which only filled the gaps
-// between blocks), this stays visible for the entire run so the live elapsed
-// counter never blinks out mid-completion.
-function shouldShowThinkingIndicator(message: ChatMessage): boolean {
-	return message.role === 'system' && message.status === 'in_progress' && !message.sigkill
-}
-
-// Backend timestamps are naive UTC (models/base.py: datetime.utcnow) — append
-// 'Z' when no timezone marker is present so Date.parse doesn't read them as
-// local time. Client-generated placeholders use toISOString(), which has 'Z'.
-function parseUtcTimestamp(value?: string): number | null {
-	if (!value) return null
-	const iso = /(Z|[+-]\d{2}:?\d{2})$/.test(value) ? value : value + 'Z'
-	const t = Date.parse(iso)
-	return Number.isNaN(t) ? null : t
-}
-
-function thinkingElapsedLabel(message: ChatMessage): string {
-	const started = parseUtcTimestamp(message.created_at)
-	if (started === null) return ''
-	const s = Math.max(0, Math.floor((thinkingNowTick.value - started) / 1000))
-	if (s < 60) return `${s}s`
-	return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+function shouldShowWorkingDots(message: ChatMessage): boolean {
+	// Only show for system messages that are in progress
+	if (message.role !== 'system' || message.status !== 'in_progress') {
+		return false
+	}
+	
+	// Don't show dots if the message was killed (sigkill timestamp exists)
+	if (message.sigkill) {
+		return false
+	}
+	
+	// CASE 1: No blocks yet - show dots (initial startup phase)
+	if (!message.completion_blocks || message.completion_blocks.length === 0) {
+		return true
+	}
+	
+	// CASE 2: Blocks exist but no meaningful content yet (early startup)
+	const hasAnyMeaningfulContent = message.completion_blocks.some(block => 
+		block.plan_decision?.reasoning || 
+		block.reasoning || 
+		block.content ||
+		block.tool_execution
+	)
+	
+	// If no meaningful content yet, show dots
+	if (!hasAnyMeaningfulContent) {
+		return true
+	}
+	
+	// CASE 3: Check if we're in a "gap" between blocks during streaming
+	const lastBlock = message.completion_blocks[message.completion_blocks.length - 1]
+	
+	// If the last block has final_answer and analysis_complete, we're truly done
+	if (lastBlock?.plan_decision?.analysis_complete === true) {
+		return false
+	}
+	
+	// Check if the last block has finished its main content but no tools are running
+	const lastBlockHasContent = lastBlock && (
+		lastBlock.content ||
+		lastBlock.plan_decision?.final_answer
+	)
+	
+	// Check if tools are actively running
+	const hasActiveTools = message.completion_blocks.some(block => 
+		block.tool_execution?.status === 'running' || 
+		block.status === 'in_progress'
+	)
+	
+	// Check if any block is actively streaming text (has reasoning but no assistant yet)
+	const hasStreamingContent = message.completion_blocks.some(block => 
+		(block.plan_decision?.reasoning && !block.content) ||
+		(block.reasoning && !block.content)
+	)
+	
+	// Show dots when:
+	// 1. System is in progress AND
+	// 2. No active tools/streaming AND
+	// 3. Last block has content but system continues (preparing next block)
+	return !hasActiveTools && !hasStreamingContent && (!!lastBlockHasContent && message.status === 'in_progress')
 }
 
 function getThoughtProcessLabel(block: CompletionBlock): string {
@@ -3310,7 +3332,6 @@ onUnmounted(() => {
 	stopScheduledCompletionsPoll()
 	stopWatchStream()
 	stopKickoffWatchdog()
-	if (thinkingTickTimer) { clearInterval(thinkingTickTimer); thinkingTickTimer = null }
 	document.removeEventListener('visibilitychange', onStreamVisibilityChange)
 	markdownAutoDir.value?.stop()
 	// Clear reasoning refs
@@ -3527,9 +3548,6 @@ function onSubmitCompletion(data: { text: string, mentions: any[]; mode?: string
 		role: 'system',
 		status: 'in_progress',
 		model: data.model_id || undefined,
-		// Anchors the thinking indicator's elapsed counter until the server
-		// message (with its own created_at) replaces this placeholder.
-		created_at: new Date().toISOString(),
 		completion_blocks: []
 	}
 	messages.value.push(sysMsg)
@@ -4336,16 +4354,8 @@ onMounted(async () => {
 	}
 }
 
-/* Shining "Thinking" label for the in-progress indicator, à la Codex */
-.thinking-shimmer {
-	background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
-	background-size: 200% 100%;
-	-webkit-background-clip: text;
-	background-clip: text;
-	color: transparent;
-	animation: shimmer 2s linear infinite;
-	font-weight: 400;
-}
+@keyframes simple-ellipsis { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }
+.simple-dots::after { content: '.'; display: inline-block; margin-top: 5px; animation: simple-ellipsis 1.5s infinite; font-weight: 400; font-size: 14px; color: #888; }
 
 @keyframes shimmer {
 	0% { background-position: -100% 0; }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -540,7 +540,7 @@
 					:initialSelectedDataSources="report?.data_sources || []"
 					:initialMode="report?.mode || 'chat'"
 					:textareaContent="prefillText"
-					:latestInProgressCompletion="(isCompletionInProgress || hasInProgressCompletion) ? {} : undefined"
+					:latestInProgressCompletion="(isCompletionInProgress || hasInProgressCompletion) ? { hasFirstToken: inProgressHasFirstToken } : undefined"
 					:isStopping="false"
 					:queryList="queryList"
 					:scheduledPrompts="scheduledPrompts"
@@ -986,6 +986,18 @@ const isCompletionInProgress = ref<boolean>(false)
 // run can always be stopped, not just one started in this page session.
 const hasInProgressCompletion = computed(() =>
 	messages.value.some(m => m.role === 'system' && m.status === 'in_progress')
+)
+// True once the in-progress completion has produced any visible output
+// (reasoning/content/tool call). Drives the prompt box indicator's label
+// switch from "Thinking" (waiting for the first token) to "Working".
+const inProgressHasFirstToken = computed(() =>
+	messages.value.some(m =>
+		m.role === 'system' && m.status === 'in_progress' &&
+		(m.completion_blocks || []).some((b: any) =>
+			b.plan_decision?.reasoning || b.reasoning || b.content ||
+			b.plan_decision?.assistant || b.plan_decision?.final_answer || b.tool_execution
+		)
+	)
 )
 const copiedMessageId = ref<string | null>(null)
 let currentController: AbortController | null = null

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "اطلب بيانات أو لوحة تحكم أو تحليلًا متعمقًا",
+    "thinking": "جارٍ التفكير",
     "placeholderCompact": "اطلب أي بيانات",
     "instructions": "التعليمات",
     "loadingReportContext": "جارٍ تحميل سياق التقرير…",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "اطلب بيانات أو لوحة تحكم أو تحليلًا متعمقًا",
     "thinking": "جارٍ التفكير",
+    "working": "جارٍ العمل",
     "placeholderCompact": "اطلب أي بيانات",
     "instructions": "التعليمات",
     "loadingReportContext": "جارٍ تحميل سياق التقرير…",

--- a/locales/de.json
+++ b/locales/de.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Fragen Sie nach Daten, einem Dashboard oder einer detaillierten Analyse",
     "thinking": "Denkt nach",
+    "working": "Arbeitet",
     "placeholderCompact": "Fragen Sie nach beliebigen Daten",
     "instructions": "Anweisungen",
     "loadingReportContext": "Berichtskontext wird geladen …",

--- a/locales/de.json
+++ b/locales/de.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Fragen Sie nach Daten, einem Dashboard oder einer detaillierten Analyse",
+    "thinking": "Denkt nach",
     "placeholderCompact": "Fragen Sie nach beliebigen Daten",
     "instructions": "Anweisungen",
     "loadingReportContext": "Berichtskontext wird geladen …",

--- a/locales/en.json
+++ b/locales/en.json
@@ -412,6 +412,7 @@
   },
   "prompt": {
     "placeholderDefault": "Ask for data, dashboard or a deep analysis",
+    "thinking": "Thinking",
     "placeholderCompact": "Ask for any data",
     "instructions": "Instructions",
     "loadingReportContext": "Loading report context…",

--- a/locales/en.json
+++ b/locales/en.json
@@ -413,6 +413,7 @@
   "prompt": {
     "placeholderDefault": "Ask for data, dashboard or a deep analysis",
     "thinking": "Thinking",
+    "working": "Working",
     "placeholderCompact": "Ask for any data",
     "instructions": "Instructions",
     "loadingReportContext": "Loading report context…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -395,6 +395,7 @@
   },
   "prompt": {
     "placeholderDefault": "Pida datos, un panel o un análisis detallado",
+    "thinking": "Pensando",
     "placeholderCompact": "Pida cualquier dato",
     "instructions": "Instrucciones",
     "loadingReportContext": "Cargando contexto del informe…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -396,6 +396,7 @@
   "prompt": {
     "placeholderDefault": "Pida datos, un panel o un análisis detallado",
     "thinking": "Pensando",
+    "working": "Trabajando",
     "placeholderCompact": "Pida cualquier dato",
     "instructions": "Instrucciones",
     "loadingReportContext": "Cargando contexto del informe…",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Demandez des données, un tableau de bord ou une analyse approfondie",
+    "thinking": "Réflexion",
     "placeholderCompact": "Demandez n'importe quelle donnée",
     "instructions": "Instructions",
     "loadingReportContext": "Chargement du contexte du rapport…",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Demandez des données, un tableau de bord ou une analyse approfondie",
     "thinking": "Réflexion",
+    "working": "En cours",
     "placeholderCompact": "Demandez n'importe quelle donnée",
     "instructions": "Instructions",
     "loadingReportContext": "Chargement du contexte du rapport…",

--- a/locales/he.json
+++ b/locales/he.json
@@ -395,6 +395,7 @@
   },
   "prompt": {
     "placeholderDefault": "בקשו נתונים, דשבורדים או ניתוח מעמיק",
+    "thinking": "חושב",
     "placeholderCompact": "בקשו נתונים",
     "instructions": "הנחיות",
     "loadingReportContext": "טוען קונטקסט של הדוח…",

--- a/locales/he.json
+++ b/locales/he.json
@@ -396,6 +396,7 @@
   "prompt": {
     "placeholderDefault": "בקשו נתונים, דשבורדים או ניתוח מעמיק",
     "thinking": "חושב",
+    "working": "עובד",
     "placeholderCompact": "בקשו נתונים",
     "instructions": "הנחיות",
     "loadingReportContext": "טוען קונטקסט של הדוח…",

--- a/locales/it.json
+++ b/locales/it.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Chiedi dati, una dashboard o un'analisi approfondita",
+    "thinking": "Sto pensando",
     "placeholderCompact": "Chiedi qualsiasi dato",
     "instructions": "Istruzioni",
     "loadingReportContext": "Caricamento del contesto del report…",

--- a/locales/it.json
+++ b/locales/it.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Chiedi dati, una dashboard o un'analisi approfondita",
     "thinking": "Sto pensando",
+    "working": "Sto lavorando",
     "placeholderCompact": "Chiedi qualsiasi dato",
     "instructions": "Istruzioni",
     "loadingReportContext": "Caricamento del contesto del report…",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Peça dados, um painel ou uma análise aprofundada",
     "thinking": "Pensando",
+    "working": "Trabalhando",
     "placeholderCompact": "Peça quaisquer dados",
     "instructions": "Instruções",
     "loadingReportContext": "Carregando contexto do relatório…",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Peça dados, um painel ou uma análise aprofundada",
+    "thinking": "Pensando",
     "placeholderCompact": "Peça quaisquer dados",
     "instructions": "Instruções",
     "loadingReportContext": "Carregando contexto do relatório…",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Запросите данные, дашборд или глубокий анализ",
     "thinking": "Думаю",
+    "working": "Работаю",
     "placeholderCompact": "Запросите любые данные",
     "instructions": "Инструкции",
     "loadingReportContext": "Загрузка контекста отчёта…",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Запросите данные, дашборд или глубокий анализ",
+    "thinking": "Думаю",
     "placeholderCompact": "Запросите любые данные",
     "instructions": "Инструкции",
     "loadingReportContext": "Загрузка контекста отчёта…",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -381,6 +381,7 @@
   "prompt": {
     "placeholderDefault": "Be om data, en instrumentpanel eller en djupanalys",
     "thinking": "Tänker",
+    "working": "Arbetar",
     "placeholderCompact": "Be om vilken data som helst",
     "instructions": "Instruktioner",
     "loadingReportContext": "Laddar rapportkontext…",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -380,6 +380,7 @@
   },
   "prompt": {
     "placeholderDefault": "Be om data, en instrumentpanel eller en djupanalys",
+    "thinking": "Tänker",
     "placeholderCompact": "Be om vilken data som helst",
     "instructions": "Instruktioner",
     "loadingReportContext": "Laddar rapportkontext…",


### PR DESCRIPTION
## Summary

While a completion is submitting or in progress, PromptBoxV2 now shows an activity indicator above the prompt container — a spinner, a shimmering "Thinking" label (Codex-style shining text, using the same gradient text effect as the existing tool components), and a live elapsed-time counter (`11s`, rolling over to `1m 05s`). It fades in/out with a short transition.

## Details

- Visibility is driven by `isSubmitting || latestInProgressCompletion`, so the indicator covers the whole run: it appears the instant the user hits send, hands off seamlessly to the in-progress completion state without resetting the counter, and disappears when the run finishes or is stopped.
- The elapsed timer is a 1-second interval started by a watcher with `immediate: true`, so it also starts when the page is refreshed mid-run (resumed in-progress runs). The interval is cleaned up on unmount.
- The label uses a new `prompt.thinking` i18n key, added to all 10 locale files with an inline English fallback.

## Testing

- `nuxt build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfKLmCXiju58PV7H9oPX5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfKLmCXiju58PV7H9oPX5c)_