### PR TITLE
Fix instruction text sometimes not appearing in chat tool cards

### DIFF
--- a/frontend/components/tools/CreateInstructionTool.vue
+++ b/frontend/components/tools/CreateInstructionTool.vue
@@ -59,7 +59,7 @@
             class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer"
             @click="currentGlobalStatus !== 'approved' ? handleEdit() : null"
           >
-            <MDC :value="instructionText" class="markdown-content" />
+            <InstructionText :text="instructionText" :markdown="true" />
           </div>
 
           <!-- Metadata row -->
@@ -161,6 +161,7 @@ import { useI18n } from 'vue-i18n'
 import InstructionModalComponent from '~/components/InstructionModalComponent.vue'
 import Spinner from '~/components/Spinner.vue'
 import ResolvedEvalStrip from '~/components/instructions/ResolvedEvalStrip.vue'
+import InstructionText from '~/components/instructions/InstructionText.vue'
 import { dispatchInstructionResolved, INSTRUCTION_RESOLVED_EVENT } from '~/composables/useTrackedChanges'
 
 const { t } = useI18n()

--- a/frontend/components/tools/EditInstructionTool.vue
+++ b/frontend/components/tools/EditInstructionTool.vue
@@ -83,7 +83,7 @@
             class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer"
             @click="handleEdit()"
           >
-            <MDC :value="displayText" class="markdown-content" />
+            <InstructionText :text="displayText" :markdown="true" />
           </div>
         </div>
 
@@ -171,6 +171,7 @@ import { useI18n } from 'vue-i18n'
 import DiffMatchPatch from 'diff-match-patch'
 import Spinner from '~/components/Spinner.vue'
 import ResolvedEvalStrip from '~/components/instructions/ResolvedEvalStrip.vue'
+import InstructionText from '~/components/instructions/InstructionText.vue'
 import TrackedChangesView from '~/components/instructions/TrackedChangesView.vue'
 import InstructionTrackedChanges from '~/components/instructions/InstructionTrackedChanges.vue'
 import {

--- a/frontend/components/tools/SearchInstructionsTool.vue
+++ b/frontend/components/tools/SearchInstructionsTool.vue
@@ -46,7 +46,7 @@
               <div v-if="isExpanded(idx)" class="ps-6 pe-1 pb-2">
                 <div class="instruction-content text-[12px] text-gray-700 dark:text-gray-300 leading-relaxed mb-1 cursor-pointer hover:text-gray-900 dark:hover:text-white"
                      @click="emit('openInstruction', item.id)">
-                  <MDC :value="item.text || ''" class="markdown-content" />
+                  <InstructionText :text="item.text || ''" :markdown="true" />
                 </div>
                 <button
                   class="text-[10px] text-blue-600 hover:text-blue-800 inline-flex items-center gap-0.5"
@@ -72,6 +72,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import InstructionText from '~/components/instructions/InstructionText.vue'
 
 const { t } = useI18n()
 


### PR DESCRIPTION
## Problem

Users reported that the instruction body **sometimes doesn't appear** in the chat "Create instruction" card — the header/summary line shows the instruction, but the card body below (with Confidence, Load, Evidence, Accept/Reject) is missing the actual instruction text.

## Root cause

The Create/Edit/Search instruction tool cards rendered the instruction body through `<MDC>` — the `@nuxtjs/mdc` runtime markdown component (`remark-mdc`). MDC parses text as **MDC-flavored** markdown and **silently strips** anything it reads as MDC syntax:

- leading `---` → treated as YAML **frontmatter** and removed
- `::name` / `:::` → block/container **components** (unregistered → dropped)
- `:icon{...}` → inline **component** (dropped)
- `{{ ... }}` → **binding** expression (evaluated to empty)

When that syntax dominates an instruction (e.g. a self-learning instruction whose whole body is wrapped in `---` … `---`), the visible body renders **completely blank**. Plain instructions are unaffected — which is why it only happened *sometimes*. The header still showed text because it uses a plain-text binding (`truncatedText`), not MDC.

## Fix

Render these instruction bodies with `InstructionText` (`:markdown`), the synchronous `markdown-it`-based renderer already used app-wide (`ReportAgentPanel`, `KnowledgeExplorer`, …). `markdown-it` treats `---` as a horizontal rule and doesn't reserve `::` / `{{ }}`, so the full instruction always renders.

Changed components:
- `frontend/components/tools/CreateInstructionTool.vue`
- `frontend/components/tools/EditInstructionTool.vue`
- `frontend/components/tools/SearchInstructionsTool.vue`

## Verification

Drove the real components in a headless browser (`nuxt dev` + Chromium):

- A 13-case battery through both renderers on identical input: `<MDC>` strips/mangles frontmatter, component, and binding syntax; `InstructionText` renders all cases in full.
- Definitive case — an instruction whose whole body is `---\n<text>\n---`: `<MDC>` renders **blank**, `InstructionText` renders the full text.
- Mounted the actual `CreateInstructionTool` with that instruction: the body now renders above Confidence/Load/Evidence (previously blank).

## Notes

The same `<MDC>` pattern still exists in `InstructionPrivateCreateComponent.vue`, `InstructionAnalysisPanel.vue`, and `BuildExplorerModal.vue`, which can blank on the same content. Left out of this PR to keep it focused; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JorChbgkz9fd7ukKv6FdDz)_