### PR TITLE
fixes

### DIFF
--- a/backend/app/services/mcp_context_injection.py
+++ b/backend/app/services/mcp_context_injection.py
@@ -14,7 +14,7 @@ access — so a misconfigured mapping can't reach a secret:
   * ``membership.role``
   * ``membership.attr:<key>``   → ``Membership.profile_attributes[<key>]``
   * ``static:<text>``           → a literal, with ``{source}`` interpolation
-    (e.g. ``static:elbit_nt\\{membership.attr:employeeId}``)
+    (e.g. ``static:corp_nt\\{membership.attr:employeeId}``)
 
 Each metadata field has a ``mode``:
 

--- a/backend/tests/unit/test_mcp_context_injection.py
+++ b/backend/tests/unit/test_mcp_context_injection.py
@@ -22,11 +22,11 @@ from app.services.mcp_context_injection import (
 
 def _ctx(**kw):
     base = dict(
-        email="Beni.Klein@elbitsystems.com",
-        name="Beni Klein",
+        email="jane.doe@example.com",
+        name="Jane Doe",
         user_id="usr_8f21c0",
         role="analyst",
-        attributes={"employeeId": "dp28376", "department": "Avionics"},
+        attributes={"employeeId": "u12345", "department": "Engineering"},
     )
     base.update(kw)
     return IdentityContext(**base)
@@ -39,12 +39,12 @@ def _ctx(**kw):
 @pytest.mark.parametrize(
     "source,expected",
     [
-        ("user.email", "Beni.Klein@elbitsystems.com"),
-        ("user.name", "Beni Klein"),
+        ("user.email", "jane.doe@example.com"),
+        ("user.name", "Jane Doe"),
         ("user.id", "usr_8f21c0"),
         ("membership.role", "analyst"),
-        ("membership.attr:employeeId", "dp28376"),
-        ("membership.attr:department", "Avionics"),
+        ("membership.attr:employeeId", "u12345"),
+        ("membership.attr:department", "Engineering"),
         ("static:BagOfWords", "BagOfWords"),
     ],
 )
@@ -67,9 +67,9 @@ def test_unknown_or_absent_sources_do_not_resolve(source):
 
 
 def test_static_interpolation_concatenates_identity():
-    # The `_client_full_userId: "elbit_nt\\dp28376"` case from the report.
-    out = resolve_source(r"static:elbit_nt\{membership.attr:employeeId}", _ctx())
-    assert out == r"elbit_nt\dp28376"
+    # The `_client_full_userId: "corp_nt\\u12345"` case from the report.
+    out = resolve_source(r"static:corp_nt\{membership.attr:employeeId}", _ctx())
+    assert out == r"corp_nt\u12345"
 
 
 def test_static_interpolation_of_missing_attr_yields_empty_token():
@@ -92,7 +92,7 @@ def test_locked_field_overrides_model_value():
     plan = build_plan(cfg, _ctx())
     args = {"prompt": "p", "custom_metadata": {"_client_userId": "hacked_by_model"}}
     apply_metadata_injection(args, plan)
-    assert args["custom_metadata"]["_client_userId"] == "dp28376"
+    assert args["custom_metadata"]["_client_userId"] == "u12345"
 
 
 def test_ai_field_fills_only_when_absent():
@@ -104,7 +104,7 @@ def test_ai_field_fills_only_when_absent():
     # model omitted it -> server fills
     a = {"prompt": "p"}
     apply_metadata_injection(a, plan)
-    assert a["custom_metadata"]["department"] == "Avionics"
+    assert a["custom_metadata"]["department"] == "Engineering"
 
     # model provided it -> model wins
     b = {"prompt": "p", "custom_metadata": {"department": "Marine"}}
@@ -120,7 +120,7 @@ def test_injection_creates_bag_and_respects_argument_key():
     plan = build_plan(cfg, _ctx())
     args = {"prompt": "p"}
     apply_metadata_injection(args, plan)
-    assert args["context"]["u"] == "Beni.Klein@elbitsystems.com"
+    assert args["context"]["u"] == "jane.doe@example.com"
     assert "custom_metadata" not in args
 
 
@@ -177,7 +177,7 @@ def test_header_injection_resolves_and_omits_empties():
         ],
     }
     plan = build_plan(cfg, _ctx())
-    assert plan.headers["X-User-Email"] == "Beni.Klein@elbitsystems.com"
+    assert plan.headers["X-User-Email"] == "jane.doe@example.com"
     assert plan.headers["X-Static"] == "fixed"          # static preserved
     assert "X-Missing" not in plan.headers              # empty header omitted
 
@@ -188,7 +188,7 @@ def test_dynamic_header_overrides_static_same_name():
         "header_injection": [{"header": "X-User-Email", "source": "user.email"}],
     }
     plan = build_plan(cfg, _ctx())
-    assert plan.headers["X-User-Email"] == "Beni.Klein@elbitsystems.com"
+    assert plan.headers["X-User-Email"] == "jane.doe@example.com"
 
 
 def test_no_spec_produces_empty_plan():

--- a/docs/feedback-loops/mcp-identity-forwarding.md
+++ b/docs/feedback-loops/mcp-identity-forwarding.md
@@ -1,16 +1,16 @@
 # Feedback Loop — "send user & membership data into each MCP invocation"
 
-A customer's MCP server (Infor LN) expects per-user identity on every tool call:
-outbound identity **HTTP headers** and a `custom_metadata` object inside the tool
-arguments, e.g.
+Some MCP servers (typically ERP-style backends) expect per-user identity on
+every tool call: outbound identity **HTTP headers** and a `custom_metadata`
+object inside the tool arguments, e.g.
 
 ```jsonc
 query_production_orders({
   "prompt": "…",
   "company": "111",
   "custom_metadata": {
-    "_client_userId": "dp28376",
-    "_client_full_userId": "elbit_nt\\dp28376"
+    "_client_userId": "u12345",
+    "_client_full_userId": "corp_nt\\u12345"
   }
 })
 ```
@@ -52,7 +52,7 @@ uv run pytest tests/unit/test_mcp_context_injection.py -q
 ```
 
 Observed: **27 passed**. Coverage includes locked-clobber, ai-fill-if-absent,
-`static:` interpolation of `_client_full_userId` (`elbit_nt\dp28376`),
+`static:` interpolation of `_client_full_userId` (`corp_nt\u12345`),
 `on_missing` empty/omit/block, header omit-empty, whitelist safety (unknown
 sources never resolve), and locked-field schema hiding.
 

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -4071,7 +4071,7 @@ function onSubmitCompletion(data: { text: string, mentions: any[]; mode?: string
 
 	// Append user message with attached files (for immediate display).
 	// Carry the mentions through so the optimistic bubble resolves mention chips
-	// (e.g. multi-word data-source names like "@Elbit Demo") immediately instead
+	// (e.g. multi-word data-source names like "@Sales Demo") immediately instead
 	// of falling back to the word-only parser until the server reloads the row.
 	const userMsg: ChatMessage = {
 		id: `user-${Date.now()}`,


### PR DESCRIPTION
Internal docs and test-fixture cleanup:

- Renamed `docs/feedback-loops/mcp-user-context-forwarding.md` to `docs/feedback-loops/mcp-identity-forwarding.md` and rewrote it with generic example data.
- Replaced example identifiers in `backend/tests/unit/test_mcp_context_injection.py` fixtures with generic placeholder values (all 27 tests pass).
- Sanitized a docstring example in `backend/app/services/mcp_context_injection.py` and a comment in `frontend/pages/reports/[id]/index.vue`.

No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7836Az2cTZ4ZnXCZxSeUv

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7836Az2cTZ4ZnXCZxSeUv)_