### PR TITLE
Fix Bedrock dropping images in the native tool_use path

### DIFF
--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -105,23 +105,34 @@ class BedrockClient(LLMClient):
         self._auth_mode = auth_mode
 
     @staticmethod
-    def _build_content(prompt: str, images: Optional[list[ImageInput]] = None) -> list[dict]:
+    def _image_block(img: ImageInput) -> Optional[dict]:
+        """Translate an ImageInput into a Bedrock Converse image content block.
+
+        Returns None for URL sources — the Converse API only accepts image
+        bytes (or S3 refs), not URLs, so a URL image is skipped rather than
+        sent in a form Bedrock would reject.
+        """
+        if img.source_type == "url":
+            return None
+        fmt = _MIME_TO_FORMAT.get(img.media_type, "png")
+        image_bytes = base64.b64decode(img.data)
+        return {
+            "image": {
+                "format": fmt,
+                "source": {"bytes": image_bytes},
+            }
+        }
+
+    @classmethod
+    def _build_content(cls, prompt: str, images: Optional[list[ImageInput]] = None) -> list[dict]:
         """Build Bedrock message content blocks."""
         content: list[dict] = []
 
         if images:
             for img in images:
-                if img.source_type == "url":
-                    # Bedrock converse only supports bytes/S3 for images, skip URLs
-                    continue
-                fmt = _MIME_TO_FORMAT.get(img.media_type, "png")
-                image_bytes = base64.b64decode(img.data)
-                content.append({
-                    "image": {
-                        "format": fmt,
-                        "source": {"bytes": image_bytes},
-                    }
-                })
+                block = cls._image_block(img)
+                if block is not None:
+                    content.append(block)
 
         content.append({"text": prompt.strip()})
         return content
@@ -270,6 +281,20 @@ class BedrockClient(LLMClient):
         event_queue: asyncio.Queue = asyncio.Queue()
 
         bedrock_messages = self._translate_messages(messages)
+        # Attach any images to the last user message as Converse image blocks.
+        # Without this, the `images` argument is silently dropped and a
+        # vision-capable Bedrock model receives no image at all — it then
+        # hallucinates that it "cannot see" the attachment. Mirrors the
+        # Anthropic client, which folds images into the last user turn.
+        if images:
+            image_blocks = [b for b in (self._image_block(img) for img in images) if b is not None]
+            if image_blocks:
+                if bedrock_messages and bedrock_messages[-1]["role"] == "user":
+                    # Converse requires image blocks to precede any tool_result
+                    # block in a message; prepend so ordering stays valid.
+                    bedrock_messages[-1]["content"] = image_blocks + bedrock_messages[-1]["content"]
+                else:
+                    bedrock_messages.append({"role": "user", "content": image_blocks})
         request_kwargs: dict = {"modelId": model_id, "messages": bedrock_messages}
         if system:
             request_kwargs["system"] = [{"text": system}]

--- a/backend/tests/unit/test_bedrock_client_auth.py
+++ b/backend/tests/unit/test_bedrock_client_auth.py
@@ -7,13 +7,23 @@ the Bearer header lands on the request, and that SigV4 signing is disabled.
 
 from __future__ import annotations
 
+import base64
+from unittest.mock import MagicMock
+
 import pytest
 from botocore import UNSIGNED
 from botocore.awsrequest import AWSRequest
 
 from app.ai.llm.clients.bedrock_client import BedrockClient
+from app.ai.llm.types import ImageInput, Message
 
 _REGION = "eu-west-1"
+
+# 1x1 transparent PNG, base64-encoded.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
 
 
 def test_unsupported_auth_mode_rejected():
@@ -72,3 +82,67 @@ def test_api_key_stays_scoped_to_its_client():
 
     assert req_a.headers["Authorization"] == "Bearer key-a"
     assert req_b.headers["Authorization"] == "Bearer key-b"
+
+
+# ---------------------------------------------------------------------------
+# Vision: images must actually reach the Converse request in the v2 path.
+# Regression for images being silently dropped (model "can't see" the image).
+# ---------------------------------------------------------------------------
+
+
+def _capture_converse_stream(client: BedrockClient) -> dict:
+    """Replace converse_stream with a recorder that returns an empty stream and
+    returns the dict the captured request kwargs land in after consumption."""
+    captured: dict = {}
+
+    def _fake_converse_stream(**kwargs):
+        captured.update(kwargs)
+        return {"stream": iter([{"messageStop": {"stopReason": "end_turn"}}])}
+
+    client.client = MagicMock()
+    client.client.converse_stream.side_effect = _fake_converse_stream
+    return captured
+
+
+async def _drain(agen):
+    async for _ in agen:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_inference_stream_v2_attaches_images_to_last_user_message():
+    client = BedrockClient(region=_REGION, auth_mode="iam")
+    captured = _capture_converse_stream(client)
+
+    images = [ImageInput(data=_PNG_B64, media_type="image/png", source_type="base64")]
+    messages = [Message(role="user", content="what does this image say?")]
+
+    await _drain(client.inference_stream_v2(model_id="anthropic.claude", messages=messages, images=images))
+
+    sent = captured["messages"]
+    last = sent[-1]
+    assert last["role"] == "user"
+    image_blocks = [b for b in last["content"] if "image" in b]
+    assert len(image_blocks) == 1
+    img = image_blocks[0]["image"]
+    assert img["format"] == "png"
+    assert img["source"]["bytes"] == base64.b64decode(_PNG_B64)
+    # Image must come BEFORE the text block (Converse ordering requirement).
+    assert "image" in last["content"][0]
+
+
+@pytest.mark.asyncio
+async def test_inference_stream_v2_skips_url_images():
+    client = BedrockClient(region=_REGION, auth_mode="iam")
+    captured = _capture_converse_stream(client)
+
+    images = [ImageInput(data="https://example.com/x.png", source_type="url")]
+    messages = [Message(role="user", content="describe this")]
+
+    await _drain(client.inference_stream_v2(model_id="anthropic.claude", messages=messages, images=images))
+
+    last = captured["messages"][-1]
+    # URL images are unsupported by Converse — none should be attached, and the
+    # text content must remain intact.
+    assert all("image" not in b for b in last["content"])
+    assert any(b.get("text") == "describe this" for b in last["content"])


### PR DESCRIPTION
## Summary

Vision-capable Bedrock models were receiving **no image** in the agent flow and hallucinating that they "cannot see" the attachment.

Root cause: `BedrockClient.inference_stream_v2` — the agent's native tool_use path (`PlannerV3` → `inference_stream_v2`) — accepted an `images` argument but **never used it**. `_translate_messages` only emits `text`/`tool_use`/`tool_result` blocks, and the `images` parameter was silently dropped before the Converse request was built. The non-v2 methods (`inference`, `inference_stream`) already handled images via `_build_content`, and the Anthropic client already folds images into the last user message — so this was a Bedrock-specific gap on the live path.

## Changes

- Added a shared `_image_block()` helper that translates an `ImageInput` into a Bedrock Converse image content block (`{"image": {"format", "source": {"bytes"}}}`), returning `None` for URL sources since Converse only accepts image bytes.
- In `inference_stream_v2`, attach images to the last user message (appending a new user message if the last turn isn't a user turn), mirroring the Anthropic client. Images are **prepended** before any text/tool_result block to satisfy Converse's content ordering.
- Refactored `_build_content` to reuse `_image_block` so both paths build identical blocks.

## Tests

Added regression tests in `tests/unit/test_bedrock_client_auth.py` that mock `converse_stream` and assert on the request payload:
- base64 images now reach the Converse request, positioned before the text block;
- URL images are skipped while text content is preserved.

## Notes / not covered

- End-to-end vision against a live Bedrock model was not exercised (no Bedrock creds in CI); the tests assert the request payload, which is where the bug lived.
- Pre-existing, provider-agnostic behavior left unchanged: user-uploaded images are loaded only on the first planner iteration (`loop_index == 0`), so they are not re-sent on later turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjyBJj8tkBsZdVqrQdBhFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjyBJj8tkBsZdVqrQdBhFN)_