### PR TITLE
Fix short docx reads degrading to opaque "binary" results

### DIFF
--- a/backend/app/data_sources/clients/_document_text.py
+++ b/backend/app/data_sources/clients/_document_text.py
@@ -34,10 +34,32 @@ DOC_EXTS = {"pdf", "docx", "pptx"}
 # images for a vision model instead of surfacing an empty/garbage "text" read.
 MIN_USABLE_DOC_CHARS = 16
 
+# Formats whose extractor is EXACT rather than heuristic. OOXML stores literal
+# text runs (<w:t> / <a:t>), so whatever comes back IS the document's text —
+# there is no "scanned docx" failure mode for the length floor to catch.
+_EXACT_TEXT_EXTS = {"docx", "pptx"}
 
-def doc_text_is_usable(text) -> bool:
-    """True when extracted document text is substantive enough to use as-is."""
-    return bool(text) and len(str(text).strip()) >= MIN_USABLE_DOC_CHARS
+
+def doc_text_is_usable(text, ext: Optional[str] = None) -> bool:
+    """True when extracted document text is substantive enough to use as-is.
+
+    ``MIN_USABLE_DOC_CHARS`` exists for PDFs, where a near-empty extraction
+    signals a scanned/image-based page and the caller should fall back to raw
+    bytes for raster + vision. It must NOT be applied to OOXML: those
+    extractors are exact, so a short result means a short *document*, not a
+    failed read. Applying the floor there discarded a correct extraction of a
+    legitimately brief file (a one-line memo) and handed the caller bytes it
+    had no way to recover from — unlike PDF, docx/pptx have no image fallback,
+    so the read dead-ended as an opaque "binary" result.
+
+    Pass ``ext`` (the source file's extension) to get the format-aware rule;
+    omitting it keeps the conservative PDF-style floor.
+    """
+    if not text or not str(text).strip():
+        return False
+    if ext and str(ext).lstrip(".").lower() in _EXACT_TEXT_EXTS:
+        return True
+    return len(str(text).strip()) >= MIN_USABLE_DOC_CHARS
 
 
 # Garble detection samples at most this many characters — plenty of signal,

--- a/backend/app/data_sources/clients/google_drive_client.py
+++ b/backend/app/data_sources/clients/google_drive_client.py
@@ -283,7 +283,7 @@ class GoogleDriveClient(DataSourceClient):
         # the tool can render it for a vision model.
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
-            return text if doc_text_is_usable(text) else content
+            return text if doc_text_is_usable(text, ext) else content
 
         from app.data_sources.clients.graph_drive_client import _trim_to_data
         if ext == "csv":

--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -423,7 +423,7 @@ class GraphDriveClient(DataSourceClient):
         # for a vision model.
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
-            return text if doc_text_is_usable(text) else content
+            return text if doc_text_is_usable(text, ext) else content
 
         if ext == "csv":
             return _trim_to_data(pd.read_csv(io.BytesIO(content), header=None))

--- a/backend/app/data_sources/clients/network_dir_client.py
+++ b/backend/app/data_sources/clients/network_dir_client.py
@@ -409,7 +409,7 @@ class NetworkDirClient(DataSourceClient):
             # Fall back to raw bytes when extraction yielded nothing OR only a
             # stray glyph (scanned / image-based / CID-font PDF) so the caller
             # can render it to images for a vision model instead of a junk read.
-            return text if doc_text_is_usable(text) else path.read_bytes()
+            return text if doc_text_is_usable(text, _ext(path.name)) else path.read_bytes()
 
         cap = max_bytes or self.max_file_bytes
         size = path.stat().st_size

--- a/backend/app/data_sources/clients/s3_client.py
+++ b/backend/app/data_sources/clients/s3_client.py
@@ -353,7 +353,7 @@ class S3Client(DataSourceClient):
             text = extract_document_text_from_bytes(data, key)
             # Near-empty extraction on a rich doc (scanned / image-based / CID
             # font) → return raw bytes so the tool can render it for vision.
-            return text if doc_text_is_usable(text) else data
+            return text if doc_text_is_usable(text, ext) else data
 
         if ext == "csv":
             return pd.read_csv(io.BytesIO(data))


### PR DESCRIPTION
## Problem

A one-line Word file read from SharePoint came back as `content_type: "binary"` on every attempt. The agent retried three times, then concluded the file was "corrupted, encrypted, or in a format the system can't parse" and gave up.

Nothing was wrong with the file. It is a normal OOXML zip with an intact `word/document.xml` whose entire body is a single text run:

```xml
<w:r><w:rPr><w:rtl /></w:rPr><w:t>בלה בלה</w:t></w:r>
```

`_docx()` extracted `'בלה בלה'` correctly — 7 characters. Then `doc_text_is_usable` discarded it because 7 < `MIN_USABLE_DOC_CHARS` (16), and the connector fell back to raw bytes.

## Root cause

That length floor is a PDF heuristic. A scanned or CID-font PDF extracts as nothing or a stray glyph, and returning raw bytes lets `read_file` rasterize it for a vision model. It was being applied to OOXML, which has no equivalent failure mode: `_docx` reads literal `<w:t>` runs, so a short result means a short *document*, not a failed read.

For docx the fallback is also a dead end, which is what turned a bad heuristic into a retry loop:

- `render_file_images` only rasterizes images and PDFs — a docx payload renders to nothing.
- The `as_images=true` escalation in `read_file` is gated on `content_type == "text"`, so on an already-`"binary"` payload the flag is ignored outright.
- `_persist_session_file` names binary payloads `.bin`, which isn't in `_ATTACHABLE_BY_EXT` — so there's no `session_file_id` to hand to `inspect_data` either.

The agent received bytes it could neither read, render, nor attach, with no indication of why.

## Change

`doc_text_is_usable` now takes the source extension and skips the length floor for formats whose extractor is exact (docx/pptx). PDFs keep the scanned-document fallback unchanged.

Empty extractions still fall through to raw bytes for every format — the exemption is for *short* text, not *absent* text, so a genuinely image-only docx behaves as before.

All four file connectors pass their extension through: Graph (SharePoint/OneDrive), Google Drive, S3, and network dir. The ext-less signature is preserved and keeps the old conservative behavior, so the PDF-only call sites in `read_file.py` are unaffected.

## Verification

Checked against the reported file:

- `doc_text_is_usable(text)` → `False` (before), `doc_text_is_usable(text, "docx")` → `True` (after)
- `SharepointClient.read_file("Document.docx")` now returns `'בלה בלה'` as a `str` instead of `bytes`, so the tool renders it as `content_type: "text"`

## Out of scope

Two related gaps surfaced during the investigation and are left for follow-up:

1. docx/pptx have no image-rendering fallback at all, so a genuinely text-free Word document is still an opaque binary result.
2. Graph item IDs are opaque and carry no extension, so when the agent passes an item ID rather than a filename, `render_file_images` derives an empty extension — meaning a **scanned PDF** from SharePoint also loses its vision fallback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhCW2yFubxZpZEkiSd3Zqp)_