### PR TITLE
Soft-delete eval cases/suites so deletion works with run history; add loading state to test case modal

### DIFF
--- a/backend/app/services/test_case_service.py
+++ b/backend/app/services/test_case_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
 from typing import List, Optional, Sequence
+from datetime import datetime
 from fastapi import HTTPException
 
 from app.models.eval import (
@@ -15,7 +16,11 @@ from app.models.llm_provider import LLMProvider
 
 class TestCaseService:
     async def _get_suite(self, db: AsyncSession, organization_id: str, current_user, suite_id: str) -> TestSuite:
-        res = await db.execute(select(TestSuite).where(TestSuite.id == suite_id, TestSuite.organization_id == str(organization_id)))
+        res = await db.execute(
+            select(TestSuite)
+            .where(TestSuite.id == suite_id, TestSuite.organization_id == str(organization_id))
+            .where(TestSuite.deleted_at.is_(None))
+        )
         suite = res.scalar_one_or_none()
         if not suite:
             raise HTTPException(status_code=404, detail="Test suite not found")
@@ -178,8 +183,12 @@ class TestCaseService:
         return suite
 
     async def delete_case(self, db: AsyncSession, organization_id: str, current_user, case_id: str) -> None:
+        # Soft delete: TestResult rows keep case_id as an FK target, so a
+        # hard DELETE fails with a foreign-key violation once the case has
+        # been part of any run.
         case = await self.get_case(db, organization_id, current_user, case_id)
-        await db.delete(case)
+        case.deleted_at = datetime.utcnow()
+        db.add(case)
         await db.commit()
 
     async def list_cases_multi(

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -116,7 +116,11 @@ class TestRunService:
     
     async def _resolve_cases_inputs(self, db: AsyncSession, organization_id: str, case_ids: Optional[List[str]], suite_id: Optional[str]) -> List[TestCase]:
         if case_ids and len(case_ids) > 0:
-            res = await db.execute(select(TestCase).where(TestCase.id.in_([str(c) for c in case_ids])))
+            res = await db.execute(
+                select(TestCase)
+                .where(TestCase.id.in_([str(c) for c in case_ids]))
+                .where(TestCase.deleted_at.is_(None))
+            )
             cases: List[TestCase] = res.scalars().all()
             if not cases:
                 raise HTTPException(status_code=400, detail="No test cases found")
@@ -147,7 +151,7 @@ class TestRunService:
         suite-level / scheduled runs skip drafts and archived cases. Pass
         ``status=None`` to include every status (e.g. for UI listings).
         """
-        stmt = select(TestCase).where(TestCase.suite_id == str(suite_id))
+        stmt = select(TestCase).where(TestCase.suite_id == str(suite_id), TestCase.deleted_at.is_(None))
         if status is not None:
             stmt = stmt.where(TestCase.status == status)
         stmt = stmt.order_by(TestCase.created_at.asc())
@@ -543,6 +547,7 @@ class TestRunService:
             .select_from(TestCase)
             .join(TestSuite, TestCase.suite_id == TestSuite.id)
             .where(TestSuite.organization_id == str(organization_id))
+            .where(TestCase.deleted_at.is_(None))
         )
         total_cases = (await db.execute(total_cases_stmt)).scalar_one() or 0
 
@@ -579,12 +584,18 @@ class TestRunService:
 
     async def get_suites_summary(self, db: AsyncSession, organization_id: str, current_user) -> List[TestSuiteSummarySchema]:
         # Return suites with counts and last run info
-        res = await db.execute(select(TestSuite).where(TestSuite.organization_id == str(organization_id)).order_by(TestSuite.created_at.desc()))
+        res = await db.execute(
+            select(TestSuite)
+            .where(TestSuite.organization_id == str(organization_id), TestSuite.deleted_at.is_(None))
+            .order_by(TestSuite.created_at.desc())
+        )
         suites = res.scalars().all()
         summaries: List[TestSuiteSummarySchema] = []
         for s in suites:
             # tests_count = number of cases in suite
-            res_cases = await db.execute(select(TestCase).where(TestCase.suite_id == str(s.id)))
+            res_cases = await db.execute(
+                select(TestCase).where(TestCase.suite_id == str(s.id), TestCase.deleted_at.is_(None))
+            )
             cases = res_cases.scalars().all()
             tests_count = len(cases)
             # last run (by picking latest TestRun that includes this suite via results → cases)

--- a/backend/app/services/test_suite_service.py
+++ b/backend/app/services/test_suite_service.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import yaml
 from fastapi import HTTPException
 
-from app.models.eval import TestSuite, TestCase
+from app.models.eval import TestSuite, TestCase, TestResult
 from app.models.data_source import DataSource
 from app.models.llm_model import LLMModel
 from app.models.llm_provider import LLMProvider
@@ -46,14 +46,18 @@ class TestSuiteService:
         return await self.create_suite(db, str(organization_id), current_user, name="Default", description="Auto-created")
 
     async def get_suite(self, db: AsyncSession, organization_id: str, current_user, suite_id: str) -> TestSuite:
-        res = await db.execute(select(TestSuite).where(TestSuite.id == suite_id, TestSuite.organization_id == str(organization_id)))
+        res = await db.execute(
+            select(TestSuite)
+            .where(TestSuite.id == suite_id, TestSuite.organization_id == str(organization_id))
+            .where(TestSuite.deleted_at.is_(None))
+        )
         suite = res.scalar_one_or_none()
         if not suite:
             raise HTTPException(status_code=404, detail="Test suite not found")
         return suite
 
     async def list_suites(self, db: AsyncSession, organization_id: str, current_user, page: int = 1, limit: int = 20, search: Optional[str] = None) -> List[TestSuite]:
-        stmt = select(TestSuite).where(TestSuite.organization_id == str(organization_id))
+        stmt = select(TestSuite).where(TestSuite.organization_id == str(organization_id), TestSuite.deleted_at.is_(None))
         if search:
             from sqlalchemy import or_
             like = f"%{search}%"
@@ -80,8 +84,19 @@ class TestSuiteService:
         return suite
 
     async def delete_suite(self, db: AsyncSession, organization_id: str, current_user, suite_id: str) -> None:
+        # Soft delete the suite and its cases. TestResult rows reference
+        # cases by FK, so hard-deleting a suite (which cascades to cases)
+        # fails once any of its cases has run history.
         suite = await self.get_suite(db, organization_id, current_user, suite_id)
-        await db.delete(suite)
+        now = datetime.utcnow()
+        suite.deleted_at = now
+        db.add(suite)
+        res = await db.execute(
+            select(TestCase).where(TestCase.suite_id == str(suite.id), TestCase.deleted_at.is_(None))
+        )
+        for case in res.scalars().all():
+            case.deleted_at = now
+            db.add(case)
         await db.commit()
 
 
@@ -344,20 +359,27 @@ class TestSuiteService:
             cases_by_name[tc.name] = str(tc.id)
 
         # Handle removed cases: soft-delete on upsert (preserves TestResult
-        # history), hard-delete on replace (full sync).
+        # history), hard-delete on replace (full sync). Even on replace,
+        # cases with existing TestResult rows are soft-deleted — they are
+        # FK targets and a hard DELETE would violate the constraint.
         removed = [
             c for name, c in existing_cases.items()
             if name not in seen_names and c.deleted_at is None
         ]
         if removed:
             now = datetime.utcnow()
-            if strategy == "replace":
-                for c in removed:
-                    await db.delete(c)
-            else:
-                for c in removed:
-                    c.deleted_at = now
-                    db.add(c)
+            for c in removed:
+                if strategy == "replace":
+                    has_results = (
+                        await db.execute(
+                            select(TestResult.id).where(TestResult.case_id == str(c.id)).limit(1)
+                        )
+                    ).scalar_one_or_none()
+                    if has_results is None:
+                        await db.delete(c)
+                        continue
+                c.deleted_at = now
+                db.add(c)
             await db.commit()
 
         return {

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -191,7 +191,7 @@ from tests.fixtures.instruction import create_instruction, create_global_instruc
 from tests.fixtures.entity import get_entities, get_entity, create_global_entity
 from tests.fixtures.console_metrics import get_console_metrics, get_console_metrics_comparison, get_timeseries_metrics, get_table_usage_metrics, get_top_users_metrics, get_recent_negative_feedback, get_diagnosis_dashboard_metrics, get_agent_execution_summaries, create_test_data_for_console, get_tool_usage_metrics, get_llm_usage_metrics, get_diagnosis_timeseries, get_diagnosis_users, seed_agent_executions
 from tests.fixtures.mention import get_available_mentions
-from tests.fixtures.eval import create_test_suite, get_test_suites, create_test_case, get_test_cases, get_test_case, get_test_suite, create_test_run, get_test_runs, get_test_run, get_suites_summary, import_suite_yaml, export_suite_yaml
+from tests.fixtures.eval import create_test_suite, get_test_suites, create_test_case, get_test_cases, get_test_case, get_test_suite, create_test_run, get_test_runs, get_test_run, get_suites_summary, import_suite_yaml, export_suite_yaml, seed_test_result
 from tests.fixtures.file import upload_file, upload_csv_file, upload_excel_file, get_files, get_files_by_report, remove_file_from_report
 from tests.fixtures.organization_settings import get_organization_settings, update_organization_settings, upload_organization_icon, delete_organization_icon, get_organization_icon
 from tests.fixtures.api_key import create_api_key, list_api_keys, delete_api_key, api_key_request

--- a/backend/tests/e2e/test_eval.py
+++ b/backend/tests/e2e/test_eval.py
@@ -282,3 +282,72 @@ def test_suites_summary_empty_suite_has_zero_count(
     assert our_suite["tests_count"] == 0, "Empty suite should have tests_count of 0"
 
 
+
+
+# ============================================================
+# Deletion Tests (soft delete — cases/suites are FK targets of
+# test_results, so hard deletes fail once run history exists)
+# ============================================================
+
+@pytest.mark.e2e
+def test_delete_case_with_results_keeps_run_history(
+    create_user, login_user, whoami,
+    create_test_suite, create_test_case, get_test_cases, get_test_case,
+    create_report, seed_test_result, get_test_run,
+    test_client,
+):
+    """Deleting a case that has TestResult rows must succeed and preserve
+    the run history that references it."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    suite = create_test_suite(name="Deletion Suite", user_token=token, org_id=org_id)
+    case = create_test_case(suite_id=suite["id"], name="case-with-history", user_token=token, org_id=org_id)
+    report = create_report(title="Eval run report", user_token=token, org_id=org_id)
+    seeded = seed_test_result(report_id=report["id"], case_id=case["id"], suite_id=suite["id"])
+
+    resp = test_client.delete(f"/api/tests/cases/{case['id']}", headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    # Case is gone from listings and direct fetch...
+    cases = get_test_cases(suite["id"], user_token=token, org_id=org_id)
+    assert case["id"] not in {c["id"] for c in cases}
+    assert get_test_case(case["id"], user_token=token, org_id=org_id).status_code == 404
+
+    # ...but the run that referenced it is still retrievable.
+    run_resp = get_test_run(seeded["run_id"], user_token=token, org_id=org_id)
+    assert run_resp.status_code == 200, run_resp.json()
+
+
+@pytest.mark.e2e
+def test_delete_suite_with_results_keeps_run_history(
+    create_user, login_user, whoami,
+    create_test_suite, create_test_case, get_test_suites, get_test_suite,
+    create_report, seed_test_result, get_test_run,
+    test_client,
+):
+    """Deleting a suite whose cases have TestResult rows must succeed and
+    preserve the run history."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    suite = create_test_suite(name="Doomed Suite", user_token=token, org_id=org_id)
+    case = create_test_case(suite_id=suite["id"], name="case-a", user_token=token, org_id=org_id)
+    report = create_report(title="Eval run report", user_token=token, org_id=org_id)
+    seeded = seed_test_result(report_id=report["id"], case_id=case["id"], suite_id=suite["id"])
+
+    resp = test_client.delete(f"/api/tests/suites/{suite['id']}", headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    # Suite is gone from listings and direct fetch...
+    suites = get_test_suites(user_token=token, org_id=org_id)
+    assert suite["id"] not in {s["id"] for s in suites}
+    assert get_test_suite(suite["id"], user_token=token, org_id=org_id).status_code == 404
+
+    # ...but the run that referenced its case is still retrievable.
+    run_resp = get_test_run(seeded["run_id"], user_token=token, org_id=org_id)
+    assert run_resp.status_code == 200, run_resp.json()

--- a/backend/tests/fixtures/eval.py
+++ b/backend/tests/fixtures/eval.py
@@ -1,4 +1,56 @@
+import os
+
 import pytest
+
+
+@pytest.fixture
+def seed_test_result():
+    """Insert a TestRun + head Completion + TestResult directly into the test DB.
+
+    Direct DB writes are a last resort per tests/AGENTS.md — TestResult rows
+    are only produced by executing a live eval run (an LLM boundary e2e tests
+    must not cross), so there is no API surface that can create them.
+    """
+    def _seed(*, report_id, case_id, suite_id, status="pass"):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session
+        from app.models.completion import Completion
+        from app.models.eval import TestRun, TestResult
+
+        url = os.environ["TEST_DATABASE_URL"]
+        sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace("postgresql+asyncpg:", "postgresql:")
+        engine = create_engine(sync_url)
+        try:
+            with Session(engine) as session:
+                head = Completion(
+                    prompt={"content": "eval prompt"},
+                    completion={"content": ""},
+                    role="user",
+                    message_type="user_message",
+                    report_id=report_id,
+                )
+                session.add(head)
+                session.flush()
+
+                run = TestRun(title="Seeded run", suite_ids=str(suite_id), status="success")
+                session.add(run)
+                session.flush()
+
+                result = TestResult(
+                    run_id=run.id,
+                    case_id=str(case_id),
+                    head_completion_id=head.id,
+                    status=status,
+                )
+                session.add(result)
+                session.flush()
+                seeded = {"run_id": str(run.id), "result_id": str(result.id)}
+                session.commit()
+                return seeded
+        finally:
+            engine.dispose()
+
+    return _seed
 
 
 @pytest.fixture

--- a/frontend/components/monitoring/AddTestCaseModal.vue
+++ b/frontend/components/monitoring/AddTestCaseModal.vue
@@ -14,6 +14,7 @@
                             <USelectMenu
                                 v-model="selectedSuiteIdLocal"
                                 :options="suiteOptions"
+                                :loading="suitesLoading"
                                 option-attribute="label"
                                 value-attribute="value"
                                 size="xs"
@@ -32,6 +33,7 @@
                             <USelectMenu
                                 v-model="selectedBuildId"
                                 :options="buildOptions"
+                                :loading="buildsLoading"
                                 option-attribute="label"
                                 value-attribute="value"
                                 size="xs"
@@ -50,7 +52,11 @@
             </template>
 
             <div class="max-h-[62vh] overflow-hidden pe-1">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[420px]">
+                <div v-if="initialLoading" class="min-h-[420px] flex flex-col items-center justify-center gap-2 text-gray-400 dark:text-gray-500">
+                    <UIcon name="i-heroicons-arrow-path" class="w-6 h-6 animate-spin" />
+                    <div class="text-xs">{{ isEditing ? 'Loading test case…' : 'Loading…' }}</div>
+                </div>
+                <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[420px]">
                 <!-- Left: Prompt -->
                 <div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
                     <div class="px-3 py-2 border-b border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-400">Prompt</div>
@@ -309,8 +315,8 @@
             <template #footer>
                 <div class="flex items-center justify-end space-x-2">
                     <UButton color="gray" variant="soft" @click="close">Cancel</UButton>
-                    <UButton :loading="isSaving" color="blue" @click="save">Save</UButton>
-                    <UButton :loading="isRunning" color="blue" variant="soft" @click="runNow">Save and Run</UButton>
+                    <UButton :loading="isSaving" :disabled="initialLoading" color="blue" @click="save">Save</UButton>
+                    <UButton :loading="isRunning" :disabled="initialLoading" color="blue" variant="soft" @click="runNow">Save and Run</UButton>
                 </div>
             </template>
         </UCard>
@@ -340,6 +346,10 @@ const isEditing = computed(() => !!props.caseId)
 const promptText = ref('')
 const isSaving = ref(false)
 const isRunning = ref(false)
+// True while the modal is fetching the data it needs to render (suites,
+// builds, catalog, and — when editing — the case itself).
+const caseLoading = ref(false)
+const buildsLoading = ref(false)
 const router = useRouter()
 // Suites
 const suitesLoading = ref(false)
@@ -376,6 +386,7 @@ type CategoryDescriptor = { id: string, label: string, kind: 'tool'|'metadata'|'
 type TestCatalog = { categories: CategoryDescriptor[] }
 
 const catalogLoading = ref(false)
+const initialLoading = computed(() => caseLoading.value || suitesLoading.value || buildsLoading.value || catalogLoading.value)
 const categories = ref<CategoryDescriptor[]>([])
 const categoryById = computed(() => Object.fromEntries(categories.value.map(c => [c.id, c])))
 
@@ -531,10 +542,8 @@ const loadCatalog = async () => {
 }
 
 onMounted(async () => {
-  await loadSuites()
-  await loadBuilds()
-  await loadCatalog()
-  await loadJudgeModels()
+  if (isEditing.value) caseLoading.value = true
+  await Promise.all([loadSuites(), loadBuilds(), loadCatalog(), loadJudgeModels()])
   // Prepopulate when editing; otherwise seed create defaults (agent + Judge rule)
   // here — the open watch doesn't fire when the modal mounts already-open (v-if).
   if (isEditing.value && props.caseId) {
@@ -551,6 +560,7 @@ watch(() => props.suiteId, (v) => {
 // Ensure we fetch latest case data when the modal opens or caseId changes
 watch([() => props.caseId, isOpen], async ([cid, open]) => {
   if (open && cid) {
+    caseLoading.value = true
     // Ensure dependencies are loaded
     if ((categories.value || []).length === 0) await loadCatalog()
     if ((suites.value || []).length === 0) await loadSuites()
@@ -574,11 +584,14 @@ async function loadSuites() {
 }
 
 async function loadBuilds() {
+  buildsLoading.value = true
   try {
     const res = await useMyFetch<{ items: BuildItem[] }>('/api/builds?limit=20')
     builds.value = (res.data.value as any)?.items || []
   } catch (e) {
     console.error('Failed to load builds', e)
+  } finally {
+    buildsLoading.value = false
   }
 }
 
@@ -961,6 +974,7 @@ const runNow = async () => {
 }
 
 async function loadCaseForEdit(caseId: string) {
+  caseLoading.value = true
   try {
     const res: any = await useMyFetch(`/api/tests/cases/${caseId}`)
     const c = res?.data?.value
@@ -1065,6 +1079,8 @@ async function loadCaseForEdit(caseId: string) {
     }
   } catch (e) {
     console.error('Failed to load case for edit', e)
+  } finally {
+    caseLoading.value = false
   }
 }
 </script>


### PR DESCRIPTION
## Problem

Deleting an eval case (or suite) that had ever been part of a run failed with a 500:

```
ForeignKeyViolationError: update or delete on table "test_cases" violates
foreign key constraint "test_results_case_id_fkey" on table "test_results"
```

`delete_case`/`delete_suite` issued hard SQL `DELETE`s, but `test_results.case_id` keeps a foreign key to `test_cases`, so Postgres rejects the delete once run history exists. The codebase already anticipated this — the YAML sync path soft-deletes removed cases for exactly this reason — but the delete endpoints never followed that pattern.

## Backend changes

- `delete_case` and `delete_suite` now soft-delete (set `deleted_at`). Suite deletion also soft-deletes its live cases.
- YAML import with `strategy=replace` had the same latent bug: it now hard-deletes only cases with no results and soft-deletes the rest.
- Added `deleted_at` filters where soft-deleted rows must not surface: suite/case lookups and listings, run case selection (both explicit `case_ids` and suite expansion — so a deleted eval can't keep running on a schedule), dashboard metrics, and the suites summary.
- Historical paths (`get_run`, `stop_run`, results views) intentionally still resolve soft-deleted rows so past runs remain viewable after their case/suite is deleted.

## Frontend changes

The Edit Test Case modal rendered a half-empty form while suites, builds, catalog, and the case were still fetching:

- Centered spinner in the modal body until the initial loads finish.
- Loading indicators on the Suite/Build selects.
- Save / Save and Run disabled while loading, so a half-loaded form can't be saved over an existing case.
- The four initial fetches now run in parallel instead of sequentially.

## Tests

- New e2e regressions: deleting a case/suite with seeded `TestResult` rows succeeds, removes it from listings, and keeps the run history retrievable; plus a `seed_test_result` fixture (direct DB seeding, since results are only produced by live runs).
- `tests/e2e/test_eval.py`, `test_eval_yaml.py`, `test_eval_drafts.py`: 26 passed on sqlite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld8z29Q5x2T1J5Es1Y1tnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ld8z29Q5x2T1J5Es1Y1tnT)_