### PR TITLE
Fix training pill nagging to publish already-accepted instructions

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -2633,8 +2633,10 @@ class ReportService:
         # 6) Find the most recent draft / pending build referenced by these
         # training tool calls, so the pill can offer approve/discard.
         from app.models.instruction_build import InstructionBuild
+        from app.models.build_content import BuildContent
         from app.schemas.report_summary_schema import PendingTrainingBuildSchema
         pending_build = None
+        staged_instruction_ids: set[str] = set()
         build_ids = [i.build_id for i in instructions if i.build_id]
         if build_ids:
             build_res = await db.execute(
@@ -2645,21 +2647,44 @@ class ReportService:
                     InstructionBuild.deleted_at == None,
                 )
                 .order_by(InstructionBuild.created_at.desc())
-                .limit(1)
             )
-            build_obj = build_res.scalar_one_or_none()
-            if build_obj:
+            candidate_builds = build_res.scalars().all()
+            # Pick the most recent build that still has staged contents. Accepting
+            # each create_instruction individually (POST /instructions/{id}/
+            # accept-staged) detaches only that instruction from the shared draft
+            # while leaving the draft in `draft` status. Once every instruction has
+            # been accepted the draft is an empty husk — status alone would still
+            # report it as pending, so the publish pill would nag the user to
+            # publish changes that are already live. Gate on live BuildContent rows
+            # (not build status or the total_instructions counter) so an emptied
+            # draft no longer surfaces as a pending training build.
+            for build_obj in candidate_builds:
+                content_res = await db.execute(
+                    select(BuildContent.instruction_id)
+                    .where(BuildContent.build_id == build_obj.id)
+                )
+                content_ids = {str(cid) for (cid,) in content_res.all()}
+                if not content_ids:
+                    continue
+                staged_instruction_ids = content_ids
                 pending_build = PendingTrainingBuildSchema(
                     id=str(build_obj.id),
                     status=build_obj.status,
-                    total_instructions=build_obj.total_instructions or 0,
+                    total_instructions=len(content_ids),
                 )
+                break
 
         # Restrict the instructions list to the current pending build so the
         # session pill only shows truly-pending changes. Without this, edits
-        # whose builds were already published earlier in the session leak in.
+        # whose builds were already published earlier in the session leak in, and
+        # instructions already accepted out of the shared draft (still carrying
+        # its build_id in their tool-call result) would linger. Match on both the
+        # build id and the set of instructions still staged in that build.
         if pending_build:
-            instructions = [i for i in instructions if i.build_id == pending_build.id]
+            instructions = [
+                i for i in instructions
+                if i.build_id == pending_build.id and i.instruction_id in staged_instruction_ids
+            ]
         else:
             instructions = []
 

--- a/backend/tests/e2e/test_training_multi_instruction_accept.py
+++ b/backend/tests/e2e/test_training_multi_instruction_accept.py
@@ -260,6 +260,150 @@ def test_accept_staged_endpoint_accepts_all_siblings(
     assert all(_run(_all_live())), "every accepted instruction should be live in main"
 
 
+# ---------------------------------------------------------------------------
+# Loop A.3 — the report-summary pill must retire once every staged instruction
+# has been individually accepted (empty draft husk regression)
+# ---------------------------------------------------------------------------
+
+async def _seed_training_report(n_instructions=3):
+    """Seed an org + admin + a training report whose completion has one
+    ``create_instruction`` tool execution per staged instruction, mirroring what
+    the training agent records. ``get_report_summary`` derives the pending build
+    from these tool executions' ``result_json.build_id``."""
+    from app.models.report import Report
+    from app.models.completion import Completion
+    from app.models.completion_block import CompletionBlock
+    from app.models.tool_execution import ToolExecution
+    from app.models.agent_execution import AgentExecution
+
+    suffix = uuid.uuid4().hex[:8]
+    build_service = BuildService()
+    instruction_service = InstructionService()
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Summary Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        admin = User(
+            name="Admin", email=f"summary-{suffix}@example.com",
+            hashed_password="x", is_active=True, is_superuser=False, is_verified=True,
+        )
+        db.add(admin)
+        await db.flush()
+        db.add(Membership(user_id=admin.id, organization_id=org.id, role="admin"))
+        await db.flush()
+
+        report = Report(
+            title="Training session", slug=f"train-{suffix}", status="active",
+            mode="training", user_id=admin.id, organization_id=org.id,
+        )
+        db.add(report)
+        await db.flush()
+
+        completion = Completion(
+            prompt={"content": "teach me"}, completion={}, status="success",
+            role="ai_system", message_type="ai_completion", report_id=report.id,
+            user_id=admin.id,
+        )
+        db.add(completion)
+        await db.flush()
+
+        agent_exec = AgentExecution(
+            completion_id=completion.id, organization_id=org.id, user_id=admin.id,
+            report_id=report.id, status="success",
+        )
+        db.add(agent_exec)
+        await db.flush()
+
+        build = await build_service.get_or_create_draft_build(
+            db=db, org_id=str(org.id), source="ai", user_id=str(admin.id),
+        )
+
+        instruction_ids = []
+        for i in range(n_instructions):
+            data = InstructionCreate(
+                text=f"Summary rule {i}: exclude test accounts.",
+                title=f"Rule {i}", category="general", load_mode="always",
+                data_source_ids=[], references=[], status="draft",
+            )
+            inst = await instruction_service.create_instruction(
+                db=db, instruction_data=data, current_user=admin, organization=org,
+                force_global=True, build=build, auto_finalize=False,
+                version_status_override="published",
+            )
+            instruction_ids.append(str(inst.id))
+
+            te = ToolExecution(
+                agent_execution_id=agent_exec.id, tool_name="create_instruction",
+                status="success", success=True,
+                arguments_json={"text": data.text, "category": "general"},
+                result_json={"success": True, "instruction_id": str(inst.id), "build_id": str(build.id)},
+            )
+            db.add(te)
+            await db.flush()
+            db.add(CompletionBlock(
+                completion_id=completion.id, agent_execution_id=agent_exec.id,
+                source_type="tool", tool_execution_id=te.id, block_index=i,
+                title="create_instruction", status="complete",
+            ))
+
+        await db.commit()
+        return str(org.id), str(admin.id), str(report.id), str(build.id), instruction_ids
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_summary_pending_build_clears_after_all_accepted():
+    """Regression: the report-summary "publish" pill must disappear once every
+    staged create_instruction has been individually accepted.
+
+    accept_staged_instruction detaches each instruction from the shared draft but
+    leaves the draft in `draft` status. get_report_summary used to key the pending
+    build purely off build status, so the emptied husk kept surfacing as
+    pending_training_build — nagging the user to publish changes already live."""
+    from app.services.report_service import ReportService
+
+    org_id, user_id, report_id, build_id, iids = await _seed_training_report(3)
+    report_service = ReportService()
+    instruction_service = InstructionService()
+
+    # Before accepting anything: the pill is live with all three staged.
+    async with async_session_maker() as db:
+        summary = await report_service.get_report_summary(db, report_id)
+    assert summary["pending_training_build"] is not None
+    assert summary["pending_training_build"]["total_instructions"] == 3
+    assert len(summary["instructions"]) == 3
+
+    # Accept two of the three: the pill stays, now scoped to the remaining one.
+    for iid in iids[:2]:
+        async with async_session_maker() as db:
+            org = await db.get(Organization, org_id)
+            user = await db.get(User, user_id)
+            await instruction_service.accept_staged_instruction(
+                db, iid, build_id=build_id, organization=org, current_user=user,
+            )
+    async with async_session_maker() as db:
+        summary = await report_service.get_report_summary(db, report_id)
+    assert summary["pending_training_build"] is not None
+    assert summary["pending_training_build"]["total_instructions"] == 1
+    assert [i.instruction_id for i in summary["instructions"]] == [iids[2]]
+
+    # Accept the last one: the draft is now an empty husk — no more pill.
+    async with async_session_maker() as db:
+        org = await db.get(Organization, org_id)
+        user = await db.get(User, user_id)
+        await instruction_service.accept_staged_instruction(
+            db, iids[2], build_id=build_id, organization=org, current_user=user,
+        )
+    async with async_session_maker() as db:
+        summary = await report_service.get_report_summary(db, report_id)
+    assert summary["pending_training_build"] is None, (
+        "pill must retire once every staged instruction has been accepted"
+    )
+    assert summary["instructions"] == []
+
+
 @pytest.mark.e2e
 def test_accept_staged_then_reject_sibling(
     create_user, login_user, whoami, test_client


### PR DESCRIPTION
## Problem

In a training session, after accepting every proposed instruction one-by-one, the report still shows a "publish instructions" pill prompting the user to publish — even though those instructions were already accepted and are live.

### Root cause

Training instructions have **two independent resolution paths that don't sync**:

- **Per-card Accept** (`frontend/components/tools/CreateInstructionTool.vue`) → `POST /instructions/{id}/accept-staged`. This promotes that one instruction live as an isolated build-of-one and detaches it from the shared draft build, but *intentionally* leaves the draft in `draft` status so sibling suggestions stay independently acceptable.
- **The end-of-session publish pill** (`frontend/components/prompt/PromptBoxV2.vue`) is driven by `pending_training_build` from `get_report_summary`, which decided "pending" purely from build **status** (`draft`/`pending_approval` + not deleted) — it never checked whether any instructions were still staged in the build.

So once every card was accepted, the shared draft became an **empty husk** (no `BuildContent` rows) but still carried `draft` status → the summary kept reporting it as pending → the pill kept nagging the user to publish changes that were already live.

## Fix

`backend/app/services/report_service.py` (`get_report_summary`): gate the pending build on **live `BuildContent` rows** instead of build status.

- Pick the most recent referenced draft that *still has staged contents*; an emptied draft no longer surfaces as `pending_training_build`.
- Report the true staged count (`len(content_ids)`) rather than the `total_instructions` counter.
- Restrict the listed instructions to those still staged in the build, so already-accepted instructions (which keep the stale `build_id` in their tool-call result) don't linger in the list.

No frontend change is needed — the pill renders on `pendingTrainingBuild`, which the backend now correctly returns as `null` once the draft is empty.

## Tests

- New regression test `test_summary_pending_build_clears_after_all_accepted` in `backend/tests/e2e/test_training_multi_instruction_accept.py`: the pill shows 3 staged, scopes down to 1 after accepting two, and disappears once the last is accepted.
- Full runs green: 5 training-accept tests + 67 `test_instruction.py` / `test_build.py` regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A5ggF82b4bisB4VQoU6E7

---
_Generated by [Claude Code](https://claude.ai/code/session_012A5ggF82b4bisB4VQoU6E7)_