### PR TITLE
Fix Google OAuth 401 by ensuring a refresh token is always available

### DIFF
--- a/backend/app/routes/connection_oauth.py
+++ b/backend/app/routes/connection_oauth.py
@@ -233,8 +233,16 @@ async def oauth_authorize(
     # instead, and some are strict about unrecognized authorize params — X's
     # OAuth2 consent screen fails with "You weren't able to give access to the
     # App" when it's present. Only send it to Google.
+    #
+    # `prompt=consent` is required alongside it: Google issues a refresh token
+    # only on the FIRST consent for a user+client. On any re-authorization of an
+    # already-consented account it returns an access token with no refresh token,
+    # so once that ~1h access token expires there is nothing to refresh and every
+    # call 401s. Forcing the consent screen makes Google mint a refresh token on
+    # every authorization, so reconnecting always self-heals.
     if oauth_params.get("provider_name") == "google":
         params["access_type"] = "offline"
+        params["prompt"] = "consent"
     # Only send a scope when we actually have one (Notion DCR issues no scopes).
     if oauth_params.get("scopes"):
         params["scope"] = _normalize_scopes(oauth_params["scopes"])
@@ -345,6 +353,22 @@ async def oauth_callback(
     prior_blob = existing.encrypted_credentials if existing else None
     prior_expires = existing.expires_at if existing else None
     prior_mode = existing.auth_mode if existing else None
+
+    # Preserve a previously-stored refresh token when this authorization didn't
+    # return one. Google (and some other providers) only mint a refresh token on
+    # first consent; a re-auth that omits it must not wipe the working token we
+    # already hold, or the credential would 401 as soon as the access token
+    # expires with nothing left to refresh. `prompt=consent` above makes Google
+    # send one every time, but this is a defense-in-depth backstop for any
+    # provider/flow that still returns a bare access token.
+    if not tokens.get("refresh_token") and prior_mode == "oauth" and existing is not None:
+        try:
+            prior_creds = existing.decrypt_credentials() or {}
+        except Exception:
+            prior_creds = {}
+        prior_refresh = prior_creds.get("refresh_token")
+        if prior_refresh:
+            tokens["refresh_token"] = prior_refresh
 
     if existing:
         row = existing

--- a/backend/tests/e2e/test_connection_oauth_flow.py
+++ b/backend/tests/e2e/test_connection_oauth_flow.py
@@ -77,6 +77,76 @@ class TestOAuthAuthorizeRoute:
         assert "conn_oauth_verifier" in response.cookies
         assert "conn_oauth_state" not in response.cookies
 
+    def test_authorize_google_requests_offline_and_consent(
+        self, test_client, login_user, create_connection, create_user, whoami
+    ):
+        """Google authorize URL must carry access_type=offline AND prompt=consent.
+
+        Google only mints a refresh token on the first consent for a user+client
+        unless prompt=consent forces the consent screen. Without it, a re-auth
+        returns a bare access token that 401s an hour later with nothing to
+        refresh — the Gmail/BigQuery "invalid authentication credentials" bug.
+        """
+        user = create_user()
+        token = login_user(user["email"], user["password"])
+        me = whoami(token)
+        org_id = me["organizations"][0]["id"]
+
+        conn = create_connection(
+            name="BigQuery Consent",
+            type="bigquery",
+            config={"project_id": "proj", "dataset": "ds"},
+            credentials={"credentials_json": "{}", "oauth_client_id": "gc1", "oauth_client_secret": "gs1"},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+            user_token=token,
+            org_id=org_id,
+        )
+
+        with patch_oauth_for_tests():
+            response = test_client.get(
+                f"/api/connections/{conn['id']}/oauth/authorize",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+            )
+
+        assert response.status_code == 200
+        url = response.json()["authorization_url"]
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        assert query.get("access_type") == ["offline"]
+        assert query.get("prompt") == ["consent"]
+
+    def test_authorize_microsoft_omits_google_only_params(
+        self, test_client, login_user, create_connection, create_user, whoami
+    ):
+        """access_type/prompt are Google-only; Microsoft (and other providers)
+        use the offline_access scope instead and can reject unknown params."""
+        user = create_user()
+        token = login_user(user["email"], user["password"])
+        me = whoami(token)
+        org_id = me["organizations"][0]["id"]
+
+        conn = create_connection(
+            name="PowerBI No Consent",
+            type="powerbi",
+            config={},
+            credentials={"tenant_id": "t1", "client_id": "c1", "client_secret": "s1"},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+            user_token=token,
+            org_id=org_id,
+        )
+
+        with patch_oauth_for_tests():
+            response = test_client.get(
+                f"/api/connections/{conn['id']}/oauth/authorize",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+            )
+
+        assert response.status_code == 200
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(response.json()["authorization_url"]).query)
+        assert "access_type" not in query
+        assert "prompt" not in query
+
     def test_authorize_nonexistent_connection(self, test_client, login_user, create_user, whoami):
         """Authorize returns 404 for non-existent connection."""
         user = create_user()
@@ -347,6 +417,89 @@ class TestOAuthReSignIn:
         # Both exchanges tracked, upsert worked (no unique constraint error)
         assert mock.total_tokens_issued == 2
         assert len(mock.exchange_log) == 2
+
+    @pytest.mark.asyncio
+    async def test_re_signin_without_refresh_token_preserves_existing(
+        self, test_client, login_user, create_connection, create_user, whoami
+    ):
+        """A re-auth that returns no refresh token must NOT wipe the stored one.
+
+        Google omits the refresh token on re-consent; the callback previously
+        overwrote credentials wholesale, leaving refresh_token=None. Once the
+        access token expired there was nothing to refresh and every query 401'd.
+        The callback now carries the prior refresh token forward.
+        """
+        from app.dependencies import async_session_maker
+        from app.models.user_connection_credentials import UserConnectionCredentials
+        from sqlalchemy import select
+
+        user = create_user()
+        token = login_user(user["email"], user["password"])
+        me = whoami(token)
+        org_id = me["organizations"][0]["id"]
+        user_id = me["id"]
+
+        conn = create_connection(
+            name="Gmail Re-signin",
+            type="bigquery",
+            config={"project_id": "proj", "dataset": "ds"},
+            credentials={"credentials_json": "{}", "oauth_client_id": "gc1", "oauth_client_secret": "gs1"},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+            user_token=token,
+            org_id=org_id,
+        )
+
+        with patch_oauth_for_tests() as mock:
+            # First sign-in — issues a refresh token.
+            auth_resp = test_client.get(
+                f"/api/connections/{conn['id']}/oauth/authorize",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+            )
+            state1 = _state_from_authorize(auth_resp)
+            test_client.get(
+                f"/api/connections/oauth/callback?code=code1&state={state1}",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+                follow_redirects=False,
+            )
+
+            async with async_session_maker() as db:
+                row = (await db.execute(
+                    select(UserConnectionCredentials).where(
+                        UserConnectionCredentials.connection_id == conn["id"],
+                        UserConnectionCredentials.user_id == user_id,
+                        UserConnectionCredentials.is_active == True,
+                    )
+                )).scalars().first()
+                original_refresh = row.decrypt_credentials()["refresh_token"]
+            assert original_refresh
+
+            # Second sign-in — provider returns NO refresh token this time.
+            mock.omit_refresh_on_exchange = True
+            auth_resp2 = test_client.get(
+                f"/api/connections/{conn['id']}/oauth/authorize",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+            )
+            state2 = _state_from_authorize(auth_resp2)
+            test_client.get(
+                f"/api/connections/oauth/callback?code=code2&state={state2}",
+                headers={"Authorization": f"Bearer {token}", "X-Organization-Id": org_id},
+                follow_redirects=False,
+            )
+
+        async with async_session_maker() as db:
+            row = (await db.execute(
+                select(UserConnectionCredentials).where(
+                    UserConnectionCredentials.connection_id == conn["id"],
+                    UserConnectionCredentials.user_id == user_id,
+                    UserConnectionCredentials.is_active == True,
+                )
+            )).scalars().first()
+            creds = row.decrypt_credentials()
+
+        # New access token stored, but the refresh token was preserved.
+        assert creds["access_token"] == "access_token_v2"
+        assert creds["refresh_token"] == original_refresh
 
 
 class TestOAuthRegistryIntegration:

--- a/backend/tests/mocks/mock_oauth_provider.py
+++ b/backend/tests/mocks/mock_oauth_provider.py
@@ -74,6 +74,10 @@ class MockOAuthProvider:
         self._obo_log: List[Dict[str, Any]] = []
         # Control OBO behavior per connection type (set to Exception to simulate failure)
         self._obo_failures: Dict[str, Exception] = {}
+        # When True, the next code exchange returns no refresh token — modeling
+        # Google re-consent, which only mints a refresh token on the first
+        # authorization (or when prompt=consent is sent).
+        self.omit_refresh_on_exchange: bool = False
 
     def get_oauth_params(self, connection) -> dict:
         """Mock replacement for connection_oauth_service.get_oauth_params()."""
@@ -107,7 +111,10 @@ class MockOAuthProvider:
             "code_verifier": code_verifier,
             "client_id": oauth_params.get("client_id"),
         })
-        return self._make_token_response(f"access_token_v{self._token_counter}")
+        return self._make_token_response(
+            f"access_token_v{self._token_counter}",
+            include_refresh=not self.omit_refresh_on_exchange,
+        )
 
     async def refresh_access_token(
         self,
@@ -150,13 +157,16 @@ class MockOAuthProvider:
         """Remove all programmed OBO failures."""
         self._obo_failures.clear()
 
-    def _make_token_response(self, access_token: str) -> dict:
-        return {
+    def _make_token_response(self, access_token: str, include_refresh: bool = True) -> dict:
+        response = {
             "access_token": access_token,
             "refresh_token": f"refresh_{secrets.token_urlsafe(8)}",
             "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
             "token_type": "Bearer",
         }
+        if not include_refresh:
+            response.pop("refresh_token")
+        return response
 
     # -- Assertion helpers for tests --
 


### PR DESCRIPTION
## Problem

Native Gmail / BigQuery (Google delegated OAuth) connections would fail mid-use with:

> `search_email failed: Gmail API 401: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential.`

Google access tokens live ~1 hour. When one expires, `maybe_refresh_oauth_credentials` is supposed to silently renew it — but that path requires a stored **refresh token**, and in two cases there wasn't one. The expired access token then went to Gmail and got a 401.

## Root cause

Two bugs left the refresh token missing:

1. **The authorize request sent `access_type=offline` but not `prompt=consent`.** Google only mints a refresh token on the *first* consent for a given user + OAuth client. Any re-authorization of an already-consented account returned a bare access token with no refresh token — so once it expired there was nothing left to refresh.
2. **The callback overwrote stored credentials wholesale.** A re-auth that omitted the refresh token wiped the working one already on file.

## Changes

- `backend/app/routes/connection_oauth.py`
  - Add `prompt=consent` alongside `access_type=offline` for Google so a refresh token is returned on **every** authorization. (Still Google-only — Microsoft and others use the `offline_access` scope and can reject unknown authorize params.)
  - In the OAuth callback, **preserve the previously-stored refresh token** when a token response omits one — a defense-in-depth backstop for any provider/flow that returns a bare access token.
- `backend/tests/e2e/test_connection_oauth_flow.py`, `backend/tests/mocks/mock_oauth_provider.py`
  - Assert the Google authorize URL carries `access_type=offline` + `prompt=consent`, while Microsoft omits both.
  - Assert a re-auth that returns no refresh token preserves the stored one (new access token saved, refresh token unchanged).

## Testing

All OAuth token/callback tests pass, including the 3 new ones. Four failures in the local run are pre-existing and unrelated (stale `ms_fabric` scope expectations); confirmed they fail identically on a clean tree without these changes.

## Recovering already-broken accounts

This fix prevents recurrence, but an already-affected user still has no refresh token stored. They need to **disconnect and reconnect Gmail once** — the reconnect now forces the consent screen and mints a fresh refresh token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rCqBBiyfaX2Vw5dLXwaLo

---
_Generated by [Claude Code](https://claude.ai/code/session_014rCqBBiyfaX2Vw5dLXwaLo)_