### PR TITLE
Cap e2e xdist at -n 2 to stop the runner OOM-killing a worker

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,9 +11,9 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     # The suite outgrew the old 60- then 90-minute caps (it was being cancelled
-    # mid-run). It now runs under pytest-xdist (-n auto, see the E2E step), which
-    # cuts wall time several-fold; 120 leaves generous headroom while still
-    # bounding runaway hangs.
+    # mid-run). It now runs under pytest-xdist (see the E2E step), which cuts
+    # wall time several-fold; 120 leaves generous headroom while still bounding
+    # runaway hangs.
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -58,12 +58,20 @@ jobs:
         TESTING: "true"
         ENVIRONMENT: "production"
         OPENAI_API_KEY_TEST: ${{ secrets.OPENAI_API_KEY_TEST }}
-      # -n auto runs the suite across one worker per CPU. Each xdist worker is a
-      # separate process, so it gets its own DB (its own Postgres testcontainer /
-      # its own PID+UUID SQLite file per tests/conftest.py) — workers never share
-      # a database, so the per-test schema reset stays isolation-safe in parallel.
+      # pytest-xdist parallelizes the suite. Each worker is a separate process
+      # with its own DB (its own Postgres testcontainer / its own PID+UUID SQLite
+      # file per tests/conftest.py), so workers never share a database and the
+      # per-test schema reset stays isolation-safe.
+      #
+      # Capped at -n 2 (not -n auto): at 4 workers the heavy app (pyspark,
+      # snowflake, databricks, pandas, grpc, …) plus the real-LLM tests pushed
+      # peak RSS high enough that the runner SIGKILLed a worker mid-test — it
+      # surfaced as "worker 'gwN' crashed" with no traceback (an uncatchable
+      # SIGKILL), always clustered around the same memory peak, and was not
+      # reproducible on an identical-spec box at -n 2. Two workers halve the
+      # peak while still cutting wall time ~2-3x vs the old serial run.
       run: |
-        uv run pytest -s -n auto -m e2e --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
+        uv run pytest -s -n 2 -m e2e --db=${{ matrix.db }} --disable-warnings --timeout=600 --timeout-method=thread
 
   playwright-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Follow-up to #740/#741. Since the e2e suite went parallel with `-n auto` (4 workers on the CI runner), a worker intermittently dies mid-test and is reported as:

```
worker 'gwN' crashed while running 'tests/e2e/test_usage_limits.py::test_usage_policy_update_persists_connection_overrides_with_unlimited_defaults'
1 failed, 8XX passed
```

This is **not an assertion failure** — the worker *process* is killed. The evidence points to an out-of-memory **SIGKILL**, not a code fault:

- **No traceback** — faulthandler is enabled but prints nothing; SIGKILL can't be caught.
- **Deterministic-ish** — it clusters on the same test each run (a memory peak, not a random failure), because xdist's `load` distribution is deterministic for a fixed test set + worker count.
- **Not reproducible** on an identical 16 GB / 4-core box: I ran the full sqlite e2e suite at `-n 4` locally to completion (872 passed) with no crash. The gap is the real-LLM tests (`test_completion`, `test_llm_providers`) that need `OPENAI_API_KEY_TEST` — they fail-fast locally but execute heavier native code in CI.

Four workers each load the full app (pyspark, snowflake, databricks, pandas, grpc, …); their combined peak RSS plus the real-LLM tests tips the 16 GB runner over and the kernel kills a worker.

## Fix

Cap the E2E step at `-n 2` instead of `-n auto`. Two workers halve the peak memory footprint while still cutting wall time ~2–3× versus the old serial run (the parallel run was ~17 min; even at `-n 2` it stays well within the 120-minute cap).

Deliberately **no** retry/rerun wrapper: a retry running on the xdist worker can't recover a controller-side worker-crash report anyway, and I don't want to mask genuine failures. If `-n 2` still isn't enough headroom, the next step is to split the heavy real-LLM tests out of the parallel pool — but memory reduction is the direct, minimal fix for the observed OOM.

## Validation

- Full sqlite e2e suite at `-n 4` locally: 872 passed (no crash on the beefier-effective box) — confirms it's environment/memory-bound, not a code bug.
- `test_usage_limits.py` under `-n 2`: 18 passed.

The real confirmation is this PR's CI run on the actual runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTXxqGzBypHnDJwFhxnkeS)_