### PR TITLE
Auto router: seed starter routing guidance on first enable

### DIFF
--- a/frontend/components/LLMsComponent.vue
+++ b/frontend/components/LLMsComponent.vue
@@ -317,6 +317,10 @@ const saveAutoRouter = async (val: boolean) => {
         body: { config: { model_routing: { value: val } } },
     });
     if (response.status.value === 'success') {
+        // On first enable, seed starter routing guidance on the default + small
+        // models so the router has candidates to route between out of the box.
+        // Only fills EMPTY hints — never overwrites an admin's own guidance.
+        if (val) await seedDefaultRoutingHints();
         toast.add({
             title: val ? t('settings.llms.autoRouterOn') : t('settings.llms.autoRouterOff'),
             color: 'green',
@@ -325,6 +329,25 @@ const saveAutoRouter = async (val: boolean) => {
         autoRouterOn.value = !val; // revert optimistic toggle
         toast.add({ title: 'Error', description: 'Could not update auto router', color: 'red' });
     }
+};
+
+const seedDefaultRoutingHints = async () => {
+    const seeds: { find: (m: Model) => boolean; hint: string }[] = [
+        { find: (m) => !!m.is_small_default, hint: t('settings.llms.routingHintSeedSmall') },
+        { find: (m) => !!m.is_default, hint: t('settings.llms.routingHintSeedDefault') },
+    ];
+    let changed = false;
+    for (const s of seeds) {
+        const m = models.value.find((x) => s.find(x) && x.is_enabled);
+        if (m && !modelHint(m)) {
+            const r = await useMyFetch(`/llm/models/${m.id}/routing_hint`, {
+                method: 'POST',
+                body: { hint: s.hint },
+            });
+            if (r.status.value === 'success') changed = true;
+        }
+    }
+    if (changed) await getModels();
 };
 
 const modelHint = (model: Model): string => (model.config?.routing_hint as string) || '';

--- a/locales/en.json
+++ b/locales/en.json
@@ -2047,7 +2047,9 @@
       "autoRouterHow4": "Explicit model picks and report-pinned models always bypass routing.",
       "costEditTooltip": "Click to edit input / output price per million tokens (USD).",
       "costInput": "Input",
-      "costOutput": "Output"
+      "costOutput": "Output",
+      "routingHintSeedSmall": "Basic questions, single metrics, and quick lookups.",
+      "routingHintSeedDefault": "Dashboards, artifacts, file analysis, and advanced multi-step analysis."
     },
     "licensePage": {
       "title": "License",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1903,7 +1903,9 @@
       "autoRouterHow4": "Las elecciones explícitas de modelo y los modelos fijados al informe siempre omiten el enrutamiento.",
       "costEditTooltip": "Haz clic para editar el precio de entrada / salida por millón de tokens (USD).",
       "costInput": "Entrada",
-      "costOutput": "Salida"
+      "costOutput": "Salida",
+      "routingHintSeedSmall": "Preguntas básicas, métricas simples y búsquedas rápidas.",
+      "routingHintSeedDefault": "Paneles, artefactos, análisis de archivos y análisis avanzado de varios pasos."
     },
     "licensePage": {
       "title": "Licencia",

--- a/locales/he.json
+++ b/locales/he.json
@@ -1903,7 +1903,9 @@
       "autoRouterHow4": "בחירת מודל מפורשת ומודל מוצמד לדוח תמיד עוקפים את הניתוב.",
       "costEditTooltip": "לחצו כדי לערוך את מחיר הקלט / פלט למיליון טוקנים (USD).",
       "costInput": "קלט",
-      "costOutput": "פלט"
+      "costOutput": "פלט",
+      "routingHintSeedSmall": "שאלות בסיסיות, מדדים בודדים וחיפושים מהירים.",
+      "routingHintSeedDefault": "לוחות מחוונים, ארטיפקטים, ניתוח קבצים וניתוח מתקדם רב-שלבי."
     },
     "licensePage": {
       "title": "רישיון",


### PR DESCRIPTION
When an admin switches the **Auto router** on, auto-fill routing guidance on the org's default and small-default models so the router has candidates to route between immediately.

## Why
Routing only *activates* when at least one model carries routing guidance (that's what makes it an escalation target). An admin who flipped the toggle and wrote no hints ended up with the router "on" but doing nothing. Seeding the two defaults makes it work out of the box.

## Behavior
On enable, fills **only empty** hints (never overwrites an admin's own text), on the enabled default + small-default models:
- **small:** "Basic questions, single metrics, and quick lookups."
- **default:** "Dashboards, artifacts, file analysis, and advanced multi-step analysis."

The admin can edit or clear them afterward in the Routing column. i18n for `en`/`es`/`he`.

## Scope
Frontend-only (`LLMsComponent.vue` + locales) — reuses the existing `POST /llm/models/{id}/routing_hint` endpoint. No backend/logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnbGR3YDAWswSJ4oGipqV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnbGR3YDAWswSJ4oGipqV7)_