### PR TITLE
Fix Power BI semantic models silently missing from schema fetch

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -346,26 +346,6 @@ class PowerBIClient(DataSourceClient):
         except Exception as e:
             return "error", str(e)
 
-    # Built-in system semantic models Power BI auto-creates per workspace once
-    # usage metrics are opened. They are not real data and must not pollute the
-    # catalog. Matched case-insensitively against the dataset name.
-    _SYSTEM_DATASET_NAMES = {
-        "usage metrics report",
-        "report usage metrics model",
-        "dashboard usage metrics model",
-    }
-
-    @classmethod
-    def _is_system_dataset(cls, name: str) -> bool:
-        """True for Power BI's built-in usage-metrics / system semantic models."""
-        n = (name or "").strip().lower()
-        if not n:
-            return False
-        if n in cls._SYSTEM_DATASET_NAMES:
-            return True
-        # Newer tenants suffix these with a workspace/guid; match the stable prefix.
-        return n.startswith("usage metrics report") or n.startswith("report usage metrics model")
-
     @staticmethod
     def _extract_pbi_error(resp) -> str:
         """Pull the human-readable detail out of a Power BI error response."""
@@ -816,14 +796,16 @@ class PowerBIClient(DataSourceClient):
                 except Exception:
                     ws_reports[ws["id"]] = []
 
-        # Collect all (workspace, dataset) pairs, skipping Power BI's built-in
-        # usage-metrics / system semantic models (they are not real data).
+        # Collect all (workspace, dataset) pairs. Every semantic model the
+        # identity can list is discovered — including Fabric default semantic
+        # models and Microsoft's built-in usage-metrics models. We do NOT hide
+        # any of them: hiding is a product decision, and in tenants where the
+        # usage-metrics models are the only ones currently visible, dropping
+        # them would make the catalog look emptier, not cleaner.
         all_ds_tasks: List[Tuple[Dict, Dict, str]] = []
         for ws in workspaces:
             ws_id = ws.get("id")
             for ds in ws_datasets.get(ws_id, []):
-                if self._is_system_dataset(ds.get("name")):
-                    continue
                 all_ds_tasks.append((ws, ds, ws_id))
 
         # Phase 2: Try batch admin scan for all workspaces (tables + relationships in bulk)

--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -94,6 +94,13 @@ class PowerBIClient(DataSourceClient):
         # datasets, admin scan, COLUMNSTATISTICS) — run it at most once per
         # client instance.
         self._schemas_cache: Optional[List[Table]] = None
+        # Per-run diagnostics: datasets that were listed but produced no schema
+        # (no Build permission, RLS, DirectLake, ...). Populated by get_schemas()
+        # and surfaced via index_stats() so the indexing job can report which
+        # semantic models were found-but-unreadable instead of dropping them
+        # silently. Each entry: {datasetId, datasetName, workspaceId,
+        # workspaceName, reason}.
+        self.discovery_diagnostics: List[Dict] = []
 
     def attach_table_metadata(self, tables: List[Dict]) -> None:
         """Inject persisted table metadata (from the indexed schema catalog).
@@ -339,6 +346,26 @@ class PowerBIClient(DataSourceClient):
         except Exception as e:
             return "error", str(e)
 
+    # Built-in system semantic models Power BI auto-creates per workspace once
+    # usage metrics are opened. They are not real data and must not pollute the
+    # catalog. Matched case-insensitively against the dataset name.
+    _SYSTEM_DATASET_NAMES = {
+        "usage metrics report",
+        "report usage metrics model",
+        "dashboard usage metrics model",
+    }
+
+    @classmethod
+    def _is_system_dataset(cls, name: str) -> bool:
+        """True for Power BI's built-in usage-metrics / system semantic models."""
+        n = (name or "").strip().lower()
+        if not n:
+            return False
+        if n in cls._SYSTEM_DATASET_NAMES:
+            return True
+        # Newer tenants suffix these with a workspace/guid; match the stable prefix.
+        return n.startswith("usage metrics report") or n.startswith("report usage metrics model")
+
     @staticmethod
     def _extract_pbi_error(resp) -> str:
         """Pull the human-readable detail out of a Power BI error response."""
@@ -460,13 +487,29 @@ class PowerBIClient(DataSourceClient):
         Returns:
             tuple: (tables_list, relationships_list)
         """
+        tables, rels, _ = self.get_dataset_tables_with_reason(workspace_id, dataset_id)
+        return tables, rels
+
+    def get_dataset_tables_with_reason(self, workspace_id: str, dataset_id: str) -> tuple:
+        """
+        Like get_dataset_tables, but also returns a human-readable reason when
+        no tables could be introspected. Lets discovery record *why* a semantic
+        model produced no schema (no Build permission, RLS, DirectLake, ...)
+        instead of dropping it silently.
+
+        Returns:
+            tuple: (tables_list, relationships_list, reason_or_None)
+                   reason is None on success, else a short diagnostic string.
+        """
         self.connect()
         headers = self._build_headers()
 
         # Try COLUMNSTATISTICS first (works for most datasets without admin perms)
-        tables, _ = self._get_tables_via_column_stats(workspace_id, dataset_id)
+        tables, _, stats_reason = self._get_tables_via_column_stats_with_reason(
+            workspace_id, dataset_id
+        )
         if tables:
-            return tables, []
+            return tables, [], None
 
         # Fallback: REST API /tables (only works for Push datasets)
         url = f"{self.BASE_URL}/groups/{workspace_id}/datasets/{dataset_id}/tables"
@@ -474,17 +517,31 @@ class PowerBIClient(DataSourceClient):
         if resp.status_code < 300:
             rest_tables = (resp.json() or {}).get("value") or []
             if rest_tables and any(t.get("columns") for t in rest_tables):
-                return rest_tables, []
+                return rest_tables, [], None
 
-        return [], []
+        # Nothing worked. Prefer the COLUMNSTATISTICS reason (most informative);
+        # fall back to describing the REST attempt.
+        reason = stats_reason or (
+            f"table introspection returned no columns (REST /tables HTTP {resp.status_code})"
+        )
+        return [], [], reason
 
     def _get_tables_via_column_stats(self, workspace_id: str, dataset_id: str) -> tuple:
+        """Back-compat wrapper: (tables, relationships) without the reason."""
+        tables, rels, _ = self._get_tables_via_column_stats_with_reason(
+            workspace_id, dataset_id
+        )
+        return tables, rels
+
+    def _get_tables_via_column_stats_with_reason(self, workspace_id: str, dataset_id: str) -> tuple:
         """
         Get table/column metadata using DAX COLUMNSTATISTICS() function.
         Works for most imported and DirectQuery datasets.
 
         Returns:
-            tuple: (tables_list, relationships_list) - relationships always empty for this method
+            tuple: (tables_list, relationships_list, reason_or_None) - relationships
+                   always empty for this method; reason is None on success, else a
+                   short diagnostic (the Power BI error, or "empty result").
         """
         import logging
 
@@ -493,7 +550,7 @@ class PowerBIClient(DataSourceClient):
             stats_dax = "EVALUATE COLUMNSTATISTICS()"
             stats_df = self._execute_dax_internal(workspace_id, dataset_id, stats_dax)
             if stats_df.empty:
-                return [], []
+                return [], [], "COLUMNSTATISTICS returned no rows"
 
             # Build tables structure from column stats
             tables_dict: Dict[str, Dict] = {}
@@ -518,11 +575,22 @@ class PowerBIClient(DataSourceClient):
                 })
 
             # No relationships available via COLUMNSTATISTICS
-            return list(tables_dict.values()), []
+            if not tables_dict:
+                return [], [], "COLUMNSTATISTICS returned only system tables"
+            return list(tables_dict.values()), [], None
 
         except Exception as e:
             logging.warning(f"COLUMNSTATISTICS failed for dataset {dataset_id}: {e}")
-            return [], []
+            return [], [], f"COLUMNSTATISTICS failed: {self._short_error(e)}"
+
+    @staticmethod
+    def _short_error(e: Exception) -> str:
+        """Condense a raised error into a short, log-safe reason. Surfaces the
+        Power BI permission signal (401/403 → Build permission) when present."""
+        msg = str(e)
+        if "HTTP 401" in msg or "HTTP 403" in msg:
+            return "not authorized to query (Build permission required, or RLS with no effective identity)"
+        return msg[:200]
 
     def _get_tables_via_admin_scan(self, workspace_id: str, dataset_id: str) -> tuple:
         """
@@ -720,6 +788,9 @@ class PowerBIClient(DataSourceClient):
         if self._schemas_cache is not None and not force_refresh:
             return self._schemas_cache
 
+        # Fresh crawl → reset per-run diagnostics.
+        self.discovery_diagnostics = []
+
         workspaces = self.list_workspaces()
         tables: List[Table] = []
 
@@ -745,11 +816,14 @@ class PowerBIClient(DataSourceClient):
                 except Exception:
                     ws_reports[ws["id"]] = []
 
-        # Collect all (workspace, dataset) pairs
+        # Collect all (workspace, dataset) pairs, skipping Power BI's built-in
+        # usage-metrics / system semantic models (they are not real data).
         all_ds_tasks: List[Tuple[Dict, Dict, str]] = []
         for ws in workspaces:
             ws_id = ws.get("id")
             for ds in ws_datasets.get(ws_id, []):
+                if self._is_system_dataset(ds.get("name")):
+                    continue
                 all_ds_tasks.append((ws, ds, ws_id))
 
         # Phase 2: Try batch admin scan for all workspaces (tables + relationships in bulk)
@@ -760,15 +834,23 @@ class PowerBIClient(DataSourceClient):
         except Exception as e:
             logging.debug(f"Batch admin scan unavailable, falling back to COLUMNSTATISTICS: {e}")
 
-        # Phase 3: For datasets not covered by admin scan, use parallel COLUMNSTATISTICS
+        # Phase 3: For datasets the admin scan did not cover WITH TABLES, use
+        # parallel COLUMNSTATISTICS. A dataset can appear in the admin-scan
+        # results with an EMPTY table list (model not refreshed since enhanced
+        # metadata scanning was enabled, all-hidden tables, some DirectLake
+        # models). Treating "present in scan" as final would shadow the DAX
+        # fallback that often *can* read it — so fall through on an empty scan
+        # result, not just a missing one.
         ds_table_results: Dict[str, tuple] = {}  # "ws_id:ds_id" -> (tables, relationships)
+        ds_reasons: Dict[str, str] = {}          # "ws_id:ds_id" -> why no tables
         fallback_tasks = []
 
         for ws, ds, ws_id in all_ds_tasks:
             ds_id = ds.get("id")
             key = f"{ws_id}:{ds_id}"
-            if ds_id in admin_scan_results:
-                ds_table_results[key] = admin_scan_results[ds_id]
+            scan_tables, scan_rels = admin_scan_results.get(ds_id, ([], []))
+            if scan_tables:
+                ds_table_results[key] = (scan_tables, scan_rels)
             else:
                 fallback_tasks.append((ws, ds, ws_id, key))
 
@@ -777,14 +859,18 @@ class PowerBIClient(DataSourceClient):
                 tbl_futures = {}
                 for ws, ds, ws_id, key in fallback_tasks:
                     ds_id = ds.get("id")
-                    tbl_futures[pool.submit(self.get_dataset_tables, ws_id, ds_id)] = key
+                    tbl_futures[pool.submit(self.get_dataset_tables_with_reason, ws_id, ds_id)] = key
 
                 for fut in as_completed(tbl_futures):
                     key = tbl_futures[fut]
                     try:
-                        ds_table_results[key] = fut.result()
-                    except Exception:
+                        tbls, rels, reason = fut.result()
+                        ds_table_results[key] = (tbls, rels)
+                        if not tbls and reason:
+                            ds_reasons[key] = reason
+                    except Exception as e:
                         ds_table_results[key] = ([], [])
+                        ds_reasons[key] = f"introspection error: {self._short_error(e)}"
 
         # Phase 4: Assemble Table objects (CPU-only, no I/O)
         for ws, ds, ws_id in all_ds_tasks:
@@ -807,6 +893,21 @@ class PowerBIClient(DataSourceClient):
                     })
 
             ds_tables, ds_relationships = ds_table_results.get(key, ([], []))
+
+            # Found-but-unreadable: the dataset was listed but no introspection
+            # path produced tables. Record it as a diagnostic (surfaced on the
+            # indexing job) instead of silently dropping the semantic model.
+            # We deliberately do NOT emit a phantom table — a column-less table
+            # is not queryable and would just move the failure downstream.
+            if not ds_tables:
+                self.discovery_diagnostics.append({
+                    "datasetId": ds_id,
+                    "datasetName": ds_name,
+                    "workspaceId": ws_id,
+                    "workspaceName": ws_name,
+                    "reason": ds_reasons.get(key, "no tables discovered"),
+                })
+                continue
 
             # Create one BOW Table per internal Power BI table
             for tbl in ds_tables:
@@ -892,6 +993,21 @@ class PowerBIClient(DataSourceClient):
 
         self._schemas_cache = tables
         return tables
+
+    def index_stats(self) -> dict:
+        """Fold discovery diagnostics into the indexing row so the job can
+        report semantic models that were found-but-unreadable (no Build
+        permission, RLS, DirectLake, ...) instead of them vanishing silently.
+
+        Empty when every listed dataset was introspected successfully.
+        """
+        diags = self.discovery_diagnostics or []
+        if not diags:
+            return {}
+        return {
+            "unreadable_datasets": diags,
+            "unreadable_dataset_count": len(diags),
+        }
 
     def get_schema(self, table_name: str) -> Table:
         """

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -528,12 +528,22 @@ class ConnectionIndexingService:
                 item_count = len(items) if items else 0
                 elapsed_s = round(time.perf_counter() - start, 3)
                 count_key = "tool_count" if is_tool_provider else "table_count"
-                fresh.stats_json = {
+                # Datasets/tables that were found but could not be introspected
+                # (e.g. Power BI models with no Build permission / RLS). Captured
+                # by refresh_schema on the service instance; report them on the
+                # job so admins can see what was skipped and why, rather than the
+                # models silently disappearing from the catalog.
+                unreadable = list(getattr(svc, "last_discovery_diagnostics", []) or [])
+                stats_json = {
                     count_key: item_count,
                     "synced_domains": synced_domains,
                     "elapsed_s": elapsed_s,
                     **extra_stats,  # source_bytes / file_count / row_count for file sources
                 }
+                if unreadable:
+                    stats_json["unreadable_datasets"] = unreadable
+                    stats_json["unreadable_dataset_count"] = len(unreadable)
+                fresh.stats_json = stats_json
                 # Ensure progress_done == progress_total so the UI settles at 100%.
                 if fresh.progress_total and fresh.progress_done < fresh.progress_total:
                     fresh.progress_done = fresh.progress_total
@@ -548,6 +558,17 @@ class ConnectionIndexingService:
                     f"Completed: {item_count} {item_label} in {elapsed_s}s{size_note}",
                     done=item_count, total=item_count,
                 )
+                if unreadable:
+                    _names = ", ".join(
+                        str(d.get("datasetName") or d.get("name") or d.get("datasetId"))
+                        for d in unreadable[:5]
+                    )
+                    _more = "" if len(unreadable) <= 5 else f" (+{len(unreadable) - 5} more)"
+                    await _append_event(
+                        "warn", _state_snapshot()["phase"],
+                        f"{len(unreadable)} semantic model(s) found but not readable "
+                        f"(check permissions): {_names}{_more}",
+                    )
 
         except IndexingCancelled:
             # A cancel that surfaced outside the inner handlers — treat as a

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1071,6 +1071,31 @@ class ConnectionService:
             if fresh_tables and len(fresh_tables) > 0:
                 logger.info(f"refresh_schema: First table name: {getattr(fresh_tables[0], 'name', 'N/A')}")
 
+            # Discovery diagnostics: semantic models/tables that were listed but
+            # could not be introspected (e.g. Power BI datasets with no Build
+            # permission / RLS / DirectLake). Surface them on the indexing job
+            # (stashed on this service instance, read by the indexing runner)
+            # and in the logs, instead of letting them vanish without a trace.
+            self.last_discovery_diagnostics = []
+            try:
+                _stats = client.index_stats() if hasattr(client, "index_stats") else {}
+                unreadable = (_stats or {}).get("unreadable_datasets") or []
+                if unreadable:
+                    self.last_discovery_diagnostics = unreadable
+                    _summary = "; ".join(
+                        f"{d.get('datasetName') or d.get('name')} "
+                        f"({d.get('workspaceName') or d.get('workspaceId')}): {d.get('reason')}"
+                        for d in unreadable[:10]
+                    )
+                    logger.warning(
+                        "refresh_schema: %d semantic model(s) on connection %s were "
+                        "found but not readable and were not indexed: %s",
+                        len(unreadable), connection.id, _summary,
+                    )
+            except Exception:
+                # Diagnostics are best-effort — never fail a refresh over them.
+                pass
+
             if not fresh_tables:
                 logger.warning(f"refresh_schema: No tables returned from get_schemas()")
                 return []

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3402,7 +3402,21 @@ class DataSourceService:
                 # Already have a canonical row for this table (by dataset/table
                 # identity first, then by display name)? Reuse it — no dup.
                 if dt_key is not None and dt_key in canonical_by_dataset_table:
-                    canonical_by_name.setdefault(table_name, canonical_by_dataset_table[dt_key])
+                    existing_row = canonical_by_dataset_table[dt_key]
+                    # A dataset/table rename keeps the same (datasetId, tableName)
+                    # identity but a new display name. Refresh the display name so
+                    # the selector (which renders DataSourceTable.name) shows the
+                    # current name instead of the stale one — but only for
+                    # user-discovered (unlinked) rows; an SP-linked row's name is
+                    # owned by the service-principal crawl.
+                    if (
+                        existing_row.connection_table_id is None
+                        and table_name
+                        and existing_row.name != table_name
+                    ):
+                        existing_row.name = table_name
+                        db.add(existing_row)
+                    canonical_by_name.setdefault(table_name, existing_row)
                     continue
                 if table_name in canonical_by_name:
                     continue

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3343,40 +3343,88 @@ class DataSourceService:
         now = datetime.now(timezone.utc)
         # Load canonical mapping to link if present
         existing_q = await db.execute(select(DataSourceTable).where(DataSourceTable.datasource_id == data_source.id))
-        canonical_by_name = {row.name: row for row in existing_q.scalars().all()}
+        existing_canonical = list(existing_q.scalars().all())
+        canonical_by_name = {row.name: row for row in existing_canonical}
 
-        # For per-user-owned catalogs (OneDrive, personal Drive) there's no
-        # admin-side sync to populate DataSourceTable — the rows would never
-        # exist. The /full_schema endpoint reads from DataSourceTable, so
-        # without canonical rows the UI shows "0 files" even after the user
-        # successfully fetched 14. Create canonical rows on-demand from
-        # whatever the first user's sync returned. Subsequent users' rows
-        # union into the same canonical set; per-user accessibility is still
-        # enforced by UserOverlayTable.
+        def _dataset_table_key(meta) -> tuple | None:
+            """Stable identity for a Power BI table independent of display name:
+            (datasetId, tableName). Lets a user's row match an existing canonical
+            row even if the dataset was renamed or two datasets share a name."""
+            try:
+                pbi = (meta or {}).get("powerbi") if isinstance(meta, dict) else None
+                if pbi and pbi.get("datasetId") and pbi.get("tableName"):
+                    return (str(pbi["datasetId"]), str(pbi["tableName"]))
+            except Exception:
+                pass
+            return None
+
+        canonical_by_dataset_table = {}
+        for row in existing_canonical:
+            k = _dataset_table_key(getattr(row, "metadata_json", None))
+            if k is not None:
+                canonical_by_dataset_table.setdefault(k, row)
+
+        # Decide whether this connection's catalog should be UNIONED with the
+        # user's own discovery (create canonical rows on demand from the user's
+        # sync) rather than intersected with the admin/SP catalog:
+        #
+        #   - per_user catalogs (OneDrive, personal Drive): there is no admin
+        #     sync at all — the canonical rows would never exist otherwise.
+        #   - user_required (delegated/OBO) shared catalogs (Power BI, Fabric):
+        #     a model the user's own token can see but the service principal
+        #     cannot must still be selectable. Without the on-demand row the
+        #     overlay link stays NULL and the table is filtered out of the
+        #     selector — the reported "missing semantic models" bug.
+        #
+        # Either way one org-level canonical row per table is created (keyed by
+        # dataset/table identity), so usage/instructions aggregate across users;
+        # per-user visibility stays enforced by UserOverlayTable.
+        union_user_discovery = False
         is_per_user_catalog = False
         try:
             from app.schemas.data_source_registry import get_entry
             conn = (data_source.connections or [None])[0]
             if conn is not None:
                 is_per_user_catalog = get_entry(conn.type).catalog_ownership == "per_user"
+                is_delegated = (conn.auth_policy or "system_only") == "user_required"
+                union_user_discovery = is_per_user_catalog or is_delegated
         except Exception:
             pass
-        if is_per_user_catalog:
+        if union_user_discovery:
+            # per_user catalogs (OneDrive/Drive) auto-activate the user's fetched
+            # files, as before. Delegated shared catalogs (Power BI/Fabric) create
+            # the row inactive — the user selects it in the wizard, matching how
+            # SP-discovered tables start.
+            new_row_active = is_per_user_catalog
             for table_name, payload in normalized.items():
+                meta = payload.get("metadata_json")
+                dt_key = _dataset_table_key(meta)
+                # Already have a canonical row for this table (by dataset/table
+                # identity first, then by display name)? Reuse it — no dup.
+                if dt_key is not None and dt_key in canonical_by_dataset_table:
+                    canonical_by_name.setdefault(table_name, canonical_by_dataset_table[dt_key])
+                    continue
                 if table_name in canonical_by_name:
                     continue
+                # Tag provenance so the SP's background re-index (which prunes by
+                # ConnectionTable membership) leaves this unlinked, user-sourced
+                # row alone; it survives until no user can access it.
+                row_meta = dict(meta) if isinstance(meta, dict) else {}
+                row_meta.setdefault("discovered_by", "user")
                 row = DataSourceTable(
                     datasource_id=str(data_source.id),
                     name=table_name,
                     columns=payload.get("columns") or [],
                     pks=payload.get("pks") or [],
                     fks=payload.get("fks") or [],
-                    metadata_json=payload.get("metadata_json"),
-                    is_active=True,
+                    metadata_json=row_meta,
+                    is_active=new_row_active,
                 )
                 db.add(row)
                 await db.flush()
                 canonical_by_name[table_name] = row
+                if dt_key is not None:
+                    canonical_by_dataset_table[dt_key] = row
 
         # Load all prior overlay rows for (data_source, user). We need them both to
         # update matches AND to detect tables that disappeared from the latest sync.

--- a/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
+++ b/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
@@ -1,24 +1,29 @@
-"""Reproduction: for a delegated (OBO) Power BI source, a signed-in user's
-selectable tables are the INTERSECTION of their own live fetch and the
-service-principal-seeded canonical catalog.
+"""Delegated (OBO) Power BI: a signed-in user's own-visible semantic models
+must be selectable even when the service-principal catalog lacks them.
 
 Reported symptom: "not all the semantic models are selectable in schema —
-some are missing from the fetch". Even when the user's delegated crawl
-returns a semantic model, it is only selectable if the service principal's
-background indexing produced a canonical row with the SAME name:
-`_upsert_user_overlay` links overlay rows to `DataSourceTable` by name and
-leaves `data_source_table_id = NULL` on a miss, and
+some are missing from the fetch". The selectable set used to be the
+INTERSECTION of the user's delegated crawl and the SP-seeded canonical
+catalog: `_upsert_user_overlay` linked overlay rows to `DataSourceTable` by
+name and left `data_source_table_id = NULL` on a miss, and
 `get_data_source_schema_paginated` scopes a signed-in user to overlay rows
-with `data_source_table_id IS NOT NULL`. Models visible to the user but not
-to the SP (SP not a Member of that workspace, or the SP crawl dropped the
-dataset) are fetched into the overlay and then filtered out of the selector.
+with `data_source_table_id IS NOT NULL`. A model the user could see but the
+SP could not was fetched into the overlay and then filtered out.
+
+Fix 3: for user_required (delegated) connections, `_upsert_user_overlay`
+creates the canonical `DataSourceTable` on demand from the user's crawl
+(tagged `discovered_by="user"`, matched by dataset/table identity) and links
+the overlay to it — so the model is selectable, ONE org-level row backs it
+(usage/instructions aggregate across users), and per-user visibility stays
+enforced by the overlay. SP re-index does not prune it (it prunes only
+ConnectionTable-linked rows).
 
 See docs/feedback-loops/powerbi-missing-semantic-models.md.
 
 Run:
     cd backend
     BOW_DATABASE_URL=sqlite:///db/app.db \
-      python -m pytest tests/e2e/test_powerbi_overlay_intersection_repro.py -v -s --runxfail
+      python -m pytest tests/e2e/test_powerbi_overlay_intersection_repro.py -v -s
 """
 import uuid
 import asyncio
@@ -40,34 +45,35 @@ from app.models.user_connection_credentials import UserConnectionCredentials
 from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable
 from app.services.data_source_service import DataSourceService
 
-XFAIL_REASON = (
-    "known bug: overlay rows without a canonical name match get "
-    "data_source_table_id=NULL and are filtered out of the tables selector; "
-    "see docs/feedback-loops/powerbi-missing-semantic-models.md"
-)
-
 
 def _run(coro):
     return asyncio.run(coro)
 
 
-def _table_payload(name):
-    return {"name": name, "columns": [{"name": "id", "dtype": "int"}],
-            "pks": [], "fks": [], "metadata_json": {}}
+def _table_payload(name, dataset_id, table_name):
+    return {
+        "name": name,
+        "columns": [{"name": "id", "dtype": "int"}],
+        "pks": [], "fks": [],
+        "metadata_json": {"powerbi": {"datasetId": dataset_id, "tableName": table_name}},
+    }
 
 
 class _FakeDelegatedPBIClient:
-    """Stands in for the live Power BI client crawling with the USER's token.
-    The user can see two semantic models; the SP-seeded canonical catalog only
-    contains the first one."""
+    """Stands in for the live Power BI client crawling with a USER's token.
+    Both demo users can see ModelA and ModelB; the SP-seeded canonical catalog
+    only contains ModelA (SP not a Member of ModelB's workspace)."""
 
     async def aget_schemas(self, progress_callback=None, prior_catalog=None):
-        return [_table_payload("ModelA/T1"), _table_payload("ModelB/T2")]
+        return [
+            _table_payload("ModelA/T1", "ds-a", "T1"),
+            _table_payload("ModelB/T2", "ds-b", "T2"),
+        ]
 
 
 async def _seed():
     """Direct DB seeding: this state (delegated token present without a real
-    OAuth round-trip, SP catalog narrower than the user's access) cannot be
+    OAuth round-trip, SP catalog narrower than the users' access) cannot be
     produced through the API in a sandbox without live Entra credentials."""
     suffix = uuid.uuid4().hex[:8]
     async with async_session_maker() as db:
@@ -75,13 +81,16 @@ async def _seed():
         db.add(org)
         await db.flush()
 
-        analyst = User(
-            name="Analyst",
-            email=f"analyst-{suffix}@example.com",
-            hashed_password="x",
-            is_active=True, is_superuser=False, is_verified=True,
-        )
-        db.add(analyst)
+        users = []
+        for uname in ("analyst1", "analyst2"):
+            u = User(
+                name=uname,
+                email=f"{uname}-{suffix}@example.com",
+                hashed_password="x",
+                is_active=True, is_superuser=False, is_verified=True,
+            )
+            db.add(u)
+            users.append(u)
         await db.flush()
 
         conn = Connection(
@@ -114,7 +123,7 @@ async def _seed():
             connection_id=conn.id,
             columns=[{"name": "id", "dtype": "int"}],
             pks=[], fks=[], no_rows=0,
-            metadata_json={},
+            metadata_json={"powerbi": {"datasetId": "ds-a", "tableName": "T1"}},
         )
         db.add(ct)
         await db.flush()
@@ -123,71 +132,88 @@ async def _seed():
             datasource_id=ds.id,
             connection_table_id=ct.id,
             is_active=False,
-            metadata_json={},
+            metadata_json={"powerbi": {"datasetId": "ds-a", "tableName": "T1"}},
             columns=[{"name": "id", "dtype": "int"}],
             pks=[], fks=[], no_rows=0,
         ))
 
-        # The analyst HAS signed in: a real delegated token row exists.
-        cred = UserConnectionCredentials(
-            connection_id=str(conn.id),
-            user_id=str(analyst.id),
-            organization_id=str(org.id),
-            auth_mode="oauth",
-            is_active=True,
-            is_primary=True,
-            last_used_at=datetime.now(timezone.utc),
-        )
-        cred.encrypt_credentials({"access_token": "delegated-token"})
-        db.add(cred)
+        # Both analysts HAVE signed in: real delegated token rows exist.
+        for u in users:
+            cred = UserConnectionCredentials(
+                connection_id=str(conn.id),
+                user_id=str(u.id),
+                organization_id=str(org.id),
+                auth_mode="oauth",
+                is_active=True,
+                is_primary=True,
+                last_used_at=datetime.now(timezone.utc),
+            )
+            cred.encrypt_credentials({"access_token": "delegated-token"})
+            db.add(cred)
 
         await db.commit()
-        return {"org_id": org.id, "ds_id": ds.id, "user_id": analyst.id}
+        return {
+            "org_id": org.id, "ds_id": ds.id,
+            "user_ids": [u.id for u in users],
+        }
 
 
-async def _sync_overlay_and_paginate(ids):
+async def _sync_overlay(ids, user_id):
+    """Run the post-sign-in overlay sync for one user (the OAuth callback path)."""
     svc = DataSourceService()
     async with async_session_maker() as db:
-        org = await db.get(Organization, ids["org_id"])
-        user = await db.get(User, ids["user_id"])
+        user = await db.get(User, user_id)
         ds = (await db.execute(
             select(DataSource)
             .options(selectinload(DataSource.connections))
             .where(DataSource.id == ids["ds_id"])
         )).scalar_one()
-
-        # Post-sign-in overlay sync (what the OAuth callback / refresh runs),
-        # with the user's crawl returning BOTH models.
         fetched = await svc.get_user_data_source_schema(db=db, data_source=ds, user=user)
-        fetched_names = sorted(t.name for t in fetched)
+        return sorted(t.name for t in fetched)
 
-        overlay_rows = (await db.execute(
-            select(UserOverlayTable).where(
-                UserOverlayTable.data_source_id == str(ds.id),
-                UserOverlayTable.user_id == str(user.id),
-                UserOverlayTable.is_accessible.is_(True),
-            )
-        )).scalars().all()
-        overlay = sorted(
-            (r.table_name, r.data_source_table_id is not None) for r in overlay_rows
-        )
 
+async def _paginate(ids, user_id):
+    """What the tables selector shows this user."""
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, user_id)
         resp = await svc.get_data_source_schema_paginated(
             db=db,
             data_source_id=ids["ds_id"],
             organization=org,
-            page=1,
-            page_size=100,
+            page=1, page_size=100,
             include_inactive=True,
             current_user=user,
         )
-        selectable = sorted(t.name for t in resp.tables)
-        return fetched_names, overlay, selectable
+        return sorted(t.name for t in resp.tables)
+
+
+async def _canonical_snapshot(ids):
+    """Return canonical DataSourceTable rows: {name: (discovered_by, id)} and
+    the overlay links per user, to prove aggregation onto ONE org-level row."""
+    async with async_session_maker() as db:
+        rows = (await db.execute(
+            select(DataSourceTable).where(DataSourceTable.datasource_id == str(ids["ds_id"]))
+        )).scalars().all()
+        canonical = {
+            r.name: ((r.metadata_json or {}).get("discovered_by"), str(r.id))
+            for r in rows
+        }
+        overlay = (await db.execute(
+            select(UserOverlayTable).where(
+                UserOverlayTable.data_source_id == str(ids["ds_id"]),
+                UserOverlayTable.is_accessible.is_(True),
+            )
+        )).scalars().all()
+        links = {}
+        for r in overlay:
+            links.setdefault(r.table_name, set()).add(r.data_source_table_id)
+        return canonical, links
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
-def test_user_visible_model_missing_from_sp_catalog_is_still_selectable(monkeypatch):
+def test_user_visible_model_missing_from_sp_catalog_is_selectable(monkeypatch):
     async def _fake_construct_client(self, db, data_source, current_user=None, **kw):
         assert current_user is not None, "overlay sync must run with the user's identity"
         return _FakeDelegatedPBIClient()
@@ -195,22 +221,40 @@ def test_user_visible_model_missing_from_sp_catalog_is_still_selectable(monkeypa
     monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
 
     ids = _run(_seed())
-    fetched, overlay, selectable = _run(_sync_overlay_and_paginate(ids))
-    print(f"\n[repro] user's live fetch returned:   {fetched}")
-    print(f"[repro] overlay rows (name, linked-to-canonical): {overlay}")
-    print(f"[repro] selectable tables in schema:  {selectable}")
+    u1, u2 = ids["user_ids"]
 
-    # Guard: fail for the RIGHT reason — the user's fetch and overlay really
-    # do contain both models before the selector drops one.
-    assert fetched == ["ModelA/T1", "ModelB/T2"]
-    assert ("ModelB/T2", False) in overlay, (
-        "expected the SP-invisible model to land in the overlay without a "
-        "canonical link (the mechanism under test)"
-    )
+    fetched1 = _run(_sync_overlay(ids, u1))
+    selectable1 = _run(_paginate(ids, u1))
+    print(f"\n[fixed] user1 live fetch:  {fetched1}")
+    print(f"[fixed] user1 selectable:  {selectable1}")
 
-    # The invariant (currently violated): every semantic model the signed-in
-    # user's own credentials can see must be selectable for them.
-    assert "ModelB/T2" in selectable, (
-        "model returned by the user's own fetch is not selectable — dropped "
-        "by the overlay∩canonical intersection"
+    # The user's own crawl saw both models...
+    assert fetched1 == ["ModelA/T1", "ModelB/T2"]
+    # ...and BOTH are now selectable — the SP-invisible model included.
+    assert "ModelB/T2" in selectable1, (
+        "model returned by the user's own fetch must be selectable after Fix 3"
     )
+    assert selectable1 == ["ModelA/T1", "ModelB/T2"]
+
+    # A second user signs in and also sees ModelB.
+    _run(_sync_overlay(ids, u2))
+
+    canonical, links = _run(_canonical_snapshot(ids))
+    print(f"[fixed] canonical rows (name -> discovered_by,id): {canonical}")
+    print(f"[fixed] overlay links (name -> set of canonical ids): {links}")
+
+    # ModelB now has exactly ONE org-level canonical row, created from user
+    # discovery (provenance tagged) — not one per user.
+    assert set(canonical) == {"ModelA/T1", "ModelB/T2"}
+    assert canonical["ModelB/T2"][0] == "user", "user-discovered row must be tagged"
+    assert canonical["ModelA/T1"][0] != "user", "SP-seeded row keeps its provenance"
+
+    # Usage aggregation: both users' overlay rows for ModelB point at the SAME
+    # canonical id (a single non-NULL link), so usage/instructions keyed on the
+    # canonical table aggregate across users instead of fragmenting per user.
+    model_b_links = links.get("ModelB/T2", set())
+    assert None not in model_b_links, "overlay link must be populated, not NULL"
+    assert len(model_b_links) == 1, (
+        f"both users must link to one canonical ModelB row, got {model_b_links}"
+    )
+    assert next(iter(model_b_links)) == canonical["ModelB/T2"][1]

--- a/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
+++ b/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
@@ -1,0 +1,216 @@
+"""Reproduction: for a delegated (OBO) Power BI source, a signed-in user's
+selectable tables are the INTERSECTION of their own live fetch and the
+service-principal-seeded canonical catalog.
+
+Reported symptom: "not all the semantic models are selectable in schema —
+some are missing from the fetch". Even when the user's delegated crawl
+returns a semantic model, it is only selectable if the service principal's
+background indexing produced a canonical row with the SAME name:
+`_upsert_user_overlay` links overlay rows to `DataSourceTable` by name and
+leaves `data_source_table_id = NULL` on a miss, and
+`get_data_source_schema_paginated` scopes a signed-in user to overlay rows
+with `data_source_table_id IS NOT NULL`. Models visible to the user but not
+to the SP (SP not a Member of that workspace, or the SP crawl dropped the
+dataset) are fetched into the overlay and then filtered out of the selector.
+
+See docs/feedback-loops/powerbi-missing-semantic-models.md.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_powerbi_overlay_intersection_repro.py -v -s --runxfail
+"""
+import uuid
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+from app.models.user_connection_credentials import UserConnectionCredentials
+from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable
+from app.services.data_source_service import DataSourceService
+
+XFAIL_REASON = (
+    "known bug: overlay rows without a canonical name match get "
+    "data_source_table_id=NULL and are filtered out of the tables selector; "
+    "see docs/feedback-loops/powerbi-missing-semantic-models.md"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _table_payload(name):
+    return {"name": name, "columns": [{"name": "id", "dtype": "int"}],
+            "pks": [], "fks": [], "metadata_json": {}}
+
+
+class _FakeDelegatedPBIClient:
+    """Stands in for the live Power BI client crawling with the USER's token.
+    The user can see two semantic models; the SP-seeded canonical catalog only
+    contains the first one."""
+
+    async def aget_schemas(self, progress_callback=None, prior_catalog=None):
+        return [_table_payload("ModelA/T1"), _table_payload("ModelB/T2")]
+
+
+async def _seed():
+    """Direct DB seeding: this state (delegated token present without a real
+    OAuth round-trip, SP catalog narrower than the user's access) cannot be
+    produced through the API in a sandbox without live Entra credentials."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"PBI Overlay Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        analyst = User(
+            name="Analyst",
+            email=f"analyst-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True, is_superuser=False, is_verified=True,
+        )
+        db.add(analyst)
+        await db.flush()
+
+        conn = Connection(
+            organization_id=org.id,
+            name=f"PowerBI {suffix}",
+            type="powerbi",
+            config={},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+        )
+        conn.encrypt_credentials({"tenant_id": "t", "client_id": "c", "client_secret": "s"})
+        db.add(conn)
+        await db.flush()
+
+        ds = DataSource(
+            name=f"PBI DS {suffix}",
+            organization_id=org.id,
+            is_active=True,
+        )
+        db.add(ds)
+        await db.flush()
+        await db.execute(domain_connection.insert().values(
+            data_source_id=ds.id, connection_id=conn.id,
+        ))
+
+        # Canonical catalog seeded by the SERVICE PRINCIPAL's crawl: it only
+        # saw ModelA (e.g. the SP is not a Member of ModelB's workspace).
+        ct = ConnectionTable(
+            name="ModelA/T1",
+            connection_id=conn.id,
+            columns=[{"name": "id", "dtype": "int"}],
+            pks=[], fks=[], no_rows=0,
+            metadata_json={},
+        )
+        db.add(ct)
+        await db.flush()
+        db.add(DataSourceTable(
+            name="ModelA/T1",
+            datasource_id=ds.id,
+            connection_table_id=ct.id,
+            is_active=False,
+            metadata_json={},
+            columns=[{"name": "id", "dtype": "int"}],
+            pks=[], fks=[], no_rows=0,
+        ))
+
+        # The analyst HAS signed in: a real delegated token row exists.
+        cred = UserConnectionCredentials(
+            connection_id=str(conn.id),
+            user_id=str(analyst.id),
+            organization_id=str(org.id),
+            auth_mode="oauth",
+            is_active=True,
+            is_primary=True,
+            last_used_at=datetime.now(timezone.utc),
+        )
+        cred.encrypt_credentials({"access_token": "delegated-token"})
+        db.add(cred)
+
+        await db.commit()
+        return {"org_id": org.id, "ds_id": ds.id, "user_id": analyst.id}
+
+
+async def _sync_overlay_and_paginate(ids):
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, ids["user_id"])
+        ds = (await db.execute(
+            select(DataSource)
+            .options(selectinload(DataSource.connections))
+            .where(DataSource.id == ids["ds_id"])
+        )).scalar_one()
+
+        # Post-sign-in overlay sync (what the OAuth callback / refresh runs),
+        # with the user's crawl returning BOTH models.
+        fetched = await svc.get_user_data_source_schema(db=db, data_source=ds, user=user)
+        fetched_names = sorted(t.name for t in fetched)
+
+        overlay_rows = (await db.execute(
+            select(UserOverlayTable).where(
+                UserOverlayTable.data_source_id == str(ds.id),
+                UserOverlayTable.user_id == str(user.id),
+                UserOverlayTable.is_accessible.is_(True),
+            )
+        )).scalars().all()
+        overlay = sorted(
+            (r.table_name, r.data_source_table_id is not None) for r in overlay_rows
+        )
+
+        resp = await svc.get_data_source_schema_paginated(
+            db=db,
+            data_source_id=ids["ds_id"],
+            organization=org,
+            page=1,
+            page_size=100,
+            include_inactive=True,
+            current_user=user,
+        )
+        selectable = sorted(t.name for t in resp.tables)
+        return fetched_names, overlay, selectable
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+def test_user_visible_model_missing_from_sp_catalog_is_still_selectable(monkeypatch):
+    async def _fake_construct_client(self, db, data_source, current_user=None, **kw):
+        assert current_user is not None, "overlay sync must run with the user's identity"
+        return _FakeDelegatedPBIClient()
+
+    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
+
+    ids = _run(_seed())
+    fetched, overlay, selectable = _run(_sync_overlay_and_paginate(ids))
+    print(f"\n[repro] user's live fetch returned:   {fetched}")
+    print(f"[repro] overlay rows (name, linked-to-canonical): {overlay}")
+    print(f"[repro] selectable tables in schema:  {selectable}")
+
+    # Guard: fail for the RIGHT reason — the user's fetch and overlay really
+    # do contain both models before the selector drops one.
+    assert fetched == ["ModelA/T1", "ModelB/T2"]
+    assert ("ModelB/T2", False) in overlay, (
+        "expected the SP-invisible model to land in the overlay without a "
+        "canonical link (the mechanism under test)"
+    )
+
+    # The invariant (currently violated): every semantic model the signed-in
+    # user's own credentials can see must be selectable for them.
+    assert "ModelB/T2" in selectable, (
+        "model returned by the user's own fetch is not selectable — dropped "
+        "by the overlay∩canonical intersection"
+    )

--- a/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
+++ b/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
@@ -71,6 +71,17 @@ class _FakeDelegatedPBIClient:
         ]
 
 
+class _FakeRenamedModelBClient:
+    """Same datasets, but ModelB's dataset has been RENAMED (same datasetId
+    ds-b, new display name). Identity (datasetId, tableName) is unchanged."""
+
+    async def aget_schemas(self, progress_callback=None, prior_catalog=None):
+        return [
+            _table_payload("ModelA/T1", "ds-a", "T1"),
+            _table_payload("RenamedB/T2", "ds-b", "T2"),
+        ]
+
+
 async def _seed():
     """Direct DB seeding: this state (delegated token present without a real
     OAuth round-trip, SP catalog narrower than the users' access) cannot be
@@ -258,3 +269,40 @@ def test_user_visible_model_missing_from_sp_catalog_is_selectable(monkeypatch):
         f"both users must link to one canonical ModelB row, got {model_b_links}"
     )
     assert next(iter(model_b_links)) == canonical["ModelB/T2"][1]
+
+
+@pytest.mark.e2e
+def test_user_discovered_model_rename_updates_canonical_name(monkeypatch):
+    """A dataset/table rename keeps its (datasetId, tableName) identity but gets
+    a new display name. The user-discovered canonical row must adopt the new
+    name (so the selector shows it), not stay stuck on the old one — while
+    remaining ONE row (matched by identity, no duplicate)."""
+    clients = {"impl": _FakeDelegatedPBIClient()}
+
+    async def _fake_construct_client(self, db, data_source, current_user=None, **kw):
+        return clients["impl"]
+
+    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
+
+    ids = _run(_seed())
+    u1 = ids["user_ids"][0]
+
+    # First sign-in: ModelB discovered under its original name.
+    _run(_sync_overlay(ids, u1))
+    assert "ModelB/T2" in _run(_paginate(ids, u1))
+
+    # Dataset renamed upstream; the same user re-syncs.
+    clients["impl"] = _FakeRenamedModelBClient()
+    _run(_sync_overlay(ids, u1))
+
+    selectable = _run(_paginate(ids, u1))
+    canonical, _ = _run(_canonical_snapshot(ids))
+    print(f"\n[fixed] selectable after rename: {selectable}")
+    print(f"[fixed] canonical rows after rename: {sorted(canonical)}")
+
+    # New name is selectable; stale name is gone; still exactly one ModelB-ish row.
+    assert "RenamedB/T2" in selectable
+    assert "ModelB/T2" not in selectable
+    assert "RenamedB/T2" in canonical and "ModelB/T2" not in canonical
+    # ModelA untouched; catalog didn't grow a duplicate for the renamed dataset.
+    assert set(canonical) == {"ModelA/T1", "RenamedB/T2"}

--- a/backend/tests/unit/test_powerbi_missing_models_repro.py
+++ b/backend/tests/unit/test_powerbi_missing_models_repro.py
@@ -1,31 +1,30 @@
-"""Reproduction: Power BI semantic models silently missing from get_schemas().
+"""Power BI semantic models missing from get_schemas() — reproduction + fix.
 
 Reported symptom: "not all the semantic models are selectable in schema —
 some are missing from the fetch". The selectable catalog is whatever
 PowerBIClient.get_schemas() emits, and a dataset whose table discovery comes
-back empty produces ZERO schema rows — the whole semantic model vanishes with
-no error surfaced (docs/feedback-loops/powerbi-missing-semantic-models.md).
+back empty produced ZERO schema rows AND no signal — the whole semantic model
+vanished (docs/feedback-loops/powerbi-missing-semantic-models.md).
 
-Two drop mechanisms are pinned here, both at the HTTP boundary (the fake
-below stands in for api.powerbi.com only — all client logic runs real):
+Two mechanisms are pinned here, both at the HTTP boundary (the fake below
+stands in for api.powerbi.com only — all client logic runs real):
 
 1. Admin-scan shadowing: _batch_admin_scan records an entry for EVERY dataset
    in the scan result, including ones the Scanner API returned no schema for
    (not refreshed since enhanced-metadata scanning was enabled, DirectLake,
-   all-hidden models). get_schemas() then treats "covered by admin scan" as
-   final and never tries the COLUMNSTATISTICS fallback for those datasets
-   (powerbi_client.py — `if ds_id in admin_scan_results`), even when the
-   fallback would have worked.
+   all-hidden models). get_schemas() used to treat "covered by admin scan" as
+   final and never try the COLUMNSTATISTICS fallback for those datasets.
+   FIX: fall through to COLUMNSTATISTICS on an EMPTY scan result, not just a
+   missing one — the model is discovered.
 
-2. Fallback failure is silent: without admin rights, discovery rests on
+2. Unreadable datasets: without admin rights, discovery rests on
    COLUMNSTATISTICS via executeQueries, which needs Build permission and
-   fails for RLS/DirectLake/Viewer-only models. The failure is swallowed
-   (`([], [])`) and the REST /tables fallback only answers for Push datasets,
-   so the dataset ends up with no rows — invisible in the schema, no signal.
-
-The invariant asserted (and currently violated, hence strict xfail): every
-dataset the identity can LIST must be represented in the emitted schema —
-that is what makes a semantic model selectable at all.
+   fails for RLS/DirectLake/Viewer-only models. This one legitimately yields
+   no columns, so it must NOT become a phantom (column-less, unqueryable)
+   table — but it must ALSO not vanish silently. FIX: record it in
+   `discovery_diagnostics` / `index_stats()` with a reason, so the indexing
+   job can report "found but not readable" instead of dropping it without a
+   trace.
 """
 from __future__ import annotations
 
@@ -36,11 +35,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.data_sources.clients.powerbi_client import PowerBIClient
-
-XFAIL_REASON = (
-    "known bug: datasets with no discoverable tables are silently dropped from "
-    "get_schemas(); see docs/feedback-loops/powerbi-missing-semantic-models.md"
-)
 
 
 def _resp(status: int, payload=None):
@@ -120,10 +114,9 @@ def _no_sleep(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda *_: None)
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
 def test_admin_scan_entry_without_schema_must_not_shadow_fallback():
-    """A dataset the admin scan covers but returns NO schema for must still be
-    discovered via the COLUMNSTATISTICS fallback (which works for it)."""
+    """Fix 1: a dataset the admin scan covers but returns NO schema for must
+    still be discovered via the COLUMNSTATISTICS fallback (which works for it)."""
     http = _FakePowerBIHttp()
     _wire_tenant(http, [
         {"id": "d1", "name": "CoveredModel"},
@@ -144,28 +137,28 @@ def test_admin_scan_entry_without_schema_must_not_shadow_fallback():
             ],
         }]
     }))
-    # The DAX fallback CAN read d2 — but current code never tries it.
+    # The DAX fallback CAN read d2 — the fix must now try it.
     http.route("POST", "/groups/ws1/datasets/d2/executeQueries", _colstats_resp(["Facts"]))
 
     client = _mk_client(http)
     names = sorted(t.name for t in client.get_schemas())
-    print(f"\n[repro] emitted schema tables: {names}")
-    print(f"[repro] COLUMNSTATISTICS attempted for d2: "
+    print(f"\n[fixed] emitted schema tables: {names}")
+    print(f"[fixed] COLUMNSTATISTICS attempted for d2: "
           f"{http.attempted('POST', 'datasets/d2/executeQueries')}")
 
     assert "ShadowedModel/Facts" in names, (
-        "dataset covered by the admin scan without schema was dropped instead "
-        "of falling back to COLUMNSTATISTICS"
+        "empty admin-scan result must fall through to COLUMNSTATISTICS, not shadow it"
     )
+    assert "CoveredModel/Sales" in names  # the non-empty scan result still works
+    assert http.attempted("POST", "datasets/d2/executeQueries")
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
-def test_unintrospectable_dataset_is_still_represented_in_schema():
-    """Without admin-scan rights, a dataset whose COLUMNSTATISTICS probe is
-    forbidden (no Build permission / RLS / DirectLake) and that is not a Push
-    dataset must not silently vanish from the schema — it is a semantic model
-    the identity can list, and it should remain visible/selectable (or at
-    minimum the failure surfaced), not disappear without a trace."""
+def test_unintrospectable_dataset_reported_not_dropped_and_not_phantom():
+    """Fix 2: a dataset whose introspection is forbidden (no Build permission /
+    RLS / DirectLake) and that is not a Push dataset must NOT become a
+    phantom column-less table, but must ALSO NOT vanish silently — it is
+    recorded in discovery_diagnostics / index_stats() with a reason so the
+    indexing job can report it."""
     http = _FakePowerBIHttp()
     _wire_tenant(http, [
         {"id": "d1", "name": "UnreadableModel"},
@@ -185,28 +178,51 @@ def test_unintrospectable_dataset_is_still_represented_in_schema():
     client = _mk_client(http)
     tables = client.get_schemas()
     names = sorted(t.name for t in tables)
-    print(f"\n[repro] emitted schema tables: {names}")
+    diagnostics = client.index_stats().get("unreadable_datasets", [])
+    diag_names = sorted(d["datasetName"] for d in diagnostics)
+    print(f"\n[fixed] emitted schema tables: {names}")
+    print(f"[fixed] unreadable diagnostics: {[(d['datasetName'], d['reason']) for d in diagnostics]}")
 
-    # The readable model is fine — proves discovery itself ran.
-    assert any(n.startswith("ReadableModel/") for n in names)
-    # The invariant (currently violated): the listed-but-unintrospectable
-    # semantic model must still be represented in the emitted schema.
-    assert any(n.startswith("UnreadableModel/") for n in names), (
-        "dataset with failed table introspection was silently dropped from the schema"
-    )
+    # The readable model is present.
+    assert names == ["ReadableModel/Orders"]
+    # The unreadable one is NOT a phantom table...
+    assert not any(n.startswith("UnreadableModel/") for n in names)
+    # ...but IS reported with a reason (not silently dropped).
+    assert diag_names == ["UnreadableModel"]
+    assert diagnostics[0]["datasetId"] == "d1"
+    assert diagnostics[0]["reason"]  # a non-empty human-readable reason
+    assert client.index_stats()["unreadable_dataset_count"] == 1
 
 
-def test_current_behavior_drops_are_silent_no_exception():
-    """Pins the 'silent' part of the bug (passes today): both drop mechanisms
-    complete without raising — the caller gets a smaller schema and no signal.
-    If a fix makes get_schemas raise or annotate instead, revisit alongside
-    the xfail tests above."""
+def test_all_readable_leaves_no_diagnostics():
+    """The diagnostics channel stays empty when every dataset introspects —
+    index_stats() must not fabricate noise on a clean crawl."""
     http = _FakePowerBIHttp()
-    _wire_tenant(http, [{"id": "d1", "name": "UnreadableModel"}])
+    _wire_tenant(http, [{"id": "d1", "name": "GoodModel"}])
     http.route("POST", "/admin/workspaces/getInfo", _resp(401, {}))
-    http.route("POST", "/groups/ws1/datasets/d1/executeQueries", _resp(403, {}))
-    http.route("GET", "/groups/ws1/datasets/d1/tables", _resp(404, {}))
+    http.route("POST", "/groups/ws1/datasets/d1/executeQueries", _colstats_resp(["T"]))
 
     client = _mk_client(http)
-    tables = client.get_schemas()  # must not raise
-    assert tables == []  # the only dataset in the tenant is simply gone
+    names = sorted(t.name for t in client.get_schemas())
+    assert names == ["GoodModel/T"]
+    assert client.index_stats() == {}
+
+
+def test_builtin_usage_metrics_models_are_skipped():
+    """Fix 4: Power BI's built-in usage-metrics system models are not real data
+    and must be skipped in discovery (not emitted, not counted as unreadable)."""
+    http = _FakePowerBIHttp()
+    _wire_tenant(http, [
+        {"id": "d1", "name": "Usage Metrics Report"},
+        {"id": "d2", "name": "Report Usage Metrics Model"},
+        {"id": "d3", "name": "RealModel"},
+    ])
+    http.route("POST", "/admin/workspaces/getInfo", _resp(401, {}))
+    http.route("POST", "/groups/ws1/datasets/d3/executeQueries", _colstats_resp(["Sales"]))
+
+    client = _mk_client(http)
+    names = sorted(t.name for t in client.get_schemas())
+    assert names == ["RealModel/Sales"]
+    # System models are skipped entirely — not surfaced as unreadable either.
+    assert client.index_stats() == {}
+    assert not http.attempted("POST", "datasets/d1/executeQueries")

--- a/backend/tests/unit/test_powerbi_missing_models_repro.py
+++ b/backend/tests/unit/test_powerbi_missing_models_repro.py
@@ -1,0 +1,212 @@
+"""Reproduction: Power BI semantic models silently missing from get_schemas().
+
+Reported symptom: "not all the semantic models are selectable in schema —
+some are missing from the fetch". The selectable catalog is whatever
+PowerBIClient.get_schemas() emits, and a dataset whose table discovery comes
+back empty produces ZERO schema rows — the whole semantic model vanishes with
+no error surfaced (docs/feedback-loops/powerbi-missing-semantic-models.md).
+
+Two drop mechanisms are pinned here, both at the HTTP boundary (the fake
+below stands in for api.powerbi.com only — all client logic runs real):
+
+1. Admin-scan shadowing: _batch_admin_scan records an entry for EVERY dataset
+   in the scan result, including ones the Scanner API returned no schema for
+   (not refreshed since enhanced-metadata scanning was enabled, DirectLake,
+   all-hidden models). get_schemas() then treats "covered by admin scan" as
+   final and never tries the COLUMNSTATISTICS fallback for those datasets
+   (powerbi_client.py — `if ds_id in admin_scan_results`), even when the
+   fallback would have worked.
+
+2. Fallback failure is silent: without admin rights, discovery rests on
+   COLUMNSTATISTICS via executeQueries, which needs Build permission and
+   fails for RLS/DirectLake/Viewer-only models. The failure is swallowed
+   (`([], [])`) and the REST /tables fallback only answers for Push datasets,
+   so the dataset ends up with no rows — invisible in the schema, no signal.
+
+The invariant asserted (and currently violated, hence strict xfail): every
+dataset the identity can LIST must be represented in the emitted schema —
+that is what makes a semantic model selectable at all.
+"""
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.data_sources.clients.powerbi_client import PowerBIClient
+
+XFAIL_REASON = (
+    "known bug: datasets with no discoverable tables are silently dropped from "
+    "get_schemas(); see docs/feedback-loops/powerbi-missing-semantic-models.md"
+)
+
+
+def _resp(status: int, payload=None):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload if payload is not None else {}
+    r.headers = {}
+    r.text = json.dumps(payload) if payload else ""
+    return r
+
+
+class _FakePowerBIHttp:
+    """Stands in for api.powerbi.com. Routes by (method, URL substring) and
+    records every call so tests can observe which endpoints were attempted."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+        self._routes: list[tuple[str, str, object]] = []
+
+    def route(self, method: str, url_substr: str, response) -> None:
+        self._routes.append((method.upper(), url_substr, response))
+
+    def _dispatch(self, method: str, url: str):
+        self.calls.append((method.upper(), url))
+        # Most specific (longest) matching substring wins, so e.g. a route for
+        # "/groups/ws1/datasets/d1/tables" beats the "/groups/ws1/datasets"
+        # dataset-listing route.
+        matches = [
+            (len(sub), response)
+            for m, sub, response in self._routes
+            if m == method.upper() and sub in url
+        ]
+        if matches:
+            return max(matches, key=lambda x: x[0])[1]
+        return _resp(404, {"error": {"code": "ItemNotFound"}})
+
+    # requests.Session surface used by the client
+    def request(self, method, url, json=None, headers=None, timeout=None):
+        return self._dispatch(method, url)
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        return self._dispatch("POST", url)
+
+    def get(self, url, headers=None, timeout=None):
+        return self._dispatch("GET", url)
+
+    def attempted(self, method: str, url_substr: str) -> bool:
+        return any(m == method.upper() and url_substr in u for m, u in self.calls)
+
+
+def _mk_client(http: _FakePowerBIHttp) -> PowerBIClient:
+    c = PowerBIClient(tenant_id="t", client_id="c", client_secret="s", access_token="tok")
+    c._http = http
+    return c
+
+
+def _colstats_resp(table_names):
+    """executeQueries response for EVALUATE COLUMNSTATISTICS()."""
+    rows = [
+        {"[Table Name]": t, "[Column Name]": "id", "[Min]": None,
+         "[Max]": None, "[Cardinality]": 1, "[Max Length]": None}
+        for t in table_names
+    ]
+    return _resp(200, {"results": [{"tables": [{"rows": rows}]}]})
+
+
+def _wire_tenant(http: _FakePowerBIHttp, datasets):
+    """One workspace with the given datasets; no reports."""
+    http.route("GET", "/groups/ws1/datasets", _resp(200, {"value": datasets}))
+    http.route("GET", "/groups/ws1/reports", _resp(200, {"value": []}))
+    http.route("GET", "/groups", _resp(200, {"value": [{"id": "ws1", "name": "Sales"}]}))
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Admin-scan polling sleeps 2s per iteration; irrelevant to the logic."""
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+def test_admin_scan_entry_without_schema_must_not_shadow_fallback():
+    """A dataset the admin scan covers but returns NO schema for must still be
+    discovered via the COLUMNSTATISTICS fallback (which works for it)."""
+    http = _FakePowerBIHttp()
+    _wire_tenant(http, [
+        {"id": "d1", "name": "CoveredModel"},
+        {"id": "d2", "name": "ShadowedModel"},
+    ])
+    # Admin scan succeeds; d1 comes back with schema, d2 with none (e.g. not
+    # refreshed since enhanced-metadata scanning was enabled).
+    http.route("POST", "/admin/workspaces/getInfo", _resp(200, {"id": "scan-1"}))
+    http.route("GET", "/admin/workspaces/scanStatus/scan-1", _resp(200, {"status": "Succeeded"}))
+    http.route("GET", "/admin/workspaces/scanResult/scan-1", _resp(200, {
+        "workspaces": [{
+            "id": "ws1",
+            "datasets": [
+                {"id": "d1", "tables": [
+                    {"name": "Sales", "columns": [{"name": "id", "dataType": "Int64"}]},
+                ]},
+                {"id": "d2"},  # covered by the scan, but no schema returned
+            ],
+        }]
+    }))
+    # The DAX fallback CAN read d2 — but current code never tries it.
+    http.route("POST", "/groups/ws1/datasets/d2/executeQueries", _colstats_resp(["Facts"]))
+
+    client = _mk_client(http)
+    names = sorted(t.name for t in client.get_schemas())
+    print(f"\n[repro] emitted schema tables: {names}")
+    print(f"[repro] COLUMNSTATISTICS attempted for d2: "
+          f"{http.attempted('POST', 'datasets/d2/executeQueries')}")
+
+    assert "ShadowedModel/Facts" in names, (
+        "dataset covered by the admin scan without schema was dropped instead "
+        "of falling back to COLUMNSTATISTICS"
+    )
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+def test_unintrospectable_dataset_is_still_represented_in_schema():
+    """Without admin-scan rights, a dataset whose COLUMNSTATISTICS probe is
+    forbidden (no Build permission / RLS / DirectLake) and that is not a Push
+    dataset must not silently vanish from the schema — it is a semantic model
+    the identity can list, and it should remain visible/selectable (or at
+    minimum the failure surfaced), not disappear without a trace."""
+    http = _FakePowerBIHttp()
+    _wire_tenant(http, [
+        {"id": "d1", "name": "UnreadableModel"},
+        {"id": "d2", "name": "ReadableModel"},
+    ])
+    # No admin rights → batch scan rejected → everything uses the fallback.
+    http.route("POST", "/admin/workspaces/getInfo", _resp(401, {"error": {"code": "Unauthorized"}}))
+    # d1: executeQueries forbidden (no Build permission), and the REST /tables
+    # fallback 404s (only Push datasets answer it).
+    http.route("POST", "/groups/ws1/datasets/d1/executeQueries",
+               _resp(403, {"error": {"code": "PowerBINotAuthorizedException"}}))
+    http.route("GET", "/groups/ws1/datasets/d1/tables",
+               _resp(404, {"error": {"code": "ItemNotFound"}}))
+    # d2: introspection works fine.
+    http.route("POST", "/groups/ws1/datasets/d2/executeQueries", _colstats_resp(["Orders"]))
+
+    client = _mk_client(http)
+    tables = client.get_schemas()
+    names = sorted(t.name for t in tables)
+    print(f"\n[repro] emitted schema tables: {names}")
+
+    # The readable model is fine — proves discovery itself ran.
+    assert any(n.startswith("ReadableModel/") for n in names)
+    # The invariant (currently violated): the listed-but-unintrospectable
+    # semantic model must still be represented in the emitted schema.
+    assert any(n.startswith("UnreadableModel/") for n in names), (
+        "dataset with failed table introspection was silently dropped from the schema"
+    )
+
+
+def test_current_behavior_drops_are_silent_no_exception():
+    """Pins the 'silent' part of the bug (passes today): both drop mechanisms
+    complete without raising — the caller gets a smaller schema and no signal.
+    If a fix makes get_schemas raise or annotate instead, revisit alongside
+    the xfail tests above."""
+    http = _FakePowerBIHttp()
+    _wire_tenant(http, [{"id": "d1", "name": "UnreadableModel"}])
+    http.route("POST", "/admin/workspaces/getInfo", _resp(401, {}))
+    http.route("POST", "/groups/ws1/datasets/d1/executeQueries", _resp(403, {}))
+    http.route("GET", "/groups/ws1/datasets/d1/tables", _resp(404, {}))
+
+    client = _mk_client(http)
+    tables = client.get_schemas()  # must not raise
+    assert tables == []  # the only dataset in the tenant is simply gone

--- a/backend/tests/unit/test_powerbi_missing_models_repro.py
+++ b/backend/tests/unit/test_powerbi_missing_models_repro.py
@@ -6,7 +6,7 @@ PowerBIClient.get_schemas() emits, and a dataset whose table discovery comes
 back empty produced ZERO schema rows AND no signal — the whole semantic model
 vanished (docs/feedback-loops/powerbi-missing-semantic-models.md).
 
-Two mechanisms are pinned here, both at the HTTP boundary (the fake below
+Two silent-drop mechanisms are pinned here, both at the HTTP boundary (the fake below
 stands in for api.powerbi.com only — all client logic runs real):
 
 1. Admin-scan shadowing: _batch_admin_scan records an entry for EVERY dataset
@@ -208,21 +208,21 @@ def test_all_readable_leaves_no_diagnostics():
     assert client.index_stats() == {}
 
 
-def test_builtin_usage_metrics_models_are_skipped():
-    """Fix 4: Power BI's built-in usage-metrics system models are not real data
-    and must be skipped in discovery (not emitted, not counted as unreadable)."""
+def test_no_models_are_hidden_from_discovery():
+    """Discovery hides NOTHING: every listed semantic model — Fabric default
+    models and Microsoft's built-in usage-metrics models alike — is discovered
+    when readable (and reported when not). We do not silently drop models."""
     http = _FakePowerBIHttp()
     _wire_tenant(http, [
         {"id": "d1", "name": "Usage Metrics Report"},
-        {"id": "d2", "name": "Report Usage Metrics Model"},
-        {"id": "d3", "name": "RealModel"},
+        {"id": "d2", "name": "RealModel"},
     ])
     http.route("POST", "/admin/workspaces/getInfo", _resp(401, {}))
-    http.route("POST", "/groups/ws1/datasets/d3/executeQueries", _colstats_resp(["Sales"]))
+    http.route("POST", "/groups/ws1/datasets/d1/executeQueries", _colstats_resp(["Views"]))
+    http.route("POST", "/groups/ws1/datasets/d2/executeQueries", _colstats_resp(["Sales"]))
 
     client = _mk_client(http)
     names = sorted(t.name for t in client.get_schemas())
-    assert names == ["RealModel/Sales"]
-    # System models are skipped entirely — not surfaced as unreadable either.
-    assert client.index_stats() == {}
-    assert not http.attempted("POST", "datasets/d1/executeQueries")
+    assert names == ["RealModel/Sales", "Usage Metrics Report/Views"]
+    # Both were introspected — nothing hidden, nothing dropped.
+    assert http.attempted("POST", "datasets/d1/executeQueries")

--- a/docs/feedback-loops/powerbi-missing-semantic-models.md
+++ b/docs/feedback-loops/powerbi-missing-semantic-models.md
@@ -3,13 +3,11 @@
 Reported against a live Entra tenant (SP-seeded catalog + OBO users): some
 Power BI semantic models that are visible in app.powerbi.com never show up as
 selectable tables in the schema step, with no error anywhere. This loop
-validates the claim that models are **silently dropped** at three independent
-places in the fetch pipeline, and pins each mechanism with a deterministic
-reproduction (no live credentials needed).
+reproduces three independent silent-drop mechanisms, fixes each, and confirms
+the discovery pipeline against the real tenant.
 
-Status: **reproduction only — no fix applied yet.** The invariant tests are
-committed as `strict xfail`; whoever lands the fix flips them to plain asserts
-by deleting the markers.
+Status: **fixed.** The reproduction tests now assert the fixed contract and
+pass (no more strict-xfail markers).
 
 ---
 
@@ -17,54 +15,79 @@ by deleting the markers.
 
 The selectable list is whatever `PowerBIClient.get_schemas()` emits into the
 canonical catalog (plus, for OBO users, an overlay filter on top). A semantic
-model can fall out at each stage:
+model could fall out at each stage:
 
-1. **Admin-scan shadowing** — `_batch_admin_scan` records an entry for every
+1. **Admin-scan shadowing.** `_batch_admin_scan` records an entry for every
    dataset present in the scan result, including datasets the Scanner API
    returned **no schema** for (model not refreshed since enhanced-metadata
-   scanning was enabled, DirectLake, all tables `isHidden`). Because
-   `get_schemas()` treats "dataset id present in admin scan results" as final
-   (`backend/app/data_sources/clients/powerbi_client.py:770-773`), the
-   COLUMNSTATISTICS fallback is **never attempted** for those datasets — even
-   when it would have worked. The model vanishes.
+   scanning was enabled, DirectLake, all tables `isHidden`). `get_schemas()`
+   used to treat "dataset id present in scan results" as final and **never
+   attempt the COLUMNSTATISTICS fallback** for those datasets — even when it
+   would have worked. The model vanished.
 
-2. **Silent fallback failure** — without admin-API rights every dataset relies
-   on `EVALUATE COLUMNSTATISTICS()` via `executeQueries`, which needs **Build**
-   permission and fails for RLS-protected / Viewer-only / some DirectLake
-   models. The failure is swallowed into `([], [])`
-   (`powerbi_client.py:523-525`), the REST `/tables` fallback only answers for
-   Push datasets (`powerbi_client.py:472-477`), and Phase 4 emits rows only by
-   iterating discovered tables (`powerbi_client.py:812`) — a dataset with zero
-   tables produces **zero schema rows and no surfaced error** (a
-   `logging.warning` is the only trace).
+2. **Silent introspection failure.** Without admin-API rights every dataset
+   relies on `EVALUATE COLUMNSTATISTICS()` via `executeQueries`, which needs
+   **Build** permission and fails for RLS-protected / Viewer-only / DirectLake
+   models. The failure was swallowed into `([], [])`, the REST `/tables`
+   fallback only answers for Push datasets, and Phase 4 emits rows only by
+   iterating discovered tables — so a dataset with zero tables produced **zero
+   schema rows and no surfaced error** (a `logging.warning` was the only trace).
 
-3. **Overlay ∩ canonical intersection (OBO)** — for a `user_required` + oauth
-   connection, a signed-in user's selector is scoped to their overlay rows
-   with `data_source_table_id IS NOT NULL`
-   (`backend/app/services/data_source_service.py:2668-2676`), but
-   `_upsert_user_overlay` links overlay rows to canonical `DataSourceTable`
-   rows **by name only** and leaves `NULL` on a miss
-   (`data_source_service.py:3400`). Power BI is a `shared`-catalog connector
-   (`backend/app/schemas/data_source_registry.py:870` — registry default), so
-   the per-user "create canonical rows on demand" escape hatch does not apply.
-   Net effect: a model the user's own token can crawl but the service
-   principal cannot (SP not a Member of that workspace, or dropped by 1/2
-   above) is fetched into the overlay **and then filtered out of the
+3. **Overlay ∩ canonical intersection (OBO).** For a `user_required` + oauth
+   connection, a signed-in user's selector is scoped to overlay rows with
+   `data_source_table_id IS NOT NULL`, but `_upsert_user_overlay` linked
+   overlay rows to canonical `DataSourceTable` rows **by name only** and left
+   `NULL` on a miss. Net effect: a model the user's own token can crawl but the
+   service principal cannot (SP not a Member of that workspace, or dropped by
+   1/2 above) was fetched into the overlay **and then filtered out of the
    selector**.
 
-Additional scoping facts (validated by API semantics, not loop-reproducible):
-`list_workspaces` uses `GET /v1.0/myorg/groups` (`powerbi_client.py:356`),
-which only returns workspaces where the identity holds a workspace role —
-datasets shared directly (dataset-level Build/Read) and "My Workspace" content
-never enter the crawl at all.
+Additional scoping fact (API semantics, not loop-reproducible):
+`list_workspaces` uses `GET /v1.0/myorg/groups`, which only returns workspaces
+where the identity holds a workspace role — datasets shared directly and "My
+Workspace" content never enter the crawl.
 
 ---
 
-## Loop A — deterministic reproduction (no external services)
+## The fix
+
+All in `backend/app/data_sources/clients/powerbi_client.py`,
+`backend/app/services/data_source_service.py`, and the indexing service.
+
+1. **Fix 1 — stop admin-scan shadowing.** `get_schemas()` now accepts an
+   admin-scan result as final only when it returned tables; an **empty** scan
+   result falls through to COLUMNSTATISTICS instead of shadowing it.
+
+2. **Fix 2 — report unreadable models, don't drop or fake them.**
+   `get_dataset_tables_with_reason` / `_get_tables_via_column_stats_with_reason`
+   return *why* introspection failed. A dataset that produced no tables is
+   recorded in `PowerBIClient.discovery_diagnostics` and surfaced via
+   `index_stats()` → the indexing runner writes `unreadable_datasets` (with
+   reasons) into the job's `stats_json` and emits a `warn` event; `refresh_schema`
+   logs a warning. No phantom column-less table is created (it would be
+   unqueryable and just move the failure downstream).
+
+3. **Fix 3 — union user-discovered tables into the canonical catalog.** For
+   `user_required` connections, `_upsert_user_overlay` now creates the canonical
+   `DataSourceTable` on demand from the user's crawl (tagged
+   `discovered_by="user"`, matched by dataset/table identity, created inactive)
+   and links the overlay to it. One org-level row backs the table, so usage /
+   instructions aggregate across users; per-user visibility stays enforced by
+   the overlay; SP re-index does not prune it (it prunes only
+   ConnectionTable-linked rows, and these are intentionally unlinked). This
+   reuses the on-demand pattern that per_user catalogs (OneDrive/Drive) already
+   had; OneDrive's auto-activate behavior is preserved.
+
+4. **Fix 4 — skip built-in system models.** `_is_system_dataset` skips Power
+   BI's auto-created usage-metrics semantic models in discovery so they never
+   pollute the catalog (nor count as "unreadable").
+
+---
+
+## Loop A — deterministic reproduction / fix verification (no external services)
 
 All Power BI HTTP traffic is faked at the `requests.Session` boundary; every
-line of client/service logic runs real. Overlay leg runs on SQLite via the
-standard test harness.
+line of client/service logic runs real. Overlay leg runs on SQLite.
 
 ```bash
 cd backend
@@ -72,91 +95,76 @@ export BOW_DATABASE_URL="sqlite:///db/app.db"
 TESTING=true uv run pytest \
   tests/unit/test_powerbi_missing_models_repro.py \
   tests/e2e/test_powerbi_overlay_intersection_repro.py \
-  -v -s --runxfail
+  -v -s
 ```
 
-**Observed (2026-07-17, current code):**
-
-Mechanism 1 — admin scan covers a dataset with no schema, fallback never tried:
+**Observed after the fix:**
 
 ```
-[repro] emitted schema tables: ['CoveredModel/Sales']
-[repro] COLUMNSTATISTICS attempted for d2: False
-AssertionError: dataset covered by the admin scan without schema was dropped
-                instead of falling back to COLUMNSTATISTICS
-  assert 'ShadowedModel/Facts' in ['CoveredModel/Sales']
+Fix 1  test_admin_scan_entry_without_schema_must_not_shadow_fallback
+       [fixed] emitted schema tables: ['CoveredModel/Sales', 'ShadowedModel/Facts']
+       [fixed] COLUMNSTATISTICS attempted for d2: True
+
+Fix 2  test_unintrospectable_dataset_reported_not_dropped_and_not_phantom
+       [fixed] emitted schema tables: ['ReadableModel/Orders']
+       [fixed] unreadable diagnostics: [('UnreadableModel', 'COLUMNSTATISTICS failed: not authorized ...')]
+       (no phantom 'UnreadableModel/*' table; index_stats() reports it with a reason)
+
+Fix 4  test_builtin_usage_metrics_models_are_skipped -> only ['RealModel/Sales'] emitted
+
+Fix 3  test_user_visible_model_missing_from_sp_catalog_is_selectable
+       [fixed] user1 selectable: ['ModelA/T1', 'ModelB/T2']    # ModelB was SP-invisible
+       [fixed] canonical rows: {'ModelA/T1': (None, ...), 'ModelB/T2': ('user', <id>)}
+       [fixed] both users' overlays link to the SAME ModelB canonical id  # usage aggregates
 ```
 
-Mechanism 2 — COLUMNSTATISTICS forbidden (no Build), not a Push dataset:
+All tests pass. `tests/unit/test_powerbi_client.py` (36) and
+`tests/e2e/test_obo_admin_catalog_before_signin.py` still pass.
 
-```
-WARNING root:powerbi_client.py:524 COLUMNSTATISTICS failed for dataset d1:
-        DAX query failed: HTTP 403 {"error": {"code": "PowerBINotAuthorizedException"}}
-[repro] emitted schema tables: ['ReadableModel/Orders']
-AssertionError: dataset with failed table introspection was silently dropped from the schema
-```
+## Loop B — live confirmation (real Entra tenant)
 
-(`test_current_behavior_drops_are_silent_no_exception` PASSES today — it pins
-that both drops complete without raising: the caller just gets a smaller
-schema.)
+Secrets via env vars only (never committed). Uses the master service principal
+and delegated ROPC tokens for the demo users.
 
-Mechanism 3 — overlay intersection (signed-in OBO user, SP catalog narrower
-than the user's access):
-
-```
-[repro] user's live fetch returned:   ['ModelA/T1', 'ModelB/T2']
-[repro] overlay rows (name, linked-to-canonical): [('ModelA/T1', True), ('ModelB/T2', False)]
-[repro] selectable tables in schema:  ['ModelA/T1']
-AssertionError: model returned by the user's own fetch is not selectable —
-                dropped by the overlay∩canonical intersection
-  assert 'ModelB/T2' in ['ModelA/T1']
+```bash
+export BOW_ENTRA_TENANT_ID=...            # tenant
+export BOW_ENTRA_CLIENT_ID=... BOW_ENTRA_CLIENT_SECRET=...   # OAuth app (user sign-in)
+export BOW_PBI_MASTER_CLIENT_ID=... BOW_PBI_MASTER_CLIENT_SECRET=...  # service principal
 ```
 
-Without `--runxfail` the same run is green (`1 passed, 3 xfailed`) — the
-invariants are recorded as strict xfails so CI stays green until the fix.
+**Observed (2026-07-18):**
 
-## Loop B — live confirmation (optional, real tenant)
+```
+SP get_schemas(): 2 workspaces (BOW, bow-bi); 4 semantic models all discovered
+  SalesPush -> [Sales, Customers]; deals2 -> [...]; leads -> [...]; mySM -> [Docum, D (2)]
+  index_stats(): {}                       # every model readable → no false diagnostics
+_batch_admin_scan(): {} (empty)           # read-only admin API NOT enabled for the SP
+                                          #  → discovery runs entirely on COLUMNSTATISTICS
+                                          #    (the Fix 1 fallthrough path is the active one)
+Delegated ROPC tokens (demo1 AllFabric, demo2 MinimalFabric): both HTTP 200
+  demo1 get_schemas(): 4 models   demo2 get_schemas(): 4 models
+```
 
-Only needed to confirm which mechanism is eating a *specific* model in a real
-tenant. Secrets via env vars only (`BOW_ENTRA_*`, `BOW_PBI_MASTER_*` — same
-set as `fabric-powerbi-obo-creator-zero-tables.md`). Triage per model:
-
-1. Present in `GET /connections/{id}/tables` (canonical, SP view)?
-   - **No**, but visible in app.powerbi.com → mechanism 1/2 on the SP crawl
-     (check backend logs for `COLUMNSTATISTICS failed for dataset …`), or the
-     SP isn't a Member of that workspace (membership scoping).
-   - **Yes**, but missing from a signed-in user's selector → mechanism 3
-     only bites the other direction (user-visible, SP-invisible); check the
-     user's `UserDataSourceTable` rows for `data_source_table_id IS NULL`.
-
-## The fix
-
-Not applied (reproduction requested only). Candidate directions, per
-mechanism:
-
-1. Fall back to COLUMNSTATISTICS whenever the admin scan yielded an **empty**
-   table list for a dataset, not just when the dataset id is absent.
-2. Emit a dataset-level placeholder row (or surface a per-dataset warning in
-   the indexing job) when every introspection path fails, so the model stays
-   visible/selectable instead of disappearing.
-3. Union user-crawled tables into the selector for the overlay identity (or
-   create canonical rows on demand as the `per_user` catalogs already do),
-   instead of intersecting with the SP catalog by name.
-
-When a fix lands: delete the `xfail` markers in the two repro test files and
-re-run Loop A — all four tests must pass.
+**What Loop B proves and what it doesn't.** This tenant's three identities (SP,
+demo1, demo2) are all Members of the same workspace and every model is
+import-mode, so all read cleanly and no divergence appears live — Loop B
+confirms the happy path (auth, discovery, no false diagnostics, delegated
+tokens) and does **not** by itself exercise the three drop mechanisms; Loop A
+covers those deterministically. Crucially, the SP's admin scan being **empty**
+(read-only admin API off) is exactly the configuration under which a customer's
+**DirectLake** models fail COLUMNSTATISTICS — which is why the top operational
+recommendation is to enable the two Fabric admin-portal settings ("Service
+principals can access read-only admin APIs" + "Enhanced admin API responses
+with detailed metadata"); with Fix 1 in place, a schema-less scan entry no
+longer shadows the DAX fallback.
 
 ## What this proves / regression notes
 
-- Datasets are **listed** correctly in every reproduced case — the loss is in
-  table introspection and in the overlay link step, which matches the report
-  ("some are missing from the fetch" while others from the same tenant show
-  up).
-- All three mechanisms are silent by construction: no exception reaches the
-  caller, nothing is surfaced to the UI (mechanism 2 leaves only a
-  `logging.warning`).
-- Pre-existing suites unaffected: `tests/unit/test_powerbi_client.py`
-  (36 passed) on the same run.
-- Sibling loops: `fabric-powerbi-obo-creator-zero-tables.md` (zero tables
-  before first sign-in — different mechanism, already fixed),
+- Datasets are **listed** correctly in every case — the loss was in table
+  introspection and the overlay link step, matching the report.
+- Pre-existing, unrelated failures (reproduce with this change stashed):
+  `tests/unit/test_connection_oauth.py::test_ms_fabric` and
+  `::test_obo_exchange_ms_fabric` assert the old `api.fabric.microsoft.com`
+  OAuth scope — untouched by this change.
+- Sibling loops: `fabric-powerbi-obo-creator-zero-tables.md`,
   `powerbi-dataset-id-resolution.md`.

--- a/docs/feedback-loops/powerbi-missing-semantic-models.md
+++ b/docs/feedback-loops/powerbi-missing-semantic-models.md
@@ -78,9 +78,12 @@ All in `backend/app/data_sources/clients/powerbi_client.py`,
    reuses the on-demand pattern that per_user catalogs (OneDrive/Drive) already
    had; OneDrive's auto-activate behavior is preserved.
 
-4. **Fix 4 — skip built-in system models.** `_is_system_dataset` skips Power
-   BI's auto-created usage-metrics semantic models in discovery so they never
-   pollute the catalog (nor count as "unreadable").
+Note: discovery deliberately hides **nothing** — every listed semantic model
+(Fabric default models and Microsoft's built-in usage-metrics models alike) is
+discovered when readable and reported when not. An earlier draft skipped the
+usage-metrics models; that was dropped because hiding models is a product
+decision and, in tenants where those are currently the only visible models,
+dropping them would make the catalog look emptier rather than cleaner.
 
 ---
 

--- a/docs/feedback-loops/powerbi-missing-semantic-models.md
+++ b/docs/feedback-loops/powerbi-missing-semantic-models.md
@@ -113,7 +113,8 @@ Fix 2  test_unintrospectable_dataset_reported_not_dropped_and_not_phantom
        [fixed] unreadable diagnostics: [('UnreadableModel', 'COLUMNSTATISTICS failed: not authorized ...')]
        (no phantom 'UnreadableModel/*' table; index_stats() reports it with a reason)
 
-Fix 4  test_builtin_usage_metrics_models_are_skipped -> only ['RealModel/Sales'] emitted
+Nothing hidden  test_no_models_are_hidden_from_discovery
+       [fixed] both a usage-metrics model and a real model are emitted when readable
 
 Fix 3  test_user_visible_model_missing_from_sp_catalog_is_selectable
        [fixed] user1 selectable: ['ModelA/T1', 'ModelB/T2']    # ModelB was SP-invisible

--- a/docs/feedback-loops/powerbi-missing-semantic-models.md
+++ b/docs/feedback-loops/powerbi-missing-semantic-models.md
@@ -1,0 +1,162 @@
+# Feedback Loop — Power BI: "not all the semantic models are selectable in schema, some are missing from the fetch"
+
+Reported against a live Entra tenant (SP-seeded catalog + OBO users): some
+Power BI semantic models that are visible in app.powerbi.com never show up as
+selectable tables in the schema step, with no error anywhere. This loop
+validates the claim that models are **silently dropped** at three independent
+places in the fetch pipeline, and pins each mechanism with a deterministic
+reproduction (no live credentials needed).
+
+Status: **reproduction only — no fix applied yet.** The invariant tests are
+committed as `strict xfail`; whoever lands the fix flips them to plain asserts
+by deleting the markers.
+
+---
+
+## Root cause (validated)
+
+The selectable list is whatever `PowerBIClient.get_schemas()` emits into the
+canonical catalog (plus, for OBO users, an overlay filter on top). A semantic
+model can fall out at each stage:
+
+1. **Admin-scan shadowing** — `_batch_admin_scan` records an entry for every
+   dataset present in the scan result, including datasets the Scanner API
+   returned **no schema** for (model not refreshed since enhanced-metadata
+   scanning was enabled, DirectLake, all tables `isHidden`). Because
+   `get_schemas()` treats "dataset id present in admin scan results" as final
+   (`backend/app/data_sources/clients/powerbi_client.py:770-773`), the
+   COLUMNSTATISTICS fallback is **never attempted** for those datasets — even
+   when it would have worked. The model vanishes.
+
+2. **Silent fallback failure** — without admin-API rights every dataset relies
+   on `EVALUATE COLUMNSTATISTICS()` via `executeQueries`, which needs **Build**
+   permission and fails for RLS-protected / Viewer-only / some DirectLake
+   models. The failure is swallowed into `([], [])`
+   (`powerbi_client.py:523-525`), the REST `/tables` fallback only answers for
+   Push datasets (`powerbi_client.py:472-477`), and Phase 4 emits rows only by
+   iterating discovered tables (`powerbi_client.py:812`) — a dataset with zero
+   tables produces **zero schema rows and no surfaced error** (a
+   `logging.warning` is the only trace).
+
+3. **Overlay ∩ canonical intersection (OBO)** — for a `user_required` + oauth
+   connection, a signed-in user's selector is scoped to their overlay rows
+   with `data_source_table_id IS NOT NULL`
+   (`backend/app/services/data_source_service.py:2668-2676`), but
+   `_upsert_user_overlay` links overlay rows to canonical `DataSourceTable`
+   rows **by name only** and leaves `NULL` on a miss
+   (`data_source_service.py:3400`). Power BI is a `shared`-catalog connector
+   (`backend/app/schemas/data_source_registry.py:870` — registry default), so
+   the per-user "create canonical rows on demand" escape hatch does not apply.
+   Net effect: a model the user's own token can crawl but the service
+   principal cannot (SP not a Member of that workspace, or dropped by 1/2
+   above) is fetched into the overlay **and then filtered out of the
+   selector**.
+
+Additional scoping facts (validated by API semantics, not loop-reproducible):
+`list_workspaces` uses `GET /v1.0/myorg/groups` (`powerbi_client.py:356`),
+which only returns workspaces where the identity holds a workspace role —
+datasets shared directly (dataset-level Build/Read) and "My Workspace" content
+never enter the crawl at all.
+
+---
+
+## Loop A — deterministic reproduction (no external services)
+
+All Power BI HTTP traffic is faked at the `requests.Session` boundary; every
+line of client/service logic runs real. Overlay leg runs on SQLite via the
+standard test harness.
+
+```bash
+cd backend
+export BOW_DATABASE_URL="sqlite:///db/app.db"
+TESTING=true uv run pytest \
+  tests/unit/test_powerbi_missing_models_repro.py \
+  tests/e2e/test_powerbi_overlay_intersection_repro.py \
+  -v -s --runxfail
+```
+
+**Observed (2026-07-17, current code):**
+
+Mechanism 1 — admin scan covers a dataset with no schema, fallback never tried:
+
+```
+[repro] emitted schema tables: ['CoveredModel/Sales']
+[repro] COLUMNSTATISTICS attempted for d2: False
+AssertionError: dataset covered by the admin scan without schema was dropped
+                instead of falling back to COLUMNSTATISTICS
+  assert 'ShadowedModel/Facts' in ['CoveredModel/Sales']
+```
+
+Mechanism 2 — COLUMNSTATISTICS forbidden (no Build), not a Push dataset:
+
+```
+WARNING root:powerbi_client.py:524 COLUMNSTATISTICS failed for dataset d1:
+        DAX query failed: HTTP 403 {"error": {"code": "PowerBINotAuthorizedException"}}
+[repro] emitted schema tables: ['ReadableModel/Orders']
+AssertionError: dataset with failed table introspection was silently dropped from the schema
+```
+
+(`test_current_behavior_drops_are_silent_no_exception` PASSES today — it pins
+that both drops complete without raising: the caller just gets a smaller
+schema.)
+
+Mechanism 3 — overlay intersection (signed-in OBO user, SP catalog narrower
+than the user's access):
+
+```
+[repro] user's live fetch returned:   ['ModelA/T1', 'ModelB/T2']
+[repro] overlay rows (name, linked-to-canonical): [('ModelA/T1', True), ('ModelB/T2', False)]
+[repro] selectable tables in schema:  ['ModelA/T1']
+AssertionError: model returned by the user's own fetch is not selectable —
+                dropped by the overlay∩canonical intersection
+  assert 'ModelB/T2' in ['ModelA/T1']
+```
+
+Without `--runxfail` the same run is green (`1 passed, 3 xfailed`) — the
+invariants are recorded as strict xfails so CI stays green until the fix.
+
+## Loop B — live confirmation (optional, real tenant)
+
+Only needed to confirm which mechanism is eating a *specific* model in a real
+tenant. Secrets via env vars only (`BOW_ENTRA_*`, `BOW_PBI_MASTER_*` — same
+set as `fabric-powerbi-obo-creator-zero-tables.md`). Triage per model:
+
+1. Present in `GET /connections/{id}/tables` (canonical, SP view)?
+   - **No**, but visible in app.powerbi.com → mechanism 1/2 on the SP crawl
+     (check backend logs for `COLUMNSTATISTICS failed for dataset …`), or the
+     SP isn't a Member of that workspace (membership scoping).
+   - **Yes**, but missing from a signed-in user's selector → mechanism 3
+     only bites the other direction (user-visible, SP-invisible); check the
+     user's `UserDataSourceTable` rows for `data_source_table_id IS NULL`.
+
+## The fix
+
+Not applied (reproduction requested only). Candidate directions, per
+mechanism:
+
+1. Fall back to COLUMNSTATISTICS whenever the admin scan yielded an **empty**
+   table list for a dataset, not just when the dataset id is absent.
+2. Emit a dataset-level placeholder row (or surface a per-dataset warning in
+   the indexing job) when every introspection path fails, so the model stays
+   visible/selectable instead of disappearing.
+3. Union user-crawled tables into the selector for the overlay identity (or
+   create canonical rows on demand as the `per_user` catalogs already do),
+   instead of intersecting with the SP catalog by name.
+
+When a fix lands: delete the `xfail` markers in the two repro test files and
+re-run Loop A — all four tests must pass.
+
+## What this proves / regression notes
+
+- Datasets are **listed** correctly in every reproduced case — the loss is in
+  table introspection and in the overlay link step, which matches the report
+  ("some are missing from the fetch" while others from the same tenant show
+  up).
+- All three mechanisms are silent by construction: no exception reaches the
+  caller, nothing is surfaced to the UI (mechanism 2 leaves only a
+  `logging.warning`).
+- Pre-existing suites unaffected: `tests/unit/test_powerbi_client.py`
+  (36 passed) on the same run.
+- Sibling loops: `fabric-powerbi-obo-creator-zero-tables.md` (zero tables
+  before first sign-in — different mechanism, already fixed),
+  `powerbi-dataset-id-resolution.md`.


### PR DESCRIPTION
## Problem

Some Power BI semantic models that are visible in `app.powerbi.com` never showed up as selectable tables in the schema step — with no error surfaced anywhere. The selectable catalog is whatever `PowerBIClient.get_schemas()` emits (plus, for OBO users, an overlay filter), and a model could be silently dropped at three independent places.

## Root causes & fixes

**1. Admin-scan shadowing** (`powerbi_client.get_schemas`)
`_batch_admin_scan` records an entry for every dataset in the scan result, including ones the Scanner API returned *no schema* for (not refreshed since enhanced-metadata scanning was enabled, DirectLake, all-hidden tables). Discovery treated "present in scan results" as final and never tried the `COLUMNSTATISTICS` fallback — even when it would have worked. Now an **empty** scan result falls through to the DAX fallback, not just a missing one.

**2. Silent introspection failure** (`powerbi_client` + `connection_service` + `connection_indexing_service`)
Without admin rights, discovery relies on `COLUMNSTATISTICS` via `executeQueries`, which needs Build permission and fails for RLS / DirectLake / Viewer-only models. The failure was swallowed into `([], [])` and the model vanished with only a `logging.warning`. Now the reason is captured (`get_dataset_tables_with_reason` / `index_stats()`) and surfaced on the indexing job (`unreadable_datasets` in `stats_json` + a `warn` event + a log line). No phantom column-less table is created — that would be unqueryable and just move the failure downstream.

**3. Overlay ∩ canonical intersection for OBO** (`data_source_service._upsert_user_overlay`)
For `user_required` (delegated) connections, a signed-in user's selector was scoped to overlay rows linked to a canonical `DataSourceTable` by name; a model the user's own token could see but the service principal could not was fetched into the overlay and then filtered out (`data_source_table_id = NULL`). Now, for delegated connections, the canonical row is created on demand from the user's crawl (tagged `discovered_by="user"`, matched by dataset/table identity, created inactive) and the overlay links to it. One org-level row backs the table, so **usage/instructions aggregate across users**; per-user visibility stays enforced by the overlay; the SP's background re-index does not prune it (it prunes only ConnectionTable-linked rows, and these are intentionally unlinked). Reuses the on-demand pattern the `per_user` catalogs (OneDrive/Drive) already had, preserving their auto-activate behavior.

Discovery deliberately hides **nothing** — every listed semantic model (Fabric default models and Microsoft's usage-metrics models alike) is discovered when readable and reported when not.

## Tests

- `tests/unit/test_powerbi_missing_models_repro.py` — Fix 1 fallthrough; Fix 2 reported-not-dropped-not-phantom; no-false-diagnostics; nothing-hidden.
- `tests/e2e/test_powerbi_overlay_intersection_repro.py` — Fix 3: SP-invisible model selectable; both users' overlays link to one canonical row (usage aggregation).
- Full targeted set green (Power BI, OBO, drive suites). Pre-existing unrelated failures `test_ms_fabric` / `test_obo_exchange_ms_fabric` (old Fabric OAuth scope) reproduce with this change stashed.

## Verification

Confirmed against a live Entra tenant: SP + delegated auth work, all real models discovered, no false diagnostics. The tenant's read-only admin API was off (discovery ran entirely on `COLUMNSTATISTICS`), which is exactly the condition under which DirectLake models fail — validating enabling the two Fabric admin-portal settings operationally. Details in `docs/feedback-loops/powerbi-missing-semantic-models.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHRP3dFWPfrWBWshYiZvG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHRP3dFWPfrWBWshYiZvG1)_