### PR TITLE
Fix Auto model erroring in triggers and saved/scheduled prompts

### DIFF
--- a/backend/tests/e2e/test_triggers.py
+++ b/backend/tests/e2e/test_triggers.py
@@ -191,6 +191,43 @@ def test_trigger_rejects_inaccessible_agents(
     assert resp.status_code == 403
 
 
+@pytest.mark.e2e
+def test_trigger_auto_model_is_valid(
+    create_user, login_user, whoami, test_client,
+):
+    """Auto model (no explicit pick) is a first-class option: model_id omitted
+    or explicitly null must succeed and round-trip as null so the run engages
+    the Auto router. Regression guard for the client sending the 'auto' UI
+    sentinel as a literal model id — the server rightly 404s an unknown id, so
+    the sentinel must never leave the client (see PromptBoxV2.getModel)."""
+    token, org_id = _setup_user(create_user, login_user, whoami)
+
+    # Omitted → Auto
+    trig = _create_trigger(test_client, token, org_id)
+    assert trig.status_code == 200, trig.json()
+    tid = trig.json()["id"]
+    assert trig.json()["model_id"] is None
+
+    # Explicit null → Auto (still valid)
+    trig2 = _create_trigger(test_client, token, org_id, name="Auto 2", model_id=None)
+    assert trig2.status_code == 200, trig2.json()
+    assert trig2.json()["model_id"] is None
+
+    # The UI sentinel is NOT a model id — the server must reject it. This is
+    # exactly the failure the client fix prevents by mapping 'auto' → null.
+    bad = _create_trigger(test_client, token, org_id, name="Bad", model_id="auto")
+    assert bad.status_code == 404, bad.json()
+
+    # Update back to Auto (null) after the fact also round-trips.
+    up = test_client.put(
+        f"/api/triggers/{tid}",
+        json={"model_id": None},
+        headers=_headers(token, org_id),
+    )
+    assert up.status_code == 200, up.json()
+    assert up.json()["model_id"] is None
+
+
 # ---------------------------------------------------------------------------
 # Delivery → spawn pipeline
 # ---------------------------------------------------------------------------

--- a/frontend/components/ScheduledPromptModal.vue
+++ b/frontend/components/ScheduledPromptModal.vue
@@ -385,7 +385,9 @@ function getCurrentPrompt(): { content: string; mentions?: any[]; mode?: string;
         content: box?.getText?.() || fallback.content || '',
         mentions: box?.getMentions?.() || fallback.mentions,
         mode: box?.getMode?.() || fallback.mode || 'chat',
-        model_id: box?.getModel?.() || fallback.model_id,
+        // Trust the box when mounted — its getModel() maps Auto to null. Use
+        // `??` so a deliberate Auto (null) isn't overridden by the saved model.
+        model_id: box ? (box.getModel?.() ?? undefined) : fallback.model_id,
     }
 }
 

--- a/frontend/components/automations/TriggersTab.vue
+++ b/frontend/components/automations/TriggersTab.vue
@@ -310,7 +310,10 @@ function readRunSpec() {
   return {
     task_template: box?.getText?.() ?? fallback.task_template ?? '',
     mode: box?.getMode?.() || fallback.mode || 'chat',
-    model_id: box?.getModel?.() || fallback.model_id || null,
+    // Trust the box when it's mounted — its getModel() already maps Auto to
+    // null. Use `??` (not `||`) so a deliberate Auto (null) is preserved
+    // instead of falling back to the previously-saved model on edit.
+    model_id: box ? (box.getModel?.() ?? null) : (fallback.model_id ?? null),
     data_source_ids: ((box?.getDataSources?.() as any[]) || fallback.data_sources || [])
       .map((d: any) => d?.id).filter(Boolean),
   }

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -1644,7 +1644,11 @@ defineExpose({
     // Expose current state for external save (e.g. ScheduledPromptModal)
     getText: () => text.value,
     getMode: () => mode.value,
-    getModel: () => selectedModel.value,
+    // Return the payload-ready model id: the 'auto' sentinel maps to null so
+    // the backend router engages. Returning the raw sentinel makes callers
+    // (triggers, saved/scheduled prompts) POST model_id='auto', which the
+    // server rejects with "Model not found".
+    getModel: () => modelIdForPayload.value,
     getMentions: () => inlineMentions.value,
     getDataSources: () => selectedDataSources.value,
 })


### PR DESCRIPTION
## Problem

When the model is left on **Auto** (the default when the org's model router is on) and you save a trigger, the request fails with **404 "Model not found"**. The same latent bug affects saved/scheduled prompts, where it surfaces at run time instead.

## Root cause

`PromptBoxV2.getModel()` exposed the raw `'auto'` UI sentinel instead of the payload-ready model id. `'auto'` is a client-only marker — the backend has no model with that id, so `webhook_service._validate_trigger_spec` rejected it with `get_model_by_id(...) → None → 404`.

Every other place in `PromptBoxV2` already used `modelIdForPayload` (which maps `'auto' → null`), but the exposed getter didn't — so the two components that build a request body from it broke:

- **Triggers tab** → `POST /api/triggers` with `model_id:"auto"` → 404
- **Scheduled/saved prompts modal** → stored `model_id:"auto"`, which then fails at run time in the completion resolver (`if prompt_model_id:` is truthy for `"auto"`, so it resolves a nonexistent model)

Evals' new-test-case box (`TestPromptBox`) is **not** affected — it has no Auto option and always sends a concrete model id, so it's on a different code path.

## Reproduction

Set up the backend per `docs/design/sandbox-feedback-loop.md` and hit the endpoint directly:

```
model_id:"auto"  → HTTP 404 {"detail":"Model not found"}   ← the bug
model_id:null    → HTTP 200 (router engages)               ← what the UI should send
```

## Fix

- `getModel()` now returns `modelIdForPayload` so the `'auto'` sentinel maps to `null` and an Auto run engages the router (one central fix covering triggers + saved/scheduled prompts).
- The two callers use `??` instead of `||` so deliberately switching an existing trigger/prompt **to** Auto persists as `null` rather than silently reverting to the previously-saved model.
- Added an e2e regression test (`test_trigger_auto_model_is_valid`) asserting Auto (omitted/null) round-trips as `null`, and that the `'auto'` sentinel is rejected.

## Testing

- New `test_trigger_auto_model_is_valid` and existing `test_trigger_crud_and_run_spec` pass (`pytest -m e2e --db=sqlite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7Qxotd5ftuXvRm8rxt2nS)_