### PR TITLE
Bump gitpython to 3.1.55 to fix high-severity Snyk advisories

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1379,14 +1379,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A full Snyk scan of the repo flagged four **high-severity** advisories, all against `gitpython==3.1.50`, a direct backend dependency:

- SNYK-PYTHON-GITPYTHON-18170134 — Command Injection (fixed in 3.1.51)
- SNYK-PYTHON-GITPYTHON-18170201 — Arbitrary Argument Injection (fixed in 3.1.51)
- SNYK-PYTHON-GITPYTHON-18170133 — Incomplete List of Disallowed Inputs (fixed in 3.1.51)
- SNYK-PYTHON-GITPYTHON-18170131 — Insertion of Sensitive Information Into Sent Data (fixed in 3.1.52)

This PR re-locks `gitpython` from 3.1.50 to 3.1.55 in `backend/uv.lock`. It is a lockfile-only change — the existing `pyproject.toml` constraint (`>=3.1.50,<3.2`) already permits the fixed versions.

## Verification

- **Snyk rescan clean**: after the bump, `snyk test` over all 235 resolved backend dependencies reports no vulnerable paths.
- **Smoke test**: exercised the GitPython API surface used by `backend/app/services/git_service.py` (the repo's only consumer — `Repo.init`, `clone_from`, `ls_remote`, branch creation/checkout, commits, `GitCommandError` handling) on 3.1.55; all pass.
- **Unit suite**: 1813 passed, 22 failed, 9 skipped. The 22 failures are **pre-existing and unrelated** — the identical set fails when run against gitpython 3.1.50 (verified by downgrading and re-running exactly those tests). They cover OAuth params, notification emails, permissions registry, and WhatsApp/Teams routing — none touch git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wqQwcKGd8DRthrdisCo2K

---
_Generated by [Claude Code](https://claude.ai/code/session_017wqQwcKGd8DRthrdisCo2K)_