### PR TITLE
Fix routing e2e stand-in missing the shared escalation method

### DIFF
--- a/backend/tests/e2e/rbac/test_auto_model_routing.py
+++ b/backend/tests/e2e/rbac/test_auto_model_routing.py
@@ -396,9 +396,13 @@ def test_escalation_updates_completion_model_in_db(test_client, cast):
 
             # Drive the REAL escalation method against this real row + session.
             fake_agent = types.SimpleNamespace(
-                model=small, _routing_escalated=False, system_completion=comp,
+                model=small, _routing_escalated=False, _fallback_engaged=False,
+                system_completion=comp,
                 db=db, planner=types.SimpleNamespace(llm=None), usage_limit_context=None,
             )
+            # The routing entry point is a thin wrapper over the shared
+            # _apply_effective_model; bind it so the stand-in can delegate.
+            fake_agent._apply_effective_model = AgentV2._apply_effective_model.__get__(fake_agent)
             AgentV2._apply_routed_model(fake_agent, big)
             await db.commit()  # the run's status finalize would do this
 


### PR DESCRIPTION
`test_escalation_updates_completion_model_in_db` was failing with:

```
AttributeError: 'types.SimpleNamespace' object has no attribute '_apply_effective_model'
```

`AgentV2._apply_routed_model` is now a thin wrapper that delegates to the shared `_apply_effective_model` (introduced so LLM fallback and Auto routing share one model-swap path). The e2e test calls the unbound method against a `SimpleNamespace` stand-in, which has no such attribute. The unit tests in `tests/unit/test_model_router.py` already bind the delegate; the e2e one was missed.

Fix: bind the real implementation onto the stand-in and add the `_fallback_engaged` attribute the shared method touches. The test still drives the real escalation code against a real DB row and session — only the stand-in wiring changed, no production code touched.

Verified: `pytest tests/e2e/rbac/test_auto_model_routing.py tests/unit/test_model_router.py` → 26 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013dVYtJ5jXUsm7SKkcNMZnL)_