### PR TITLE
perf: scope pending-change sweep in SQL + batch starter-prompt fetch

### DIFF
--- a/backend/app/routes/prompt.py
+++ b/backend/app/routes/prompt.py
@@ -32,6 +32,10 @@ async def list_prompts(
     category: Optional[str] = None,
     starters_only: bool = False,
     data_source_id: Optional[str] = None,
+    data_source_ids: Optional[str] = Query(
+        default=None,
+        description="Comma-separated agent IDs; returns prompts attached to ANY of them (union). Lets callers batch what would otherwise be one request per agent.",
+    ),
     created_by: Optional[str] = None,
     scope: Optional[str] = None,
     search: Optional[str] = None,
@@ -40,9 +44,13 @@ async def list_prompts(
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
 ):
+    parsed_ds_ids = None
+    if data_source_ids:
+        parsed_ds_ids = [d.strip() for d in data_source_ids.split(',') if d.strip()]
     return await prompt_service.list_prompts(
         db, current_user, organization,
         category=category, starters_only=starters_only, data_source_id=data_source_id,
+        data_source_ids=parsed_ds_ids,
         created_by=created_by, scope=scope, search=search, limit=limit,
     )
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -1625,6 +1625,30 @@ class InstructionService:
         ]
         if candidate_ids is not None:
             sug_where.append(BuildContent.instruction_id.in_([str(i) for i in candidate_ids]))
+
+        # A build snapshots EVERY instruction, so the vast majority of a pending
+        # build's contents are unchanged carry-over rows inherited from its base
+        # build. The word-level diff below only cares about rows whose proposed
+        # version differs from the base — exactly the rows the Python pass at
+        # `changed_rows` used to keep AFTER materializing all of them. Push that
+        # skip into SQL: exclude a content row when the base build holds the same
+        # instruction at the same version. (base_build_id NULL -> no match ->
+        # row kept, matching the old behaviour.) This turns an org-wide load of
+        # every pending build's full contents into just the handful of actual
+        # changes, without altering the result set.
+        from sqlalchemy.orm import aliased as _aliased
+        _BaseBC = _aliased(BuildContent)
+        _carryover = (
+            select(_BaseBC.id)
+            .where(and_(
+                _BaseBC.build_id == InstructionBuild.base_build_id,
+                _BaseBC.instruction_id == BuildContent.instruction_id,
+                _BaseBC.instruction_version_id == BuildContent.instruction_version_id,
+            ))
+            .exists()
+        )
+        sug_where.append(~_carryover)
+
         sug_rows = (await db.execute(
             select(
                 BuildContent.instruction_id,

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -143,6 +143,7 @@ class PromptService:
         self, db: AsyncSession, current_user: User, organization: Organization,
         category: Optional[str] = None, starters_only: bool = False,
         data_source_id: Optional[str] = None,
+        data_source_ids: Optional[List[str]] = None,
         created_by: Optional[str] = None, scope: Optional[str] = None,
         search: Optional[str] = None,
         limit: Optional[int] = None,
@@ -156,7 +157,13 @@ class PromptService:
         )
         if starters_only:
             q = q.filter(Prompt.is_starter == True)
-        if data_source_id:
+        # Single-agent (legacy) or multi-agent union filter. `data_source_ids`
+        # returns prompts attached to ANY of the given agents in one query — the
+        # batched form of calling this endpoint once per agent. `.unique()`
+        # below dedups prompts shared across several of them.
+        if data_source_ids:
+            q = q.join(Prompt.data_sources).filter(DataSource.id.in_(data_source_ids))
+        elif data_source_id:
             q = q.join(Prompt.data_sources).filter(DataSource.id == data_source_id)
         if created_by:
             q = q.filter(Prompt.user_id == created_by)

--- a/backend/scripts/bench_pending_sweep.py
+++ b/backend/scripts/bench_pending_sweep.py
@@ -1,0 +1,53 @@
+"""Benchmark + equivalence capture for the instruction 'pending changes' sweep
+(instruction_service.get_pending_change_instruction_ids) and the unfiltered
+instruction list — the org-wide path that materialized every pending build's
+contents. Prints wall time and an md5 of the resulting id set so before/after
+runs can be diffed for behavioural equivalence.
+
+Usage (from backend/, running-stack env):
+  uv run python scripts/bench_pending_sweep.py <org_id> <admin_email> <password>
+"""
+import asyncio
+import hashlib
+import sys
+import time
+
+import main  # noqa: F401
+
+from sqlalchemy import select
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.services.instruction_service import InstructionService
+
+ORG_ID = sys.argv[1]
+EMAIL = sys.argv[2]
+
+
+async def run():
+    svc = InstructionService()
+    async with async_session_maker() as db:
+        org = (await db.execute(select(Organization).where(Organization.id == ORG_ID))).scalar_one()
+        user = (await db.execute(select(User).where(User.email == EMAIL))).scalar_one()
+
+        # warm
+        ids = await svc.get_pending_change_instruction_ids(db, org, user)
+        # timed
+        t0 = time.perf_counter()
+        ids = await svc.get_pending_change_instruction_ids(db, org, user)
+        sweep_ms = (time.perf_counter() - t0) * 1000
+        digest = hashlib.md5("\n".join(sorted(str(i) for i in ids)).encode()).hexdigest()[:12]
+        print(f"SWEEP get_pending_change_instruction_ids: {sweep_ms:.0f} ms, {len(ids)} ids, md5={digest}")
+
+        # full unfiltered list (what home/agents prefetch: limit=50)
+        t0 = time.perf_counter()
+        res = await svc.get_instructions(db, org, user, skip=0, limit=50)
+        list_ms = (time.perf_counter() - t0) * 1000
+        total = res["total"]
+        rows = res["items"]
+        row_ids = hashlib.md5("\n".join(str(r.id) for r in rows).encode()).hexdigest()[:12]
+        print(f"LIST GET /instructions?limit=50: {list_ms:.0f} ms, total={total}, page_rows={len(rows)}, page_md5={row_ids}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/frontend/components/DataSourceQuestionsHome.vue
+++ b/frontend/components/DataSourceQuestionsHome.vue
@@ -30,22 +30,40 @@ type Suggestion = { key: string, label: string, value: string }
 // re-selecting an already-loaded source is cheap.
 const starterTextsByDs = ref<Record<string, string[]>>({})
 
-const fetchStartersForDs = async (dsId: string) => {
-    if (!dsId || starterTextsByDs.value[dsId]) return
+// Fetch starter prompts for all selected agents in ONE request (batched union)
+// instead of one request per agent — a report/home with dozens of attached
+// agents previously fired dozens of /prompts calls just to fill 5 suggestions.
+// Prompts carry their agent ids, so we still bucket by data source id for the
+// per-source pool, and skip ids already loaded.
+const fetchStartersForDsIds = async (dsIds: string[]) => {
+    const missing = dsIds.filter((id) => id && !(id in starterTextsByDs.value))
+    if (!missing.length) return
+    // Seed as empty so concurrent watches don't refetch the same ids.
+    const seeded: Record<string, string[]> = {}
+    for (const id of missing) seeded[id] = []
+    starterTextsByDs.value = { ...starterTextsByDs.value, ...seeded }
     try {
-        const { data } = await useMyFetch(`/prompts?data_source_id=${dsId}`)
+        const { data } = await useMyFetch(`/prompts?data_source_ids=${missing.join(',')}`)
         const prompts = (data?.value as any)?.prompts || []
-        starterTextsByDs.value = {
-            ...starterTextsByDs.value,
-            [dsId]: prompts.map((p: any) => String(p?.text ?? '')).filter((t: string) => t.trim().length > 0),
+        const byDs: Record<string, string[]> = { ...seeded }
+        for (const p of prompts) {
+            const text = String(p?.text ?? '')
+            if (!text.trim()) continue
+            const ids: string[] = Array.isArray(p?.data_source_ids)
+                ? p.data_source_ids
+                : (p?.data_sources || []).map((d: any) => d?.id).filter(Boolean)
+            for (const id of ids) {
+                if (id in byDs) byDs[id].push(text)
+            }
         }
+        starterTextsByDs.value = { ...starterTextsByDs.value, ...byDs }
     } catch {
-        starterTextsByDs.value = { ...starterTextsByDs.value, [dsId]: [] }
+        // leave the seeded empties in place
     }
 }
 
 watch(() => (props.data_sources || []).map((ds: any) => ds?.id).filter(Boolean).join(','), (ids) => {
-    for (const id of (ids ? ids.split(',') : [])) fetchStartersForDs(id)
+    fetchStartersForDsIds(ids ? ids.split(',') : [])
 }, { immediate: true })
 
 // Build a flat pool of suggestions from the selected data sources' starter Prompts


### PR DESCRIPTION
Two load-investigation follow-ups (#3 and #5.2). **No behavioural change** — outputs are byte-identical, verified against the 112k-instruction / 1500-pending-build sandbox.

## #3 — instruction list (~14s at 100k rows → ~3s)

`get_pending_change_instruction_ids` (the "pending changes" sweep behind `GET /api/instructions`, `/counts`, and the detail view) materialised **every** pending build's contents — 301,500 rows, because a build snapshots *all* instructions so almost all are unchanged carry-over — then discarded the carry-over in Python. Pushed that skip into SQL via `NOT EXISTS` against the base build, so only the actually-changed rows (**1,500**) are fetched. The result set is unchanged.

| measurement (112k instructions) | before | after |
|---|---|---|
| sweep `get_pending_change_instruction_ids` | 6345 ms | **644 ms** |
| step-1 rows materialised | 301,500 | **1,500** |
| `GET /instructions?limit=50` (HTTP) | ~14 s | **~3 s** |
| `GET /instructions/counts` (HTTP) | ~5 s | **1.4 s** |
| pending id set | md5 `43e0f4cdf0fb` | md5 `43e0f4cdf0fb` (identical) |
| list page rows | md5 `91775caf0e69` | md5 `91775caf0e69` (identical) |

UI: the agents/instructions page renders with the correct **"1500 pending"** badge and per-agent counts, unchanged.

*Residual (not in this PR):* the remaining ~3s in the list is a count + two visibility selects scanning 112k rows — a separate, index-touching change I left out to keep this behaviour-preserving.

## #5.2 — starter-prompt fanout (40 requests → 1)

The home starter-suggestion panel fired `GET /prompts?data_source_id=` once **per attached agent** (40 calls for a 40-agent workspace, just to fill 5 chips). Added a `data_source_ids` (plural, union) filter to `GET /prompts`; `DataSourceQuestionsHome` now fetches all agents in one request. Prompts already carry their `data_source_ids`, so per-source bucketing is unchanged. Batch result == per-ds union (identical ids); the home chips render correctly from the single call.

## Verification
- `scripts/bench_pending_sweep.py` — the before/after numbers above (equivalence by md5).
- Existing **instruction/build (69)** and **rbac-prompt (13)** test suites pass.
- Playwright: home fires 1 batched `/prompts` call and renders the seeded starter chips; agents page renders identical counts (screenshots captured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSbshcmAVhoj72FpLxDKKp)_