### PR TITLE
Shared conversations: tool UI for notes, route_model, create_instruction + RTL support

### DIFF
--- a/frontend/components/tools/CreateInstructionTool.vue
+++ b/frontend/components/tools/CreateInstructionTool.vue
@@ -56,8 +56,9 @@
           <div
             v-if="instructionText"
             dir="auto"
-            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer"
-            @click="currentGlobalStatus !== 'approved' ? handleEdit() : null"
+            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2"
+            :class="readonly ? '' : 'cursor-pointer'"
+            @click="!readonly && currentGlobalStatus !== 'approved' ? handleEdit() : null"
           >
             <MDC :value="instructionText" class="markdown-content" />
           </div>
@@ -98,7 +99,7 @@
           </div>
 
           <!-- Status + Accept/Reject actions -->
-          <div v-if="isSuccess && instructionId" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
+          <div v-if="!readonly && isSuccess && instructionId" class="flex items-center gap-1.5 pt-2 border-t border-gray-200 dark:border-gray-700">
             <template v-if="resolution === 'accepted'">
               <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
               <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">{{ $t('tools.createInstruction.accepted', 'Accepted') }}</span>
@@ -147,6 +148,7 @@
 
     <!-- Instruction Modal -->
     <InstructionModalComponent
+      v-if="!readonly"
       v-model="showInstructionModal"
       :instruction="editingInstruction"
       :initial-type="'global'"
@@ -178,6 +180,8 @@ interface ToolExecution {
 
 interface Props {
   toolExecution: ToolExecution
+  // Shared/public view: no click-to-edit, no accept/reject, no authed fetches.
+  readonly?: boolean
 }
 
 const props = defineProps<Props>()
@@ -357,6 +361,7 @@ const canResolve = computed(() => !!buildId.value && resolution.value === null &
 // If our build_id isn't in pending-builds for this instruction, it's resolved.
 // Distinguish by whether the instruction still exists (reject = deleted).
 async function refreshResolutionState() {
+  if (props.readonly) return
   if (!instructionId.value || !buildId.value) return
   isCheckingResolution.value = true
   try {

--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -97,7 +97,7 @@
                             <template v-if="m.role === 'user'">
                                 <div class="flex items-start gap-2 max-w-xl w-full mb-4">
                                     <div class="flex-1 flex justify-end">
-                                        <div class="inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start">
+                                        <div class="inline-block rounded-xl px-3 py-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white text-start" dir="auto">
                                             <div v-if="m.prompt?.content" class="pt-1 markdown-wrapper">
                                                 <MDC :value="m.prompt.content" class="markdown-content" />
                                             </div>
@@ -146,7 +146,7 @@
                                             </div>
 
                                             <!-- 2. Block content - assistant message -->
-                                            <div v-if="(block.content || block.plan_decision?.assistant) && !block.plan_decision?.final_answer && block.status !== 'error'" class="block-content markdown-wrapper">
+                                            <div v-if="(block.content || block.plan_decision?.assistant) && !block.plan_decision?.final_answer && block.status !== 'error'" class="block-content markdown-wrapper" dir="auto">
                                                 <MDC :value="block.content || block.plan_decision?.assistant || ''" class="markdown-content" />
                                             </div>
 
@@ -179,7 +179,7 @@
                                             </div>
 
                                             <!-- 4. Final answer -->
-                                            <div v-if="block.plan_decision?.analysis_complete && (block.plan_decision?.final_answer || (!block.content && !block.tool_execution))" class="mt-2 markdown-wrapper">
+                                            <div v-if="block.plan_decision?.analysis_complete && (block.plan_decision?.final_answer || (!block.content && !block.tool_execution))" class="mt-2 markdown-wrapper" dir="auto">
                                                 <MDC :value="block.plan_decision?.final_answer || block.plan_decision?.assistant || block.content || ''" class="markdown-content" />
                                             </div>
                                         </div>
@@ -245,7 +245,12 @@ import SearchReportsTool from '~/components/tools/SearchReportsTool.vue'
 import ReadReportTool from '~/components/tools/ReadReportTool.vue'
 import SearchInstructionsTool from '~/components/tools/SearchInstructionsTool.vue'
 import ReadInstructionTool from '~/components/tools/ReadInstructionTool.vue'
+import CreateNoteTool from '~/components/tools/CreateNoteTool.vue'
+import EditNoteTool from '~/components/tools/EditNoteTool.vue'
+import RouteModelTool from '~/components/tools/RouteModelTool.vue'
+import CreateInstructionTool from '~/components/tools/CreateInstructionTool.vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
+import { useMarkdownAutoDir } from '~/composables/useMarkdownAutoDir'
 
 const route = useRoute()
 const token = route.params.token as string
@@ -429,6 +434,14 @@ function getToolComponent(toolName: string) {
             return SearchInstructionsTool
         case 'read_instruction':
             return ReadInstructionTool
+        case 'create_note':
+            return CreateNoteTool
+        case 'edit_note':
+            return EditNoteTool
+        case 'route_model':
+            return RouteModelTool
+        case 'create_instruction':
+            return CreateInstructionTool
         default:
             return null
     }
@@ -552,12 +565,16 @@ function handleScroll(event: Event) {
     }
 }
 
+// Fixes list-marker direction for RTL content (see useMarkdownAutoDir).
+const markdownAutoDir = ref<{ stop: () => void } | null>(null)
+
 onMounted(() => {
     loadConversation()
+    markdownAutoDir.value = useMarkdownAutoDir()
 })
 
 onUnmounted(() => {
-    // Cleanup handled by Vue's event binding
+    markdownAutoDir.value?.stop()
 })
 </script>
 


### PR DESCRIPTION
## Summary

The public conversation share page (`/c/[token]`) rendered `create_note`, `edit_note`, `route_model`, and `create_instruction` tool executions with the generic `tool_name → tool_call (status)` fallback row. This PR maps them to their dedicated tool components (matching `/reports/[id]`) and brings over the reports page's RTL handling.

## Changes

### Tool UI (`frontend/pages/c/[token]/index.vue`)
- Map `create_note` → `CreateNoteTool`, `edit_note` → `EditNoteTool`, `route_model` → `RouteModelTool`, `create_instruction` → `CreateInstructionTool` in `getToolComponent`.

### Readonly support (`frontend/components/tools/CreateInstructionTool.vue`)
- New `readonly` prop (the share page already passes `:readonly="true"` to all tool components). In readonly mode:
  - no click-to-edit instruction modal
  - Accept/Reject action row hidden (incl. `ResolvedEvalStrip`)
  - resolution-state fetches to `/instructions/...` skipped — these would 401 for anonymous share viewers
- The instruction card still shows text, category, confidence, load mode, and evidence.
- `CreateNoteTool`, `EditNoteTool`, and `RouteModelTool` are pure display components and needed no changes.

### RTL (`frontend/pages/c/[token]/index.vue`)
- `dir="auto"` on user bubbles, assistant block content, and final-answer markdown wrappers — same as the reports page.
- Wire up `useMarkdownAutoDir` on mount (stopped on unmount) so list markers land on the correct edge for Hebrew/Arabic content; the matching `.markdown-wrapper ol[dir="rtl"]` rules in the global `rtl.css` already apply.

## Notes
- Scoped to the tools requested: `edit_instruction` still uses the generic fallback row on the share page; it has the same interactive/authed-fetch pattern and would need the same readonly treatment if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01178ZdEGgCC6fmd6fFgQUqh

---
_Generated by [Claude Code](https://claude.ai/code/session_01178ZdEGgCC6fmd6fFgQUqh)_