### PR TITLE
Add copy query ID button to ToolWidgetPreview header

### DIFF
--- a/frontend/components/tools/SearchReportsTool.vue
+++ b/frontend/components/tools/SearchReportsTool.vue
@@ -1,12 +1,21 @@
 <template>
   <div class="mt-1">
     <!-- Status header -->
-    <div class="mb-2 flex items-center text-xs text-gray-500 dark:text-gray-400">
+    <div
+      class="mb-2 flex items-center text-xs text-gray-500 dark:text-gray-400"
+      :class="{ 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-300': reports.length }"
+      @click="toggleCollapsed"
+    >
       <span v-if="status === 'running'" class="tool-shimmer flex items-center">
         <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
         <span>Searching reports{{ queryLabel ? ` for ${queryLabel}` : '' }}…</span>
       </span>
       <span v-else class="text-gray-700 dark:text-gray-300 flex items-center">
+        <Icon
+          v-if="reports.length"
+          :name="isCollapsed ? 'heroicons-chevron-right' : 'heroicons-chevron-down'"
+          class="w-3 h-3 me-1.5 text-gray-400 rtl-flip"
+        />
         <Icon name="heroicons-magnifying-glass" class="w-3 h-3 me-1 text-gray-400" />
         <span class="align-middle">Searched reports{{ queryLabel ? ` for ${queryLabel}` : '' }}</span>
         <span v-if="total > 0" class="ms-1.5 text-[10px] text-gray-400">· {{ total }} {{ total === 1 ? 'match' : 'matches' }}</span>
@@ -14,7 +23,7 @@
     </div>
 
     <!-- Results list -->
-    <div v-if="reports.length" class="text-xs text-gray-600 dark:text-gray-400">
+    <div v-if="reports.length && !isCollapsed" class="text-xs text-gray-600 dark:text-gray-400">
       <ul class="ms-1 space-y-0.5 leading-snug">
         <li v-for="(item, idx) in reports" :key="item.id || idx">
           <div class="flex items-center py-1 px-1 rounded">
@@ -42,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 interface ToolExecution {
   id: string
@@ -61,6 +70,10 @@ interface Props {
 const props = defineProps<Props>()
 
 const status = computed<string>(() => props.toolExecution?.status || '')
+
+// Results are collapsed by default; the header chevron reveals them.
+const isCollapsed = ref(true)
+function toggleCollapsed() { isCollapsed.value = !isCollapsed.value }
 
 const queryLabel = computed<string>(() => {
   const rj = props.toolExecution?.result_json || {}

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -17,6 +17,15 @@
           </button>
         </div>
         <div class="flex items-center gap-3">
+          <UTooltip v-if="queryId" :text="$t('tools.widgetPreview.copyIdTooltip')">
+            <button
+              @click.stop="copyQueryId"
+              class="flex items-center gap-0.5 text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 font-mono transition-colors"
+            >
+              <Icon name="heroicons:clipboard-document" class="w-3 h-3" />
+              {{ queryId.slice(0, 8) }}
+            </button>
+          </UTooltip>
           <div v-if="rowCount" class="text-[11px] text-gray-400 leading-none">
             {{ activeFilterCount > 0 ? $t('tools.widgetPreview.rowsFiltered', { filtered: filteredRowCount, total: rowCount }) : $t('tools.widgetPreview.rows', { count: rowCount }) }}
           </div>
@@ -372,6 +381,7 @@ const emit = defineEmits(['toggleSplitScreen', 'editQuery'])
 const { canEditCode } = useOrgSettings()
 const { isExcel } = useExcel()
 const { t } = useI18n()
+const toast = useToast()
 
 // Reactive state for collapsible behavior
 const isCollapsed = ref(props.initialCollapsed ?? false)
@@ -1239,6 +1249,16 @@ function addToSpreadsheet() {
   })
   const payload = { widget: { last_step: { ...step, data: { ...step.data, rows: normalizedRows } } } }
   window.parent.postMessage({ type: 'applyToExcel', data: JSON.stringify(payload) }, '*')
+}
+
+async function copyQueryId() {
+  if (!queryId.value) return
+  try {
+    await navigator.clipboard.writeText(queryId.value)
+    toast.add({ title: t('tools.widgetPreview.copied'), description: t('tools.widgetPreview.copiedDesc'), color: 'green' })
+  } catch {
+    toast.add({ title: t('tools.widgetPreview.copyFailed'), color: 'red' })
+  }
 }
 
 function onEditClick() {

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "تمت الإضافة إلى لوحة التحكم",
       "addToDashboard": "إضافة إلى لوحة التحكم",
       "saveQuery": "حفظ الاستعلام",
-      "savedQuery": "الاستعلام المحفوظ"
+      "savedQuery": "الاستعلام المحفوظ",
+      "copyIdTooltip": "نسخ معرّف الاستعلام",
+      "copied": "تم النسخ",
+      "copiedDesc": "تم نسخ معرّف الاستعلام إلى الحافظة",
+      "copyFailed": "تعذّر النسخ"
     },
     "generic": {
       "running": "جارٍ التشغيل...",

--- a/locales/de.json
+++ b/locales/de.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Zum Dashboard hinzugefügt",
       "addToDashboard": "Zum Dashboard hinzufügen",
       "saveQuery": "Abfrage speichern",
-      "savedQuery": "Gespeicherte Abfrage"
+      "savedQuery": "Gespeicherte Abfrage",
+      "copyIdTooltip": "Abfrage-ID kopieren",
+      "copied": "Kopiert",
+      "copiedDesc": "Abfrage-ID in die Zwischenablage kopiert",
+      "copyFailed": "Kopieren fehlgeschlagen"
     },
     "generic": {
       "running": "Läuft ...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1091,7 +1091,11 @@
       "addedToDashboard": "Added to Dashboard",
       "addToDashboard": "Add to Dashboard",
       "saveQuery": "Save Query",
-      "savedQuery": "Saved Query"
+      "savedQuery": "Saved Query",
+      "copyIdTooltip": "Copy query ID",
+      "copied": "Copied",
+      "copiedDesc": "Query ID copied to clipboard",
+      "copyFailed": "Failed to copy"
     },
     "generic": {
       "running": "Running...",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1042,7 +1042,11 @@
       "addedToDashboard": "Agregado al panel",
       "addToDashboard": "Agregar al panel",
       "saveQuery": "Guardar consulta",
-      "savedQuery": "Consulta guardada"
+      "savedQuery": "Consulta guardada",
+      "copyIdTooltip": "Copiar ID de la consulta",
+      "copied": "Copiado",
+      "copiedDesc": "ID de la consulta copiado al portapapeles",
+      "copyFailed": "Error al copiar"
     },
     "generic": {
       "running": "Ejecutando...",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Ajouté au tableau de bord",
       "addToDashboard": "Ajouter au tableau de bord",
       "saveQuery": "Enregistrer la requête",
-      "savedQuery": "Requête enregistrée"
+      "savedQuery": "Requête enregistrée",
+      "copyIdTooltip": "Copier l'ID de la requête",
+      "copied": "Copié",
+      "copiedDesc": "ID de la requête copié dans le presse-papiers",
+      "copyFailed": "Échec de la copie"
     },
     "generic": {
       "running": "Exécution...",

--- a/locales/he.json
+++ b/locales/he.json
@@ -1042,7 +1042,11 @@
       "addedToDashboard": "נוסף ללוח מחוונים",
       "addToDashboard": "הוסף ללוח מחוונים",
       "saveQuery": "שמור שאילתה",
-      "savedQuery": "שאילתה נשמרה"
+      "savedQuery": "שאילתה נשמרה",
+      "copyIdTooltip": "העתק את מזהה השאילתה",
+      "copied": "הועתק",
+      "copiedDesc": "מזהה השאילתה הועתק ללוח",
+      "copyFailed": "ההעתקה נכשלה"
     },
     "generic": {
       "running": "פועל...",

--- a/locales/it.json
+++ b/locales/it.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Aggiunto alla dashboard",
       "addToDashboard": "Aggiungi alla dashboard",
       "saveQuery": "Salva query",
-      "savedQuery": "Query salvata"
+      "savedQuery": "Query salvata",
+      "copyIdTooltip": "Copia l'ID della query",
+      "copied": "Copiato",
+      "copiedDesc": "ID della query copiato negli appunti",
+      "copyFailed": "Impossibile copiare"
     },
     "generic": {
       "running": "In esecuzione...",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Adicionado ao painel",
       "addToDashboard": "Adicionar ao painel",
       "saveQuery": "Salvar consulta",
-      "savedQuery": "Consulta salva"
+      "savedQuery": "Consulta salva",
+      "copyIdTooltip": "Copiar ID da consulta",
+      "copied": "Copiado",
+      "copiedDesc": "ID da consulta copiado para a área de transferência",
+      "copyFailed": "Falha ao copiar"
     },
     "generic": {
       "running": "Executando...",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Добавлено в дашборд",
       "addToDashboard": "Добавить в дашборд",
       "saveQuery": "Сохранить запрос",
-      "savedQuery": "Сохранённый запрос"
+      "savedQuery": "Сохранённый запрос",
+      "copyIdTooltip": "Скопировать ID запроса",
+      "copied": "Скопировано",
+      "copiedDesc": "ID запроса скопирован в буфер обмена",
+      "copyFailed": "Не удалось скопировать"
     },
     "generic": {
       "running": "Выполнение...",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -951,7 +951,11 @@
       "addedToDashboard": "Tillagd i instrumentpanel",
       "addToDashboard": "Lägg till i instrumentpanel",
       "saveQuery": "Spara fråga",
-      "savedQuery": "Sparad fråga"
+      "savedQuery": "Sparad fråga",
+      "copyIdTooltip": "Kopiera fråge-ID",
+      "copied": "Kopierat",
+      "copiedDesc": "Fråge-ID kopierat till urklipp",
+      "copyFailed": "Det gick inte att kopiera"
     },
     "generic": {
       "running": "Kör...",


### PR DESCRIPTION
## What

Adds a small copy-query-ID button to the `ToolWidgetPreview` header, mirroring the artifact ID copy pattern in `CreateArtifactTool`. Users can copy a query's full UUID and paste it into chat so the agent can read it via the `read_query` tool.

Also collapses the `SearchReportsTool` results list by default.

## Changes

- **`frontend/components/tools/ToolWidgetPreview.vue`**
  - New button in the header's right-side action cluster (before row count / PNG / download): clipboard icon + first 8 chars of the query ID in mono text, wrapped in a `UTooltip` ("Copy query ID").
  - Uses `@click.stop` so clicking never toggles the header collapse, and stays visible while the card is collapsed.
  - Copies the **full** query UUID via `navigator.clipboard.writeText` with success/failure toasts, same as `copyArtifactId` in `CreateArtifactTool`.
  - Renders only when a `queryId` resolves (`visualization.query_id` → `step.query_id` → `result_json.query_id`), so tools without a query are unaffected.
- **`frontend/components/tools/SearchReportsTool.vue`** — the matched-reports list previously expanded unconditionally, pushing long result sets into the chat. The header now toggles the list with a chevron, collapsed by default, matching the other tool components.
- **`locales/*.json` (all 10 languages)** — added `copyIdTooltip`, `copied`, `copiedDesc`, `copyFailed` under `tools.widgetPreview`, translations adapted from the existing `tools.createArtifact` copy keys.

## Notes

- `ChatSummary.vue` (Summary tab Queries list) renders the same component, so it gets the button automatically — no separate change needed.
- No backend changes: `queryId` was already computed in the component, and `read_query` already accepts pasted query IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNkikrQcooQ12Ss4Hd7ViG