### PR TITLE
Fold read_file Preview into the tool header collapse

### DIFF
--- a/frontend/components/tools/ReadFileTool.vue
+++ b/frontend/components/tools/ReadFileTool.vue
@@ -6,7 +6,14 @@
           <Spinner class="w-3 h-3 me-1.5 shrink-0 text-gray-400" />
           <span class="tool-shimmer">{{ modelTitle ? modelTitle + '…' : 'Reading ' + fileLabel + '…' }}</span>
         </span>
-        <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
+        <span
+          v-else
+          class="text-gray-700 dark:text-gray-300 flex items-center"
+          :class="hasContent ? 'cursor-pointer' : ''"
+          @click="hasContent && (expanded = !expanded)"
+          :aria-expanded="hasContent ? expanded : undefined"
+        >
+          <Icon v-if="hasContent" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500 rtl-flip" />
           <DataSourceIcon v-if="connIcon" :type="connIcon.type" :connector-key="connIcon.connectorKey" class="w-3 h-3 me-1 shrink-0" />
           <Icon v-else name="heroicons-document-arrow-down" class="w-3 h-3 me-1 text-gray-400" />
           <span>{{ modelTitle || ('Read ' + fileLabel) }}</span>
@@ -20,29 +27,18 @@
     </Transition>
 
     <Transition name="fade" appear>
-      <div v-if="hasContent" class="text-xs text-gray-600 dark:text-gray-400">
-        <div
-          class="flex items-center py-1 px-1 rounded cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
-          @click="expanded = !expanded"
-        >
-          <Icon :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 text-gray-400 me-1 rtl-flip" />
-          <span class="text-gray-500 dark:text-gray-400">Preview</span>
+      <div v-if="expanded && hasContent" class="text-xs text-gray-600 dark:text-gray-400">
+        <div v-if="filePath" class="mb-1 text-[11px] text-gray-500 dark:text-gray-400">
+          <span class="text-gray-400 dark:text-gray-500">Path:</span>
+          <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 break-all" dir="ltr">{{ filePath }}</code>
         </div>
-        <Transition name="fade">
-          <div v-if="expanded" class="ps-6 pe-1 pb-1">
-            <div v-if="filePath" class="mb-1 text-[11px] text-gray-500 dark:text-gray-400">
-              <span class="text-gray-400 dark:text-gray-500">Path:</span>
-              <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 break-all" dir="ltr">{{ filePath }}</code>
-            </div>
-            <pre class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
-            <div v-if="sessionFileId" class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
-              <Icon name="heroicons-paper-clip" class="w-3 h-3 inline align-text-bottom me-0.5" />
-              Attached to this conversation as session file
-              <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ sessionFileId.slice(0, 8) }}…</code>
-            </div>
-            <ToolCallParams :params="toolExecution?.arguments_json" />
-          </div>
-        </Transition>
+        <pre class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
+        <div v-if="sessionFileId" class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
+          <Icon name="heroicons-paper-clip" class="w-3 h-3 inline align-text-bottom me-0.5" />
+          Attached to this conversation as session file
+          <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ sessionFileId.slice(0, 8) }}…</code>
+        </div>
+        <ToolCallParams :params="toolExecution?.arguments_json" />
       </div>
     </Transition>
 


### PR DESCRIPTION
## Summary

The `read_file` tool row (`ReadFileTool.vue`) rendered a standalone **"Preview"** disclosure line beneath its header. As a result, a collapsed read_file row showed *two* lines — the summary header ("Read …" plus `tabular` / rows×cols badges) **and** a separate `Preview ›` toggle.

This is inconsistent with the sibling file tools (`list_files`, `search_files`, `grep_files`), where the **header line itself is the collapse toggle**, so a collapsed row is just the header line.

## Changes

- Make the `read_file` header line the collapse toggle: the chevron now sits on the header, and clicking it expands the preview.
- The preview content (path, file contents, session-file note, and Parameters) now expands directly under the header — the standalone "Preview" row is removed.
- Stays **collapsed by default**, so a collapsed read_file row is now just its single header line, matching the other file tools.
- The chevron only appears when there is preview content; binary/error reads keep their existing inline params/error fallback.

## Before / After

**Before (collapsed):**
```
Read competitor-prices.csv  [tabular]  10 rows × 95 cols
› Preview
```

**After (collapsed):**
```
› Read competitor-prices.csv  [tabular]  10 rows × 95 cols
```

Reuses existing component bindings (`expanded`, `hasContent`, …) and mirrors the already-shipping `ListFilesTool` / `GrepFilesTool` pattern — a self-contained template edit with no new script logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQaGdPsUpyBUpfkhyVaDU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQaGdPsUpyBUpfkhyVaDU2)_