### PR TITLE
Fix empty review for NEW instructions pending approval

### DIFF
--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -1213,6 +1213,22 @@ async def get_instruction_pending_builds(
                 select(InstructionVersion.text).where(InstructionVersion.id == main_version_id)
             )
         ).scalar_one_or_none()
+    else:
+        # Instruction absent from main. When the org HAS a main build this is a
+        # CREATE suggestion whose live baseline is empty text — run it through
+        # the same per-hunk rule as edits (mirrors _main_text_of), so a create
+        # rejected in the per-hunk review resolves here too instead of
+        # resurfacing as a whole snapshot. main_text stays None only for legacy
+        # orgs that predate main-build content.
+        has_main_build = (await db.execute(
+            select(InstructionBuild.id).where(and_(
+                InstructionBuild.organization_id == str(organization.id),
+                InstructionBuild.is_main.is_(True),
+                InstructionBuild.deleted_at.is_(None),
+            )).limit(1)
+        )).scalar_one_or_none()
+        if has_main_build:
+            main_text = ""
 
     where_clauses = [
         BuildContent.instruction_id == instruction_id,

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -1413,10 +1413,29 @@ class InstructionService:
             main_vid = str(row[0])
             meta_src = await self.version_service.get_version(db, main_vid)
             return (row[1] or ""), main_vid, meta_src
-        # Fallback: no main build content (legacy) — use the cached row / version.
+        # No main-build content row for this instruction — two distinct cases.
         meta_src = None
         if instruction.current_version_id:
             meta_src = await self.version_service.get_version(db, instruction.current_version_id)
+        has_main_build = (await db.execute(
+            select(InstructionBuild.id).where(
+                InstructionBuild.organization_id == str(instruction.organization_id),
+                InstructionBuild.is_main == True,  # noqa: E712
+                InstructionBuild.deleted_at == None,  # noqa: E711
+            ).limit(1)
+        )).scalar_one_or_none()
+        if has_main_build:
+            # The org HAS a main build and this instruction isn't in it: a NEW
+            # instruction that so far exists only in pending suggestion builds.
+            # Its live baseline is EMPTY text. The row/current-version cache
+            # holds the staged draft itself, so falling back to it would diff
+            # the proposal against its own text and collapse the review to zero
+            # hunks ("no pending changes" for a change nobody has approved).
+            # meta_src still comes from the staged version so accept flows
+            # preserve its title/status/references when creating the live one.
+            return "", None, meta_src
+        # Legacy: the org predates main-build content — the cached row/current
+        # version IS the live text.
         main_text = (meta_src.text if meta_src else getattr(instruction, "text", "")) or ""
         main_vid = str(instruction.current_version_id) if instruction.current_version_id else None
         return main_text, main_vid, meta_src
@@ -1666,9 +1685,13 @@ class InstructionService:
 
         cand_ids = list({str(iid) for iid, _b, _t in sug_rows})
 
-        # (3) Live main text per candidate (authoritative is_main build content),
-        #     with a fallback to the live instruction row for legacy instructions
-        #     that predate main-build content — mirrors _main_text_of().
+        # (3) Live main text per candidate (authoritative is_main build content).
+        #     Mirrors _main_text_of(): a candidate absent from the org's main
+        #     build is NOT live — its baseline is empty text, so a NEW pending
+        #     instruction counts as one whole-text insertion. Falling back to
+        #     the live row (which caches the staged draft itself) would diff
+        #     the proposal against its own text and hide it. The row fallback
+        #     only applies to legacy orgs that predate main-build content.
         main_text: dict = {}
         for iid, t in (await db.execute(
             select(BuildContent.instruction_id, _IV.text)
@@ -1684,10 +1707,18 @@ class InstructionService:
             main_text[str(iid)] = t or ""
         missing_main = [i for i in cand_ids if i not in main_text]
         if missing_main:
-            for iid, txt in (await db.execute(
-                select(Instruction.id, Instruction.text).where(Instruction.id.in_(missing_main))
-            )).all():
-                main_text[str(iid)] = txt or ""
+            has_main_build = (await db.execute(
+                select(InstructionBuild.id).where(and_(
+                    InstructionBuild.organization_id == org_id,
+                    InstructionBuild.is_main.is_(True),
+                    InstructionBuild.deleted_at.is_(None),
+                )).limit(1)
+            )).scalar_one_or_none()
+            if not has_main_build:
+                for iid, txt in (await db.execute(
+                    select(Instruction.id, Instruction.text).where(Instruction.id.in_(missing_main))
+                )).all():
+                    main_text[str(iid)] = txt or ""
 
         # (4) Pure-Python pass — no awaits in the loop.
         # Process conclusive unchanged-main suggestions first. Once one such row

--- a/backend/tests/e2e/test_instruction.py
+++ b/backend/tests/e2e/test_instruction.py
@@ -1328,3 +1328,193 @@ def test_pending_badge_excludes_inaccessible_private_agent(
     sweep = test_client.get("/api/instructions/pending-changes", headers=headers)
     assert sweep.status_code == 200, sweep.json()
     assert sweep.json()["instruction_ids"] == []
+
+
+def _inject_new_instruction_suggestion(org_id, proposed_text, source="ai", status="pending_approval"):
+    """Insert a brand-NEW instruction that exists ONLY in a pending suggestion
+    build — absent from the main build. Mirrors what the AI training flow's
+    create_instruction tool leaves behind: a draft live row caching the proposed
+    text, current_version_id pointing at the staged (status='published') version,
+    and a non-main build (forked from main) carrying it. Returns (iid, bid)."""
+    import os, uuid, datetime
+    from sqlalchemy import create_engine, text
+
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    now = datetime.datetime.utcnow()
+    iid, vid, bid, bcid = (str(uuid.uuid4()) for _ in range(4))
+    try:
+        with engine.begin() as conn:
+            main = conn.execute(
+                text(
+                    "SELECT id FROM instruction_builds WHERE organization_id=:org"
+                    " AND is_main=:is_main AND deleted_at IS NULL"
+                ),
+                {"org": org_id, "is_main": True},
+            ).mappings().fetchone()
+            assert main is not None, "org should already have a main build"
+            bnum = conn.execute(
+                text("SELECT COALESCE(MAX(build_number),0)+1 FROM instruction_builds WHERE organization_id=:org"),
+                {"org": org_id},
+            ).scalar()
+            conn.execute(
+                text(
+                    "INSERT INTO instructions (id,created_at,updated_at,text,thumbs_up,status,category,kind,"
+                    "is_seen,can_user_toggle,organization_id,source_type,load_mode,source_sync_enabled)"
+                    " VALUES (:id,:ca,:ua,:txt,:tu,:status,:cat,:kind,:seen,:tog,:org,:st,:lm,:sync)"
+                ),
+                {"id": iid, "ca": now, "ua": now, "txt": proposed_text, "tu": 0,
+                 "status": "draft", "cat": "general", "kind": "instruction",
+                 "seen": True, "tog": True, "org": org_id, "st": source, "lm": "always", "sync": True},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_versions (id,created_at,updated_at,instruction_id,version_number,text,status,load_mode,content_hash)"
+                    " VALUES (:id,:ca,:ua,:iid,:vnum,:txt,:status,:load_mode,:chash)"
+                ),
+                {"id": vid, "ca": now, "ua": now, "iid": iid, "vnum": 1, "txt": proposed_text,
+                 "status": "published", "load_mode": "always", "chash": "h" + uuid.uuid4().hex[:12]},
+            )
+            conn.execute(
+                text("UPDATE instructions SET current_version_id=:vid WHERE id=:iid"),
+                {"vid": vid, "iid": iid},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO instruction_builds (id,created_at,updated_at,build_number,status,source,is_main,organization_id,base_build_id,title)"
+                    " VALUES (:id,:ca,:ua,:bnum,:status,:source,:is_main,:org,:base,:title)"
+                ),
+                {"id": bid, "ca": now, "ua": now, "bnum": bnum, "status": status, "source": source,
+                 "is_main": False, "org": org_id, "base": main["id"], "title": "new-instruction suggestion"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO build_contents (id,created_at,updated_at,build_id,instruction_id,instruction_version_id)"
+                    " VALUES (:id,:ca,:ua,:bid,:iid,:vid)"
+                ),
+                {"id": bcid, "ca": now, "ua": now, "bid": bid, "iid": iid, "vid": vid},
+            )
+    finally:
+        engine.dispose()
+    return iid, bid
+
+
+@pytest.mark.e2e
+def test_new_instruction_review_shows_full_text_as_pending_hunk(
+    test_client,
+    create_global_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Regression: a brand-NEW instruction staged in a pending build (absent from
+    main) used to render an EMPTY review — "0 changes / all resolved" — because
+    the main-text fallback read the instruction's own staged draft and diffed the
+    proposal against itself. The correct baseline for a not-yet-live instruction
+    is empty text: the review must surface the whole draft as one insertion hunk,
+    and every pending surface (review-hunks, /pending-changes, the pending_only
+    list, pending-builds) must agree it is pending."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    # Ensure the org has a main build (a live instruction creates+promotes one).
+    create_global_instruction(text="existing live rule", user_token=token, org_id=org_id, status="published")
+    iid, bid = _inject_new_instruction_suggestion(org_id, "brand new AI rule")
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["main_text"] == ""
+    assert review["main_version_id"] is None
+    assert [s["build_id"] for s in review["suggestions"]] == [bid]
+    hunks = review["suggestions"][0]["hunks"]
+    assert len(hunks) == 1, hunks
+    assert hunks[0]["before"] == ""
+    assert hunks[0]["after"] == "brand new AI rule"
+
+    sweep = test_client.get("/api/instructions/pending-changes", headers=headers).json()
+    assert iid in sweep["instruction_ids"]
+
+    plist = test_client.get(
+        "/api/instructions",
+        params={"pending_only": "true", "include_own": "true",
+                "include_drafts": "true", "include_archived": "true", "limit": 200},
+        headers=headers,
+    ).json()
+    assert iid in {r["id"] for r in plist["items"]}
+
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert [b["build_id"] for b in pending] == [bid]
+    assert pending[0]["pending_text"] == "brand new AI rule"
+    assert pending[0]["base_text"] == ""
+
+
+@pytest.mark.e2e
+def test_new_instruction_accept_all_makes_it_live(
+    test_client,
+    create_global_instruction,
+    get_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Accepting a NEW instruction's insertion hunk promotes it into main and
+    flips the live row to published; every pending surface then agrees it is
+    resolved."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    create_global_instruction(text="existing live rule", user_token=token, org_id=org_id, status="published")
+    iid, _bid = _inject_new_instruction_suggestion(org_id, "brand new AI rule")
+
+    resp = test_client.post(f"/api/instructions/{iid}/hunks/accept-all", json={}, headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    detail = get_instruction(iid, user_token=token, org_id=org_id)
+    assert detail["text"] == "brand new AI rule"
+    assert detail["status"] == "published"
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["suggestions"] == []
+    assert review["main_text"] == "brand new AI rule"
+    sweep = test_client.get("/api/instructions/pending-changes", headers=headers).json()
+    assert iid not in sweep["instruction_ids"]
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert pending == []
+
+
+@pytest.mark.e2e
+def test_new_instruction_reject_all_resolves_everywhere(
+    test_client,
+    create_global_instruction,
+    get_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Rejecting a NEW instruction's insertion hunk resolves it on EVERY pending
+    surface (review-hunks, the sweep, and pending-builds — which used to ignore
+    per-hunk rejections for creates) without making it live."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    create_global_instruction(text="existing live rule", user_token=token, org_id=org_id, status="published")
+    iid, _bid = _inject_new_instruction_suggestion(org_id, "brand new AI rule")
+
+    resp = test_client.post(f"/api/instructions/{iid}/hunks/reject-all", json={}, headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["suggestions"] == []
+    sweep = test_client.get("/api/instructions/pending-changes", headers=headers).json()
+    assert iid not in sweep["instruction_ids"]
+    pending = test_client.get(f"/api/instructions/{iid}/pending-builds", headers=headers).json()
+    assert pending == []
+    # Not live: the row stays a draft and main gained no content for it.
+    detail = get_instruction(iid, user_token=token, org_id=org_id)
+    assert detail["status"] == "draft"


### PR DESCRIPTION
## Problem

A brand-new instruction staged in a pending suggestion build (e.g. created by the AI training flow) rendered an **empty** tracked-changes review — "Pending review · 0 changes / No pending changes — all resolved" — with no way to see, accept, or reject its content, even while the pending-changes panel listed it as a `NEW` change.

## Root cause

`_main_text_of()` (which feeds `GET /instructions/{id}/review-hunks` and the accept/reject flows) falls back to the instruction's own `current_version_id` when the instruction has no main-build content row. For a fresh draft, that version **is** the pending suggestion — so the proposal was diffed against itself and every hunk collapsed as "already applied". The batched pending sweep (`get_pending_change_instruction_ids`) had the same class of fallback via `Instruction.text`, so surfaces also disagreed about whether the instruction was pending at all.

## Fix

The correct live baseline for an instruction absent from the org's main build is **empty text**:

- **`_main_text_of()`**: when the org has a main build and the instruction isn't in it, return `""` as main text (keeping `meta_src` from the staged version so accepts preserve title/status/references/load mode). The row/current-version fallback now applies only to legacy orgs that predate main-build content.
- **`get_pending_change_instruction_ids()`**: same rule, so the pending badge/list agrees with the per-instruction review.
- **`GET /pending-builds`**: CREATE suggestions now go through the same per-hunk rule as edits — previously they ignored per-hunk rejections and kept resurfacing as whole snapshots.

The review now surfaces the whole draft as one insertion hunk; accepting promotes it into main and flips the live row to `published` (via the staged version's status), rejecting resolves it everywhere without publishing.

No frontend changes needed — the UI renders whatever hunks the server returns.

## Tests

Three new e2e regression tests (with a helper that injects exactly what the AI training flow leaves behind: draft row + staged version + pending build absent from main):

1. `review-hunks` returns one insertion hunk (`before: ""`, `after: <draft>`); `/pending-changes`, the `pending_only` list, and `pending-builds` all agree it's pending.
2. Accept-all promotes the text into main, flips the row to `published`, and every surface reads resolved.
3. Reject-all resolves every surface without publishing (row stays `draft`, main gains nothing).

All instruction/build/training/git-sync e2e suites pass (30 + 63 + 28 tests) plus related unit tests. The one unit-test failure (`test_whatsapp_webhook_route`) also fails on a clean checkout — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBCVtFiXNRdokUVB71yZ2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBCVtFiXNRdokUVB71yZ2o)_