### PR TITLE
Fix Postgres FK violation when deleting an agent used by a trigger webhook

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from uuid import UUID
 import uuid as uuid_module
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload, lazyload
@@ -25,6 +26,7 @@ from app.models.organization import Organization
 from app.models.user import User
 from app.models.user_connection_credentials import UserConnectionCredentials
 from app.models.user_connection_overlay import UserConnectionTable, UserConnectionColumn
+from app.models.webhook_data_source_association import webhook_data_source_association
 from app.schemas.data_source_registry import (
     resolve_client_class,
     list_available_data_sources,
@@ -622,6 +624,15 @@ class ConnectionService:
                     if len(ds.connections) == 1:
                         deleted_agent_names.append(ds.name)
                         logger.info(f"Deleting data source {ds.name} ({ds.id}) as it only has this connection")
+                        # Detach from trigger webhooks first. The M2M lives only
+                        # on Webhook.data_sources, so the ORM cascade below never
+                        # clears these rows and Postgres rejects the DELETE on
+                        # webhook_data_source_association_data_source_id_fkey.
+                        await db.execute(
+                            delete(webhook_data_source_association).where(
+                                webhook_data_source_association.c.data_source_id == ds.id
+                            )
+                        )
                         await db.delete(ds)
 
             await db.delete(connection)

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -86,6 +86,7 @@ from sqlalchemy.exc import IntegrityError
 from app.schemas.datasource_table_schema import DataSourceTableSchema
 from app.models.datasource_table import DataSourceTable  # Add this import at the top of the file
 from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable, UserDataSourceColumn as UserOverlayColumn
+from app.models.webhook_data_source_association import webhook_data_source_association
 
 from typing import List, Dict, Any, Optional
 from sqlalchemy.orm import selectinload, lazyload
@@ -1627,6 +1628,18 @@ class DataSourceService:
         )
         await db.execute(
             delete(UserDataSourceCredentials).where(UserDataSourceCredentials.data_source_id == data_source_id)
+        )
+
+        # 2b) Detach this agent from any trigger webhooks. The M2M is declared
+        #     only on the Webhook side (Webhook.data_sources), so the ORM has no
+        #     idea the secondary table points at us and leaves the rows behind —
+        #     Postgres then rejects the parent DELETE with
+        #     webhook_data_source_association_data_source_id_fkey. SQLite never
+        #     enforced the FK, which is why this only ever bit in production.
+        await db.execute(
+            delete(webhook_data_source_association).where(
+                webhook_data_source_association.c.data_source_id == data_source_id
+            )
         )
 
         # 3) Delete dependent metadata resources first (they FK both data source and jobs)

--- a/backend/tests/training/test_connection_agent_tools.py
+++ b/backend/tests/training/test_connection_agent_tools.py
@@ -437,6 +437,59 @@ async def test_agent_with_tool_overlays_can_be_deleted():
 
 
 @pytest.mark.asyncio
+async def test_agent_attached_to_trigger_webhook_can_be_deleted():
+    """Deleting an agent that a trigger webhook points at must clear the
+    webhook_data_source_association rows. The M2M is declared only on
+    Webhook.data_sources, so the ORM leaves them behind and Postgres rejects
+    the parent DELETE (webhook_data_source_association_data_source_id_fkey).
+    SQLite doesn't enforce the FK, so assert on the leftover rows directly."""
+    from app.services.data_source_service import DataSourceService
+    from app.models.webhook import Webhook
+    from app.models.webhook_data_source_association import webhook_data_source_association
+
+    ids = await _seed()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org"])
+        admin = await db.get(User, ids["admin"])
+        ctx = {"db": db, "organization": org, "user": admin}
+
+        ev = await _final(CreateAgentTool(), {
+            "name": f"Triggered {ids['suffix']}",
+            "connection_ids": [ids["conn_mcp"]],
+            "tools": ["get_*"],
+        }, ctx)
+        ds_id = ev.payload["output"]["data_source_id"]
+
+        wh = Webhook(
+            report_id=None,  # standalone trigger — the spawn-mode shape
+            organization_id=str(org.id),
+            user_id=str(admin.id),
+            name=f"Trigger {ids['suffix']}",
+            token=Webhook.generate_token(),
+        )
+        wh.set_secret(Webhook.generate_secret())
+        wh.data_sources = [await db.get(DataSource, ds_id)]
+        db.add(wh)
+        await db.commit()
+
+        assoc = webhook_data_source_association
+        assert (await db.execute(
+            select(assoc).where(assoc.c.data_source_id == ds_id)
+        )).all(), "setup must have linked the agent to the trigger"
+
+        await DataSourceService().delete_data_source(db, ds_id, org, admin)
+
+        assert (await db.execute(
+            select(DataSource).where(DataSource.id == ds_id)
+        )).scalar_one_or_none() is None
+        assert not (await db.execute(
+            select(assoc).where(assoc.c.data_source_id == ds_id)
+        )).all(), "association rows must not outlive the agent"
+        # The trigger itself survives — only the link is dropped.
+        assert await db.get(Webhook, wh.id) is not None
+
+
+@pytest.mark.asyncio
 async def test_instruction_after_create_agent_scopes_to_new_agent():
     """The keystone integration: an instruction created later in the SAME run
     (same ctx/report) attaches to the just-created agent, not org-wide."""


### PR DESCRIPTION
Deleting a data source (or the connection behind it) failed on Postgres with a foreign-key violation when the agent was attached to a trigger webhook:

```
update or delete on table "data_sources" violates foreign key constraint
"webhook_data_source_association_data_source_id_fkey" on table "webhook_data_source_association"
```

## Root cause

The M2M is declared **only** on `Webhook.data_sources` (`app/models/webhook.py:61-65`) — `DataSource` has no back-reference, so SQLAlchemy never knew the secondary table pointed at it and left the association rows behind. The FK created in `trig0001_trigger_webhooks.py:35-41` carries no `ON DELETE`, so Postgres rejected the parent `DELETE`.

`app/settings/database.py` sets `busy_timeout` / `journal_mode` / `synchronous` but never `PRAGMA foreign_keys=ON`, so SQLite doesn't enforce the constraint — which is why tests and local dev passed and this only ever surfaced in production. Same class of bug as the one already documented in `connection_service.py:588-598`.

## Changes

Both delete paths were affected; both are fixed by purging the association rows before the parent delete.

- **`app/services/data_source_service.py`** — new step 2b in `delete_data_source`. Its `IntegrityError` retry loop only re-cleared `datasource_tables`, so all 8 attempts failed and the request 500'd after ~5s of accumulated backoff.
- **`app/services/connection_service.py`** — same purge before `db.delete(ds)` for agents whose only connection is being removed. That path never routed through `delete_data_source`, so it needed its own fix.

The trigger itself survives; only the link is dropped.

## Tests

`tests/training/test_connection_agent_tools.py::test_agent_attached_to_trigger_webhook_can_be_deleted`, a sibling to the existing overlay-cascade case. Since SQLite doesn't enforce the FK, it asserts on the leftover association rows directly rather than expecting an `IntegrityError`, and checks the webhook survives.

- `tests/training/test_connection_agent_tools.py` + `tests/e2e/test_data_source.py` — 18 passed.
- Mutation-checked: with the `delete_data_source` purge disabled the new test fails with `association rows must not outlive the agent`; restored, it passes.

To find rows currently affected in an existing database:

```sql
SELECT ds.id, ds.name, w.id AS webhook_id, w.name AS trigger_name
FROM webhook_data_source_association a
JOIN data_sources ds ON ds.id = a.data_source_id
JOIN webhooks w ON w.id = a.webhook_id;
```

## Deliberately out of scope

- **No `ON DELETE CASCADE` migration.** The two service call-sites are the only places a `DataSource` is deleted, so this closes the bug. A DB-level cascade would be the durable belt-and-braces version, but `alembic/versions` currently resolves to multiple heads, so adding a revision is a larger change than this fix warrants.
- **Orphaned triggers.** A trigger that loses its last agent now stays active with no data sources attached, where it previously 500'd. Whether to deactivate such triggers is a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs6wfLZwSGbqAHRhSGtUd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qs6wfLZwSGbqAHRhSGtUd3)_