### PR TITLE
Fix saved-prompt param modal not opening for non-ASCII and multi-word {{param}} names

### DIFF
--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -34,7 +34,7 @@ from app.schemas.prompt_schema import PromptCreate, PromptUpdate
 from app.core.permission_resolver import resolve_permissions, ResolvedPermissions, FULL_ADMIN
 
 # Mirrors the frontend usePromptFill.substitute placeholder regex.
-_PLACEHOLDER_RE = re.compile(r"\{\{\s*([\w.-]+)\s*\}\}")
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([\w.-]+(?:[ \t]+[\w.-]+)*)\s*\}\}")
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tests/prompts/test_prompt_run.py
+++ b/backend/tests/prompts/test_prompt_run.py
@@ -89,6 +89,9 @@ async def test_substitute_semantics():
     assert s("{{region}} for {{period}}", {"region": "EMEA", "period": {"start": "Jan", "end": "Mar"}}) == "EMEA for Jan to Mar"
     assert s("X {{missing}} Y", {}) == "X  Y"            # missing → empty
     assert s("{{r}}", {"r": {"start": "", "end": ""}}) == ""  # empty range → empty
+    # names may be non-ASCII and contain internal spaces
+    assert s("תיק {{מספרתיק}}", {"מספרתיק": "42"}) == "תיק 42"
+    assert s("תיק {{ file number }}", {"file number": "42"}) == "תיק 42"
 
 
 @pytest.mark.asyncio

--- a/frontend/components/prompt/PromptCard.vue
+++ b/frontend/components/prompt/PromptCard.vue
@@ -153,7 +153,7 @@ const scopeChipClass = computed(() => {
 const previewSegments = computed(() => {
   const text = props.prompt.text || ''
   const segments: { text: string; param: boolean }[] = []
-  const re = /\{\{\s*[\p{L}\p{N}_.-]+\s*\}\}/gu
+  const re = /\{\{\s*[\p{L}\p{N}_.-]+(?:[ \t]+[\p{L}\p{N}_.-]+)*\s*\}\}/gu
   let last = 0
   let m: RegExpExecArray | null
   while ((m = re.exec(text)) !== null) {

--- a/frontend/components/prompt/PromptCard.vue
+++ b/frontend/components/prompt/PromptCard.vue
@@ -153,7 +153,7 @@ const scopeChipClass = computed(() => {
 const previewSegments = computed(() => {
   const text = props.prompt.text || ''
   const segments: { text: string; param: boolean }[] = []
-  const re = /\{\{\s*[\w.-]+\s*\}\}/g
+  const re = /\{\{\s*[\p{L}\p{N}_.-]+\s*\}\}/gu
   let last = 0
   let m: RegExpExecArray | null
   while ((m = re.exec(text)) !== null) {

--- a/frontend/components/prompt/PromptEditModal.vue
+++ b/frontend/components/prompt/PromptEditModal.vue
@@ -280,7 +280,7 @@ function onMentionsGroups(groups: any[]) {
 function insertParameterPrompt() {
   const name = (window.prompt(t('prompts.insertParamPromptLabel'), 'param') || '').trim()
   if (!name) return
-  const clean = name.replace(/[^\p{L}\p{N}_.-]/gu, '_')
+  const clean = name.replace(/[^\p{L}\p{N} _.-]/gu, '_').replace(/\s+/g, ' ').trim()
   form.text = `${form.text || ''}{{${clean}}}`
 }
 

--- a/frontend/components/prompt/PromptEditModal.vue
+++ b/frontend/components/prompt/PromptEditModal.vue
@@ -280,7 +280,7 @@ function onMentionsGroups(groups: any[]) {
 function insertParameterPrompt() {
   const name = (window.prompt(t('prompts.insertParamPromptLabel'), 'param') || '').trim()
   if (!name) return
-  const clean = name.replace(/[^\w.-]/g, '_')
+  const clean = name.replace(/[^\p{L}\p{N}_.-]/gu, '_')
   form.text = `${form.text || ''}{{${clean}}}`
 }
 

--- a/frontend/components/prompt/PromptViewModal.vue
+++ b/frontend/components/prompt/PromptViewModal.vue
@@ -193,7 +193,7 @@ const scopeChipClass = computed(() => {
 const textSegments = computed(() => {
   const text = props.prompt?.text || ''
   const segments: { text: string; param: boolean }[] = []
-  const re = /\{\{\s*[\w.-]+\s*\}\}/g
+  const re = /\{\{\s*[\p{L}\p{N}_.-]+\s*\}\}/gu
   let last = 0
   let m: RegExpExecArray | null
   while ((m = re.exec(text)) !== null) {

--- a/frontend/components/prompt/PromptViewModal.vue
+++ b/frontend/components/prompt/PromptViewModal.vue
@@ -193,7 +193,7 @@ const scopeChipClass = computed(() => {
 const textSegments = computed(() => {
   const text = props.prompt?.text || ''
   const segments: { text: string; param: boolean }[] = []
-  const re = /\{\{\s*[\p{L}\p{N}_.-]+\s*\}\}/gu
+  const re = /\{\{\s*[\p{L}\p{N}_.-]+(?:[ \t]+[\p{L}\p{N}_.-]+)*\s*\}\}/gu
   let last = 0
   let m: RegExpExecArray | null
   while ((m = re.exec(text)) !== null) {

--- a/frontend/composables/usePromptFill.ts
+++ b/frontend/composables/usePromptFill.ts
@@ -32,7 +32,7 @@ export function usePromptFill() {
     if (!text) return []
     const names: string[] = []
     const seen = new Set<string>()
-    const re = /\{\{\s*([\p{L}\p{N}_.-]+)\s*\}\}/gu
+    const re = /\{\{\s*([\p{L}\p{N}_.-]+(?:[ \t]+[\p{L}\p{N}_.-]+)*)\s*\}\}/gu
     let m: RegExpExecArray | null
     while ((m = re.exec(text)) !== null) {
       const name = String(m[1]).trim()
@@ -49,7 +49,7 @@ export function usePromptFill() {
   // - missing values collapse the placeholder to an empty string.
   function substitute(text: string, values: Record<string, PromptParamValue>): string {
     if (!text) return ''
-    return text.replace(/\{\{\s*([\p{L}\p{N}_.-]+)\s*\}\}/gu, (_match, rawName: string) => {
+    return text.replace(/\{\{\s*([\p{L}\p{N}_.-]+(?:[ \t]+[\p{L}\p{N}_.-]+)*)\s*\}\}/gu, (_match, rawName: string) => {
       const name = String(rawName).trim()
       const v = values?.[name]
       if (v == null) return ''

--- a/frontend/composables/usePromptFill.ts
+++ b/frontend/composables/usePromptFill.ts
@@ -32,7 +32,7 @@ export function usePromptFill() {
     if (!text) return []
     const names: string[] = []
     const seen = new Set<string>()
-    const re = /\{\{\s*([\w.-]+)\s*\}\}/g
+    const re = /\{\{\s*([\p{L}\p{N}_.-]+)\s*\}\}/gu
     let m: RegExpExecArray | null
     while ((m = re.exec(text)) !== null) {
       const name = String(m[1]).trim()
@@ -49,7 +49,7 @@ export function usePromptFill() {
   // - missing values collapse the placeholder to an empty string.
   function substitute(text: string, values: Record<string, PromptParamValue>): string {
     if (!text) return ''
-    return text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_match, rawName: string) => {
+    return text.replace(/\{\{\s*([\p{L}\p{N}_.-]+)\s*\}\}/gu, (_match, rawName: string) => {
       const name = String(rawName).trim()
       const v = values?.[name]
       if (v == null) return ''


### PR DESCRIPTION
## Problem

Clicking **Run** on a saved prompt with `{{param}}` placeholders should open the parameter-fill modal, but for prompts like `{{מספרתיק}}` or `{{ file number }}` it ran immediately and the placeholder was never filled — the raw `{{ file number }}` text even passed through verbatim into the completion.

Two holes in the placeholder regex:

1. **Non-ASCII names** — JS `\w` only matches `[A-Za-z0-9_]`, so Hebrew (or any non-Latin) names were invisible to `extractParamNames` in `usePromptFill.ts`. The run flow concluded the prompt had zero parameters and skipped the modal. (Python's `\w` *is* Unicode-aware, so the backend silently collapsed the placeholder to an empty string — worst of both worlds.)
2. **Multi-word names** — the pattern only accepted a single unbroken token, so `{{ file number }}` wasn't recognized by the frontend *or* the backend.

## Fix

- Frontend: switched the placeholder regexes in `usePromptFill.ts` (extract + substitute), `PromptCard.vue`, and `PromptViewModal.vue` to Unicode property classes with optional internal spaces/tabs: `[\p{L}\p{N}_.-]+(?:[ \t]+[\p{L}\p{N}_.-]+)*` with the `u` flag.
- Frontend: the insert-parameter sanitizer in `PromptEditModal.vue` now keeps letters in any script and spaces instead of mangling them to underscores.
- Backend: `_PLACEHOLDER_RE` in `prompt_service.py` got the identical change, kept in lockstep with the frontend so the parameter-value dict keys always match what substitution looks up.
- `{{viz:<uuid>}}` doc placeholders are unaffected (colon never matches the name class).

## Tests

- Extended `test_substitute_semantics` with Hebrew (`{{מספרתיק}}`) and multi-word (`{{ file number }}`) names.
- `backend/tests/prompts/` passes except `test_prompt_model_access_and_parameters`, which fails identically on `main` without these changes (pre-existing agent-permission visibility issue, unrelated).
- Verified the JS and Python regexes produce identical captures on the exact text from the bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MV5h34qBiZAspLuunA6zLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV5h34qBiZAspLuunA6zLm)_