### PR TITLE
Make the eval run-finished wake durable (scheduler job, not in-process task)

### DIFF
--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -2,10 +2,42 @@ from typing import Optional, List, Tuple, Dict, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from fastapi import HTTPException
-from datetime import datetime
+from datetime import datetime, timezone
 import asyncio
 import logging
 import uuid
+
+
+# --- Durable run-finished wake dispatch ---------------------------------------
+# The wake that resumes the origin chat when an agent-started eval run finishes
+# is dispatched as a one-shot APScheduler job (same durable pattern as
+# WaitService.run_wait_wake), NOT an in-process asyncio task. The shared
+# jobstore IS the queue: a worker that dies before the job runs recovers it on
+# restart via misfire_grace_time — no lost wakes, and no recurring poll.
+_EVAL_WAKE_PREFIX = "eval_wake:"
+
+
+def _eval_wake_job_id(run_id: str) -> str:
+    # Deterministic per run: replace_existing collapses duplicate schedules
+    # (finalizer + streamer both observing the same finalize) into one job.
+    return f"{_EVAL_WAKE_PREFIX}{run_id}"
+
+
+async def run_eval_wake(job_id: str, run_id: str) -> None:
+    """APScheduler callback: deliver the run-finished wake for ``run_id``.
+
+    Every worker runs its own scheduler against the shared jobstore, so this
+    may fire on more than one — the cross-worker claim lets exactly one
+    proceed. Idempotency across separate fires (e.g. a misfire re-run after a
+    crash) is handled by ``wake_on_finish``: it is cleared only after the wake
+    completion is created, so a crash mid-delivery re-fires (at-least-once,
+    absorbed by the 'already handled, acknowledge and stop' wake guidance)
+    rather than dropping the notification.
+    """
+    from app.core.scheduler import claim_scheduled_run
+    if not await asyncio.to_thread(claim_scheduled_run, job_id):
+        return
+    await TestRunService()._fire_eval_wake(run_id)
 
 
 def _agent_metadata_from_execution(ae) -> Dict[str, Any]:
@@ -493,7 +525,8 @@ class TestRunService:
         await db.refresh(run)
 
         # A stopped run is terminal — notify the origin conversation (if any).
-        asyncio.create_task(self._maybe_fire_wake(str(run.id)))
+        if getattr(run, "wake_on_finish", False):
+            self._schedule_eval_wake(str(run.id))
         return run
 
     # ---- Dashboard helpers (mock data for MVP) ----
@@ -914,16 +947,45 @@ class TestRunService:
         await session.refresh(run)
         return run
 
-    async def _maybe_fire_wake(self, run_id: str) -> None:
-        """Fire the wake-on-finish completion for a terminal run, at most once.
+    def _schedule_eval_wake(self, run_id: str) -> None:
+        """Arm the durable run-finished wake for a run.
 
-        The flag is flipped off *before* the completion is created so a racing
-        second caller no-ops. Best-effort: a lost wake degrades to the agent
-        polling with get_eval_run (or a user checking the UI) — it must never
-        block or fail run finalization.
+        Registers a one-shot APScheduler job on the shared jobstore (same
+        pattern as WaitService). Fires ~immediately in the normal case; if the
+        worker dies before it runs, it recovers on restart via
+        misfire_grace_time. Idempotent by ``run_id`` — a second schedule for
+        the same run replaces the first, so the finalizer and a live
+        ``stream_run`` client both calling this collapse to one job. Best-effort:
+        a scheduler hiccup must never block run finalization.
+        """
+        try:
+            from app.core.scheduler import scheduler
+            job_id = _eval_wake_job_id(str(run_id))
+            scheduler.add_job(
+                func=run_eval_wake,
+                trigger="date",
+                run_date=datetime.now(timezone.utc),
+                id=job_id,
+                kwargs={"job_id": job_id, "run_id": str(run_id)},
+                replace_existing=True,
+                misfire_grace_time=3600,  # survive a worker restart within the hour
+            )
+        except Exception as e:
+            logging.warning(f"failed to schedule eval wake for run {run_id}: {e}")
+
+    async def _fire_eval_wake(self, run_id: str) -> None:
+        """Deliver the wake-on-finish completion for a terminal run.
+
+        Ordering is deliberate: the wake completion is created FIRST, and
+        ``wake_on_finish`` is cleared only AFTER it succeeds. So a crash between
+        the two re-fires (the durable job / a later schedule finds the flag
+        still set) rather than silently dropping the notification — at-least-once
+        delivery, with duplicates absorbed by the 'already handled, acknowledge
+        and stop' text in the wake prompt.
         """
         async_session = create_async_session_factory()
         try:
+            # 1. Eligibility snapshot — do NOT clear the flag yet.
             async with async_session() as session:
                 run = (
                     await session.execute(select(TestRun).where(TestRun.id == str(run_id)))
@@ -935,19 +997,16 @@ class TestRunService:
                     or run.status not in RUN_TERMINAL_STATUSES
                 ):
                     return
-                # Claim the wake before doing anything visible.
-                run.wake_on_finish = False
                 origin_report_id = str(run.origin_report_id)
                 origin_user_id = str(run.origin_user_id) if run.origin_user_id else None
                 summary = dict(run.summary_json or {})
                 run_status = run.status
                 run_title = run.title
-                session.add(run)
-                await session.commit()
 
             from app.models.user import User
             from app.models.organization import Organization as _Org
 
+            # 2. Create the visible wake completion.
             async with async_session() as session:
                 report = await session.get(Report, origin_report_id)
                 if not report or getattr(report, "deleted_at", None):
@@ -997,6 +1056,16 @@ class TestRunService:
                     },
                     mode="training",
                 )
+
+            # 3. Mark the wake delivered — only now that the completion exists.
+            async with async_session() as session:
+                run = (
+                    await session.execute(select(TestRun).where(TestRun.id == str(run_id)))
+                ).scalar_one_or_none()
+                if run is not None and getattr(run, "wake_on_finish", False):
+                    run.wake_on_finish = False
+                    session.add(run)
+                    await session.commit()
         except Exception as e:
             logging.error(f"eval wake for run {run_id} failed: {e}")
 
@@ -1212,8 +1281,8 @@ class TestRunService:
         try:
             async with async_session() as session:
                 finalized = await self._finalize_run_if_done(session, str(run_id))
-            if finalized is not None:
-                await self._maybe_fire_wake(str(run_id))
+            if finalized is not None and getattr(finalized, "wake_on_finish", False):
+                self._schedule_eval_wake(str(run_id))
         except Exception as e:
             logging.exception(f"eval watcher: run {run_id} finalize failed: {e}")
 
@@ -2113,10 +2182,10 @@ class TestRunService:
                         try:
                             finalized = await self._finalize_run_if_done(db, str(run.id))
                             await db.refresh(run)
-                            if finalized is not None:
+                            if finalized is not None and getattr(finalized, "wake_on_finish", False):
                                 # e.g. a wake-armed run adopted via dedupe but
                                 # driven to completion by this streamer.
-                                asyncio.create_task(self._maybe_fire_wake(str(run.id)))
+                                self._schedule_eval_wake(str(run.id))
                         except Exception:
                             pass
                         yield format_sse_event(SSEEvent(event="run.finished", completion_id=str(run.id), data={"run_id": str(run.id), "status": run.status}))
@@ -2153,8 +2222,8 @@ class TestRunService:
                             try:
                                 finalized = await self._finalize_run_if_done(db, str(run.id))
                                 await db.refresh(run)
-                                if finalized is not None:
-                                    asyncio.create_task(self._maybe_fire_wake(str(run.id)))
+                                if finalized is not None and getattr(finalized, "wake_on_finish", False):
+                                    self._schedule_eval_wake(str(run.id))
                             except Exception:
                                 pass
                             yield format_sse_event(SSEEvent(event="run.finished", completion_id=str(run.id), data={"run_id": str(run.id), "status": run.status}))

--- a/backend/tests/unit/test_eval_wake_dispatch.py
+++ b/backend/tests/unit/test_eval_wake_dispatch.py
@@ -1,0 +1,63 @@
+"""Unit tests for the durable eval run-finished wake dispatch.
+
+The wake is delivered as a one-shot APScheduler job (durable jobstore) rather
+than an in-process asyncio task, so a worker crash before it runs recovers on
+restart. These tests cover the dispatch/claim wiring deterministically; the
+create-then-clear ordering and the actual completion are exercised in the
+sandbox loop.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.test_run_service import (
+    TestRunService,
+    _eval_wake_job_id,
+    run_eval_wake,
+)
+
+
+def test_job_id_is_deterministic_per_run():
+    assert _eval_wake_job_id("run-1") == "eval_wake:run-1"
+    assert _eval_wake_job_id("run-1") == _eval_wake_job_id("run-1")
+    assert _eval_wake_job_id("run-2") != _eval_wake_job_id("run-1")
+
+
+def test_schedule_registers_a_durable_oneshot_job():
+    with patch("app.core.scheduler.scheduler") as sched:
+        TestRunService()._schedule_eval_wake("run-1")
+    sched.add_job.assert_called_once()
+    kwargs = sched.add_job.call_args.kwargs
+    assert kwargs["func"] is run_eval_wake
+    assert kwargs["trigger"] == "date"
+    assert kwargs["id"] == "eval_wake:run-1"
+    # Deterministic id + replace_existing collapses duplicate schedules to one.
+    assert kwargs["replace_existing"] is True
+    # Survives a worker restart within the hour.
+    assert kwargs["misfire_grace_time"] == 3600
+    assert kwargs["kwargs"] == {"job_id": "eval_wake:run-1", "run_id": "run-1"}
+
+
+def test_schedule_never_raises_on_scheduler_error():
+    # A scheduler hiccup must not block run finalization.
+    with patch("app.core.scheduler.scheduler") as sched:
+        sched.add_job.side_effect = RuntimeError("scheduler down")
+        TestRunService()._schedule_eval_wake("run-1")  # should swallow
+
+
+@pytest.mark.asyncio
+async def test_run_eval_wake_claims_then_delivers():
+    with patch("app.core.scheduler.claim_scheduled_run", return_value=True) as claim, \
+         patch.object(TestRunService, "_fire_eval_wake", new=AsyncMock()) as fire:
+        await run_eval_wake("eval_wake:run-1", "run-1")
+    claim.assert_called_once_with("eval_wake:run-1")
+    fire.assert_awaited_once_with("run-1")
+
+
+@pytest.mark.asyncio
+async def test_run_eval_wake_skips_when_claim_lost():
+    # Another worker already claimed this fire — we must not deliver twice.
+    with patch("app.core.scheduler.claim_scheduled_run", return_value=False), \
+         patch.object(TestRunService, "_fire_eval_wake", new=AsyncMock()) as fire:
+        await run_eval_wake("eval_wake:run-1", "run-1")
+    fire.assert_not_awaited()

--- a/docs/feedback-loops/eval-wake-durable.md
+++ b/docs/feedback-loops/eval-wake-durable.md
@@ -1,0 +1,61 @@
+# Feedback Loop — durable eval run-finished wake
+
+The eval run-finished wake (the hook that resumes the origin chat when an
+agent-started run completes) was dispatched as `asyncio.create_task(...)` —
+fire-and-forget, in-process. If the worker restarted in the window between the
+run finalizing and the wake completion being written, **the notification was
+silently lost and nothing retried it**. Ironically the general `wait` tool was
+already durable (APScheduler jobstore + misfire grace); the newer eval wake
+traded that away for immediacy.
+
+## Change
+
+Dispatch the wake as a one-shot APScheduler `date` job on the shared jobstore —
+the exact pattern `WaitService.run_wait_wake` uses — instead of an in-process
+task. **No recurring sweep** (that would poll for a rare event and be empty
+99.9% of the time); the jobstore *is* the durable queue, and a job exists only
+when there's an actual wake to deliver.
+
+- Module-level `run_eval_wake(job_id, run_id)` — the scheduler callable
+  (serializable by import path); claims the fire cross-worker
+  (`claim_scheduled_run`) then delegates to `_fire_eval_wake`.
+- `_schedule_eval_wake(run_id)` — `scheduler.add_job(trigger="date",
+  run_date=now, id="eval_wake:<run_id>", replace_existing=True,
+  misfire_grace_time=3600)`. Deterministic id collapses duplicate schedules
+  (finalizer + a live `stream_run` client) to one job; misfire grace recovers a
+  job whose worker died before it ran.
+- The four dispatch sites (finalizer, `stop_run`, two `stream_run` paths) now
+  call `_schedule_eval_wake` when `wake_on_finish` is set, instead of
+  `asyncio.create_task(_maybe_fire_wake)`.
+- **Ordering fix:** `_fire_eval_wake` creates the wake completion FIRST and
+  clears `wake_on_finish` only AFTER it succeeds. A crash between the two
+  re-fires (flag still set) rather than dropping — at-least-once delivery, with
+  duplicates absorbed by the existing "already handled, acknowledge and stop"
+  wake-prompt guidance. (Previously the flag was cleared *before* the
+  completion, so a crash mid-fire lost the wake permanently.)
+
+UI is unchanged: still `run_machine_turn` → the same `role='external'` event
+strip. Durability only changes *how* the wake is dispatched, not what it renders.
+
+## Verification
+
+- `backend/tests/unit/test_eval_wake_dispatch.py` — deterministic job id;
+  `_schedule_eval_wake` registers a durable one-shot job with the right kwargs
+  and never raises on a scheduler error; `run_eval_wake` claims then delivers,
+  and skips when the cross-worker claim is lost. (5 tests; eval+wait unit set:
+  52 passed.)
+- Integration smoke (no live agent — `run_machine_turn` stubbed so the
+  credit-limited sandbox agent isn't needed):
+  1. the **real** scheduler accepts the job (`misfire_grace_time=3600`);
+  2. `_fire_eval_wake` delivers exactly once with the right payload
+     (`trigger_source=eval_run`, meta counts, `mode=training`);
+  3. `wake_on_finish` flips to False only after delivery, so a second call
+     no-ops (idempotent).
+
+## Notes
+
+- Guaranteed-delivery now matches the `wait` tool. A worker crash between
+  "run finished" and "chat notified" recovers on restart instead of dropping.
+- Deliberately out of scope: baking per-case results into the event strip so
+  the outcome survives a *dead agent turn* (today detail comes from the agent's
+  `get_eval_run` follow-up). Separate enhancement.


### PR DESCRIPTION
The eval run-finished wake — the hook that resumes the origin chat when an agent-started run completes — was dispatched as `asyncio.create_task(_maybe_fire_wake)`: fire-and-forget, in-process. **A worker restart in the window between the run finalizing and the wake completion being written silently lost the notification, and nothing retried it.** The general `wait` tool was already durable (APScheduler jobstore + misfire grace); the newer eval wake had traded that away.

## Change

Dispatch the wake as a **one-shot APScheduler `date` job** on the shared jobstore — the same pattern `WaitService.run_wait_wake` uses. **Not a recurring sweep** (that would poll for a rare event and be empty ~all the time); the jobstore *is* the durable queue — a job exists only when there's an actual wake to deliver, and `misfire_grace_time` recovers a job whose worker died before it ran.

- **`run_eval_wake(job_id, run_id)`** (module-level, serializable) — claims the fire cross-worker via `claim_scheduled_run`, then delegates to `_fire_eval_wake`.
- **`_schedule_eval_wake(run_id)`** — `add_job(trigger="date", run_date=now, id="eval_wake:<run_id>", replace_existing=True, misfire_grace_time=3600)`. The deterministic id collapses duplicate schedules (finalizer + a live `stream_run` client) into one job.
- The four dispatch sites (finalizer, `stop_run`, two `stream_run` paths) now call `_schedule_eval_wake` when `wake_on_finish` is set.
- **Ordering fix** (the other half of the reliability gap): `_fire_eval_wake` creates the wake completion **first** and clears `wake_on_finish` only **after** it succeeds. A crash between the two re-fires (flag still set) instead of dropping — at-least-once delivery, with duplicates absorbed by the existing *"already handled, acknowledge and stop"* wake-prompt text. Previously the flag was cleared *before* the completion, so a crash mid-fire lost the wake permanently.

**UI is unchanged** — still `run_machine_turn` → the same `role='external'` event strip. Durability only changes *how* the wake is dispatched, not what it renders.

## Verification

- `backend/tests/unit/test_eval_wake_dispatch.py` (5 tests): deterministic job id; `_schedule_eval_wake` registers a durable one-shot job with the right kwargs and never raises on a scheduler error; `run_eval_wake` claims-then-delivers and skips when the cross-worker claim is lost. Eval + wait unit set: **52 passed**. Eval e2e: **14 passed**.
- **Integration smoke** (no live agent — `run_machine_turn` stubbed, since the sandbox Anthropic key is credit-limited):
  1. the **real** scheduler accepts the job (`misfire_grace_time=3600`);
  2. `_fire_eval_wake` delivers **exactly once** with the right payload (`trigger_source=eval_run`, meta counts, `mode=training`);
  3. `wake_on_finish` flips to `False` **only after** delivery, so a second call no-ops (idempotent).

Full record in `docs/feedback-loops/eval-wake-durable.md`.

> Deliberately out of scope: baking per-case results into the event strip so the outcome survives a *dead agent turn* (today the detail comes from the agent's `get_eval_run` follow-up). Separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc1RpGwqVvj7g6H5nYvm1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc1RpGwqVvj7g6H5nYvm1q)_