### PR TITLE
Fix AI Mailbox "Test connection" 404 (External platform not found)

### DIFF
--- a/backend/app/routes/external_platform.py
+++ b/backend/app/routes/external_platform.py
@@ -34,6 +34,27 @@ async def get_integrations(
     """Get all integrations for an organization"""
     return await external_platform_service.get_platforms(db, organization)
 
+# NOTE: Static/literal sub-paths (e.g. ``/email/test``) MUST be declared before
+# the parameterized ``/{platform_id}`` routes below. FastAPI/Starlette matches
+# routes in registration order and ``{platform_id}`` compiles to a ``[^/]+``
+# pattern that also matches literals like ``email`` — so a parameterized route
+# declared first would shadow ``/email/test`` and 404 with
+# "External platform not found".
+@router.post("/settings/integrations/email/test", response_model=dict)
+@requires_permission('manage_settings')
+async def test_email_config(
+    data: EmailConfig,
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db)
+):
+    """Test email credentials WITHOUT saving the integration.
+
+    Backs the setup form's pre-save "Test connection" button. Returns
+    ``{success, smtp, imap}``.
+    """
+    return await external_platform_service.test_email_config(data)
+
 @router.get("/settings/integrations/{platform_id}", response_model=ExternalPlatformSchema)
 @requires_permission('manage_settings', model=ExternalPlatform)
 async def get_integration(
@@ -165,21 +186,6 @@ async def create_whatsapp_integration(
     except Exception:
         pass
     return result
-
-@router.post("/settings/integrations/email/test", response_model=dict)
-@requires_permission('manage_settings')
-async def test_email_config(
-    data: EmailConfig,
-    current_user: User = Depends(current_user),
-    organization: Organization = Depends(get_current_organization),
-    db: AsyncSession = Depends(get_async_db)
-):
-    """Test email credentials WITHOUT saving the integration.
-
-    Backs the setup form's pre-save "Test connection" button. Returns
-    ``{success, smtp, imap}``.
-    """
-    return await external_platform_service.test_email_config(data)
 
 @router.post("/settings/integrations/email", response_model=ExternalPlatformSchema)
 @requires_permission('manage_settings')

--- a/backend/tests/e2e/test_email_integration.py
+++ b/backend/tests/e2e/test_email_integration.py
@@ -121,6 +121,53 @@ def test_create_smtp_only_integration_and_resolver(
 
 
 # ---------------------------------------------------------------------------
+# 1b. API: pre-save "Test connection" reaches its own handler
+#
+# Regression: ``POST /email/test`` must NOT be shadowed by the parameterized
+# ``POST /{platform_id}/test`` route (which would treat "email" as a platform id
+# and 404 with "External platform not found"). The static route has to be
+# registered before the parameterized one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_email_test_connection_not_shadowed_by_platform_id_route(
+    smtp_sink, create_user, login_user, whoami
+):
+    host, port, _handler = smtp_sink
+    email = _unique_email()
+    create_user(email=email)
+    token = login_user(email, "test123")
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    from main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    body = {
+        "smtp_host": host,
+        "smtp_port": port,
+        "smtp_username": "analyst@bow.test",
+        "smtp_password": "",
+        "smtp_security": "none",
+        "from_address": "analyst@bow.test",
+        "from_name": "BOW Analyst",
+    }
+    res = client.post(
+        "/api/settings/integrations/email/test",
+        json=body,
+        headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+    )
+    # The static test handler answers (SMTP probe against the local sink), rather
+    # than the parameterized handler 404ing on a non-existent platform id.
+    assert res.status_code == 200, res.text
+    assert "External platform not found" not in res.text
+    data = res.json()
+    assert data["success"] is True
+    assert data["smtp"] == "ok"
+
+
+# ---------------------------------------------------------------------------
 # 2. Manager: inbound email auto-links to a member, threads, stamps metadata
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The AI Mailbox setup form's **"Test connection"** button fails with a red **"External platform not found"** error (see below), even with valid credentials. This is a FastAPI route-shadowing bug, not a credentials/config problem.

## Root cause

In `backend/app/routes/external_platform.py`, two POST routes collided:

- `POST /settings/integrations/{platform_id}/test` — declared **first**
- `POST /settings/integrations/email/test` — declared **after**

The form posts to `/api/settings/integrations/email/test`. Starlette matches routes in registration order, and `{platform_id}` compiles to a `[^/]+` regex that also matches the literal `email`. So the request was captured by the parameterized handler with `platform_id="email"`, which looked up a platform with id `"email"`, found none, and returned `404 External platform not found`.

Reproduced with a `TestClient`:
- Buggy ordering → `404 {"detail": "External platform not found"}`
- Fixed ordering → `200`

## Changes

- **`backend/app/routes/external_platform.py`** — Moved the static `/settings/integrations/email/test` route ahead of the parameterized `/{platform_id}` routes, with a comment explaining why the ordering matters (there is precedent for this in `main.py`).
- **`backend/tests/e2e/test_email_integration.py`** — Added a regression test (`test_email_test_connection_not_shadowed_by_platform_id_route`) that posts to `/email/test` against the local SMTP sink and asserts it reaches the real handler (`200`, `smtp: "ok"`) rather than 404ing.

## Scope / safety

No behavior change for other endpoints. The `email` create, `slack`, `whatsapp`, and `teams` routes were not shadowed (no matching parameterized POST), and the `{platform_id}` GET/PUT/DELETE/test routes still resolve for real platform ids.

## Testing

- Reproduced the buggy vs. fixed behavior directly with FastAPI's `TestClient`.
- Syntax-checked both changed files. The full e2e suite requires the backend stack (not available in the authoring environment); the added test should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114Wj1cTDDGdjyRQvx35mHe)_