### PR TITLE
Make Salesforce results and errors legible to the agent

### DIFF
--- a/backend/app/data_sources/clients/salesforce_client.py
+++ b/backend/app/data_sources/clients/salesforce_client.py
@@ -16,14 +16,20 @@ Schema discovery enumerates the org's queryable objects dynamically (standard
 AND custom `__c`), filtering system/noise objects — replacing the previous
 hardcoded five-object list. Field types are mapped to canonical dtypes and
 reference fields become foreign keys.
+
+Query results are shaped so callers can treat them like any other tabular
+source: nested relationship payloads are flattened to dotted columns, and a
+result with no rows still carries the columns the SELECT list asked for.
 """
 from __future__ import annotations
 
+import json
 import logging
+import re
 import time
 from contextlib import contextmanager
 from functools import cached_property
-from typing import Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional
 
 import pandas as pd
 import requests
@@ -91,6 +97,222 @@ _SF_TYPE_MAP = {
     "time": "time",
     "anyType": "str",
 }
+
+# `SELECT COUNT() FROM X` answers in `totalSize` and returns no records at all.
+_COUNT_QUERY_RE = re.compile(r"^\s*SELECT\s+COUNT\s*\(\s*\)\s+FROM\s", re.IGNORECASE)
+
+
+class SalesforceConnectionError(RuntimeError):
+    """Establishing the Salesforce session failed (credentials, auth, transport).
+
+    Distinct from a query failure so the two never get labelled as each other —
+    and so `execute_query` can re-raise it untouched instead of prefixing a
+    connection error with a query-error message.
+    """
+
+
+def format_salesforce_error(exc: Exception) -> str:
+    """Render a Salesforce API exception as `ERRORCODE: message`.
+
+    simple_salesforce's own `__str__` leads with the full request URL — which
+    for a query carries the entire URL-encoded SOQL — and leaves the errorCode
+    and message at the very end. Callers truncate error strings (the planner
+    observation keeps 200 characters), so the actionable part is exactly the
+    part that gets cut. Salesforce returns a list of
+    `{message, errorCode, fields}` objects; surface those first and drop the
+    URL, since the failing query is already reported alongside the error.
+    """
+    content = getattr(exc, "content", None)
+    if isinstance(content, (bytes, str)):
+        try:
+            content = json.loads(content)
+        except Exception:
+            content = None
+
+    entries: List[Any] = []
+    if isinstance(content, list):
+        entries = content
+    elif isinstance(content, dict):
+        entries = [content]
+
+    parts: List[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        code = str(entry.get("errorCode") or "").strip()
+        message = str(entry.get("message") or "").strip()
+        if code and message:
+            text = f"{code}: {message}"
+        elif code or message:
+            text = code or message
+        else:
+            continue
+        fields = [str(f) for f in (entry.get("fields") or []) if f]
+        if fields:
+            text += f" (fields: {', '.join(fields)})"
+        parts.append(text)
+
+    if parts:
+        return " | ".join(parts)
+
+    # Not a structured Salesforce API error. Keep the exception class — a bare
+    # str() on a KeyError is just the key, which tells the caller nothing.
+    text = str(exc).strip()
+    return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+
+def _outside_parens(text: str) -> str:
+    """Drop parenthesized spans, so `SUM(Amount) total` tokenizes as `SUM total`."""
+    out: List[str] = []
+    depth = 0
+    for ch in text:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(ch)
+    return "".join(out)
+
+
+def soql_select_columns(query: str) -> List[str]:
+    """Column names a SOQL SELECT list produces, in order.
+
+    Lets a zero-row result carry the same columns a non-empty one would have
+    had. Best-effort: returns [] for anything it can't parse, and callers then
+    fall back to whatever the records themselves produced.
+    """
+    if not isinstance(query, str):
+        return []
+    head = re.match(r"\s*SELECT\s+", query, re.IGNORECASE)
+    if not head:
+        return []
+
+    # Split the select list on top-level commas, stopping at the top-level FROM.
+    # Parenthesized child subqueries carry their own FROM, hence the depth test.
+    items: List[str] = []
+    current: List[str] = []
+    depth = 0
+    in_quote = False
+    i, n = head.end(), len(query)
+    while i < n:
+        ch = query[i]
+        if in_quote:
+            current.append(ch)
+            if ch == "\\" and i + 1 < n:
+                current.append(query[i + 1])
+                i += 2
+                continue
+            if ch == "'":
+                in_quote = False
+            i += 1
+            continue
+        if ch == "'":
+            in_quote = True
+            current.append(ch)
+        elif ch == "(":
+            depth += 1
+            current.append(ch)
+        elif ch == ")":
+            depth -= 1
+            current.append(ch)
+        elif depth == 0 and ch == ",":
+            items.append("".join(current))
+            current = []
+        elif (
+            depth == 0
+            and query[i:i + 4].lower() == "from"
+            and (query[i - 1].isspace() if i else True)
+            and (i + 4 >= n or not (query[i + 4].isalnum() or query[i + 4] == "_"))
+        ):
+            break
+        else:
+            current.append(ch)
+        i += 1
+    items.append("".join(current))
+
+    columns: List[str] = []
+    expr_index = 0
+    for raw in items:
+        item = raw.strip()
+        if not item:
+            continue
+        if item.startswith("("):
+            # Child relationship subquery — the column is the relationship name.
+            match = re.search(r"\bFROM\s+([A-Za-z0-9_.]+)", item, re.IGNORECASE)
+            if match:
+                columns.append(match.group(1))
+            else:
+                columns.append(f"expr{expr_index}")
+                expr_index += 1
+            continue
+        tokens = _outside_parens(item).split()
+        if len(tokens) >= 2:
+            # `SUM(Amount) total` — and be lenient about a stray `AS`, which
+            # SOQL rejects but models write anyway.
+            columns.append(tokens[-1])
+        elif "(" in item:
+            # Unaliased aggregate: Salesforce names these expr0, expr1, ...
+            columns.append(f"expr{expr_index}")
+            expr_index += 1
+        elif tokens:
+            columns.append(tokens[0])
+    return columns
+
+
+def flatten_record(record: Dict[str, Any], prefix: str = "") -> Dict[str, Any]:
+    """Flatten one SOQL record into scalar, dotted-name columns.
+
+    Parent traversal (`SELECT Account.Name`) arrives as a nested object, and a
+    child subquery arrives as a nested `records` envelope — both of which land
+    in the DataFrame as dict-valued columns that break charting and
+    serialization. Parents become `Account.Name`; child rows are serialized to
+    compact JSON so the value stays primitive without discarding data.
+    """
+    flat: Dict[str, Any] = {}
+    for key, value in record.items():
+        if key == "attributes":
+            continue
+        name = f"{prefix}{key}"
+        if isinstance(value, dict):
+            if isinstance(value.get("records"), list):
+                children = [flatten_record(r) for r in value["records"] if isinstance(r, dict)]
+                flat[name] = json.dumps(children, default=str) if children else None
+            else:
+                flat.update(flatten_record(value, prefix=f"{name}."))
+            continue
+        flat[name] = value
+    return flat
+
+
+def _records_to_df(records: List[Dict[str, Any]], expected_columns: List[str]) -> pd.DataFrame:
+    """Build the result frame, preserving the SELECT list's columns.
+
+    `pd.DataFrame([])` has zero columns, so an object that simply holds no
+    matching rows used to come back shapeless — downstream code indexing a
+    column raised a bare KeyError, and empty-result guards read it as "the
+    query was never run". A zero-row frame keeps its columns here, the way
+    every SQL client's does.
+    """
+    rows = [flatten_record(r) for r in records if isinstance(r, dict)]
+    df = pd.DataFrame(rows)
+    ordered_expected = list(dict.fromkeys(expected_columns or []))
+    if not ordered_expected:
+        return df
+    if df.empty:
+        return pd.DataFrame(columns=ordered_expected)
+
+    # A parent lookup that is null on every row yields no dotted column at all;
+    # fill it so the caller sees nulls rather than a missing column. Limited to
+    # dotted names — a bare name may legitimately be absent (a compound field
+    # expands into its own subcolumns) and inventing it would be wrong.
+    for name in ordered_expected:
+        if name not in df.columns and "." in name:
+            df[name] = None
+
+    ordered = [c for c in ordered_expected if c in df.columns]
+    ordered += [c for c in df.columns if c not in ordered]
+    return df[ordered]
 
 
 class SalesforceClient(DataSourceClient):
@@ -179,7 +401,7 @@ class SalesforceClient(DataSourceClient):
                 detail = f"{body.get('error')}: {body.get('error_description', detail)}"
             except Exception:
                 pass
-            raise RuntimeError(
+            raise SalesforceConnectionError(
                 f"Salesforce JWT authentication failed ({resp.status_code}): {detail}. "
                 "Check the Connected App consumer key, the certificate, the user "
                 "(sub), and that the app is admin pre-authorized for that user."
@@ -202,7 +424,7 @@ class SalesforceClient(DataSourceClient):
                 security_token=self.security_token or "",
                 domain=self._sf_domain(),
             )
-        raise RuntimeError(
+        raise SalesforceConnectionError(
             "Salesforce client has no usable credentials: provide a Connected App "
             "(consumer_key + private_key + username), an access_token + instance_url, "
             "or username + password."
@@ -210,11 +432,22 @@ class SalesforceClient(DataSourceClient):
 
     @contextmanager
     def connect(self) -> Generator[Salesforce, None, None]:
-        """Yield a connection to Salesforce."""
+        """Yield a connection to Salesforce.
+
+        Only the connect step is wrapped. Wrapping the yielded body as well
+        relabelled every query failure — malformed SOQL, an unknown field — as
+        a connection error, and stacked a second prefix onto a message that
+        already had one.
+        """
         try:
-            yield self.sf
+            session = self.sf
+        except SalesforceConnectionError:
+            raise
         except Exception as e:
-            raise RuntimeError(f"Error while connecting to Salesforce: {e}")
+            raise SalesforceConnectionError(
+                f"Salesforce connection failed: {format_salesforce_error(e)}"
+            ) from e
+        yield session
 
     def test_connection(self):
         """Test the Salesforce connection with a lightweight authenticated call."""
@@ -222,8 +455,10 @@ class SalesforceClient(DataSourceClient):
             with self.connect() as sf:
                 sf.limits()
                 return {"success": True, "message": "Connected to Salesforce"}
-        except Exception as e:
+        except SalesforceConnectionError as e:
             return {"success": False, "message": str(e)}
+        except Exception as e:
+            return {"success": False, "message": format_salesforce_error(e)}
 
     # ── schema discovery ─────────────────────────────────────────────────────
 
@@ -276,14 +511,23 @@ class SalesforceClient(DataSourceClient):
             except Exception as e:
                 # A single unreadable object (field-level security, odd metadata)
                 # must not abort the whole catalog.
-                logger.warning("Skipping Salesforce object %s: %s", name, e)
+                logger.warning(
+                    "Skipping Salesforce object %s: %s", name, format_salesforce_error(e)
+                )
             reporter.tick(name)
         return schemas
 
     def get_schema(self, object_name: str) -> Table:
         """Get schema for a specific Salesforce object, with FKs and dtypes."""
-        with self.connect() as sf:
-            describe = sf.__getattr__(object_name).describe()
+        try:
+            with self.connect() as sf:
+                describe = sf.__getattr__(object_name).describe()
+        except SalesforceConnectionError:
+            raise
+        except Exception as e:
+            raise RuntimeError(
+                f"Salesforce describe failed for {object_name}: {format_salesforce_error(e)}"
+            ) from e
 
         columns: List[TableColumn] = []
         fks: List[ForeignKey] = []
@@ -319,8 +563,13 @@ class SalesforceClient(DataSourceClient):
         """Execute a SOQL query and return results as a DataFrame.
 
         Paginates up to MAX_ROWS so a LIMIT-less query can't stream an entire
-        object into memory.
+        object into memory. Nested relationship payloads are flattened, and a
+        result with no rows keeps the SELECT list's columns so an empty object
+        is distinguishable from a broken query.
         """
+        expected_columns = soql_select_columns(query)
+        records: List[Dict[str, Any]] = []
+        total_size: Optional[int] = None
         try:
             with self.connect() as sf:
                 result = sf.query(query)
@@ -329,40 +578,128 @@ class SalesforceClient(DataSourceClient):
                     result = sf.query_more(result["nextRecordsUrl"], identifier_is_url=True)
                     records.extend(result.get("records", []))
                 records = records[:MAX_ROWS]
-
-                df = pd.DataFrame(records)
-                if not df.empty and "attributes" in df.columns:
-                    df = df.drop("attributes", axis=1)
-                return df
+                total_size = result.get("totalSize")
+        except SalesforceConnectionError:
+            raise
         except Exception as e:
-            raise RuntimeError(f"Error executing Salesforce query: {e}")
+            raise RuntimeError(
+                f"Salesforce query failed: {format_salesforce_error(e)}"
+            ) from e
+
+        # `SELECT COUNT() FROM X` reports its answer in `totalSize` and returns
+        # no records; without this the count is silently lost to an empty frame.
+        if not records and total_size is not None and _COUNT_QUERY_RE.match(query or ""):
+            return pd.DataFrame([{"expr0": int(total_size)}])
+
+        return _records_to_df(records, expected_columns)
 
     # ── prompts / description ────────────────────────────────────────────────
 
     def system_prompt(self):
         """Provide a detailed system prompt for LLM integration."""
         text = """
-        ## System Prompt for Salesforce Integration
-        This service allows querying Salesforce data using SOQL (Salesforce Object Query Language).
-        Use `execute_query` to run SOQL queries.
+## Salesforce SOQL Query Guide
 
-        Example:
-        ```python
-        df = client.execute_query("SELECT Id, Name, Type, Industry FROM Account LIMIT 10")
-        df_lead = client.execute_query("SELECT Id, FirstName, LastName, Company, Status FROM Lead LIMIT 10")
-        df_case = client.execute_query("SELECT Id, CaseNumber, Status, Priority, Subject FROM Case LIMIT 10")
-        ```
+This connection speaks **SOQL**, not SQL — generic SQL guidance does not apply
+here. There are no JOINs, no table aliases, no `SELECT *`, no subqueries in
+FROM, no CASE expressions and no window functions. Run queries with
+`execute_query("<soql>")`, which returns a pandas DataFrame.
 
-        SOQL is similar to SQL but has some differences:
-        1. FROM clause comes immediately after SELECT
-        2. Supports relationship queries using dot notation (e.g. Contact.Account.Name)
-        3. No table aliases or joins (use relationship queries instead)
-        4. Always include a LIMIT — result sets are capped for performance
+### Query rules
 
-        Both standard objects (Account, Contact, Opportunity, Lead, Case, ...) and
-        custom objects (suffixed `__c`) are available; consult the indexed schema
-        for the exact objects and fields in this org.
-        """
+- **No JOIN, no table aliases.** `LEFT JOIN Order o ON a.Id = o.AccountId` is
+  not valid SOQL. Relate records one of two ways instead:
+  * **Parent traversal** (up to 5 levels), which replaces most joins:
+    `SELECT Name, Account.Name, Account.Owner.Name FROM Opportunity`
+    — these arrive as flattened columns `Account.Name`, `Account.Owner.Name`.
+  * **Two queries + pandas**, when you need to aggregate across objects: query
+    each object separately and `pd.merge` the DataFrames on the id column.
+- **Aggregate aliases take no `AS`:** `SUM(Amount) totalSales` is correct;
+  `SUM(Amount) AS totalSales` fails with `unexpected token: 'as'`.
+- **ORDER BY and HAVING must repeat the expression, never the alias:**
+  `ORDER BY SUM(Amount) DESC`. `ORDER BY totalSales` fails with
+  `No such column 'totalSales' on entity '<Object>'` — an alias is not a column.
+- **Unaliased aggregates come back as `expr0`, `expr1`, …** in select-list
+  order. Alias them, or read the `expr` columns.
+- **Every non-aggregated selected field must appear in GROUP BY.**
+- **No `SELECT *`** — list fields explicitly. Take the names from the indexed
+  schema; if an object's fields are not in the schema excerpt, inspect the
+  object before guessing.
+- **Custom fields end in `__c`; custom relationship traversal uses `__r`:**
+  `Widget__r.Name`, not `Widget__c.Name`. A field named `Revenue__c` cannot be
+  referenced as `Revenue`.
+- **Nulls:** `WHERE Amount != null` / `WHERE Amount = null`. `IS NULL` and
+  `IS NOT NULL` are not valid SOQL.
+- **Literals:** strings in single quotes (`'Acme'`); dates unquoted
+  (`2024-01-01`, `2024-01-01T00:00:00Z`); relative ranges via date literals
+  such as `LAST_N_DAYS:30`, `THIS_QUARTER`, `LAST_YEAR`.
+- **Row limiting:** `LIMIT n` — not `TOP n`, not `FETCH FIRST n ROWS ONLY`.
+  `OFFSET` is supported but capped at 2000.
+- **Counting:** `SELECT COUNT() FROM Account` returns one row in a column named
+  `expr0`. Prefer `SELECT COUNT(Id) total FROM Account` when grouping.
+- Long text areas and some formula fields cannot be filtered, sorted or grouped.
+
+### Reading results
+
+- **An empty DataFrame means zero matching rows, not a broken query** — the
+  columns are still present. Check the filter, or whether the object holds data
+  in this org, before rewriting the query.
+- Results are capped at 10,000 rows. For larger sets, aggregate in SOQL with
+  `GROUP BY` rather than fetching rows and summing in pandas.
+- A null parent lookup yields a null value, not a missing column. A child
+  subquery column holds JSON — prefer querying the child object directly.
+
+### Examples
+
+```python
+# Accounts, with the fields named explicitly
+df = client.execute_query(
+    "SELECT Id, Name, Industry, AnnualRevenue FROM Account ORDER BY Name LIMIT 200"
+)
+
+# Total won opportunity amount per account: aggregate in SOQL, alias without AS,
+# and order by the expression rather than the alias.
+df = client.execute_query(\"\"\"
+    SELECT AccountId, SUM(Amount) totalSales, COUNT(Id) dealCount
+    FROM Opportunity
+    WHERE IsWon = true AND Amount != null
+    GROUP BY AccountId
+    ORDER BY SUM(Amount) DESC
+    LIMIT 100
+\"\"\")
+
+# Add the account names — two queries merged in pandas, since SOQL has no JOIN.
+accounts = client.execute_query("SELECT Id, Name FROM Account LIMIT 10000")
+df = df.merge(accounts, left_on="AccountId", right_on="Id", how="left")
+
+# Parent traversal instead of a join, when no aggregation is needed.
+df = client.execute_query(\"\"\"
+    SELECT Name, Amount, CloseDate, Account.Name, Account.Industry
+    FROM Opportunity
+    WHERE IsWon = true
+    ORDER BY Amount DESC
+    LIMIT 500
+\"\"\")   # columns: Name, Amount, CloseDate, Account.Name, Account.Industry
+
+# Recent cases, using a date literal
+df = client.execute_query(\"\"\"
+    SELECT CaseNumber, Status, Priority, Subject
+    FROM Case
+    WHERE CreatedDate = LAST_N_DAYS:30
+    LIMIT 500
+\"\"\")
+
+# Custom object and custom field
+df = client.execute_query(
+    "SELECT Id, Name, Revenue__c FROM Widget__c WHERE Revenue__c != null "
+    "ORDER BY Revenue__c DESC LIMIT 100"
+)
+```
+
+Both standard objects (Account, Contact, Opportunity, Lead, Case, …) and custom
+objects (suffixed `__c`) are available; consult the indexed schema for the exact
+objects and fields in this org.
+"""
         return text
 
     @property

--- a/backend/tests/unit/test_salesforce_client.py
+++ b/backend/tests/unit/test_salesforce_client.py
@@ -9,12 +9,17 @@ Covers:
   objects excluded, and no longer the hardcoded five
 - get_schema field-type mapping + reference-field foreign keys + Id primary key
 - execute_query -> DataFrame (attributes dropped, MAX_ROWS pagination cap)
+- empty results keeping the SELECT list's columns, and COUNT() reporting
+- relationship payloads flattened to dotted columns / primitive values
+- error reporting: errorCode first, query failures not labelled connection failures
 - registry wiring for the jwt + userpass variants
 
 simple_salesforce.Salesforce and the token HTTP endpoint are mocked, so these
 run without a live org or network.
 """
 from __future__ import annotations
+
+import json
 
 import pandas as pd
 import pytest
@@ -53,12 +58,15 @@ class _FakeSalesforce:
     """Records constructor kwargs; serves canned describe/query responses."""
 
     last_kwargs: dict = {}
+    # Per-test override of the canned query pages (see _set_pages).
+    pages: list | None = None
 
     def __init__(self, **kwargs):
         type(self).last_kwargs = kwargs
         self._global = _global_describe
         self._object_fields = _object_fields
-        self._pages = list(_query_pages)
+        override = type(self).pages
+        self._pages = list(override if override is not None else _query_pages)
 
     def limits(self):
         return {}
@@ -131,7 +139,32 @@ _query_pages = [
 @pytest.fixture(autouse=True)
 def _patch_salesforce(monkeypatch):
     _FakeSalesforce.last_kwargs = {}
+    monkeypatch.setattr(_FakeSalesforce, "pages", None)
     monkeypatch.setattr(sfmod, "Salesforce", _FakeSalesforce)
+
+
+def _set_pages(monkeypatch, pages):
+    """Point the fake org at a specific set of query-result pages."""
+    monkeypatch.setattr(_FakeSalesforce, "pages", pages)
+
+
+class _FakeSalesforceError(Exception):
+    """Stands in for simple_salesforce's SalesforceError shape.
+
+    Its `__str__` leads with the request URL — which for a query carries the
+    whole URL-encoded SOQL — and leaves errorCode/message at the end, which is
+    exactly what format_salesforce_error has to undo.
+    """
+
+    def __init__(self, url, content, status=400, resource_name="query"):
+        super().__init__("Malformed request")
+        self.url = url
+        self.status = status
+        self.resource_name = resource_name
+        self.content = content
+
+    def __str__(self):
+        return f"Malformed request {self.url}. Response content: {self.content}"
 
 
 class _FakeResponse:
@@ -325,8 +358,186 @@ class TestExecuteQuery:
             raise ValueError("MALFORMED_QUERY")
         monkeypatch.setattr(_FakeSalesforce, "query", boom)
         c = SalesforceClient(access_token="t", instance_url="https://x")
-        with pytest.raises(RuntimeError, match="Error executing Salesforce query"):
+        with pytest.raises(RuntimeError, match="Salesforce query failed"):
             c.execute_query("SELECT bad FROM Account")
+
+    def test_query_error_is_not_labelled_a_connection_error(self, monkeypatch):
+        # connect() used to wrap the yielded body too, so every malformed query
+        # was reported as "Error while connecting to Salesforce".
+        def boom(self, soql):
+            raise ValueError("MALFORMED_QUERY")
+        monkeypatch.setattr(_FakeSalesforce, "query", boom)
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        with pytest.raises(RuntimeError) as excinfo:
+            c.execute_query("SELECT bad FROM Account")
+        assert "connect" not in str(excinfo.value).lower()
+        assert not isinstance(excinfo.value, sfmod.SalesforceConnectionError)
+
+    def test_api_error_leads_with_error_code_not_url(self, monkeypatch):
+        # The actionable part must survive a 200-character truncation.
+        def boom(self, soql):
+            raise _FakeSalesforceError(
+                url="https://acme.my.salesforce.com/services/data/v60.0/query/?q=" + "%20" * 200,
+                content=[{
+                    "message": "\nORDER BY totalSales DESC\n       ^\nERROR at Row:5:Column:14\n"
+                               "No such column 'totalSales' on entity 'Opportunity'.",
+                    "errorCode": "INVALID_FIELD",
+                }],
+            )
+        monkeypatch.setattr(_FakeSalesforce, "query", boom)
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        with pytest.raises(RuntimeError) as excinfo:
+            c.execute_query("SELECT SUM(Amount) totalSales FROM Opportunity ORDER BY totalSales")
+        message = str(excinfo.value)
+        assert "INVALID_FIELD" in message[:200]
+        assert "No such column 'totalSales'" in message[:200]
+        assert "salesforce.com/services/data" not in message
+
+    def test_api_error_includes_offending_fields(self, monkeypatch):
+        def boom(self, soql):
+            raise _FakeSalesforceError(
+                url="https://acme.my.salesforce.com/x",
+                content=[{"message": "No such column", "errorCode": "INVALID_FIELD",
+                          "fields": ["Revenue__c"]}],
+            )
+        monkeypatch.setattr(_FakeSalesforce, "query", boom)
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        with pytest.raises(RuntimeError, match=r"fields: Revenue__c"):
+            c.execute_query("SELECT Revenue__c FROM Account")
+
+    def test_connection_failure_is_not_relabelled_as_a_query_failure(self, monkeypatch):
+        c = SalesforceClient()  # no credentials -> connection error
+        with pytest.raises(sfmod.SalesforceConnectionError) as excinfo:
+            c.execute_query("SELECT Id FROM Account")
+        assert "query failed" not in str(excinfo.value).lower()
+
+
+# ---------- empty results keep their columns ---------- #
+
+
+class TestEmptyResultColumns:
+    """A query that matches no rows must not come back shapeless.
+
+    `pd.DataFrame([])` has zero columns, so callers indexing a column got a
+    bare KeyError and empty-result guards read it as "execute_query was never
+    called" — both of which look like a broken query rather than an empty table.
+    """
+
+    def test_empty_result_keeps_select_list_columns(self, monkeypatch):
+        _set_pages(monkeypatch, [{"done": True, "totalSize": 0, "records": []}])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT AccountId, TotalAmount FROM Order LIMIT 10000")
+        assert len(df) == 0
+        assert list(df.columns) == ["AccountId", "TotalAmount"]
+        # The failure this prevents: KeyError('AccountId') on an empty object.
+        assert list(df["AccountId"]) == []
+
+    def test_empty_result_keeps_aggregate_alias_columns(self, monkeypatch):
+        _set_pages(monkeypatch, [{"done": True, "totalSize": 0, "records": []}])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query(
+            "SELECT AccountId, SUM(Amount) totalSales, COUNT(Id) dealCount "
+            "FROM Opportunity GROUP BY AccountId"
+        )
+        assert list(df.columns) == ["AccountId", "totalSales", "dealCount"]
+
+    def test_empty_result_names_unaliased_aggregates_expr_n(self, monkeypatch):
+        _set_pages(monkeypatch, [{"done": True, "totalSize": 0, "records": []}])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT SUM(Amount), COUNT(Id) FROM Opportunity")
+        assert list(df.columns) == ["expr0", "expr1"]
+
+    def test_unparseable_query_falls_back_to_empty_frame(self, monkeypatch):
+        _set_pages(monkeypatch, [{"done": True, "totalSize": 0, "records": []}])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("FIND {Acme} RETURNING Account(Name)")
+        assert list(df.columns) == []
+
+    def test_count_query_returns_the_count(self, monkeypatch):
+        # SELECT COUNT() answers in totalSize and returns no records at all.
+        _set_pages(monkeypatch, [{"done": True, "totalSize": 1474, "records": []}])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT COUNT() FROM Account")
+        assert df.to_dict("records") == [{"expr0": 1474}]
+
+
+# ---------- nested relationship payloads ---------- #
+
+
+class TestRelationshipFlattening:
+    def test_parent_traversal_flattens_to_dotted_columns(self, monkeypatch):
+        _set_pages(monkeypatch, [{
+            "done": True,
+            "records": [{
+                "attributes": {"type": "Opportunity"},
+                "Amount": 100,
+                "Account": {"attributes": {"type": "Account"}, "Name": "Acme",
+                            "Owner": {"attributes": {"type": "User"}, "Name": "Dana"}},
+            }],
+        }])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT Amount, Account.Name, Account.Owner.Name FROM Opportunity")
+        assert list(df.columns) == ["Amount", "Account.Name", "Account.Owner.Name"]
+        assert df["Account.Name"][0] == "Acme"
+        assert df["Account.Owner.Name"][0] == "Dana"
+        # Nested `attributes` keys must not survive the flattening.
+        assert not any("attributes" in c for c in df.columns)
+
+    def test_null_parent_still_yields_the_dotted_column(self, monkeypatch):
+        _set_pages(monkeypatch, [{
+            "done": True,
+            "records": [{"attributes": {}, "Amount": 100, "Account": None}],
+        }])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT Amount, Account.Name FROM Opportunity")
+        assert "Account.Name" in df.columns
+        assert df["Account.Name"][0] is None
+
+    def test_child_subquery_serialized_to_primitives(self, monkeypatch):
+        _set_pages(monkeypatch, [{
+            "done": True,
+            "records": [{
+                "attributes": {},
+                "Name": "Acme",
+                "Opportunities": {
+                    "done": True,
+                    "totalSize": 2,
+                    "records": [
+                        {"attributes": {}, "Amount": 10},
+                        {"attributes": {}, "Amount": 20},
+                    ],
+                },
+            }],
+        }])
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        df = c.execute_query("SELECT Name, (SELECT Amount FROM Opportunities) FROM Account")
+        assert list(df.columns) == ["Name", "Opportunities"]
+        value = df["Opportunities"][0]
+        # Primitive, per the output contract — not a dict the chart layer chokes on.
+        assert isinstance(value, str)
+        assert json.loads(value) == [{"Amount": 10}, {"Amount": 20}]
+
+
+# ---------- SOQL select-list parsing ---------- #
+
+
+class TestSoqlSelectColumns:
+    @pytest.mark.parametrize("query,expected", [
+        ("SELECT Id, Name FROM Account", ["Id", "Name"]),
+        ("select id, name from account limit 5", ["id", "name"]),
+        ("SELECT Account.Name, Owner.Profile.Name FROM Contact", ["Account.Name", "Owner.Profile.Name"]),
+        ("SELECT SUM(Amount) totalSales FROM Opportunity", ["totalSales"]),
+        ("SELECT SUM( Amount ) FROM Opportunity", ["expr0"]),
+        ("SELECT COUNT() FROM Account", ["expr0"]),
+        ("SELECT Id, SUM(Amount) AS total FROM Opportunity", ["Id", "total"]),
+        ("SELECT Name, (SELECT Amount FROM Opportunities) FROM Account", ["Name", "Opportunities"]),
+        ("SELECT Id FROM Account WHERE Name = 'from, here'", ["Id"]),
+        ("SELECT\n  Id,\n  Name\nFROM Account", ["Id", "Name"]),
+        ("SELECT FromDate__c FROM Event__c", ["FromDate__c"]),
+        ("not a soql query", []),
+    ])
+    def test_parsing(self, query, expected):
+        assert sfmod.soql_select_columns(query) == expected
 
 
 # ---------- connection / prompts ---------- #


### PR DESCRIPTION
Three defects in the Salesforce client turned ordinary situations into failures that read like broken queries, so the codegen retry loop kept rewriting code that was already correct. All changes are confined to `salesforce_client.py` and its test file.

## Empty results lost their schema

`execute_query` built the frame with `pd.DataFrame(records)`, and zero records means zero columns — unlike every SQL client, where `pd.read_sql` returns an empty frame that still carries its columns. Querying an object that simply holds no rows therefore raised a bare `KeyError` in any downstream code that indexed a column, and the 0-column guard in the executor reported it as "code executed but never called execute_query" — accusing the model of writing a stub when it had run a perfectly good query.

A zero-row result now keeps the columns its SELECT list asked for, derived from the query by a best-effort SOQL parser that returns `[]` (and so falls back to the previous behavior) on anything it can't read.

```
columns: ['AccountId', 'TotalAmount'] | rows: 0
df['AccountId'] -> [] (no KeyError)
```

## Errors were double-wrapped and mislabelled

`connect()` wrapped the yielded body as well as the connect step, so every query failure was announced as a connection failure; `execute_query` then added a second prefix. Both prefixes plus `simple_salesforce`'s URL-first message meant the `errorCode` and message — the only actionable part — fell outside the 200-character budget the planner observation keeps.

- `connect()` now wraps only the connect step and raises a distinct `SalesforceConnectionError`, which `execute_query` re-raises untouched.
- `format_salesforce_error` pulls `errorCode` / `message` / `fields` out of the API response and leads with them, dropping the URL (redundant with the failing query reported alongside). Non-API exceptions keep their class name, so a `KeyError` no longer arrives as a bare quoted string.

## The system prompt described SOQL as "similar to SQL"

Which is where the generated `LEFT JOIN`s, `AS` aliases and `ORDER BY <alias>` came from. It now follows the Power BI and NetSuite pattern in this repo: an explicit not-SQL opener, the syntax rules SOQL actually enforces (no joins, aliases without `AS`, `ORDER BY` the expression, `expr0` naming, `__r` vs `__c`, `= null`, `LIMIT`), guidance on reading results, and worked examples — including the two-query + `pd.merge` pattern that replaces a join.

## Also in the same methods

- Relationship payloads are flattened: parent traversal becomes dotted columns (`Account.Name`), child subqueries become compact JSON, so neither reaches the chart layer as a dict in violation of the primitives-only output contract.
- `SELECT COUNT()` returns its count, which reports in `totalSize` with no records and was previously lost to an empty frame.

## Testing

`tests/unit/test_salesforce_client.py`: 48 passed (24 pre-existing, 24 new) covering empty-result columns, aggregate aliasing, `COUNT()`, parent/child flattening, null parent lookups, error formatting under truncation, and the connection-vs-query distinction.

One pre-existing test asserted on the old `"Error executing Salesforce query"` string — the behavior being fixed — and was updated. Nothing else in the codebase matches either old message string.

Ruff introduces no new categories of finding; the additions match the file's existing `List`/`Dict`/`Optional` typing style, which accounts for all of its baseline findings.

## Not included

Deliberately out of scope, each worth its own change: the executor's generic `str(e)`-only error text (helps every connector, but cross-cutting), the SQL framing in the codegen prompt (worked around per-client here, as Power BI already does), schema visibility for large orgs, and the silent 10,000-row truncation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MevQpaFVbM31r9HyJHCkyH)_