### PR TITLE
Give Office documents a vision fallback and keep binary reads identifiable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,8 +132,15 @@ RUN apt-get update && \
       apt-get update && \
       (ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql17 || echo "WARN: msodbcsql17 install failed"); \
     fi && \
-    # For PPTX to PNG preview generation (slides mode)
-    apt-get install -y --no-install-recommends libreoffice-impress poppler-utils && \
+    # PPTX/DOCX to PDF to PNG: slide previews (slides mode) and the read_file
+    # vision fallback for Office documents that yield no extractable text.
+    # Both modules are required — libreoffice-core ships the soffice binary and
+    # the UNO framework, but each format's import filter lives with its
+    # application module (Writer's WordprocessingML filter is in
+    # libreoffice-writer, Impress's in libreoffice-impress). With one missing,
+    # type detection still succeeds and the load then fails with
+    # "source file could not be loaded".
+    apt-get install -y --no-install-recommends libreoffice-impress libreoffice-writer poppler-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -18,6 +18,10 @@ import pandas as pd
 from sqlalchemy import select
 
 from app.data_sources.clients.base import Capability, DataSourceClient
+from app.data_sources.clients._office_convert import (
+    CONVERTIBLE_EXTS,
+    office_to_pdf_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -404,6 +408,14 @@ _ATTACHABLE_BY_EXT = {
     "txt": "text/plain",
     "md": "text/markdown",
     "pdf": "application/pdf",
+    # Office documents. Attachable so a read that could NOT be turned into text
+    # still lands in the conversation as the original file — before this, such
+    # a read produced neither text, nor images, nor a session file, leaving the
+    # model with an opaque byte count and no next move.
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "doc": "application/msword",
+    "ppt": "application/vnd.ms-powerpoint",
     # Rendered page images / picture files — materialized so they get a file id
     # (referenceable in later turns and visible in the UI).
     "png": "image/png",
@@ -442,11 +454,21 @@ def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 
     - PDFs are rasterized page-by-page with pypdfium2 (PDFium — the same engine
       Chromium uses for PDFs — as a self-contained wheel, so no system poppler
       and no headless-browser launch).
+    - Office documents (docx/pptx/…) are converted to PDF with LibreOffice
+      first, then rasterized by the same path. Their layout doesn't exist until
+      a layout engine has run, so without this a text-free Word file — one
+      wrapping scanned images, say — had no vision fallback at all.
+
+    ``file_id`` is used only to pick the format, so pass the file's real NAME
+    when the id is opaque (Graph item ids carry no extension).
 
     Returns ``(images, total_pages)`` where ``images`` is a list of
     ``(png_bytes, "image/png")``, capped at ``max_pages``. Best-effort: returns
     ``([], 0)`` when the payload isn't a renderable binary or the renderer is
     unavailable, so the caller simply keeps the original (binary) result.
+
+    Blocking — the PDF rasterizer is CPU-bound and the Office path spawns a
+    subprocess. Call it from a worker thread.
     """
     if not isinstance(payload, (bytes, bytearray)):
         return [], 0
@@ -454,6 +476,11 @@ def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 
     ext = file_id.rsplit(".", 1)[-1].lower() if "." in (file_id or "") else ""
     import io
     try:
+        if ext in CONVERTIBLE_EXTS:
+            converted = office_to_pdf_bytes(data, file_id)
+            if not converted:
+                return [], 0
+            data, ext = converted, "pdf"
         if ext in _RENDERABLE_IMAGE_EXTS:
             from PIL import Image
             im = Image.open(io.BytesIO(data))

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -17,7 +17,7 @@ from app.data_sources.clients._document_text import (
     doc_text_is_usable,
     doc_text_looks_garbled,
 )
-from app.data_sources.clients._file_source_common import GlobScopeError
+from app.data_sources.clients._file_source_common import GlobScopeError, payload_name
 
 from . import _file_cache
 from ._file_tool_common import (
@@ -459,14 +459,21 @@ class ReadFileTool(Tool):
         # ToUnicode map: renders fine, extracts as symbol salad) — a length
         # gate can't catch that. When the extracted text looks garbled, or the
         # model explicitly asked with as_images, re-fetch the ORIGINAL bytes
-        # and reshape this read as binary so the existing vision fallback
-        # below renders the pages. PDF only — that's what render_file_images
-        # can rasterize; a garbled docx/pptx keeps its text, flagged, instead.
+        # and reshape this read as binary so the vision path renders the pages.
+        # Every DOC_EXTS format qualifies now that render_file_images routes
+        # docx/pptx through LibreOffice; previously this was PDF-only, so
+        # as_images on a Word file was silently a no-op.
         garble_note: Optional[str] = None
+        # Dispatch on the file's real NAME. Opaque provider ids (Graph) carry no
+        # extension, so without the connector-supplied name a scanned PDF from
+        # SharePoint reached the renderer unidentifiable and never rendered.
         render_name = (
-            getattr(client, "display_name", None)
-            if session_file is not None else data.file_id
+            getattr(client, "display_name", None) if session_file is not None
+            else payload_name(payload, data.file_id)
         )
+        # Images rendered during escalation, reused below rather than rendered
+        # twice — a LibreOffice conversion is far too expensive to repeat.
+        prerendered: Optional[tuple] = None
         if rendered.get("content_type") == "text" and _doc_ext(render_name) in DOC_EXTS:
             garbled = doc_text_looks_garbled(rendered.get("text"))
             if data.as_images or garbled:
@@ -476,13 +483,26 @@ class ReadFileTool(Tool):
                     and allow_llm_see_data(runtime_ctx)
                 )
                 raw_bytes = None
-                if vision_ok and _doc_ext(render_name) == "pdf" and hasattr(client, "read_raw_bytes"):
+                if vision_ok and hasattr(client, "read_raw_bytes"):
                     try:
                         raw = await asyncio.to_thread(client.read_raw_bytes, data.file_id)
                         raw_bytes = raw[0] if isinstance(raw, tuple) else raw
                     except Exception:
                         raw_bytes = None
+                # Render BEFORE discarding the text: conversion can fail (no
+                # soffice, missing format filter, corrupt file), and dropping
+                # readable text for a render that never materializes would be a
+                # strictly worse read than the one we started with.
+                imgs, total = [], None
                 if raw_bytes is not None:
+                    try:
+                        rimgs, total = await asyncio.to_thread(
+                            render_file_images, render_name, raw_bytes
+                        )
+                        imgs = [png for png, _mtype in rimgs]
+                    except Exception:
+                        imgs, total = [], None
+                if imgs:
                     payload = raw_bytes
                     rendered = {
                         "file_name": rendered.get("file_name"),
@@ -490,14 +510,15 @@ class ReadFileTool(Tool):
                         "byte_count": len(raw_bytes),
                         "truncated": False,
                     }
+                    prerendered = (imgs, total)
                     garble_note = (
                         "extracted text was garbled (broken font encoding) — showing pages as images"
                         if garbled else "as images (as_images requested)"
                     )
                 elif garbled:
-                    # No vision / non-PDF / raw fetch failed: keep the text —
-                    # digits and layout may still carry signal — but mark it
-                    # so the model doesn't treat it as a faithful read.
+                    # No vision / render unavailable / raw fetch failed: keep the
+                    # text — digits and layout may still carry signal — but mark
+                    # it so the model doesn't treat it as a faithful read.
                     rendered["garbled"] = True
 
         # Persist the file as a session attachment so the existing analysis
@@ -517,11 +538,17 @@ class ReadFileTool(Tool):
         # Extension dispatch uses the DISPLAY name (a session file's id is a
         # bare UUID that would never match _RENDERABLE_IMAGE_EXTS).
         image_pngs, pages_total = [], None
-        if rendered.get("content_type") == "binary":
+        if prerendered is not None:
+            image_pngs, pages_total = prerendered
+        elif rendered.get("content_type") == "binary":
             model = runtime_ctx.get("model")
             if model and getattr(model, "supports_vision", False) and allow_llm_see_data(runtime_ctx):
                 try:
-                    rendered_imgs, pages_total = render_file_images(render_name, payload)
+                    # Off the event loop: PDF rasterizing is CPU-bound and the
+                    # Office path shells out to LibreOffice.
+                    rendered_imgs, pages_total = await asyncio.to_thread(
+                        render_file_images, render_name, payload
+                    )
                     image_pngs = [png for png, _mtype in rendered_imgs]
                 except Exception:
                     image_pngs, pages_total = [], None
@@ -677,7 +704,13 @@ async def _persist_session_file(
 
     Tabular  → CSV bytes, filename `<file_id>.csv`
     Text/JSON → utf-8 bytes, filename `<file_id>.txt` or `.json`
-    Binary   → raw bytes, filename `<file_id>.bin`
+    Binary   → raw bytes under the source file's own name when the connector
+               supplied one (`Document.docx`), else `<file_id>.bin`
+
+    The name matters: `.bin` isn't in `_ATTACHABLE_BY_EXT`, so an unnamed binary
+    is dropped. That's how a docx whose text extraction came up empty ended up
+    with no text, no images AND no session file — nothing for the model to act
+    on. Keeping the real name lands the original file in the conversation.
 
     Returns the resulting session File id, or None if attach was skipped.
     """
@@ -705,7 +738,11 @@ async def _persist_session_file(
         mime = "text/plain"
     elif isinstance(payload, (bytes, bytearray)):
         content = bytes(payload)
-        name = f"{file_id}.bin"  # _ATTACHABLE_BY_EXT skips .bin → won't persist
+        leaf = payload_name(payload).rsplit("/", 1)[-1]
+        # Unknown extension still falls through to .bin (and is skipped) rather
+        # than littering the conversation with opaque blobs.
+        name = leaf if "." in leaf else f"{file_id}.bin"
+        mime = getattr(payload, "mime", "") or None
     else:
         return None
 

--- a/backend/app/data_sources/clients/_file_source_common.py
+++ b/backend/app/data_sources/clients/_file_source_common.py
@@ -22,6 +22,39 @@ INDEX_CONTENT = "content"    # cache list + extracted keywords/hash (topic searc
 INDEX_MODES = (INDEX_NONE, INDEX_METADATA, INDEX_CONTENT)
 
 
+class NamedBytes(bytes):
+    """Raw file bytes that remember the source file's name and MIME type.
+
+    `read_file()` returns bare bytes whenever a file can't be turned into text
+    (a scanned PDF, a picture, a document whose extraction came up empty). The
+    tool layer then has to work out the FORMAT to decide how to render it, and
+    its only handle was the caller-supplied file id. That works for the
+    path-shaped ids network_dir and s3 hand out, but Graph item ids are opaque
+    tokens with no extension — so a scanned PDF or an image from SharePoint
+    reached the renderer as an unidentifiable blob and lost its vision
+    fallback entirely.
+
+    Subclassing `bytes` carries the name the connector already had in hand
+    without disturbing anything: every `isinstance(payload, (bytes, bytearray))`
+    check, equality test, and `bytes(payload)` conversion behaves identically.
+    (`__slots__` is deliberately absent — CPython rejects non-empty slots on a
+    subtype of a variable-length builtin.)
+    """
+
+    def __new__(cls, data, name: Optional[str] = None, mime: Optional[str] = None):
+        obj = super().__new__(cls, data)
+        obj.name = name or ""
+        obj.mime = mime or ""
+        return obj
+
+
+def payload_name(payload, fallback: str = "") -> str:
+    """Best display/dispatch name for a read payload: the connector-supplied
+    name when the bytes carry one, else the caller's fallback (usually the
+    file id, which IS a path for the path-addressed connectors)."""
+    return (getattr(payload, "name", "") or "").strip() or fallback
+
+
 def normalize_index_mode(
     index_mode: Optional[str], *, index_content_legacy: Optional[bool] = None
 ) -> str:

--- a/backend/app/data_sources/clients/_office_convert.py
+++ b/backend/app/data_sources/clients/_office_convert.py
@@ -1,0 +1,131 @@
+"""LibreOffice-backed conversion of Office documents to PDF.
+
+Why this exists: PDFs that can't be extracted as text have a vision fallback —
+rasterize the pages and let the model look at them. docx/pptx had none, because
+their page layout doesn't exist until a layout engine has run. A Word file
+wrapping scanned images therefore dead-ended as an opaque "binary" read: no
+text, nothing to rasterize, and (before this) not even attachable.
+
+LibreOffice is already in the runtime image — it backs the pptx slide previews
+in `pptx_executor` — so converting to PDF and handing the result to the
+existing pypdfium2 rasterizer gives docx/pptx the same fallback PDFs have,
+with no new Python dependency.
+
+Note on packaging: `soffice` on PATH is NOT sufficient. The binary and UNO
+framework ship in `libreoffice-core`, but each format's import filter ships
+with its application module — Writer's WordprocessingML filter
+(`libwriterfilterlo.so`) is in `libreoffice-writer`, Impress's in
+`libreoffice-impress`. With the wrong module set, type detection succeeds and
+loading then fails with "source file could not be loaded". The Dockerfile
+installs both.
+
+Best-effort by contract: every failure mode (binary absent, missing format
+filter, timeout, corrupt input) returns None and the caller keeps its original
+binary result.
+"""
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Formats worth routing through LibreOffice. Deliberately limited to the
+# document types the read path can otherwise do nothing with — PDFs and
+# pictures already rasterize directly, and tabular formats render as text.
+CONVERTIBLE_EXTS = {"docx", "doc", "pptx", "ppt", "odt", "odp", "rtf"}
+
+# LibreOffice cold-starts in seconds and is slower on a big document; this is a
+# backstop against a wedged process, not an expected duration.
+DEFAULT_TIMEOUT_SECONDS = 90
+
+
+def _ext(name: str) -> str:
+    leaf = str(name or "").rsplit("/", 1)[-1]
+    return leaf.rsplit(".", 1)[-1].lower() if "." in leaf else ""
+
+
+def soffice_available() -> bool:
+    return shutil.which("soffice") is not None
+
+
+def office_to_pdf_bytes(
+    data: bytes,
+    name: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> Optional[bytes]:
+    """Convert an Office document to PDF bytes, or None if it can't be done.
+
+    Blocking (spawns a subprocess) — call it from a worker thread, never
+    directly on the event loop.
+    """
+    ext = _ext(name)
+    if ext not in CONVERTIBLE_EXTS:
+        return None
+    if not data:
+        return None
+    if not soffice_available():
+        logger.info(
+            "office_to_pdf_bytes: soffice not on PATH — cannot render %s for vision", name
+        )
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="bow_soffice_") as tmp:
+        src = os.path.join(tmp, f"source.{ext}")
+        try:
+            with open(src, "wb") as fh:
+                fh.write(data)
+        except OSError as e:
+            logger.info("office_to_pdf_bytes: could not stage %s: %s", name, e)
+            return None
+
+        # A per-call user profile. LibreOffice serializes on a shared profile
+        # directory, so concurrent conversions with the default profile either
+        # block each other or fail outright — this makes parallel reads safe.
+        # It lives inside the temp dir, so cleanup is automatic.
+        profile = os.path.join(tmp, "profile")
+        cmd = [
+            "soffice",
+            "--headless",
+            "--norestore",
+            "--invisible",
+            f"-env:UserInstallation=file://{profile}",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            tmp,
+            src,
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.info("office_to_pdf_bytes: timed out after %ss on %s", timeout, name)
+            return None
+        except (OSError, ValueError) as e:
+            logger.info("office_to_pdf_bytes: could not run soffice for %s: %s", name, e)
+            return None
+
+        # soffice exits 0 even when it refuses the input (the "source file
+        # could not be loaded" case), so the produced file is the real check.
+        produced = glob.glob(os.path.join(tmp, "*.pdf"))
+        if not produced:
+            detail = (proc.stderr or proc.stdout or b"").decode("utf-8", "replace").strip()
+            logger.info(
+                "office_to_pdf_bytes: no PDF produced for %s (rc=%s) %s",
+                name, proc.returncode, detail[:300],
+            )
+            return None
+        try:
+            with open(produced[0], "rb") as fh:
+                pdf = fh.read()
+        except OSError as e:
+            logger.info("office_to_pdf_bytes: could not read converted PDF for %s: %s", name, e)
+            return None
+
+    return pdf or None

--- a/backend/app/data_sources/clients/google_drive_client.py
+++ b/backend/app/data_sources/clients/google_drive_client.py
@@ -21,6 +21,7 @@ from app.data_sources.clients._document_text import (
     doc_text_is_usable,
     extract_document_text_from_bytes,
 )
+from app.data_sources.clients._file_source_common import NamedBytes
 from app.data_sources.clients.base import Capability, DataSourceClient
 
 
@@ -283,7 +284,9 @@ class GoogleDriveClient(DataSourceClient):
         # the tool can render it for a vision model.
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
-            return text if doc_text_is_usable(text, ext) else content
+            if doc_text_is_usable(text, ext):
+                return text
+            return NamedBytes(content, name=name)
 
         from app.data_sources.clients.graph_drive_client import _trim_to_data
         if ext == "csv":
@@ -299,7 +302,7 @@ class GoogleDriveClient(DataSourceClient):
                 return content.decode("utf-8", errors="replace")
         if ext in TEXT_EXTS:
             return content.decode("utf-8", errors="replace")
-        return content
+        return NamedBytes(content, name=name)
 
     def read_raw_bytes(self, file_id: str):
         """Raw file bytes + name + mime, unparsed — for attach_file (persist

--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -29,6 +29,7 @@ from app.data_sources.clients._document_text import (
 )
 from app.data_sources.clients._file_source_common import (
     GlobScopeError,
+    NamedBytes,
     globs_from_str,
     path_matches_globs,
 )
@@ -421,9 +422,14 @@ class GraphDriveClient(DataSourceClient):
         # as the network_dir and s3 clients. Near-empty extraction (scanned /
         # image-based PDF) falls back to raw bytes so the tool can render it
         # for a vision model.
+        mime = (meta.get("file") or {}).get("mimeType")
+        # Graph item ids are opaque tokens with no extension, so bare bytes
+        # would reach the renderer unidentifiable. Carry the real name.
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
-            return text if doc_text_is_usable(text, ext) else content
+            if doc_text_is_usable(text, ext):
+                return text
+            return NamedBytes(content, name=name, mime=mime)
 
         if ext == "csv":
             return _trim_to_data(pd.read_csv(io.BytesIO(content), header=None))
@@ -438,7 +444,7 @@ class GraphDriveClient(DataSourceClient):
                 return content.decode("utf-8", errors="replace")
         if ext in TEXT_EXTS:
             return content.decode("utf-8", errors="replace")
-        return content
+        return NamedBytes(content, name=name, mime=mime)
 
     def read_raw_bytes(self, file_id: str):
         """Raw item bytes + name + mime, unparsed — for attach_file (persist

--- a/backend/app/data_sources/clients/network_dir_client.py
+++ b/backend/app/data_sources/clients/network_dir_client.py
@@ -43,6 +43,7 @@ from app.data_sources.clients._file_source_common import (
     INDEX_METADATA,
     INDEX_NONE,
     GlobScopeError,
+    NamedBytes,
     globs_from_str,
     legacy_fs_candidates,
     normalize_index_mode,
@@ -409,7 +410,9 @@ class NetworkDirClient(DataSourceClient):
             # Fall back to raw bytes when extraction yielded nothing OR only a
             # stray glyph (scanned / image-based / CID-font PDF) so the caller
             # can render it to images for a vision model instead of a junk read.
-            return text if doc_text_is_usable(text, _ext(path.name)) else path.read_bytes()
+            if doc_text_is_usable(text, _ext(path.name)):
+                return text
+            return NamedBytes(path.read_bytes(), name=path.name)
 
         cap = max_bytes or self.max_file_bytes
         size = path.stat().st_size

--- a/backend/app/data_sources/clients/s3_client.py
+++ b/backend/app/data_sources/clients/s3_client.py
@@ -47,6 +47,7 @@ from app.data_sources.clients._file_source_common import (
     INDEX_CONTENT,
     INDEX_NONE,
     GlobScopeError,
+    NamedBytes,
     globs_from_str,
     normalize_index_mode,
     path_matches_globs,
@@ -353,7 +354,9 @@ class S3Client(DataSourceClient):
             text = extract_document_text_from_bytes(data, key)
             # Near-empty extraction on a rich doc (scanned / image-based / CID
             # font) → return raw bytes so the tool can render it for vision.
-            return text if doc_text_is_usable(text, ext) else data
+            if doc_text_is_usable(text, ext):
+                return text
+            return NamedBytes(data, name=key)
 
         if ext == "csv":
             return pd.read_csv(io.BytesIO(data))


### PR DESCRIPTION
Follow-up to #775, closing the two gaps that PR called out. Both turned an unreadable document into a dead end rather than a degraded read.

## Gap 1 — docx/pptx had no image-rendering fallback

A PDF that yields no extractable text gets rasterized for a vision model. A Word file wrapping scanned images could not be: its page layout doesn't exist until a layout engine has run. So it returned bytes that could be neither read, rendered, nor attached.

`render_file_images` now routes Office formats through LibreOffice to PDF, then hands the result to the existing pypdfium2 rasterizer. Bytes in, bytes out — so it works for all four connectors at once, with no new Python dependency.

**This required a Dockerfile change.** `soffice` on `PATH` is not sufficient: `libreoffice-core` ships the binary and the UNO framework, but each format's import filter ships with its application module — Writer's WordprocessingML filter (`libwriterfilterlo.so`) is in `libreoffice-writer`, Impress's in `libreoffice-impress`. The image had Impress only, so type detection succeeded and the load then failed with `source file could not be loaded`. Verified by reproducing the exact prod package set:

| Packages | `.pptx` | `.docx` |
|---|---|---|
| `libreoffice-impress` (before) | ✅ `impress_pdf_Export` | ❌ `source file could not be loaded` |
| `+ libreoffice-writer` (after) | ✅ | ✅ `writer_pdf_Export` |

Cost is **~46 MB installed / 11.6 MB download** (`libreoffice-writer` 34.9, `libreoffice-uiconfig-writer` 9.1, `libreoffice-base-core` 3.5) on top of the ~240 MB LibreOffice stack already in the image for slide previews.

## Gap 2 — binary payloads lost their identity

`read_file` returned bare `bytes`, so the tool layer had to infer the format from the caller-supplied file id. That works for the path-shaped ids `network_dir` and `s3` hand out, but Graph item ids are opaque tokens with no extension — and `list_files` hands the agent that id directly. So a scanned PDF or an image from SharePoint reached the renderer unidentifiable and lost its vision fallback, then was attached (if at all) as an opaque `.bin`.

Connectors now return `NamedBytes`, a `bytes` subclass carrying the name and MIME type they already had in hand. Every `isinstance` check, equality test and `bytes()` conversion is unaffected — verified, and there are no exact-type (`type(x) is bytes`) checks in `app/`. `docx`/`pptx`/`doc`/`ppt` also join `_ATTACHABLE_BY_EXT`, so a document that still can't be rendered at least lands in the conversation as itself.

## Supporting changes

- The `as_images` escalation was gated on PDF, so the flag was **silently a no-op on Word files**. It now covers every `DOC_EXTS` format, and renders *before* discarding the extracted text — a failed conversion can no longer leave a read worse off than it started.
- `render_file_images` moves onto a worker thread; it now spawns a subprocess on top of being CPU-bound.
- Per-call `-env:UserInstallation` profile, so concurrent conversions don't collide on a shared LibreOffice profile. (`pptx_executor` does not do this — worth a separate look.)

## Verification

Against the real file from the original report, and a purpose-built text-free docx (a "scanned invoice" image pasted into Word, zero `<w:t>` runs):

```
text extraction: '' -> usable: False
connector returns: NamedBytes | name: Scan.docx
tool renders: 1 image(s) pages=1 (dispatch name='Scan.docx')
session attach name: Scan.docx
```

The rendered PNG is legible: `INVOICE 2026-114  TOTAL: $8,420.00` — content that was previously unreachable.

Gap 2 isolated:

```
dispatch on file_id   (old): 0 images
dispatch on real name (new): 1 images
```

Existing paths unchanged: `pdf → 1 image`, `png → 1 image`, `csv → ([], 0)`, non-bytes → `([], 0)`. Conversion of the reported file takes ~1.6s.

Regression check: the six related unit suites produce an **identical failure set** before and after (45 pre-existing failures in this bare container, from `--noconftest` and absent DB drivers) — `diff` of the sorted FAILED/ERROR lists is empty.

One honest caveat: a corrupt file with a `.docx` name does **not** return `None` — LibreOffice falls back to text-import and produces a PDF of the raw content. That's a strictly better outcome than the previous binary dead end, but it isn't a clean rejection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhCW2yFubxZpZEkiSd3Zqp)_