### PR TITLE
Speed up e2e CI with pytest-xdist and raise the job timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,10 +10,11 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
-    # The sqlite matrix leg runs a full alembic up/down per test on a file DB
-    # and the suite has grown past the old 60-minute cap (it was being
-    # cancelled mid-run). 90 gives headroom while still bounding runaway hangs.
-    timeout-minutes: 90
+    # The suite outgrew the old 60- then 90-minute caps (it was being cancelled
+    # mid-run). It now runs under pytest-xdist (-n auto, see the E2E step), which
+    # cuts wall time several-fold; 120 leaves generous headroom while still
+    # bounding runaway hangs.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -57,8 +58,12 @@ jobs:
         TESTING: "true"
         ENVIRONMENT: "production"
         OPENAI_API_KEY_TEST: ${{ secrets.OPENAI_API_KEY_TEST }}
+      # -n auto runs the suite across one worker per CPU. Each xdist worker is a
+      # separate process, so it gets its own DB (its own Postgres testcontainer /
+      # its own PID+UUID SQLite file per tests/conftest.py) — workers never share
+      # a database, so the per-test schema reset stays isolation-safe in parallel.
       run: |
-        uv run pytest -s -m e2e --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
+        uv run pytest -s -n auto -m e2e --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
 
   playwright-tests:
     runs-on: ubuntu-latest

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -119,6 +119,7 @@ dev = [
     "pytest>=8.4.2,<8.5",
     "pytest-asyncio>=0.23.8,<0.24",
     "pytest-timeout>=2.4.0,<2.5",
+    "pytest-xdist>=3.6.1,<4",
     "testcontainers[postgres,mysql]>=4.14.2,<4.15",
     "aiosmtpd>=1.4.6,<1.5",
     "ruff>=0.15.18,<0.16",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,13 +18,25 @@ _postgres_container = None
 
 
 def _get_db_backend_from_argv():
-    """Parse --db option from sys.argv before pytest processes it."""
+    """Resolve the DB backend at conftest module-load time (before pytest has
+    parsed options).
+
+    Under pytest-xdist the worker subprocesses do NOT receive the original
+    ``--db`` on ``sys.argv`` — only the controller does. So we check the
+    ``TEST_DB`` env var FIRST: the controller exports it in ``pytest_configure``
+    (see below) before xdist spawns workers, and workers inherit it. Without
+    this, a worker would fall back to sqlite even for ``--db=postgres`` and then
+    try to run the Postgres schema reset against a sqlite URL.
+    """
+    env_backend = os.environ.get("TEST_DB")
+    if env_backend:
+        return env_backend
     for i, arg in enumerate(sys.argv):
         if arg == "--db" and i + 1 < len(sys.argv):
             return sys.argv[i + 1]
         if arg.startswith("--db="):
             return arg.split("=", 1)[1]
-    return os.environ.get("TEST_DB", "sqlite")
+    return "sqlite"
 
 
 def _setup_test_database():
@@ -98,6 +110,12 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """Configure pytest markers."""
+    # Export the selected backend so pytest-xdist workers pick it up at
+    # module-load (their sys.argv lacks --db). This runs in the controller
+    # before workers are spawned, and again harmlessly in each worker; either
+    # way _get_db_backend_from_argv() then resolves the same backend everywhere,
+    # so every worker starts its own Postgres container / sqlite file.
+    os.environ["TEST_DB"] = config.getoption("--db", default="sqlite")
     config.addinivalue_line("markers", "e2e: marks tests as end-to-end tests")
     config.addinivalue_line(
         "markers",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -481,6 +481,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testcontainers", extra = ["mysql"] },
     { name = "ty" },
@@ -573,6 +574,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2,<8.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.8,<0.24" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0,<2.5" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1,<4" },
     { name = "python-dotenv", specifier = ">=1.2.2,<1.3" },
     { name = "python-multipart", specifier = ">=0.0.32,<0.1" },
     { name = "python-pptx", specifier = ">=1.0.2,<1.1" },
@@ -1211,6 +1213,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -3786,6 +3797,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `e2e-tests (postgres)` job was hitting its 90-minute cap and getting **cancelled mid-run** — not failing on a test. The suite's wall time crept past the ceiling (the last green run took `5172.18s` / `1:26:12`, right against the wall), so a slightly slower run gets guillotined partway through with `##[error]The operation was canceled.` and no test summary.

## Changes

- **Parallelize the E2E step with `pytest-xdist` (`-n auto`)** — one worker per CPU, which cuts wall time several-fold. Each xdist worker is a separate process that starts its **own** Postgres testcontainer (or its own PID+UUID SQLite file), so workers never share a database and the per-test schema reset stays isolation-safe in parallel.
- **Fix an xdist-compat bug in `tests/conftest.py`.** The module-load DB-backend detection read `--db` from `sys.argv`, which xdist worker subprocesses don't receive — so workers fell back to sqlite and then ran the Postgres schema reset against a sqlite URL (`sqlite3.OperationalError: unable to open database file`). The controller now exports `TEST_DB` in `pytest_configure` (before workers spawn) and workers resolve the backend from it, matching the `db_backend` fixture.
- **Raise `timeout-minutes` 90 → 120** for generous headroom on top of the speedup.
- Added `pytest-xdist` to `backend/pyproject.toml` and refreshed `backend/uv.lock` (CI uses `uv sync --frozen`).

The AI step (`-m ai`) is intentionally left serial — it uses the real OpenAI API and parallelizing it would risk rate-limit flakes.

## Validation

Ran locally with Docker on small slices of both matrix legs:

| Run | Result |
|---|---|
| Postgres `-n 2` | ✅ 11 passed |
| SQLite `-n 2` | ✅ 11 passed |
| SQLite serial (regression) | ✅ 2 passed |

Full-suite wall time and confirmation will come from this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTXxqGzBypHnDJwFhxnkeS)_