### PR TITLE
Add range/grep/outline reads to read_artifact for long artifacts

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -366,7 +366,7 @@ Two cases — handle them differently:
 Artifact tool selection:
   - `create_artifact` — brand-new dashboard, rebuild, or large change. **First check past_observations for existing viz_ids. If they cover the ask, go straight here without calling create_data.** Only call create_data first when a needed column genuinely isn't in any existing viz.
   - `edit_artifact` — small/focused change to current dashboard. Needs an `artifact_id`.
-  - `read_artifact` — when the next step depends on the artifact's current content. Works on ALL artifact modes: dashboards/slides (returns the JSX code) AND docs (returns the document's markdown in the same `code` field).
+  - `read_artifact` — when the next step depends on the artifact's current content. Works on ALL artifact modes: dashboards/slides (returns the JSX code) AND docs (returns the document's markdown in the same `code` field). LONG artifacts: a plain read returns a line-numbered OUTLINE instead of code — follow up with `offset`/`limit` (line range) or `grep_pattern` (+`before`/`after` context) to pull only the region you need; both return verbatim code safe to quote in edit_artifact SEARCH blocks / edit_doc find strings.
   - Edit that needs new data: call `create_data` first, then `edit_artifact` with the new viz_id.
   - `create_doc` / `edit_doc` — WRITTEN documents (see DOCUMENT DELIVERABLES below), not dashboards.
 

--- a/backend/app/ai/context/builders/observation_context_builder.py
+++ b/backend/app/ai/context/builders/observation_context_builder.py
@@ -64,6 +64,21 @@ class ObservationContextBuilder:
                 if "images" in prev_observation:
                     del prev_observation["images"]
                     prev_observation["images_compacted"] = True
+                # Windowed-read payloads (long-artifact support) are just as
+                # heavy as full code — keep them for one iteration only, same
+                # as `code`. The summary line (match counts, line ranges)
+                # survives so the planner remembers WHAT it already saw.
+                if "matches" in prev_observation:
+                    match_count = len(prev_observation["matches"] or [])
+                    del prev_observation["matches"]
+                    prev_observation["matches_compacted"] = f"{match_count} grep matches (already shown — re-run read_artifact if needed)"
+                if "outline" in prev_observation:
+                    outline_len = len(prev_observation["outline"] or "")
+                    del prev_observation["outline"]
+                    prev_observation["outline_compacted"] = f"{outline_len} chars"
+                if "runtime_environment" in prev_observation:
+                    del prev_observation["runtime_environment"]
+                    prev_observation["runtime_environment_compacted"] = True
             elif prev_obs["tool_name"] == "inspect_data":
                 if "details" in prev_observation:
                     details_len = len(prev_observation["details"])

--- a/backend/app/ai/tools/implementations/read_artifact.py
+++ b/backend/app/ai/tools/implementations/read_artifact.py
@@ -2,10 +2,16 @@
 read_artifact tool - Read an existing artifact's code and metadata.
 
 Use this to load previous artifact code into context before modifying with create_artifact.
+
+Long-artifact support: full reads of artifacts above FULL_READ_MAX_CHARS return a
+structural outline (with line numbers) instead of the whole code, and the planner
+can then use range reads (offset/limit) or grep reads (grep_pattern with
+before/after context) to pull only the regions it needs into context.
 """
 
 import logging
-from typing import AsyncIterator, Dict, Any, Type, List
+import re
+from typing import AsyncIterator, Dict, Any, Optional, Tuple, Type, List
 
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -28,6 +34,119 @@ from app.ai.tools.implementations._sandbox_context import SANDBOX_RUNTIME_OBSERV
 
 logger = logging.getLogger(__name__)
 
+# ─── Long-artifact windowing knobs ───────────────────────────────────────────
+# Full reads at or below this size return the whole code (previous behavior).
+# Above it, a full read returns a structural outline instead, and the planner
+# is expected to follow up with range/grep reads.
+FULL_READ_MAX_CHARS = 50_000
+DEFAULT_RANGE_LIMIT = 400
+GREP_LINE_CLIP = 500
+OUTLINE_MAX_ENTRIES = 300
+
+
+def _outline_patterns(mode: str) -> List[re.Pattern]:
+    """Structural line patterns per artifact mode, used to build the outline."""
+    if mode == "doc":
+        return [re.compile(r"^#{1,6}\s+\S")]
+    if mode == "slides":
+        return [
+            re.compile(r"^// Slide \d+"),
+            re.compile(r"^\s*(?:def|class)\s+\w+"),
+            re.compile(r"^\s*#\s*[-=─═*]{3,}"),
+        ]
+    # page (React/JSX dashboards)
+    return [
+        re.compile(r"^\s*(?:async\s+)?function\s+\w+"),
+        re.compile(r"^\s*const\s+\w+\s*=\s*(?:async\s+)?(?:function\b|\()"),
+        re.compile(r"^\s*const\s+\{[^}]*\}\s*=\s*use\w+"),
+        re.compile(r"^\s*//\s*.*[-=─═*]{3,}"),
+        re.compile(r"<(?:SectionCard|KPICard|EChart|FilterSelect|FilterSearch|FilterDateRange|BowFile)\b"),
+        re.compile(r"^\s*ReactDOM\.createRoot"),
+    ]
+
+
+def build_outline(code: str, mode: str) -> str:
+    """Build a line-numbered structural outline of the artifact code.
+
+    Returns lines like `  123: function RevenueChart()` so the planner can
+    navigate a long artifact and follow up with targeted range/grep reads.
+    """
+    patterns = _outline_patterns(mode)
+    lines = code.split("\n")
+    entries: List[str] = []
+    for i, line in enumerate(lines):
+        if any(p.search(line) for p in patterns):
+            text = line.strip()
+            if len(text) > 160:
+                text = text[:160] + "…"
+            entries.append(f"{i + 1:>6}: {text}")
+            if len(entries) >= OUTLINE_MAX_ENTRIES:
+                entries.append(f"     … outline truncated at {OUTLINE_MAX_ENTRIES} entries ({len(lines)} lines total)")
+                break
+    if not entries:
+        # Nothing structural matched — show evenly spaced sample lines so the
+        # planner still gets landmarks to range-read around.
+        step = max(1, len(lines) // 40)
+        for i in range(0, len(lines), step):
+            text = lines[i].strip()
+            if text:
+                entries.append(f"{i + 1:>6}: {text[:160]}")
+            if len(entries) >= 40:
+                break
+    return "\n".join(entries)
+
+
+def slice_range(code: str, offset: int, limit: Optional[int]) -> Tuple[str, int, int, int, bool]:
+    """Return (slice_text, start_line, end_line, total_lines, truncated) for a
+    1-based line range read. The slice is verbatim (no line-number prefixes) so
+    it can be quoted directly in edit_artifact SEARCH blocks."""
+    lines = code.split("\n")
+    total_lines = len(lines)
+    limit = limit or DEFAULT_RANGE_LIMIT
+    start = max(1, offset)
+    if start > total_lines:
+        return "", start, start - 1, total_lines, False
+    end = min(total_lines, start + limit - 1)
+    text = "\n".join(lines[start - 1:end])
+    return text, start, end, total_lines, end < total_lines
+
+
+def grep_code(
+    code: str,
+    pattern: str,
+    ignore_case: bool = False,
+    before: int = 0,
+    after: int = 0,
+    max_matches: int = 50,
+) -> Tuple[List[Dict[str, Any]], int, bool]:
+    """Grep the artifact code line-by-line.
+
+    Returns (matches, total_matches, truncated). Each match carries the verbatim
+    matching line plus verbatim before/after context and 1-based line numbers.
+    Raises re.error for an invalid pattern — callers surface that to the planner.
+    """
+    flags = re.IGNORECASE if ignore_case else 0
+    rx = re.compile(pattern, flags)
+    lines = code.split("\n")
+    matches: List[Dict[str, Any]] = []
+    total = 0
+    for i, line in enumerate(lines):
+        if not rx.search(line):
+            continue
+        total += 1
+        if len(matches) >= max_matches:
+            continue
+        ctx_start = max(0, i - before)
+        clipped = line if len(line) <= GREP_LINE_CLIP else line[:GREP_LINE_CLIP]
+        matches.append({
+            "line_no": i + 1,
+            "line": clipped,
+            "before": lines[ctx_start:i],
+            "after": lines[i + 1:i + 1 + after],
+            "context_start_line": ctx_start + 1,
+        })
+    return matches, total, total > len(matches)
+
 
 class ReadArtifactTool(Tool):
     """Tool to read an existing artifact's code and metadata."""
@@ -44,12 +163,15 @@ class ReadArtifactTool(Tool):
                 "Use this also if the user is saying something is not working like filters or UI elements are not showing up - to check the existing code and visualizations for debugging. "
                 "ALWAYS use this before editing an artifact (edit_artifact) to have a full view of the existing code, visualizations, and layout. "
                 "If the user refers to a specific version of an artifact, ALWAYS load that version with this tool to have the correct code context for the edit. "
+                "LONG ARTIFACTS: when the code is too large to return in full, a plain read returns a structural OUTLINE with line numbers instead of code. "
+                "Then use `offset`/`limit` to read a specific line range, or `grep_pattern` (with `before`/`after` context lines) to find the exact region to edit. "
+                "Both return VERBATIM code you can quote in edit_artifact SEARCH blocks or edit_doc find strings. "
                 "Pass load_screenshot=true to include the last rendered preview screenshot in the observation — use this when debugging visual issues or when you need to see the current state before deciding how to edit. "
                 "IMPORTANT: The artifact_id is found in previous create_artifact results shown as 'artifact_id: <uuid>' in the conversation. "
                 "Do NOT ask the user for URLs or artifact IDs - extract the artifact_id from the conversation context."
             ),
             category="research",  # Must be research/action/both to be discovered by registry
-            version="1.0.0",
+            version="1.1.0",
             input_schema=ReadArtifactInput.model_json_schema(),
             output_schema=ReadArtifactOutput.model_json_schema(),
             max_retries=0,
@@ -161,6 +283,98 @@ class ReadArtifactTool(Tool):
                 for i, s in enumerate(slides)
             )
 
+        total_chars = len(code)
+        total_lines = code.count("\n") + 1 if code else 0
+
+        # ─── Resolve read mode: grep > range > full/outline ──────────────────
+        read_mode = "full"
+        code_view = code            # what goes into output.code / observation.code
+        start_line: Optional[int] = None
+        end_line: Optional[int] = None
+        range_truncated = False
+        matches: Optional[List[Dict[str, Any]]] = None
+        grep_total: Optional[int] = None
+        grep_truncated: Optional[bool] = None
+        outline: Optional[str] = None
+        window_note = ""
+
+        if data.grep_pattern:
+            read_mode = "grep"
+            code_view = ""
+            try:
+                matches, grep_total, grep_truncated = grep_code(
+                    code,
+                    data.grep_pattern,
+                    ignore_case=data.ignore_case,
+                    before=data.before,
+                    after=data.after,
+                    max_matches=data.max_matches,
+                )
+            except re.error as e:
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload={
+                        "output": ReadArtifactOutput(
+                            artifact_id=str(artifact.id),
+                            title=artifact.title,
+                            mode=artifact.mode,
+                            code="",
+                            visualization_ids=content.get("visualization_ids", []),
+                            version=artifact.version,
+                            read_mode="grep",
+                            total_lines=total_lines,
+                            total_chars=total_chars,
+                        ).model_dump(),
+                        "observation": {
+                            "summary": f"Invalid grep_pattern regex: {e}. Fix the pattern and retry.",
+                            "error": {"type": "invalid_pattern", "message": str(e)},
+                            "artifact_id": str(artifact.id),
+                        },
+                    },
+                )
+                return
+            if grep_total == 0:
+                # No matches — return the outline as a navigation aid so the
+                # planner's next read is informed instead of another guess.
+                outline = build_outline(code, artifact.mode)
+                window_note = (
+                    f"0 matches for pattern {data.grep_pattern!r}. "
+                    "A structural outline (line numbers) is included — use it to pick an offset/limit range or a better pattern."
+                )
+            else:
+                shown = len(matches)
+                window_note = f"{grep_total} match(es) for pattern {data.grep_pattern!r}"
+                if grep_truncated:
+                    window_note += f", showing first {shown} (max_matches={data.max_matches}) — narrow the pattern for the rest"
+                window_note += ". Matched lines and before/after context are verbatim — safe to quote in SEARCH blocks."
+
+        elif data.offset is not None or data.limit is not None:
+            read_mode = "range"
+            offset = data.offset or 1
+            code_view, start_line, end_line, total_lines, range_truncated = slice_range(
+                code, offset, data.limit
+            )
+            if not code_view and start_line > total_lines:
+                window_note = (
+                    f"offset {start_line} is beyond the end of the code ({total_lines} lines total). "
+                    "Retry with a smaller offset."
+                )
+            else:
+                window_note = f"showing lines {start_line}-{end_line} of {total_lines}"
+                if range_truncated:
+                    window_note += f" — continue with offset={end_line + 1} for more"
+                window_note += ". The slice is verbatim — safe to quote in SEARCH blocks."
+
+        elif total_chars > FULL_READ_MAX_CHARS:
+            read_mode = "outline"
+            code_view = ""
+            outline = build_outline(code, artifact.mode)
+            window_note = (
+                f"code is {total_chars:,} chars / {total_lines:,} lines — too large to return in full. "
+                "A structural OUTLINE with line numbers is included instead. "
+                "Use offset/limit to read a specific line range, or grep_pattern (with before/after) to find the exact region to edit."
+            )
+
         # Extract visualization_ids if stored
         visualization_ids: List[str] = content.get("visualization_ids", [])
 
@@ -238,46 +452,82 @@ class ReadArtifactTool(Tool):
             artifact_id=str(artifact.id),
             title=artifact.title,
             mode=artifact.mode,
-            code=code,
+            code=code_view,
             visualization_ids=visualization_ids,
             version=artifact.version,
+            read_mode=read_mode,
+            total_lines=total_lines,
+            total_chars=total_chars,
+            start_line=start_line,
+            end_line=end_line,
+            truncated=range_truncated,
+            matches=matches,
+            grep_total_matches=grep_total,
+            grep_truncated=grep_truncated,
+            outline=outline,
         ).model_dump()
 
         # Add UI preview fields (similar to describe_tables top_tables)
-        code_lines = code.count('\n') + 1 if code else 0
         output["artifact_preview"] = {
             "artifact_id": str(artifact.id),
             "title": artifact.title or "Untitled",
             "mode": artifact.mode,
             "version": artifact.version,
             "code_stats": {
-                "chars": len(code),
-                "lines": code_lines,
+                "chars": total_chars,
+                "lines": total_lines,
             },
+            "read_mode": read_mode,
             "visualization_ids": visualization_ids,
             "created_at": str(artifact.created_at) if artifact.created_at else None,
         }
-        # Code for collapsible toggle (collapsed by default in UI)
+        # Code for collapsible toggle (collapsed by default in UI).
+        # For windowed reads show what the tool actually returned.
+        if read_mode == "grep" and matches:
+            preview_code = "\n\n".join(
+                "\n".join([*m["before"], m["line"], *m["after"]]) for m in matches[:20]
+            )
+        elif read_mode in ("outline", "grep"):
+            preview_code = outline or ""
+        else:
+            preview_code = code_view
         output["code_preview"] = {
             "language": "jsx",
-            "code": code,
+            "code": preview_code,
             "collapsed_default": True,
         }
 
-        # Build observation with code for context
-        summary = f"Read artifact '{artifact.title or 'Untitled'}' ({artifact.mode}, v{artifact.version}) - {len(code)} chars of code"
+        # Build observation with the windowed view for context
+        summary = f"Read artifact '{artifact.title or 'Untitled'}' ({artifact.mode}, v{artifact.version}, {total_chars:,} chars / {total_lines:,} lines, read_mode={read_mode})"
+        if window_note:
+            summary += f" — {window_note}"
 
         observation = {
             "summary": summary,
             "artifact_id": str(artifact.id),
             "title": artifact.title,
             "mode": artifact.mode,
-            "code": code,  # Available for 1 iteration; compacted by observation builder on next tool call
+            "read_mode": read_mode,
+            "total_lines": total_lines,
+            "total_chars": total_chars,
             "visualization_ids": visualization_ids,
             "visualization_profiles": viz_profiles,  # columns, sample rows (gated by allow_llm_see_data), data model
             "version": artifact.version,
             "runtime_environment": SANDBOX_RUNTIME_OBSERVATION,
         }
+        # Available for 1 iteration; compacted by observation builder on next tool call
+        if read_mode in ("full", "range"):
+            observation["code"] = code_view
+        if read_mode == "range":
+            observation["start_line"] = start_line
+            observation["end_line"] = end_line
+            observation["truncated"] = range_truncated
+        if matches is not None:
+            observation["matches"] = matches
+            observation["grep_total_matches"] = grep_total
+            observation["grep_truncated"] = grep_truncated
+        if outline is not None:
+            observation["outline"] = outline
 
         # Include stored screenshot if requested, gated by privacy and vision support
         if data.load_screenshot:

--- a/backend/app/ai/tools/schemas/read_artifact.py
+++ b/backend/app/ai/tools/schemas/read_artifact.py
@@ -6,6 +6,13 @@ class ReadArtifactInput(BaseModel):
     """Input for read_artifact tool.
 
     - artifact_id: ID of the artifact to read (from previous create_artifact results)
+
+    Read modes (for LONG artifacts that don't fit in context):
+    - Full read (default): returns the whole code when it is small enough,
+      otherwise returns a structural OUTLINE with line numbers.
+    - Range read: pass offset (+ optional limit) to read a specific line range.
+    - Grep read: pass grep_pattern (+ optional before/after context lines) to
+      find matching lines with line numbers.
     """
 
     artifact_id: str = Field(
@@ -16,17 +23,88 @@ class ReadArtifactInput(BaseModel):
         default=False,
         description="If true, include the artifact's last rendered preview screenshot in the observation images. Use this when debugging visual issues or when you need to see what the artifact currently looks like before deciding how to edit it."
     )
+    offset: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "RANGE READ: 1-based line number to start reading from. Use together with `limit` "
+            "to read a slice of a LONG artifact (one whose full read returned an outline instead of code). "
+            "The returned code slice is VERBATIM — safe to quote in edit_artifact SEARCH blocks or edit_doc find strings."
+        ),
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=2000,
+        description=(
+            "RANGE READ: number of lines to return starting at `offset` (default 400 when offset is set). "
+            "Check `end_line` and `total_lines` in the result to page forward."
+        ),
+    )
+    grep_pattern: Optional[str] = Field(
+        default=None,
+        description=(
+            "GREP READ: Python regex matched against each LINE of the artifact's code (or markdown for docs). "
+            "Returns matching lines with 1-based line numbers plus `before`/`after` context lines — all VERBATIM, "
+            "safe to quote in edit_artifact SEARCH blocks or edit_doc find strings. "
+            "Use this to locate the exact region to edit in a LONG artifact without loading the whole code. "
+            "Mutually exclusive with offset/limit (grep wins if both are set)."
+        ),
+    )
+    ignore_case: bool = Field(
+        default=False,
+        description="GREP READ: case-insensitive matching."
+    )
+    before: int = Field(
+        default=0,
+        ge=0,
+        le=20,
+        description="GREP READ: number of context lines to include BEFORE each matching line (grep -B)."
+    )
+    after: int = Field(
+        default=0,
+        ge=0,
+        le=20,
+        description="GREP READ: number of context lines to include AFTER each matching line (grep -A)."
+    )
+    max_matches: int = Field(
+        default=50,
+        ge=1,
+        le=200,
+        description="GREP READ: cap on returned matches. `grep_truncated` is set when more matches exist — narrow the pattern."
+    )
+
+
+class ArtifactGrepMatch(BaseModel):
+    """A single grep match inside the artifact's code."""
+
+    line_no: int = Field(..., description="1-based line number of the matching line.")
+    line: str = Field(..., description="The matching line, verbatim (clipped at 500 chars).")
+    before: List[str] = Field(default_factory=list, description="Context lines immediately before the match, verbatim.")
+    after: List[str] = Field(default_factory=list, description="Context lines immediately after the match, verbatim.")
+    context_start_line: int = Field(..., description="1-based line number of the first `before` context line (equals line_no when before is empty). Use for follow-up range reads.")
 
 
 class ReadArtifactOutput(BaseModel):
     """Output from read_artifact tool.
 
     Returns the artifact's code and metadata for iteration/refinement.
+    For long artifacts, `code` may be a windowed view — check `read_mode`.
     """
 
     artifact_id: str = Field(..., description="ID of the artifact")
     title: Optional[str] = Field(None, description="Artifact title")
     mode: str = Field(..., description="Artifact mode: 'page' or 'slides'")
-    code: str = Field(..., description="The React/JSX code of the artifact")
+    code: str = Field(..., description="The artifact code — full code for read_mode='full', the requested slice for 'range', empty for 'grep'/'outline' (see matches/outline).")
     visualization_ids: List[str] = Field(default_factory=list, description="Visualization IDs used in this artifact")
     version: int = Field(default=1, description="Current version number")
+    read_mode: str = Field(default="full", description="How the code was returned: 'full' | 'range' | 'grep' | 'outline'.")
+    total_lines: int = Field(default=0, description="Total lines in the artifact's full code.")
+    total_chars: int = Field(default=0, description="Total characters in the artifact's full code.")
+    start_line: Optional[int] = Field(default=None, description="RANGE READ: 1-based first line of the returned slice.")
+    end_line: Optional[int] = Field(default=None, description="RANGE READ: 1-based last line of the returned slice.")
+    truncated: bool = Field(default=False, description="True when the returned view does not reach the end of the code (range read stopped before total_lines).")
+    matches: Optional[List[ArtifactGrepMatch]] = Field(default=None, description="GREP READ: matching lines with context.")
+    grep_total_matches: Optional[int] = Field(default=None, description="GREP READ: total matches found (may exceed len(matches)).")
+    grep_truncated: Optional[bool] = Field(default=None, description="GREP READ: true when matches were dropped due to max_matches.")
+    outline: Optional[str] = Field(default=None, description="OUTLINE: structural map of the code with line numbers (returned for long artifacts on a full read, or as a navigation aid when grep found no matches).")

--- a/backend/tests/unit/test_read_artifact_windowing.py
+++ b/backend/tests/unit/test_read_artifact_windowing.py
@@ -1,0 +1,227 @@
+"""Unit tests for read_artifact long-artifact windowing: range reads, grep
+reads, outline building, and observation compaction of windowed payloads."""
+
+import pytest
+
+from app.ai.tools.implementations.read_artifact import (
+    FULL_READ_MAX_CHARS,
+    build_outline,
+    grep_code,
+    slice_range,
+)
+from app.ai.context.builders.observation_context_builder import ObservationContextBuilder
+
+
+SAMPLE_JSX = "\n".join([
+    "// ─── KPI section ───────────────────────",
+    "function App() {",
+    "  const data = useArtifactData();",
+    "  const { filters, setFilter, filterRows } = useFilters();",
+    "  const revenue = 1;",
+    "  return (",
+    '    <SectionCard title="Revenue by Region">',
+    "      <EChart option={chartOption} height={300} />",
+    "    </SectionCard>",
+    "  );",
+    "}",
+    "const buildChart = (rows) => {",
+    "  return { xAxis: {}, series: [] };",
+    "};",
+    "ReactDOM.createRoot(document.getElementById('root')).render(<App />);",
+])
+
+
+# ─── slice_range ─────────────────────────────────────────────────────────────
+
+def test_slice_range_basic():
+    text, start, end, total, truncated = slice_range(SAMPLE_JSX, 2, 3)
+    assert start == 2 and end == 4
+    assert total == 15
+    assert truncated is True
+    assert text.split("\n") == [
+        "function App() {",
+        "  const data = useArtifactData();",
+        "  const { filters, setFilter, filterRows } = useFilters();",
+    ]
+
+
+def test_slice_range_verbatim_lines():
+    # The slice must be quotable in SEARCH blocks: exact substring of the code.
+    text, *_ = slice_range(SAMPLE_JSX, 6, 4)
+    assert text in SAMPLE_JSX
+
+
+def test_slice_range_to_end_not_truncated():
+    text, start, end, total, truncated = slice_range(SAMPLE_JSX, 14, 100)
+    assert start == 14 and end == 15 and truncated is False
+    assert text.endswith("render(<App />);")
+
+
+def test_slice_range_offset_beyond_end():
+    text, start, end, total, truncated = slice_range(SAMPLE_JSX, 999, 10)
+    assert text == "" and total == 15 and truncated is False
+    assert start == 999 and end == 998  # empty range signalled by end < start
+
+
+def test_slice_range_default_limit():
+    long_code = "\n".join(f"line {i}" for i in range(1, 1001))
+    text, start, end, total, truncated = slice_range(long_code, 1, None)
+    assert start == 1 and end == 400 and total == 1000 and truncated is True
+    assert len(text.split("\n")) == 400
+
+
+# ─── grep_code ───────────────────────────────────────────────────────────────
+
+def test_grep_basic_match_with_context():
+    matches, total, truncated = grep_code(SAMPLE_JSX, r"SectionCard title", before=1, after=1)
+    assert total == 1 and truncated is False
+    m = matches[0]
+    assert m["line_no"] == 7
+    assert m["line"] == '    <SectionCard title="Revenue by Region">'
+    assert m["before"] == ["  return ("]
+    assert m["after"] == ["      <EChart option={chartOption} height={300} />"]
+    assert m["context_start_line"] == 6
+
+
+def test_grep_verbatim_context_lines():
+    # before/line/after joined must be an exact substring of the code (quotable).
+    matches, _, _ = grep_code(SAMPLE_JSX, r"EChart", before=2, after=2)
+    m = matches[0]
+    joined = "\n".join([*m["before"], m["line"], *m["after"]])
+    assert joined in SAMPLE_JSX
+
+
+def test_grep_ignore_case():
+    matches, total, _ = grep_code(SAMPLE_JSX, r"sectioncard", ignore_case=True)
+    assert total == 2  # opening and closing tag lines
+
+
+def test_grep_no_matches():
+    matches, total, truncated = grep_code(SAMPLE_JSX, r"NoSuchThing")
+    assert matches == [] and total == 0 and truncated is False
+
+
+def test_grep_max_matches_cap():
+    code = "\n".join("hit" for _ in range(30))
+    matches, total, truncated = grep_code(code, r"hit", max_matches=5)
+    assert len(matches) == 5 and total == 30 and truncated is True
+
+
+def test_grep_invalid_regex_raises():
+    import re
+    with pytest.raises(re.error):
+        grep_code(SAMPLE_JSX, r"[unclosed")
+
+
+def test_grep_context_at_boundaries():
+    matches, _, _ = grep_code(SAMPLE_JSX, r"KPI section", before=5, after=1)
+    m = matches[0]
+    assert m["line_no"] == 1
+    assert m["before"] == []  # clamped at start of file
+    assert m["context_start_line"] == 1
+
+
+def test_grep_long_line_clipped():
+    code = "x" * 2000
+    matches, _, _ = grep_code(code, r"x")
+    assert len(matches[0]["line"]) == 500
+
+
+# ─── build_outline ───────────────────────────────────────────────────────────
+
+def test_outline_page_mode_structure():
+    outline = build_outline(SAMPLE_JSX, "page")
+    lines = outline.split("\n")
+    text = "\n".join(lines)
+    assert "     1: // ─── KPI section" in text
+    assert "function App()" in text
+    assert "SectionCard" in text
+    assert "ReactDOM.createRoot" in text
+    # Every entry is "  <line_no>: <content>"
+    for entry in lines:
+        num = entry.split(":")[0].strip()
+        assert num.isdigit()
+
+
+def test_outline_doc_mode_headings():
+    md = "# Title\n\nsome text\n\n## Section A\nbody\n### Sub\nmore\nnot a heading"
+    outline = build_outline(md, "doc")
+    assert "     1: # Title" in outline
+    assert "5: ## Section A" in outline
+    assert "7: ### Sub" in outline
+    assert "not a heading" not in outline
+
+
+def test_outline_fallback_sampling_when_nothing_structural():
+    code = "\n".join(f"plain text line {i}" for i in range(200))
+    outline = build_outline(code, "doc")  # no headings → fallback sampler
+    assert outline  # non-empty landmarks
+    assert "plain text line" in outline
+
+
+def test_outline_truncation_cap():
+    code = "\n".join("# heading" for _ in range(1000))
+    outline = build_outline(code, "doc")
+    assert "outline truncated at 300 entries" in outline
+
+
+# ─── threshold sanity ────────────────────────────────────────────────────────
+
+def test_full_read_threshold_constant():
+    # A typical dashboard (10-40k chars) must stay on the full-read path.
+    assert FULL_READ_MAX_CHARS == 50_000
+
+
+# ─── observation compaction of windowed payloads ─────────────────────────────
+
+def _read_obs(**extra):
+    obs = {
+        "summary": "Read artifact 'X' (page, v1, 120,000 chars / 3,000 lines, read_mode=grep)",
+        "artifact_id": "a-1",
+        "runtime_environment": "SANDBOX DOCS " * 100,
+    }
+    obs.update(extra)
+    return obs
+
+
+def test_compaction_strips_matches_outline_and_runtime_env():
+    builder = ObservationContextBuilder()
+    builder.add_tool_observation(
+        "read_artifact", {"artifact_id": "a-1", "grep_pattern": "foo"},
+        _read_obs(matches=[{"line_no": 1, "line": "foo", "before": [], "after": [], "context_start_line": 1}],
+                  outline="     1: function App()"),
+        loop_index=1,
+    )
+    # Same-iteration observations are exempt — matches must survive
+    assert "matches" in builder.tool_observations[0]["observation"]
+
+    builder.add_tool_observation(
+        "read_artifact", {"artifact_id": "a-1", "offset": 100},
+        _read_obs(code="lines 100-500"),
+        loop_index=2,
+    )
+    prev = builder.tool_observations[0]["observation"]
+    assert "matches" not in prev
+    assert "1 grep matches" in prev["matches_compacted"]
+    assert "outline" not in prev
+    assert "runtime_environment" not in prev
+    assert prev["runtime_environment_compacted"] is True
+    # Summary survives so the planner remembers what it saw
+    assert "read_mode=grep" in prev["summary"]
+
+    # Latest observation keeps its full payload
+    latest = builder.tool_observations[1]["observation"]
+    assert latest["code"] == "lines 100-500"
+
+
+def test_compaction_still_strips_code_for_full_reads():
+    builder = ObservationContextBuilder()
+    builder.add_tool_observation(
+        "read_artifact", {"artifact_id": "a-1"}, _read_obs(code="x" * 1000), loop_index=1,
+    )
+    builder.add_tool_observation(
+        "create_data", {}, {"summary": "made data"}, loop_index=2,
+    )
+    prev = builder.tool_observations[0]["observation"]
+    assert "code" not in prev
+    assert prev["code_compacted"] == "1000 chars"


### PR DESCRIPTION
Very long artifacts (>50k chars) previously blew the planner's context
window: read_artifact put the full code into its observation, which on a
175k-char dashboard produced a ~52k-token observation and a hard API
failure (prompt is too long: 200440 tokens > 200000 maximum).

read_artifact now supports three windowed read modes:

- Range read: offset/limit (1-based lines) returns a verbatim slice with
  start_line/end_line/total_lines and a truncated flag for paging.
- Grep read: grep_pattern (Python regex) with before/after context lines,
  ignore_case and max_matches; matches carry 1-based line numbers and
  verbatim context safe to quote in edit_artifact SEARCH blocks and
  edit_doc find strings.
- Outline: a plain read of an artifact over 50k chars returns a
  line-numbered structural outline (functions, components, section
  comments, headings for docs) instead of the full code, plus guidance
  to follow up with range/grep. Small artifacts keep the previous
  full-read behavior unchanged.

The observation builder now also compacts the new windowed payloads
(matches, outline) and the static runtime_environment block from
superseded artifact observations, mirroring the existing code compaction.
The planner prompt documents the long-artifact flow.

Verified e2e in the sandbox with a seeded 174,877-char / 4,224-line
dashboard: plain read drops from ~52k to ~10k tokens (outline), the
planner chains grep reads on its own to quote exact code, and
edit_artifact applies surgical diffs to the long artifact successfully.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PwVhenQhxvrrSTGVVmSLfM