### PR TITLE
Fix 500 on duplicate LLM provider name

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -63,7 +63,12 @@ class LLMService:
         provider_data
     ):
         """Create a new custom LLM provider"""
-        logger.info("Creating LLM provider: name=%s, type=%s, org_id=%s, user_id=%s", provider_data.name, provider_data.provider_type, organization.id, current_user.id)
+        # Capture identifiers up front. After a failed commit + rollback the ORM
+        # objects get expired, and touching their attributes would trigger a lazy
+        # (sync) DB load outside the greenlet context -> MissingGreenlet.
+        org_id = organization.id
+        provider_name = provider_data.name
+        logger.info("Creating LLM provider: name=%s, type=%s, org_id=%s, user_id=%s", provider_name, provider_data.provider_type, org_id, current_user.id)
 
         models = provider_data.models
         del provider_data.models
@@ -83,10 +88,10 @@ class LLMService:
             await db.refresh(provider)
         except IntegrityError:
             await db.rollback()
-            logger.warning("Duplicate LLM provider name: name=%s, org_id=%s", provider.name, organization.id)
+            logger.warning("Duplicate LLM provider name: name=%s, org_id=%s", provider_name, org_id)
             raise HTTPException(
                 status_code=409,
-                detail=f"A provider named '{provider.name}' already exists in this organization. Please choose a different name."
+                detail=f"A provider named '{provider_name}' already exists in this organization. Please choose a different name."
             )
 
         logger.info("LLM provider created: id=%s, name=%s, type=%s, org_id=%s", provider.id, provider.name, provider.provider_type, organization.id)


### PR DESCRIPTION
## Problem

Creating an LLM provider with a name that already exists in the organization returns a **500 Internal Server Error** instead of the intended **409 Conflict**.

## Root cause

The `IntegrityError` handler in `create_provider` (`backend/app/services/llm_service.py`) is structured correctly — catch the unique-constraint violation on `uq_llm_providers_org_name`, roll back, and raise a clean 409. But `await db.rollback()` **expires all ORM objects in the session**. The handler then read `organization.id` and `provider.name` to build the log message and response, which triggered a synchronous lazy reload of those expired attributes outside the async greenlet context:

```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here.
```

That second exception escaped the handler, so the 409 was never returned and the request 500'd.

## Fix

Capture `org_id` and `provider_name` into plain locals *before* the commit/rollback, and use those locals in the error-path log message and the `HTTPException` detail. The handler no longer touches expired ORM state, so duplicate names now correctly return a 409 with the friendly "choose a different name" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNqU89wVT2jTfCcXAbVgaC)_