### PR TITLE
Fix inflated token count in the conversation trace roll-up

### DIFF
--- a/backend/app/schemas/agent_execution_trace_schema.py
+++ b/backend/app/schemas/agent_execution_trace_schema.py
@@ -96,8 +96,11 @@ class ConversationTraceResponse(BaseModel):
     failed_turns: int = 0
     negative_feedback_turns: int = 0
     # LLM usage roll-up aggregated from llm_usage_records for this report.
-    # Tokens include prompt + completion + cache read/write; cost may be 0
-    # when the model has no pricing configured.
+    # Counts only the turns' own work — the planner loop plus the tool calls it
+    # makes — and excludes background/observability scopes (judge grading,
+    # follow-up/title generation, context compaction). Tokens include prompt +
+    # completion + cache read/write; cost may be 0 when the model has no
+    # pricing configured.
     total_llm_tokens: Optional[int] = None
     total_llm_cost_usd: Optional[float] = None
     turns: List[ConversationTurnSchema] = []

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -96,6 +96,26 @@ def _turn_usage_scope_clause():
     return not_(is_non_turn)
 
 
+def _row_total_tokens_expr():
+    """SQLAlchemy per-row token total that doesn't double-count cache, for use
+    inside func.sum(). Mirrors ConsoleService._row_total_tokens: Anthropic
+    reports cache_read/cache_creation SEPARATELY from prompt_tokens (add them
+    in), while OpenAI/Azure fold cache_read into prompt_tokens already (must
+    not re-add, or the cached prefix is counted twice). Other providers record
+    zero cache tokens, so the else-branch is a no-op for them."""
+    return (
+        LLMUsageRecord.prompt_tokens
+        + LLMUsageRecord.completion_tokens
+        + case(
+            (
+                LLMUsageRecord.provider_type == "anthropic",
+                LLMUsageRecord.cache_read_tokens + LLMUsageRecord.cache_creation_tokens,
+            ),
+            else_=0,
+        )
+    )
+
+
 class ConsoleService:
 
     def _parse_data_source_ids(self, data_source_ids: Optional[str]) -> List[str]:
@@ -2345,17 +2365,13 @@ class ConsoleService:
         # follow-up/title generation, context compaction; see
         # _turn_usage_scope_clause). Without this a one-line question rolls up
         # the judge's full-context re-reads and reports 200k+ tokens.
+        #
+        # _row_total_tokens_expr keeps the sum from double-counting cache:
+        # OpenAI/Azure already fold cache_read into prompt_tokens, so cache
+        # tokens are only added for Anthropic (which reports them separately).
         usage_q = (
             select(
-                func.coalesce(
-                    func.sum(
-                        LLMUsageRecord.prompt_tokens
-                        + LLMUsageRecord.completion_tokens
-                        + LLMUsageRecord.cache_read_tokens
-                        + LLMUsageRecord.cache_creation_tokens
-                    ),
-                    0,
-                ),
+                func.coalesce(func.sum(_row_total_tokens_expr()), 0),
                 func.coalesce(func.sum(LLMUsageRecord.total_cost_usd), 0),
             )
             .where(

--- a/backend/app/services/console_service.py
+++ b/backend/app/services/console_service.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func, text, literal, Integer, case
+from sqlalchemy import select, func, text, literal, Integer, case, or_, not_
 from app.models.organization import Organization
 from app.models.user import User
 from app.models.completion import Completion
@@ -61,6 +61,40 @@ from app.models.group_membership import GroupMembership
 from app.schemas.console_schema import CostMetrics, CostBreakdownItem, CostTimeSeriesPoint
 
 logger = get_logger(__name__)
+
+# LLM usage scopes that are NOT part of answering a user's turn. These are
+# background / observability calls recorded against the report for cost
+# accounting — LLM-judge grading, follow-up & title generation, context
+# compaction, and eval/classifier helpers. Rolling them into a turn's token
+# count makes a trivial question look enormous: the judge alone re-sends the
+# full context to grade the answer, so a one-line question can report 200k+
+# "tokens". The conversation roll-up counts only the turn's own work — the
+# planner loop plus the tool calls it makes (create_data / create_artifact /
+# edit_artifact / …). Namespaced families are matched by prefix so new
+# sub-scopes (e.g. a new judge.* dimension) are excluded automatically; flat
+# names are matched exactly.
+_NON_TURN_USAGE_SCOPE_PREFIXES = (
+    "judge.",
+    "report.",
+    "suggest_eval.",
+    "suggest_instructions.",
+)
+_NON_TURN_USAGE_SCOPES = (
+    "tool_call_judge",
+    "webhook_classifier",
+)
+
+
+def _turn_usage_scope_clause():
+    """SQLAlchemy predicate keeping only user-turn LLM usage (planner + tool
+    calls), excluding the background/observability scopes above. ``scope`` is
+    NOT NULL on llm_usage_records, so no NULL handling is needed."""
+    is_non_turn = or_(
+        LLMUsageRecord.scope.in_(_NON_TURN_USAGE_SCOPES),
+        *[LLMUsageRecord.scope.like(f"{prefix}%") for prefix in _NON_TURN_USAGE_SCOPE_PREFIXES],
+    )
+    return not_(is_non_turn)
+
 
 class ConsoleService:
 
@@ -2305,6 +2339,12 @@ class ConsoleService:
         # attributed per report (not per agent execution), so this is the one
         # place a trustworthy total exists. Older records predate attribution
         # and simply don't count here.
+        #
+        # Count only the turns' own work — the planner loop plus the tool calls
+        # it makes — and drop background/observability scopes (judge grading,
+        # follow-up/title generation, context compaction; see
+        # _turn_usage_scope_clause). Without this a one-line question rolls up
+        # the judge's full-context re-reads and reports 200k+ tokens.
         usage_q = (
             select(
                 func.coalesce(
@@ -2318,7 +2358,10 @@ class ConsoleService:
                 ),
                 func.coalesce(func.sum(LLMUsageRecord.total_cost_usd), 0),
             )
-            .where(LLMUsageRecord.report_id == str(report.id))
+            .where(
+                LLMUsageRecord.report_id == str(report.id),
+                _turn_usage_scope_clause(),
+            )
         )
         usage_tokens, usage_cost = (await db.execute(usage_q)).one()
         total_llm_tokens = int(usage_tokens or 0) or None


### PR DESCRIPTION
## Problem

A trivial one-turn question showed **200k+ tokens** in the trace-modal header. Verified live on two reports (same question, *"how many hours worked today?"*): **221k / 180k tokens at ~$0.17**. Two independent defects compounded to produce this:

1. **Non-turn scopes were rolled in.** The conversation roll-up (`get_report_conversation`) summed *every* `llm_usage_records` row for the report — including background/observability calls: LLM-judge grading, follow-up & title generation, context compaction, eval helpers. The judge alone re-sends the full context to grade each answer, so it roughly doubled the count. This was ~26% of the total on the live reports, and it's why the header exceeded the per-turn value.
2. **OpenAI/Azure cache tokens were double-counted.** The sum was `prompt + completion + cache_read + cache_creation` unconditionally. That is only correct for Anthropic (which reports cache tokens separately from `input_tokens`). OpenAI/Azure fold `cache_read` into `prompt_tokens` (`prompt_tokens_details.cached_tokens` is a subset), so re-adding it counted the cached prefix twice.

The low cost ($0.17) next to a huge token count was the tell — most of the number was discounted cache re-reads and grading overhead, not the work of answering the question.

Not an arithmetic bug in the per-provider fields — the raw numbers are right. This is about what the roll-up chooses to sum.

## Changes

`backend/app/services/console_service.py`

- **`_turn_usage_scope_clause()`** — the roll-up now counts only the turn's own work: the planner loop plus the tool calls it makes (`create_data` / `create_artifact` / `edit_artifact` / …). Excluded scopes are matched by prefix (`judge.`, `report.`, `suggest_eval.`, `suggest_instructions.`) so new sub-scopes drop out automatically, plus exact flat names (`tool_call_judge`, `webhook_classifier`).
- **`_row_total_tokens_expr()`** — a provider-aware SQL sum that only adds cache tokens for Anthropic. Mirrors the existing `_row_total_tokens` helper the cost and llm-usage dashboards already use, so all three surfaces now agree. Other providers record zero cache tokens and are unaffected.

`backend/app/schemas/agent_execution_trace_schema.py` — doc comment updated to describe the new semantics.

## Scope / non-goals

- **Cost console is intentionally unchanged** — it still reports full org spend, since judge/title/etc. are real costs the org pays. This change only affects the per-conversation "what did answering this question cost" roll-up.
- The dashboards (`get_llm_usage_metrics`, `get_cost_metrics`) and the quota path (`_quota_total_tokens`) were already provider-aware; the conversation roll-up was the sole outlier.

## Verification

- Filter semantics proven against a real in-memory SQLite engine: keeps `planner` + all `create_data.*` (tool) scopes, drops every `judge.*` / `report.*` / eval scope.
- Provider split proven with mixed anthropic/openai/azure/google rows: OpenAI/Azure `cache_read` no longer re-added (e.g. `10000 prompt incl. 6000 cached + 500` → **10,500**, not 16,500), Anthropic cache still additive. SQL result matched the Python reference exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaPVanufwx7ki68n9FXtKx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaPVanufwx7ki68n9FXtKx)_