### PR TITLE
TraceModal: show conversation LLM tokens and cost in the header

### DIFF
--- a/backend/app/schemas/agent_execution_trace_schema.py
+++ b/backend/app/schemas/agent_execution_trace_schema.py
@@ -88,6 +88,11 @@ class ConversationTraceResponse(BaseModel):
     total_turns: int = 0
     failed_turns: int = 0
     negative_feedback_turns: int = 0
+    # LLM usage roll-up aggregated from llm_usage_records for this report.
+    # Tokens include prompt + completion + cache read/write; cost may be 0
+    # when the model has no pricing configured.
+    total_llm_tokens: Optional[int] = None
+    total_llm_cost_usd: Optional[float] = None
     turns: List[ConversationTurnSchema] = []
 
 

--- a/backend/app/schemas/agent_execution_trace_schema.py
+++ b/backend/app/schemas/agent_execution_trace_schema.py
@@ -71,6 +71,13 @@ class ConversationTurnSchema(BaseModel):
     # scores above when present). None when the judge didn't run.
     judge: Optional[Dict[str, Any]] = None
     total_duration_ms: Optional[float] = None
+    # Per-turn LLM usage from the quota pipeline (usage_events rows written by
+    # the agent's UsageLimitContext, keyed by the head/user completion id).
+    # Covers every LLM call in the run (planner + tool codegen), but is only
+    # recorded on instances licensed for the usage_limits feature — None
+    # elsewhere (the UI falls back to the planner-only token_usage_json).
+    llm_tokens: Optional[int] = None
+    llm_cost_usd: Optional[float] = None
     created_at: OptionalUTCDatetime = None
 
     # Rendered blocks for the chat-style left pane (same shape the report chat

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -52,6 +52,7 @@ from sqlalchemy.orm import aliased
 from app.schemas.console_schema import ToolUsageMetrics, ToolUsageItem
 from app.models.llm_usage_record import LLMUsageRecord
 from app.models.llm_model import LLMModel
+from app.models.usage_policy import UsageEvent
 from app.models.instruction_build import InstructionBuild
 from app.models.report_data_source_association import report_data_source_association
 from app.models.data_source import DataSource
@@ -2118,6 +2119,34 @@ class ConsoleService:
                 if lst is not None and step_title and step_title not in lst:
                     lst.append(step_title)
 
+        # Per-turn LLM usage from the quota pipeline. The agent's
+        # UsageLimitContext writes one usage_events row per metric per run,
+        # keyed by source_ref_id = head (user) completion id, covering every
+        # LLM call in the run (planner + tool codegen). Only recorded on
+        # instances licensed for usage_limits — the map stays empty elsewhere
+        # and turns fall back to the planner-only token_usage_json in the UI.
+        _METRIC_LLM_TOKENS = "llm_tokens"
+        _METRIC_LLM_COST = "llm_cost_micro_usd"
+        turn_usage: dict[str, dict[str, int]] = {}
+        user_completion_ids = [str(r.user_completion_id) for r in rows if r.user_completion_id]
+        if user_completion_ids:
+            ue_q = (
+                select(
+                    UsageEvent.source_ref_id,
+                    UsageEvent.metric,
+                    func.coalesce(func.sum(UsageEvent.amount), 0),
+                )
+                .where(
+                    UsageEvent.organization_id == organization.id,
+                    UsageEvent.source == 'agent',
+                    UsageEvent.source_ref_id.in_(user_completion_ids),
+                    UsageEvent.metric.in_([_METRIC_LLM_TOKENS, _METRIC_LLM_COST]),
+                )
+                .group_by(UsageEvent.source_ref_id, UsageEvent.metric)
+            )
+            for ref_id, metric, amount in (await db.execute(ue_q)).all():
+                turn_usage.setdefault(str(ref_id), {})[metric] = int(amount or 0)
+
         # Most recent feedback per system completion.
         feedback_map: dict[str, dict] = {}
         if completion_ids:
@@ -2173,6 +2202,10 @@ class ConsoleService:
         for r in rows:
             counts = te_counts.get(str(r.ae_id), {'total': 0, 'success': 0, 'failed': 0})
             fb = feedback_map.get(str(r.completion_id), {'direction': 0, 'status': 'none', 'message': None})
+            usage = turn_usage.get(str(r.user_completion_id), {}) if r.user_completion_id else {}
+            turn_llm_tokens = usage.get(_METRIC_LLM_TOKENS) or None
+            _cost_micro = usage.get(_METRIC_LLM_COST) or 0
+            turn_llm_cost_usd = round(_cost_micro / 1_000_000, 6) if _cost_micro else None
             derived_status = 'error' if (counts.get('failed', 0) or 0) > 0 else (r.ae_status or 'success')
             if derived_status == 'error':
                 failed_turns += 1
@@ -2200,6 +2233,8 @@ class ConsoleService:
                 response_score=r.response_score,
                 judge=r.judge_json if isinstance(r.judge_json, dict) else None,
                 total_duration_ms=r.total_duration_ms,
+                llm_tokens=turn_llm_tokens,
+                llm_cost_usd=turn_llm_cost_usd,
                 created_at=r.created_at,
                 completion_blocks=blocks_by_ae.get(str(r.ae_id), []),
             ))

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -2208,6 +2208,29 @@ class ConsoleService:
         # (rows are ordered ascending by created_at). null = web UI.
         external_platform = next((r.external_platform for r in rows if r.external_platform), None)
 
+        # LLM usage roll-up for the whole conversation. Usage records are
+        # attributed per report (not per agent execution), so this is the one
+        # place a trustworthy total exists. Older records predate attribution
+        # and simply don't count here.
+        usage_q = (
+            select(
+                func.coalesce(
+                    func.sum(
+                        LLMUsageRecord.prompt_tokens
+                        + LLMUsageRecord.completion_tokens
+                        + LLMUsageRecord.cache_read_tokens
+                        + LLMUsageRecord.cache_creation_tokens
+                    ),
+                    0,
+                ),
+                func.coalesce(func.sum(LLMUsageRecord.total_cost_usd), 0),
+            )
+            .where(LLMUsageRecord.report_id == str(report.id))
+        )
+        usage_tokens, usage_cost = (await db.execute(usage_q)).one()
+        total_llm_tokens = int(usage_tokens or 0) or None
+        total_llm_cost_usd = round(float(usage_cost or 0), 6) or None
+
         # Header user = the report owner.
         owner_name = None
         owner_email = None
@@ -2226,6 +2249,8 @@ class ConsoleService:
             total_turns=len(turns),
             failed_turns=failed_turns,
             negative_feedback_turns=negative_feedback_turns,
+            total_llm_tokens=total_llm_tokens,
+            total_llm_cost_usd=total_llm_cost_usd,
             turns=turns,
         )
 

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -152,9 +152,12 @@
                             <UIcon name="i-heroicons-clock" class="w-3.5 h-3.5" />
                             {{ formatDuration(traceData.timing_breakdown.total_duration_ms) }}
                         </span>
-                        <span v-if="selectedTurnTokens" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-400" :title="$t('traceModal.turnTokensTooltip')">
+                        <span v-if="selectedTurnTokens" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-400" :title="selectedTurnHasFullUsage ? $t('traceModal.turnUsageTooltip') : $t('traceModal.turnTokensTooltip')">
                             <UIcon name="i-heroicons-cpu-chip" class="w-3.5 h-3.5" />
                             {{ $t('traceModal.tokensCount', { count: formatTokens(selectedTurnTokens) }) }}
+                        </span>
+                        <span v-if="selectedTurn.llm_cost_usd" class="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-medium text-gray-600 dark:text-gray-400" :title="$t('traceModal.turnUsageTooltip')">
+                            {{ formatCost(selectedTurn.llm_cost_usd) }}
                         </span>
                         <span v-if="selectedTurn.feedback_status !== 'none'"
                               :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs', selectedTurn.feedback_status === 'positive' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700']">
@@ -678,6 +681,8 @@ interface ConversationTurn {
     response_score?: number | null
     judge?: Record<string, { score?: number | null; reasoning?: string | null }> | null
     total_duration_ms?: number | null
+    llm_tokens?: number | null
+    llm_cost_usd?: number | null
     created_at?: string | null
 }
 
@@ -720,11 +725,16 @@ const blocks = computed(() => traceData.value?.completion_blocks || [])
 const turns = computed(() => conversation.value?.turns || [])
 const selectedTurn = computed(() => turns.value.find(t => t.completion_id === selectedCompletionId.value) || null)
 
-// Per-turn LLM tokens: summed from the planner loop's plan decisions into
-// agent_execution.token_usage_json when the execution finishes. Covers the
-// planner calls only (tool codegen isn't attributed per execution), so it
-// undercounts vs the conversation-level roll-up in the header.
+// Per-turn LLM tokens. Preferred source: turn.llm_tokens, aggregated from
+// the quota pipeline's usage_events (covers every LLM call in the run —
+// planner + tool codegen — but only recorded on instances licensed for
+// usage_limits). Fallback: agent_execution.token_usage_json, summed from
+// the planner loop's plan decisions — always available but planner-only,
+// so it undercounts vs the conversation-level roll-up in the header.
+const selectedTurnHasFullUsage = computed(() => (selectedTurn.value?.llm_tokens || 0) > 0)
 const selectedTurnTokens = computed(() => {
+    const full = selectedTurn.value?.llm_tokens
+    if (full && full > 0) return full
     const u = traceData.value?.agent_execution?.token_usage_json
     if (!u) return 0
     const total = Number(u.total_tokens ?? 0)

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -152,6 +152,10 @@
                             <UIcon name="i-heroicons-clock" class="w-3.5 h-3.5" />
                             {{ formatDuration(traceData.timing_breakdown.total_duration_ms) }}
                         </span>
+                        <span v-if="selectedTurnTokens" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-400" :title="$t('traceModal.turnTokensTooltip')">
+                            <UIcon name="i-heroicons-cpu-chip" class="w-3.5 h-3.5" />
+                            {{ $t('traceModal.tokensCount', { count: formatTokens(selectedTurnTokens) }) }}
+                        </span>
                         <span v-if="selectedTurn.feedback_status !== 'none'"
                               :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs', selectedTurn.feedback_status === 'positive' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700']">
                             <UIcon :name="selectedTurn.feedback_status === 'positive' ? 'i-heroicons-hand-thumb-up' : 'i-heroicons-hand-thumb-down'" class="w-3.5 h-3.5" />
@@ -715,6 +719,18 @@ const selectedItemType = ref<'block'>('block')
 const blocks = computed(() => traceData.value?.completion_blocks || [])
 const turns = computed(() => conversation.value?.turns || [])
 const selectedTurn = computed(() => turns.value.find(t => t.completion_id === selectedCompletionId.value) || null)
+
+// Per-turn LLM tokens: summed from the planner loop's plan decisions into
+// agent_execution.token_usage_json when the execution finishes. Covers the
+// planner calls only (tool codegen isn't attributed per execution), so it
+// undercounts vs the conversation-level roll-up in the header.
+const selectedTurnTokens = computed(() => {
+    const u = traceData.value?.agent_execution?.token_usage_json
+    if (!u) return 0
+    const total = Number(u.total_tokens ?? 0)
+    if (total > 0) return total
+    return (Number(u.prompt_tokens ?? 0) + Number(u.completion_tokens ?? 0)) || 0
+})
 
 const selectedItemSubTimings = computed(() => {
     const te = selectedItem.value?.tool_execution

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -27,6 +27,13 @@
                             <span>{{ conversation.total_turns }} {{ conversation.total_turns === 1 ? 'turn' : 'turns' }}</span>
                             <span v-if="conversation.failed_turns" class="text-red-500">{{ conversation.failed_turns }} failed</span>
                             <span v-if="conversation.negative_feedback_turns" class="text-amber-600">{{ conversation.negative_feedback_turns }} negative</span>
+                            <span v-if="conversation.total_llm_tokens" class="inline-flex items-center gap-1" :title="$t('traceModal.llmUsageTooltip')">
+                                <UIcon name="i-heroicons-cpu-chip" class="w-3.5 h-3.5" />
+                                {{ $t('traceModal.tokensCount', { count: formatTokens(conversation.total_llm_tokens) }) }}
+                            </span>
+                            <span v-if="conversation.total_llm_cost_usd" class="font-medium text-gray-600 dark:text-gray-300" :title="$t('traceModal.llmUsageTooltip')">
+                                {{ formatCost(conversation.total_llm_cost_usd) }}
+                            </span>
                         </div>
                         <UButton
                             color="gray"
@@ -679,6 +686,8 @@ interface ConversationTraceResponse {
     total_turns: number
     failed_turns: number
     negative_feedback_turns: number
+    total_llm_tokens?: number | null
+    total_llm_cost_usd?: number | null
     turns: ConversationTurn[]
 }
 
@@ -1020,6 +1029,17 @@ function getTopStages(subTimings: any): Array<{ stage: string; ms: number }> {
 
 function humanizeStage(stage: string): string {
     return stage.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function formatTokens(n: number): string {
+    if (n < 1000) return String(n)
+    if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`
+    return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+function formatCost(usd: number): string {
+    if (usd < 0.01) return '<$0.01'
+    return `$${usd.toFixed(2)}`
 }
 
 function formatDuration(ms: number): string {

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "القرار: analysis_completed",
     "block": "كتلة",
     "tokensCount": "{count} رمز",
-    "llmUsageTooltip": "استخدام LLM في هذه المحادثة"
+    "llmUsageTooltip": "استخدام LLM في هذه المحادثة",
+    "turnTokensTooltip": "رموز LLM للمخطط في هذا الدور"
   },
   "reportView": {
     "tabChat": "محادثة",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "اكتمل التحليل",
     "analysisMarkedComplete": "تم تعليم التحليل كمكتمل.",
     "decisionAnalysisCompleted": "القرار: analysis_completed",
-    "block": "كتلة"
+    "block": "كتلة",
+    "tokensCount": "{count} رمز",
+    "llmUsageTooltip": "استخدام LLM في هذه المحادثة"
   },
   "reportView": {
     "tabChat": "محادثة",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -586,7 +586,8 @@
     "block": "كتلة",
     "tokensCount": "{count} رمز",
     "llmUsageTooltip": "استخدام LLM في هذه المحادثة",
-    "turnTokensTooltip": "رموز LLM للمخطط في هذا الدور"
+    "turnTokensTooltip": "رموز LLM للمخطط في هذا الدور",
+    "turnUsageTooltip": "استخدام LLM في هذا الدور"
   },
   "reportView": {
     "tabChat": "محادثة",

--- a/locales/de.json
+++ b/locales/de.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Entscheidung: analysis_completed",
     "block": "Block",
     "tokensCount": "{count} Token",
-    "llmUsageTooltip": "LLM-Nutzung für diese Konversation"
+    "llmUsageTooltip": "LLM-Nutzung für diese Konversation",
+    "turnTokensTooltip": "Planner-LLM-Token in dieser Runde"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/de.json
+++ b/locales/de.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Analyse abgeschlossen",
     "analysisMarkedComplete": "Analyse als abgeschlossen markiert.",
     "decisionAnalysisCompleted": "Entscheidung: analysis_completed",
-    "block": "Block"
+    "block": "Block",
+    "tokensCount": "{count} Token",
+    "llmUsageTooltip": "LLM-Nutzung für diese Konversation"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/de.json
+++ b/locales/de.json
@@ -586,7 +586,8 @@
     "block": "Block",
     "tokensCount": "{count} Token",
     "llmUsageTooltip": "LLM-Nutzung für diese Konversation",
-    "turnTokensTooltip": "Planner-LLM-Token in dieser Runde"
+    "turnTokensTooltip": "Planner-LLM-Token in dieser Runde",
+    "turnUsageTooltip": "LLM-Nutzung in dieser Runde"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/en.json
+++ b/locales/en.json
@@ -657,7 +657,9 @@
     "analysisCompleted": "Analysis Completed",
     "analysisMarkedComplete": "Analysis marked complete.",
     "decisionAnalysisCompleted": "Decision: analysis_completed",
-    "block": "Block"
+    "block": "Block",
+    "tokensCount": "{count} tokens",
+    "llmUsageTooltip": "LLM usage for this conversation"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/en.json
+++ b/locales/en.json
@@ -660,7 +660,8 @@
     "block": "Block",
     "tokensCount": "{count} tokens",
     "llmUsageTooltip": "LLM usage for this conversation",
-    "turnTokensTooltip": "Planner LLM tokens for this turn"
+    "turnTokensTooltip": "Planner LLM tokens for this turn",
+    "turnUsageTooltip": "LLM usage for this turn"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/en.json
+++ b/locales/en.json
@@ -659,7 +659,8 @@
     "decisionAnalysisCompleted": "Decision: analysis_completed",
     "block": "Block",
     "tokensCount": "{count} tokens",
-    "llmUsageTooltip": "LLM usage for this conversation"
+    "llmUsageTooltip": "LLM usage for this conversation",
+    "turnTokensTooltip": "Planner LLM tokens for this turn"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/es.json
+++ b/locales/es.json
@@ -607,7 +607,8 @@
     "decisionAnalysisCompleted": "Decisión: análisis completado",
     "block": "Bloque",
     "tokensCount": "{count} tokens",
-    "llmUsageTooltip": "Uso de LLM en esta conversación"
+    "llmUsageTooltip": "Uso de LLM en esta conversación",
+    "turnTokensTooltip": "Tokens LLM del planificador en este turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/es.json
+++ b/locales/es.json
@@ -605,7 +605,9 @@
     "analysisCompleted": "Análisis completado",
     "analysisMarkedComplete": "Análisis marcado como completo.",
     "decisionAnalysisCompleted": "Decisión: análisis completado",
-    "block": "Bloque"
+    "block": "Bloque",
+    "tokensCount": "{count} tokens",
+    "llmUsageTooltip": "Uso de LLM en esta conversación"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/es.json
+++ b/locales/es.json
@@ -608,7 +608,8 @@
     "block": "Bloque",
     "tokensCount": "{count} tokens",
     "llmUsageTooltip": "Uso de LLM en esta conversación",
-    "turnTokensTooltip": "Tokens LLM del planificador en este turno"
+    "turnTokensTooltip": "Tokens LLM del planificador en este turno",
+    "turnUsageTooltip": "Uso de LLM en este turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -586,7 +586,8 @@
     "block": "Bloc",
     "tokensCount": "{count} tokens",
     "llmUsageTooltip": "Utilisation du LLM pour cette conversation",
-    "turnTokensTooltip": "Tokens LLM du planificateur pour ce tour"
+    "turnTokensTooltip": "Tokens LLM du planificateur pour ce tour",
+    "turnUsageTooltip": "Utilisation du LLM pour ce tour"
   },
   "reportView": {
     "tabChat": "Conversation",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Analyse terminée",
     "analysisMarkedComplete": "Analyse marquée comme terminée.",
     "decisionAnalysisCompleted": "Décision : analysis_completed",
-    "block": "Bloc"
+    "block": "Bloc",
+    "tokensCount": "{count} tokens",
+    "llmUsageTooltip": "Utilisation du LLM pour cette conversation"
   },
   "reportView": {
     "tabChat": "Conversation",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Décision : analysis_completed",
     "block": "Bloc",
     "tokensCount": "{count} tokens",
-    "llmUsageTooltip": "Utilisation du LLM pour cette conversation"
+    "llmUsageTooltip": "Utilisation du LLM pour cette conversation",
+    "turnTokensTooltip": "Tokens LLM du planificateur pour ce tour"
   },
   "reportView": {
     "tabChat": "Conversation",

--- a/locales/he.json
+++ b/locales/he.json
@@ -608,7 +608,8 @@
     "block": "בלוק",
     "tokensCount": "{count} טוקנים",
     "llmUsageTooltip": "שימוש ב-LLM בשיחה זו",
-    "turnTokensTooltip": "טוקני LLM של המתכנן בסבב זה"
+    "turnTokensTooltip": "טוקני LLM של המתכנן בסבב זה",
+    "turnUsageTooltip": "שימוש ב-LLM בסבב זה"
   },
   "reportView": {
     "tabChat": "צ'אט",

--- a/locales/he.json
+++ b/locales/he.json
@@ -605,7 +605,9 @@
     "analysisCompleted": "הניתוח הושלם",
     "analysisMarkedComplete": "הניתוח סומן כהושלם.",
     "decisionAnalysisCompleted": "החלטה: הניתוח הושלם",
-    "block": "בלוק"
+    "block": "בלוק",
+    "tokensCount": "{count} טוקנים",
+    "llmUsageTooltip": "שימוש ב-LLM בשיחה זו"
   },
   "reportView": {
     "tabChat": "צ'אט",

--- a/locales/he.json
+++ b/locales/he.json
@@ -607,7 +607,8 @@
     "decisionAnalysisCompleted": "החלטה: הניתוח הושלם",
     "block": "בלוק",
     "tokensCount": "{count} טוקנים",
-    "llmUsageTooltip": "שימוש ב-LLM בשיחה זו"
+    "llmUsageTooltip": "שימוש ב-LLM בשיחה זו",
+    "turnTokensTooltip": "טוקני LLM של המתכנן בסבב זה"
   },
   "reportView": {
     "tabChat": "צ'אט",

--- a/locales/it.json
+++ b/locales/it.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Decisione: analysis_completed",
     "block": "Blocco",
     "tokensCount": "{count} token",
-    "llmUsageTooltip": "Utilizzo LLM per questa conversazione"
+    "llmUsageTooltip": "Utilizzo LLM per questa conversazione",
+    "turnTokensTooltip": "Token LLM del pianificatore per questo turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/it.json
+++ b/locales/it.json
@@ -586,7 +586,8 @@
     "block": "Blocco",
     "tokensCount": "{count} token",
     "llmUsageTooltip": "Utilizzo LLM per questa conversazione",
-    "turnTokensTooltip": "Token LLM del pianificatore per questo turno"
+    "turnTokensTooltip": "Token LLM del pianificatore per questo turno",
+    "turnUsageTooltip": "Utilizzo LLM per questo turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/it.json
+++ b/locales/it.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Analisi completata",
     "analysisMarkedComplete": "Analisi contrassegnata come completata.",
     "decisionAnalysisCompleted": "Decisione: analysis_completed",
-    "block": "Blocco"
+    "block": "Blocco",
+    "tokensCount": "{count} token",
+    "llmUsageTooltip": "Utilizzo LLM per questa conversazione"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Análise concluída",
     "analysisMarkedComplete": "Análise marcada como concluída.",
     "decisionAnalysisCompleted": "Decisão: analysis_completed",
-    "block": "Bloco"
+    "block": "Bloco",
+    "tokensCount": "{count} tokens",
+    "llmUsageTooltip": "Uso de LLM nesta conversa"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -586,7 +586,8 @@
     "block": "Bloco",
     "tokensCount": "{count} tokens",
     "llmUsageTooltip": "Uso de LLM nesta conversa",
-    "turnTokensTooltip": "Tokens LLM do planejador neste turno"
+    "turnTokensTooltip": "Tokens LLM do planejador neste turno",
+    "turnUsageTooltip": "Uso de LLM neste turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Decisão: analysis_completed",
     "block": "Bloco",
     "tokensCount": "{count} tokens",
-    "llmUsageTooltip": "Uso de LLM nesta conversa"
+    "llmUsageTooltip": "Uso de LLM nesta conversa",
+    "turnTokensTooltip": "Tokens LLM do planejador neste turno"
   },
   "reportView": {
     "tabChat": "Chat",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -586,7 +586,8 @@
     "block": "Блок",
     "tokensCount": "{count} токенов",
     "llmUsageTooltip": "Использование LLM в этом диалоге",
-    "turnTokensTooltip": "Токены LLM планировщика за этот ход"
+    "turnTokensTooltip": "Токены LLM планировщика за этот ход",
+    "turnUsageTooltip": "Использование LLM за этот ход"
   },
   "reportView": {
     "tabChat": "Чат",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Решение: analysis_completed",
     "block": "Блок",
     "tokensCount": "{count} токенов",
-    "llmUsageTooltip": "Использование LLM в этом диалоге"
+    "llmUsageTooltip": "Использование LLM в этом диалоге",
+    "turnTokensTooltip": "Токены LLM планировщика за этот ход"
   },
   "reportView": {
     "tabChat": "Чат",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Анализ завершён",
     "analysisMarkedComplete": "Анализ отмечен как завершённый.",
     "decisionAnalysisCompleted": "Решение: analysis_completed",
-    "block": "Блок"
+    "block": "Блок",
+    "tokensCount": "{count} токенов",
+    "llmUsageTooltip": "Использование LLM в этом диалоге"
   },
   "reportView": {
     "tabChat": "Чат",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -583,7 +583,9 @@
     "analysisCompleted": "Analys slutförd",
     "analysisMarkedComplete": "Analysen är markerad som slutförd.",
     "decisionAnalysisCompleted": "Beslut: analysis_completed",
-    "block": "Block"
+    "block": "Block",
+    "tokensCount": "{count} tokens",
+    "llmUsageTooltip": "LLM-användning för denna konversation"
   },
   "reportView": {
     "tabChat": "Chatt",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -586,7 +586,8 @@
     "block": "Block",
     "tokensCount": "{count} tokens",
     "llmUsageTooltip": "LLM-användning för denna konversation",
-    "turnTokensTooltip": "Planerarens LLM-tokens för denna tur"
+    "turnTokensTooltip": "Planerarens LLM-tokens för denna tur",
+    "turnUsageTooltip": "LLM-användning för denna tur"
   },
   "reportView": {
     "tabChat": "Chatt",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -585,7 +585,8 @@
     "decisionAnalysisCompleted": "Beslut: analysis_completed",
     "block": "Block",
     "tokensCount": "{count} tokens",
-    "llmUsageTooltip": "LLM-användning för denna konversation"
+    "llmUsageTooltip": "LLM-användning för denna konversation",
+    "turnTokensTooltip": "Planerarens LLM-tokens för denna tur"
   },
   "reportView": {
     "tabChat": "Chatt",


### PR DESCRIPTION
Aggregate llm_usage_records per report in get_report_conversation
(prompt + completion + cache tokens, and total cost) and surface the
roll-up in the TraceModal header next to the turn counts. Chips hide
when no usage is attributed; cost hides when pricing isn't configured.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0137WNBAegxAsmtpF1iZB1hQ