### PR TITLE
Refine error handling guidance in planner prompts

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -144,8 +144,8 @@ PLAN TYPE DECISION FRAMEWORK
 - write_csv is useful when the user asks to create a table of data from scratch, or when raw/unstructured data needs to be cleaned into tabular format.
 
 ERROR HANDLING (robust; no blind retries)
-- If ANY tool error occurred, start reasoning_message with: 
-  "I see the previous attempt failed: <specific error>."
+- If the IMMEDIATELY PRECEDING tool call failed (an error in last_observation), start reasoning_message with:
+  "The previous attempt failed: <specific error>." Acknowledge an error only on the turn right after it happens; once you've recovered, do NOT mention it again on later steps.
 - Verify tool name/arguments against the schema before retrying.
 - Change something meaningful on retry (parameters, SQL, path). Max two retries per phase; otherwise pivot to ask a focused clarifying question via final_answer.
 - If the error is related to size of the query, try to use known partitions or search through metadata resources for partitions.

--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -274,7 +274,7 @@ when to call clarify — strict for DRAFT sources (and the rare published blocke
 - the optional `context` arg is a brief internal note about why you're asking — not shown to the user.
 
 ERROR HANDLING (robust; no blind retries)
-- If ANY tool error occurred, start your message text with: "I see the previous attempt failed: <specific error>."
+- If the IMMEDIATELY PRECEDING tool call failed (an error in last_observation), acknowledge it once in your message text — e.g. "The previous attempt failed: <specific error>." — then explain your adjusted approach. Acknowledge an error only on the turn right after it happens; once you've recovered, do NOT mention it again on later steps.
 - Verify tool name/arguments against the schema before retrying.
 - Change something meaningful on retry (parameters, SQL, path). Max two retries per phase; otherwise pivot to a clarifying question.
 - Treat "already exists/conflict" as a verification branch, not a fatal error.


### PR DESCRIPTION
## Summary
Updated error handling instructions in both planner prompt builders to be more precise about when and how to acknowledge tool failures, preventing unnecessary repetition of error messages across multiple reasoning steps.

## Key Changes
- **Clarified error acknowledgment scope**: Changed from "ANY tool error" to "IMMEDIATELY PRECEDING tool call failed" to ensure errors are only acknowledged on the turn right after they occur
- **Updated prompt language**: Changed "I see the previous attempt failed" to "The previous attempt failed" for more concise messaging
- **Added recovery guidance**: Explicitly instructed the agent to stop mentioning errors once recovery has occurred, preventing error messages from persisting across subsequent steps
- **Applied consistently**: Updated both `prompt_builder.py` and `prompt_builder_v3.py` with aligned error handling instructions

## Implementation Details
The changes ensure that:
1. Errors are only acknowledged when they appear in `last_observation` (the immediately preceding tool call result)
2. The agent explains its adjusted approach after acknowledging the error
3. Subsequent reasoning steps do not re-mention errors that have already been addressed
4. This prevents error context from polluting later steps and keeps the reasoning focused on forward progress

https://claude.ai/code/session_01VBLkJhcPyohsioSfAxrbex