### PR TITLE
Fall back when a provider's quota or credit balance runs out

### DIFF
--- a/backend/app/ai/llm/errors.py
+++ b/backend/app/ai/llm/errors.py
@@ -23,11 +23,93 @@ from typing import Optional
 ERROR_CODES = (
     "auth",
     "rate_limit",
+    "quota",
     "context_length",
     "provider_error",
     "network",
     "unknown",
 )
+
+# ---- quota vs rate limit -------------------------------------------------
+#
+# Both classes usually arrive as a 429, but they behave nothing alike: a rate
+# limit heals in seconds (retry it), an exhausted quota / empty credit balance
+# does not heal at all within a run (don't retry — switch providers or fail).
+# Providers don't agree on a machine-readable marker, so we match on the
+# message and keep the two apart with the transient markers below.
+
+# Text that means "the account/project is out of budget or allowance".
+_QUOTA_MARKERS = (
+    "insufficient_quota",
+    "insufficient quota",
+    "exceeded your current quota",
+    "exceeded your assigned quota",
+    "quota exceeded",
+    "exceeded the service quota",
+    "servicequotaexceededexception",
+    "resource_exhausted",
+    "resource has been exhausted",
+    "credit balance is too low",
+    "insufficient credits",
+    "insufficient balance",
+    "out of credits",
+    "check your plan and billing",
+    # Billing phrasings are kept specific on purpose: a bare "billing" would
+    # also match a provider echoing the user's prompt back in a 400 body.
+    "enable billing",
+    "billing to be enabled",
+    "billing is not enabled",
+    "billing account for project",
+)
+
+# Text that means "too fast right now" — wins over the quota markers above,
+# because Google reuses RESOURCE_EXHAUSTED / "Quota exceeded for quota metric"
+# for plain per-minute throttling, which is transient and worth retrying.
+_TRANSIENT_LIMIT_MARKERS = (
+    "rate limit",
+    "rate_limit",
+    "per minute",
+    "per-minute",
+    "per min",
+    "requests per",
+    "tokens per",
+    "try again in",
+    "retry after",
+    "retry_after",
+    "slow down",
+)
+
+# Our *own* usage caps (app.services.usage_policy_service.UsageLimitExceeded)
+# say "quota exceeded" too. They must never read as a provider quota error:
+# the provider is fine, the org spent its budget, and substituting another
+# model would only spend someone else's. They stay 'unknown' → no retry, no
+# fallback, message surfaced verbatim.
+_INTERNAL_QUOTA_MARKERS = (
+    "monthly llm token quota",
+    "monthly llm spend quota",
+    "monthly usage quota",
+)
+
+# AWS surfaces everything as botocore ClientError: no HTTP status on the
+# exception (it lives in a dict) and none in ``str(exc)`` either, which reads
+# "An error occurred (ThrottlingException) when calling the Converse
+# operation: ...". Map the error names we care about directly.
+_AWS_ERROR_CODES = (
+    ("servicequotaexceededexception", "quota"),
+    ("throttlingexception", "rate_limit"),
+    ("toomanyrequestsexception", "rate_limit"),
+    ("requestthrottled", "rate_limit"),
+    ("modelnotreadyexception", "provider_error"),
+    ("modeltimeoutexception", "provider_error"),
+    ("serviceunavailableexception", "provider_error"),
+    ("internalserverexception", "provider_error"),
+)
+
+_AWS_SUMMARIES = {
+    "quota": "{provider} quota or credit balance exhausted",
+    "rate_limit": "{provider} is rate-limiting requests",
+    "provider_error": "{provider} could not serve the request",
+}
 
 
 @dataclass
@@ -91,6 +173,56 @@ def classify(
             raw_tail=raw_tail,
         )
 
+    # Context length. Ahead of the quota and rate-limit branches: an
+    # over-long prompt is unambiguous, and checking it first means a provider
+    # that happens to echo prompt text into the error body can't have that text
+    # matched as a billing marker.
+    if status == 400 and any(t in pmsg_low for t in ("maximum context", "context length", "too many tokens", "context_length_exceeded")):
+        return LLMError(
+            code="context_length",
+            provider=provider,
+            model=model,
+            status=status,
+            summary="Conversation too long for this model",
+            provider_message=provider_message,
+            request_id=request_id,
+            raw_tail=raw_tail,
+        )
+
+    # Provider quota / credit exhaustion. Checked before rate_limit because
+    # most providers report it as a 429 (OpenAI ``insufficient_quota``, Google
+    # RESOURCE_EXHAUSTED); 402 is Payment Required by definition. Our own usage
+    # caps are excluded — see _INTERNAL_QUOTA_MARKERS.
+    haystack = f"{pmsg_low}\n{low}"
+    if not any(t in haystack for t in _INTERNAL_QUOTA_MARKERS):
+        quota_hit = status == 402 or any(t in haystack for t in _QUOTA_MARKERS)
+        if quota_hit and not any(t in haystack for t in _TRANSIENT_LIMIT_MARKERS):
+            return LLMError(
+                code="quota",
+                provider=provider,
+                model=model,
+                status=status,
+                summary=f"{provider} quota or credit balance exhausted",
+                provider_message=provider_message,
+                request_id=request_id,
+                raw_tail=raw_tail,
+            )
+
+    # AWS error names — botocore carries no usable status, so name-match first
+    # (a ThrottlingException must not fall through to 'unknown').
+    for marker, aws_code in _AWS_ERROR_CODES:
+        if marker in low:
+            return LLMError(
+                code=aws_code,
+                provider=provider,
+                model=model,
+                status=status,
+                summary=_AWS_SUMMARIES[aws_code].format(provider=provider),
+                provider_message=provider_message,
+                request_id=request_id,
+                raw_tail=raw_tail,
+            )
+
     # Rate limit
     if status == 429 or "ratelimit" in cls_name or "rate limit" in pmsg_low:
         return LLMError(
@@ -99,19 +231,6 @@ def classify(
             model=model,
             status=status,
             summary=f"{provider} is rate-limiting requests",
-            provider_message=provider_message,
-            request_id=request_id,
-            raw_tail=raw_tail,
-        )
-
-    # Context length
-    if status == 400 and any(t in pmsg_low for t in ("maximum context", "context length", "too many tokens", "context_length_exceeded")):
-        return LLMError(
-            code="context_length",
-            provider=provider,
-            model=model,
-            status=status,
-            summary="Conversation too long for this model",
             provider_message=provider_message,
             request_id=request_id,
             raw_tail=raw_tail,
@@ -165,15 +284,37 @@ def _extract_status(exc: BaseException, raw: str) -> Optional[int]:
     s = getattr(exc, "status_code", None) or getattr(exc, "status", None)
     if isinstance(s, int):
         return s
+    # google.genai APIError keeps the int status on ``.code`` — ``.status`` is
+    # a string enum ('RESOURCE_EXHAUSTED'), so the check above skips it.
+    c = getattr(exc, "code", None)
+    if isinstance(c, int) and 100 <= c < 600:
+        return c
     resp = getattr(exc, "response", None)
     if resp is not None:
         s2 = getattr(resp, "status_code", None) or getattr(resp, "status", None)
         if isinstance(s2, int):
             return s2
+        # botocore ClientError.response is a dict, not an object.
+        if isinstance(resp, dict):
+            meta = resp.get("ResponseMetadata")
+            s3 = meta.get("HTTPStatusCode") if isinstance(meta, dict) else None
+            if isinstance(s3, int):
+                return s3
     m = re.search(r"\b(?:Error code:|status[_ ]code[=:]|HTTP/\d\.\d)\s*(\d{3})\b", raw)
     if m:
         try:
             return int(m.group(1))
+        except Exception:
+            pass
+    # Stringified google.genai error: "429 RESOURCE_EXHAUSTED. {...}". The
+    # trailing name must be 4+ chars so token counts ("... 429 TPM") don't
+    # masquerade as a status.
+    m = re.search(r"(?<!\d)(\d{3})(?!\d)\s+[A-Z][A-Z_]{3,}\b", raw)
+    if m:
+        try:
+            code = int(m.group(1))
+            if 100 <= code < 600:
+                return code
         except Exception:
             pass
     return None

--- a/backend/app/ai/llm/fallback.py
+++ b/backend/app/ai/llm/fallback.py
@@ -1,19 +1,22 @@
 """LLM fallback — availability-driven model substitution (Enterprise).
 
 When the effective model fails with an availability-class error (rate limit,
-provider overload, network), the agent walks the org's admin-configured
-fallback order and swaps to the first eligible candidate for the rest of the
-run. This is orthogonal to the Auto model router (quality/cost, planner-invoked
-via the route_model tool): routing decides the *desired* model, fallback decides
-who *actually serves* when the desired one can't.
+exhausted quota or credit balance, provider overload, network), the agent walks
+the org's admin-configured fallback order and swaps to the first eligible
+candidate for the rest of the run. This is orthogonal to the Auto model router
+(quality/cost, planner-invoked via the route_model tool): routing decides the
+*desired* model, fallback decides who *actually serves* when the desired one
+can't.
 
 Key pieces:
   - ``FALLBACK_ELIGIBLE_CODES`` — which classified error codes may trigger a
     substitution (see app.ai.llm.errors.classify).
   - ``CircuitBreaker`` — in-process failure tracker. Trips at *model* scope for
-    rate_limit/provider_error (per-model quotas and capacity) and at *provider*
-    scope for network/auth (endpoint-wide outages), so a Claude Opus 429 never
-    blocks Claude Haiku, while an unreachable endpoint blocks every model on it.
+    rate_limit/provider_error (per-model limits and capacity) and at *provider*
+    scope for network/auth/quota (endpoint- or account-wide problems), so a
+    Claude Opus 429 never blocks Claude Haiku, while an unreachable endpoint or
+    an empty credit balance blocks every model on it. quota also trips on the
+    first failure and holds a much longer cooldown — it won't heal by itself.
   - ``resolve_fallback_chain`` — loads the org's ordered candidate list
     (org settings key ``llm_fallback_order``) as live LLMModel rows.
   - ``FallbackController`` — per-run walker over the chain: skips the failing
@@ -43,11 +46,26 @@ logger = logging.getLogger(__name__)
 # auth won't heal by switching (and often means misconfiguration the admin must
 # see), context_length follows the conversation to any model of similar window,
 # and unknown could be anything — surfacing it is safer than masking it.
-FALLBACK_ELIGIBLE_CODES = ("rate_limit", "provider_error", "network")
+#
+# ``quota`` (exhausted allowance / empty credit balance) is the one eligible
+# code that will *not* heal on its own: another provider is the only way to
+# serve the run at all, which makes it the strongest fallback signal of the
+# four. Note this is the *provider's* quota — the org's own usage caps
+# (usage_policy_service) classify as 'unknown' by design and never fall back.
+FALLBACK_ELIGIBLE_CODES = ("rate_limit", "quota", "provider_error", "network")
 
 # Codes that indicate the whole provider endpoint is unhealthy (breaker trips
 # at provider scope). Everything else eligible trips at model scope.
-PROVIDER_SCOPE_CODES = ("network", "auth")
+# quota belongs here: allowance and credit balance are billed per account, so
+# an exhausted OpenAI key fails every OpenAI model — walking the rest of the
+# chain on that provider only buys more of the same error.
+PROVIDER_SCOPE_CODES = ("network", "auth", "quota")
+
+# Codes where a single failure is proof enough to open the breaker, and where
+# the usual cooldown is far too optimistic. A rate limit clears in seconds; a
+# spent monthly allowance or an empty credit balance does not clear until
+# someone tops it up, so probing it again mid-run is pure latency.
+STICKY_CODES = ("quota",)
 
 # Bound the chain walk; the admin UI shouldn't produce lists this long anyway.
 MAX_FALLBACK_CHAIN = 10
@@ -62,10 +80,17 @@ class CircuitBreaker:
     which is acceptable — the worst case is one extra doomed attempt per worker.
     """
 
-    def __init__(self, threshold: int = 2, window_s: float = 120.0, cooldown_s: float = 60.0):
+    def __init__(
+        self,
+        threshold: int = 2,
+        window_s: float = 120.0,
+        cooldown_s: float = 60.0,
+        sticky_cooldown_s: float = 900.0,
+    ):
         self.threshold = threshold
         self.window_s = window_s
         self.cooldown_s = cooldown_s
+        self.sticky_cooldown_s = sticky_cooldown_s
         self._failures: Dict[str, deque] = {}
         self._open_until: Dict[str, float] = {}
 
@@ -77,14 +102,23 @@ class CircuitBreaker:
 
     def record_failure(self, provider_id: str, model_id: str, code: str) -> None:
         now = time.monotonic()
+        sticky = code in STICKY_CODES
+        threshold = 1 if sticky else self.threshold
+        cooldown = self.sticky_cooldown_s if sticky else self.cooldown_s
         for key in self._keys_for(str(provider_id), str(model_id), code):
             q = self._failures.setdefault(key, deque())
             q.append(now)
             while q and now - q[0] > self.window_s:
                 q.popleft()
-            if len(q) >= self.threshold:
-                self._open_until[key] = now + self.cooldown_s
-                logger.info("[fallback] circuit open: %s (cooldown %ss)", key, self.cooldown_s)
+            if len(q) >= threshold:
+                # Never shorten an open window: a sticky trip must not be
+                # downgraded by a later transient failure on the same key.
+                until = max(now + cooldown, self._open_until.get(key, 0.0))
+                self._open_until[key] = until
+                logger.info(
+                    "[fallback] circuit open: %s (code=%s, cooldown %ss)",
+                    key, code, cooldown,
+                )
 
     def is_open(self, provider_id: str, model_id: str) -> bool:
         now = time.monotonic()

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -55,6 +55,9 @@ _PENDING_RECORD_TASKS: set = set()
 # façade only smooths over blips — it must not mask a real outage from them.
 _MAX_SYNC_RETRIES = 2
 _MAX_STREAM_RETRIES = 1
+# 'quota' is deliberately absent: an exhausted allowance or empty credit
+# balance is not transient, so retrying it only adds backoff latency to a call
+# that cannot succeed. It goes straight up to the fallback chain instead.
 _RETRYABLE_CODES = ("rate_limit", "network", "provider_error")
 
 

--- a/backend/tests/unit/test_llm_error_classification.py
+++ b/backend/tests/unit/test_llm_error_classification.py
@@ -1,0 +1,244 @@
+"""Classification of provider errors — with an emphasis on quota exhaustion.
+
+The fallback chain decides whether to substitute a model purely from the code
+``classify`` returns, and it does so from a *string*: planner_v3 wraps the
+provider exception as ``PlannerError(message=str(exc))`` and agent_v2
+re-classifies ``Exception(err_msg)``. So the cases below are written the way
+they actually reach that decision — the wrapped RuntimeError text, not a live
+SDK exception object.
+
+The distinction that matters most here is quota vs rate_limit: both usually
+arrive as a 429, but a rate limit heals in seconds (retry it) and an exhausted
+allowance does not heal at all (switch providers, don't retry).
+"""
+import pytest
+
+from app.ai.llm.errors import classify
+from app.ai.llm.fallback import FALLBACK_ELIGIBLE_CODES
+from app.ai.llm.llm import _RETRYABLE_CODES
+
+
+def _wrapped(provider: str, body: str) -> Exception:
+    """The exception shape the agent's fallback path actually classifies."""
+    return Exception(
+        f"LLM v2 streaming failed (provider={provider}, model=m): {body}"
+    )
+
+
+def _code(provider: str, body: str) -> str:
+    return classify(_wrapped(provider, body), provider=provider, model="m").code
+
+
+# ── quota / credit exhaustion, per provider ────────────────────────────────
+
+QUOTA_CASES = [
+    (
+        "openai",
+        "Error code: 429 - {'error': {'message': 'You exceeded your current quota, "
+        "please check your plan and billing details.', 'type': 'insufficient_quota', "
+        "'code': 'insufficient_quota'}}",
+    ),
+    (
+        "anthropic",
+        "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', "
+        "'message': 'Your credit balance is too low to access the Anthropic API. Please "
+        "go to Plans & Billing to upgrade or purchase credits.'}}",
+    ),
+    (
+        "google",
+        "429 RESOURCE_EXHAUSTED. {'error': {'code': 429, 'message': 'You exceeded your "
+        "current quota, please check your plan and billing details.', 'status': "
+        "'RESOURCE_EXHAUSTED'}}",
+    ),
+    (
+        "google",
+        "400 FAILED_PRECONDITION. {'error': {'code': 400, 'message': 'Please enable "
+        "billing on your project.', 'status': 'FAILED_PRECONDITION'}}",
+    ),
+    (
+        "bedrock",
+        "An error occurred (ServiceQuotaExceededException) when calling the Converse "
+        "operation: Your account has exceeded the service quota for this model.",
+    ),
+    (
+        "azure",
+        "Error code: 429 - {'error': {'code': 'insufficient_quota', 'message': 'You have "
+        "exceeded your assigned quota for this deployment.'}}",
+    ),
+    (
+        "custom",  # OpenRouter / DeepSeek and other OpenAI-compatible endpoints
+        "Error code: 402 - {'error': {'message': 'Insufficient credits. Add more using "
+        "https://openrouter.ai/credits', 'code': 402}}",
+    ),
+]
+
+
+@pytest.mark.parametrize("provider,body", QUOTA_CASES)
+def test_quota_exhaustion_is_classified_as_quota(provider, body):
+    assert _code(provider, body) == "quota"
+
+
+def test_quota_is_fallback_eligible_but_never_retried():
+    # The whole point: another provider is the only way to serve the run, and
+    # retrying the exhausted one just adds backoff to a doomed call.
+    assert "quota" in FALLBACK_ELIGIBLE_CODES
+    assert "quota" not in _RETRYABLE_CODES
+
+
+# ── rate limits stay rate limits ───────────────────────────────────────────
+
+RATE_LIMIT_CASES = [
+    (
+        "openai",
+        "Error code: 429 - {'error': {'message': 'Rate limit reached for gpt-4o in "
+        "organization org-x on tokens per min (TPM): Limit 30000.', 'code': "
+        "'rate_limit_exceeded'}}",
+    ),
+    (
+        "anthropic",
+        "Error code: 429 - {'type': 'error', 'error': {'type': 'rate_limit_error', "
+        "'message': 'Number of request tokens has exceeded your per-minute rate limit'}}",
+    ),
+    (
+        "azure",
+        "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the "
+        "ChatCompletions_Create Operation have exceeded token rate limit of your current "
+        "OpenAI S0 pricing tier.'}}",
+    ),
+    (
+        # Google reuses RESOURCE_EXHAUSTED and the word "quota" for plain
+        # per-minute throttling — transient, and must not read as exhaustion.
+        "google",
+        "429 RESOURCE_EXHAUSTED. {'error': {'code': 429, 'message': \"Quota exceeded for "
+        "quota metric 'GenerateContent requests per minute'\", 'status': "
+        "'RESOURCE_EXHAUSTED'}}",
+    ),
+    (
+        "bedrock",
+        "An error occurred (ThrottlingException) when calling the ConverseStream "
+        "operation (reached max retries: 4): Too many requests, please wait before "
+        "trying again.",
+    ),
+]
+
+
+@pytest.mark.parametrize("provider,body", RATE_LIMIT_CASES)
+def test_transient_throttling_is_classified_as_rate_limit(provider, body):
+    assert _code(provider, body) == "rate_limit"
+
+
+# ── our own usage caps are not provider quota ──────────────────────────────
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "Monthly LLM token quota exceeded.",
+        "Monthly LLM spend quota exceeded.",
+        "Monthly usage quota exceeded.",
+    ],
+)
+def test_internal_usage_limits_never_classify_as_quota(detail):
+    """UsageLimitExceeded says "quota exceeded" too, and must not fall back.
+
+    The provider is healthy; the org spent its own budget. Substituting a
+    model would only spend it somewhere else, so these stay 'unknown' —
+    surfaced verbatim, not retried, not eligible for substitution.
+    """
+    code = _code("openai", detail)
+    assert code == "unknown"
+    assert code not in FALLBACK_ELIGIBLE_CODES
+
+
+# ── providers previously invisible to the classifier ───────────────────────
+
+def test_bedrock_error_names_classify_without_an_http_status():
+    """botocore keeps the status in a dict, so name-matching is the only signal.
+
+    Before this, every Bedrock failure fell through to 'unknown' — neither
+    retried by the façade nor eligible for fallback.
+    """
+    assert _code(
+        "bedrock",
+        "An error occurred (ModelNotReadyException) when calling the Converse "
+        "operation: Model is not ready to serve inference requests.",
+    ) == "provider_error"
+
+
+def test_google_stringified_status_is_extracted():
+    """google.genai renders as "503 UNAVAILABLE. {...}" — no "Error code:"."""
+    err = classify(
+        _wrapped(
+            "google",
+            "503 UNAVAILABLE. {'error': {'code': 503, 'message': 'The model is "
+            "overloaded. Please try again later.', 'status': 'UNAVAILABLE'}}",
+        ),
+        provider="google",
+        model="m",
+    )
+    assert err.status == 503
+    assert err.code == "provider_error"
+
+
+def test_status_extraction_ignores_token_counts():
+    """A bare "429 TPM"-style number must not be mistaken for a status."""
+    err = classify(
+        _wrapped("custom", "budget of 500 TPM reached for this deployment"),
+        provider="custom",
+        model="m",
+    )
+    assert err.status is None
+
+
+def test_google_apierror_object_exposes_status_on_code():
+    """Live google.genai APIError: int status on .code, string enum on .status."""
+
+    class _APIError(Exception):
+        code = 429
+        status = "RESOURCE_EXHAUSTED"
+
+    err = classify(_APIError("resource exhausted"), provider="google", model="m")
+    assert err.status == 429
+
+
+def test_botocore_client_error_object_exposes_status_in_response_dict():
+    class _ClientError(Exception):
+        response = {"ResponseMetadata": {"HTTPStatusCode": 429}}
+
+    err = classify(
+        _ClientError("An error occurred (ThrottlingException) when calling Converse"),
+        provider="bedrock",
+        model="m",
+    )
+    assert err.status == 429
+    assert err.code == "rate_limit"
+
+
+# ── untouched classes ──────────────────────────────────────────────────────
+
+def test_auth_and_context_length_still_win_over_quota():
+    # An invalid key is not a billing problem, and neither is an over-long
+    # prompt — both must keep their non-eligible codes.
+    assert _code(
+        "anthropic",
+        "Error code: 401 - {'type': 'error', 'error': {'message': 'invalid x-api-key'}}",
+    ) == "auth"
+    assert _code(
+        "anthropic",
+        "Error code: 400 - {'type': 'error', 'error': {'message': 'prompt is too long: "
+        "250000 tokens > maximum context length'}}",
+    ) == "context_length"
+
+
+def test_provider_message_is_preserved_on_quota():
+    """The user sees what the provider actually said, never just our headline."""
+    err = classify(
+        _wrapped(
+            "openai",
+            "Error code: 429 - {'error': {'message': 'You exceeded your current quota, "
+            "please check your plan and billing details.', 'type': 'insufficient_quota'}}",
+        ),
+        provider="openai",
+        model="m",
+    )
+    assert "exceeded your current quota" in err.provider_message
+    assert err.summary and err.summary != err.provider_message

--- a/backend/tests/unit/test_llm_fallback.py
+++ b/backend/tests/unit/test_llm_fallback.py
@@ -68,6 +68,49 @@ def test_breaker_cooldown_elapses(monkeypatch):
     assert br.is_open("prov-1", "model-a") is False
 
 
+# ── quota: provider scope, first failure, long cooldown ────────────────────
+
+def test_breaker_trips_provider_scope_on_quota():
+    """Allowance and credit balance are billed per account, not per model.
+
+    An exhausted OpenAI key fails GPT-5 and GPT-5-mini alike, so trying the
+    sibling model would only buy the same error.
+    """
+    br = CircuitBreaker(threshold=2, window_s=60, cooldown_s=60)
+    br.record_failure("prov-1", "model-a", "quota")
+
+    assert br.is_open("prov-1", "model-a") is True
+    assert br.is_open("prov-1", "model-b") is True
+    assert br.is_open("prov-2", "model-z") is False
+
+
+def test_breaker_quota_trips_on_first_failure_and_holds_longer(monkeypatch):
+    br = CircuitBreaker(threshold=5, window_s=600, cooldown_s=60, sticky_cooldown_s=900)
+    t = [1000.0]
+    monkeypatch.setattr("app.ai.llm.fallback.time.monotonic", lambda: t[0])
+    br.record_failure("prov-1", "model-a", "quota")
+
+    # One failure is proof enough — no threshold to reach.
+    assert br.is_open("prov-1", "model-a") is True
+    # Still shut well past the ordinary cooldown: a spent allowance doesn't
+    # heal on its own, so re-probing it is pure latency.
+    t[0] += 120
+    assert br.is_open("prov-1", "model-a") is True
+    t[0] += 800
+    assert br.is_open("prov-1", "model-a") is False
+
+
+def test_later_transient_failure_does_not_shorten_a_quota_trip(monkeypatch):
+    br = CircuitBreaker(threshold=1, window_s=600, cooldown_s=60, sticky_cooldown_s=900)
+    t = [1000.0]
+    monkeypatch.setattr("app.ai.llm.fallback.time.monotonic", lambda: t[0])
+    br.record_failure("prov-1", "model-a", "quota")
+    br.record_failure("prov-1", "model-a", "network")
+
+    t[0] += 120  # past the network cooldown, inside the quota one
+    assert br.is_open("prov-1", "model-a") is True
+
+
 # ── fallback controller ────────────────────────────────────────────────────
 
 def _fresh_breaker(monkeypatch, **kw):
@@ -132,6 +175,28 @@ def test_controller_records_failure_for_failing_model(monkeypatch):
     # usable for sibling models.
     assert br.is_open("p1", "m1") is True
     assert br.is_open("p1", "m1-sibling") is False
+
+
+def test_controller_falls_back_on_quota(monkeypatch):
+    _fresh_breaker(monkeypatch)
+    primary = _model("gpt-5", "GPT-5", provider_id="openai")
+    other = _model("claude-sonnet", "Claude Sonnet", provider_id="anthropic")
+    ctl = FallbackController([other], current_model=primary)
+
+    assert "quota" in FALLBACK_ELIGIBLE_CODES
+    assert ctl.next_candidate("quota") is other
+
+
+def test_controller_skips_siblings_of_a_quota_exhausted_provider(monkeypatch):
+    """The chain must not walk three models on the same spent account."""
+    _fresh_breaker(monkeypatch, threshold=99)
+    primary = _model("gpt-5", "GPT-5", provider_id="openai")
+    sibling = _model("gpt-5-mini", "GPT-5 mini", provider_id="openai")
+    elsewhere = _model("claude-sonnet", "Claude Sonnet", provider_id="anthropic")
+
+    ctl = FallbackController([sibling, elsewhere], current_model=primary)
+    # Skips gpt-5-mini: the whole OpenAI account is out of budget.
+    assert ctl.next_candidate("quota") is elsewhere
 
 
 def test_controller_never_returns_same_model_twice(monkeypatch):

--- a/docs/design/llm-fallback.md
+++ b/docs/design/llm-fallback.md
@@ -1,9 +1,9 @@
 # LLM Fallback (Enterprise)
 
 Availability-driven model substitution. When the effective model fails with a
-rate limit, provider overload, or network error, the agent swaps to the next
-model in the org's admin-configured fallback order for the rest of the run —
-instead of failing the whole turn. Typical deployment: an on-prem vLLM box
+rate limit, an exhausted quota or credit balance, a provider overload, or a
+network error, the agent swaps to the next model in the org's admin-configured
+fallback order for the rest of the run — instead of failing the whole turn. Typical deployment: an on-prem vLLM box
 (e.g. a DGX serving Qwen) as the default model, bursting to a cloud provider
 (Anthropic / Bedrock / OpenAI) when the box is saturated or unreachable; or a
 cloud primary falling back to the same model on another provider during a
@@ -23,7 +23,8 @@ out of the router's candidate set.
    backoff on transient classified errors (`rate_limit` / `network` /
    `provider_error`): 2 retries on sync `inference()`, 1 retry on
    `inference_stream_v2` and only before the first streamed event. Smooths
-   blips; never masks an outage from the layers above.
+   blips; never masks an outage from the layers above. `quota` is deliberately
+   excluded — see below.
 2. **Fallback chain** (EE feature `llm_fallback`, `app/ai/llm/fallback.py`) —
    an ordered list of models tried top-to-bottom. Engaged from the agent's
    planner-retry path (`agent_v2.py`, `stream_error` handling): on an eligible
@@ -34,15 +35,59 @@ out of the router's candidate set.
    the completion's model badge and usage records reflect the serving model.
 3. **Circuit breaker** (`app/ai/llm/fallback.py`, in-process singleton) —
    failure window + cooldown, keyed at two scopes: **model** scope for
-   `rate_limit`/`provider_error` (per-model quotas/capacity: an Opus 429 never
+   `rate_limit`/`provider_error` (per-model limits/capacity: an Opus 429 never
    blocks Haiku on the same provider — same-provider fallback is expected and
-   supported), **provider** scope for `network`/`auth` (endpoint-wide).
-   In-memory only; approximate under multi-worker deployments by design.
+   supported), **provider** scope for `network`/`auth`/`quota` (endpoint- or
+   account-wide). In-memory only; approximate under multi-worker deployments
+   by design.
 
 Not eligible for fallback: `auth` (won't heal by switching and must surface to
 the admin), `context_length` (follows the conversation), `unknown` (safer to
 surface). Mid-stream failures after content reached the SSE wire are not
 transparently retried — they surface to the agent-level retry/fallback.
+
+## Quota exhaustion vs rate limiting
+
+Both classes usually arrive as a 429, but they behave nothing alike: a rate
+limit heals in seconds, an exhausted allowance or empty credit balance does not
+heal within the run at all. `app/ai/llm/errors.py` separates them into
+`rate_limit` and `quota` by matching the provider's message — no provider
+offers a reliable machine-readable marker, and Google in particular reuses
+`RESOURCE_EXHAUSTED` and the word "quota" for plain per-minute throttling
+(markers like "per minute" / "rate limit" therefore win over the billing ones).
+
+`quota` covers OpenAI `insufficient_quota`, Anthropic "credit balance is too
+low", Google `RESOURCE_EXHAUSTED` / `FAILED_PRECONDITION` billing errors,
+Azure "exceeded your assigned quota", Bedrock `ServiceQuotaExceededException`,
+and the 402 "insufficient credits" that OpenRouter/DeepSeek-style endpoints
+return. It behaves differently from the other eligible codes in three ways:
+
+- **Never retried** by the façade (`_RETRYABLE_CODES`) — backoff can't fix it.
+- **Provider-scope breaker**, because allowance is billed per account: an
+  exhausted OpenAI key fails every OpenAI model, so the chain skips the
+  siblings instead of collecting the same error three times.
+- **Trips on the first failure** with a much longer cooldown
+  (`sticky_cooldown_s`, 15 min default) rather than the usual threshold. A
+  later transient failure on the same key can never shorten that window.
+
+**Our own usage caps are not this.** `UsageLimitExceeded`
+(`usage_policy_service`) also says "quota exceeded", but there the provider is
+healthy and the *org* is out of budget — substituting a model would only spend
+the budget elsewhere. Those messages are explicitly excluded from the `quota`
+markers and stay `unknown`: surfaced verbatim, never retried, never eligible
+for substitution.
+
+**Provider status extraction.** Google and Bedrock used to fall through to
+`unknown` for *every* failure — neither retried nor eligible for fallback —
+because `_extract_status` only understood `status_code`/`status` ints and an
+`Error code: NNN` string. It now also reads google-genai's int `.code` (its
+`.status` is a string enum), unwraps botocore's
+`ClientError.response["ResponseMetadata"]["HTTPStatusCode"]`, parses the
+stringified `429 RESOURCE_EXHAUSTED` form, and name-matches the AWS exception
+names (`ThrottlingException`, `ServiceQuotaExceededException`,
+`ModelNotReadyException`, …) that carry no status at all. This matters beyond
+quota: it is what makes Bedrock and Vertex throttling and overloads visible to
+the retry and fallback layers in the first place.
 
 **Per-user access control.** The chain is org-wide admin config, but access is
 per-user: at run time `resolve_fallback_chain` filters the chain through


### PR DESCRIPTION
The fallback chain only engaged on rate_limit/provider_error/network, and
those codes came almost entirely from an HTTP status parsed out of the
exception text. Two consequences: quota exhaustion was either mislabelled as
a transient rate limit (OpenAI insufficient_quota is a 429) or missed
outright, and Google and Bedrock failures never classified at all — botocore
keeps the status in a dict and google-genai puts a string enum on .status, so
every one of their errors, throttling and overload included, fell through to
'unknown' and was neither retried nor eligible for substitution.

Add a distinct 'quota' code covering OpenAI insufficient_quota, Anthropic
"credit balance is too low", Google RESOURCE_EXHAUSTED / billing
FAILED_PRECONDITION, Azure "exceeded your assigned quota", Bedrock
ServiceQuotaExceededException, and the 402 insufficient-credits that
OpenRouter/DeepSeek-style endpoints return. It is fallback-eligible but
deliberately not retryable — backoff cannot refill an allowance — trips the
circuit breaker at provider scope on the first failure, and holds a long
cooldown that a later transient failure cannot shorten, so a chain of three
models on one spent account no longer collects the same error three times.

Quota and rate limiting are separated by message markers because no provider
offers a reliable machine-readable one, and transient markers ("per minute",
"rate limit") deliberately win: Google reuses RESOURCE_EXHAUSTED and the word
"quota" for plain per-minute throttling, which should still be retried.

Status extraction now also reads google-genai's int .code, unwraps botocore's
ResponseMetadata.HTTPStatusCode, parses the stringified "429
RESOURCE_EXHAUSTED" form, and name-matches the AWS exception names that carry
no status at all. That is what makes Bedrock and Vertex throttling and
overloads visible to the retry and fallback layers in the first place.

Our own usage caps are explicitly excluded. UsageLimitExceeded also says
"quota exceeded", but there the provider is healthy and the org is out of
budget — substituting a model would only spend that budget somewhere else, so
those stay 'unknown': surfaced verbatim, never retried, never a fallback.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017gCBVC56kadntUtHwgazZu