### PR TITLE
Fix ghost-text overlay on LLM settings Actions menu

### DIFF
--- a/frontend/components/LLMsComponent.vue
+++ b/frontend/components/LLMsComponent.vue
@@ -221,8 +221,16 @@
                                 <span>{{ accessLabel(model) }}</span>
                             </button>
                         </td>
-                        <td class="sticky right-0 z-10 bg-white dark:bg-gray-900 group-hover:bg-gray-50/70 dark:group-hover:bg-gray-800/50 border-s border-gray-200 dark:border-gray-800 px-4 py-2 whitespace-nowrap text-sm text-end transition-colors" v-if="useCan('manage_llm_settings')">
-                            <UDropdown :items="dropdownItemsByModel[model.id]" :popper="{ strategy: 'fixed' }">
+                        <td
+                            class="sticky right-0 bg-white dark:bg-gray-900 group-hover:bg-gray-50/70 dark:group-hover:bg-gray-800/50 border-s border-gray-200 dark:border-gray-800 px-4 py-2 whitespace-nowrap text-sm text-end transition-colors"
+                            :class="openMenuModelId === model.id ? 'z-30' : 'z-10'"
+                            v-if="useCan('manage_llm_settings')"
+                        >
+                            <UDropdown
+                                :items="dropdownItemsByModel[model.id]"
+                                :popper="{ strategy: 'fixed' }"
+                                @update:open="(open) => openMenuModelId = open ? model.id : null"
+                            >
                                 <UButton class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white font-medium transition-colors duration-150" color="white" label="" trailing-icon="i-heroicons-ellipsis-vertical" />
                             </UDropdown>
                         </td>
@@ -279,6 +287,14 @@ const props = defineProps({
 const { t } = useI18n();
 const toast = useToast();
 const searchQuery = ref('');
+
+// Which row's Actions menu is open. The menu is rendered inline inside the
+// sticky (z-10) Actions cell, so an open menu is trapped in that cell's
+// stacking context and gets painted over by the sibling rows' sticky cells
+// below it (equal z-index, later in DOM order) — the "ghost text" overlay.
+// Lifting only the open row's cell above its siblings while the menu is open
+// lets the menu paint cleanly over the table.
+const openMenuModelId = ref<string | null>(null);
 
 type Provider = { id: string; name: string; provider_type: string };
 type Model = {


### PR DESCRIPTION
## Problem

On the **LLM settings** page (`/settings/models`), opening a per-model **Actions** menu shows a "weird overlay": table text (the `default` badges and `Everyone (default)` access labels) ghosts through the open menu, and menu items like "Manage Provider" get visually cut off.

![weird overlay in the LLM page](https://github.com/user-attachments/assets/placeholder)

## Root cause

A CSS stacking-context trap:

- The Actions column cell is `sticky right-0 z-10`, which makes each cell its own stacking context capped at `z-10`.
- Nuxt UI (v2.16) renders the `UDropdown` menu **inline inside that cell** — there is no teleport/portal — so an open menu can never rise above its own cell's `z-10` level.
- Every other row's sticky Actions cell is also `z-10` and comes **later in the DOM**, so those opaque cells paint over the open menu's edges, and neighboring cells' text bleeds through.

The pre-existing `:popper="{ strategy: 'fixed' }"` only dodges the table's `overflow` clipping; it does nothing about this z-index competition between rows.

## Fix

Track which row's menu is open via `UDropdown`'s `@update:open` event, and lift **only that row's** sticky cell from `z-10` to `z-30` while its menu is open. This raises the open cell (and its inline menu) above the sibling rows' `z-10` cells and the base-level data cells, so the menu paints cleanly. When the menu closes, the cell drops back to `z-10` and the normal sticky-column layering is unchanged.

Self-contained change: one `openMenuModelId` ref plus the template binding. No change to menu behavior.

## Testing

`node_modules` was not available in the working environment, so this was not exercised in a running build. The change is a pure template/z-index adjustment using the `@update:open` event that Nuxt UI's `UDropdown` documents and emits (verified against the library source). Manual verification suggested: open an Actions menu on a middle row of the LLM models table and confirm no table text bleeds through and no menu items are clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQjaLHhsBAEa9cx4tuPrzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQjaLHhsBAEa9cx4tuPrzq)_