### PR TITLE
Stop Outlook Mail's admin credential test from failing on delegated-only /me

### DIFF
--- a/backend/app/data_sources/clients/graph_mail_client.py
+++ b/backend/app/data_sources/clients/graph_mail_client.py
@@ -53,6 +53,13 @@ class GraphMailClient(GraphDriveClient):
         }
 
     def list_files(self, folder_id: Optional[str] = None, recursive: Optional[bool] = None) -> List[dict]:
+        # Mailbox enumeration goes through /me/messages, which only works with a
+        # delegated user token. Without one (e.g. the admin's credential test, or
+        # admin-save indexing before any user has signed in), return an empty
+        # inventory rather than 400. The real enumeration runs per-user once a
+        # user completes OAuth. Mirrors the OneDrive guard in the parent client.
+        if not getattr(self, "_user_token_provided", True):
+            return []
         data = self._get(
             "/me/messages?$top=25&$select=id,subject,from,receivedDateTime"
             "&$orderby=receivedDateTime%20desc"
@@ -86,6 +93,26 @@ class GraphMailClient(GraphDriveClient):
         return []
 
     def test_connection(self) -> dict:
+        # Admin-only (service-principal credentials, no user token yet): every
+        # mail endpoint here is `/me/*`, which Graph serves for delegated tokens
+        # only. Probing it with an app-only token always fails with
+        # `/me request is only valid with delegated authentication flow`, and the
+        # raw Graph body was surfaced to the admin as if their credentials were
+        # wrong. Verify the credentials can mint a token and stop there —
+        # GraphDriveClient already does exactly this for OneDrive.
+        if not getattr(self, "_user_token_provided", True):
+            try:
+                self._token()
+            except Exception as e:
+                return {"success": False, "message": str(e)}
+            return {
+                "success": True,
+                "message": (
+                    "Service principal credentials verified. Have a user sign "
+                    "in with Microsoft to access their mailbox."
+                ),
+            }
+
         try:
             me = self._get("/me?$select=userPrincipalName,displayName")
             who = me.get("userPrincipalName") or me.get("displayName") or "Microsoft account"

--- a/backend/tests/unit/test_graph_mail_test_connection.py
+++ b/backend/tests/unit/test_graph_mail_test_connection.py
@@ -15,9 +15,13 @@ import pytest
 from app.data_sources.clients.graph_mail_client import GraphMailClient
 
 
-def _client(get_impl):
+def _client(get_impl, user_token=True, token_impl=None):
     client = GraphMailClient.__new__(GraphMailClient)  # skip network/auth setup
     client._get = get_impl
+    # Mirrors GraphDriveClient.__init__: True when a delegated user token was
+    # supplied, False in admin/service-principal mode.
+    client._user_token_provided = user_token
+    client._token = token_impl or (lambda: "app-only-token")
     return client
 
 
@@ -74,3 +78,92 @@ def test_identity_failure_reported_as_before():
     result = _client(_get).test_connection()
     assert result["success"] is False
     assert "InvalidAuthenticationToken" in result["message"]
+
+
+# --- admin / service-principal mode (no user has signed in yet) --------------
+#
+# Second fix: the admin's "Test credentials" button runs with app-only client
+# credentials. `/me` is delegated-only, so probing it there ALWAYS returned
+# HTTP 400 `/me request is only valid with delegated authentication flow`, and
+# the raw Graph body was rendered in the connection form as if the credentials
+# were bad. Observed live against a real tenant while configuring Outlook Mail.
+
+ME_DELEGATED_ONLY = (
+    'Graph https://graph.microsoft.com/v1.0/me?$select=userPrincipalName,displayName → 400 '
+    '{"error":{"code":"BadRequest","message":"/me request is only valid with delegated '
+    'authentication flow.","innerError":{"date":"2026-07-26T03:10:29",'
+    '"request-id":"3089e8a6-524d-49a7-a6aa-589326821ce9"}}}'
+)
+
+
+def test_admin_mode_does_not_probe_me_and_succeeds():
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        raise ValueError(ME_DELEGATED_ONLY)  # what Graph really does here
+
+    result = _client(_get, user_token=False).test_connection()
+    assert result["success"] is True, "verifying service-principal credentials is not a failure"
+    assert calls == [], "no /me* call may be made without a delegated token"
+    assert "sign in" in result["message"].lower(), "tell the admin what happens next"
+
+
+def test_admin_mode_surfaces_bad_service_principal_credentials():
+    def _token():
+        raise ValueError("AADSTS7000215: Invalid client secret provided")
+
+    result = _client(lambda path: None, user_token=False, token_impl=_token).test_connection()
+    assert result["success"] is False, "credentials that cannot mint a token must fail"
+    assert "AADSTS7000215" in result["message"]
+
+
+def test_admin_mode_never_leaks_the_raw_graph_body():
+    def _get(path):
+        raise ValueError(ME_DELEGATED_ONLY)
+
+    msg = _client(_get, user_token=False).test_connection()["message"]
+    for leak in ("graph.microsoft.com", "BadRequest", "request-id", "innerError"):
+        assert leak not in msg, f"raw Graph detail {leak!r} must not reach the admin"
+
+
+def test_delegated_mode_still_probes_the_mailbox_after_the_admin_branch():
+    """The admin branch must not short-circuit the delegated path (fix 1)."""
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        return ME if path.startswith("/me?") else {"value": [{"id": "1"}]}
+
+    result = _client(_get, user_token=True).test_connection()
+    assert result["success"] is True
+    assert any("/me/messages" in c for c in calls)
+
+
+# --- the same guard is needed on the inventory path -------------------------
+#
+# `POST /connections/test-params` (the "Test credentials" button) does not stop
+# at test_connection: it then counts the inventory via
+# _acount_files_for_validation -> client.list_files(). That is another `/me/*`
+# call, so guarding only test_connection moved the raw 400 from
+# `/me?$select=...` to `/me/messages?$top=25...` instead of removing it.
+# GraphDriveClient already returns [] for OneDrive in exactly this situation.
+
+
+def test_list_files_returns_empty_without_a_delegated_token():
+    def _get(path):
+        raise AssertionError(f"no /me* call may be made app-only, got {path}")
+
+    assert _client(_get, user_token=False).list_files() == []
+
+
+def test_list_files_still_reads_the_mailbox_with_a_delegated_token():
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        return {"value": [{"id": "1", "subject": "Hello", "receivedDateTime": "2026-07-26T00:00:00Z"}]}
+
+    items = _client(_get, user_token=True).list_files()
+    assert len(items) == 1 and items[0]["name"] == "Hello"
+    assert any("/me/messages" in c for c in calls)


### PR DESCRIPTION
## The bug

Outlook Mail is a per-user connector — its own setup panel says so: *"Each user signs in individually to access their own data — no shared service account."* But the admin's **Test credentials** button runs with **app-only client credentials**, and every mail endpoint is `/me/*`, which Graph serves for **delegated tokens only**.

So the probe failed 100% of the time, and the raw Graph body was rendered in the connection form as if the credentials were wrong:

```
Graph https://graph.microsoft.com/v1.0/me?$select=userPrincipalName,displayName → 400
{"error":{"code":"BadRequest","message":"/me request is only valid with delegated
authentication flow.","innerError":{"date":"2026-07-26T03:10:29",
"request-id":"3089e8a6-524d-49a7-a6aa-589326821ce9", ...}}}
```

Reproduced independently twice (different `request-id`s and timestamps), so it is deterministic rather than a transient tenant hiccup. The connection still saves afterwards, so it is a scare rather than a blocker — but it reads as a hard failure to whoever is configuring it, and it points them at the credentials, which are fine.

## Why it's a clean fix

`GraphMailClient` **extends** `GraphDriveClient`, which already solved this exact case for OneDrive. Its `test_connection` branches on `_user_token_provided`, and its docstring names the error verbatim:

> *"Admin-only (service-principal credentials, no user token yet): just verify the token can be acquired. Drive/root access needs a user token, which arrives after a user completes OAuth — testing it now would fail with `/me request is only valid with delegated authentication flow` for OneDrive…"*

The mail subclass overrides the relevant methods and drops the guard. This restores it.

## What changed

Two call sites, because `/me/*` is reached twice without a user token:

- **`test_connection`** — verifies the service principal can mint a token and returns an actionable message instead of probing `/me`.
- **`list_files`** — returns an empty inventory instead of calling `/me/messages`, mirroring the parent's OneDrive guard.

The second one matters: `POST /connections/test-params` does **not** stop at `test_connection`. It then counts the inventory via `_acount_files_for_validation` → `client.list_files()`. Guarding only `test_connection` **moved** the raw 400 from `/me?$select=...` to `/me/messages?$top=25...` rather than removing it — caught by re-testing through the UI after the first change.

Credentials that genuinely cannot mint a token still fail, and the delegated paths are untouched, including the no-mailbox message.

## Verification

Live against the real Entra tenant, all four cases:

| case | result |
|---|---|
| ADMIN app-only *(the bug)* | `success=True` — "Service principal credentials verified. Have a user sign in with Microsoft to access their mailbox." |
| ADMIN bad secret | `success=False` — `AADSTS7000215: Invalid client secret provided` |
| DELEGATED, has mailbox | `success=True` — `Connected as YochayEttun@…` |
| DELEGATED, no mailbox | `success=False` — "…this account has no Exchange mailbox (…missing a Microsoft 365 mail licence)" |

Through the UI, **Test credentials** now returns green:

> Connected successfully. Each user sees their own messages after signing in — no admin-side catalog for this connector.

— the same shape OneDrive already gave on the same screen. A deliberately wrong secret still surfaces `AADSTS7000215`.

## Tests

`tests/unit/test_graph_mail_test_connection.py` grows **4 → 10** cases, covering both call sites, the raw-Graph-detail leak, and bad service-principal credentials.

```
tests/unit/test_graph_mail_test_connection.py
tests/unit/test_graph_drive_search_term.py
tests/e2e/test_connection.py                    39 passed
```

## Context

Found during a full Entra `sso_only` + OBO + Graph-connectors e2e loop; the write-up of that run is on a separate branch and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VA96mXyFPiL432iyG3nf6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA96mXyFPiL432iyG3nf6j)_