### PR TITLE
Make model-id test parametrize deterministic for pytest-xdist

### DIFF
--- a/backend/tests/e2e/test_completion_model_id_resolution.py
+++ b/backend/tests/e2e/test_completion_model_id_resolution.py
@@ -78,7 +78,11 @@ def test_completion_resolves_default_when_model_id_omitted(
     "bad_model_id",
     [
         "auto",                       # the exact sentinel the home box leaked
-        str(uuid.uuid4()),            # a well-formed id the org does not own
+        # A well-formed id the org does not own. Must be a FIXED literal, not
+        # uuid.uuid4(): parametrize values are evaluated at collection time, so
+        # a random value makes each pytest-xdist worker collect a differently-
+        # named test id and xdist aborts with "Different tests were collected".
+        "00000000-0000-4000-8000-000000000000",
         "definitely-not-a-model",     # arbitrary garbage
     ],
 )


### PR DESCRIPTION
## Problem

Follow-up to #740 (which parallelized the e2e suite with pytest-xdist). Under `-n auto`, the e2e run aborted at **collection** with 0 tests run:

```
Different tests were collected between gw2 and gw3
3 errors
```

`test_completion_rejects_unknown_model_id` parametrized one case with `str(uuid.uuid4())`. Parametrize arguments are evaluated at collection time, and each xdist worker collects independently — so every worker generated a different UUID, produced a differently-named test id, and xdist's cross-worker consistency check killed the whole run.

## Fix

Replace the random UUID with a fixed, well-formed literal (`00000000-0000-4000-8000-000000000000`) that the org still doesn't own. The test's intent ("a well-formed id the org does not own") is unchanged, but collection is now identical across workers. The `uuid.uuid4()` calls inside the test bodies are unaffected — they run at test time, not collection time.

Grepped every `@pytest.mark.parametrize` in the suite for other non-deterministic values (`uuid4`, `random`, `datetime.now`, `secrets`, …) — this was the only offender.

## Validation

Ran the file under `-n 4 --db=postgres` (multi-worker forces the collection-consistency check that was failing): **5 passed**, no collection errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTXxqGzBypHnDJwFhxnkeS)_