### PR TITLE
Right-align session-event strips to the user-bubble edge

### DIFF
--- a/frontend/components/SessionEvent.vue
+++ b/frontend/components/SessionEvent.vue
@@ -1,9 +1,11 @@
 <template>
   <!-- Silent session event: a lightweight, gray, ambient line — deliberately
-       quieter than a message bubble or a tool card. Dark-mode aware. -->
-  <div class="flex items-center justify-center my-1.5 select-none">
+       quieter than a message bubble or a tool card. Right-aligned to the
+       user-bubble edge, since these are the user's own out-of-band actions.
+       Dark-mode aware. -->
+  <div class="flex items-center justify-end my-1.5 select-none me-2 md:me-[36px]">
     <div
-      class="flex items-center gap-1.5 text-[11px] leading-none text-gray-400 dark:text-gray-500 max-w-xl px-2"
+      class="flex items-center gap-1.5 text-[11px] leading-none text-gray-400 dark:text-gray-500 max-w-xl px-1"
       :title="label"
     >
       <Icon :name="icon" class="w-3 h-3 flex-shrink-0 opacity-60" />


### PR DESCRIPTION
Follow-up to the session-events feature (#708, merged).

## What

Session events are the user's own out-of-band actions (uploaded a file, shared, switched the model, changed scope, thumbed an answer), so the timeline strips now align to the **right** — matching user prompts — instead of centered. It reads as "you did this" rather than a system banner.

## Change

`components/SessionEvent.vue`: `justify-center` → `justify-end`, with a right margin (`md:me-[36px]`) so the strip's right edge lines up with the user bubble's content edge (clearing the 28px avatar + 8px gap), falling back to a small margin on mobile where the avatar is hidden. Gray/minimalist styling and the per-kind icon map are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MKox6zcHduwSWiXvPknPs

---
_Generated by [Claude Code](https://claude.ai/code/session_016MKox6zcHduwSWiXvPknPs)_