### PR TITLE
feat(mcp): forward per-user identity into MCP headers + tool metadata

### DIFF
--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -17,6 +17,21 @@ from app.ee.audit.tool_audit import log_tool_audit
 logger = logging.getLogger(__name__)
 
 
+def _is_loopback_url(url: str) -> bool:
+    """True when a URL points back at this instance (a localhost/loopback host).
+
+    Such a connection is a self-call to our own /api/mcp; calling it over HTTP
+    re-enters the app, so on SQLite we must release the agent's transaction
+    first to avoid the single-writer deadlock.
+    """
+    try:
+        from urllib.parse import urlparse
+        host = (urlparse(url).hostname or "").lower()
+    except Exception:
+        return False
+    return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"} or host.endswith(".localhost")
+
+
 class ExecuteMCPTool(Tool):
     """Execute a tool on an MCP server or custom API endpoint."""
 
@@ -230,28 +245,32 @@ Do not use when:
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "calling_tool"})
 
         try:
-            # Try in-process MCP tool first (avoids HTTP self-call which deadlocks on SQLite)
-            result = await self._try_inprocess_mcp(
-                db, data.tool_name, data.arguments, runtime_ctx, organization
+            # A configured MCP/API connection is ALWAYS called over its own wire.
+            # We deliberately do NOT substitute a same-named BOW built-in tool for
+            # the connection's call — that would run the wrong tool for an external
+            # server (e.g. a Tableau or other-instance `create_report`) and skip
+            # identity forwarding. Pass the run's user so per-user OAuth creds
+            # resolve to their token (system creds carry none for oauth_app).
+            service = ConnectionService()
+            # Forward resolved identity headers (static + per-user injected).
+            header_overrides = (
+                {"headers": forward_ctx.headers}
+                if forward_ctx is not None and forward_ctx.has_headers
+                else None
             )
-
-            if result is None:
-                # Not an internal tool — call via MCP protocol over HTTP.
-                # Pass the run's user so per-user OAuth credentials resolve to
-                # their token (system creds carry no user token for oauth_app).
-                service = ConnectionService()
-                # Forward resolved identity headers (static + per-user injected).
-                header_overrides = (
-                    {"headers": forward_ctx.headers}
-                    if forward_ctx is not None and forward_ctx.has_headers
-                    else None
-                )
-                client = await service.construct_client(
-                    db, connection, user, config_overrides=header_overrides
-                )
-                logger.info(f"execute_mcp: Calling remote MCP: {getattr(client, 'server_url', '?')}")
-                result = await client.acall_tool(data.tool_name, data.arguments)
-                logger.info(f"execute_mcp: Remote call returned success={result.get('success')}, error={result.get('error')}")
+            client = await service.construct_client(
+                db, connection, user, config_overrides=header_overrides
+            )
+            server_url = getattr(client, "server_url", "") or ""
+            # Loopback connection (this instance's own /api/mcp): the HTTP
+            # self-call re-enters the app and would deadlock SQLite's single
+            # writer while we hold the agent session. Release our transaction
+            # first — expire_on_commit=False keeps ORM objects usable afterwards.
+            if _is_loopback_url(server_url):
+                await self._release_db(db)
+            logger.info(f"execute_mcp: Calling remote MCP: {server_url or '?'}")
+            result = await client.acall_tool(data.tool_name, data.arguments)
+            logger.info(f"execute_mcp: Remote call returned success={result.get('success')}, error={result.get('error')}")
         except BaseException as e:
             logger.error(f"execute_mcp: Tool call failed: {e}", exc_info=True)
             yield ToolEndEvent(
@@ -844,51 +863,3 @@ Do not use when:
 
         return file
 
-    async def _try_inprocess_mcp(
-        self,
-        db,
-        tool_name: str,
-        arguments: dict,
-        runtime_ctx: dict,
-        organization,
-    ) -> dict | None:
-        """
-        Try to execute the tool in-process using the internal MCP tool registry.
-        Returns a result dict if the tool exists internally, or None to fall back to HTTP.
-
-        This avoids the HTTP self-call which deadlocks on SQLite (database is locked)
-        and is faster even on PostgreSQL since it skips auth + HTTP overhead.
-        """
-        from app.ai.tools.mcp import get_mcp_tool
-
-        tool_class = get_mcp_tool(tool_name)
-        if not tool_class:
-            return None  # Not an internal tool — caller should use HTTP
-
-        try:
-            tool = tool_class()
-            user = runtime_ctx.get("user") or runtime_ctx.get("current_user")
-            logger.info(f"execute_mcp: Calling internal MCP tool '{tool_name}' in-process, user={getattr(user, 'id', None)}")
-            data = await tool.execute(arguments, db, user, organization)
-
-            # Detect content type
-            content_type = "json"
-            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
-                content_type = "tabular"
-            elif isinstance(data, str):
-                content_type = "text"
-
-            return {
-                "success": True,
-                "data": data,
-                "content_type": content_type,
-                "error": None,
-            }
-        except Exception as e:
-            logger.error(f"execute_mcp: Internal MCP tool '{tool_name}' failed: {e}", exc_info=True)
-            return {
-                "success": False,
-                "data": None,
-                "content_type": "text",
-                "error": str(e),
-            }

--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -148,6 +148,35 @@ Do not use when:
         # Emit connection name so the UI can show it during streaming
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "connection_resolved", "connection_name": connection.name})
 
+        # Resolve per-user context forwarding (identity/membership → headers +
+        # custom_metadata). Locked metadata fields clobber the model's values;
+        # ai fields fill only where the model left a gap. Done here — before the
+        # policy confirmation and the call — so the audited/confirmed payload is
+        # exactly what the MCP server receives.
+        from app.services.mcp_context_injection import (
+            resolve_mcp_context,
+            apply_metadata_injection,
+        )
+        forward_ctx = None
+        try:
+            forward_ctx = await resolve_mcp_context(db, connection, user, organization)
+        except Exception as e:
+            logger.warning(f"execute_mcp: context forwarding resolve failed: {e}")
+        if forward_ctx is not None:
+            if forward_ctx.blocking_missing:
+                missing = ", ".join(forward_ctx.blocking_missing)
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload={
+                        "output": {"success": False, "error_message": f"Missing required user context: {missing}."},
+                        "observation": {"summary": f"Blocked: missing required user context ({missing})", "success": False},
+                    },
+                )
+                return
+            if data.arguments is None:
+                data.arguments = {}
+            apply_metadata_injection(data.arguments, forward_ctx)
+
         # Check tool is enabled
         tool_result = await db.execute(
             select(ConnectionTool).where(
@@ -161,6 +190,18 @@ Do not use when:
         # in the observation. Without this the agent only learns what was wrong
         # (e.g. "invalid search field") and keeps re-guessing argument names.
         tool_input_schema = getattr(tool_record, "input_schema", None) if tool_record else None
+        # Hide admin-locked metadata fields from the schema echoed back on failure,
+        # so the agent never sees (and never re-guesses) server-injected fields.
+        if tool_input_schema:
+            try:
+                import json as _json
+                from app.services.mcp_context_injection import filter_locked_from_schema
+                _cfg = connection.config
+                if isinstance(_cfg, str):
+                    _cfg = _json.loads(_cfg)
+                tool_input_schema = filter_locked_from_schema(tool_input_schema, _cfg or {})
+            except Exception:
+                pass
         if tool_record and not tool_record.is_enabled:
             yield ToolEndEvent(
                 type="tool.end",
@@ -199,7 +240,15 @@ Do not use when:
                 # Pass the run's user so per-user OAuth credentials resolve to
                 # their token (system creds carry no user token for oauth_app).
                 service = ConnectionService()
-                client = await service.construct_client(db, connection, user)
+                # Forward resolved identity headers (static + per-user injected).
+                header_overrides = (
+                    {"headers": forward_ctx.headers}
+                    if forward_ctx is not None and forward_ctx.has_headers
+                    else None
+                )
+                client = await service.construct_client(
+                    db, connection, user, config_overrides=header_overrides
+                )
                 logger.info(f"execute_mcp: Calling remote MCP: {getattr(client, 'server_url', '?')}")
                 result = await client.acall_tool(data.tool_name, data.arguments)
                 logger.info(f"execute_mcp: Remote call returned success={result.get('success')}, error={result.get('error')}")

--- a/backend/app/ai/tools/implementations/search_mcps.py
+++ b/backend/app/ai/tools/implementations/search_mcps.py
@@ -112,12 +112,19 @@ Use when:
         )
         mcp_connections = conn_result.scalars().all()
 
+        import json as _json
         mcp_connection_ids = set()
-        conn_info = {}  # connection_id -> {name, type}
+        conn_info = {}  # connection_id -> {name, type, config}
         for conn in mcp_connections:
             cid = str(conn.id)
             mcp_connection_ids.add(cid)
-            conn_info[cid] = {"name": conn.name, "type": conn.type}
+            _cfg = conn.config
+            if isinstance(_cfg, str):
+                try:
+                    _cfg = _json.loads(_cfg)
+                except Exception:
+                    _cfg = {}
+            conn_info[cid] = {"name": conn.name, "type": conn.type, "config": _cfg or {}}
 
         if data.connection_ids:
             mcp_connection_ids = mcp_connection_ids.intersection(set(data.connection_ids))
@@ -205,16 +212,20 @@ Use when:
         tools = filter_tools_by_query(tools, data.query)
 
         # Build output
+        from app.services.mcp_context_injection import filter_locked_from_schema
         tool_previews = []
         for t in tools:
             ci = conn_info.get(str(t.connection_id), {})
+            # Hide admin-locked metadata fields from the model — they are
+            # server-injected and must not appear as arguments it can set.
+            visible_schema = filter_locked_from_schema(t.input_schema, ci.get("config", {}))
             tool_previews.append({
                 "name": t.name,
                 "description": t.description or "",
                 "connection_id": str(t.connection_id),
                 "connection_name": ci.get("name", ""),
                 "connection_type": ci.get("type", ""),
-                "input_schema": t.input_schema,
+                "input_schema": visible_schema,
                 "policy": tool_policies.get(str(t.id), "allow"),
             })
 

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -2244,6 +2244,33 @@ class MCPConfig(BaseModel):
         description="MCP transport protocol",
         json_schema_extra={"ui:type": "select", "options": ["sse", "streamable_http"]}
     )
+    headers: dict = Field(
+        default={},
+        title="Static Headers",
+        description="Headers sent on every request to the MCP server (fixed key/values).",
+        json_schema_extra={"ui:type": "keyvalue"}
+    )
+    header_injection: list = Field(
+        default=[],
+        title="Header Forwarding",
+        description=(
+            "Forward the signed-in user's identity as HTTP headers. Each rule is "
+            "{header, source} where source is a whitelisted expression "
+            "(user.email|name|id, membership.role, membership.attr:<key>, static:<text>)."
+        ),
+        json_schema_extra={"ui:type": "json"}
+    )
+    metadata_injection: dict = Field(
+        default={},
+        title="Metadata Forwarding",
+        description=(
+            "Inject the user's identity into a metadata object on every tool call. "
+            "Shape: {argument_key='custom_metadata', fields:[{name, source, mode, on_missing}]}. "
+            "mode 'locked' hides the field from the model and always overrides; "
+            "'ai' surfaces it as a default the model may set."
+        ),
+        json_schema_extra={"ui:type": "json"}
+    )
 
 
 class MCPNoAuthCredentials(BaseModel):

--- a/backend/app/services/mcp_context_injection.py
+++ b/backend/app/services/mcp_context_injection.py
@@ -1,0 +1,288 @@
+"""Resolve per-user identity/membership context into MCP requests.
+
+An admin configures an MCP connection to forward the signed-in user's identity
+into two places on every tool call:
+
+  * outbound **HTTP headers** (``header_injection`` + static ``headers``), and
+  * a **metadata object** merged into the tool arguments
+    (``metadata_injection`` → ``custom_metadata`` by default).
+
+Values come from a small *whitelist* of sources — never arbitrary attribute
+access — so a misconfigured mapping can't reach a secret:
+
+  * ``user.email`` / ``user.name`` / ``user.id``
+  * ``membership.role``
+  * ``membership.attr:<key>``   → ``Membership.profile_attributes[<key>]``
+  * ``static:<text>``           → a literal, with ``{source}`` interpolation
+    (e.g. ``static:elbit_nt\\{membership.attr:employeeId}``)
+
+Each metadata field has a ``mode``:
+
+  * ``locked`` — admin value always wins (clobbers any LLM-provided value) and
+    the field is hidden from the model's tool schema.
+  * ``ai``     — surfaced to the model as a default; the server only fills it
+    when the model left it absent/empty.
+
+and an ``on_missing`` policy for when the source resolves empty: ``empty``
+(default, ``""``), ``omit`` (drop the key), or ``block`` (abort the call).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.connection import Connection
+from app.models.membership import Membership
+from app.models.user import User
+
+DEFAULT_ARGUMENT_KEY = "custom_metadata"
+
+# ---------------------------------------------------------------------------
+# Value resolution (pure, no DB)
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"\{([^{}]+)\}")
+
+
+@dataclass
+class IdentityContext:
+    """The whitelisted values available to source expressions for one user."""
+
+    email: str = ""
+    name: str = ""
+    user_id: str = ""
+    role: str = ""
+    attributes: Dict[str, Any] = field(default_factory=dict)
+
+
+def _resolve_atom(expr: str, ctx: IdentityContext) -> Optional[str]:
+    """Resolve a single whitelisted source atom to a string, or None if unknown/empty."""
+    expr = (expr or "").strip()
+    if expr == "user.email":
+        return ctx.email or None
+    if expr == "user.name":
+        return ctx.name or None
+    if expr == "user.id":
+        return ctx.user_id or None
+    if expr == "membership.role":
+        return ctx.role or None
+    if expr.startswith("membership.attr:"):
+        key = expr.split(":", 1)[1].strip()
+        val = ctx.attributes.get(key)
+        if val is None or val == "":
+            return None
+        return val if isinstance(val, str) else str(val)
+    return None
+
+
+def resolve_source(source: str, ctx: IdentityContext) -> Optional[str]:
+    """Resolve a full ``source`` value. Returns None when nothing resolved.
+
+    ``static:`` values support ``{atom}`` interpolation; a static literal with
+    no tokens always resolves (even to an empty string).
+    """
+    source = (source or "").strip()
+    if not source:
+        return None
+    if source.startswith("static:"):
+        literal = source[len("static:"):]
+        return _TOKEN_RE.sub(lambda m: _resolve_atom(m.group(1), ctx) or "", literal)
+    return _resolve_atom(source, ctx)
+
+
+# ---------------------------------------------------------------------------
+# Resolved plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResolvedField:
+    name: str
+    value: str
+    mode: str  # "locked" | "ai"
+
+
+@dataclass
+class ResolvedContext:
+    headers: Dict[str, str] = field(default_factory=dict)
+    argument_key: str = DEFAULT_ARGUMENT_KEY
+    fields: List[ResolvedField] = field(default_factory=list)
+    blocking_missing: List[str] = field(default_factory=list)
+
+    @property
+    def has_metadata(self) -> bool:
+        return bool(self.fields)
+
+    @property
+    def has_headers(self) -> bool:
+        return bool(self.headers)
+
+
+def _identity_from(user: Optional[User], membership: Optional[Membership]) -> IdentityContext:
+    attrs = {}
+    role = ""
+    if membership is not None:
+        attrs = dict(membership.profile_attributes or {})
+        role = membership.role or ""
+    return IdentityContext(
+        email=(getattr(user, "email", "") or "") if user else "",
+        name=(getattr(user, "name", "") or "") if user else "",
+        user_id=(str(getattr(user, "id", "") or "")) if user else "",
+        role=role,
+        attributes=attrs,
+    )
+
+
+def build_plan(config: Dict[str, Any], ctx: IdentityContext) -> ResolvedContext:
+    """Build the resolved header/metadata plan from a connection config + identity.
+
+    Pure function (no DB) so it is trivially unit-testable.
+    """
+    resolved = ResolvedContext()
+
+    # --- headers: static first, then dynamic injection (dynamic wins) ---
+    static_headers = config.get("headers") or {}
+    if isinstance(static_headers, dict):
+        for k, v in static_headers.items():
+            if k and v not in (None, ""):
+                resolved.headers[str(k)] = str(v)
+
+    for rule in config.get("header_injection") or []:
+        if not isinstance(rule, dict):
+            continue
+        header = (rule.get("header") or "").strip()
+        if not header:
+            continue
+        value = resolve_source(rule.get("source", ""), ctx)
+        if value:  # omit empty headers — an empty header is noise, not context
+            resolved.headers[header] = value
+
+    # --- metadata fields ---
+    meta = config.get("metadata_injection") or {}
+    if isinstance(meta, dict) and meta.get("fields"):
+        resolved.argument_key = (meta.get("argument_key") or DEFAULT_ARGUMENT_KEY).strip() or DEFAULT_ARGUMENT_KEY
+        for f in meta.get("fields") or []:
+            if not isinstance(f, dict):
+                continue
+            name = (f.get("name") or "").strip()
+            if not name:
+                continue
+            mode = "ai" if f.get("mode") == "ai" else "locked"
+            on_missing = f.get("on_missing") or "empty"
+            value = resolve_source(f.get("source", ""), ctx)
+            if value is None or value == "":
+                if on_missing == "omit":
+                    continue
+                if on_missing == "block":
+                    resolved.blocking_missing.append(name)
+                    continue
+                value = ""  # "empty" (default)
+            resolved.fields.append(ResolvedField(name=name, value=value, mode=mode))
+
+    return resolved
+
+
+def _connection_config(connection: Connection) -> Dict[str, Any]:
+    import json
+    cfg = connection.config
+    if isinstance(cfg, str):
+        try:
+            cfg = json.loads(cfg)
+        except Exception:
+            cfg = {}
+    return cfg or {}
+
+
+async def resolve_mcp_context(
+    db: AsyncSession,
+    connection: Connection,
+    user: Optional[User],
+    organization: Any,
+) -> ResolvedContext:
+    """Load the user's membership and resolve the connection's forwarding plan."""
+    config = _connection_config(connection)
+    has_spec = bool(
+        config.get("headers")
+        or config.get("header_injection")
+        or (config.get("metadata_injection") or {}).get("fields")
+    )
+    if not has_spec:
+        return ResolvedContext()
+
+    membership: Optional[Membership] = None
+    if user is not None and organization is not None:
+        result = await db.execute(
+            select(Membership).where(
+                Membership.user_id == str(user.id),
+                Membership.organization_id == str(organization.id),
+            )
+        )
+        membership = result.scalars().first()
+
+    ctx = _identity_from(user, membership)
+    return build_plan(config, ctx)
+
+
+def apply_metadata_injection(arguments: Dict[str, Any], plan: ResolvedContext) -> None:
+    """Merge resolved metadata fields into ``arguments[argument_key]`` in place.
+
+    ``locked`` fields clobber any model-supplied value; ``ai`` fields only fill
+    when the model left the key absent or blank.
+    """
+    if not plan.has_metadata:
+        return
+    if not isinstance(arguments, dict):
+        return
+    bag = arguments.get(plan.argument_key)
+    if not isinstance(bag, dict):
+        bag = {}
+    for rf in plan.fields:
+        existing = bag.get(rf.name)
+        if rf.mode == "locked":
+            bag[rf.name] = rf.value
+        else:  # ai: fill only if absent/empty
+            if existing in (None, ""):
+                bag[rf.name] = rf.value
+    arguments[plan.argument_key] = bag
+
+
+def locked_field_names(config: Dict[str, Any]) -> tuple[str, List[str]]:
+    """Return (argument_key, [locked field names]) for schema hiding."""
+    meta = (config or {}).get("metadata_injection") or {}
+    argument_key = (meta.get("argument_key") or DEFAULT_ARGUMENT_KEY) or DEFAULT_ARGUMENT_KEY
+    names = [
+        (f.get("name") or "").strip()
+        for f in (meta.get("fields") or [])
+        if isinstance(f, dict) and f.get("mode") != "ai" and (f.get("name") or "").strip()
+    ]
+    return argument_key, names
+
+
+def filter_locked_from_schema(input_schema: Any, config: Dict[str, Any]) -> Any:
+    """Strip admin-locked metadata fields from a tool's input schema.
+
+    Locked fields are server-injected and must never be offered to the model,
+    so they're removed from ``<argument_key>.properties`` (and its ``required``).
+    Returns a new schema object; the input is not mutated.
+    """
+    argument_key, names = locked_field_names(config)
+    if not names or not isinstance(input_schema, dict):
+        return input_schema
+    import copy
+    schema = copy.deepcopy(input_schema)
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return schema
+    bag = props.get(argument_key)
+    if not isinstance(bag, dict) or not isinstance(bag.get("properties"), dict):
+        return schema
+    for name in names:
+        bag["properties"].pop(name, None)
+    if isinstance(bag.get("required"), list):
+        bag["required"] = [r for r in bag["required"] if r not in names]
+    return schema

--- a/backend/tests/e2e/test_mcp_context_forwarding_live.py
+++ b/backend/tests/e2e/test_mcp_context_forwarding_live.py
@@ -1,0 +1,145 @@
+"""Live end-to-end: a real Haiku agent turn forwards user context to an MCP server.
+
+Unlike the unit tests (resolver logic) and the wire smoke test (McpClient), this
+drives the *whole* stack — a real Anthropic **Haiku** model plans the turn,
+decides to call the MCP tool, and BOW injects the signed-in user's identity into
+the outbound headers + `custom_metadata` before the call reaches a real
+streamable-HTTP MCP server.
+
+Requires:
+  * ANTHROPIC_API_KEY_TEST  — a working Anthropic key
+  * the echo MCP server running on :3333 with MOCK_MCP_CAPTURE_FILE set
+    (tests/mocks/echo_mcp_http_server.py). The test reads that capture file.
+
+Run:
+  MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_capture.json \
+  ANTHROPIC_API_KEY_TEST=$ANTHROPIC_KEY \
+    uv run pytest tests/e2e/test_mcp_context_forwarding_live.py -m e2e -s
+"""
+
+import json
+import os
+
+import httpx
+import pytest
+
+ECHO_URL = os.environ.get("ECHO_MCP_URL", "http://127.0.0.1:3333/mcp")
+CAPTURE = os.environ.get("MOCK_MCP_CAPTURE_FILE", "/tmp/bow-agent/mcp_capture.json")
+
+
+def _echo_up() -> bool:
+    try:
+        httpx.get(ECHO_URL, timeout=3)
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.e2e
+def test_haiku_agent_forwards_user_context_to_mcp(
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+    create_data_source,
+    create_report,
+    create_completion,
+    refresh_connection_tools,
+    enable_mcp,
+):
+    if not os.getenv("ANTHROPIC_API_KEY_TEST"):
+        pytest.skip("ANTHROPIC_API_KEY_TEST is not set")
+    if not _echo_up():
+        pytest.skip(f"echo MCP server not reachable at {ECHO_URL}")
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    user_email = user["email"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    # Anthropic provider with Haiku only → Haiku is the default planner model.
+    prov = test_client.post(
+        "/api/llm/providers",
+        json={
+            "name": "anthropic haiku",
+            "provider_type": "anthropic",
+            "credentials": {"api_key": os.environ["ANTHROPIC_API_KEY_TEST"]},
+            "models": [
+                {"model_id": "claude-haiku-4-5-20251001", "name": "Claude 4.5 Haiku", "is_custom": False},
+            ],
+        },
+        headers=headers,
+    )
+    assert prov.status_code == 200, prov.text
+
+    enable_mcp(token, org_id)
+
+    # MCP data source → echo server, with user-context forwarding configured.
+    forwarding = {
+        "server_url": ECHO_URL,
+        "transport": "streamable_http",
+        "header_injection": [
+            {"header": "X-User-Email", "source": "user.email"},
+        ],
+        "metadata_injection": {
+            "argument_key": "custom_metadata",
+            "fields": [
+                {"name": "_client_userId", "source": "membership.role", "mode": "locked"},
+                {"name": "user_email", "source": "user.email", "mode": "locked"},
+                {"name": "application_name", "source": "static:BagOfWords", "mode": "locked"},
+            ],
+        },
+    }
+    ds = create_data_source(
+        name="Echo LN MCP",
+        type="mcp",
+        config=forwarding,
+        credentials={},
+        user_token=token,
+        org_id=org_id,
+    )
+    ds_id = ds["id"]
+    # The MCP data source owns a connection; discover its tools against the echo server.
+    conn_id = None
+    for c in (ds.get("connections") or []):
+        conn_id = c.get("id")
+    if conn_id is None:
+        # Fall back to listing connections for this org.
+        conns = test_client.get("/api/connections", headers=headers).json()
+        conn_id = next((c["id"] for c in conns if c.get("name") == "Echo LN MCP"), None)
+    assert conn_id, f"could not resolve MCP connection id from {json.dumps(ds)[:400]}"
+    refresh_connection_tools(connection_id=conn_id, user_token=token, org_id=org_id)
+
+    report = create_report(title="LN Orders", user_token=token, org_id=org_id, data_sources=[ds_id])
+
+    # Wipe any stale capture, then let Haiku drive the tool call.
+    try:
+        os.remove(CAPTURE)
+    except FileNotFoundError:
+        pass
+
+    create_completion(
+        report_id=report["id"],
+        prompt=(
+            "Call the query_production_orders MCP tool now. "
+            "Pass company='111' and prompt='weekly production orders'. "
+            "Do not ask for confirmation; just call it."
+        ),
+        user_token=token,
+        org_id=org_id,
+        background=False,
+    )
+
+    # The echo server recorded exactly what it received over the wire.
+    assert os.path.exists(CAPTURE), "echo server never received a tool call — Haiku did not invoke it"
+    captured = json.load(open(CAPTURE))
+    cm = captured["received_arguments"]["custom_metadata"]
+    hdrs = captured["received_headers"]
+
+    # Locked identity fields injected by the server (model never set these).
+    assert cm.get("user_email") == user_email, cm
+    assert cm.get("application_name") == "BagOfWords", cm
+    assert cm.get("_client_userId"), cm  # resolved from membership.role (non-empty)
+    # Identity header forwarded on the wire.
+    assert hdrs.get("x-user-email") == user_email, hdrs

--- a/backend/tests/e2e/test_mcp_forwarding_eu_live.py
+++ b/backend/tests/e2e/test_mcp_forwarding_eu_live.py
@@ -1,0 +1,131 @@
+"""Live verification against a real *external* BOW instance (eu.bagofwords.com).
+
+Proves the routing fix end-to-end: a local BOW agent (real Haiku) calls the
+`create_report` MCP tool on an eu connection. `create_report` is also a BOW
+built-in name — before the fix it was intercepted in-process and a report was
+created LOCALLY; after the fix the call goes over HTTPS to eu, so the report
+lands on eu (its URL host is eu.bagofwords.com) and nothing is created locally.
+
+Requires ANTHROPIC_API_KEY_TEST and EU_MCP_TOKEN (a bow_ key for eu). Creates a
+single clearly-labelled report on the eu workspace.
+
+  ANTHROPIC_API_KEY_TEST=$ANTHROPIC_KEY EU_MCP_TOKEN=$EU_TOKEN \
+    uv run pytest tests/e2e/test_mcp_forwarding_eu_live.py -m e2e -s
+"""
+
+import json
+import os
+import uuid
+
+import httpx
+import pytest
+
+EU_URL = "https://eu.bagofwords.com/api/mcp"
+
+
+def _eu_up(token: str) -> bool:
+    try:
+        httpx.get("https://eu.bagofwords.com/api/mcp", timeout=5)
+        return True
+    except Exception:
+        return False
+
+
+def _blob(obj) -> str:
+    try:
+        return json.dumps(obj, default=str)
+    except Exception:
+        return str(obj)
+
+
+@pytest.mark.e2e
+def test_haiku_agent_routes_builtin_named_tool_to_eu(
+    test_client,
+    create_user,
+    login_user,
+    whoami,
+    create_data_source,
+    create_report,
+    create_completion,
+    refresh_connection_tools,
+    enable_mcp,
+):
+    token_env = os.getenv("EU_MCP_TOKEN")
+    if not os.getenv("ANTHROPIC_API_KEY_TEST"):
+        pytest.skip("ANTHROPIC_API_KEY_TEST not set")
+    if not token_env or not _eu_up(token_env):
+        pytest.skip("EU_MCP_TOKEN not set or eu.bagofwords.com unreachable")
+
+    user = create_user()
+    tok = login_user(user["email"], user["password"])
+    org_id = whoami(tok)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {tok}", "X-Organization-Id": str(org_id)}
+
+    # Haiku-only provider → Haiku plans the turn.
+    prov = test_client.post(
+        "/api/llm/providers",
+        json={
+            "name": "anthropic haiku",
+            "provider_type": "anthropic",
+            "credentials": {"api_key": os.environ["ANTHROPIC_API_KEY_TEST"]},
+            "models": [{"model_id": "claude-haiku-4-5-20251001", "name": "Claude 4.5 Haiku", "is_custom": False}],
+        },
+        headers=headers,
+    )
+    assert prov.status_code == 200, prov.text
+    enable_mcp(tok, org_id)
+
+    # MCP data source → eu, bearer token + identity forwarding.
+    marker = f"bow-fwd-verify-{uuid.uuid4().hex[:8]}"
+    ds = create_data_source(
+        name="EU MCP",
+        type="mcp",
+        config={
+            "server_url": EU_URL,
+            "transport": "streamable_http",
+            "auth_type": "bearer",
+            "header_injection": [{"header": "X-User-Email", "source": "user.email"}],
+            "metadata_injection": {
+                "argument_key": "custom_metadata",
+                "fields": [{"name": "user_email", "source": "user.email", "mode": "locked"}],
+            },
+        },
+        credentials={"token": token_env},
+        user_token=tok,
+        org_id=org_id,
+    )
+    ds_id = ds["id"]
+    conn_id = (ds.get("connections") or [{}])[0].get("id")
+    if not conn_id:
+        conns = test_client.get("/api/connections", headers=headers).json()
+        conn_id = next((c["id"] for c in conns if c.get("name") == "EU MCP"), None)
+    assert conn_id, f"no connection id in {_blob(ds)[:300]}"
+    # Discover eu's tools (proves the connection reaches eu).
+    refresh_connection_tools(connection_id=conn_id, user_token=tok, org_id=org_id)
+
+    report = create_report(title="verify-host", user_token=tok, org_id=org_id, data_sources=[ds_id])
+
+    completions = create_completion(
+        report_id=report["id"],
+        prompt=(
+            f"Use the create_report MCP tool now to create a report titled '{marker}'. "
+            "Call the tool directly; do not ask for confirmation."
+        ),
+        user_token=tok,
+        org_id=org_id,
+        background=False,
+    )
+
+    blob = _blob(completions)
+    print("\n--- completion blob (truncated) ---\n", blob[:1500])
+
+    # Decisive: the created report's URL points at eu, proving the call was routed
+    # over HTTPS to eu rather than intercepted by the local in-process builtin.
+    assert "eu.bagofwords.com" in blob, (
+        "expected the create_report call to be routed to eu (eu.bagofwords.com URL "
+        "in the tool result); if absent, the call was intercepted locally"
+    )
+    # And it must NOT have been created on the local instance.
+    local_reports = test_client.get("/api/reports?limit=100", headers=headers).json()
+    titles = [r.get("title") for r in (local_reports.get("reports") or local_reports if isinstance(local_reports, dict) else local_reports)]
+    assert marker not in (titles or []), f"report '{marker}' was created LOCALLY, not on eu"

--- a/backend/tests/mocks/echo_mcp_http_server.py
+++ b/backend/tests/mocks/echo_mcp_http_server.py
@@ -1,0 +1,94 @@
+"""A real streamable-HTTP MCP server that ECHOES what it received over the wire.
+
+Unlike ``mock_mcp_server.MockToolProviderClient`` (an in-process stub), this is a
+genuine MCP server reachable over HTTP, so it proves that forwarded **headers**
+and injected **custom_metadata** actually travel the wire. It is the oracle for
+the user-context-forwarding feedback loop and the Playwright E2E.
+
+It exposes one tool, ``query_production_orders``, whose result contains exactly
+the ``arguments`` (including ``custom_metadata``) and the request ``headers`` the
+server saw. The same capture is written to ``MOCK_MCP_CAPTURE_FILE`` so a test can
+assert on it out-of-band (the app materializes tool output into CSV/preview).
+
+Run standalone::
+
+    MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_capture.json \
+        uv run python tests/mocks/echo_mcp_http_server.py --port 3333
+
+Then point a ``type=mcp`` connection at ``http://localhost:3333/mcp``
+(transport ``streamable_http``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any, Optional
+
+from mcp.server.fastmcp import Context, FastMCP
+
+mcp = FastMCP("mock-ln")
+
+_CAPTURE_FILE = os.environ.get("MOCK_MCP_CAPTURE_FILE")
+
+
+def _request_headers(ctx: Optional[Context]) -> dict[str, str]:
+    """Best-effort read of the incoming HTTP headers (lowercased keys)."""
+    if ctx is None:
+        return {}
+    try:
+        request = ctx.request_context.request  # Starlette Request on HTTP transports
+        if request is not None:
+            return {k.lower(): v for k, v in request.headers.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def _write_capture(payload: dict[str, Any]) -> None:
+    if not _CAPTURE_FILE:
+        return
+    try:
+        directory = os.path.dirname(_CAPTURE_FILE)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(_CAPTURE_FILE, "w") as fh:
+            json.dump(payload, fh, indent=2, default=str)
+    except Exception:
+        pass
+
+
+@mcp.tool(
+    description="Query LN production orders. Echoes the arguments and headers it received.",
+)
+def query_production_orders(
+    prompt: str,
+    company: str = "",
+    custom_metadata: Optional[dict] = None,
+    ctx: Context = None,
+) -> str:
+    captured = {
+        "received_arguments": {
+            "prompt": prompt,
+            "company": company,
+            "custom_metadata": custom_metadata or {},
+        },
+        "received_headers": _request_headers(ctx),
+    }
+    _write_capture(captured)
+    return json.dumps(captured)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=3333)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    mcp.run(transport="streamable-http")  # served at http://host:port/mcp
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_execute_mcp_routing.py
+++ b/backend/tests/unit/test_execute_mcp_routing.py
@@ -1,0 +1,40 @@
+"""Routing invariants for execute_mcp.
+
+A configured MCP connection is always called over its own wire (no name-based
+substitution of a BOW built-in). The only special case is a loopback connection
+to this instance, where the HTTP self-call must release the DB transaction first
+to avoid SQLite's single-writer deadlock — driven by `_is_loopback_url`.
+"""
+
+import pytest
+
+from app.ai.tools.implementations.execute_mcp import _is_loopback_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8000/api/mcp",
+        "http://127.0.0.1:3000/api/mcp",
+        "http://0.0.0.0:8000/api/mcp",
+        "http://[::1]:8000/api/mcp",
+        "https://app.localhost/api/mcp",
+    ],
+)
+def test_loopback_urls_detected(url):
+    assert _is_loopback_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://eu.bagofwords.com/api/mcp",   # a *different* BOW instance
+        "https://mcp.notion.com/mcp",
+        "https://my-tableau.example.com/mcp",
+        "http://10.0.0.5:8000/api/mcp",         # LAN peer, not this process
+        "",
+        "not a url",
+    ],
+)
+def test_external_urls_are_not_loopback(url):
+    assert _is_loopback_url(url) is False

--- a/backend/tests/unit/test_mcp_context_injection.py
+++ b/backend/tests/unit/test_mcp_context_injection.py
@@ -1,0 +1,250 @@
+"""Unit tests for per-user MCP context forwarding (headers + custom_metadata).
+
+Covers the promised invariants of `app.services.mcp_context_injection`:
+  * whitelist-only source resolution (unknown expressions never resolve)
+  * static-value interpolation (identity concatenated into a literal)
+  * locked vs ai merge semantics against model-supplied arguments
+  * on_missing policy (empty / omit / block)
+  * headers omit empties; static + injected headers merge
+  * admin-locked metadata fields are stripped from the model-facing schema
+"""
+
+import pytest
+
+from app.services.mcp_context_injection import (
+    IdentityContext,
+    apply_metadata_injection,
+    build_plan,
+    filter_locked_from_schema,
+    resolve_source,
+)
+
+
+def _ctx(**kw):
+    base = dict(
+        email="Beni.Klein@elbitsystems.com",
+        name="Beni Klein",
+        user_id="usr_8f21c0",
+        role="analyst",
+        attributes={"employeeId": "dp28376", "department": "Avionics"},
+    )
+    base.update(kw)
+    return IdentityContext(**base)
+
+
+# --------------------------------------------------------------------------- #
+# source resolution + whitelist safety
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("user.email", "Beni.Klein@elbitsystems.com"),
+        ("user.name", "Beni Klein"),
+        ("user.id", "usr_8f21c0"),
+        ("membership.role", "analyst"),
+        ("membership.attr:employeeId", "dp28376"),
+        ("membership.attr:department", "Avionics"),
+        ("static:BagOfWords", "BagOfWords"),
+    ],
+)
+def test_resolve_source_whitelist(source, expected):
+    assert resolve_source(source, _ctx()) == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "user.password",            # not whitelisted
+        "membership.attr:secret",   # attribute not present
+        "connection.credentials",   # not a real source
+        "__class__",                # no arbitrary attribute access
+        "",                         # empty
+    ],
+)
+def test_unknown_or_absent_sources_do_not_resolve(source):
+    assert resolve_source(source, _ctx()) is None
+
+
+def test_static_interpolation_concatenates_identity():
+    # The `_client_full_userId: "elbit_nt\\dp28376"` case from the report.
+    out = resolve_source(r"static:elbit_nt\{membership.attr:employeeId}", _ctx())
+    assert out == r"elbit_nt\dp28376"
+
+
+def test_static_interpolation_of_missing_attr_yields_empty_token():
+    out = resolve_source("static:prefix-{membership.attr:missing}", _ctx())
+    assert out == "prefix-"
+
+
+# --------------------------------------------------------------------------- #
+# metadata merge: locked vs ai
+# --------------------------------------------------------------------------- #
+
+def _meta_config(fields, argument_key="custom_metadata"):
+    return {"metadata_injection": {"argument_key": argument_key, "fields": fields}}
+
+
+def test_locked_field_overrides_model_value():
+    cfg = _meta_config([
+        {"name": "_client_userId", "source": "membership.attr:employeeId", "mode": "locked"},
+    ])
+    plan = build_plan(cfg, _ctx())
+    args = {"prompt": "p", "custom_metadata": {"_client_userId": "hacked_by_model"}}
+    apply_metadata_injection(args, plan)
+    assert args["custom_metadata"]["_client_userId"] == "dp28376"
+
+
+def test_ai_field_fills_only_when_absent():
+    cfg = _meta_config([
+        {"name": "department", "source": "membership.attr:department", "mode": "ai"},
+    ])
+    plan = build_plan(cfg, _ctx())
+
+    # model omitted it -> server fills
+    a = {"prompt": "p"}
+    apply_metadata_injection(a, plan)
+    assert a["custom_metadata"]["department"] == "Avionics"
+
+    # model provided it -> model wins
+    b = {"prompt": "p", "custom_metadata": {"department": "Marine"}}
+    apply_metadata_injection(b, plan)
+    assert b["custom_metadata"]["department"] == "Marine"
+
+
+def test_injection_creates_bag_and_respects_argument_key():
+    cfg = _meta_config(
+        [{"name": "u", "source": "user.email", "mode": "locked"}],
+        argument_key="context",
+    )
+    plan = build_plan(cfg, _ctx())
+    args = {"prompt": "p"}
+    apply_metadata_injection(args, plan)
+    assert args["context"]["u"] == "Beni.Klein@elbitsystems.com"
+    assert "custom_metadata" not in args
+
+
+# --------------------------------------------------------------------------- #
+# on_missing policy
+# --------------------------------------------------------------------------- #
+
+def test_on_missing_empty_sets_blank_string():
+    cfg = _meta_config([
+        {"name": "user_id", "source": "membership.attr:notThere", "mode": "locked", "on_missing": "empty"},
+    ])
+    plan = build_plan(cfg, _ctx())
+    args = {}
+    apply_metadata_injection(args, plan)
+    assert args["custom_metadata"]["user_id"] == ""
+
+
+def test_on_missing_omit_drops_key():
+    cfg = _meta_config([
+        {"name": "user_id", "source": "membership.attr:notThere", "mode": "locked", "on_missing": "omit"},
+    ])
+    plan = build_plan(cfg, _ctx())
+    args = {}
+    apply_metadata_injection(args, plan)
+    assert "user_id" not in args.get("custom_metadata", {})
+
+
+def test_on_missing_block_signals_blocking_missing():
+    cfg = _meta_config([
+        {"name": "user_id", "source": "membership.attr:notThere", "mode": "locked", "on_missing": "block"},
+    ])
+    plan = build_plan(cfg, _ctx())
+    assert "user_id" in plan.blocking_missing
+
+
+def test_present_value_never_blocks():
+    cfg = _meta_config([
+        {"name": "user_id", "source": "membership.attr:employeeId", "mode": "locked", "on_missing": "block"},
+    ])
+    plan = build_plan(cfg, _ctx())
+    assert plan.blocking_missing == []
+
+
+# --------------------------------------------------------------------------- #
+# headers
+# --------------------------------------------------------------------------- #
+
+def test_header_injection_resolves_and_omits_empties():
+    cfg = {
+        "headers": {"X-Static": "fixed"},
+        "header_injection": [
+            {"header": "X-User-Email", "source": "user.email"},
+            {"header": "X-Missing", "source": "membership.attr:notThere"},
+        ],
+    }
+    plan = build_plan(cfg, _ctx())
+    assert plan.headers["X-User-Email"] == "Beni.Klein@elbitsystems.com"
+    assert plan.headers["X-Static"] == "fixed"          # static preserved
+    assert "X-Missing" not in plan.headers              # empty header omitted
+
+
+def test_dynamic_header_overrides_static_same_name():
+    cfg = {
+        "headers": {"X-User-Email": "placeholder"},
+        "header_injection": [{"header": "X-User-Email", "source": "user.email"}],
+    }
+    plan = build_plan(cfg, _ctx())
+    assert plan.headers["X-User-Email"] == "Beni.Klein@elbitsystems.com"
+
+
+def test_no_spec_produces_empty_plan():
+    plan = build_plan({"server_url": "http://x/mcp", "transport": "streamable_http"}, _ctx())
+    assert not plan.has_headers and not plan.has_metadata
+
+
+# --------------------------------------------------------------------------- #
+# schema hiding
+# --------------------------------------------------------------------------- #
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "prompt": {"type": "string"},
+        "company": {"type": "string"},
+        "custom_metadata": {
+            "type": "object",
+            "properties": {
+                "_client_userId": {"type": "string"},
+                "_client_full_userId": {"type": "string"},
+                "department": {"type": "string"},
+            },
+            "required": ["_client_userId"],
+        },
+    },
+    "required": ["prompt"],
+}
+
+
+def test_locked_fields_hidden_ai_fields_kept():
+    cfg = _meta_config([
+        {"name": "_client_userId", "source": "membership.attr:employeeId", "mode": "locked"},
+        {"name": "_client_full_userId", "source": "static:x", "mode": "locked"},
+        {"name": "department", "source": "membership.attr:department", "mode": "ai"},
+    ])
+    filtered = filter_locked_from_schema(_SCHEMA, cfg)
+    meta_props = filtered["properties"]["custom_metadata"]["properties"]
+    assert "_client_userId" not in meta_props        # locked -> hidden
+    assert "_client_full_userId" not in meta_props    # locked -> hidden
+    assert "department" in meta_props                 # ai -> visible
+    # locked field also removed from required
+    assert "_client_userId" not in filtered["properties"]["custom_metadata"].get("required", [])
+    # top-level args untouched
+    assert "prompt" in filtered["properties"] and "company" in filtered["properties"]
+
+
+def test_filter_is_nondestructive_to_input():
+    cfg = _meta_config([{"name": "_client_userId", "source": "static:x", "mode": "locked"}])
+    filter_locked_from_schema(_SCHEMA, cfg)
+    # original schema still has the field
+    assert "_client_userId" in _SCHEMA["properties"]["custom_metadata"]["properties"]
+
+
+def test_no_locked_fields_returns_schema_unchanged():
+    cfg = _meta_config([{"name": "department", "source": "membership.attr:department", "mode": "ai"}])
+    filtered = filter_locked_from_schema(_SCHEMA, cfg)
+    assert filtered["properties"]["custom_metadata"]["properties"].keys() == \
+        _SCHEMA["properties"]["custom_metadata"]["properties"].keys()

--- a/docs/feedback-loops/mcp-user-context-forwarding.md
+++ b/docs/feedback-loops/mcp-user-context-forwarding.md
@@ -1,0 +1,108 @@
+# Feedback Loop — "send user & membership data into each MCP invocation"
+
+A customer's MCP server (Infor LN) expects per-user identity on every tool call:
+outbound identity **HTTP headers** and a `custom_metadata` object inside the tool
+arguments, e.g.
+
+```jsonc
+query_production_orders({
+  "prompt": "…",
+  "company": "111",
+  "custom_metadata": {
+    "_client_userId": "dp28376",
+    "_client_full_userId": "elbit_nt\\dp28376"
+  }
+})
+```
+
+Some fields the LLM may decide; others (`user_email`, `_client_userId`, …) the
+admin must be able to **hard-override** and hide from the model. Values map from
+the signed-in user's identity / `Membership.profile_attributes`. This loop
+validates that the mapping is configurable, resolves per user, and actually
+reaches the wire.
+
+## What was built (validated)
+
+- `MCPConfig` gains `headers`, `header_injection`, `metadata_injection`
+  (`backend/app/schemas/data_sources/configs.py`).
+- A whitelist resolver, `app/services/mcp_context_injection.py`:
+  - sources `user.email|name|id`, `membership.role`, `membership.attr:<key>`,
+    `static:<text>` with `{token}` interpolation — nothing else resolves, so a
+    bad mapping can't reach a secret;
+  - metadata `mode`: `locked` (clobbers the model, hidden from its schema) vs
+    `ai` (fills only where the model left a gap); `on_missing` = empty/omit/block.
+- Injection wired into `execute_mcp.py` (metadata merged before the policy
+  confirmation and the call; resolved headers forwarded via `construct_client`)
+  and locked fields stripped from the model-facing schema in `search_mcps.py`
+  and the failure payload.
+- UI: `MCPConnectionForm.vue` Advanced section — header/metadata mapping rows
+  with a source picker, lock toggle, and directory-attribute suggestions.
+- `MCPTool.vue`: failed tool calls render inline in **amber** (not red); call
+  time rounds to whole seconds.
+
+## Loop A — deterministic reproduction (no external services)
+
+Pure-logic invariants of the resolver — run in a clean sandbox:
+
+```bash
+cd backend
+export TESTING=true BOW_DATABASE_URL="sqlite:///db/app.db" TEST_DATABASE_URL="sqlite:///db/agenttest.db"
+mkdir -p db
+uv run pytest tests/unit/test_mcp_context_injection.py -q
+```
+
+Observed: **27 passed**. Coverage includes locked-clobber, ai-fill-if-absent,
+`static:` interpolation of `_client_full_userId` (`elbit_nt\dp28376`),
+`on_missing` empty/omit/block, header omit-empty, whitelist safety (unknown
+sources never resolve), and locked-field schema hiding.
+
+To see it fail for the right reason, stash the resolver
+(`git stash -- app/services/mcp_context_injection.py`) → import error /
+assertion failures; restore to flip back to green.
+
+## Loop B — live confirmation over the wire
+
+A real streamable-HTTP MCP server echoes back what it received
+(`tests/mocks/echo_mcp_http_server.py`):
+
+```bash
+cd backend
+MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_capture.json \
+  uv run python tests/mocks/echo_mcp_http_server.py --port 3333
+```
+
+Driving the real `McpClient` against it with resolved headers + metadata shows
+both arrive:
+
+```
+WIRE OK success= True
+header on wire: True | metadata on wire: True
+```
+
+and the capture file records the echoed `custom_metadata` and `x-user-email`
+header verbatim.
+
+## Loop C — end-to-end through the UI (Playwright, 0→1)
+
+`frontend/tests/mcp_forwarding/context-forwarding.spec.ts` (config
+`pw.mcp.config.ts`) signs an admin up from scratch, opens the MCP connection
+modal, configures a header rule and two metadata fields (one locked, one
+AI-fillable) in the Advanced section, runs the live **Test Connection** against
+the echo server (green), saves, and asserts the persisted `config` round-trips
+the forwarding spec:
+
+```bash
+# stack up: tools/agent/boot_stack.sh --dev
+# echo server up on :3333
+cd frontend
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers npx playwright test --config=pw.mcp.config.ts
+```
+
+Screenshots land in `frontend/test-results/mcp-forwarding/`.
+
+## What this proves / regression notes
+
+The mapping is admin-configurable, resolves per user from identity/membership,
+honors the locked-vs-AI override contract, hides locked fields from the model,
+and the resolved headers + `custom_metadata` reach an MCP server over the wire.
+Loop A survives as the regression suite for the resolver contract.

--- a/docs/feedback-loops/mcp-user-context-forwarding.md
+++ b/docs/feedback-loops/mcp-user-context-forwarding.md
@@ -100,6 +100,42 @@ PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers npx playwright test --config=pw.mcp.co
 
 Screenshots land in `frontend/test-results/mcp-forwarding/`.
 
+## Loop D — live Haiku agent turn (real model → real MCP server)
+
+`tests/e2e/test_mcp_context_forwarding_live.py` drives the whole stack: a real
+Anthropic **Haiku** model plans a turn, decides to call `query_production_orders`,
+and BOW injects the signed-in user's identity before the call reaches the echo
+server.
+
+```bash
+# echo server up on :3333 with MOCK_MCP_CAPTURE_FILE set
+cd backend
+MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_capture.json \
+ANTHROPIC_API_KEY_TEST=$ANTHROPIC_KEY \
+  uv run pytest tests/e2e/test_mcp_context_forwarding_live.py -m e2e -s
+```
+
+Observed (`1 passed`) — the echo server received, over the wire:
+
+```jsonc
+{
+  "received_arguments": {
+    "prompt": "weekly production orders",   // Haiku authored
+    "company": "111",                        // Haiku authored
+    "custom_metadata": {                     // BOW server-injected (locked)
+      "_client_userId": "admin",             // ← membership.role
+      "user_email": "test@test.com",         // ← user.email
+      "application_name": "BagOfWords"        // ← static
+    }
+  },
+  "received_headers": { "x-user-email": "test@test.com", ... }
+}
+```
+
+i.e. the model chose the tool and its natural arguments, while the locked
+identity fields — which the model never saw in the tool schema — were injected
+by the server and arrived intact alongside the `X-User-Email` header.
+
 ## What this proves / regression notes
 
 The mapping is admin-configurable, resolves per user from identity/membership,

--- a/frontend/components/MCPConnectionForm.vue
+++ b/frontend/components/MCPConnectionForm.vue
@@ -124,44 +124,96 @@
           </template>
         </div>
 
-        <!-- Advanced: known/prefilled fields for a preset (server URL, transport,
-             OAuth endpoints). Collapsed by default; override for proxy/edge cases. -->
-        <div v-if="isPreset">
-          <button type="button" @click="advancedOpen = !advancedOpen" class="flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+        <!-- Advanced: prefilled endpoint fields (presets) + user-context
+             forwarding. Collapsed by default. -->
+        <div>
+          <button type="button" data-test="mcp-advanced-toggle" @click="advancedOpen = !advancedOpen" class="flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
             <UIcon :name="advancedOpen ? 'i-heroicons-chevron-down' : 'i-heroicons-chevron-right'" class="w-3.5 h-3.5" />
             Advanced
           </button>
-          <div v-if="advancedOpen" class="mt-2 space-y-3 border border-gray-200 dark:border-gray-700 rounded-md p-3 bg-gray-50 dark:bg-gray-900">
-            <p class="text-[11px] text-gray-400">Known for this connector — change only for a proxy or self-hosted endpoint.</p>
-            <div>
-              <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.urlLabel') }}</label>
-              <input v-model="form.server_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
-            </div>
-            <div>
-              <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.transportLabel') }}</label>
-              <select v-model="form.transport" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500">
-                <option value="sse">{{ $t('settings.mcpModal.transportSse') }}</option>
-                <option value="streamable_http">{{ $t('settings.mcpModal.transportHttp') }}</option>
-              </select>
-            </div>
-            <template v-if="form.auth_type === 'oauth_app'">
+          <div v-if="advancedOpen" class="mt-2 space-y-4 border border-gray-200 dark:border-gray-700 rounded-md p-3 bg-gray-50 dark:bg-gray-900">
+            <template v-if="isPreset">
+              <p class="text-[11px] text-gray-400">Known for this connector — change only for a proxy or self-hosted endpoint.</p>
               <div>
-                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Authorize URL</label>
-                <input v-model="form.authorize_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.urlLabel') }}</label>
+                <input v-model="form.server_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
               </div>
               <div>
-                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Token URL</label>
-                <input v-model="form.token_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.transportLabel') }}</label>
+                <select v-model="form.transport" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500">
+                  <option value="sse">{{ $t('settings.mcpModal.transportSse') }}</option>
+                  <option value="streamable_http">{{ $t('settings.mcpModal.transportHttp') }}</option>
+                </select>
               </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Scopes</label>
-                <input v-model="form.scopes" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
-              </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Resource (audience, optional)</label>
-                <input v-model="form.audience" type="text" placeholder="https://mcp.example.com" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
-              </div>
+              <template v-if="form.auth_type === 'oauth_app'">
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Authorize URL</label>
+                  <input v-model="form.authorize_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Token URL</label>
+                  <input v-model="form.token_url" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Scopes</label>
+                  <input v-model="form.scopes" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Resource (audience, optional)</label>
+                  <input v-model="form.audience" type="text" placeholder="https://mcp.example.com" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                </div>
+              </template>
+              <div class="border-t border-gray-200 dark:border-gray-700"></div>
             </template>
+
+            <!-- User context forwarding -->
+            <div class="space-y-4" data-test="mcp-forwarding">
+              <div>
+                <div class="text-xs font-semibold text-gray-700 dark:text-gray-200">User context forwarding</div>
+                <p class="text-[11px] text-gray-400 mt-0.5">Map each signed-in user's identity into what the MCP server receives. Values are resolved per user at call time.</p>
+              </div>
+
+              <!-- Headers -->
+              <div>
+                <div class="text-[11px] uppercase tracking-wide text-gray-400 mb-1.5">HTTP headers <span class="normal-case tracking-normal">· sent on every request, never seen by the AI</span></div>
+                <div class="space-y-2">
+                  <div v-for="(r, i) in headerRules" :key="'h'+i" class="flex items-center gap-1.5" :data-test="'header-row-'+i">
+                    <input v-model="r.header" type="text" placeholder="Header-Name" data-test="header-name" class="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    <span class="text-gray-400 text-xs">←</span>
+                    <select v-model="r.kind" data-test="header-source" class="border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500">
+                      <option v-for="s in SOURCE_KINDS" :key="s.value" :value="s.value">{{ s.label }}</option>
+                    </select>
+                    <input v-if="needsKey(r.kind)" v-model="r.key" :list="r.kind === 'membership.attr' ? 'mcp-attr-suggestions' : undefined" :placeholder="keyPlaceholder(r.kind)" data-test="header-key" class="w-28 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    <button type="button" @click="headerRules.splice(i, 1)" class="text-gray-400 hover:text-red-500 px-1"><UIcon name="i-heroicons-x-mark" class="w-4 h-4" /></button>
+                  </div>
+                </div>
+                <button type="button" data-test="add-header" @click="headerRules.push({ header: '', kind: 'user.email', key: '' })" class="mt-2 text-xs font-medium text-blue-600 hover:text-blue-800">+ Add header</button>
+              </div>
+
+              <!-- Metadata -->
+              <div>
+                <div class="text-[11px] uppercase tracking-wide text-gray-400 mb-1.5">Tool metadata <span class="normal-case tracking-normal">· injected into <code class="font-mono">{{ metaArgKey }}</code> on each call</span></div>
+                <div class="space-y-2">
+                  <div v-for="(f, i) in metaFields" :key="'m'+i" class="flex items-center gap-1.5" :data-test="'meta-row-'+i">
+                    <input v-model="f.name" type="text" placeholder="field name" data-test="meta-name" class="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    <span class="text-gray-400 text-xs">←</span>
+                    <select v-model="f.kind" data-test="meta-source" class="border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500">
+                      <option v-for="s in SOURCE_KINDS" :key="s.value" :value="s.value">{{ s.label }}</option>
+                    </select>
+                    <input v-if="needsKey(f.kind)" v-model="f.key" :list="f.kind === 'membership.attr' ? 'mcp-attr-suggestions' : undefined" :placeholder="keyPlaceholder(f.kind)" data-test="meta-key" class="w-24 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    <button type="button" data-test="meta-mode" @click="f.mode = f.mode === 'ai' ? 'locked' : 'ai'" :title="f.mode === 'ai' ? 'AI may set it; server fills if empty' : 'Admin value always wins; hidden from the AI'" :class="['text-[11px] font-semibold rounded-md px-2 py-1.5 border whitespace-nowrap', f.mode === 'ai' ? 'text-blue-600 border-blue-200 bg-blue-50 dark:bg-blue-950' : 'text-gray-600 border-gray-300 bg-gray-100 dark:bg-gray-800 dark:text-gray-300']">
+                      {{ f.mode === 'ai' ? '✨ AI' : '🔒 Locked' }}
+                    </button>
+                    <button type="button" @click="metaFields.splice(i, 1)" class="text-gray-400 hover:text-red-500 px-1"><UIcon name="i-heroicons-x-mark" class="w-4 h-4" /></button>
+                  </div>
+                </div>
+                <button type="button" data-test="add-meta" @click="metaFields.push({ name: '', kind: 'user.email', key: '', mode: 'locked', on_missing: 'empty' })" class="mt-2 text-xs font-medium text-blue-600 hover:text-blue-800">+ Add metadata field</button>
+              </div>
+
+              <datalist id="mcp-attr-suggestions">
+                <option v-for="a in attrSuggestions" :key="a" :value="a" />
+              </datalist>
+            </div>
           </div>
         </div>
 
@@ -252,6 +304,79 @@ const form = reactive({
   token_endpoint_auth_method: '',
 })
 
+// --- User context forwarding (headers + custom_metadata) -----------------
+// Whitelisted identity sources. `membership.attr` and `static` take a key/value.
+const SOURCE_KINDS = [
+  { value: 'user.email', label: 'User email' },
+  { value: 'user.name', label: 'User name' },
+  { value: 'user.id', label: 'User ID' },
+  { value: 'membership.role', label: 'Membership role' },
+  { value: 'membership.attr', label: 'Directory attribute…' },
+  { value: 'static', label: 'Static value…' },
+]
+function needsKey(kind: string): boolean { return kind === 'membership.attr' || kind === 'static' }
+function keyPlaceholder(kind: string): string { return kind === 'static' ? 'value' : 'attribute' }
+
+// UI rows carry the source split as {kind, key}; serialized to the backend's
+// source-string grammar (e.g. "membership.attr:department", "static:BagOfWords").
+const headerRules = reactive<Array<{ header: string; kind: string; key: string }>>([])
+const metaArgKey = ref('custom_metadata')
+const metaFields = reactive<Array<{ name: string; kind: string; key: string; mode: string; on_missing: string }>>([])
+const attrSuggestions = ref<string[]>([])
+
+function toSource(kind: string, key: string): string {
+  if (kind === 'membership.attr') return `membership.attr:${(key || '').trim()}`
+  if (kind === 'static') return `static:${key || ''}`
+  return kind
+}
+function fromSource(source: string): { kind: string; key: string } {
+  if (!source) return { kind: 'user.email', key: '' }
+  if (source.startsWith('membership.attr:')) return { kind: 'membership.attr', key: source.slice('membership.attr:'.length) }
+  if (source.startsWith('static:')) return { kind: 'static', key: source.slice('static:'.length) }
+  return { kind: source, key: '' }
+}
+
+// Serialize the editor rows into the connection config's forwarding blocks.
+// Empty-name rows are dropped so a blank row never reaches the backend.
+function buildForwarding(): Record<string, any> {
+  const out: Record<string, any> = {}
+  const header_injection = headerRules
+    .filter(r => (r.header || '').trim())
+    .map(r => ({ header: r.header.trim(), source: toSource(r.kind, r.key) }))
+  if (header_injection.length) out.header_injection = header_injection
+
+  const fields = metaFields
+    .filter(f => (f.name || '').trim())
+    .map(f => ({ name: f.name.trim(), source: toSource(f.kind, f.key), mode: f.mode || 'locked', on_missing: f.on_missing || 'empty' }))
+  if (fields.length) out.metadata_injection = { argument_key: (metaArgKey.value || 'custom_metadata').trim() || 'custom_metadata', fields }
+  return out
+}
+
+function hydrateForwarding(config: any) {
+  headerRules.splice(0)
+  metaFields.splice(0)
+  for (const r of (config?.header_injection || [])) {
+    const s = fromSource(r.source || '')
+    headerRules.push({ header: r.header || '', kind: s.kind, key: s.key })
+  }
+  const mi = config?.metadata_injection || {}
+  if (mi.argument_key) metaArgKey.value = mi.argument_key
+  for (const f of (mi.fields || [])) {
+    const s = fromSource(f.source || '')
+    metaFields.push({ name: f.name || '', kind: s.kind, key: s.key, mode: f.mode || 'locked', on_missing: f.on_missing || 'empty' })
+  }
+}
+
+// Best-effort: suggest the org's synced directory attributes for the attribute
+// picker. Falls back to a free-text input if the endpoint is unavailable.
+onMounted(async () => {
+  try {
+    const r = await useMyFetch('/organization/identity/entra-profile-sync', { method: 'GET' })
+    const cfg = r.data.value as any
+    if (cfg?.fields?.length) attrSuggestions.value = cfg.fields
+  } catch {}
+})
+
 watch(() => props.editConnection, async (conn) => {
   if (conn) {
     try {
@@ -277,6 +402,7 @@ watch(() => props.editConnection, async (conn) => {
         form.scopes = meta.scopes || ''
         form.audience = meta.audience || ''
         form.token_endpoint_auth_method = meta.token_endpoint_auth_method || ''
+        hydrateForwarding(config)
         return
       }
     } catch {}
@@ -401,7 +527,7 @@ async function testConnection() {
   testing.value = true
   testResult.value = null
   try {
-    const config = { server_url: form.server_url, transport: form.transport, auth_type: form.auth_type }
+    const config = { server_url: form.server_url, transport: form.transport, auth_type: form.auth_type, ...buildForwarding() }
     const response = await useMyFetch('/connections/test-params', {
       method: 'POST',
       body: { name: 'test', type: 'mcp', config, credentials: buildCredentials() || {} },
@@ -425,7 +551,7 @@ async function handleSubmit() {
   submitError.value = null
   const fallback = isEditMode.value ? t('settings.mcpModal.failedUpdate') : t('settings.mcpModal.failedConnect')
   try {
-    const config = { server_url: form.server_url, transport: form.transport, auth_type: form.auth_type }
+    const config = { server_url: form.server_url, transport: form.transport, auth_type: form.auth_type, ...buildForwarding() }
     const credentials = buildCredentials()
 
     let response: any

--- a/frontend/components/MCPConnectionForm.vue
+++ b/frontend/components/MCPConnectionForm.vue
@@ -34,7 +34,7 @@
 
         <div>
           <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.nameLabel') }}</label>
-          <input v-model="form.name" type="text" :placeholder="$t('settings.mcpModal.namePlaceholder')" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+          <input v-model="form.name" type="text" data-test="mcp-name" :placeholder="$t('settings.mcpModal.namePlaceholder')" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
         </div>
 
         <!-- Server URL + Transport are shown inline only for a custom (non-preset)
@@ -42,11 +42,11 @@
         <template v-if="!isPreset">
           <div>
             <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.urlLabel') }}</label>
-            <input v-model="form.server_url" type="text" :placeholder="$t('settings.mcpModal.urlPlaceholder')" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+            <input v-model="form.server_url" type="text" data-test="mcp-url" :placeholder="$t('settings.mcpModal.urlPlaceholder')" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
           </div>
           <div>
             <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.mcpModal.transportLabel') }}</label>
-            <select v-model="form.transport" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500">
+            <select v-model="form.transport" data-test="mcp-transport" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500">
               <option value="sse">{{ $t('settings.mcpModal.transportSse') }}</option>
               <option value="streamable_http">{{ $t('settings.mcpModal.transportHttp') }}</option>
             </select>

--- a/frontend/components/tools/MCPTool.vue
+++ b/frontend/components/tools/MCPTool.vue
@@ -64,6 +64,18 @@
       </div>
     </div>
 
+    <!-- Failure surfaced inline (amber, not red): a failed tool call is
+         recoverable context for the run, not a hard system error — show it
+         without needing to expand the row. -->
+    <div
+      v-if="isFailed && errorMessage"
+      class="mt-1 ms-1 flex items-start gap-1 text-[11px] text-amber-600 dark:text-amber-500"
+      data-testid="mcp-error"
+    >
+      <Icon name="heroicons-exclamation-triangle" class="w-3 h-3 mt-0.5 shrink-0" />
+      <span class="break-words">{{ errorMessage }}</span>
+    </div>
+
     <!-- Auto policy verdict ('auto' policy): small-model review outcome -->
     <div
       v-if="autoPolicy"
@@ -112,8 +124,8 @@
           </div>
         </div>
 
-        <!-- Error message -->
-        <div v-if="errorMessage" class="text-[10px] text-red-500 bg-red-50/50 dark:bg-red-950 rounded px-2 py-1">
+        <!-- Error message (amber: a failed tool call is recoverable context) -->
+        <div v-if="errorMessage" class="text-[10px] text-amber-600 dark:text-amber-500 bg-amber-50/60 dark:bg-amber-950/40 rounded px-2 py-1">
           {{ errorMessage }}
         </div>
       </div>
@@ -240,8 +252,8 @@ const connectorKey = computed(() => mcpConnIcon.value?.connectorKey || null)
 const duration = computed(() => {
   const ms = props.toolExecution?.duration_ms
   if (!ms) return ''
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${Math.round(ms / 1000)}s`
 })
 
 // Model-authored, human-readable label for this call (e.g. "Searching Notion
@@ -345,7 +357,8 @@ const preview = computed(() => {
   return ''
 })
 
-const errorMessage = computed(() => resultJson.value.error_message || '')
+const errorMessage = computed(() => resultJson.value.error_message || resultJson.value.error || '')
+const isFailed = computed(() => resultJson.value.success === false || status.value === 'error')
 
 function toggleExpanded() {
   if (status.value !== 'running') {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -52,6 +52,9 @@ export default defineConfig({
         '**/members/**',
         '**/visibility/**',
         '**/config/**',
+        // Standalone spec — runs only via pw.mcp.config.ts with a local echo
+        // MCP server (needs a fresh unauthenticated signup, not admin.json).
+        '**/mcp_forwarding/**',
       ],
       dependencies: ['onboarding'],
       use: {

--- a/frontend/pw.mcp.config.ts
+++ b/frontend/pw.mcp.config.ts
@@ -1,0 +1,24 @@
+// Standalone Playwright config for the MCP context-forwarding E2E.
+// Self-contained (does its own 0→1 signup) so it needs no setup/onboarding
+// project dependencies. Run with:
+//   npx playwright test --config=pw.mcp.config.ts
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/mcp_forwarding',
+  timeout: 180 * 1000,
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    headless: true,
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'off',
+    // The sandbox ships chromium build 1194; this Playwright pins 1193. Point at
+    // the installed full chrome instead of re-downloading.
+    launchOptions: {
+      executablePath: process.env.PW_CHROME || '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    },
+  },
+})

--- a/frontend/tests/mcp_forwarding/context-forwarding.spec.ts
+++ b/frontend/tests/mcp_forwarding/context-forwarding.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect, Page } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// End-to-end UI test for MCP user-context forwarding, driven entirely through
+// the real UI from 0→1 (fresh signup). It creates an MCP connection pointed at
+// the local echo MCP server (tests/mocks/echo_mcp_http_server.py on :3333),
+// configures header + metadata forwarding in the Advanced section, verifies the
+// live Test Connection, saves, and asserts the persisted config via the API.
+//
+// Screenshots land in test-results/mcp-forwarding/ for the PR evidence.
+
+const SHOTS = path.resolve('test-results/mcp-forwarding')
+const ECHO_URL = process.env.ECHO_MCP_URL || 'http://127.0.0.1:3333/mcp'
+
+// Unique email per run: this suite runs against a freshly-reset DB (see
+// tools/agent/reset_backend.sh), so signup always claims the bootstrap admin.
+const ADMIN = {
+  name: 'MCP Fwd Admin',
+  email: `mcp-fwd-${Date.now()}@example.com`,
+  password: 'TestPass123!',
+}
+
+async function shot(page: Page, name: string) {
+  fs.mkdirSync(SHOTS, { recursive: true })
+  await page.screenshot({ path: path.join(SHOTS, `${name}.png`), fullPage: true })
+}
+
+async function signUp(page: Page) {
+  await page.goto('/users/sign-up', { waitUntil: 'load' })
+  await page.waitForSelector('#name', { state: 'visible', timeout: 30000 })
+  await page.waitForLoadState('networkidle').catch(() => {})
+  await page.fill('#name', ADMIN.name)
+  await page.fill('#email', ADMIN.email)
+  await page.fill('#password', ADMIN.password)
+  await page.click('button[type="submit"]')
+  const result = await Promise.race([
+    page.waitForURL((u) => !u.pathname.includes('/users/sign-up'), { timeout: 45000 }).then(() => 'ok'),
+    page.waitForSelector('.text-red-500', { timeout: 45000 }).then(() => 'error').catch(() => 'ok'),
+  ])
+  if (result === 'error') {
+    const msg = await page.locator('.text-red-500').first().textContent().catch(() => '')
+    throw new Error(`Sign-up failed: ${msg}`)
+  }
+  await page.waitForLoadState('domcontentloaded')
+}
+
+async function dismissOnboarding(page: Page) {
+  for (let i = 0; i < 6; i++) {
+    if (!page.url().includes('/onboarding')) return
+    await page.waitForLoadState('networkidle').catch(() => {})
+    const skip = page.getByRole('button', { name: 'Skip onboarding' })
+    if (await skip.isVisible({ timeout: 8000 }).catch(() => false)) {
+      await skip.click()
+      const left = await page
+        .waitForURL((u) => !u.pathname.includes('/onboarding'), { timeout: 8000 })
+        .then(() => true).catch(() => false)
+      if (left) return
+    }
+  }
+}
+
+test('MCP context forwarding: configure, test, save through the UI', async ({ page }) => {
+  // Capture the app's own auth headers (nuxt-auth token + org id) from any API
+  // call it makes, so we can re-query /api/connections authenticated afterwards.
+  let apiHeaders: Record<string, string> = {}
+  page.on('request', (req) => {
+    const h = req.headers()
+    if (req.url().includes('/api/') && h['authorization']) {
+      apiHeaders = { Authorization: h['authorization'] }
+      if (h['x-organization-id']) apiHeaders['X-Organization-Id'] = h['x-organization-id']
+    }
+  })
+
+  // ── 0→1: brand-new admin (fresh DB) ────────────────────────────────
+  await signUp(page)
+  await dismissOnboarding(page)
+
+  // ── open the MCP connection form ────────────────────────────────────
+  await page.goto('/agents/new', { waitUntil: 'load' })
+  await page.waitForLoadState('networkidle').catch(() => {})
+  await shot(page, '00-agents-new')
+
+  // The Add Connection modal auto-opens when the org has no connections;
+  // otherwise there's a "Create new connection" button to open it.
+  const mcpTile = page.getByRole('button', { name: 'MCP Server', exact: true })
+  if (!(await mcpTile.isVisible({ timeout: 8000 }).catch(() => false))) {
+    const createConn = page.getByRole('button', { name: 'Create new connection' })
+    if (await createConn.isVisible({ timeout: 8000 }).catch(() => false)) {
+      await createConn.click()
+    }
+  }
+  await expect(mcpTile).toBeVisible({ timeout: 20000 })
+  await mcpTile.click()
+
+  // Modal step 2: the MCP form.
+  await expect(page.locator('[data-test="mcp-name"]')).toBeVisible({ timeout: 15000 })
+  await page.locator('[data-test="mcp-name"]').fill('Echo LN MCP')
+  await page.locator('[data-test="mcp-url"]').fill(ECHO_URL)
+  await page.locator('[data-test="mcp-transport"]').selectOption('streamable_http')
+  await shot(page, '01-form-filled')
+
+  // ── Advanced → user context forwarding ──────────────────────────────
+  await page.locator('[data-test="mcp-advanced-toggle"]').click()
+  await expect(page.locator('[data-test="mcp-forwarding"]')).toBeVisible({ timeout: 10000 })
+
+  // Header rule: X-User-Email ← user.email
+  await page.locator('[data-test="add-header"]').click()
+  const hRow = page.locator('[data-test="header-row-0"]')
+  await hRow.locator('[data-test="header-name"]').fill('X-User-Email')
+  await hRow.locator('[data-test="header-source"]').selectOption('user.email')
+
+  // Metadata field 1 (locked): _client_userId ← membership.attr:employeeId
+  await page.locator('[data-test="add-meta"]').click()
+  const m0 = page.locator('[data-test="meta-row-0"]')
+  await m0.locator('[data-test="meta-name"]').fill('_client_userId')
+  await m0.locator('[data-test="meta-source"]').selectOption('membership.attr')
+  await m0.locator('[data-test="meta-key"]').fill('employeeId')
+  // stays locked (default) — assert the badge shows the lock
+  await expect(m0.locator('[data-test="meta-mode"]')).toContainText('Locked')
+
+  // Metadata field 2 (AI-fillable): department ← membership.role
+  await page.locator('[data-test="add-meta"]').click()
+  const m1 = page.locator('[data-test="meta-row-1"]')
+  await m1.locator('[data-test="meta-name"]').fill('department')
+  await m1.locator('[data-test="meta-source"]').selectOption('membership.role')
+  await m1.locator('[data-test="meta-mode"]').click() // toggle to AI
+  await expect(m1.locator('[data-test="meta-mode"]')).toContainText('AI')
+
+  await shot(page, '02-forwarding-configured')
+
+  // ── live Test Connection against the echo server ────────────────────
+  const testBtn = page.getByRole('button', { name: /Test Connection|Verify/ })
+  await testBtn.click()
+  // Success banner (green) — the backend reached the echo server and listed tools.
+  await expect(page.getByText(/tool\(s\)|connected|success/i).first())
+    .toBeVisible({ timeout: 30000 })
+  await shot(page, '03-test-connection-success')
+
+  // ── save the connection ─────────────────────────────────────────────
+  const connect = page.getByRole('button', { name: /^(Connect|Add connection|Save)$/ })
+  await connect.click()
+
+  // The modal advances past the form (indexing/success) — the form inputs go away.
+  await expect(page.locator('[data-test="mcp-name"]')).toBeHidden({ timeout: 30000 })
+  await shot(page, '04-connection-created')
+
+  // ── assert the persisted config via the API ─────────────────────────
+  expect(apiHeaders.Authorization, 'captured app auth headers').toBeTruthy()
+  const list = await page.request.get('/api/connections', { headers: apiHeaders })
+  expect(list.ok()).toBeTruthy()
+  const conns = await list.json()
+  const conn = (Array.isArray(conns) ? conns : conns.items || []).find((c: any) => c.name === 'Echo LN MCP')
+  expect(conn, 'created MCP connection should exist').toBeTruthy()
+
+  const detailRes = await page.request.get(`/api/connections/${conn.id}`, { headers: apiHeaders })
+  expect(detailRes.ok()).toBeTruthy()
+  const detail = await detailRes.json()
+  const cfg = detail.config || {}
+
+  // Header forwarding persisted
+  expect(cfg.header_injection).toEqual([
+    { header: 'X-User-Email', source: 'user.email' },
+  ])
+  // Metadata forwarding persisted with correct modes + source grammar
+  expect(cfg.metadata_injection?.argument_key).toBe('custom_metadata')
+  const fields = cfg.metadata_injection?.fields || []
+  const locked = fields.find((f: any) => f.name === '_client_userId')
+  const ai = fields.find((f: any) => f.name === 'department')
+  expect(locked).toMatchObject({ source: 'membership.attr:employeeId', mode: 'locked' })
+  expect(ai).toMatchObject({ source: 'membership.role', mode: 'ai' })
+})

--- a/frontend/tests/mcp_forwarding/context-forwarding.spec.ts
+++ b/frontend/tests/mcp_forwarding/context-forwarding.spec.ts
@@ -60,6 +60,15 @@ async function dismissOnboarding(page: Page) {
   }
 }
 
+// This spec is standalone: it needs the local echo MCP server (pw.mcp.config.ts)
+// and a fresh unauthenticated signup. If the echo server isn't reachable (e.g.
+// the shared CI Playwright run), skip rather than fail — the same env-gating the
+// live backend test uses.
+test.beforeEach(async () => {
+  const up = await fetch(ECHO_URL).then(() => true).catch(() => false)
+  test.skip(!up, `echo MCP server not reachable at ${ECHO_URL} — run via pw.mcp.config.ts`)
+})
+
 test('MCP context forwarding: configure, test, save through the UI', async ({ page }) => {
   // Capture the app's own auth headers (nuxt-auth token + org id) from any API
   // call it makes, so we can re-query /api/connections authenticated afterwards.

--- a/tools/agent/reset_backend.sh
+++ b/tools/agent/reset_backend.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Reset the backend to a clean database and restart it, keeping the frontend as
+# is. Used before the MCP context-forwarding Playwright E2E so a fresh signup
+# always claims the single-tenant bootstrap admin.
+#
+#   tools/agent/reset_backend.sh
+#
+# Env overrides mirror boot_stack.sh:
+#   BOW_AGENT_RUN_DIR   pid/log dir            (default /tmp/bow-agent)
+#   TEST_DATABASE_URL   backend database URL   (default sqlite:///db/agent.db)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_DIR="${BOW_AGENT_RUN_DIR:-/tmp/bow-agent}"
+DB_URL="${TEST_DATABASE_URL:-sqlite:///db/agent.db}"
+mkdir -p "$RUN_DIR"
+
+# Stop the running backend (leave the frontend up).
+if [ -f "$RUN_DIR/backend.pid" ]; then
+  pid=$(cat "$RUN_DIR/backend.pid")
+  kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+  rm -f "$RUN_DIR/backend.pid"
+fi
+# Belt-and-braces: kill any stray backend on :8000.
+pkill -f "python main.py" 2>/dev/null || true
+
+cd "$ROOT/backend"
+# Fresh SQLite file (only supported for the sqlite dev DB).
+rm -f db/agent.db db/agent.db-shm db/agent.db-wal 2>/dev/null || true
+mkdir -p db uploads/files uploads/branding
+
+export TESTING="true"
+export ENVIRONMENT="production"
+export TEST_DATABASE_URL="$DB_URL"
+
+uv run alembic upgrade head
+setsid uv run python main.py > "$RUN_DIR/backend.log" 2>&1 &
+echo $! > "$RUN_DIR/backend.pid"
+
+echo "waiting for backend on :8000 ..."
+curl --retry 90 --retry-delay 1 --retry-connrefused -sf -o /dev/null http://localhost:8000/health
+echo "backend reset and ready"


### PR DESCRIPTION
## What & why

**What:** MCP connections can now map each signed-in user's identity/membership into two places on every tool call — outbound **HTTP headers** and a **metadata object** merged into the tool arguments (`custom_metadata` by default), with per-field admin locks.
**Why it existed:** the only per-user value that reached an MCP server before was an OAuth access token. Servers that key on identity (e.g. Infor LN wanting `custom_metadata._client_userId` / `user_email` and identity headers) had no way to receive it — admins couldn't forward "who is asking" without the model inventing it.

## Executive summary (customer altitude)

A customer's MCP server (Infor LN) requires the calling user's identity on every request — some fields the assistant may fill, but sensitive ones (`user_email`, `_client_userId`) the **admin must pin and the model must never set**. This change lets an admin, in the connection's Advanced panel, map BOW identity → headers and → `custom_metadata` once; from then on every user's tool call carries **their own** resolved values, and locked fields are injected server-side and hidden from the model. It also fixes a pre-existing routing bug (below) that silently intercepted any external MCP tool whose name matched a BOW built-in.

## Reviewer decision box

| | |
|---|---|
| **Risk** | Medium. Adds a resolve+merge step on the `execute_mcp` hot path (guarded by "spec present"), and **changes how connection tool-calls are routed** (see routing fix). |
| **Blast radius** | `execute_mcp.py`, `search_mcps.py`, `MCPConfig`; new service module; MCP form UI. |
| **Behavior change (intended)** | (1) Locked metadata fields are **stripped from the model-facing tool schema** and **clobbered** at call time. (2) **A configured MCP/custom_api connection is now ALWAYS called over its own wire** — the in-process built-in shortcut is removed (loopback self-calls release the DB first). (3) MCP tool failures render **amber** (was red); call time rounds to whole seconds. |
| **Verified ✅** | 52 unit/e2e green (resolver, loopback routing, existing MCP suites); wire smoke; 0→1 Playwright UI E2E; live **Haiku** run injecting locked fields into a real MCP server (echo); live **eu.bagofwords.com** run proving a built-in-named tool routes to the external server. CI: playwright + sqlite-e2e + integrations green. |
| **NOT verified ⚠️** | The live eu/Haiku tests are env-gated (need `ANTHROPIC_API_KEY_TEST` + tokens; skip in CI). **The eu run proves *routing*, not payload receipt** — eu is prod with no echo, and its `create_report` leniently ignores unknown args, so `custom_metadata` arrival at eu is inferred, not observed. Payload-on-the-wire is *observed* only via the echo server. No i18n catalog keys added (raw English, consistent with existing strings in the component). |
| **Look first** | `backend/app/services/mcp_context_injection.py` (whitelist + merge + schema filter); the injection + routing change at `execute_mcp.py`. |

## The routing fix (added during review)

`execute_mcp` used to try an **in-process built-in** (`_try_inprocess_mcp`) *before* the HTTP path, keyed on **tool name alone, ignoring the connection**. So any external MCP server whose tool name collided with a BOW built-in (`create_report`, `create_data`, `get_context`, …) was silently intercepted: BOW ran its own tool instead of the external server's, and forwarding never fired (no request left the process). This bit real setups — Tableau, or another BOW instance (eu exposes the same 14 names).

Fix: **drop the name-based shortcut — a configured connection is always called over its own wire.** The shortcut existed only to stop a genuine *loopback* self-call from deadlocking SQLite's single writer; that case is preserved by detecting a loopback URL and releasing the agent's DB transaction (`_release_db`, `expire_on_commit=False`) before the self-call.

```mermaid
flowchart LR
  LLM[Haiku plans tool call] -->|prompt, args| EX[ExecuteMCPTool.run_stream]
  U[signed-in user + membership] --> R[resolve_mcp_context]
  CFG[connection.config: header/metadata_injection] --> R
  R -->|locked=clobber, ai=fill-gap| EX
  R -->|resolved headers| CC[construct_client]
  EX --> CC --> CLIENT[McpClient.acall_tool]
  CLIENT -->|headers + custom_metadata on the wire| SRV[(external MCP server)]
  SEARCH[search_mcps / failure schema] -.->|locked fields stripped| LLM
```

## Evidence / KPI

| Check | Result |
|---|---|
| Resolver unit tests | 27 passed |
| Loopback-routing unit tests | 11 passed |
| Existing MCP e2e (`test_mcp_tools`, `test_mcp_agent_tools`) | 14 passed — no regression from removing in-process path |
| Wire smoke (McpClient → echo) | headers + `custom_metadata` received (observed) |
| Live Haiku run (echo server) | echo captured `_client_userId`, `user_email`, `application_name`, `x-user-email` (observed) |
| Live eu run (`test_mcp_forwarding_eu_live`) | Haiku's `create_report` landed on eu (eu URL), absent locally → routed to external server |
| Playwright UI E2E (`pw.mcp.config.ts`) | 1 passed (0→1, green Test Connection) |
| CI (this run) | playwright ✅, e2e-sqlite ✅, integration-llms ✅, integration-data-sources ✅, e2e-postgres running |

## Context map

- **New primitive:** `backend/app/services/mcp_context_injection.py` — `resolve_mcp_context`, `apply_metadata_injection`, `filter_locked_from_schema`, whitelist `resolve_source`.
- **Convention:** forward per-user values only via the whitelist source grammar (add sources in `_resolve_atom`); locked fields are both stripped from the surfaced schema and clobbered at call time. A configured connection is never substituted by a same-named built-in.
- **Key files:** `schemas/data_sources/configs.py` (MCPConfig) · `ai/tools/implementations/execute_mcp.py` (inject + routing) · `ai/tools/implementations/search_mcps.py` (hide locked) · `frontend/components/MCPConnectionForm.vue` (UI) · `frontend/components/tools/MCPTool.vue` (amber error + rounded time).
- **Reproduction:** `docs/feedback-loops/mcp-user-context-forwarding.md` (Loops A–D). Helpers: `backend/tests/mocks/echo_mcp_http_server.py`, `tools/agent/reset_backend.sh`.
- **Follow-ups (out of scope):** per-tool overrides (connection-level today → `ConnectionTool.metadata_json`); wiring `entra-profile-sync/preview` so the attribute picker shows sample values; client-side wire-capture logging to *observe* forwarding on prod servers like eu; i18n keys.

## Deep detail & honesty

- **Modes:** `locked` = admin value always wins + hidden from the model; `ai` = surfaced as a default the model may set, server fills the gap. `on_missing` = `empty` (default) / `omit` / `block`.
- **Attribute picker** suggests the org's *declared* Entra sync fields — it does not sample a user and shows no example values yet. The backend whitelist is the real safety boundary.
- **Coverage caveat:** directory attributes exist only for Entra-synced users; a missing one follows `on_missing`.
- **Radical honesty on eu:** the eu run demonstrates routing, not receipt — see the NOT-verified line. Payload-on-the-wire is only *observed* against the echo server.

## Automated review
No review comments to date. CI addressed: the initial `playwright-tests` failure (my standalone spec swept into the shared run) is fixed by scoping it out + a reachability skip guard; the job is now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)