### PR TITLE
Fix thinking indicator: survive refresh, hide on landing page

### DIFF
--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -2,10 +2,13 @@
     <div ref="rootRef" class="flex-shrink-0 p-3 pb-3 sm:p-4 sm:pb-8 bg-white dark:bg-gray-900">
         <!-- Thinking indicator (visible while a completion is running).
              While running, Enter queues the typed prompt; steering happens
-             from a queued chip's "send now" action. -->
+             from a queued chip's "send now" action. Report pages only: the
+             landing page redirects to the new report as soon as it's created,
+             so no run ever happens there — the send button's spinner is the
+             only feedback needed. -->
         <Transition name="thinking-fade">
             <div
-                v-if="isThinking"
+                v-if="isThinking && props.report_id"
                 class="mb-2 px-1 flex items-center gap-2 text-xs select-none"
                 aria-live="polite"
             >
@@ -796,16 +799,28 @@ const thinkingStartedAt = ref<number | null>(null)
 const thinkingElapsedSeconds = ref(0)
 let thinkingTimer: ReturnType<typeof setInterval> | null = null
 
+// Server timestamps are naive-UTC (no Z suffix) — parse them as UTC or the
+// elapsed time is off by the local timezone offset.
+function parseServerTimestamp(v: any): number | null {
+    if (!v) return null
+    const s = String(v)
+    const t = Date.parse(/Z|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + 'Z')
+    return Number.isNaN(t) ? null : t
+}
+
 // immediate: also starts the timer when the component mounts mid-run
-// (e.g. page refresh while a completion is streaming).
+// (e.g. page refresh while a completion is streaming). In that case the
+// parent passes the run's server-side start on latestInProgressCompletion
+// so the elapsed counter resumes from the true start instead of 0s.
 watch(isThinking, (active) => {
     if (active) {
         if (thinkingTimer) return // submit → in-progress handoff: keep counting
-        thinkingStartedAt.value = Date.now()
-        thinkingElapsedSeconds.value = 0
+        const serverStart = parseServerTimestamp((props.latestInProgressCompletion as any)?.startedAt)
+        thinkingStartedAt.value = serverStart ?? Date.now()
+        thinkingElapsedSeconds.value = Math.max(0, Math.floor((Date.now() - thinkingStartedAt.value) / 1000))
         thinkingTimer = setInterval(() => {
             if (thinkingStartedAt.value !== null) {
-                thinkingElapsedSeconds.value = Math.floor((Date.now() - thinkingStartedAt.value) / 1000)
+                thinkingElapsedSeconds.value = Math.max(0, Math.floor((Date.now() - thinkingStartedAt.value) / 1000))
             }
         }, 1000)
     } else {

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -628,7 +628,7 @@
 					:initialMode="report?.mode || 'chat'"
 					:initialModel="report?.model_id || ''"
 					:textareaContent="prefillText"
-					:latestInProgressCompletion="(isCompletionInProgress || hasInProgressCompletion) ? { hasFirstToken: inProgressHasFirstToken } : undefined"
+					:latestInProgressCompletion="(isCompletionInProgress || hasInProgressCompletion) ? { hasFirstToken: inProgressHasFirstToken, startedAt: inProgressStartedAt } : undefined"
 					:isStopping="false"
 					:queryList="queryList"
 					:scheduledPrompts="scheduledPrompts"
@@ -1115,6 +1115,13 @@ const inProgressHasFirstToken = computed(() =>
 		)
 	)
 )
+// Server-side start of the in-progress run (naive-UTC). Lets the prompt box
+// thinking timer resume from the true elapsed time after a page refresh
+// instead of restarting at 0s.
+const inProgressStartedAt = computed(() => {
+	const m = messages.value.find(m => m.role === 'system' && m.status === 'in_progress')
+	return m?.created_at || null
+})
 // Prompts waiting in the queue — rendered as chips in the prompt box, not as
 // chat bubbles (visibleMessages filters them from the timeline).
 const queuedPrompts = computed(() =>


### PR DESCRIPTION
## What

Two fixes to the PromptBoxV2 thinking/working indicator:

1. **Timer survives page refresh.** The elapsed timer seeded from `Date.now()` on mount, so refreshing mid-run restarted it at 0s. The report page now passes the in-progress run's server-side `created_at` as `startedAt` on `latestInProgressCompletion`, and PromptBoxV2 seeds the timer from it — resuming at the true elapsed time (e.g. "3m 20s"). Server timestamps are naive-UTC, so they're parsed with a `Z` suffix appended to avoid being off by the viewer's timezone offset; elapsed values are clamped to ≥0. Fresh submits still fall back to `Date.now()`, and the submit → in-progress handoff keeps the running timer untouched.

2. **No shimmer on the landing page.** On `/`, submitting creates a report and redirects — no completion ever runs there — yet the "Thinking" shimmer flashed during the create-and-redirect window. The indicator is now gated on `report_id`; the send button's existing spinner remains the landing-page feedback. The report page is the only caller passing `latestInProgressCompletion`, so the other PromptBoxV2 embeds are unaffected.

## Verification

- Full `nuxt build` passes with the changes.
- Timestamp parsing tested against every format the codebase produces: naive-UTC with microseconds (backend `datetime.utcnow`), naive with milliseconds (client `toISOString().replace('Z','')` stamps), `Z`-suffixed, and explicit-offset forms — all yield correct elapsed seconds; null/garbage inputs fall back to `Date.now()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzW8hoxrLRjvnL2Fpfs6KK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzW8hoxrLRjvnL2Fpfs6KK)_