### PR TITLE
perf: filter instruction-context load in SQL + cache tool metadata (completion path)

### DIFF
--- a/backend/app/ai/context/builders/instruction_context_builder.py
+++ b/backend/app/ai/context/builders/instruction_context_builder.py
@@ -2,11 +2,11 @@ from typing import List, Optional, Set, Tuple, Dict
 import re
 import logging
 
-from sqlalchemy import select, and_, or_, func
-from sqlalchemy.orm import selectinload, lazyload
+from sqlalchemy import select, and_, or_, func, exists
+from sqlalchemy.orm import selectinload, lazyload, contains_eager
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.instruction import Instruction
+from app.models.instruction import Instruction, instruction_data_source_association
 from app.models.instruction_stats import InstructionStats
 from app.models.instruction_build import InstructionBuild
 from app.models.build_content import BuildContent
@@ -658,21 +658,69 @@ class InstructionContextBuilder:
         
         if not build:
             return None  # No build available, fallback to legacy
-        
-        # Load build contents with versions
-        contents_result = await self.db.execute(
+
+        # Load build contents with versions.
+        #
+        # Push the status / kind / load_mode / data-source predicates into SQL
+        # instead of hydrating every content row of the build and filtering in
+        # Python. On an org whose main build holds thousands of instructions,
+        # the old shape loaded ALL of them plus each instruction's data_sources
+        # (an extra selectin per chunk) on every completion, then discarded the
+        # out-of-scope rows — O(all instructions) work on the event loop per
+        # turn. The data_sources relationship is no longer hydrated at all: the
+        # only thing it was used for (the data-source scope check) is now an
+        # EXISTS in the query. instruction + version come back via the join
+        # (contains_eager, no extra round-trip); labels are still batched.
+        stmt = (
             select(BuildContent)
+            .join(Instruction, BuildContent.instruction_id == Instruction.id)
+            .join(InstructionVersion, BuildContent.instruction_version_id == InstructionVersion.id)
             .options(
-                selectinload(BuildContent.instruction).selectinload(Instruction.data_sources).options(lazyload("*")),
-                selectinload(BuildContent.instruction).selectinload(Instruction.labels),
-                selectinload(BuildContent.instruction_version),
+                # Only hydrate the columns the item builder actually reads —
+                # avoids pulling every instruction/version column for thousands
+                # of rows. (id + FKs are always loaded.)
+                contains_eager(BuildContent.instruction)
+                .load_only(Instruction.category, Instruction.source_type)
+                .selectinload(Instruction.labels),
+                contains_eager(BuildContent.instruction_version).load_only(
+                    InstructionVersion.text,
+                    InstructionVersion.title,
+                    InstructionVersion.load_mode,
+                    InstructionVersion.version_number,
+                    InstructionVersion.content_hash,
+                    InstructionVersion.applicable_modes,
+                    InstructionVersion.applicable_channels,
+                ),
             )
             .where(BuildContent.build_id == build.id)
+            .where(Instruction.status == "published")
+            # Skills are advertised via the catalog, not force-loaded. NULL kind
+            # (legacy rows) is treated as a normal instruction, so keep it.
+            .where(or_(Instruction.kind.is_(None), Instruction.kind != "skill"))
+            # 'disabled' versions are skipped; NULL load_mode means 'always'.
+            .where(or_(InstructionVersion.load_mode.is_(None), InstructionVersion.load_mode != "disabled"))
         )
-        contents = contents_result.scalars().all()
-        
+
+        # Data-source scope: keep global instructions (no association rows) and
+        # those attached to one of the report's data sources. Mirrors the old
+        # Python set-intersection exactly, in SQL.
+        if data_source_ids is not None:
+            has_any_ds = exists().where(
+                instruction_data_source_association.c.instruction_id == Instruction.id
+            )
+            in_scope_ds = exists().where(
+                and_(
+                    instruction_data_source_association.c.instruction_id == Instruction.id,
+                    instruction_data_source_association.c.data_source_id.in_(data_source_ids),
+                )
+            )
+            stmt = stmt.where(or_(~has_any_ds, in_scope_ds))
+
+        contents_result = await self.db.execute(stmt)
+        contents = contents_result.unique().scalars().all()
+
         if not contents:
-            return []  # Build exists but is empty
+            return []  # Build exists but is empty (or nothing in scope)
         
         # Separate by load_mode
         always_contents: List[Tuple[BuildContent, Instruction, InstructionVersion]] = []
@@ -681,34 +729,18 @@ class InstructionContextBuilder:
         for content in contents:
             instruction = content.instruction
             version = content.instruction_version
-            
+
             if not instruction or not version:
                 continue
-            
-            # Skip unpublished and disabled
-            if instruction.status != "published":
-                continue
-            if version.load_mode == "disabled":
-                continue
-            # Skills are advertised via the skills catalog (read on demand), not
-            # force-loaded into context — skip them here.
-            if getattr(instruction, "kind", "instruction") == "skill":
-                continue
 
-            # Skip instructions scoped to other modes/channels than this request.
-            # Build-based loading is version-driven, so read the version snapshot.
+            # status / kind / load_mode='disabled' / data-source scope are all
+            # enforced in the query above. Only the mode/channel scope remains a
+            # Python check because it reads JSON columns on the version snapshot.
             if not self._passes_mode_channel(
                 getattr(version, "applicable_modes", None),
                 getattr(version, "applicable_channels", None),
             ):
                 continue
-
-            # Filter by data sources: include global instructions (no data sources)
-            # and instructions associated with the report's data sources
-            if data_source_ids is not None:
-                inst_ds_ids = {str(ds.id) for ds in instruction.data_sources} if instruction.data_sources else set()
-                if inst_ds_ids and not inst_ds_ids.intersection(data_source_ids):
-                    continue
 
             # Categorize by load_mode
             if version.load_mode == "intelligent":

--- a/backend/app/ai/runner/tool_runner.py
+++ b/backend/app/ai/runner/tool_runner.py
@@ -30,8 +30,11 @@ class ToolRunner:
         self.max_validation_failures = 2   # Max before giving up
 
     async def run(self, tool, arguments: Dict[str, Any], runtime_ctx: Dict[str, Any], emit) -> Dict[str, Any]:
-        # Runtime mode access control - check if tool is allowed in current mode
-        tool_allowed_modes = getattr(tool.metadata, 'allowed_modes', None) if hasattr(tool, 'metadata') else None
+        # Runtime mode access control - check if tool is allowed in current mode.
+        # Prefer `spec` (class-cached metadata) over `metadata` (rebuilds tool
+        # schemas on every call) — this runs for every tool execution.
+        _meta = getattr(tool, 'spec', None) or getattr(tool, 'metadata', None)
+        tool_allowed_modes = getattr(_meta, 'allowed_modes', None) if _meta is not None else None
         current_mode = runtime_ctx.get('mode') or 'chat'  # Default to 'chat' if mode is None
         if tool_allowed_modes is not None and current_mode not in tool_allowed_modes:
             return {

--- a/backend/app/ai/tools/base.py
+++ b/backend/app/ai/tools/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, Dict, Any, Optional, Type
+from typing import AsyncIterator, ClassVar, Dict, Any, Optional, Type
 from pydantic import BaseModel
 
 from .metadata import ToolMetadata
@@ -11,6 +11,15 @@ class Tool(ABC):
     Tools must implement run_stream and declare metadata property.
     """
 
+    # Per-class cache of the built ToolMetadata. Each subclass's `metadata`
+    # property rebuilds a ToolMetadata — including two model_json_schema()
+    # calls — on every access, and a fresh tool instance is created for every
+    # tool call (registry.get() -> tool_class()). Since registry tools are
+    # constructed with no args, their metadata is class-invariant, so we build
+    # it once per class. Callers on the hot path (tool_runner, name/description)
+    # use `spec`; `metadata` stays uncached for anything that needs it live.
+    _META_CACHE: ClassVar[Dict[type, ToolMetadata]] = {}
+
     @property
     @abstractmethod
     def metadata(self) -> ToolMetadata:
@@ -18,14 +27,29 @@ class Tool(ABC):
         pass
 
     @property
+    def spec(self) -> ToolMetadata:
+        """Class-cached tool metadata (avoids per-call schema regeneration).
+
+        Safe for all registry-constructed tools, whose metadata depends only on
+        class-level constants. A tool whose metadata varies per instance must
+        override this to return ``self.metadata``.
+        """
+        cls = type(self)
+        cached = Tool._META_CACHE.get(cls)
+        if cached is None:
+            cached = self.metadata
+            Tool._META_CACHE[cls] = cached
+        return cached
+
+    @property
     def name(self) -> str:
         """Tool name from metadata."""
-        return self.metadata.name
+        return self.spec.name
 
     @property
     def description(self) -> str:
         """Tool description from metadata."""
-        return self.metadata.description
+        return self.spec.description
 
     @property
     def input_model(self) -> Optional[Type[BaseModel]]:

--- a/backend/app/ai/tools/eval_result_view.py
+++ b/backend/app/ai/tools/eval_result_view.py
@@ -1,0 +1,136 @@
+"""Shared view helpers that turn a TestResult's ``result_json`` into the
+compact, agent-readable shape the eval-read tools return.
+
+``result_json`` (persisted by ``TestEvaluationService``) has the shape::
+
+    {
+      "spec":  {"spec_version": 1, "rules": [ {type, ...}, ... ], "order_mode": ...},
+      "totals": {...},
+      "rule_results": [ {ok, status, message, actual, evidence}, ... ],  # index-aligned with spec.rules
+    }
+
+The tools previously surfaced only ``TestResult.status`` + the (usually null)
+``failure_reason`` column, so the agent that woke on a failed run couldn't see
+*why* it failed. These helpers expose the rules, the per-rule verdicts (judge
+messages, expected/actual), and a derived failure reason.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+_MSG_MAX = 400
+_ACTUAL_MAX = 200
+_PROMPT_MAX = 400
+_MAX_RULE_RESULTS = 10
+
+
+def _truncate(text: Any, limit: int) -> Optional[str]:
+    if text is None:
+        return None
+    s = str(text)
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def rule_summary(rule: Dict[str, Any]) -> Optional[str]:
+    """One-line human description of an expectation rule."""
+    if not isinstance(rule, dict):
+        return None
+    t = rule.get("type") or "rule"
+    if t == "tool.calls":
+        tool = rule.get("tool") or "?"
+        parts = [f"tool.calls: {tool}"]
+        if rule.get("min_calls") is not None:
+            parts.append(f"min {rule['min_calls']}")
+        if rule.get("max_calls") is not None:
+            parts.append(f"max {rule['max_calls']}")
+        return " ".join(parts)
+    if t == "judge":
+        return "judge: " + (_truncate(rule.get("prompt"), 200) or "")
+    if t == "field":
+        return f"field: {rule.get('target') or rule.get('field') or ''}".strip()
+    if t == "ordering":
+        return "ordering"
+    if t == "phase":
+        return f"phase: {rule.get('phase') or ''}".strip()
+    # Fallback: type + any short scalar params
+    extras = [f"{k}={v}" for k, v in rule.items() if k != "type" and isinstance(v, (str, int, float, bool))]
+    return t + ((": " + ", ".join(extras[:3])) if extras else "")
+
+
+def _rr_status(rr: Dict[str, Any]) -> str:
+    st = rr.get("status")
+    if st in ("pass", "fail", "skipped"):
+        return st
+    return "pass" if rr.get("ok") else "fail"
+
+
+def rules_view(result_json: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compact list of the case's expectation rules."""
+    spec = ((result_json or {}).get("spec") or {})
+    out: List[Dict[str, Any]] = []
+    for r in (spec.get("rules") or []):
+        if isinstance(r, dict):
+            out.append({"type": r.get("type"), "summary": rule_summary(r)})
+    return out
+
+
+def rule_results_view(result_json: Optional[Dict[str, Any]], limit: int = _MAX_RULE_RESULTS) -> List[Dict[str, Any]]:
+    """Per-rule verdicts (judge message, expected/actual), failing rules first."""
+    rr_list = (result_json or {}).get("rule_results") or []
+    spec_rules = ((result_json or {}).get("spec") or {}).get("rules") or []
+    items: List[Dict[str, Any]] = []
+    for i, rr in enumerate(rr_list):
+        if not isinstance(rr, dict):
+            continue
+        rule = spec_rules[i] if i < len(spec_rules) else {}
+        # Judge reasoning may live on evidence.reasoning rather than message.
+        message = rr.get("message")
+        if not message:
+            ev = rr.get("evidence")
+            if isinstance(ev, dict):
+                message = ev.get("reasoning")
+        items.append({
+            "rule": rule_summary(rule) if isinstance(rule, dict) else None,
+            "status": _rr_status(rr),
+            "message": _truncate(message, _MSG_MAX),
+            "actual": _truncate(rr.get("actual"), _ACTUAL_MAX),
+        })
+    # Failing first, then skipped, then passing — the agent cares about failures.
+    order = {"fail": 0, "skipped": 1, "pass": 2}
+    items.sort(key=lambda x: order.get(x["status"], 3))
+    return items[:limit]
+
+
+def derive_failure_reason(
+    status: Optional[str],
+    failure_reason_col: Optional[str],
+    result_json: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """The persisted ``failure_reason`` column when set, else a reason
+    synthesized from the failing rules' messages. Normal ``fail`` results
+    leave the column null and put everything in ``rule_results``."""
+    if failure_reason_col:
+        return failure_reason_col
+    if status not in ("fail", "error"):
+        return None
+    msgs: List[str] = []
+    for rr in ((result_json or {}).get("rule_results") or []):
+        if not isinstance(rr, dict) or _rr_status(rr) != "fail":
+            continue
+        msg = rr.get("message")
+        if not msg:
+            ev = rr.get("evidence")
+            if isinstance(ev, dict):
+                msg = ev.get("reasoning")
+        if msg:
+            msgs.append(str(msg))
+    if msgs:
+        return _truncate(" | ".join(msgs), 500)
+    return None
+
+
+def prompt_text(prompt_json: Optional[Dict[str, Any]]) -> Optional[str]:
+    """The case's replay prompt content, truncated."""
+    if not isinstance(prompt_json, dict):
+        return None
+    return _truncate(prompt_json.get("content"), _PROMPT_MAX)

--- a/backend/app/ai/tools/implementations/get_eval_run.py
+++ b/backend/app/ai/tools/implementations/get_eval_run.py
@@ -21,10 +21,16 @@ from app.ai.tools.schemas.events import (
     ToolErrorEvent,
 )
 from app.ai.tools.schemas.get_eval_run import (
+    EvalCaseDetail,
     GetEvalRunInput,
     GetEvalRunOutput,
 )
-from app.ai.tools.schemas.run_eval import RunEvalCaseResult
+from app.ai.tools.eval_result_view import (
+    derive_failure_reason,
+    prompt_text,
+    rule_results_view,
+    rules_view,
+)
 from app.ai.tools.implementations.get_eval_runs import _iso, run_counts
 from app.core.permission_resolver import resolve_permissions
 from app.models.eval import TestCase, TestResult, TestRun, TestSuite
@@ -38,19 +44,23 @@ class GetEvalRunTool(Tool):
         return ToolMetadata(
             name="get_eval_run",
             description=(
-                "RESEARCH: Read one eval TestRun — status, build, counts, and "
-                "per-case pass/fail with failure reasons. Safe while the run is "
-                "still executing (returns a live snapshot). Set "
-                "compare_to_previous=true to also get fixed/regressed flips vs. "
-                "the previous comparable run. Find run ids with get_eval_runs "
-                "or from run_eval's output."
+                "RESEARCH: Read one eval TestRun in detail. Per case you get the "
+                "replay prompt, the expectation rules, and the per-rule verdicts "
+                "(judge messages, expected vs. actual) — so you can see WHY a "
+                "case failed, not just that it did. failure_reason is derived "
+                "from the failing rules when no explicit reason was stored. Safe "
+                "while the run is still executing (live snapshot). "
+                "compare_to_previous=true adds fixed/regressed flips vs. the "
+                "previous comparable run; include_transcript=true attaches the "
+                "agent transcript for failed cases. Find run ids with "
+                "get_eval_runs or from run_eval's output."
             ),
             category="research",
-            version="1.0.0",
+            version="1.1.0",
             input_schema=GetEvalRunInput.model_json_schema(),
             output_schema=GetEvalRunOutput.model_json_schema(),
             max_retries=1,
-            timeout_seconds=20,
+            timeout_seconds=30,
             idempotent=True,
             required_permissions=["manage_evals"],
             tags=["eval", "run", "read"],
@@ -144,22 +154,57 @@ class GetEvalRunTool(Tool):
 
             rows = (
                 await db.execute(
-                    select(TestResult, TestCase.name)
+                    select(TestResult, TestCase.name, TestCase.prompt_json)
                     .join(TestCase, TestCase.id == TestResult.case_id)
                     .where(TestResult.run_id == str(run.id))
                     .execution_options(populate_existing=True)
                 )
             ).all()
-            results = [
-                RunEvalCaseResult(
-                    case_id=str(r.case_id),
-                    case_name=name,
-                    status=r.status,
-                    failure_reason=getattr(r, "failure_reason", None),
+
+            results: list[EvalCaseDetail] = []
+            for r, name, prompt_json in rows:
+                rj = getattr(r, "result_json", None)
+                if not isinstance(rj, dict):
+                    rj = {}
+                results.append(
+                    EvalCaseDetail(
+                        case_id=str(r.case_id),
+                        case_name=name,
+                        status=r.status,
+                        failure_reason=derive_failure_reason(
+                            r.status, getattr(r, "failure_reason", None), rj
+                        ),
+                        prompt=prompt_text(prompt_json),
+                        rules=rules_view(rj),
+                        rule_results=rule_results_view(rj),
+                    )
                 )
-                for r, name in rows
-            ]
-            counts = run_counts(run, [r for r, _ in rows])
+
+            # Optional: attach the agent transcript for failed cases only
+            # (bounded; off by default). Uses the same builder the run detail
+            # page and the agent's own context use.
+            if data.include_transcript:
+                from app.services.test_run_service import TestRunService
+
+                trs = TestRunService()
+                failed_result_ids = {
+                    str(r.id) for r, _, _ in rows if r.status in ("fail", "error")
+                }
+                detail_by_case = {d.case_id: d for d in results}
+                for r, _name, _pj in rows:
+                    if str(r.id) not in failed_result_ids:
+                        continue
+                    try:
+                        transcript = await trs.get_result_transcript(
+                            db, organization, user, str(r.id), max_messages=30
+                        )
+                        d = detail_by_case.get(str(r.case_id))
+                        if d is not None and transcript:
+                            d.transcript = transcript[-4000:]
+                    except Exception as te:
+                        logger.warning(f"get_eval_run transcript for {r.id} failed: {te}")
+
+            counts = run_counts(run, [r for r, _, _ in rows])
 
             compare = None
             if data.compare_to_previous:
@@ -176,6 +221,16 @@ class GetEvalRunTool(Tool):
                         "flips": flips,
                     }
 
+            # Lead the observation summary with the first failing case's reason
+            # so the digest that lands in conversation history is actionable.
+            first_fail = next((d for d in results if d.status in ("fail", "error")), None)
+            summary = (
+                f"Run {run.status}: {counts['passed']}/{counts['total']} passed, "
+                f"{counts['failed']} failed ({counts['finished']}/{counts['total']} finished)"
+            )
+            if first_fail is not None and first_fail.failure_reason:
+                summary += f" — {first_fail.case_name or first_fail.case_id}: {first_fail.failure_reason[:160]}"
+
             output = GetEvalRunOutput(
                 success=True,
                 run_id=str(run.id),
@@ -187,10 +242,7 @@ class GetEvalRunTool(Tool):
                 finished_at=_iso(run.finished_at),
                 results=results,
                 compare=compare,
-                message=(
-                    f"Run {run.status}: {counts['passed']}/{counts['total']} passed, "
-                    f"{counts['failed']} failed ({counts['finished']}/{counts['total']} finished)"
-                ),
+                message=summary,
                 **counts,
             )
             yield ToolEndEvent(

--- a/backend/app/ai/tools/implementations/run_eval.py
+++ b/backend/app/ai/tools/implementations/run_eval.py
@@ -53,6 +53,7 @@ from app.ai.tools.schemas.run_eval import (
     RunEvalInput,
     RunEvalOutput,
 )
+from app.ai.tools.eval_result_view import derive_failure_reason
 from app.core.permission_resolver import resolve_permissions
 from app.models.completion import Completion
 from app.models.eval import (
@@ -554,12 +555,19 @@ class RunEvalTool(Tool):
             )
             rows = (await db.execute(results_stmt)).all()
             for result, case_name in rows:
+                rj = getattr(result, "result_json", None)
                 final_results.append(
                     RunEvalCaseResult(
                         case_id=str(result.case_id),
                         case_name=case_name,
                         status=result.status,
-                        failure_reason=getattr(result, "failure_reason", None),
+                        # Derive from failing rules when no explicit reason was
+                        # stored (a plain `fail` leaves the column null).
+                        failure_reason=derive_failure_reason(
+                            result.status,
+                            getattr(result, "failure_reason", None),
+                            rj if isinstance(rj, dict) else {},
+                        ),
                     )
                 )
             passed = sum(1 for r in final_results if r.status == "pass")

--- a/backend/app/ai/tools/schemas/get_eval_run.py
+++ b/backend/app/ai/tools/schemas/get_eval_run.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
-from app.ai.tools.schemas.run_eval import RunEvalCaseResult
-
 
 class GetEvalRunsInput(BaseModel):
     """Input schema for ``get_eval_runs`` (list mode — cheap summaries only)."""
@@ -47,6 +45,44 @@ class GetEvalRunInput(BaseModel):
             "fix it?' in one call (fixed / regressed / same per case)."
         ),
     )
+    include_transcript: bool = Field(
+        default=False,
+        description=(
+            "Attach the agent's execution transcript for FAILED cases (tool "
+            "calls, data digests). Off by default to keep reads small; turn on "
+            "to debug *why* the agent produced a failing answer beyond the rule "
+            "verdicts."
+        ),
+    )
+
+
+class EvalRuleView(BaseModel):
+    """A compact expectation rule (what the case asserts)."""
+    type: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class EvalRuleResultView(BaseModel):
+    """The verdict for one rule — the judge's message / expected-vs-actual."""
+    rule: Optional[str] = None
+    status: str
+    message: Optional[str] = None
+    actual: Optional[Any] = None
+
+
+class EvalCaseDetail(BaseModel):
+    """Per-case detail: enough to see why a case passed or failed without a
+    second lookup. ``failure_reason`` is derived from failing rules when the
+    persisted column is null (the common case for a plain ``fail``)."""
+    case_id: str
+    case_name: Optional[str] = None
+    status: str
+    failure_reason: Optional[str] = None
+    prompt: Optional[str] = None
+    rules: List[EvalRuleView] = Field(default_factory=list)
+    rule_results: List[EvalRuleResultView] = Field(default_factory=list)
+    # Populated only when include_transcript=true and the case failed.
+    transcript: Optional[str] = None
 
 
 class GetEvalRunOutput(BaseModel):
@@ -62,7 +98,7 @@ class GetEvalRunOutput(BaseModel):
     finished: int = 0
     passed: int = 0
     failed: int = 0
-    results: List[RunEvalCaseResult] = Field(default_factory=list)
+    results: List[EvalCaseDetail] = Field(default_factory=list)
     # Present only when compare_to_previous=true and a baseline run exists:
     # {against_run: {...}, summary: {fixed, regressed, same, added, removed},
     #  flips: [{case_id, case_name, base_status, status, flip}, ...]}

--- a/backend/scripts/bench_instruction_context.py
+++ b/backend/scripts/bench_instruction_context.py
@@ -1,0 +1,95 @@
+"""Micro-benchmark for the agent's instruction-context load (the completion
+hot path: InstructionContextBuilder.build -> _load_from_build).
+
+Measures wall time + peak rows hydrated for a report scoped to a heavy agent,
+and prints the resulting instruction id set so before/after runs can be diffed
+for behavioral equivalence. Also runs N concurrent builds to expose event-loop
+serialization.
+
+Usage (from backend/, with the running stack env):
+  TESTING=true TEST_DATABASE_URL=... BOW_DATABASE_URL=... BOW_ENCRYPTION_KEY=... \
+    uv run python scripts/bench_instruction_context.py <org_id> <agent_id> [user_id]
+"""
+import asyncio
+import sys
+import time
+
+import main  # noqa: F401  register all models
+
+from sqlalchemy import select, event
+from sqlalchemy.engine import Engine
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
+
+ORG_ID = sys.argv[1]
+AGENT_ID = sys.argv[2]
+USER_ID = sys.argv[3] if len(sys.argv) > 3 else None
+
+_stmt_count = 0
+_rows = 0
+
+
+def _hook(conn, cursor, statement, params, context, executemany):
+    global _stmt_count
+    _stmt_count += 1
+
+
+async def load_org_settings(db, org):
+    try:
+        from app.services.organization_settings_service import OrganizationSettingsService
+        return await OrganizationSettingsService().get_settings(db, str(org.id))
+    except Exception:
+        return None
+
+
+async def one_build():
+    async with async_session_maker() as db:
+        org = (await db.execute(select(Organization).where(Organization.id == ORG_ID))).scalar_one()
+        user = None
+        if USER_ID:
+            user = (await db.execute(select(User).where(User.id == USER_ID))).scalar_one_or_none()
+        settings = await load_org_settings(db, org)
+        builder = InstructionContextBuilder(
+            db, org, current_user=user, organization_settings=settings,
+            data_source_ids=[AGENT_ID], mode="chat", channel="app",
+        )
+        section = await builder.build(query="Show total revenue by billing country", data_source_ids=[AGENT_ID])
+        ids = sorted({it.id for it in (section.items or [])})
+        return ids
+
+
+async def main_run():
+    global _stmt_count
+    event.listen(Engine, "before_cursor_execute", _hook)
+
+    # warm + correctness snapshot
+    ids = await one_build()
+
+    # timed single build
+    _stmt_count = 0
+    t0 = time.perf_counter()
+    ids2 = await one_build()
+    single_ms = (time.perf_counter() - t0) * 1000
+    single_stmts = _stmt_count
+
+    # concurrent builds (event-loop serialization proxy)
+    _stmt_count = 0
+    N = 8
+    t0 = time.perf_counter()
+    await asyncio.gather(*(one_build() for _ in range(N)))
+    conc_ms = (time.perf_counter() - t0) * 1000
+
+    event.remove(Engine, "before_cursor_execute", _hook)
+
+    import hashlib
+    digest = hashlib.md5("\n".join(ids).encode()).hexdigest()[:12]
+    print(f"RESULT items={len(ids)} ids_md5={digest}")
+    print(f"SINGLE build: {single_ms:.0f} ms, {single_stmts} SQL statements")
+    print(f"CONCURRENT x{N}: {conc_ms:.0f} ms total ({conc_ms/N:.0f} ms/build)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main_run())

--- a/backend/tests/unit/test_eval_result_view.py
+++ b/backend/tests/unit/test_eval_result_view.py
@@ -1,0 +1,82 @@
+"""Unit tests for the eval result-view helpers that turn a TestResult's
+result_json into the agent-readable detail get_eval_run returns.
+
+The tool integration is exercised in the sandbox loop; here we cover the
+pure transforms deterministically.
+"""
+from app.ai.tools.eval_result_view import (
+    derive_failure_reason,
+    prompt_text,
+    rule_results_view,
+    rule_summary,
+    rules_view,
+)
+
+RJ_FAIL = {
+    "spec": {
+        "rules": [
+            {"type": "tool.calls", "tool": "create_data", "min_calls": 1},
+            {"type": "judge", "prompt": "The answer must be a monthly breakdown; reject a total count."},
+        ]
+    },
+    "rule_results": [
+        {"ok": True, "status": "pass"},
+        {"ok": False, "status": "fail", "message": "Returned a single total, not a monthly breakdown."},
+    ],
+}
+
+
+def test_rule_summary_shapes():
+    assert rule_summary({"type": "tool.calls", "tool": "create_data", "min_calls": 1}) == "tool.calls: create_data min 1"
+    assert rule_summary({"type": "judge", "prompt": "abc"}).startswith("judge: abc")
+    assert rule_summary({"type": "phase", "phase": "explore"}) == "phase: explore"
+
+
+def test_rules_view_lists_all_rules():
+    v = rules_view(RJ_FAIL)
+    assert [r["type"] for r in v] == ["tool.calls", "judge"]
+    assert "create_data" in v[0]["summary"]
+
+
+def test_rule_results_view_failing_first():
+    v = rule_results_view(RJ_FAIL)
+    # Failing rule sorts ahead of the passing one.
+    assert v[0]["status"] == "fail"
+    assert "monthly breakdown" in v[0]["message"]
+    assert v[0]["rule"].startswith("judge:")
+    assert v[1]["status"] == "pass"
+
+
+def test_rule_results_view_reads_evidence_reasoning_when_no_message():
+    rj = {
+        "spec": {"rules": [{"type": "judge", "prompt": "x"}]},
+        "rule_results": [{"ok": False, "status": "fail", "evidence": {"type": "judge", "reasoning": "wrong shape"}}],
+    }
+    v = rule_results_view(rj)
+    assert v[0]["message"] == "wrong shape"
+
+
+def test_derive_failure_reason_prefers_explicit_column():
+    assert derive_failure_reason("error", "Stopped by user", RJ_FAIL) == "Stopped by user"
+
+
+def test_derive_failure_reason_synthesizes_from_rules():
+    reason = derive_failure_reason("fail", None, RJ_FAIL)
+    assert reason == "Returned a single total, not a monthly breakdown."
+
+
+def test_derive_failure_reason_none_for_pass():
+    assert derive_failure_reason("pass", None, RJ_FAIL) is None
+
+
+def test_derive_failure_reason_none_when_no_messages():
+    rj = {"spec": {"rules": []}, "rule_results": []}
+    assert derive_failure_reason("fail", None, rj) is None
+
+
+def test_prompt_text_truncates():
+    assert prompt_text({"content": "hi"}) == "hi"
+    long = "x" * 600
+    out = prompt_text({"content": long})
+    assert out is not None and len(out) <= 400 and out.endswith("…")
+    assert prompt_text(None) is None

--- a/docs/feedback-loops/eval-run-read-detail.md
+++ b/docs/feedback-loops/eval-run-read-detail.md
@@ -1,0 +1,79 @@
+# Feedback Loop — "read eval result should show the full trace … it doesn't see the expectations/prompt at all"
+
+When the agent woke on a failed eval run and called `get_eval_run`, it got back
+per case only `{case_id, case_name, status, failure_reason}` — and
+`failure_reason` is **null for a normal `fail`** (the evaluator persists
+`failure_reason=None` and puts everything in `TestResult.result_json`). So the
+agent saw the string `"fail"` and nothing else: not the prompt, not the
+expectation rules, not the judge's reasoning. It then flailed ("ended in error
+without detailing the failure reason…"). The run detail *page* showed all of it
+because the page reads `result_json`; the tool never did.
+
+## Root cause (validated)
+
+- `get_eval_run` built each result from the `TestResult` row's `status` +
+  `failure_reason` column only (`get_eval_run.py`), ignoring
+  `TestResult.result_json` (`spec.rules`, `rule_results` — the per-rule verdicts
+  with judge messages / expected-vs-actual) and `TestCase.prompt_json`.
+- `failure_reason` is almost always null for `fail`: the evaluator
+  (`TestEvaluationService`) records the substance in `rule_results`, not the
+  column.
+
+## Loop A — real data (validated on a production `result_json`)
+
+A case with a `tool.calls` + `judge` rule that failed, read straight from the
+sandbox DB and passed through the new view helpers
+(`app/ai/tools/eval_result_view.py`):
+
+```
+CASE: Genres broken down by media type  | status: fail | failure_reason col: None
+  -> prompt: How many genres are in the database? Answer with a single number.
+  -> derived failure_reason: create_data calls=0, expected min=1, max=None | Judge evaluation failed
+  -> rules: [tool.calls: create_data min 1, judge: The answer MUST be a table with one row per genre …]
+  -> rule_results: [
+       {rule: "tool.calls: create_data min 1", status: fail, message: "create_data calls=0, expected min=1", actual: "0"},
+       {rule: "judge: …", status: fail, message: "<judge reasoning>", actual: "False"}]
+```
+
+**Before** this change the same read returned `status: "fail",
+failure_reason: null` and nothing else.
+
+Judge reasoning: `rule_results_view` surfaces the rule's `message`, falling back
+to `evidence.reasoning` — exactly where the evaluator writes the judge's
+free-text verdict (e.g. the Hebrew "לא ביצע פילוח לפי SH_SHUMOT…" from the
+reported run). When the judge produces rich reasoning, it appears verbatim
+(truncated to 400 chars); when the underlying agent run itself errored (so the
+judge had no answer to grade), the message is the evaluator's generic string —
+faithfully reflecting what was stored.
+
+## The change
+
+- New `app/ai/tools/eval_result_view.py`: `rules_view`, `rule_results_view`
+  (failing rules first), `derive_failure_reason` (synthesize from failing rules
+  when the column is null), `prompt_text`.
+- `get_eval_run` now returns `EvalCaseDetail` per case: `prompt`, `rules`,
+  `rule_results`, a derived `failure_reason`, and — with the new
+  `include_transcript=true` input — the agent transcript for failed cases
+  (bounded, via the existing `get_result_transcript`). The observation summary
+  leads with the first failing case's reason so the conversation-history digest
+  is actionable.
+- `run_eval`'s inline results reuse `derive_failure_reason` for consistency.
+
+## Verification
+
+- `backend/tests/unit/test_eval_result_view.py` — 9 tests over the transforms
+  (rule summaries, failing-first ordering, evidence.reasoning fallback, derived
+  reason, truncation). Full eval unit set: 36 passed.
+- In-process end-to-end: ran a failing case, invoked `GetEvalRunTool.run_stream`
+  with `include_transcript=true` — output carried `prompt`, `rules`,
+  `rule_results`, derived `failure_reason`, and a transcript; `GetEvalRunOutput`
+  validated.
+
+## Notes
+
+- Backend-only; no new UI surface (the chat card already renders
+  `failure_reason`, which is now populated). The run detail page was already
+  correct — it read `result_json` all along.
+- Live re-run with a fresh judge answer was blocked by Anthropic API credit
+  exhaustion in the sandbox (`credit balance is too low`); the transform is
+  validated against real stored `result_json` instead.


### PR DESCRIPTION
## Summary

Fixes the completion-path bottleneck (#2) found during the load investigation. Under 10 concurrent long completions, one uvicorn worker pegged 100% CPU with the DB **idle** — `py-spy` showed the event loop blocked in SQLAlchemy instruction hydration and pydantic JSON-schema generation, driving TTFB to ~30s and dropping SSE streams.

Two causes, both per-completion:

**1. `InstructionContextBuilder._load_from_build` loaded the whole main build**
It selected *every* `BuildContent` row of the org's main build, eager-loaded each instruction's `data_sources` relationship (an extra selectin), then filtered by status / kind / load_mode / data-source **in Python** — O(all instructions in the build) work on the event loop every turn.
Now those predicates are pushed into the query (the `data_sources` relationship is no longer hydrated at all — its only use was the scope check, now an `EXISTS`), and only the columns the item builder reads are loaded. **Output is identical** (same instruction set).

**2. `Tool.metadata` regenerated JSON schemas on every tool call**
`metadata` is an abstract `@property` each subclass rebuilds — including two `model_json_schema()` calls — and a fresh tool instance is created per call, so `tool_runner` regenerated schemas on every execution. Added a class-level cache (`Tool.spec`) used by the hot paths. Registry tools are constructed with no args, so their metadata is class-invariant; `MCPTool` is a separate hierarchy and is unaffected.

## Verification

Micro-benchmark on a report whose agent holds **10k instructions in the main build** (`scripts/bench_instruction_context.py`), before → after:

| metric | before | after |
|---|---|---|
| single context build | 1934 ms | **981 ms** |
| SQL statements / build | 88 | **25** |
| 8 concurrent builds | 19.2 s | **6.8 s** (2402 → 856 ms/build) |
| tool metadata / access | 1280 µs | **0.3 µs** |
| output (instruction id set) | md5 `0f6913608dfe` | md5 `0f6913608dfe` (identical) |

- Existing `instruction` / `build` / `instruction_resolve` / tool-dispatch / tool-title / skills-catalog suites pass (135 tests).
- A live SSE completion streams `block.upsert` events and finishes end-to-end (`[DONE]`).

## Notes

- This branch also carries an earlier commit from the same investigation (`perf(reports): lazy-load step result data instead of embedding it in completions`). Happy to split into two PRs if preferred.
- Not addressed here (separate follow-ups from the investigation): the instruction **list** endpoint materializing all open builds' contents (5–14 s at 100k rows), and the quadratic build-copy on instruction create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSbshcmAVhoj72FpLxDKKp)_