### PR TITLE
Let a SharePoint connection span every document library on the site

### DIFF
--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -79,9 +80,15 @@ class GraphDriveClient(DataSourceClient):
     @property
     def description(self) -> str:
         if self.mode == "sharepoint":
+            if self._all_libraries:
+                library = " / all document libraries"
+            elif self.drive_name:
+                library = f" / library {self.drive_name}"
+            else:
+                library = ""
             return (
                 f"SharePoint site {self.site_url}"
-                + (f" / library {self.drive_name}" if self.drive_name else "")
+                + library
                 + (f" / folder {self.folder_path}" if self.folder_path else "")
             )
         return "OneDrive" + (f" / folder {self.folder_path}" if self.folder_path else "")
@@ -142,6 +149,12 @@ class GraphDriveClient(DataSourceClient):
         # Cached IDs (resolved lazily)
         self._site_id: Optional[str] = None
         self._drive_id: Optional[str] = None
+        # Every drive this connection spans: [(drive_id, library_name), ...].
+        # One entry unless drive_name == '*' (all libraries on the site).
+        self._drives: Optional[List[tuple]] = None
+        # Per-drive scoped roots, keyed by drive id (folder_path resolves per
+        # library, and may legitimately be absent from some of them).
+        self._root_item_ids: Dict[str, str] = {}
         self._root_item_id: Optional[str] = None  # scoped root (after folder_path)
 
     # ------------------------------------------------------------------ auth
@@ -200,6 +213,22 @@ class GraphDriveClient(DataSourceClient):
             full = full[len(root):].strip("/")
         return full
 
+    def _library_name(self, drive_id: str) -> str:
+        for did, lib in (self._drives or []):
+            if did == drive_id:
+                return lib
+        return ""
+
+    def _scoped_path(self, drive_id: str, parent_path: Optional[str], name: str) -> str:
+        """Path as the LISTING presents it — library-prefixed when the
+        connection spans several libraries — so globs are matched against the
+        same string the user sees and writes patterns for."""
+        rel = self._rel_from_parent(parent_path, name)
+        if not self._all_libraries:
+            return rel
+        lib = self._library_name(drive_id)
+        return f"{lib}/{rel}" if lib and rel else (lib or rel)
+
     def _enforce_scope(self, rel_path: str) -> None:
         """Single access chokepoint: an in-drive but off-glob path is DENIED
         (not merely hidden), mirroring network_dir / s3."""
@@ -245,39 +274,84 @@ class GraphDriveClient(DataSourceClient):
         self._site_id = data["id"]
         return self._site_id
 
-    def _resolve_drive_id(self) -> str:
-        if self._drive_id:
-            return self._drive_id
+    @property
+    def _all_libraries(self) -> bool:
+        """True when the connection spans EVERY document library on the site.
+
+        Opted into with the ``*`` sentinel in ``drive_name``. A blank field keeps
+        the historical behaviour (the site's default library only) so existing
+        connections do not silently change shape — their indexed paths, globs and
+        catalog rows stay exactly as they were.
+        """
+        return self.mode != "onedrive" and (self.drive_name or "").strip() == "*"
+
+    def _resolve_drives(self) -> List[tuple]:
+        """Resolve the drives this connection spans as ``[(drive_id, name), ...]``.
+
+        One entry for OneDrive, for a named library, and for the default-library
+        case; every library on the site when ``drive_name == '*'``. Cached.
+        """
+        if self._drives is not None:
+            return self._drives
 
         if self.mode == "onedrive":
             data = self._get("/me/drive")
-            self._drive_id = data["id"]
-            return self._drive_id
+            self._drives = [(data["id"], data.get("name") or "OneDrive")]
+            return self._drives
 
         site_id = self._resolve_site_id()
+
+        if self._all_libraries:
+            data = self._get(f"/sites/{site_id}/drives")
+            drives = [(d["id"], d.get("name") or d["id"]) for d in data.get("value", [])]
+            if not drives:
+                raise ValueError("No document libraries found on site")
+            # Stable order so listings (and the 500-result cap) are deterministic.
+            self._drives = sorted(drives, key=lambda t: t[1].lower())
+            return self._drives
+
         if not self.drive_name:
             data = self._get(f"/sites/{site_id}/drive")
-            self._drive_id = data["id"]
-            return self._drive_id
+            self._drives = [(data["id"], data.get("name") or data["id"])]
+            return self._drives
 
         data = self._get(f"/sites/{site_id}/drives")
         for d in data.get("value", []):
             if d.get("name") == self.drive_name:
-                self._drive_id = d["id"]
-                return self._drive_id
+                self._drives = [(d["id"], d.get("name") or d["id"])]
+                return self._drives
         raise ValueError(f"Document library '{self.drive_name}' not found on site")
 
-    def _resolve_root_item_id(self) -> str:
-        if self._root_item_id:
+    def _resolve_drive_id(self) -> str:
+        """The primary drive — first of :meth:`_resolve_drives`.
+
+        Retained for single-drive call sites; multi-library paths must iterate
+        ``_resolve_drives()`` instead.
+        """
+        if self._drive_id:
+            return self._drive_id
+        self._drive_id = self._resolve_drives()[0][0]
+        return self._drive_id
+
+    def _resolve_root_item_id(self, drive_id: Optional[str] = None) -> str:
+        """Scoped root of a drive (``folder_path`` applied), cached per drive."""
+        if drive_id is None:
+            if self._root_item_id:
+                return self._root_item_id
+            drive_id = self._resolve_drive_id()
+            self._root_item_id = self._fetch_root_item_id(drive_id)
             return self._root_item_id
-        drive_id = self._resolve_drive_id()
+        if drive_id not in self._root_item_ids:
+            self._root_item_ids[drive_id] = self._fetch_root_item_id(drive_id)
+        return self._root_item_ids[drive_id]
+
+    def _fetch_root_item_id(self, drive_id: str) -> str:
         if not self.folder_path:
             data = self._get(f"/drives/{drive_id}/root")
         else:
             encoded = quote(self.folder_path)
             data = self._get(f"/drives/{drive_id}/root:/{encoded}")
-        self._root_item_id = data["id"]
-        return self._root_item_id
+        return data["id"]
 
     # ----------------------------------------------------------- enumeration
 
@@ -289,7 +363,6 @@ class GraphDriveClient(DataSourceClient):
             page = data.get("value", []) or []
             out.extend(page)
             url = data.get("@odata.nextLink")
-        import logging
         logging.getLogger(__name__).info(
             "graph_drive._list_children: drive=%s item=%s → %d entries "
             "(folders=%d files=%d)",
@@ -316,7 +389,11 @@ class GraphDriveClient(DataSourceClient):
             if self.include_globs and not path_matches_globs(path, self.include_globs):
                 continue
             results.append({
-                "id": entry["id"],
+                # Spanning several libraries makes a bare item id ambiguous —
+                # read_file would have to guess which drive to open it from.
+                # Qualify it so the id round-trips back to its own library.
+                # Single-library connections keep the plain id they always had.
+                "id": self._qualify_item_id(drive_id, entry["id"]),
                 "name": name,
                 "path": path,
                 "mime_type": (entry.get("file") or {}).get("mimeType"),
@@ -328,6 +405,27 @@ class GraphDriveClient(DataSourceClient):
             })
         return results
 
+    # ------------------------------------------------------- id qualification
+
+    def _qualify_item_id(self, drive_id: str, item_id: str) -> str:
+        """``drive_id|item_id`` when the connection spans several libraries.
+
+        Graph drive ids contain ``!`` and item ids are base64url, so ``|`` never
+        occurs in either and is a safe separator.
+        """
+        if not self._all_libraries:
+            return item_id
+        return f"{drive_id}|{item_id}"
+
+    @staticmethod
+    def _split_item_id(value: str) -> tuple:
+        """Split a qualified id back into ``(drive_id_or_None, item_id)``."""
+        if value and "|" in value:
+            did, _, iid = value.partition("|")
+            if did and iid:
+                return did, iid
+        return None, value
+
     # ---------------------------------------------------- public capabilities
 
     def list_files(self, folder_id: Optional[str] = None, recursive: Optional[bool] = None) -> List[dict]:
@@ -337,16 +435,34 @@ class GraphDriveClient(DataSourceClient):
         # The real enumeration runs per-user once a user completes OAuth.
         if self.mode == "onedrive" and not self._user_token_provided:
             return []
-        drive_id = self._resolve_drive_id()
-        item_id = folder_id or self._resolve_root_item_id()
         prev = self.recursive
         if recursive is not None:
             self.recursive = bool(recursive)
         try:
+            if self._all_libraries and not folder_id:
+                # Fan out across every library. Paths are prefixed with the
+                # library name so they stay unique (two libraries can both hold
+                # 'report.xlsx') and globs can address a specific library.
+                results = []
+                for did, lib in self._resolve_drives():
+                    try:
+                        root = self._resolve_root_item_id(did)
+                    except Exception as e:
+                        # folder_path need not exist in every library, and a
+                        # library can be inaccessible to this identity. Skip it
+                        # rather than failing the whole listing.
+                        logging.getLogger(__name__).info(
+                            "graph_drive: skipping library %r — %s", lib, str(e)[:200]
+                        )
+                        continue
+                    results.extend(self._walk(did, root, prefix=lib))
+                return results
+
+            drive_id = self._resolve_drive_id()
+            item_id = folder_id or self._resolve_root_item_id()
             results = self._walk(drive_id, item_id)
         finally:
             self.recursive = prev
-        import logging
         logging.getLogger(__name__).info(
             "graph_drive.list_files: mode=%s drive=%s root=%s recursive=%s "
             "ext_filter=%s → %d file(s)",
@@ -400,18 +516,60 @@ class GraphDriveClient(DataSourceClient):
         # Couldn't resolve — pass original through so Graph raises a clear 404.
         return file_id_or_name
 
+    def _locate(self, file_id: str) -> tuple:
+        """Resolve ``file_id`` to ``(drive_id, item_id)``.
+
+        Handles the three things a caller can hand us when the connection spans
+        several libraries:
+          1. a qualified ``drive|item`` id straight from list_files — routed
+             directly, no extra calls;
+          2. a bare item id — tried against each library in turn;
+          3. a filename (which the model passes often) — resolved per library
+             via the existing path-then-search fallback.
+        Single-library connections take the first branch's fast path unchanged.
+        """
+        qualified_drive, raw_id = self._split_item_id(file_id)
+        if qualified_drive:
+            return qualified_drive, raw_id
+
+        if not self._all_libraries:
+            drive_id = self._resolve_drive_id()
+            return drive_id, self._resolve_item_id(drive_id, raw_id)
+
+        # Unqualified id/filename against a multi-library connection: probe each
+        # library and keep the first that actually resolves to an item.
+        last_error: Optional[Exception] = None
+        for did, _lib in self._resolve_drives():
+            try:
+                candidate = self._resolve_item_id(did, raw_id)
+                # _resolve_item_id echoes the input back when it cannot resolve;
+                # confirm the item really lives in this drive before committing.
+                self._get(f"/drives/{did}/items/{candidate}")
+                return did, candidate
+            except Exception as e:
+                last_error = e
+                continue
+        if last_error is not None:
+            raise ValueError(
+                f"'{file_id}' was not found in any document library on this site "
+                f"({last_error})"
+            )
+        return self._resolve_drive_id(), raw_id
+
     def read_file(self, file_id: str, sheet: Optional[str] = None, max_bytes: Optional[int] = None, **_) -> Any:
-        drive_id = self._resolve_drive_id()
-        # The LLM frequently passes the filename (e.g. "Book 7.xlsx") where
-        # an opaque item id is expected; Graph rejects that with 400. Resolve
-        # filename → item id defensively before hitting /items/{id}.
-        resolved_id = self._resolve_item_id(drive_id, file_id)
+        # Routes to the owning library AND resolves a filename → item id (the
+        # LLM frequently passes "Book 7.xlsx" where an opaque id is expected,
+        # which Graph rejects with 400).
+        drive_id, resolved_id = self._locate(file_id)
         meta = self._get(f"/drives/{drive_id}/items/{resolved_id}")
         name = meta.get("name", "")
         # Access boundary: enforce the connection's glob scope BEFORE fetching
         # bytes. We already hold the item metadata (parentReference + name), so
         # this costs no extra round-trip. An in-drive but off-glob item is denied.
-        self._enforce_scope(self._rel_from_parent((meta.get("parentReference") or {}).get("path"), name))
+        # Across libraries the listed paths carry a library prefix, so the path
+        # checked here must carry it too or the globs would be matched against a
+        # different string than the one the user wrote them for.
+        self._enforce_scope(self._scoped_path(drive_id, (meta.get("parentReference") or {}).get("path"), name))
         ext = _ext(name)
         content = self._get_bytes(f"/drives/{drive_id}/items/{resolved_id}/content")
         if max_bytes and len(content) > max_bytes:
@@ -491,9 +649,21 @@ class GraphDriveClient(DataSourceClient):
         return quote(cleaned, safe="")
 
     def search_files(self, query: str, **_) -> List[dict]:
-        drive_id = self._resolve_drive_id()
         encoded = self._search_term(query)
-        data = self._get(f"/drives/{drive_id}/root/search(q='{encoded}')")
+        results = []
+        for drive_id, _lib in self._resolve_drives():
+            try:
+                data = self._get(f"/drives/{drive_id}/root/search(q='{encoded}')")
+            except Exception as e:
+                # One unreadable library must not fail a site-wide search.
+                logging.getLogger(__name__).info(
+                    "graph_drive: search skipped library %r — %s", _lib, str(e)[:200]
+                )
+                continue
+            results.extend(self._search_hits(drive_id, data))
+        return results
+
+    def _search_hits(self, drive_id: str, data: dict) -> List[dict]:
         results = []
         for entry in data.get("value", []):
             if "folder" in entry:
@@ -502,7 +672,7 @@ class GraphDriveClient(DataSourceClient):
                 continue
             # Drive-wide search can return hits outside the connection's scoped
             # root / globs — keep only in-scope results.
-            rel = self._rel_from_parent((entry.get("parentReference") or {}).get("path"), entry.get("name", ""))
+            rel = self._scoped_path(drive_id, (entry.get("parentReference") or {}).get("path"), entry.get("name", ""))
             root = (self.folder_path or "").strip("/")
             if root:
                 pr = (entry.get("parentReference") or {}).get("path") or ""
@@ -513,7 +683,7 @@ class GraphDriveClient(DataSourceClient):
             if self.include_globs and not path_matches_globs(rel, self.include_globs):
                 continue
             results.append({
-                "id": entry["id"],
+                "id": self._qualify_item_id(drive_id, entry["id"]),
                 "name": entry.get("name"),
                 # The clean root-relative path (same shape as list_files),
                 # NOT the raw Graph parentReference ("/drives/b!…/root:/…")
@@ -553,8 +723,18 @@ class GraphDriveClient(DataSourceClient):
 
             if self._user_token_provided:
                 # We have a user token — exercise the real read path.
-                self._resolve_drive_id()
-                self._resolve_root_item_id()
+                drives = self._resolve_drives()
+                self._resolve_root_item_id(drives[0][0])
+                if self._all_libraries:
+                    names = ", ".join(n for _, n in drives[:5])
+                    more = f" (+{len(drives) - 5} more)" if len(drives) > 5 else ""
+                    return {
+                        "success": True,
+                        "message": (
+                            f"Connected. Indexing {len(drives)} document "
+                            f"librar{'y' if len(drives) == 1 else 'ies'}: {names}{more}."
+                        ),
+                    }
                 return {"success": True, "message": "Connected"}
 
             if self.mode == "sharepoint":

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -1731,15 +1731,26 @@ class SharePointConfig(BaseModel):
         json_schema_extra={"ui:type": "string"}
     )
     drive_name: Optional[str] = Field(
-        None,
+        "*",
         title="Document Library",
-        description="Name of the document library (drive) on the site. Leave blank to use the site's default Documents library.",
+        description=(
+            "Document library (drive) to index. Use '*' for ALL libraries on the "
+            "site — listed paths are then prefixed with the library name "
+            "(e.g. 'Policies/2026/handbook.pdf'). Name a single library to "
+            "restrict the connection to it, or leave blank for the site's "
+            "default Documents library only."
+        ),
         json_schema_extra={"ui:type": "string"}
     )
     folder_path: Optional[str] = Field(
         None,
         title="Folder Path",
-        description="Optional folder path within the drive to scope the connection (e.g. 'Reports/2025'). The efficient server-side base; leave blank for the root.",
+        description=(
+            "Optional folder path within the library to scope the connection "
+            "(e.g. 'Reports/2025'). The efficient server-side base; leave blank "
+            "for the root. With '*' it is applied inside each library, and "
+            "libraries that do not contain it are skipped."
+        ),
         json_schema_extra={"ui:type": "string"}
     )
     include_globs: Optional[str] = Field(

--- a/backend/tests/unit/test_graph_drive_multi_library.py
+++ b/backend/tests/unit/test_graph_drive_multi_library.py
@@ -1,0 +1,189 @@
+"""A SharePoint connection must be able to span EVERY document library on a site.
+
+Before this, `_resolve_drive_id` returned exactly one drive:
+`GET /sites/{id}/drive` (the site's DEFAULT library) when the Document Library
+field was blank, or the single library whose `name` matched when it was set.
+There was no code path that unioned libraries, so a site whose content is spread
+across several libraries surfaced only one of them — reported live as "4 files
+instead of thousands", while other (single-library) sites looked fine.
+
+Opting in with `drive_name='*'`:
+  - listing/search fan out across every library;
+  - paths are prefixed with the library name so they stay unique and globs can
+    address one library;
+  - ids are qualified `drive|item` so read_file routes back to the owning
+    library — a bare item id is ambiguous once several drives are in play.
+
+Blank keeps the historical single-default-library behaviour so existing
+connections do not silently change shape.
+
+Run:
+    cd backend && python -m pytest tests/unit/test_graph_drive_multi_library.py -v
+"""
+import pytest
+
+from app.data_sources.clients.graph_drive_client import GRAPH_BASE, GraphDriveClient
+
+
+SITE = "contoso.sharepoint.com,site-guid,web-guid"
+
+# Two libraries; 'Policies' holds a nested file, mirroring the real shape.
+GRAPH = {
+    "/sites/contoso.sharepoint.com:/sites/hr": {"id": SITE},
+    f"/sites/{SITE}/drive": {"id": "drv-docs", "name": "Documents"},
+    f"/sites/{SITE}/drives": {"value": [
+        {"id": "drv-docs", "name": "Documents"},
+        {"id": "drv-pol", "name": "Policies"},
+    ]},
+    "/drives/drv-docs/root": {"id": "root-docs"},
+    "/drives/drv-pol/root": {"id": "root-pol"},
+    "/drives/drv-docs/items/root-docs/children?$top=200": {"value": [
+        {"id": "d1", "name": "budget.xlsx", "file": {"mimeType": "x"}, "size": 1},
+    ]},
+    "/drives/drv-pol/items/root-pol/children?$top=200": {"value": [
+        {"id": "p1", "name": "code_of_conduct.pdf", "file": {"mimeType": "y"}, "size": 2},
+        {"id": "f1", "name": "2026", "folder": {}},
+    ]},
+    "/drives/drv-pol/items/f1/children?$top=200": {"value": [
+        {"id": "p2", "name": "handbook.pdf", "file": {"mimeType": "y"}, "size": 3},
+    ]},
+}
+
+
+def _client(drive_name, **kw):
+    c = GraphDriveClient(
+        site_url="https://contoso.sharepoint.com/sites/hr",
+        drive_name=drive_name, mode="sharepoint", access_token="tok",
+        recursive=True, **kw,
+    )
+    calls = []
+
+    def _get(path, **_ignored):
+        # _list_children passes an absolute URL; everything else passes a path.
+        key = path[len(GRAPH_BASE):] if path.startswith(GRAPH_BASE) else path
+        calls.append(key)
+        if key in GRAPH:
+            return GRAPH[key]
+        raise ValueError(f"Graph {key} → 404 not found")
+
+    c._get = _get
+    c._calls = calls
+    return c
+
+
+# --------------------------------------------------------------- listing
+
+def test_all_libraries_lists_every_library():
+    files = _client("*").list_files()
+    assert sorted(f["name"] for f in files) == [
+        "budget.xlsx", "code_of_conduct.pdf", "handbook.pdf",
+    ], "every library on the site must be walked"
+
+
+def test_paths_are_prefixed_with_the_library_name():
+    paths = sorted(f["path"] for f in _client("*").list_files())
+    assert paths == [
+        "Documents/budget.xlsx",
+        "Policies/2026/handbook.pdf",
+        "Policies/code_of_conduct.pdf",
+    ], "two libraries may hold the same filename — paths must stay unique"
+
+
+def test_ids_are_qualified_so_reads_can_be_routed():
+    by_name = {f["name"]: f for f in _client("*").list_files()}
+    assert by_name["handbook.pdf"]["id"] == "drv-pol|p2"
+    assert by_name["budget.xlsx"]["id"] == "drv-docs|d1"
+
+
+def test_a_library_that_cannot_be_read_is_skipped_not_fatal():
+    c = _client("*")
+    real = c._get
+
+    def _get(path, **kw):
+        if path == "/drives/drv-docs/root":
+            raise ValueError("Graph … → 403 accessDenied")
+        return real(path, **kw)
+
+    c._get = _get
+    names = [f["name"] for f in c.list_files()]
+    assert "code_of_conduct.pdf" in names, "the readable library must still list"
+    assert "budget.xlsx" not in names
+
+
+# ------------------------------------------------- single-library regression
+
+def test_blank_keeps_the_default_library_only():
+    c = _client(None)
+    files = c.list_files()
+    assert [f["name"] for f in files] == ["budget.xlsx"]
+    assert f"/sites/{SITE}/drives" not in c._calls, (
+        "a blank field must not enumerate libraries — existing connections "
+        "keep hitting /sites/{id}/drive"
+    )
+
+
+def test_blank_leaves_paths_and_ids_untouched():
+    f = _client(None).list_files()[0]
+    assert f["path"] == "budget.xlsx", "no library prefix for single-library connections"
+    assert f["id"] == "d1", "ids stay plain so existing catalog rows keep resolving"
+
+
+def test_named_library_still_selects_exactly_one():
+    files = _client("Policies").list_files()
+    assert sorted(f["name"] for f in files) == ["code_of_conduct.pdf", "handbook.pdf"]
+    assert all(not f["path"].startswith("Policies/") for f in files), (
+        "an explicitly named single library needs no prefix"
+    )
+
+
+def test_unknown_library_name_still_errors():
+    with pytest.raises(ValueError, match="not found on site"):
+        _client("Nope").list_files()
+
+
+# --------------------------------------------------------------- read routing
+
+def test_qualified_id_routes_to_its_own_library():
+    c = _client("*")
+    assert c._locate("drv-pol|p2") == ("drv-pol", "p2")
+    assert c._locate("drv-docs|d1") == ("drv-docs", "d1")
+
+
+def test_bare_id_is_probed_across_libraries():
+    """The model does not always echo back the qualified id."""
+    c = _client("*")
+    GRAPH["/drives/drv-pol/items/p2"] = {"id": "p2", "name": "handbook.pdf"}
+    try:
+        assert c._locate("p2") == ("drv-pol", "p2")
+    finally:
+        GRAPH.pop("/drives/drv-pol/items/p2", None)
+
+
+def test_unresolvable_id_names_the_site_not_one_drive():
+    c = _client("*")
+    with pytest.raises(ValueError, match="not found in any document library"):
+        c._locate("nope-id")
+
+
+# ------------------------------------------------------------- glob scoping
+
+def test_globs_match_the_library_prefixed_path():
+    files = _client("*", include_globs="Policies/**").list_files()
+    assert sorted(f["name"] for f in files) == ["code_of_conduct.pdf", "handbook.pdf"], (
+        "globs must be matched against the same path the listing shows"
+    )
+
+
+def test_scoped_path_used_for_enforcement_carries_the_prefix():
+    c = _client("*")
+    c._resolve_drives()  # populate the drive→library map
+    rel = c._scoped_path("drv-pol", "/drives/drv-pol/root:/2026", "handbook.pdf")
+    assert rel == "Policies/2026/handbook.pdf", (
+        "read_file enforces globs on this path — it must match the listed one"
+    )
+
+
+def test_scoped_path_unprefixed_for_single_library():
+    c = _client(None)
+    c._resolve_drives()
+    assert c._scoped_path("drv-docs", "/drives/drv-docs/root:/", "budget.xlsx") == "budget.xlsx"


### PR DESCRIPTION
## The bug

A SharePoint connection could only ever read **one** document library. `_resolve_drive_id` returned:

```python
if not self.drive_name:
    data = self._get(f"/sites/{site_id}/drive")   # ← the site's DEFAULT library
...
for d in self._get(f"/sites/{site_id}/drives")["value"]:
    if d.get("name") == self.drive_name:          # ← plural endpoint, but picks exactly ONE
```

No code path unioned libraries. A site whose content is spread across several of them surfaced only one — reported live as **"4 files instead of thousands"**, while other sites (everything in `Documents`) looked fine.

## The change — opt in with `drive_name = '*'`

- **`_resolve_drives()`** replaces the single cached drive id and returns `[(drive_id, library_name), ...]`. `list_files` and `search_files` fan out across all of them. A library that's inaccessible to this identity, or that lacks the configured `folder_path`, is **skipped with a log line** rather than failing the whole listing.
- **Paths are prefixed with the library name** — `Policies/2026/handbook.pdf` — so they stay unique (two libraries can both hold `report.xlsx`) and a glob can address one library.
- **Ids are qualified `drive|item`.** This is the part that's easy to miss: a bare item id is ambiguous once several drives are in play, and `read_file` would open it against the default drive and 404. `_locate()` routes a qualified id directly, and falls back to probing each library for a bare id *or a filename* — which the model passes often, and is precisely why `_resolve_item_id` already exists.
- **Glob enforcement now compares the prefixed path** via `_scoped_path`, so patterns are matched against the same string the listing showed. Without it, `read_file`'s scope check would silently compare a different path than the one the globs were written for.

## Backwards compatibility

**Blank keeps the historical single-default-library behaviour** — same paths, same ids, same catalog rows, same globs, and it still doesn't call `/sites/{id}/drives` at all (asserted in a test).

Only the config schema's **default** flips to `'*'`. That reaches **new connections only**: `_resolve_client_by_type` hands the client the *raw stored config dict* rather than a re-validated Pydantic model, so existing stored blanks stay blank. New connections pick it up through the form's schema-default prefill (`ConnectForm.vue:461`).

This was deliberate — flipping blank→all would have silently expanded every existing connection's scope, renamed every indexed path (breaking `include_globs`), and churned `DataSourceTable` rows that per-user overlays link to by id.

## Verification

**Live, against a real SharePoint site:**

| mode | result |
|---|---|
| blank | `Connected` · `drives=['Documents']` · 10 files · ids plain (`01GSDIVN…`) · paths unprefixed · `read_file` → DataFrame · `search_files('2017')` → 2 hits, unprefixed — **byte-identical to before** |
| `'*'` | `Connected. Indexing 1 document library: Documents.` · enumerated via `/drives` · paths `Documents/…` · ids qualified (`b!70h6q4xB…\|…`) · **`read_file` round-trips the qualified id** → DataFrame · search hits prefixed |

**Limitation, stated plainly:** the sandbox tenant has exactly **one** library on every site, and Graph refuses to let us create another (`403 accessDenied`, `Sites.Manage.All` not consented). So true fan-out across ≥2 libraries is covered by deterministic unit tests against a stubbed Graph, not live. Everything else — drive enumeration, prefixing, id qualification, read routing — *is* exercised live.

**Tests** — `tests/unit/test_graph_drive_multi_library.py`, 14 cases: fan-out, path prefixing, id qualification, read routing (qualified id / bare id / unresolvable), glob scoping against prefixed paths, unreadable-library skip, and single-library regressions asserting paths, ids and the call pattern are untouched.

```
tests/unit/test_graph_drive_multi_library.py
tests/unit/test_graph_drive_search_term.py
tests/unit/test_graph_mail_test_connection.py
tests/e2e/test_connection.py                    53 passed
```

One incidental fix: two function-local `import logging` statements shadowed the new module-level import. The unreadable-library test caught the resulting `UnboundLocalError`.

## Known adjacent gaps (not in this PR)

- **Subsites** are still never traversed — no `/sites/{id}/sites` walk exists, so a site collection's subsites remain invisible.
- **SharePoint lists** (`/sites/{id}/lists`) are still unsupported; they're tabular, not files, so they need their own shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VA96mXyFPiL432iyG3nf6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA96mXyFPiL432iyG3nf6j)_