### PR TITLE
Surface the Outlook web link on listed and searched emails

### DIFF
--- a/backend/app/ai/tools/implementations/email_tools.py
+++ b/backend/app/ai/tools/implementations/email_tools.py
@@ -79,9 +79,12 @@ class ReadEmailTool(ReadFileTool):
                 "attach it to the conversation. Pass the message id (from "
                 "`list_emails` or `search_email`) as `file_id`, and the mailbox "
                 "connection as `connection_id`. Returns the message headers "
-                "(subject, from, to, date) plus the body as plain text, so you "
-                "can quote and analyse it directly. USE THIS — not read_file — "
-                "to open a message surfaced by list_emails / search_email."
+                "(subject, from, to, date, and a `Link:` line with the message's "
+                "URL in Gmail or Outlook on the web) plus the body as plain "
+                "text, so you can quote and analyse it directly — cite the "
+                "`Link:` URL when pointing the user at the message, never the "
+                "opaque id. USE THIS — not read_file — to open a message "
+                "surfaced by list_emails / search_email."
             ),
             category="research",
             input_schema=ReadFileInput.model_json_schema(),

--- a/backend/app/data_sources/clients/gmail_mail_client.py
+++ b/backend/app/data_sources/clients/gmail_mail_client.py
@@ -245,11 +245,16 @@ class GmailMailClient(DataSourceClient):
         else:
             body = str(message.get("snippet") or "").strip()
 
+        # Same header-block link as the Outlook client: read_email backs both
+        # mailboxes, so a message opened from Gmail has to carry its permalink
+        # too. _web_url falls back to the message id when threadId is absent,
+        # so this line is always populated here.
         return (
             f"Subject: {headers.get('subject') or '(no subject)'}\n"
             f"From: {headers.get('from', '')}\n"
             f"To: {headers.get('to', '')}\n"
-            f"Date: {headers.get('date', '')}\n\n"
+            f"Date: {headers.get('date', '')}\n"
+            f"Link: {self._web_url(message)}\n\n"
             f"{body}"
         )
 

--- a/backend/app/data_sources/clients/graph_mail_client.py
+++ b/backend/app/data_sources/clients/graph_mail_client.py
@@ -4,7 +4,7 @@ Reuses GraphDriveClient's Entra OAuth (delegated per-user + service-principal
 fallback) and HTTP plumbing. Message payloads reuse the file transport while
 the client advertises distinct mail capabilities:
 
-  list_emails  -> recent messages (id, subject, from, received)
+  list_emails  -> recent messages (id, subject, from, received, web link)
   search_email -> Graph $search over messages
   read_email   -> the message rendered as plain text (headers + body)
 
@@ -50,6 +50,12 @@ class GraphMailClient(GraphDriveClient):
             "mime_type": "message/rfc822",
             "from": self._addr(m.get("from")),
             "modified_at": m.get("receivedDateTime"),
+            # Graph's own deep link to the message in Outlook on the web. Carried
+            # through FileEntry.web_url by list_files/search_files, so the agent
+            # can cite a message the user can actually click through to — the
+            # opaque Graph id is useless outside a tool call. GmailMailClient
+            # already does this; this keeps the two mailboxes at parity.
+            "web_url": m.get("webLink"),
         }
 
     def list_files(self, folder_id: Optional[str] = None, recursive: Optional[bool] = None) -> List[dict]:
@@ -61,14 +67,16 @@ class GraphMailClient(GraphDriveClient):
         if not getattr(self, "_user_token_provided", True):
             return []
         data = self._get(
-            "/me/messages?$top=25&$select=id,subject,from,receivedDateTime"
+            "/me/messages?$top=25&$select=id,subject,from,receivedDateTime,webLink"
             "&$orderby=receivedDateTime%20desc"
         )
         return [self._msg_to_item(m) for m in (data.get("value") or [])]
 
     def search_files(self, query: str, **_) -> List[dict]:
         q = urllib.parse.quote(f'"{query}"')
-        data = self._get(f"/me/messages?$search={q}&$top=25&$select=id,subject,from,receivedDateTime")
+        data = self._get(
+            f"/me/messages?$search={q}&$top=25&$select=id,subject,from,receivedDateTime,webLink"
+        )
         return [self._msg_to_item(m) for m in (data.get("value") or [])]
 
     def read_file(self, file_id: str, **_) -> Any:

--- a/backend/app/data_sources/clients/graph_mail_client.py
+++ b/backend/app/data_sources/clients/graph_mail_client.py
@@ -6,7 +6,7 @@ the client advertises distinct mail capabilities:
 
   list_emails  -> recent messages (id, subject, from, received, web link)
   search_email -> Graph $search over messages
-  read_email   -> the message rendered as plain text (headers + body)
+  read_email   -> the message rendered as plain text (headers + link + body)
 
 The shared execution layer still materializes message bodies as session files
 when needed, but the planner and the user see email vocabulary throughout.
@@ -82,7 +82,7 @@ class GraphMailClient(GraphDriveClient):
     def read_file(self, file_id: str, **_) -> Any:
         m = self._get(
             f"/me/messages/{file_id}"
-            "?$select=subject,from,toRecipients,receivedDateTime,body,bodyPreview"
+            "?$select=subject,from,toRecipients,receivedDateTime,body,bodyPreview,webLink"
         )
         frm = self._addr(m.get("from"))
         to = ", ".join(self._addr(r) for r in (m.get("toRecipients") or []))
@@ -92,9 +92,19 @@ class GraphMailClient(GraphDriveClient):
             content = strip_html(content)
         header = (
             f"Subject: {m.get('subject') or '(no subject)'}\n"
-            f"From: {frm}\nTo: {to}\nDate: {m.get('receivedDateTime') or ''}\n\n"
+            f"From: {frm}\nTo: {to}\nDate: {m.get('receivedDateTime') or ''}\n"
         )
-        return header + content
+        # The link rides in the header block rather than a structured output
+        # field because read_file returns rendered TEXT — that text is what
+        # reaches the model, what the observation excerpts, and what the
+        # cross-turn digest snapshots. A sibling field on ReadFileOutput would
+        # need a new client-to-tool channel and would still be invisible in all
+        # three. Omitted entirely when Graph doesn't serve one, so the model
+        # never sees an empty `Link:` and cites it as a dead URL.
+        link = m.get("webLink")
+        if link:
+            header += f"Link: {link}\n"
+        return header + "\n" + content
 
     # Email has no pre-indexed admin catalog — it's searched/read live per user.
     def get_schemas(self, *args, **kwargs) -> List:

--- a/backend/tests/unit/test_gmail_mail_client.py
+++ b/backend/tests/unit/test_gmail_mail_client.py
@@ -135,6 +135,27 @@ def test_read_email_prefers_plain_text_across_nested_multipart_payloads():
     assert "HTML version" not in content
 
 
+def test_read_email_header_block_carries_the_message_permalink():
+    # A read that only rendered Subject/From/To/Date left the model holding an
+    # opaque message id, so it could summarize a message and not point the user
+    # at it. The link goes in the header text (not a sibling output field)
+    # because the rendered text is what the model, the observation excerpt and
+    # the cross-turn digest all actually see.
+    message = _metadata("m1")
+    message["payload"].update(
+        {"mimeType": "text/plain", "body": {"data": _b64url("Body text")}}
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=message)
+
+    content = _client(handler).read_file("m1")
+
+    assert "Link: https://mail.google.com/mail/u/0/#all/thread-m1" in content
+    # The link must not displace the body or collide with the headers.
+    assert content.index("Date:") < content.index("Link:") < content.index("Body text")
+
+
 def test_read_email_uses_clean_html_fallback_when_plain_text_is_absent():
     message = _metadata("m2", "HTML only")
     message["payload"].update(

--- a/backend/tests/unit/test_graph_mail_test_connection.py
+++ b/backend/tests/unit/test_graph_mail_test_connection.py
@@ -209,6 +209,31 @@ def test_searched_messages_carry_the_outlook_web_link():
     assert any("webLink" in c for c in calls), "search must select the link too, not just list"
 
 
+def test_read_email_header_block_carries_the_message_permalink():
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        return dict(MESSAGE, body={"contentType": "text", "content": "Body text"})
+
+    content = _client(_get, user_token=True).read_file("AAMk-opaque")
+    assert f"Link: {MESSAGE['webLink']}" in content
+    assert any("webLink" in c for c in calls), "the read must select the link too"
+    # The link belongs with the headers, above the body — not spliced into it.
+    assert content.index("Date:") < content.index("Link:") < content.index("Body text")
+
+
+def test_read_email_omits_the_link_line_when_graph_serves_none():
+    # An empty `Link:` would read as a citable URL to the model and resolve to
+    # nothing for the user. Better to have no line at all.
+    def _get(path):
+        return {"subject": "No link", "body": {"contentType": "text", "content": "Body text"}}
+
+    content = _client(_get, user_token=True).read_file("1")
+    assert "Link:" not in content
+    assert content.startswith("Subject: No link") and content.endswith("Body text")
+
+
 def test_a_message_without_a_web_link_still_lists():
     # Graph omits webLink on some items (drafts synced oddly, mocked responses).
     # A missing link is not a listing failure — FileEntry.web_url is Optional.

--- a/backend/tests/unit/test_graph_mail_test_connection.py
+++ b/backend/tests/unit/test_graph_mail_test_connection.py
@@ -167,3 +167,53 @@ def test_list_files_still_reads_the_mailbox_with_a_delegated_token():
     items = _client(_get, user_token=True).list_files()
     assert len(items) == 1 and items[0]["name"] == "Hello"
     assert any("/me/messages" in c for c in calls)
+
+
+# --- a listed message must carry a link the user can click ------------------
+#
+# The listing only ever exposed the opaque Graph id, which is addressable by
+# read_email but useless to a human: the agent could name a message and had no
+# way to point at it. Graph serves `webLink` (Outlook on the web deep link) on
+# the message resource, and FileEntry.web_url already carries it end to end —
+# it just was never selected or mapped. GmailMailClient has done this all along.
+
+MESSAGE = {
+    "id": "AAMk-opaque",
+    "subject": "Q3 invoice",
+    "receivedDateTime": "2026-07-26T00:00:00Z",
+    "webLink": "https://outlook.office365.com/owa/?ItemID=AAMk-opaque&viewmodel=ReadMessageItem",
+}
+
+
+def test_listed_messages_carry_the_outlook_web_link():
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        return {"value": [MESSAGE]}
+
+    items = _client(_get, user_token=True).list_files()
+    assert items[0]["web_url"] == MESSAGE["webLink"]
+    assert any("webLink" in c for c in calls), "the link has to be requested in $select to come back"
+
+
+def test_searched_messages_carry_the_outlook_web_link():
+    calls = []
+
+    def _get(path):
+        calls.append(path)
+        return {"value": [MESSAGE]}
+
+    items = _client(_get, user_token=True).search_files("invoice")
+    assert items[0]["web_url"] == MESSAGE["webLink"]
+    assert any("webLink" in c for c in calls), "search must select the link too, not just list"
+
+
+def test_a_message_without_a_web_link_still_lists():
+    # Graph omits webLink on some items (drafts synced oddly, mocked responses).
+    # A missing link is not a listing failure — FileEntry.web_url is Optional.
+    def _get(path):
+        return {"value": [{"id": "1", "subject": "No link"}]}
+
+    items = _client(_get, user_token=True).list_files()
+    assert items[0]["web_url"] is None and items[0]["name"] == "No link"


### PR DESCRIPTION
Outlook mail listings exposed only the opaque Graph message id. That id is
addressable by read_email but useless to a human, so the agent could name a
message it found and had no way to point the user at it.

Graph serves `webLink` (the Outlook on the web deep link) on the message
resource, and FileEntry.web_url already carries the field end to end through
list_files/search_files — it was simply never requested in $select nor mapped
in _msg_to_item. GmailMailClient has populated web_url all along, so Outlook
mailboxes were the odd one out.

Request webLink on the list and search calls and map it onto web_url. Missing
links stay None: Graph omits webLink on some items and FileEntry.web_url is
Optional, so an absent link must not fail the listing.

Body-level links (hrefs inside the message HTML, which strip_html drops) are a
separate concern and unchanged here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011A38xaM2FJHn2P4NGP5QJp