### PR TITLE
Fix Entra profile sync when the login token has a custom API audience (OBO fallback)

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -515,6 +515,24 @@ class UserManager(BaseUserManager[User, str]):
         try:
             # First try to get user by OAuth account
             user = await self.get_by_oauth_account(oauth_name, account_id)
+            # Keep the stored tokens current. They used to be written only on
+            # the account's first login, so anything reading them later (Entra
+            # profile sync/preview) worked against a long-expired token.
+            async with self.user_db.session as session:
+                stmt = select(OAuthAccount).where(
+                    and_(
+                        OAuthAccount.oauth_name == oauth_name,
+                        OAuthAccount.account_id == account_id,
+                    )
+                )
+                acc = (await session.execute(stmt)).scalar_one_or_none()
+                if acc:
+                    acc.access_token = access_token
+                    acc.expires_at = expires_at
+                    if refresh_token:
+                        acc.refresh_token = refresh_token
+                    session.add(acc)
+                    await session.commit()
             return user
         except exceptions.UserNotExists:
             # If OAuth account doesn't exist, check if user exists by email

--- a/backend/app/ee/oidc/profile_service.py
+++ b/backend/app/ee/oidc/profile_service.py
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 # call. offline_access keeps the refresh token rolling.
 _GRAPH_REFRESH_SCOPE = "openid profile email https://graph.microsoft.com/User.Read offline_access"
 
+# Scope requested when OBO-exchanging a login token for a Graph /me call.
+# OBO requests must target a single resource, so no openid/profile/email here.
+_GRAPH_OBO_SCOPE = "https://graph.microsoft.com/User.Read offline_access"
+
+
+class EntraReauthRequired(Exception):
+    """The stored Entra tokens can no longer produce a usable Graph token —
+    the user has to sign in with Entra ID again."""
+
 
 async def _entra_oauth_account(db: AsyncSession, user_id: str) -> Optional[OAuthAccount]:
     """Return the user's Entra-based OAuth login account, if any."""
@@ -107,6 +116,102 @@ async def get_entra_graph_token(db: AsyncSession, user) -> Optional[str]:
     return acc.access_token
 
 
+async def _obo_exchange_for_graph(oauth_name: str, assertion: str) -> Optional[dict]:
+    """Exchange a login access token for a Graph-audience token via OBO.
+
+    Entra configs that also drive data-source OBO request an
+    ``api://<client-id>/...`` scope at login, which makes the login token's
+    audience the app's own API — Graph rejects it with 401 InvalidAuthenticationToken.
+    That same token is a valid OBO assertion, so exchange it for a User.Read
+    Graph token using the provider's client credentials. Returns the token
+    response dict, or None when the provider config can't do the exchange or
+    Entra refuses it (e.g. expired assertion, missing consent).
+    """
+    from app.services.auth_providers import _get_oidc_config, _discover_endpoints
+
+    cfg = _get_oidc_config(oauth_name)
+    if not cfg or not (cfg.client_id and cfg.client_secret and cfg.issuer):
+        return None
+
+    issuer = cfg.issuer.rstrip("/")
+    well_known = issuer if "well-known" in issuer else f"{issuer}/.well-known/openid-configuration"
+    try:
+        token_endpoint = (await _discover_endpoints(well_known))["token_endpoint"]
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(
+                token_endpoint,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "client_id": cfg.client_id,
+                    "client_secret": cfg.client_secret,
+                    "assertion": assertion,
+                    "scope": _GRAPH_OBO_SCOPE,
+                    "requested_token_use": "on_behalf_of",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    f"Entra OBO exchange for Graph failed: {resp.status_code} {resp.text[:300]}"
+                )
+                return None
+            return resp.json()
+    except Exception as e:
+        logger.warning(f"Entra OBO exchange for Graph failed: {e}")
+        return None
+
+
+async def _persist_graph_tokens(db: AsyncSession, acc: OAuthAccount, token: dict) -> None:
+    """Store an OBO/refresh token response on the user's Entra OAuth account.
+
+    Later preview/sync calls then start from a Graph-audience token (with a
+    refresh token, thanks to offline_access) instead of the login token.
+    """
+    access = token.get("access_token")
+    if not access:
+        return
+    acc.access_token = access
+    if token.get("refresh_token"):
+        acc.refresh_token = token["refresh_token"]
+    expires_in = token.get("expires_in")
+    if isinstance(expires_in, int):
+        acc.expires_at = int(time.time()) + expires_in
+    db.add(acc)
+    await db.commit()
+
+
+async def fetch_profile_fields(
+    db: AsyncSession,
+    user,
+    fields: List[str],
+    access_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Raw Graph /me projection for the given fields (unset fields → None).
+
+    Tries the supplied/stored token first; a Graph 401 (wrong audience — e.g.
+    an api://-scoped login token — or an expired token) falls back to an OBO
+    exchange, persists the resulting Graph tokens, and retries once. Raises
+    EntraReauthRequired when no path yields a usable Graph token.
+    """
+    acc = await _entra_oauth_account(db, str(user.id))
+    token = access_token or await get_entra_graph_token(db, user)
+    if not token:
+        return {}
+
+    try:
+        return await resolve_user_profile(token, fields)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code != 401:
+            raise
+
+    assertion = access_token or (acc.access_token if acc else None)
+    obo = await _obo_exchange_for_graph(acc.oauth_name, assertion) if (acc and assertion) else None
+    if not obo or not obo.get("access_token"):
+        raise EntraReauthRequired()
+    await _persist_graph_tokens(db, acc, obo)
+    return await resolve_user_profile(obo["access_token"], fields)
+
+
 async def fetch_profile(
     db: AsyncSession,
     user,
@@ -120,11 +225,7 @@ async def fetch_profile(
     Returns a dict of field → value (unset fields come back as None). Fields
     whose Graph value is None/empty are dropped so we don't store noise.
     """
-    token = access_token or await get_entra_graph_token(db, user)
-    if not token:
-        return {}
-
-    raw = await resolve_user_profile(token, fields)
+    raw = await fetch_profile_fields(db, user, fields, access_token=access_token)
     return {k: v for k, v in raw.items() if v not in (None, "", [], {})}
 
 

--- a/backend/app/services/organization_settings_service.py
+++ b/backend/app/services/organization_settings_service.py
@@ -743,8 +743,11 @@ class OrganizationSettingsService:
         from app.schemas.organization_settings_schema import (
             ENTRA_PROFILE_SYNC_ALLOWED_FIELDS,
         )
-        from app.ee.oidc.profile_service import get_entra_graph_token
-        from app.ee.oidc.graph_client import resolve_user_profile
+        from app.ee.oidc.profile_service import (
+            EntraReauthRequired,
+            fetch_profile_fields,
+            get_entra_graph_token,
+        )
 
         result = {
             "connected": False,
@@ -759,7 +762,12 @@ class OrganizationSettingsService:
             return result
 
         try:
-            samples = await resolve_user_profile(token, ENTRA_PROFILE_SYNC_ALLOWED_FIELDS)
+            samples = await fetch_profile_fields(
+                db, current_user, ENTRA_PROFILE_SYNC_ALLOWED_FIELDS, access_token=token
+            )
+        except EntraReauthRequired:
+            result["error"] = "reauth_required"
+            return result
         except Exception as e:
             result["error"] = f"graph_error: {e}"
             return result

--- a/backend/tests/unit/test_entra_profile_obo.py
+++ b/backend/tests/unit/test_entra_profile_obo.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for the Entra profile-sync OBO fallback.
+
+Customer Entra configs request an api://<client-id>/access_as_user scope at
+login (needed for data-source OBO), so the stored login token's audience is the
+app's own API and Graph /me rejects it with 401. The profile service must fall
+back to an On-Behalf-Of exchange for a Graph User.Read token, persist it, and
+retry. No database or network — collaborators are patched.
+"""
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.ee.oidc import profile_service
+from app.ee.oidc.profile_service import (
+    EntraReauthRequired,
+    fetch_profile,
+    fetch_profile_fields,
+    _obo_exchange_for_graph,
+)
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("GET", "https://graph.microsoft.com/v1.0/me")
+    return httpx.HTTPStatusError(
+        f"HTTP {status}", request=req, response=httpx.Response(status, request=req)
+    )
+
+
+def _fake_account(token: str = "login-token") -> MagicMock:
+    acc = MagicMock()
+    acc.oauth_name = "entra"
+    acc.access_token = token
+    acc.refresh_token = None
+    acc.expires_at = None
+    return acc
+
+
+@pytest.mark.asyncio
+async def test_fetch_profile_falls_back_to_obo_on_401():
+    """Graph 401 (wrong-audience login token) → OBO exchange → retry succeeds."""
+    calls = []
+
+    async def fake_resolve(token, fields):
+        calls.append(token)
+        if token == "login-token":
+            raise _http_status_error(401)
+        return {"jobTitle": "hello world", "department": None}
+
+    obo_response = {"access_token": "graph-token", "refresh_token": "rt", "expires_in": 3600}
+    persist = AsyncMock()
+
+    with patch.object(profile_service, "resolve_user_profile", side_effect=fake_resolve), \
+         patch.object(profile_service, "_entra_oauth_account", AsyncMock(return_value=_fake_account())), \
+         patch.object(profile_service, "_obo_exchange_for_graph", AsyncMock(return_value=obo_response)), \
+         patch.object(profile_service, "_persist_graph_tokens", persist):
+        result = await fetch_profile(
+            db=MagicMock(), user=MagicMock(id="u1"),
+            fields=["jobTitle", "department"], access_token="login-token",
+        )
+
+    assert result == {"jobTitle": "hello world"}  # empty values dropped
+    assert calls == ["login-token", "graph-token"]
+    persist.assert_awaited_once()
+    assert persist.await_args.args[2] == obo_response
+
+
+@pytest.mark.asyncio
+async def test_fetch_profile_fields_uses_stored_token_as_assertion():
+    """Without an explicit token (preview path), the stored token is the OBO assertion."""
+    obo = AsyncMock(return_value={"access_token": "graph-token", "expires_in": 3600})
+
+    async def fake_resolve(token, fields):
+        if token == "stored-token":
+            raise _http_status_error(401)
+        return {"jobTitle": "x"}
+
+    with patch.object(profile_service, "resolve_user_profile", side_effect=fake_resolve), \
+         patch.object(profile_service, "_entra_oauth_account", AsyncMock(return_value=_fake_account("stored-token"))), \
+         patch.object(profile_service, "get_entra_graph_token", AsyncMock(return_value="stored-token")), \
+         patch.object(profile_service, "_obo_exchange_for_graph", obo), \
+         patch.object(profile_service, "_persist_graph_tokens", AsyncMock()):
+        result = await fetch_profile_fields(MagicMock(), MagicMock(id="u1"), ["jobTitle"])
+
+    assert result == {"jobTitle": "x"}
+    obo.assert_awaited_once_with("entra", "stored-token")
+
+
+@pytest.mark.asyncio
+async def test_fetch_profile_raises_reauth_when_obo_fails():
+    """401 and a failed OBO exchange (expired assertion, no consent) → EntraReauthRequired."""
+    with patch.object(profile_service, "resolve_user_profile", AsyncMock(side_effect=_http_status_error(401))), \
+         patch.object(profile_service, "_entra_oauth_account", AsyncMock(return_value=_fake_account())), \
+         patch.object(profile_service, "_obo_exchange_for_graph", AsyncMock(return_value=None)):
+        with pytest.raises(EntraReauthRequired):
+            await fetch_profile_fields(
+                MagicMock(), MagicMock(id="u1"), ["jobTitle"], access_token="login-token"
+            )
+
+
+@pytest.mark.asyncio
+async def test_fetch_profile_non_401_errors_propagate():
+    """Only 401 triggers the OBO fallback — other Graph errors surface as-is."""
+    obo = AsyncMock()
+    with patch.object(profile_service, "resolve_user_profile", AsyncMock(side_effect=_http_status_error(500))), \
+         patch.object(profile_service, "_entra_oauth_account", AsyncMock(return_value=_fake_account())), \
+         patch.object(profile_service, "_obo_exchange_for_graph", obo):
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch_profile_fields(
+                MagicMock(), MagicMock(id="u1"), ["jobTitle"], access_token="login-token"
+            )
+    obo.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_obo_exchange_posts_jwt_bearer_grant():
+    """The OBO request carries the jwt-bearer grant, assertion, and Graph scope."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        form = dict(pair.split("=", 1) for pair in request.content.decode().split("&"))
+        seen.update(form)
+        return httpx.Response(200, json={"access_token": "graph-token", "expires_in": 3599})
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient
+
+    class _Patched(original):
+        def __init__(self, *a, **kw):
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    cfg = MagicMock(client_id="cid", client_secret="sec", issuer="https://login.microsoftonline.com/tid/v2.0")
+
+    with patch.object(httpx, "AsyncClient", _Patched), \
+         patch("app.services.auth_providers._get_oidc_config", return_value=cfg), \
+         patch("app.services.auth_providers._discover_endpoints",
+               AsyncMock(return_value={"token_endpoint": "https://login.microsoftonline.com/tid/oauth2/v2.0/token"})):
+        token = await _obo_exchange_for_graph("entra", "assertion-token")
+
+    assert token == {"access_token": "graph-token", "expires_in": 3599}
+    assert seen["grant_type"] == "urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer"
+    assert seen["assertion"] == "assertion-token"
+    assert seen["requested_token_use"] == "on_behalf_of"
+    assert "graph.microsoft.com%2FUser.Read" in seen["scope"]
+
+
+@pytest.mark.asyncio
+async def test_obo_exchange_returns_none_on_entra_error():
+    """A 400 from the token endpoint (e.g. AADSTS500133 expired assertion) → None."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "invalid_grant", "error_description": "AADSTS500133"})
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient
+
+    class _Patched(original):
+        def __init__(self, *a, **kw):
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    cfg = MagicMock(client_id="cid", client_secret="sec", issuer="https://login.microsoftonline.com/tid/v2.0")
+
+    with patch.object(httpx, "AsyncClient", _Patched), \
+         patch("app.services.auth_providers._get_oidc_config", return_value=cfg), \
+         patch("app.services.auth_providers._discover_endpoints",
+               AsyncMock(return_value={"token_endpoint": "https://login.microsoftonline.com/tid/oauth2/v2.0/token"})):
+        assert await _obo_exchange_for_graph("entra", "stale") is None

--- a/docs/feedback-loops/entra-profile-sync.md
+++ b/docs/feedback-loops/entra-profile-sync.md
@@ -97,3 +97,39 @@ Secrets via env only (`T`, `CID`, `SEC`, demo creds, `ANTHROPIC_KEY`,
 The permission premise (default `User.Read`, no admin consent), the per-org
 opt-in, the on-login fetch+store, and the `<user_profile>` context injection all
 work against a real Entra tenant, and a real LLM consumes the result.
+
+## Follow-up loop — customer-style api:// login scopes (OBO fallback)
+
+The original Loop B validated Graph access with a token minted directly for
+`User.Read` (ROPC). Real SSO deployments that use data-source OBO request
+`api://<client-id>/access_as_user` at login, so the token BOW stores has the
+app's own API as its audience — Graph `/me` rejects it with
+`401 InvalidAuthenticationToken (Invalid audience)`. Symptom: the settings
+preview shows "Couldn't load live values from Microsoft Graph", every
+attribute renders "not set", and the on-login sync never stores anything.
+
+Fix (`app/ee/oidc/profile_service.py`): on Graph 401, exchange the login token
+for a Graph `User.Read` token via OBO (jwt-bearer grant, provider client
+credentials, `offline_access` for a refresh token), persist it on the user's
+OAuth account, retry once. `app/core/auth.py::oauth_callback` now also updates
+the stored tokens on every login (previously only the first login ever wrote
+them).
+
+Validated live against `bow14.onmicrosoft.com` with the full sandbox
+(backend + frontend + real browser SSO as `demo1`, login scopes including the
+`api://` scope, no `offline_access`):
+
+1. Settings → Identity Provider preview: backend log shows
+   `GET /v1.0/me → 401` → OBO token `POST → 200` → `GET /v1.0/me → 200`; the
+   UI renders live samples (`jobTitle: hello world`, `companyName: company`).
+2. Second SSO login with sync enabled → `Membership.profile_attributes =
+   {"jobTitle": "hello world", "companyName": "company"}`.
+3. `oauth_accounts` now holds a Graph-audience token **with a refresh token**,
+   so later previews survive login-token expiry.
+4. `uv run pytest tests/unit/test_entra_profile_obo.py` — 6 tests cover the
+   fallback, assertion choice, reauth error, non-401 passthrough, and the OBO
+   request shape.
+
+No tenant-side changes were needed: `User.Read` was already on the app
+registration and consent already granted (required anyway for the data-source
+OBO scopes).

--- a/frontend/pages/settings/identity-provider.vue
+++ b/frontend/pages/settings/identity-provider.vue
@@ -53,7 +53,9 @@
           <p v-if="preview && !preview.connected" class="text-[11px] text-amber-600 dark:text-amber-500 mb-2">
             {{ preview.error === 'no_entra_login'
               ? $t('settings.identityProvider.entraNoLogin')
-              : $t('settings.identityProvider.entraPreviewError') }}
+              : preview.error === 'reauth_required'
+                ? $t('settings.identityProvider.entraReauth')
+                : $t('settings.identityProvider.entraPreviewError') }}
           </p>
 
           <!-- Field rows: checkbox (in context) | label | sample value | remove -->

--- a/locales/en.json
+++ b/locales/en.json
@@ -1620,6 +1620,7 @@
       "entraAdd": "Add",
       "entraRemove": "Remove",
       "entraNoLogin": "Sign in with Entra ID to preview live values from your profile.",
+      "entraReauth": "Your Entra ID session has expired — sign in with Entra ID again to load live values.",
       "entraPreviewError": "Couldn't load live values from Microsoft Graph.",
       "entraContextTitle": "From your directory profile",
       "field_jobTitle": "Job title",


### PR DESCRIPTION
## Problem

Entra SSO deployments that use data-source OBO auto-provisioning (Power BI / Fabric / SharePoint) request `api://<client-id>/access_as_user` in their login scopes. The access token BOW stores at login therefore has the app's **own API** as its audience, and Microsoft Graph rejects it with `401 InvalidAuthenticationToken (Invalid audience)`.

Symptoms (as reported):
- Settings → Identity Provider shows **"Couldn't load live values from Microsoft Graph"** and every attribute renders *"not set"*.
- The on-login profile sync silently fails, so `Membership.profile_attributes` is never populated and job title / department never reach the AI's `<user_profile>` context.

A second latent bug compounded it: `oauth_callback` only wrote the stored OAuth tokens on the account's **first** login ever, so the preview endpoint was always working against a long-expired token.

## Fix

- **`app/ee/oidc/profile_service.py`** — on Graph 401, exchange the login token for a Graph `User.Read` token via the On-Behalf-Of flow (`jwt-bearer` grant with the OIDC provider's client credentials, `offline_access` included), persist the resulting access + refresh tokens on the user's OAuth account, and retry once. Raises `EntraReauthRequired` when no path yields a usable Graph token.
- **`app/services/organization_settings_service.py`** — the preview endpoint uses the OBO-aware fetch and surfaces a distinct `reauth_required` error code.
- **`app/core/auth.py`** — `oauth_callback` updates the stored tokens on every login, not just the first.
- **Frontend** — the settings page shows a specific "sign in with Entra ID again" hint for `reauth_required` instead of the generic Graph error.

No tenant-side changes are required: `User.Read` is a default delegated permission and its consent is already in place wherever data-source OBO works today.

## Validation

- **Unit tests** (`backend/tests/unit/test_entra_profile_obo.py`, 6 tests): OBO fallback on 401, assertion selection, reauth error, non-401 passthrough, OBO request shape. All pass alongside the existing 13 `<user_profile>` rendering tests.
- **Live reproduction + fix against the real `bow14.onmicrosoft.com` tenant**, full sandbox (backend + frontend + real browser SSO with customer-style scopes, no `offline_access`):
  1. Preview: backend log shows `GET /v1.0/me → 401` → OBO `POST /token → 200` → `GET /v1.0/me → 200`; UI renders live samples (`jobTitle: hello world`, `companyName: company`) with no warning.
  2. Second login with sync enabled → `Membership.profile_attributes = {"jobTitle": "hello world", "companyName": "company"}`.
  3. `oauth_accounts` now holds a Graph-audience token **with a refresh token**, so previews survive login-token expiry.
- The validation loop is documented in `docs/feedback-loops/entra-profile-sync.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv5LgLnQRkuyJYptWdCBbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv5LgLnQRkuyJYptWdCBbZ)_