### PR TITLE
fix(judge): skip LLM judge when the small default is missing or same as the regular default

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -916,10 +916,11 @@ class AgentV2:
     def _llm_judgement_enabled(self) -> bool:
         """Whether the background Judge scoring may run for this completion.
 
-        Requires the org setting, a regular chat report, and a genuine
-        small-default model in the org — self.small_model is resolved with a
-        fallback to the regular default, so the flag on the resolved model is
-        what tells a configured small default apart from the fallback.
+        Requires the org setting, a regular chat report, and a small-default
+        model distinct from the regular default — self.small_model is resolved
+        with a fallback to the regular default, and provider creation often
+        flags one model as both defaults, so the flags on the resolved model
+        are what tell a separate small model apart from either case.
         """
         setting = self.organization_settings.get_config("enable_llm_judgement")
         return (

--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -265,7 +265,7 @@ from sqlalchemy import select, func, update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.tool_execution import ToolExecution
 from app.models.agent_execution import AgentExecution
-from app.ai.agents.judge.judge import Judge
+from app.ai.agents.judge.judge import Judge, judge_model_allowed
 from app.ai.agents.suggest_instructions import InstructionTriggerEvaluator
 from app.dependencies import async_session_maker
 from app.core.telemetry import telemetry
@@ -913,13 +913,28 @@ class AgentV2:
             except Exception as e:
                 logger.warning(f"_resolve_file_references: ref {getattr(ref, 'id', '?')} failed: {e}")
 
+    def _llm_judgement_enabled(self) -> bool:
+        """Whether the background Judge scoring may run for this completion.
+
+        Requires the org setting, a regular chat report, and a genuine
+        small-default model in the org — self.small_model is resolved with a
+        fallback to the regular default, so the flag on the resolved model is
+        what tells a configured small default apart from the fallback.
+        """
+        setting = self.organization_settings.get_config("enable_llm_judgement")
+        return (
+            bool(setting and setting.value)
+            and self.report_type == 'regular'
+            and judge_model_allowed(self.small_model)
+        )
+
     async def _run_early_scoring_background(self, planner_input: PlannerInput):
         """Run instructions/context scoring in a fresh DB session to avoid concurrency conflicts."""
         try:
             # Score once, up-front. The Judge LLM call is expensive and must NOT
             # sit inside the DB retry loop below — a locked-SQLite write should
             # only retry the write, never re-run the model.
-            if self.organization_settings.get_config("enable_llm_judgement") and self.organization_settings.get_config("enable_llm_judgement").value and self.report_type == 'regular':
+            if self._llm_judgement_enabled():
                 judge = Judge(
                     model=self.model,
                     organization_settings=self.organization_settings,
@@ -949,7 +964,7 @@ class AgentV2:
         try:
             # Score once, up-front — keep the Judge LLM call out of the DB retry
             # loop so a locked-SQLite write never triggers a redundant model call.
-            if self.organization_settings.get_config("enable_llm_judgement") and self.organization_settings.get_config("enable_llm_judgement").value and self.report_type == 'regular':
+            if self._llm_judgement_enabled():
                 judge = Judge(
                     model=self.model,
                     organization_settings=self.organization_settings,

--- a/backend/app/ai/agents/judge/__init__.py
+++ b/backend/app/ai/agents/judge/__init__.py
@@ -1,1 +1,1 @@
-from .judge import Judge
+from .judge import Judge, judge_model_allowed

--- a/backend/app/ai/agents/judge/judge.py
+++ b/backend/app/ai/agents/judge/judge.py
@@ -14,13 +14,21 @@ import asyncio
 def judge_model_allowed(model) -> bool:
     """Whether the LLM judge may run on this model.
 
-    The judge only runs on an org's designated small-default model. Model
-    resolution (get_default_model(is_small=True)) silently falls back to the
-    regular default when no small default is configured, so callers must not
-    treat "a model was resolved" as "judging is allowed" — without a genuine
-    small default the judge is skipped instead of billed to the big model.
+    The judge only runs on an org's designated small-default model, and only
+    when that model is distinct from the regular default. A small default is
+    almost always set — provider creation marks the first enabled model as
+    BOTH default and small default — so the flag alone doesn't prove the org
+    has a separate small model. When the small default is the same row as the
+    regular default it carries both flags, and judging is skipped instead of
+    billed to the org's only (big) model. The is_small_default check also
+    covers resolution's silent fallback (get_default_model(is_small=True)
+    returns the regular default when no small default exists).
     """
-    return model is not None and bool(getattr(model, "is_small_default", False))
+    return (
+        model is not None
+        and bool(getattr(model, "is_small_default", False))
+        and not bool(getattr(model, "is_default", False))
+    )
 
 
 class Judge:

--- a/backend/app/ai/agents/judge/judge.py
+++ b/backend/app/ai/agents/judge/judge.py
@@ -10,6 +10,19 @@ from partialjson.json_parser import JSONParser
 from app.schemas.ai.planner import PlannerInput
 import asyncio
 
+
+def judge_model_allowed(model) -> bool:
+    """Whether the LLM judge may run on this model.
+
+    The judge only runs on an org's designated small-default model. Model
+    resolution (get_default_model(is_small=True)) silently falls back to the
+    regular default when no small default is configured, so callers must not
+    treat "a model was resolved" as "judging is allowed" — without a genuine
+    small default the judge is skipped instead of billed to the big model.
+    """
+    return model is not None and bool(getattr(model, "is_small_default", False))
+
+
 class Judge:
 
     def __init__(

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -81,7 +81,7 @@ from app.settings.database import create_async_session_factory
 from app.ai.agent_v2 import AgentV2
 from app.models.agent_execution import AgentExecution
 from app.services.test_evaluation_service import TestEvaluationService
-from app.ai.agents.judge.judge import Judge
+from app.ai.agents.judge.judge import Judge, judge_model_allowed
 from app.schemas.test_results_schema import TestResultTotals, TestResultJsonSchema, RuleSpec
 from app.models.organization import Organization
 
@@ -1103,7 +1103,7 @@ class TestRunService:
             return None
         snapshot = await self.evaluator.build_final_snapshot(session, str(report_id))
         try:
-            judge = Judge(model=small_model, organization_settings=org_settings) if small_model else None
+            judge = Judge(model=small_model, organization_settings=org_settings) if judge_model_allowed(small_model) else None
         except Exception:
             judge = None
 
@@ -1683,7 +1683,8 @@ class TestRunService:
                             snapshot = await self.evaluator.build_final_snapshot(session, str(head.report_id))
                             judge = None
                             try:
-                                judge = Judge(model=small_model, organization_settings=org_settings)
+                                if judge_model_allowed(small_model):
+                                    judge = Judge(model=small_model, organization_settings=org_settings)
                             except Exception:
                                 judge = None
                             # Determine AgentExecution and duration
@@ -1953,7 +1954,7 @@ class TestRunService:
                                 snapshot = await self.evaluator.build_final_snapshot(session, str(report_obj.id))
                                 # Prepare judge (optional)
                                 try:
-                                    judge = Judge(model=small_model, organization_settings=org_settings)
+                                    judge = Judge(model=small_model, organization_settings=org_settings) if judge_model_allowed(small_model) else None
                                 except Exception:
                                     judge = None
                                 # Determine AgentExecution and duration

--- a/backend/tests/unit/test_judge_gating.py
+++ b/backend/tests/unit/test_judge_gating.py
@@ -1,0 +1,71 @@
+"""Unit tests for LLM-judge gating on the small-default model.
+
+The judge must only run when the org has a genuine small-default model.
+Model resolution (get_default_model(is_small=True)) silently falls back to
+the regular default model when no small default is configured, so the gate
+checks the ``is_small_default`` flag on the resolved model rather than mere
+presence of a model.
+"""
+import types
+
+from app.ai.agents.judge.judge import judge_model_allowed
+
+
+def _model(*, small=False, default=False):
+    m = types.SimpleNamespace()
+    m.is_small_default = small
+    m.is_default = default
+    return m
+
+
+def test_no_model_disallows_judge():
+    assert judge_model_allowed(None) is False
+
+
+def test_fallback_default_model_disallows_judge():
+    # What get_default_model(is_small=True) returns when no small default
+    # exists: the regular default. The judge must not run on it.
+    assert judge_model_allowed(_model(default=True)) is False
+
+
+def test_small_default_model_allows_judge():
+    assert judge_model_allowed(_model(small=True)) is True
+
+
+def test_model_without_flag_attribute_disallows_judge():
+    assert judge_model_allowed(object()) is False
+
+
+def test_agent_scoring_gate_requires_small_default():
+    from app.ai.agent_v2 import AgentV2
+
+    setting_on = types.SimpleNamespace(value=True)
+
+    def fake_agent(*, setting, report_type, small_model):
+        settings = types.SimpleNamespace(get_config=lambda key: setting)
+        return types.SimpleNamespace(
+            organization_settings=settings,
+            report_type=report_type,
+            small_model=small_model,
+        )
+
+    # All conditions met → judge runs.
+    agent = fake_agent(setting=setting_on, report_type="regular", small_model=_model(small=True))
+    assert AgentV2._llm_judgement_enabled(agent) is True
+
+    # No small default (fallback resolved the big default) → judge skipped.
+    agent = fake_agent(setting=setting_on, report_type="regular", small_model=_model(default=True))
+    assert AgentV2._llm_judgement_enabled(agent) is False
+
+    # No small model at all → judge skipped.
+    agent = fake_agent(setting=setting_on, report_type="regular", small_model=None)
+    assert AgentV2._llm_judgement_enabled(agent) is False
+
+    # Setting off → judge skipped even with a small default.
+    setting_off = types.SimpleNamespace(value=False)
+    agent = fake_agent(setting=setting_off, report_type="regular", small_model=_model(small=True))
+    assert AgentV2._llm_judgement_enabled(agent) is False
+
+    # Non-regular report → judge skipped.
+    agent = fake_agent(setting=setting_on, report_type="dashboard", small_model=_model(small=True))
+    assert AgentV2._llm_judgement_enabled(agent) is False

--- a/backend/tests/unit/test_judge_gating.py
+++ b/backend/tests/unit/test_judge_gating.py
@@ -1,10 +1,11 @@
 """Unit tests for LLM-judge gating on the small-default model.
 
-The judge must only run when the org has a genuine small-default model.
-Model resolution (get_default_model(is_small=True)) silently falls back to
-the regular default model when no small default is configured, so the gate
-checks the ``is_small_default`` flag on the resolved model rather than mere
-presence of a model.
+The judge must only run when the org has a small-default model that is
+distinct from the regular default. A small default is almost always set —
+provider creation flags the first enabled model as both default and small
+default — so the gate requires ``is_small_default and not is_default`` on
+the resolved model: a same-as-default small model (both flags on one row)
+and resolution's silent fallback to the regular default are both rejected.
 """
 import types
 
@@ -28,8 +29,15 @@ def test_fallback_default_model_disallows_judge():
     assert judge_model_allowed(_model(default=True)) is False
 
 
-def test_small_default_model_allows_judge():
+def test_distinct_small_default_model_allows_judge():
     assert judge_model_allowed(_model(small=True)) is True
+
+
+def test_small_default_same_as_regular_default_disallows_judge():
+    # Provider creation flags the first enabled model as BOTH default and
+    # small default. That means the org has no separate small model, so the
+    # judge must not run on it.
+    assert judge_model_allowed(_model(small=True, default=True)) is False
 
 
 def test_model_without_flag_attribute_disallows_judge():
@@ -55,6 +63,10 @@ def test_agent_scoring_gate_requires_small_default():
 
     # No small default (fallback resolved the big default) → judge skipped.
     agent = fake_agent(setting=setting_on, report_type="regular", small_model=_model(default=True))
+    assert AgentV2._llm_judgement_enabled(agent) is False
+
+    # Small default is the same model as the regular default → judge skipped.
+    agent = fake_agent(setting=setting_on, report_type="regular", small_model=_model(small=True, default=True))
     assert AgentV2._llm_judgement_enabled(agent) is False
 
     # No small model at all → judge skipped.


### PR DESCRIPTION
## What + why

Gates every `Judge` (LLM judgement) creation site on the org having a small-default model **distinct from the regular default**, skipping the judge entirely otherwise.

It existed because a small default is *almost always* set — provider creation flags the first enabled model as **both** default and small default, and `get_default_model(is_small=True)` additionally falls back to the regular default — so every judge call site mistook "a small model was resolved" for "the org has a separate small model to judge with."

## Executive summary

Orgs without a separate small/cheap model (typically single-model setups, where the one model is flagged as both defaults) were still getting background LLM-judge scoring on every chat completion and eval run — billed to their big, expensive model, without ever opting into that spend. After this PR, the judge only runs when an admin has designated a small-default model that differs from the regular default; otherwise scoring is skipped exactly as if the "Enable LLM Judge" setting were off.

## Product impact — before vs after

```mermaid
flowchart LR
    subgraph Before
        A1[User sends chat message] --> B1[Agent answers] --> C1[Judge scores the run<br/>on the org's only, BIG model]:::bad --> D1[Org billed big-model tokens<br/>for background scoring]:::bad
    end
    subgraph After
        A2[User sends chat message] --> B2[Agent answers] --> C2{Small default exists<br/>AND differs from<br/>regular default?}
        C2 -- yes --> D2[Judge scores on the<br/>small-default model]:::good
        C2 -- no --> E2[Judge skipped —<br/>neutral scores persisted]:::good
    end
    classDef bad fill:#7f1d1d,stroke:#ef4444,color:#fff
    classDef good fill:#14532d,stroke:#22c55e,color:#fff
```

## Technical mechanism

```mermaid
flowchart TD
    R["get_default_model(is_small=True)"] --> S{what does the org have?}
    S -- "distinct small default" --> M1["model: is_small_default=True,<br/>is_default=False"]
    S -- "one model flagged as BOTH<br/>(provider-creation default)" --> M2["model: is_small_default=True,<br/>is_default=True"]:::bad
    S -- "no small default at all" --> M3["silent fallback: regular default<br/>is_small_default=False"]:::bad
    M1 --> G["judge_model_allowed(model):<br/>is_small_default AND NOT is_default"]
    M2 --> G
    M3 --> G
    G -- true --> J[Judge runs]:::good
    G -- false --> K[Judge = None / scoring skipped<br/>evaluator reports 'Judge unavailable']:::good
    classDef bad fill:#7f1d1d,stroke:#ef4444,color:#fff
    classDef good fill:#14532d,stroke:#22c55e,color:#fff
```

When the small default is the *same row* as the regular default it carries both flags, so `is_small_default and not is_default` on the resolved model distinguishes a genuinely separate small model from both degenerate cases — with no extra DB query.

## Reviewer decision box

| | |
|---|---|
| **Risk** | Low — pure gating; no schema, API, or resolution changes |
| **Blast radius** | AgentV2 background scoring (early + late) and eval-run judging; nothing else touches `Judge` |
| **Behavior change (intended)** | Orgs whose small default is missing *or identical to* the regular default: judge skipped (was: ran on the big model). Orgs with a distinct small default: unchanged |
| **Verified ✅** | 17/17 unit tests pass (6 new + 11 neighboring `test_model_router.py`); all touched files parse |
| **NOT verified ⚠️** | No live e2e run of a full completion/eval across the three org configurations |
| **Where to look first** | `judge_model_allowed()` in `backend/app/ai/agents/judge/judge.py`, then `AgentV2._llm_judgement_enabled()` |

## Evidence

| Check | Result | Attributable to this PR |
|---|---|---|
| `tests/unit/test_judge_gating.py` (new) | 6 passed | new coverage for the gate, incl. the both-flags-on-one-model case |
| `tests/unit/test_model_router.py` | 11 passed | no regression |
| Syntax/AST check of touched files | pass | — |
| E2E / eval suites | not run locally (CI runs them on this PR) | eval fixtures install a distinct small default, so no expected change |

## Context map

**Key files**
- `backend/app/ai/agents/judge/judge.py` — `judge_model_allowed()`, the single source of truth for the gate
- `backend/app/ai/agent_v2.py` — `_llm_judgement_enabled()` folds the gate into the existing `enable_llm_judgement` + `report_type` checks; both background scoring paths use it
- `backend/app/services/test_run_service.py` — all three eval-run `Judge` creation sites gated
- `backend/app/services/llm_service.py` (unchanged, load-bearing context) — provider creation sets the first enabled model as both defaults (`should_be_default` / `should_be_small_default`), and `get_default_model(is_small=True)` falls back to the regular default
- `backend/tests/unit/test_judge_gating.py` — gate matrix

**Convention established:** never create a `Judge` from a model resolved via `get_default_model(is_small=True)` without passing it through `judge_model_allowed()` first — a resolved small model proves neither that a small default exists nor that it differs from the regular default.

**Related / follow-ups**
- `ToolCallJudge` (MCP "auto" tool-policy review) deliberately **not** gated — gating it would hard-deny auto-policy tool calls in orgs without a distinct small model, a separate product decision.
- The unused `self.judge` attribute on `AgentV2` (built at init, never called) was left as-is; candidate for removal in a cleanup PR.

## Deep detail

**Root cause.** Two mechanisms conspire to make "a small model was resolved" meaningless as a gate: (1) provider creation marks the first enabled model as both default and small default, so `is_small_default` is set even in single-model orgs; (2) `get_default_model(is_small=True)` falls back to the regular default when no small default exists. Both are correct for their other consumers (Reporter, compaction budgets, routing — they just need *a* model and must never break chat), so neither could be changed.

**Approach & roads not taken.**
- *Not* comparing `small_model.id` against the run's active model: the active model can be an explicit per-message/report pick (a user legitimately chatting on the small model would wrongly disable the judge). The flag pair on the resolved row identifies "small default == regular default" directly.
- *Not* switching AgentV2's judge from `self.model` to `self.small_model`: that would change score quality/cost for every already-configured org — beyond the ask and riskier than gating.
- *Not* adding a strict `get_small_default_model()` service method: the flags on the already-resolved model give the same answer with zero extra queries.

**Graceful degradation.** When the gate fails, AgentV2 persists the same neutral scores (3) it uses when the org setting is off, and `TestEvaluationService` already handles `judge=None` (judge-based expectations report "Judge unavailable"). No new failure modes.

**Honest limits.** The gate depends on `llm_service` maintaining the flag invariants (set/clear on default changes, disable, delete — verified by reading, not by new tests). An org that *deliberately* points both defaults at one genuinely small model will also have its judge skipped; that is the requested behavior (distinct small default required), but worth knowing. No live end-to-end verification across the three org configurations was performed in this session.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W2EMckfutSSVjqEvbPcGm