### PR TITLE
Allow saving a per-user Power BI connection when the service account can't query

### DIFF
--- a/backend/tests/unit/test_powerbi_client.py
+++ b/backend/tests/unit/test_powerbi_client.py
@@ -157,6 +157,19 @@ class TestTestConnection:
         assert out["success"] is False
         assert "Member or Contributor" in out["message"]
 
+    def test_forbidden_still_reports_connectivity(self):
+        """When the service principal authenticated and listed workspaces but is
+        not authorized to QUERY any probed dataset (401/403 — e.g. RLS-only
+        workspaces, where executeQueries rejects a service principal), the result
+        must carry `connectivity: True`. Per-user (delegated) connections rely on
+        this to remain savable: they query with each user's own sign-in, not the
+        service account, so an SP query failure must not read as 'not connected'."""
+        c = _mk_client()
+        _wire_probe(c, WS, DS, [_resp(401), _resp(401)])
+        out = c.test_connection()
+        assert out["success"] is False
+        assert out.get("connectivity") is True
+
     def test_404_skipped_then_success(self):
         c = _mk_client()
         _wire_probe(c, WS, DS, [_resp(404), _resp(200, {"results": []})])

--- a/frontend/components/datasources/ConnectForm.vue
+++ b/frontend/components/datasources/ConnectForm.vue
@@ -131,8 +131,15 @@
             <UToggle color="blue" v-model="use_llm_onboarding" />
             <span class="text-xs text-gray-700 dark:text-gray-300">Use LLM to learn data source</span>
           </div>
-          <div v-if="testResultOk !== null" class="mb-2">
-            <div :class="testResultOk ? 'text-green-600' : 'text-red-600'" class="text-xs break-words line-clamp-2">
+          <div v-if="testResultLevel !== null" class="mb-2">
+            <div
+              :class="{
+                'text-green-600': testResultLevel === 'success',
+                'text-amber-600': testResultLevel === 'warning',
+                'text-red-600': testResultLevel === 'error',
+              }"
+              class="text-xs break-words line-clamp-3"
+            >
               {{ testResultMessage }}
             </div>
           </div>
@@ -294,7 +301,10 @@ const submitting = ref(false)
 const isTestingConnection = ref(false)
 const connectionTestPassed = ref(false)
 const testResultMessage = ref('')
-const testResultOk = ref<boolean | null>(null)
+// null = untested, 'success' = fully OK, 'warning' = savable but service
+// account can't query (per-user connections rely on each user's own sign-in),
+// 'error' = not savable.
+const testResultLevel = ref<'success' | 'warning' | 'error' | null>(null)
 const preserveOnNextFetch = ref(false)
 
 const auth_policy = computed(() => (require_user_auth.value ? 'user_required' : 'system_only'))
@@ -632,13 +642,32 @@ async function testConnection() {
 
     const data: any = (res.data as any)?.value
     const ok = !!(data?.success)
+    // A per-user (delegated) connection queries with each user's own sign-in,
+    // NOT the service account. So "connected & authenticated, but the service
+    // account can't query the datasets" (e.g. RLS-only workspaces, where the
+    // executeQueries API rejects a service principal) is a savable state — the
+    // backend signals it with `connectivity: true`. Without this, such a
+    // connection could never be saved even though it's correctly configured.
+    const connectivityOk = !!(data?.connectivity)
+    const savableViaUserAuth = !ok && require_user_auth.value && connectivityOk
     const msg = data?.message || (ok ? 'Connection successful' : 'Connection failed')
-    connectionTestPassed.value = ok
-    testResultOk.value = ok
-    testResultMessage.value = String(msg)
+
+    connectionTestPassed.value = ok || savableViaUserAuth
+    if (ok) {
+      testResultLevel.value = 'success'
+      testResultMessage.value = String(msg)
+    } else if (savableViaUserAuth) {
+      testResultLevel.value = 'warning'
+      testResultMessage.value =
+        'Connected. The service account can\'t query these datasets, but users will ' +
+        'query with their own Microsoft sign-in — you can save and continue. (' + String(msg) + ')'
+    } else {
+      testResultLevel.value = 'error'
+      testResultMessage.value = String(msg)
+    }
   } catch (e) {
     connectionTestPassed.value = false
-    testResultOk.value = false
+    testResultLevel.value = 'error'
     testResultMessage.value = 'Request failed'
   } finally {
     isTestingConnection.value = false
@@ -648,7 +677,7 @@ async function testConnection() {
 function clearTestResult() {
   connectionTestPassed.value = false
   testResultMessage.value = ''
-  testResultOk.value = null
+  testResultLevel.value = null
 }
 
 watch(require_user_auth, () => {


### PR DESCRIPTION
## Problem

The connection form gates **Save and Continue** on **Test Connection** passing (`ConnectForm.vue` — `:disabled="!connectionTestPassed"`), and the test runs with the **service-principal** credentials even for per-user (`user_required`) connections.

For a Power BI workspace whose semantic models use **row-level security**, the `executeQueries` REST API rejects a service principal (HTTP 401) — so the test always fails and the connection can **never be saved**, even though per-user authentication would query it correctly at runtime (each user signs in with their own Microsoft account and RLS resolves against their role).

This is a catch-22: the only correct way to query RLS models is per-user auth, but you can't save a per-user connection because the SP-based test fails.

## Fix

When **Require user authentication** is enabled and the backend reports **connectivity** (authenticated + workspaces listed) but the service account can't query, treat the connection as **savable** and show an explanatory notice instead of a blocking red error:

> Connected. The service account can't query these datasets, but users will query with their own Microsoft sign-in — you can save and continue.

- Scoped precisely: only unblocks when per-user auth is on — the exact case where the connection works at runtime. **SP-only connections are unchanged** (still require a passing query probe).
- The backend already surfaces `connectivity: true` in this "connected but SP can't query" case; the fix consumes it.
- Introduces a `success | warning | error` result level so the message color reflects the savable-warning state.

## Tests

Backend contract the fix depends on is locked in `tests/unit/test_powerbi_client.py`:
`test_forbidden_still_reports_connectivity` — PowerBI `test_connection` returns `connectivity: True` on the 401/403 probe path (37 passed).

Frontend has no component-test harness (Playwright e2e only), and exercising this exact path needs a live RLS tenant, so the frontend change is covered by the backend contract test plus manual review. Note: `vue-tsc` could not run in this environment (Node 22 package-exports incompatibility), so no automated frontend typecheck was performed.

## Context

Follow-up to #714 (Power BI missing semantic models). That PR fixed discovery + the OBO overlay; this fixes the connection-save UX for the RLS / per-user case surfaced during live testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHRP3dFWPfrWBWshYiZvG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHRP3dFWPfrWBWshYiZvG1)_