### PR TITLE
Render prompt content with InstructionText component

### DIFF
--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -287,7 +287,13 @@
 														<span>{{ s.steering_applied ? $t('reportView.steeringApplied') : $t('reportView.steered') }}</span>
 													</div>
 													<div class="user-bubble inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start border border-amber-200 dark:border-amber-900/60" dir="auto">
-														<div class="pt-1">{{ s.prompt?.content }}</div>
+														<div v-if="s.prompt?.content" class="pt-1">
+															<InstructionText
+																:text="s.prompt.content"
+																:references="promptMentionsToRefs(s.prompt.mentions)"
+																:prose="true"
+															/>
+														</div>
 													</div>
 												</div>
 											</div>
@@ -386,7 +392,13 @@
 													<span>{{ s.steering_applied ? $t('reportView.steeringApplied') : $t('reportView.steered') }}</span>
 												</div>
 												<div class="user-bubble inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start border border-amber-200 dark:border-amber-900/60" dir="auto">
-													<div class="pt-1">{{ s.prompt?.content }}</div>
+													<div v-if="s.prompt?.content" class="pt-1">
+														<InstructionText
+															:text="s.prompt.content"
+															:references="promptMentionsToRefs(s.prompt.mentions)"
+															:prose="true"
+														/>
+													</div>
 												</div>
 											</div>
 										</div>


### PR DESCRIPTION
## Summary
Updated the report view to render prompt content using the `InstructionText` component instead of plain text interpolation. This enables proper formatting and reference handling for prompt instructions.

## Key Changes
- Replaced plain text rendering (`{{ s.prompt?.content }}`) with `InstructionText` component in two locations within the report view
- Added conditional rendering with `v-if="s.prompt?.content"` to ensure the component only renders when content exists
- Integrated prompt mentions into references using the `promptMentionsToRefs()` method
- Enabled prose formatting mode for improved text presentation

## Implementation Details
- The `InstructionText` component receives:
  - `text`: The prompt content
  - `references`: Converted from `s.prompt.mentions` via `promptMentionsToRefs()`
  - `prose`: Set to `true` for enhanced formatting
- Changes applied consistently across two similar sections in the template

https://claude.ai/code/session_018t81Pj2Wda5escHJfKaMsL