### PR TITLE
get_eval_run: surface prompt, expectation rules, and per-rule verdicts

### DIFF
--- a/backend/app/ai/tools/eval_result_view.py
+++ b/backend/app/ai/tools/eval_result_view.py
@@ -1,0 +1,136 @@
+"""Shared view helpers that turn a TestResult's ``result_json`` into the
+compact, agent-readable shape the eval-read tools return.
+
+``result_json`` (persisted by ``TestEvaluationService``) has the shape::
+
+    {
+      "spec":  {"spec_version": 1, "rules": [ {type, ...}, ... ], "order_mode": ...},
+      "totals": {...},
+      "rule_results": [ {ok, status, message, actual, evidence}, ... ],  # index-aligned with spec.rules
+    }
+
+The tools previously surfaced only ``TestResult.status`` + the (usually null)
+``failure_reason`` column, so the agent that woke on a failed run couldn't see
+*why* it failed. These helpers expose the rules, the per-rule verdicts (judge
+messages, expected/actual), and a derived failure reason.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+_MSG_MAX = 400
+_ACTUAL_MAX = 200
+_PROMPT_MAX = 400
+_MAX_RULE_RESULTS = 10
+
+
+def _truncate(text: Any, limit: int) -> Optional[str]:
+    if text is None:
+        return None
+    s = str(text)
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def rule_summary(rule: Dict[str, Any]) -> Optional[str]:
+    """One-line human description of an expectation rule."""
+    if not isinstance(rule, dict):
+        return None
+    t = rule.get("type") or "rule"
+    if t == "tool.calls":
+        tool = rule.get("tool") or "?"
+        parts = [f"tool.calls: {tool}"]
+        if rule.get("min_calls") is not None:
+            parts.append(f"min {rule['min_calls']}")
+        if rule.get("max_calls") is not None:
+            parts.append(f"max {rule['max_calls']}")
+        return " ".join(parts)
+    if t == "judge":
+        return "judge: " + (_truncate(rule.get("prompt"), 200) or "")
+    if t == "field":
+        return f"field: {rule.get('target') or rule.get('field') or ''}".strip()
+    if t == "ordering":
+        return "ordering"
+    if t == "phase":
+        return f"phase: {rule.get('phase') or ''}".strip()
+    # Fallback: type + any short scalar params
+    extras = [f"{k}={v}" for k, v in rule.items() if k != "type" and isinstance(v, (str, int, float, bool))]
+    return t + ((": " + ", ".join(extras[:3])) if extras else "")
+
+
+def _rr_status(rr: Dict[str, Any]) -> str:
+    st = rr.get("status")
+    if st in ("pass", "fail", "skipped"):
+        return st
+    return "pass" if rr.get("ok") else "fail"
+
+
+def rules_view(result_json: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compact list of the case's expectation rules."""
+    spec = ((result_json or {}).get("spec") or {})
+    out: List[Dict[str, Any]] = []
+    for r in (spec.get("rules") or []):
+        if isinstance(r, dict):
+            out.append({"type": r.get("type"), "summary": rule_summary(r)})
+    return out
+
+
+def rule_results_view(result_json: Optional[Dict[str, Any]], limit: int = _MAX_RULE_RESULTS) -> List[Dict[str, Any]]:
+    """Per-rule verdicts (judge message, expected/actual), failing rules first."""
+    rr_list = (result_json or {}).get("rule_results") or []
+    spec_rules = ((result_json or {}).get("spec") or {}).get("rules") or []
+    items: List[Dict[str, Any]] = []
+    for i, rr in enumerate(rr_list):
+        if not isinstance(rr, dict):
+            continue
+        rule = spec_rules[i] if i < len(spec_rules) else {}
+        # Judge reasoning may live on evidence.reasoning rather than message.
+        message = rr.get("message")
+        if not message:
+            ev = rr.get("evidence")
+            if isinstance(ev, dict):
+                message = ev.get("reasoning")
+        items.append({
+            "rule": rule_summary(rule) if isinstance(rule, dict) else None,
+            "status": _rr_status(rr),
+            "message": _truncate(message, _MSG_MAX),
+            "actual": _truncate(rr.get("actual"), _ACTUAL_MAX),
+        })
+    # Failing first, then skipped, then passing — the agent cares about failures.
+    order = {"fail": 0, "skipped": 1, "pass": 2}
+    items.sort(key=lambda x: order.get(x["status"], 3))
+    return items[:limit]
+
+
+def derive_failure_reason(
+    status: Optional[str],
+    failure_reason_col: Optional[str],
+    result_json: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """The persisted ``failure_reason`` column when set, else a reason
+    synthesized from the failing rules' messages. Normal ``fail`` results
+    leave the column null and put everything in ``rule_results``."""
+    if failure_reason_col:
+        return failure_reason_col
+    if status not in ("fail", "error"):
+        return None
+    msgs: List[str] = []
+    for rr in ((result_json or {}).get("rule_results") or []):
+        if not isinstance(rr, dict) or _rr_status(rr) != "fail":
+            continue
+        msg = rr.get("message")
+        if not msg:
+            ev = rr.get("evidence")
+            if isinstance(ev, dict):
+                msg = ev.get("reasoning")
+        if msg:
+            msgs.append(str(msg))
+    if msgs:
+        return _truncate(" | ".join(msgs), 500)
+    return None
+
+
+def prompt_text(prompt_json: Optional[Dict[str, Any]]) -> Optional[str]:
+    """The case's replay prompt content, truncated."""
+    if not isinstance(prompt_json, dict):
+        return None
+    return _truncate(prompt_json.get("content"), _PROMPT_MAX)

--- a/backend/app/ai/tools/implementations/get_eval_run.py
+++ b/backend/app/ai/tools/implementations/get_eval_run.py
@@ -21,10 +21,16 @@ from app.ai.tools.schemas.events import (
     ToolErrorEvent,
 )
 from app.ai.tools.schemas.get_eval_run import (
+    EvalCaseDetail,
     GetEvalRunInput,
     GetEvalRunOutput,
 )
-from app.ai.tools.schemas.run_eval import RunEvalCaseResult
+from app.ai.tools.eval_result_view import (
+    derive_failure_reason,
+    prompt_text,
+    rule_results_view,
+    rules_view,
+)
 from app.ai.tools.implementations.get_eval_runs import _iso, run_counts
 from app.core.permission_resolver import resolve_permissions
 from app.models.eval import TestCase, TestResult, TestRun, TestSuite
@@ -38,19 +44,23 @@ class GetEvalRunTool(Tool):
         return ToolMetadata(
             name="get_eval_run",
             description=(
-                "RESEARCH: Read one eval TestRun — status, build, counts, and "
-                "per-case pass/fail with failure reasons. Safe while the run is "
-                "still executing (returns a live snapshot). Set "
-                "compare_to_previous=true to also get fixed/regressed flips vs. "
-                "the previous comparable run. Find run ids with get_eval_runs "
-                "or from run_eval's output."
+                "RESEARCH: Read one eval TestRun in detail. Per case you get the "
+                "replay prompt, the expectation rules, and the per-rule verdicts "
+                "(judge messages, expected vs. actual) — so you can see WHY a "
+                "case failed, not just that it did. failure_reason is derived "
+                "from the failing rules when no explicit reason was stored. Safe "
+                "while the run is still executing (live snapshot). "
+                "compare_to_previous=true adds fixed/regressed flips vs. the "
+                "previous comparable run; include_transcript=true attaches the "
+                "agent transcript for failed cases. Find run ids with "
+                "get_eval_runs or from run_eval's output."
             ),
             category="research",
-            version="1.0.0",
+            version="1.1.0",
             input_schema=GetEvalRunInput.model_json_schema(),
             output_schema=GetEvalRunOutput.model_json_schema(),
             max_retries=1,
-            timeout_seconds=20,
+            timeout_seconds=30,
             idempotent=True,
             required_permissions=["manage_evals"],
             tags=["eval", "run", "read"],
@@ -144,22 +154,57 @@ class GetEvalRunTool(Tool):
 
             rows = (
                 await db.execute(
-                    select(TestResult, TestCase.name)
+                    select(TestResult, TestCase.name, TestCase.prompt_json)
                     .join(TestCase, TestCase.id == TestResult.case_id)
                     .where(TestResult.run_id == str(run.id))
                     .execution_options(populate_existing=True)
                 )
             ).all()
-            results = [
-                RunEvalCaseResult(
-                    case_id=str(r.case_id),
-                    case_name=name,
-                    status=r.status,
-                    failure_reason=getattr(r, "failure_reason", None),
+
+            results: list[EvalCaseDetail] = []
+            for r, name, prompt_json in rows:
+                rj = getattr(r, "result_json", None)
+                if not isinstance(rj, dict):
+                    rj = {}
+                results.append(
+                    EvalCaseDetail(
+                        case_id=str(r.case_id),
+                        case_name=name,
+                        status=r.status,
+                        failure_reason=derive_failure_reason(
+                            r.status, getattr(r, "failure_reason", None), rj
+                        ),
+                        prompt=prompt_text(prompt_json),
+                        rules=rules_view(rj),
+                        rule_results=rule_results_view(rj),
+                    )
                 )
-                for r, name in rows
-            ]
-            counts = run_counts(run, [r for r, _ in rows])
+
+            # Optional: attach the agent transcript for failed cases only
+            # (bounded; off by default). Uses the same builder the run detail
+            # page and the agent's own context use.
+            if data.include_transcript:
+                from app.services.test_run_service import TestRunService
+
+                trs = TestRunService()
+                failed_result_ids = {
+                    str(r.id) for r, _, _ in rows if r.status in ("fail", "error")
+                }
+                detail_by_case = {d.case_id: d for d in results}
+                for r, _name, _pj in rows:
+                    if str(r.id) not in failed_result_ids:
+                        continue
+                    try:
+                        transcript = await trs.get_result_transcript(
+                            db, organization, user, str(r.id), max_messages=30
+                        )
+                        d = detail_by_case.get(str(r.case_id))
+                        if d is not None and transcript:
+                            d.transcript = transcript[-4000:]
+                    except Exception as te:
+                        logger.warning(f"get_eval_run transcript for {r.id} failed: {te}")
+
+            counts = run_counts(run, [r for r, _, _ in rows])
 
             compare = None
             if data.compare_to_previous:
@@ -176,6 +221,16 @@ class GetEvalRunTool(Tool):
                         "flips": flips,
                     }
 
+            # Lead the observation summary with the first failing case's reason
+            # so the digest that lands in conversation history is actionable.
+            first_fail = next((d for d in results if d.status in ("fail", "error")), None)
+            summary = (
+                f"Run {run.status}: {counts['passed']}/{counts['total']} passed, "
+                f"{counts['failed']} failed ({counts['finished']}/{counts['total']} finished)"
+            )
+            if first_fail is not None and first_fail.failure_reason:
+                summary += f" — {first_fail.case_name or first_fail.case_id}: {first_fail.failure_reason[:160]}"
+
             output = GetEvalRunOutput(
                 success=True,
                 run_id=str(run.id),
@@ -187,10 +242,7 @@ class GetEvalRunTool(Tool):
                 finished_at=_iso(run.finished_at),
                 results=results,
                 compare=compare,
-                message=(
-                    f"Run {run.status}: {counts['passed']}/{counts['total']} passed, "
-                    f"{counts['failed']} failed ({counts['finished']}/{counts['total']} finished)"
-                ),
+                message=summary,
                 **counts,
             )
             yield ToolEndEvent(

--- a/backend/app/ai/tools/implementations/run_eval.py
+++ b/backend/app/ai/tools/implementations/run_eval.py
@@ -53,6 +53,7 @@ from app.ai.tools.schemas.run_eval import (
     RunEvalInput,
     RunEvalOutput,
 )
+from app.ai.tools.eval_result_view import derive_failure_reason
 from app.core.permission_resolver import resolve_permissions
 from app.models.completion import Completion
 from app.models.eval import (
@@ -554,12 +555,19 @@ class RunEvalTool(Tool):
             )
             rows = (await db.execute(results_stmt)).all()
             for result, case_name in rows:
+                rj = getattr(result, "result_json", None)
                 final_results.append(
                     RunEvalCaseResult(
                         case_id=str(result.case_id),
                         case_name=case_name,
                         status=result.status,
-                        failure_reason=getattr(result, "failure_reason", None),
+                        # Derive from failing rules when no explicit reason was
+                        # stored (a plain `fail` leaves the column null).
+                        failure_reason=derive_failure_reason(
+                            result.status,
+                            getattr(result, "failure_reason", None),
+                            rj if isinstance(rj, dict) else {},
+                        ),
                     )
                 )
             passed = sum(1 for r in final_results if r.status == "pass")

--- a/backend/app/ai/tools/schemas/get_eval_run.py
+++ b/backend/app/ai/tools/schemas/get_eval_run.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
-from app.ai.tools.schemas.run_eval import RunEvalCaseResult
-
 
 class GetEvalRunsInput(BaseModel):
     """Input schema for ``get_eval_runs`` (list mode — cheap summaries only)."""
@@ -47,6 +45,44 @@ class GetEvalRunInput(BaseModel):
             "fix it?' in one call (fixed / regressed / same per case)."
         ),
     )
+    include_transcript: bool = Field(
+        default=False,
+        description=(
+            "Attach the agent's execution transcript for FAILED cases (tool "
+            "calls, data digests). Off by default to keep reads small; turn on "
+            "to debug *why* the agent produced a failing answer beyond the rule "
+            "verdicts."
+        ),
+    )
+
+
+class EvalRuleView(BaseModel):
+    """A compact expectation rule (what the case asserts)."""
+    type: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class EvalRuleResultView(BaseModel):
+    """The verdict for one rule — the judge's message / expected-vs-actual."""
+    rule: Optional[str] = None
+    status: str
+    message: Optional[str] = None
+    actual: Optional[Any] = None
+
+
+class EvalCaseDetail(BaseModel):
+    """Per-case detail: enough to see why a case passed or failed without a
+    second lookup. ``failure_reason`` is derived from failing rules when the
+    persisted column is null (the common case for a plain ``fail``)."""
+    case_id: str
+    case_name: Optional[str] = None
+    status: str
+    failure_reason: Optional[str] = None
+    prompt: Optional[str] = None
+    rules: List[EvalRuleView] = Field(default_factory=list)
+    rule_results: List[EvalRuleResultView] = Field(default_factory=list)
+    # Populated only when include_transcript=true and the case failed.
+    transcript: Optional[str] = None
 
 
 class GetEvalRunOutput(BaseModel):
@@ -62,7 +98,7 @@ class GetEvalRunOutput(BaseModel):
     finished: int = 0
     passed: int = 0
     failed: int = 0
-    results: List[RunEvalCaseResult] = Field(default_factory=list)
+    results: List[EvalCaseDetail] = Field(default_factory=list)
     # Present only when compare_to_previous=true and a baseline run exists:
     # {against_run: {...}, summary: {fixed, regressed, same, added, removed},
     #  flips: [{case_id, case_name, base_status, status, flip}, ...]}

--- a/backend/tests/unit/test_eval_result_view.py
+++ b/backend/tests/unit/test_eval_result_view.py
@@ -1,0 +1,82 @@
+"""Unit tests for the eval result-view helpers that turn a TestResult's
+result_json into the agent-readable detail get_eval_run returns.
+
+The tool integration is exercised in the sandbox loop; here we cover the
+pure transforms deterministically.
+"""
+from app.ai.tools.eval_result_view import (
+    derive_failure_reason,
+    prompt_text,
+    rule_results_view,
+    rule_summary,
+    rules_view,
+)
+
+RJ_FAIL = {
+    "spec": {
+        "rules": [
+            {"type": "tool.calls", "tool": "create_data", "min_calls": 1},
+            {"type": "judge", "prompt": "The answer must be a monthly breakdown; reject a total count."},
+        ]
+    },
+    "rule_results": [
+        {"ok": True, "status": "pass"},
+        {"ok": False, "status": "fail", "message": "Returned a single total, not a monthly breakdown."},
+    ],
+}
+
+
+def test_rule_summary_shapes():
+    assert rule_summary({"type": "tool.calls", "tool": "create_data", "min_calls": 1}) == "tool.calls: create_data min 1"
+    assert rule_summary({"type": "judge", "prompt": "abc"}).startswith("judge: abc")
+    assert rule_summary({"type": "phase", "phase": "explore"}) == "phase: explore"
+
+
+def test_rules_view_lists_all_rules():
+    v = rules_view(RJ_FAIL)
+    assert [r["type"] for r in v] == ["tool.calls", "judge"]
+    assert "create_data" in v[0]["summary"]
+
+
+def test_rule_results_view_failing_first():
+    v = rule_results_view(RJ_FAIL)
+    # Failing rule sorts ahead of the passing one.
+    assert v[0]["status"] == "fail"
+    assert "monthly breakdown" in v[0]["message"]
+    assert v[0]["rule"].startswith("judge:")
+    assert v[1]["status"] == "pass"
+
+
+def test_rule_results_view_reads_evidence_reasoning_when_no_message():
+    rj = {
+        "spec": {"rules": [{"type": "judge", "prompt": "x"}]},
+        "rule_results": [{"ok": False, "status": "fail", "evidence": {"type": "judge", "reasoning": "wrong shape"}}],
+    }
+    v = rule_results_view(rj)
+    assert v[0]["message"] == "wrong shape"
+
+
+def test_derive_failure_reason_prefers_explicit_column():
+    assert derive_failure_reason("error", "Stopped by user", RJ_FAIL) == "Stopped by user"
+
+
+def test_derive_failure_reason_synthesizes_from_rules():
+    reason = derive_failure_reason("fail", None, RJ_FAIL)
+    assert reason == "Returned a single total, not a monthly breakdown."
+
+
+def test_derive_failure_reason_none_for_pass():
+    assert derive_failure_reason("pass", None, RJ_FAIL) is None
+
+
+def test_derive_failure_reason_none_when_no_messages():
+    rj = {"spec": {"rules": []}, "rule_results": []}
+    assert derive_failure_reason("fail", None, rj) is None
+
+
+def test_prompt_text_truncates():
+    assert prompt_text({"content": "hi"}) == "hi"
+    long = "x" * 600
+    out = prompt_text({"content": long})
+    assert out is not None and len(out) <= 400 and out.endswith("…")
+    assert prompt_text(None) is None

--- a/docs/feedback-loops/eval-run-read-detail.md
+++ b/docs/feedback-loops/eval-run-read-detail.md
@@ -1,0 +1,79 @@
+# Feedback Loop — "read eval result should show the full trace … it doesn't see the expectations/prompt at all"
+
+When the agent woke on a failed eval run and called `get_eval_run`, it got back
+per case only `{case_id, case_name, status, failure_reason}` — and
+`failure_reason` is **null for a normal `fail`** (the evaluator persists
+`failure_reason=None` and puts everything in `TestResult.result_json`). So the
+agent saw the string `"fail"` and nothing else: not the prompt, not the
+expectation rules, not the judge's reasoning. It then flailed ("ended in error
+without detailing the failure reason…"). The run detail *page* showed all of it
+because the page reads `result_json`; the tool never did.
+
+## Root cause (validated)
+
+- `get_eval_run` built each result from the `TestResult` row's `status` +
+  `failure_reason` column only (`get_eval_run.py`), ignoring
+  `TestResult.result_json` (`spec.rules`, `rule_results` — the per-rule verdicts
+  with judge messages / expected-vs-actual) and `TestCase.prompt_json`.
+- `failure_reason` is almost always null for `fail`: the evaluator
+  (`TestEvaluationService`) records the substance in `rule_results`, not the
+  column.
+
+## Loop A — real data (validated on a production `result_json`)
+
+A case with a `tool.calls` + `judge` rule that failed, read straight from the
+sandbox DB and passed through the new view helpers
+(`app/ai/tools/eval_result_view.py`):
+
+```
+CASE: Genres broken down by media type  | status: fail | failure_reason col: None
+  -> prompt: How many genres are in the database? Answer with a single number.
+  -> derived failure_reason: create_data calls=0, expected min=1, max=None | Judge evaluation failed
+  -> rules: [tool.calls: create_data min 1, judge: The answer MUST be a table with one row per genre …]
+  -> rule_results: [
+       {rule: "tool.calls: create_data min 1", status: fail, message: "create_data calls=0, expected min=1", actual: "0"},
+       {rule: "judge: …", status: fail, message: "<judge reasoning>", actual: "False"}]
+```
+
+**Before** this change the same read returned `status: "fail",
+failure_reason: null` and nothing else.
+
+Judge reasoning: `rule_results_view` surfaces the rule's `message`, falling back
+to `evidence.reasoning` — exactly where the evaluator writes the judge's
+free-text verdict (e.g. the Hebrew "לא ביצע פילוח לפי SH_SHUMOT…" from the
+reported run). When the judge produces rich reasoning, it appears verbatim
+(truncated to 400 chars); when the underlying agent run itself errored (so the
+judge had no answer to grade), the message is the evaluator's generic string —
+faithfully reflecting what was stored.
+
+## The change
+
+- New `app/ai/tools/eval_result_view.py`: `rules_view`, `rule_results_view`
+  (failing rules first), `derive_failure_reason` (synthesize from failing rules
+  when the column is null), `prompt_text`.
+- `get_eval_run` now returns `EvalCaseDetail` per case: `prompt`, `rules`,
+  `rule_results`, a derived `failure_reason`, and — with the new
+  `include_transcript=true` input — the agent transcript for failed cases
+  (bounded, via the existing `get_result_transcript`). The observation summary
+  leads with the first failing case's reason so the conversation-history digest
+  is actionable.
+- `run_eval`'s inline results reuse `derive_failure_reason` for consistency.
+
+## Verification
+
+- `backend/tests/unit/test_eval_result_view.py` — 9 tests over the transforms
+  (rule summaries, failing-first ordering, evidence.reasoning fallback, derived
+  reason, truncation). Full eval unit set: 36 passed.
+- In-process end-to-end: ran a failing case, invoked `GetEvalRunTool.run_stream`
+  with `include_transcript=true` — output carried `prompt`, `rules`,
+  `rule_results`, derived `failure_reason`, and a transcript; `GetEvalRunOutput`
+  validated.
+
+## Notes
+
+- Backend-only; no new UI surface (the chat card already renders
+  `failure_reason`, which is now populated). The run detail page was already
+  correct — it read `result_json` all along.
+- Live re-run with a fresh judge answer was blocked by Anthropic API credit
+  exhaustion in the sandbox (`credit balance is too low`); the transform is
+  validated against real stored `result_json` instead.


### PR DESCRIPTION
Follow-up to #682. When the agent woke on a failed eval run and called `get_eval_run`, it could not see **why** a case failed.

## The problem

`get_eval_run` returned per case only `{case_id, case_name, status, failure_reason}` — and `failure_reason` is **null for a normal `fail`**: the evaluator (`TestEvaluationService`) persists `failure_reason=None` and puts the substance in `TestResult.result_json` (`spec.rules`, `rule_results` — the per-rule verdicts with judge messages and expected-vs-actual). The tool never read `result_json`, nor the case's `prompt_json`. So the woken agent saw the string `"fail"` and nothing else, and flailed ("ended in error without detailing the failure reason…"). The run detail *page* showed all of it because it reads `result_json`; the tool didn't.

## The change

- **New `app/ai/tools/eval_result_view.py`** — turns `result_json` into an agent-readable shape:
  - `rules_view` — the expectation rules, each summarized (`tool.calls: create_data min 1`, `judge: <rubric excerpt>`).
  - `rule_results_view` — per-rule verdicts, **failing rules first**, judge reasoning read from `message` (falling back to `evidence.reasoning`), with truncated `actual`.
  - `derive_failure_reason` — synthesizes a reason from the failing rules' messages when the persisted column is null (the common `fail` case).
  - `prompt_text` — the case's replay prompt.
- **`get_eval_run`** now returns `EvalCaseDetail` per case: `prompt`, `rules`, `rule_results`, a derived `failure_reason`, and — with the new `include_transcript=true` input — the agent transcript for failed cases (bounded, via the existing `get_result_transcript`). The observation summary leads with the first failing case's reason so the conversation-history digest is actionable. Bumped to v1.1.0.
- **`run_eval`** inline results reuse `derive_failure_reason` for consistency.

Before → after for a real failing case (read from stored `result_json`):

```
before:  { status: "fail", failure_reason: null }

after:   prompt: "How many genres are in the database? Answer with a single number."
         failure_reason: "create_data calls=0, expected min=1 | <judge reasoning>"
         rules: [tool.calls: create_data min 1, judge: The answer MUST be a table …]
         rule_results: [
           {rule: "tool.calls: create_data min 1", status: fail, message: "create_data calls=0, expected min=1", actual: "0"},
           {rule: "judge: …", status: fail, message: "<judge reasoning>", actual: "False"}]
```

## Verification

- `backend/tests/unit/test_eval_result_view.py` — 9 tests over the transforms (rule summaries, failing-first ordering, `evidence.reasoning` fallback, derived reason, truncation). Full eval unit set: **36 passed**.
- In-process end-to-end: ran a failing case and invoked `GetEvalRunTool.run_stream` with `include_transcript=true` — the output carried `prompt`, `rules`, `rule_results`, derived `failure_reason`, and a transcript; `GetEvalRunOutput` validated.
- Validated the transform against **real production `result_json`** from the earlier sandbox.

Backend-only — no new UI surface. The chat card already renders `failure_reason` (now populated); the run detail page was already correct. Full record in `docs/feedback-loops/eval-run-read-detail.md`.

> Note: a fresh live re-run with a new judge answer was blocked by Anthropic API credit exhaustion in the sandbox, so judge-reasoning is validated against stored `result_json` rather than a new run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc1RpGwqVvj7g6H5nYvm1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc1RpGwqVvj7g6H5nYvm1q)_