### PR TITLE
Fix mention chip rendering in chat messages

### DIFF
--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -2167,8 +2167,11 @@ function promptMentionsToRefs(mentions?: Array<{ name: string; items: any[] }>) 
 			refs.push({
 				id: item.id,
 				type,
+				// `icon_type` is what the mention items actually carry (set to the
+				// data source's type); include it so the chip renders the correct
+				// data-source icon instead of the generic fallback glyph.
+				data_source_type: item.connection_type || item.data_source_type || item.icon_type || undefined,
 				name,
-				data_source_type: item.connection_type || item.data_source_type || undefined,
 			})
 		}
 	}
@@ -3951,11 +3954,14 @@ function onSubmitCompletion(data: { text: string, mentions: any[]; mode?: string
 	const text = data.text.trim()
 	if (!text) return
 
-	// Append user message with attached files (for immediate display)
+	// Append user message with attached files (for immediate display).
+	// Carry the mentions through so the optimistic bubble resolves mention chips
+	// (e.g. multi-word data-source names like "@Elbit Demo") immediately instead
+	// of falling back to the word-only parser until the server reloads the row.
 	const userMsg: ChatMessage = {
 		id: `user-${Date.now()}`,
 		role: 'user',
-		prompt: { content: text },
+		prompt: { content: text, mentions: data.mentions || [] },
 		files: data.files || [],
 		created_at: new Date().toISOString()
 	}


### PR DESCRIPTION
## Summary
This PR fixes mention chip rendering in chat messages by ensuring mention data is properly preserved and passed through the message pipeline.

## Key Changes
- **Mention data source icon rendering**: Updated `promptMentionsToRefs()` to include `icon_type` as a fallback when resolving the `data_source_type`. This ensures mention chips render the correct data-source icon instead of falling back to a generic glyph, even when the mention item uses `icon_type` instead of `data_source_type` or `connection_type`.

- **Optimistic message rendering**: Modified `onSubmitCompletion()` to carry mentions through to the optimistic user message bubble. This allows mention chips (e.g., multi-word data-source names like "@Elbit Demo") to resolve immediately in the UI instead of falling back to word-only parsing until the server reloads the row.

## Implementation Details
- The `data_source_type` field now checks three sources in order: `item.connection_type`, `item.data_source_type`, and `item.icon_type`, with `undefined` as the final fallback
- The user message object now includes `mentions: data.mentions || []` in its `prompt` field to preserve mention metadata for optimistic rendering
- Comments added to clarify the purpose of these changes for future maintainers

https://claude.ai/code/session_0139bZx1mEW2yMTW5751S4kr