### PR TITLE
Set explicit socket timeouts on Bedrock runtime client

### DIFF
--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncGenerator, AsyncIterator, Optional
 
@@ -28,6 +29,40 @@ from app.ai.llm.types import (
 )
 
 _STREAM_EXECUTOR = ThreadPoolExecutor(max_workers=4)
+
+
+def _int_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back on any bad value."""
+    try:
+        val = int(os.environ.get(name, "").strip())
+        return val if val > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+# Bedrock streaming responses can have long inter-event gaps — large
+# long-context prompts mean a long time-to-first-token and pauses between
+# chunks — which blow past botocore's default 60s read timeout and surface as
+# "AWSHTTPSConnectionPool(...): Read timed out" mid-stream. Give each socket
+# read a generous window while keeping connect fast, so a genuinely
+# unreachable endpoint still fails quickly instead of hanging. Both are
+# env-overridable so prod can tune without a redeploy.
+_READ_TIMEOUT_S = _int_env("BEDROCK_READ_TIMEOUT_S", 300)
+_CONNECT_TIMEOUT_S = _int_env("BEDROCK_CONNECT_TIMEOUT_S", 10)
+
+
+def _http_config(**overrides) -> Config:
+    """botocore Config with Bedrock-appropriate socket timeouts.
+
+    ``read_timeout`` is the per-read gap (not a total-response budget), so a
+    high value tolerates slow streams without capping overall latency. Extra
+    kwargs (e.g. ``signature_version``) merge in for the caller's auth mode.
+    """
+    return Config(
+        read_timeout=_READ_TIMEOUT_S,
+        connect_timeout=_CONNECT_TIMEOUT_S,
+        **overrides,
+    )
 
 
 # Map MIME types to Bedrock image format strings
@@ -78,7 +113,7 @@ class BedrockClient(LLMClient):
             self.client = boto3.client(
                 "bedrock-runtime",
                 region_name=region,
-                config=Config(signature_version=UNSIGNED),
+                config=_http_config(signature_version=UNSIGNED),
             )
             def _add_bearer_auth(request, **kwargs):
                 request.headers["Authorization"] = f"Bearer {api_key}"
@@ -97,9 +132,11 @@ class BedrockClient(LLMClient):
                 aws_secret_access_key=aws_secret_access_key,
                 region_name=region,
             )
-            self.client = session.client("bedrock-runtime")
+            self.client = session.client("bedrock-runtime", config=_http_config())
         else:
-            self.client = boto3.client("bedrock-runtime", region_name=region)
+            self.client = boto3.client(
+                "bedrock-runtime", region_name=region, config=_http_config()
+            )
 
         self._region = region
         self._auth_mode = auth_mode


### PR DESCRIPTION
## Summary

Bedrock streaming responses can have long inter-event gaps on large long-context prompts (long time-to-first-token and pauses between chunks). These exceed botocore's default 60s read timeout and surface as `AWSHTTPSConnectionPool(...): Read timed out` **mid-stream** — killing an otherwise-healthy agent run after tool calls have already succeeded.

This PR gives the `bedrock-runtime` client an explicit `botocore.config.Config` so slow streams are tolerated while a genuinely unreachable endpoint still fails fast.

## Changes

`backend/app/ai/llm/clients/bedrock_client.py`:
- Construct the client with an explicit `Config` across **all three** auth paths (`iam`, `access_keys`, `api_key`).
- `read_timeout` default **300s** (was botocore's default 60s) — this is the per-read gap on the stream, not a total-response budget, so it tolerates slow streams without capping overall latency.
- `connect_timeout` default **10s** — kept short so an unreachable endpoint fails fast instead of hanging for the full read window.
- Both values are env-overridable via `BEDROCK_READ_TIMEOUT_S` / `BEDROCK_CONNECT_TIMEOUT_S` for tuning without a redeploy.
- The `api_key` path preserves `signature_version=UNSIGNED`, so the existing Bearer-token / SigV4-disabled behavior is unchanged.

## Scope

This addresses the common *slow-stream* timeout case. It does **not** cover genuine region/provider outages (where a longer read timeout only delays failure) — that resilience (app-layer retry + model fallback) is intentionally out of scope for this PR.

## Testing

Existing unit tests in `tests/unit/test_bedrock_client_auth.py` cover construction across the three auth modes, including the `signature_version=UNSIGNED` assertion that this change preserves. The suite was not run in the authoring environment (dependencies not installed there); please run it in CI/local before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pNRYSkJVqzHBFDvEW8i8G)_