### PR TITLE
Inline MCP tool schemas in context; validate arguments locally

### DIFF
--- a/backend/app/ai/agents/planner/planner_v3.py
+++ b/backend/app/ai/agents/planner/planner_v3.py
@@ -87,6 +87,34 @@ from .planner_state_v3 import PlannerStateV3
 from .prompt_builder_v3 import PromptBuilderV3
 
 
+def _dump_planner_input(v3_input) -> None:
+    """Append the exact system / user / tools payload to BOW_PLANNER_DUMP_FILE.
+
+    Diagnostic only, off unless the env var is set. This is the ground truth for
+    "what did the planner actually see" — the alternative is inferring it from
+    the builder, which is what let the missing MCP schemas go unnoticed.
+    """
+    import os
+
+    path = os.environ.get("BOW_PLANNER_DUMP_FILE")
+    if not path:
+        return
+    try:
+        import json as _json
+        from datetime import datetime, timezone
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(_json.dumps({
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "system": v3_input.system,
+                "messages": v3_input.messages,
+                "tools": v3_input.tools,
+            }, default=str) + "\n")
+    except Exception:
+        pass
+
+
 class PlannerV3:
     """Native tool_use planner. Mirrors PlannerV2's I/O contract.
 
@@ -124,6 +152,7 @@ class PlannerV3:
         thinking: Optional[dict] = None,
     ) -> AsyncIterator[PlannerEvent]:
         v3_input = self.prompt_builder.build(planner_input)
+        _dump_planner_input(v3_input)
 
         state = PlannerStateV3(
             input=v3_input,

--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -24,6 +24,11 @@ _OBS_KEEP_KEYS = {
     # Preserve the small sampled preview (kept by the observation builder's
     # compaction) so older create_data results stay referenceable.
     "data_preview",
+    # A tool's argument schema, carried by search_mcps results and by failed
+    # execute_mcp calls. Dropping it was silently deleting the only copy of the
+    # argument shape from context after _RECENT_OBS_FULL calls, leaving the
+    # agent to re-guess or pay for another discovery round trip.
+    "input_schema",
 }
 
 class PromptBuilder:
@@ -580,6 +585,12 @@ CRITICAL: assistant_message and final_answer are mutually exclusive. Never set b
                 for key in _OBS_KEEP_KEYS:
                     if key in inner:
                         minified[key] = inner[key]
+                # For a FAILED call, keep the arguments that were sent. Without
+                # them the agent can see that something failed but not what it
+                # tried, so it has nothing to diff against and re-issues the
+                # same broken call. Successful calls don't need this.
+                if inner.get("success") is False and obs.get("tool_input") is not None:
+                    minified["tool_input"] = obs.get("tool_input")
                 result.append(minified)
             else:
                 result.append(obs)

--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -262,6 +262,17 @@ PLAN TYPE GUIDANCE
 - If the user's message is a greeting/thanks/farewell, do not call any tool; respond briefly.
 - Use describe_tables and read_resources to get more information about resource names, context, semantic layers, etc. before the next step.
 - When MCP connections are attached, their servers may expose business rules/definitions/schemas as MCP resources (URIs like 'pulse://rules'). Use list_mcp_resources to discover them, then read_mcp_resource to fetch a resource's content BEFORE querying. (read_resources only covers indexed dbt/LookML/docs, not MCP resource URIs.)
+
+MCP / EXTERNAL API TOOLS (when <mcp_tools> is present in context)
+- execute_mcp invokes a tool on a connected MCP server or custom API; pass `connection_id`, `tool_name`, and `arguments`.
+- **If a tool's <tool> entry already lists <arg> elements, that IS its complete argument schema — call execute_mcp directly. Do NOT call search_mcps first; it would return the same information and waste a turn.** Only use search_mcps when the tool you need has no <arg> elements shown, or is not listed at all.
+- `arguments` is validated against the tool's real schema before the call goes out, so match the declared types exactly:
+  - An arg typed "string" takes a STRING even when its content is JSON — serialize the JSON into a string rather than passing an object. Vendors like monday and Jira use this shape for column/field maps.
+  - An arg typed "integer" takes a NUMBER — a unix epoch is `1740787200`, not `"2026-03-01"`.
+  - An arg with `enum=` takes one of exactly those values; integer enums are numbers, not labels.
+  - An arg containing nested <arg> elements is an OBJECT with that inner shape; one containing <item> is an ARRAY of objects, not an array of strings.
+- Omit optional arguments you have no value for rather than passing null or an empty string.
+- Flow: execute_mcp → (optional: write_csv) → create_data for visualization. Tabular results are auto-saved as CSV files that create_data can load.
 - Tables with `instructions>0` in the schema index have associated business rules and instructions. Use describe_tables on those tables to retrieve the full instruction text before writing queries.
 - Not every organization instruction is force-loaded: <available_instructions> and <available_skills> list additional ones by short id + title only. Scan them for entries relevant to the request and call read_instruction with the short_id to load the full text BEFORE writing queries or building output. If you suspect a rule exists but nothing listed matches, call search_instructions.
 - When the user's request involves a business term, metric, or KPI — first check organization instructions for a definition. If found, use it (read_instruction if it's only listed in <available_instructions>). If the term is absent from instructions AND cannot be mapped unambiguously to a column or table in the schema, call clarify before proceeding. Never invent a definition.

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -598,6 +598,19 @@ class SchemaContextBuilder:
                 effective = resolve_effective_policy(admin_policy, user_prefs.get(str(t.id)))
                 if effective == "deny":
                     continue
+                # Carry the argument schema through, minus admin-locked
+                # metadata fields (server-injected — the model must never see
+                # them as arguments it can set).
+                visible_schema = None
+                try:
+                    import json as _json
+                    from app.services.mcp_context_injection import filter_locked_from_schema
+                    _cfg = getattr(t.connection, 'config', None)
+                    if isinstance(_cfg, str):
+                        _cfg = _json.loads(_cfg)
+                    visible_schema = filter_locked_from_schema(t.input_schema, _cfg or {})
+                except Exception:
+                    visible_schema = t.input_schema
                 items.append(
                     MCPToolItem(
                         name=t.name,
@@ -605,6 +618,7 @@ class SchemaContextBuilder:
                         connection_id=str(t.connection_id),
                         connection_name=getattr(t.connection, 'name', None),
                         policy=effective,
+                        input_schema=visible_schema if isinstance(visible_schema, dict) else None,
                     )
                 )
             return items

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -39,6 +39,12 @@ class MCPToolItem(BaseModel):
     # Effective execution policy for the run's user (allow | ask | auto).
     # deny tools are excluded from context entirely.
     policy: Optional[str] = None
+    # The tool's declared JSON Schema, admin-locked fields already stripped.
+    # Carried so <mcp_tools> can render the argument shape inline instead of
+    # sending the agent on a search_mcps round trip for it. The block is
+    # rebuilt every turn, so a schema here never ages out of context — unlike
+    # a search_mcps observation, which past-observation compaction minifies.
+    input_schema: Optional[dict] = None
 
 
 class FileScopeItem(BaseModel):
@@ -184,6 +190,11 @@ class TablesSchemaContext(ContextSection):
         # Below this many files, list them inline (cheap + lets the agent pick
         # directly); above it, emit only scope + sample + topics.
         _FILE_INLINE_THRESHOLD: ClassVar[int] = 15
+
+        # Below this many MCP/custom-API tools, inline each tool's argument
+        # schema in <mcp_tools>; above it the block would dominate the prompt
+        # every turn, so those connections keep the search_mcps discovery hop.
+        _MCP_INLINE_SCHEMA_MAX: ClassVar[int] = 40
 
         # Short, human-readable explanations of each agent (data source)
         # publishing-status value so the planner understands what the status
@@ -343,6 +354,12 @@ class TablesSchemaContext(ContextSection):
                 key = tool.connection_id or 'default'
                 groups[key].append(tool)
 
+            # Inline argument schemas when the catalog is small enough to
+            # afford it. Above the threshold the block would dominate the
+            # prompt every turn, so those fall back to search_mcps discovery.
+            total_tools = sum(len(v) for v in groups.values())
+            inline_schemas = total_tools <= self._MCP_INLINE_SCHEMA_MAX
+
             conn_parts = []
             has_gated = False
             for conn_id, tools in groups.items():
@@ -354,20 +371,43 @@ class TablesSchemaContext(ContextSection):
                     if policy and policy != "allow":
                         policy_attr = f' policy="{xml_escape(policy)}"'
                         has_gated = True
-                    tool_xmls.append(f'<tool name="{xml_escape(t.name)}"{policy_attr}>{desc}</tool>')
+                    args_xml = ""
+                    if inline_schemas and getattr(t, "input_schema", None):
+                        try:
+                            from app.ai.tools.mcp_schema import resolve_refs, render_schema_xml
+                            args_xml = render_schema_xml(resolve_refs(t.input_schema))
+                        except Exception:
+                            args_xml = ""
+                    if args_xml:
+                        body = (desc + "\n" if desc else "") + args_xml
+                        tool_xmls.append(
+                            f'<tool name="{xml_escape(t.name)}"{policy_attr}>\n{body}\n</tool>'
+                        )
+                    else:
+                        tool_xmls.append(f'<tool name="{xml_escape(t.name)}"{policy_attr}>{desc}</tool>')
                 conn_name = tools[0].connection_name or 'unknown'
                 conn_attrs = {"name": conn_name, "type": "mcp"}
                 if conn_id != 'default':
                     conn_attrs["id"] = conn_id
                 conn_parts.append(xml_tag("connection", "\n".join(tool_xmls), conn_attrs))
-            # Only tool names + descriptions are listed above — not argument
-            # schemas. Tell the agent to fetch the exact schema before calling,
-            # so it doesn't guess argument names and burn turns on failed calls.
-            conn_parts.append(
-                "<note>Only tool names and descriptions are shown above, not their argument schemas. "
-                "Call search_mcps to get a tool's full input schema (exact argument names and types) "
-                "before calling execute_mcp — do not guess arguments.</note>"
-            )
+            if inline_schemas:
+                # Schemas are right here, every turn. Say so explicitly —
+                # otherwise the agent defensively calls search_mcps before each
+                # execute_mcp anyway, which is a wasted planner turn plus a
+                # wasted tool round trip per call.
+                conn_parts.append(
+                    "<note>The <arg> elements above ARE each tool's full argument schema — name, type, "
+                    "requiredness, enums and nested shape. They are authoritative and always current, so "
+                    "call execute_mcp directly; do NOT call search_mcps first. Match the declared type "
+                    "exactly: an arg typed \"string\" takes a string even when its content is JSON "
+                    "(serialize it), and an arg typed \"integer\" takes a number, not a formatted date.</note>"
+                )
+            else:
+                conn_parts.append(
+                    "<note>Only tool names and descriptions are shown above, not their argument schemas. "
+                    "Call search_mcps to get a tool's full input schema (exact argument names and types) "
+                    "before calling execute_mcp — do not guess arguments.</note>"
+                )
             if has_gated:
                 conn_parts.append(
                     '<note>Tools marked policy="ask" pause the run for the user to approve the call '

--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -241,6 +241,32 @@ Do not use when:
                     return
                 yield ev
 
+        # Validate arguments against the tool's own schema BEFORE going to the
+        # network. We already hold the schema locally, so a shape error costs
+        # nothing to catch here — whereas the remote equivalent costs a full
+        # round trip and comes back as a vendor string that usually doesn't name
+        # the offending field. The failure payload carries the schema, so the
+        # agent gets the mismatch and the correct shape in one observation.
+        if tool_input_schema:
+            from app.ai.tools.mcp_schema import validate_arguments
+
+            ok, arg_errors = validate_arguments(data.arguments, tool_input_schema)
+            if not ok:
+                logger.info(
+                    "execute_mcp: local schema validation rejected %s: %s",
+                    data.tool_name, "; ".join(arg_errors),
+                )
+                yield ToolEndEvent(
+                    type="tool.end",
+                    payload=self._failure_payload(
+                        data.tool_name,
+                        "Arguments do not match the tool's input schema — "
+                        + "; ".join(arg_errors),
+                        tool_input_schema,
+                    ),
+                )
+                return
+
         # Construct client and call tool
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "calling_tool"})
 
@@ -727,19 +753,28 @@ Do not use when:
         """
         err = error or "Unknown error"
         summary = f"Tool '{tool_name}' failed: {err}"
+        resolved = input_schema
         if input_schema:
-            props = (input_schema.get("properties") or {}) if isinstance(input_schema, dict) else {}
-            required = input_schema.get("required") or [] if isinstance(input_schema, dict) else []
-            if props:
-                def _fmt(name: str) -> str:
-                    spec = props.get(name) or {}
-                    typ = spec.get("type") or "any"
-                    return f"{name}*:{typ}" if name in required else f"{name}:{typ}"
-                arg_list = ", ".join(_fmt(n) for n in props.keys())
-                summary += f". Valid arguments for '{tool_name}': {{{arg_list}}} (* = required). Retry with these argument names."
+            # Render the FULL shape, not one flat level: nested objects, array
+            # item shape and enums are exactly where the agent goes wrong, and a
+            # flattened "columnValues:string" hint tells it nothing about what
+            # belongs inside. $refs are inlined first, since a bare
+            # {"$ref": "#/$defs/X"} is unreadable at the point of use.
+            try:
+                from app.ai.tools.mcp_schema import resolve_refs, render_schema_xml
+
+                resolved = resolve_refs(input_schema)
+                args_xml = render_schema_xml(resolved)
+                if args_xml:
+                    summary += (
+                        f". The full argument schema for '{tool_name}' is:\n{args_xml}\n"
+                        "Retry with arguments matching these names and types exactly."
+                    )
+            except Exception:
+                resolved = input_schema
         return {
-            "output": {"success": False, "error_message": err, "input_schema": input_schema},
-            "observation": {"summary": summary, "success": False, "input_schema": input_schema},
+            "output": {"success": False, "error_message": err, "input_schema": resolved},
+            "observation": {"summary": summary, "success": False, "input_schema": resolved},
         }
 
     async def _materialize_to_csv(self, data: list, tool_name: str, runtime_ctx: dict):

--- a/backend/app/ai/tools/mcp_schema.py
+++ b/backend/app/ai/tools/mcp_schema.py
@@ -1,0 +1,194 @@
+"""Shared helpers for turning a raw MCP tool input schema into something an
+LLM can actually follow, and for checking arguments against it locally.
+
+Two jobs:
+
+``resolve_refs``
+    Inline ``$ref``/``$defs`` indirection. MCP servers built on
+    zod-to-json-schema (monday, Linear, Notion, Sentry) routinely emit
+    ``{"$ref": "#/$defs/Foo"}``. That is fine for a validator but useless to a
+    model reading the schema as text — it has to chase a pointer through a JSON
+    blob. Inlining puts the real shape at the point of use.
+
+``render_schema_xml``
+    Render a resolved schema as compact XML for the ``<mcp_tools>`` context
+    block. Deliberately not raw JSON: the block is rebuilt every turn, so it has
+    to stay cheap. Types, requiredness, enums and nested shape survive;
+    descriptions are kept only where they carry real information.
+
+``validate_arguments``
+    Check arguments against the tool's own schema *before* the network call, and
+    return path-qualified errors. A local failure is instant and precise; the
+    remote equivalent costs a round trip and usually comes back as a vendor
+    string that does not name the offending field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+# Guard against pathological / self-referential schemas.
+_MAX_DEPTH = 12
+
+
+def resolve_refs(schema: Any, _defs: Optional[Dict[str, Any]] = None, _depth: int = 0) -> Any:
+    """Inline local ``$ref`` pointers against ``$defs`` / ``definitions``.
+
+    Only local pointers (``#/$defs/X``, ``#/definitions/X``) are resolved;
+    anything else is left alone. Recursion is depth-capped, and a ref that
+    cannot be resolved is left as-is rather than dropped — losing a field
+    silently would be worse than showing the model a pointer.
+    """
+    if _depth > _MAX_DEPTH:
+        return schema
+    if isinstance(schema, list):
+        return [resolve_refs(item, _defs, _depth + 1) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    defs = dict(_defs or {})
+    for key in ("$defs", "definitions"):
+        if isinstance(schema.get(key), dict):
+            defs.update(schema[key])
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        name = None
+        for prefix in ("#/$defs/", "#/definitions/"):
+            if ref.startswith(prefix):
+                name = ref[len(prefix):]
+                break
+        target = defs.get(name) if name else None
+        if target is None:
+            return schema
+        merged = resolve_refs(target, defs, _depth + 1)
+        # Sibling keywords (description, default) win over the target's.
+        siblings = {k: v for k, v in schema.items() if k != "$ref"}
+        if siblings and isinstance(merged, dict):
+            merged = {**merged, **resolve_refs(siblings, defs, _depth + 1)}
+        return merged
+
+    out: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key in ("$defs", "definitions"):
+            continue  # inlined above; no longer needed downstream
+        out[key] = resolve_refs(value, defs, _depth + 1)
+    return out
+
+
+def _type_of(spec: Dict[str, Any]) -> str:
+    t = spec.get("type")
+    if isinstance(t, list):
+        return "|".join(str(x) for x in t)
+    if t:
+        return str(t)
+    for key in ("anyOf", "oneOf", "allOf"):
+        if isinstance(spec.get(key), list):
+            parts = [_type_of(s) for s in spec[key] if isinstance(s, dict)]
+            parts = [p for p in parts if p and p != "any"]
+            if parts:
+                return "|".join(dict.fromkeys(parts))
+    return "any"
+
+
+def render_schema_xml(schema: Any, indent: str = "  ", _depth: int = 0) -> str:
+    """Render a resolved schema as nested ``<arg>`` elements.
+
+    Emits name, type, requiredness, enum, and — for the shapes that actually
+    trip agents up — nested object properties and array item shape.
+    """
+    from app.ai.context.sections.base import xml_escape
+
+    if not isinstance(schema, dict) or _depth > _MAX_DEPTH:
+        return ""
+    props = schema.get("properties")
+    if not isinstance(props, dict) or not props:
+        return ""
+    required = set(schema.get("required") or [])
+
+    lines: List[str] = []
+    for name, spec in props.items():
+        if not isinstance(spec, dict):
+            continue
+        attrs = [f'name="{xml_escape(str(name))}"', f'type="{xml_escape(_type_of(spec))}"']
+        if name in required:
+            attrs.append('required="true"')
+        enum = spec.get("enum")
+        if isinstance(enum, list) and enum:
+            rendered = ",".join(str(e) for e in enum[:12])
+            attrs.append(f'enum="{xml_escape(rendered)}"')
+        pattern = spec.get("pattern")
+        if isinstance(pattern, str):
+            attrs.append(f'pattern="{xml_escape(pattern)}"')
+
+        desc = spec.get("description")
+        desc_txt = xml_escape(str(desc)) if isinstance(desc, str) and desc.strip() else ""
+
+        inner = ""
+        if spec.get("type") == "object":
+            inner = render_schema_xml(spec, indent, _depth + 1)
+        elif spec.get("type") == "array" and isinstance(spec.get("items"), dict):
+            items = spec["items"]
+            item_inner = render_schema_xml(items, indent, _depth + 1)
+            if item_inner:
+                inner = f"{indent * (_depth + 1)}<item type=\"object\">\n{item_inner}\n{indent * (_depth + 1)}</item>"
+            else:
+                attrs.append(f'items="{xml_escape(_type_of(items))}"')
+
+        pad = indent * (_depth + 1)
+        open_tag = f"{pad}<arg {' '.join(attrs)}>"
+        if inner:
+            body = (desc_txt + "\n" if desc_txt else "") + inner
+            lines.append(f"{open_tag}\n{body}\n{pad}</arg>")
+        elif desc_txt:
+            lines.append(f"{open_tag}{desc_txt}</arg>")
+        else:
+            lines.append(f"{pad}<arg {' '.join(attrs)}/>")
+    return "\n".join(lines)
+
+
+def validate_arguments(
+    arguments: Any, input_schema: Any
+) -> Tuple[bool, List[str]]:
+    """Validate ``arguments`` against a tool's declared input schema.
+
+    Returns ``(ok, errors)`` where each error is path-qualified
+    (``columnValues: expected string, got object``). Never raises: an
+    unusable schema means "cannot validate", which is reported as OK so a
+    malformed schema can't block an otherwise-fine call.
+    """
+    if not isinstance(input_schema, dict) or not input_schema:
+        return True, []
+    if not isinstance(arguments, dict):
+        return False, ["<root>: arguments must be an object"]
+
+    try:
+        from jsonschema import Draft202012Validator
+    except Exception:
+        return True, []
+
+    try:
+        validator = Draft202012Validator(input_schema)
+        errors = sorted(validator.iter_errors(arguments), key=lambda e: list(e.absolute_path))
+    except Exception:
+        # A schema the validator itself rejects — do not block the call.
+        return True, []
+
+    out: List[str] = []
+    for err in errors[:12]:
+        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        msg = err.message
+        # jsonschema's phrasing is verbose; the type mismatch is the common
+        # case and reads better tightened up.
+        if err.validator == "type":
+            expected = err.validator_value
+            expected = "|".join(expected) if isinstance(expected, list) else expected
+            got = type(err.instance).__name__
+            got = {
+                "dict": "object", "list": "array", "str": "string",
+                "int": "integer", "float": "number", "bool": "boolean",
+                "NoneType": "null",
+            }.get(got, got)
+            msg = f"expected {expected}, got {got}"
+        out.append(f"{path}: {msg}")
+    return (not out), out

--- a/backend/tests/mocks/complex_schema_mcp_server.py
+++ b/backend/tests/mocks/complex_schema_mcp_server.py
@@ -1,0 +1,450 @@
+"""A real streamable-HTTP MCP server with 10 deliberately hard tool schemas.
+
+This is the **oracle** for the MCP argument-fidelity feedback loop. Unlike
+``echo_mcp_http_server`` (one trivial tool, proves headers travel), every tool
+here reproduces a schema shape that real MCP servers use and that agents get
+wrong: JSON-encoded string fields, integer enums, ``$ref``/``$defs`` nesting,
+unix-timestamp integers, arrays of objects, pattern-constrained strings.
+
+Each call is validated against the tool's declared JSON Schema *server-side* and
+recorded to ``MOCK_MCP_CAPTURE_FILE`` as one JSONL line:
+
+    {"tool", "arguments", "valid", "violations": [{"path", "message"}], "ts"}
+
+That file is the score sheet: "first-call argument validity" is just the
+fraction of first-attempt calls per tool with ``valid == true``. Invalid calls
+come back as ``isError`` with a vendor-flavored message (terse on purpose — real
+servers do not hand you a corrected schema).
+
+Run standalone::
+
+    MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_calls.jsonl \
+        uv run python tests/mocks/complex_schema_mcp_server.py --port 3334
+
+Then point a ``type=mcp`` connection at ``http://localhost:3334/mcp``
+(transport ``streamable_http``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+_CAPTURE_FILE = os.environ.get("MOCK_MCP_CAPTURE_FILE")
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+#
+# Every schema below is hand-written (not derived from type hints) so the exact
+# wire shape is under test — including the `$ref`/`$defs` indirection that
+# zod-to-json-schema servers emit and that a text-rendered schema loses.
+# ---------------------------------------------------------------------------
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        # FAILURE MODE: JSON-encoded string. The classic monday.com case — the
+        # field is a *string* whose content is JSON, not an object.
+        "name": "board_change_column_values",
+        "description": "Change multiple column values of a board item. Returns the updated item.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "boardId": {"type": "string", "description": "The board's unique identifier."},
+                "itemId": {"type": "string", "description": "The item's unique identifier."},
+                "columnValues": {
+                    "type": "string",
+                    "description": "The column values to update, keyed by column id.",
+                },
+                "createLabelsIfMissing": {
+                    "type": "boolean",
+                    "description": "Create status/dropdown labels that do not exist yet.",
+                    "default": False,
+                },
+            },
+            "required": ["boardId", "itemId", "columnValues"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: integer enum (not a string label) + $ref to a nested def.
+        "name": "issue_create",
+        "description": "Create a new issue in a team's backlog.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "teamId": {"type": "string"},
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "priority": {
+                    "type": "integer",
+                    "enum": [0, 1, 2, 3, 4],
+                    "description": "0=None, 1=Urgent, 2=High, 3=Normal, 4=Low.",
+                },
+                "labelIds": {"type": "array", "items": {"type": "string"}},
+                "estimate": {"$ref": "#/$defs/Estimate"},
+            },
+            "required": ["teamId", "title", "priority"],
+            "additionalProperties": False,
+            "$defs": {
+                "Estimate": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "unit": {"type": "string", "enum": ["points", "hours", "days"]},
+                    },
+                    "required": ["value", "unit"],
+                    "additionalProperties": False,
+                }
+            },
+        },
+    },
+    {
+        # FAILURE MODE: nested object whose inner field is a constrained enum,
+        # plus a bounded integer.
+        "name": "search_workspace",
+        "description": "Search pages and databases across the workspace.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "property": {"type": "string", "enum": ["object"]},
+                        "value": {"type": "string", "enum": ["page", "database"]},
+                    },
+                    "required": ["property", "value"],
+                    "additionalProperties": False,
+                },
+                "pageSize": {"type": "integer", "minimum": 1, "maximum": 100, "default": 25},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: pattern-constrained string that LOOKS like a free-form
+        # duration, plus an enum that overlaps with common natural phrasings.
+        "name": "find_errors",
+        "description": "Find errors in a project over a rolling stats window.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "organizationSlug": {"type": "string"},
+                "projectSlug": {"type": "string"},
+                "statsPeriod": {
+                    "type": "string",
+                    "pattern": "^[0-9]+[hd]$",
+                    "description": "Rolling window, digits followed by h or d. e.g. '24h', '14d'.",
+                },
+                "sortBy": {"type": "string", "enum": ["last_seen", "first_seen", "count", "userCount"]},
+            },
+            "required": ["organizationSlug", "projectSlug", "statsPeriod"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: second JSON-encoded string field, different vendor
+        # flavour (Atlassian `fields`).
+        "name": "jira_edit_issue",
+        "description": "Edit fields on an existing Jira issue.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "issueIdOrKey": {"type": "string"},
+                "fields": {
+                    "type": "string",
+                    "description": "The issue fields to set.",
+                },
+                "notifyUsers": {"type": "boolean", "default": True},
+            },
+            "required": ["issueIdOrKey", "fields"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: unix-epoch INTEGERS where a model reaches for ISO dates.
+        "name": "metrics_query",
+        "description": "Query a timeseries of metrics over a time range.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Metric query, e.g. 'avg:system.cpu.user{*}'."},
+                "from": {"type": "integer", "description": "Start of the range."},
+                "to": {"type": "integer", "description": "End of the range."},
+            },
+            "required": ["query", "from", "to"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: two levels of $ref/$defs indirection.
+        "name": "contact_upsert",
+        "description": "Create or update a CRM contact record.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+                "displayName": {"type": "string"},
+                "address": {"$ref": "#/$defs/Address"},
+            },
+            "required": ["email", "displayName"],
+            "additionalProperties": False,
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "line1": {"type": "string"},
+                        "city": {"type": "string"},
+                        "countryCode": {"type": "string", "pattern": "^[A-Z]{2}$"},
+                        "geo": {"$ref": "#/$defs/Geo"},
+                    },
+                    "required": ["line1", "city", "countryCode"],
+                    "additionalProperties": False,
+                },
+                "Geo": {
+                    "type": "object",
+                    "properties": {"lat": {"type": "number"}, "lng": {"type": "number"}},
+                    "required": ["lat", "lng"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    },
+    {
+        # FAILURE MODE: array of objects, each with its own required keys —
+        # models commonly flatten this to an array of strings.
+        "name": "analytics_run_report",
+        "description": "Run an analytics report over dimensions and metrics.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "propertyId": {"type": "string"},
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                        "additionalProperties": False,
+                    },
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                        "additionalProperties": False,
+                    },
+                },
+                "dateRanges": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "startDate": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+                            "endDate": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+                        },
+                        "required": ["startDate", "endDate"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["propertyId", "metrics"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        # FAILURE MODE: array items behind a $ref, with a discriminated shape.
+        "name": "records_batch_update",
+        "description": "Apply a batch of record operations atomically.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tableId": {"type": "string"},
+                "operations": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"$ref": "#/$defs/Operation"},
+                },
+            },
+            "required": ["tableId", "operations"],
+            "additionalProperties": False,
+            "$defs": {
+                "Operation": {
+                    "type": "object",
+                    "properties": {
+                        "op": {"type": "string", "enum": ["set", "delete"]},
+                        "recordId": {"type": "string"},
+                        "field": {"type": "string"},
+                        "value": {"type": "string"},
+                    },
+                    "required": ["op", "recordId"],
+                    "additionalProperties": False,
+                }
+            },
+        },
+    },
+    {
+        # FAILURE MODE: JSON-encoded string payload + pattern-constrained key.
+        "name": "workflow_trigger",
+        "description": "Trigger a workflow run with a payload.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workflowId": {"type": "string"},
+                "payload": {
+                    "type": "string",
+                    "description": "The run payload.",
+                },
+                "idempotencyKey": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]{8,32}$",
+                    "description": "Lowercase alphanumeric, 8-32 chars.",
+                },
+            },
+            "required": ["workflowId", "payload", "idempotencyKey"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+TOOLS_BY_NAME = {t["name"]: t for t in TOOLS}
+
+
+# ---------------------------------------------------------------------------
+# Validation + capture
+# ---------------------------------------------------------------------------
+
+def _violations(tool_name: str, arguments: dict[str, Any]) -> list[dict[str, str]]:
+    """Validate arguments against the tool's declared schema."""
+    from jsonschema import Draft202012Validator
+
+    schema = TOOLS_BY_NAME[tool_name]["inputSchema"]
+    validator = Draft202012Validator(schema)
+    out: list[dict[str, str]] = []
+    for err in sorted(validator.iter_errors(arguments), key=lambda e: list(e.absolute_path)):
+        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        out.append({"path": path, "message": err.message})
+    return out
+
+
+def _capture(record: dict[str, Any]) -> None:
+    if not _CAPTURE_FILE:
+        return
+    try:
+        directory = os.path.dirname(_CAPTURE_FILE)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(_CAPTURE_FILE, "a") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")
+    except Exception:
+        pass
+
+
+def _success_payload(tool_name: str, arguments: dict[str, Any]) -> Any:
+    """A plausible success result. Content is irrelevant to the metric —
+    what matters is that a valid call is clearly distinguishable from an
+    invalid one in the transcript."""
+    return {
+        "ok": True,
+        "tool": tool_name,
+        "echo": arguments,
+        "note": "arguments validated against the declared input schema",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+server = Server("complex-schema-mock")
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name=t["name"],
+            description=t["description"],
+            inputSchema=t["inputSchema"],
+        )
+        for t in TOOLS
+    ]
+
+
+# validate_input=False is essential: the SDK's default handler validates against
+# inputSchema and short-circuits BEFORE our function runs, so invalid calls would
+# never be captured — and invalid calls are the entire measurement. We take over
+# validation so every attempt, valid or not, lands in the capture file.
+@server.call_tool(validate_input=False)
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.ContentBlock]:
+    arguments = arguments or {}
+
+    if name not in TOOLS_BY_NAME:
+        _capture({
+            "tool": name, "arguments": arguments, "valid": False,
+            "violations": [{"path": "<root>", "message": "unknown tool"}],
+            "ts": datetime.now(timezone.utc).isoformat(),
+        })
+        raise ValueError(f"Unknown tool: {name}")
+
+    violations = _violations(name, arguments)
+    _capture({
+        "tool": name,
+        "arguments": arguments,
+        "valid": not violations,
+        "violations": violations,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    })
+
+    if violations:
+        # Deliberately terse and vendor-flavoured: a real server tells you
+        # something is wrong, not how to fix it. This is what makes the
+        # recovery loop expensive.
+        first = violations[0]
+        raise ValueError(f"400 Bad Request: invalid value for '{first['path']}'")
+
+    return [types.TextContent(type="text", text=json.dumps(_success_payload(name, arguments)))]
+
+
+def build_app():
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    manager = StreamableHTTPSessionManager(app=server, json_response=False, stateless=True)
+
+    async def handle(scope, receive, send):
+        await manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        async with manager.run():
+            yield
+
+    return Starlette(routes=[Mount("/mcp", app=handle)], lifespan=lifespan)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=3334)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    import uvicorn
+
+    uvicorn.run(build_app(), host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/mocks/mcp_argument_fidelity_eval.py
+++ b/backend/tests/mocks/mcp_argument_fidelity_eval.py
@@ -1,0 +1,299 @@
+"""MCP argument-fidelity eval — drives the real agent against the
+complex-schema mock MCP server and scores what it put on the wire.
+
+Ten prompts, one per mock tool, each phrased the way a user actually would —
+in natural language, never naming argument names or types. The mock server is
+the oracle: it validates each call against the tool's declared JSON Schema and
+records every attempt. The headline metric is **first-call validity**: did the
+agent's FIRST attempt at a given tool satisfy the schema?
+
+Usage (from backend/, with the mock server running on :3334)::
+
+    BOW_DATABASE_URL='sqlite:///db/app.db' \
+    MOCK_MCP_CAPTURE_FILE=/tmp/bow-agent/mcp_calls.jsonl \
+    BOW_PLANNER_DUMP_FILE=/tmp/bow-agent/ctx_before.jsonl \
+        uv run python tests/mocks/mcp_argument_fidelity_eval.py --label before
+
+Writes a scored JSON report to /tmp/bow-agent/report_<label>.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+
+import httpx
+
+BASE = "http://localhost:8000/api"
+SEED = "/tmp/bow-agent/seed.json"
+
+# One prompt per tool. Deliberately natural: no argument names, no type hints —
+# the agent must get the shape from the schema, which is exactly what is under
+# test. Each names the tool's *purpose* so tool selection isn't the variable.
+CASES: list[dict[str, str]] = [
+    {
+        "tool": "board_change_column_values",
+        "prompt": "On board 7788 in MockOps, set item 4455's status column (id 'status3') to Done and its text column (id 'text5') to 'Reviewed'. Use the board column update tool.",
+    },
+    {
+        "tool": "issue_create",
+        "prompt": "Create an issue in MockOps for team 'team_abc' titled 'Fix login redirect', with urgent priority, estimated at 3 points.",
+    },
+    {
+        "tool": "search_workspace",
+        "prompt": "Search the MockOps workspace for 'quarterly planning', restricted to pages only, and give me 10 results.",
+    },
+    {
+        "tool": "find_errors",
+        "prompt": "In MockOps, find errors for organization 'acme' project 'checkout' over the last 24 hours, sorted by how many users were affected.",
+    },
+    {
+        "tool": "jira_edit_issue",
+        "prompt": "In MockOps, edit Jira issue PROJ-142: change the summary to 'Checkout timeout on mobile' and add the label 'urgent'. Don't notify anyone.",
+    },
+    {
+        "tool": "metrics_query",
+        "prompt": "In MockOps, query the metric 'avg:system.cpu.user{*}' for the period from midnight on 1 March 2026 to midnight on 2 March 2026 UTC.",
+    },
+    {
+        "tool": "contact_upsert",
+        "prompt": "In MockOps, upsert a contact: email dana@acme.io, display name 'Dana Reed', address 12 King St, London, United Kingdom.",
+    },
+    {
+        "tool": "analytics_run_report",
+        "prompt": "In MockOps, run an analytics report on property '9911' for the metrics 'activeUsers' and 'sessions', broken down by the 'country' dimension, for March 2026.",
+    },
+    {
+        "tool": "records_batch_update",
+        "prompt": "In MockOps, on table 'tbl_99', set field 'owner' to 'dana' on record 'rec_1', and delete record 'rec_2'. Do it as one batch.",
+    },
+    {
+        "tool": "workflow_trigger",
+        "prompt": "In MockOps, trigger workflow 'wf_nightly' with a payload saying region is 'emea' and dryRun is true. Use idempotency key 'nightly2026a'.",
+    },
+]
+
+
+# A single prompt that forces MANY sequential MCP calls in one agent run.
+#
+# This is the scenario the per-case suite above cannot reach. With one task per
+# report the agent calls search_mcps and then execute_mcp one turn later, so the
+# schema is sitting verbatim in <last_observation> and argument fidelity is easy.
+# Real sessions are not like that. Here the schemas are fetched ONCE at the top
+# and then have to survive nine more tool observations — past the
+# _RECENT_OBS_FULL=5 window, after which _compact_past_observations strips
+# observation["tools"] (not in _OBS_KEEP_KEYS) down to a bare summary line.
+#
+# The tools are ordered so the hardest shapes (JSON-encoded strings, unix
+# epochs, $ref arrays) land LAST, i.e. furthest from the schema.
+PRESSURE_PROMPT = (
+    "Using MockOps, work through this checklist in order, one tool call at a time. "
+    "Do not stop until all nine are done.\n"
+    "1. Search the workspace for 'quarterly planning', pages only, 10 results.\n"
+    "2. Find errors for organization 'acme' project 'checkout' over the last 24 hours, sorted by user count.\n"
+    "3. Create an issue for team 'team_abc' titled 'Fix login redirect', urgent priority, estimated 3 points.\n"
+    "4. Upsert a contact: email dana@acme.io, display name 'Dana Reed', address 12 King St, London, United Kingdom.\n"
+    "5. Run an analytics report on property '9911' for metrics 'activeUsers' and 'sessions', by 'country', for March 2026.\n"
+    "6. On board 7788, set item 4455's status column (id 'status3') to Done and text column (id 'text5') to 'Reviewed'.\n"
+    "7. Edit Jira issue PROJ-142: summary to 'Checkout timeout on mobile', add label 'urgent', don't notify.\n"
+    "8. Query metric 'avg:system.cpu.user{*}' from midnight 1 March 2026 to midnight 2 March 2026 UTC.\n"
+    "9. On table 'tbl_99', set field 'owner' to 'dana' on record 'rec_1' and delete record 'rec_2', as one batch.\n"
+)
+
+PRESSURE_EXPECTED = [
+    "search_workspace", "find_errors", "issue_create", "contact_upsert",
+    "analytics_run_report", "board_change_column_values", "jira_edit_issue",
+    "metrics_query", "records_batch_update",
+]
+
+
+def load_seed() -> dict:
+    """Load seeded ids and mint a FRESH token.
+
+    The dev JWT secret is regenerated per backend process, so a token stored at
+    seed time is dead after any restart — re-authenticate instead of reusing it.
+    """
+    with open(SEED) as f:
+        seed = json.load(f)
+    r = httpx.post(
+        f"{BASE}/auth/jwt/login",
+        data={"username": seed["email"], "password": "TestPassword123!"},
+        timeout=60.0,
+    )
+    r.raise_for_status()
+    seed["token"] = r.json()["access_token"]
+    return seed
+
+
+def headers(seed: dict) -> dict:
+    return {
+        "Authorization": f"Bearer {seed['token']}",
+        "X-Organization-Id": seed["org_id"],
+    }
+
+
+def run_case(c: httpx.Client, seed: dict, case: dict, timeout_s: int = 240) -> dict:
+    """Create a fresh report per case (isolated context) and run one turn."""
+    H = headers(seed)
+    r = c.post("/reports", headers=H, json={
+        "title": f"eval-{case['tool']}",
+        "data_sources": [seed["ds_id"]],
+    })
+    r.raise_for_status()
+    report_id = r.json()["id"]
+
+    r = c.post(f"/reports/{report_id}/completions", headers=H, json={
+        "prompt": {"content": case["prompt"]},
+        "stream": False,
+    })
+    r.raise_for_status()
+
+    deadline = time.time() + timeout_s
+    status = "unknown"
+    while time.time() < deadline:
+        time.sleep(4)
+        rr = c.get(f"/reports/{report_id}/completions", headers=H)
+        if rr.status_code != 200:
+            continue
+        comps = rr.json()
+        sys_comps = [x for x in comps if x.get("role") == "system"]
+        if sys_comps and sys_comps[-1].get("status") in ("success", "error"):
+            status = sys_comps[-1]["status"]
+            break
+    return {"tool": case["tool"], "report_id": report_id, "status": status}
+
+
+def score(capture_file: str, cases: list[dict]) -> dict:
+    """First-call validity per tool, from the oracle's capture file."""
+    calls: list[dict] = []
+    if os.path.exists(capture_file):
+        with open(capture_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    calls.append(json.loads(line))
+
+    per_tool: dict[str, dict] = {}
+    for call in calls:
+        t = call["tool"]
+        entry = per_tool.setdefault(t, {"attempts": 0, "first_valid": None, "violations": []})
+        entry["attempts"] += 1
+        if entry["first_valid"] is None:
+            entry["first_valid"] = bool(call["valid"])
+            if not call["valid"]:
+                entry["violations"] = call["violations"]
+        if call["valid"]:
+            entry["eventually_valid"] = True
+
+    expected = [c["tool"] for c in cases]
+    attempted = [t for t in expected if t in per_tool]
+    first_valid = [t for t in attempted if per_tool[t]["first_valid"]]
+    ever_valid = [t for t in attempted if per_tool[t].get("eventually_valid")]
+
+    return {
+        "tools_expected": len(expected),
+        "tools_attempted": len(attempted),
+        "first_call_valid": len(first_valid),
+        "eventually_valid": len(ever_valid),
+        "never_attempted": [t for t in expected if t not in per_tool],
+        "total_calls": len(calls),
+        "per_tool": per_tool,
+    }
+
+
+def schema_in_context(dump_file: str) -> dict:
+    """How often was a real argument schema present in the prompt at generation
+    time? Looks for schema-shaped markers inside the rendered <mcp_tools> block
+    and in past observations."""
+    if not os.path.exists(dump_file):
+        return {"error": "no dump file"}
+    total = 0
+    with_schema = 0
+    with open(dump_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            total += 1
+            blob = (rec.get("messages") or [{}])[0].get("content", "")
+            # A schema is "present" if the prompt contains an actual properties
+            # map for a mock tool, not merely the tool's name.
+            if '"properties"' in blob or "<arg " in blob:
+                with_schema += 1
+    return {"planner_turns": total, "turns_with_schema": with_schema}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--only", default=None, help="comma-separated tool names")
+    ap.add_argument("--mode", default="cases", choices=["cases", "pressure"],
+                    help="'cases' = one fresh report per tool (schema always fresh); "
+                         "'pressure' = one report, nine sequential calls (schema ages out)")
+    args = ap.parse_args()
+
+    seed = load_seed()
+
+    if args.mode == "pressure":
+        capture = os.environ.get("MOCK_MCP_CAPTURE_FILE", "/tmp/bow-agent/mcp_calls.jsonl")
+        dump = os.environ.get("BOW_PLANNER_DUMP_FILE", "")
+        with httpx.Client(base_url=BASE, timeout=900.0) as c:
+            res = run_case(
+                c, seed,
+                {"tool": "pressure", "prompt": PRESSURE_PROMPT},
+                timeout_s=900,
+            )
+        print("   ", res)
+        cases = [{"tool": t} for t in PRESSURE_EXPECTED]
+        report = {
+            "label": args.label,
+            "mode": "pressure",
+            "runs": [res],
+            "score": score(capture, cases),
+            "context": schema_in_context(dump) if dump else {},
+        }
+        out = f"/tmp/bow-agent/report_{args.label}.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report["score"], indent=2))
+        print("wrote", out)
+        return
+
+    cases = CASES
+    if args.only:
+        want = set(args.only.split(","))
+        cases = [c for c in CASES if c["tool"] in want]
+
+    capture = os.environ.get("MOCK_MCP_CAPTURE_FILE", "/tmp/bow-agent/mcp_calls.jsonl")
+    dump = os.environ.get("BOW_PLANNER_DUMP_FILE", "")
+
+    results = []
+    with httpx.Client(base_url=BASE, timeout=300.0) as c:
+        for case in cases:
+            print(f"--- {case['tool']}")
+            try:
+                res = run_case(c, seed, case)
+            except Exception as e:
+                res = {"tool": case["tool"], "status": f"harness_error: {e}"}
+            print("   ", res)
+            results.append(res)
+
+    report = {
+        "label": args.label,
+        "runs": results,
+        "score": score(capture, cases),
+        "context": schema_in_context(dump) if dump else {},
+    }
+    out = f"/tmp/bow-agent/report_{args.label}.json"
+    with open(out, "w") as f:
+        json.dump(report, f, indent=2)
+    print(json.dumps(report["score"], indent=2))
+    print(json.dumps(report["context"], indent=2))
+    print("wrote", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/analysis/mcp-connector-reliability-rca.md
+++ b/docs/analysis/mcp-connector-reliability-rca.md
@@ -1,0 +1,485 @@
+# MCP connector reliability — root cause analysis
+
+**Status:** investigation only. No code changed.
+**Symptom:** agent calls to customer-configured MCP connectors fail often — wrong
+argument types, wrong/missing values, arguments that don't match the tool's
+schema. Reported as materially worse than other MCP clients (OpenCode, OpenClaw,
+Hermes) on the same models, including Sonnet. Concrete example: monday.com, where
+the agent "forgets to put the right type".
+
+---
+
+## TL;DR
+
+BOW exposes MCP tools through a **generic gateway tool** (`execute_mcp`) whose
+`arguments` field is an unconstrained `Dict[str, Any]`. Every other serious MCP
+client registers **each MCP tool as a first-class provider tool carrying its own
+JSON Schema**.
+
+That one difference removes the provider's schema-constrained decoding from the
+loop. The model is no longer *sampling into a grammar* — it is free-writing a
+JSON object from memory of a schema it read, as text, several turns earlier, and
+which our context compaction may already have deleted.
+
+Everything else below compounds it. This is not a model-quality problem; it is a
+**schema-plumbing problem**. Better models degrade later, not differently.
+
+---
+
+## The current architecture
+
+```
+<mcp_tools> context block      names + descriptions only, NO schemas
+        │                       tables_schema_section.py:338-377
+        ▼
+   search_mcps                 returns full input_schemas — but only inside a
+        │                       tool *observation* (text/JSON blob)
+        ▼                       search_mcps.py:214-243
+   execute_mcp                 {connection_id, tool_name, arguments: Dict[str,Any]}
+        │                       schemas/execute_mcp.py:5-28
+        ▼
+   McpClient.acall_tool        raw passthrough, no validation
+                                mcp_client.py:211-247
+```
+
+Three hops, and the type information present at hop 2 is gone by hop 3.
+
+### How the reference implementations do it
+
+OpenCode (`sst/opencode`, `packages/opencode/src/mcp/catalog.ts`):
+
+```ts
+export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: number): Tool {
+  const inputSchema: JSONSchema7 = {
+    ...(mcpTool.inputSchema as JSONSchema7),
+    type: "object",
+    properties: (mcpTool.inputSchema.properties ?? {}) as JSONSchema7["properties"],
+    additionalProperties: false,
+  }
+  return dynamicTool({
+    description: mcpTool.description ?? "",
+    inputSchema: jsonSchema(inputSchema),   // ← the MCP schema IS the tool schema
+    execute: async (args, options) => { /* client.callTool(...) */ },
+  })
+}
+
+export const sanitize  = (v: string) => v.replace(/[^a-zA-Z0-9_-]/g, "_")
+export const toolName  = (client: string, name: string) => sanitize(client) + "_" + sanitize(name)
+```
+
+One flat tool name per MCP tool. Real schema. Provider enforces it. Same core
+pattern in Claude Code, Cline, Goose, and OpenClaw. Nobody in the ecosystem uses
+a discover-then-invoke gateway as the *primary* path — gateways exist only as a
+scaling escape hatch for very large catalogs, with a known accuracy cost.
+
+---
+
+## Root causes, ranked by impact
+
+### RC-1 — `arguments` is an unconstrained object (PRIMARY)
+
+`backend/app/ai/tools/schemas/execute_mcp.py:14`
+
+```python
+arguments: Dict[str, Any] = Field(
+    default={},
+    description="Arguments to pass to the tool, matching the tool's input schema."
+)
+```
+
+Serialized to the provider this is approximately
+`{"type": "object", "additionalProperties": true}`. The description literally
+says "matching the tool's input schema" — but that schema is nowhere in the
+request.
+
+What is lost:
+
+| Enforcement | Native registration | BOW today |
+|---|---|---|
+| Field types (`string` vs `object` vs `integer`) | provider-enforced | none |
+| Required fields | provider-enforced | none |
+| Enums / `const` | provider-enforced | none |
+| Nested object shape | provider-enforced | none |
+| Unknown-key rejection | `additionalProperties:false` | none |
+
+**Why monday.com fails specifically.** monday's `change_item_column_values`
+takes `columnValues` as a **JSON-encoded string**, not an object —
+`'{"text5": "New text", "status3": {"label": "Done"}}'`. With a native schema the
+provider sees `"type": "string"` and emits a string. With an open dict the model
+does the natural thing and emits a nested object. The server rejects it. Same
+class of bug for `boardId`/`itemId` (numeric IDs that several monday tools want
+as strings, or vice versa depending on the tool).
+
+This is *exactly* the reported symptom, and it is structural.
+
+---
+
+### RC-2 — The schema is delivered as prose, far from the point of use
+
+The `<mcp_tools>` block deliberately ships names and descriptions only:
+
+`backend/app/ai/context/sections/tables_schema_section.py:363-370`
+
+```python
+conn_parts.append(
+    "<note>Only tool names and descriptions are shown above, not their argument schemas. "
+    "Call search_mcps to get a tool's full input schema (exact argument names and types) "
+    "before calling execute_mcp — do not guess arguments.</note>"
+)
+```
+
+So the model must: read a note → call a discovery tool → parse a JSON blob out
+of an observation → hold it → construct a matching object N turns later. Every
+one of those steps is lossy, and none of them is enforced. A native tool schema
+is present in the request *at the moment of generation*, every time, for free.
+
+---
+
+### RC-3 — The schema is silently deleted from context after 5 tool calls
+
+`backend/app/ai/agents/planner/prompt_builder.py:17-27`
+
+```python
+_RECENT_OBS_FULL = 5
+_OBS_KEEP_KEYS = {
+    "summary", "step_id", "artifact_id", "visualization_id",
+    "visualization_ids", "query_id", "mode", "title",
+    "analysis_complete", "success", "data_preview",
+}
+```
+
+`search_mcps` puts the schemas under `observation["tools"]`
+(`search_mcps.py:240`). **`tools` is not in `_OBS_KEEP_KEYS`.** Once the
+observation falls outside the 5-item full window, `_compact_past_observations`
+(`prompt_builder.py:543-586`) reduces it to:
+
+```json
+{"tool_name": "search_mcps", "execution_number": 3, "summary": "Found 20 tool(s) across 1 connection(s).", "success": true}
+```
+
+Every argument name and every type — gone. The model has been *told* it
+discovered 20 tools and given nothing about them. From here it must guess, and
+the prompt contains no signal that it is guessing.
+
+Two aggravating details:
+
+- `input_schema` is also not in `_OBS_KEEP_KEYS`, so the good recovery hint that
+  `_failure_payload` attaches (`execute_mcp.py:741-743`) evaporates on the same
+  schedule.
+- Minified observations drop `tool_input` entirely. The model cannot see the
+  arguments it previously sent, so it has no way to diff a failed attempt against
+  a new one — a direct driver of repeated identical failures.
+
+Five observations is a handful of turns in any real MCP flow
+(`search_mcps → execute_mcp → fail → execute_mcp → create_data → …`).
+
+---
+
+### RC-4 — No native `tool_use` / `tool_result` transcript
+
+`backend/app/ai/agents/planner/prompt_builder_v3.py:67-75`
+
+```python
+msg = Message(role="user", content=user_content)
+return PlannerInputV3(
+    system=system,
+    messages=[{"role": msg.role, "content": msg.content}],   # ← always exactly one message
+    ...
+)
+```
+
+Every planner iteration is a **fresh single-turn request**. Conversation history
+is re-serialized into that one user message as a JSON blob:
+
+`prompt_builder_v3.py:795-798`
+
+```python
+compacted = PromptBuilder._compact_past_observations(planner_input.past_observations)
+parts.append(f"  <past_observations>{json.dumps(compacted)}</past_observations>")
+last_obs = json.dumps(planner_input.last_observation) if planner_input.last_observation else "None"
+parts.append(f"  <last_observation>{last_obs}</last_observation>")
+```
+
+The LLM client layer already supports the native blocks —
+`anthropic_client.py:191-204` translates `tool_use` and `tool_result` — but
+nothing ever constructs them.
+
+Consequences:
+
+1. **Tool-calling fidelity.** Frontier models are post-trained on the native
+   tool loop. Re-presenting history as narrated JSON inside a user turn is
+   off-distribution and measurably degrades argument accuracy. This hurts *all*
+   tools; it hurts MCP most because MCP is where the schema isn't enforced.
+2. **No `tool_use_id` correlation.** The model cannot bind "this error" to
+   "that call I made". Errors arrive as
+   `summary: "Tool 'x' failed: ..."` inside a blob rather than as an
+   `is_error: true` tool_result attached to the offending call.
+3. **Prompt cache is defeated for the bulk of the prompt.** Cache breakpoints
+   sit on the system block and the last tool
+   (`anthropic_client.py:294-311`) — but all the volatile *and* all the heavy
+   content (schema context, instructions, observations) lives in the single user
+   message, which changes every iteration and is never cacheable. It also grows
+   monotonically, pushing whatever schema survives ever deeper into a long
+   prompt.
+
+---
+
+### RC-5 — No argument validation before dispatch
+
+`backend/app/ai/runner/tool_runner.py:52-53`
+
+```python
+if getattr(tool, "input_model", None) is not None:
+    arguments = tool.input_model(**arguments).model_dump()
+```
+
+This validates against `ExecuteMCPInput` — the *wrapper*. `arguments` is
+`Dict[str, Any]`, so it always passes. Then:
+
+`backend/app/ai/tools/implementations/execute_mcp.py:272`
+
+```python
+result = await client.acall_tool(data.tool_name, data.arguments)
+```
+
+Straight to the network. Every type error costs a full remote round-trip
+(hundreds of ms to seconds on an OAuth'd server) and comes back as a
+vendor-specific message that may or may not name the offending field.
+
+We already store `ConnectionTool.input_schema` locally
+(`models/connection_tool.py:22`). Validating against it before the call is free
+and would convert most of these failures into an instant, precise, local error.
+
+**The recovery path is better than nothing but too shallow.**
+`execute_mcp.py:719-743` builds a hint like
+`Valid arguments for 'change_item_column_values': {boardId*:string, itemId*:string, columnValues*:string} (* = required)`.
+That flattens `properties` **one level only** — it drops nested object shape,
+enums, formats, and (critically) the fact that a `string` must *contain* JSON.
+For monday/Atlassian-shaped schemas the hint is close to useless.
+
+---
+
+### RC-6 — `$ref` / `$defs` are never resolved for prompt rendering
+
+The only `$ref` inlining in the codebase is Gemini-specific:
+
+`backend/app/ai/llm/clients/google_client.py:158-166` —
+*"Inline `$ref` references and strip / convert fields Google's SDK doesn't accept."*
+
+MCP servers built on `zod-to-json-schema` (monday, Linear, Notion, Sentry — most
+of our preset catalog) routinely emit `$ref`, `$defs`, `anyOf`, `allOf`. Dumped
+raw into a text observation, `{"$ref": "#/$defs/ColumnValue"}` conveys nothing to
+the model at the point where it must produce the value.
+
+OpenCode does per-provider schema lowering as a first-class concern —
+`packages/opencode/src/provider/transform.ts:1489 ProviderTransform.schema()`:
+`sanitizeOpenAISchema` (mirrors Codex's Rust lowering), Moonshot `$ref`-sibling
+stripping and tuple-`items` collapse, Gemini integer→string enum conversion.
+BOW has no equivalent anywhere on the MCP path.
+
+---
+
+### RC-7 — Tool identity is indirect
+
+`execute_mcp` requires `connection_id` **and** `tool_name` **and** `arguments`.
+Three independent things to get right per call, versus one flat tool name. When
+several MCP connections are attached to an agent, cross-wiring
+`connection_id` to the wrong tool is a live failure mode.
+`execute_mcp.py:138-148` softens this by accepting a name *or* an id, which is
+good, but the coupling itself is the problem.
+
+---
+
+### RC-8 — A brand-new MCP session on every single call
+
+`mcp_client.py:355-391` — `_connect()` opens a fresh SSE / streamable-HTTP
+connection and runs `session.initialize()` for **every** `acall_tool`. And
+`execute_mcp.py:261` re-runs `ConnectionService.construct_client` each time.
+
+Costs:
+
+- Full transport + handshake latency per tool call.
+- No session state — servers that expect a stable session get none.
+- `notifications/tools/list_changed` is never received, so schema drift is
+  invisible at runtime.
+- Capability negotiation repeated every call.
+
+OpenCode holds long-lived clients (`s.clients`), caches tool defs (`s.defs`), and
+refreshes on `ToolListChangedNotificationSchema` (`mcp/index.ts:461, 666-687`).
+
+---
+
+### RC-9 — No repair hook; the only backstop is a kill switch
+
+OpenCode, `packages/opencode/src/session/llm.ts:296`:
+
+```ts
+async experimental_repairToolCall(failed) {
+  const lower = failed.toolCall.toolName.toLowerCase()
+  if (lower !== failed.toolCall.toolName && prepared.tools[lower]) {
+    return { ...failed.toolCall, toolName: lower }        // fix casing
+  }
+  return {                                                // else hand the model
+    ...failed.toolCall,                                   // a structured error
+    input: JSON.stringify({ tool: failed.toolCall.toolName, error: failed.error.message }),
+    toolName: "invalid",
+  }
+}
+```
+
+BOW's nearest equivalent is `tool_runner.py:54-83`: count validation failures,
+and at 2 **terminate the entire run** with
+`analysis_complete: True, final_answer: "Unable to complete task due to repeated
+tool validation errors"`. That is a kill switch, not a repair — and because
+`arguments` is an open dict it almost never fires for MCP anyway. Instead you get
+remote errors, which count toward nothing, until the repeated-identical-call
+breaker (`agent_v2.py:66-110`) eventually stops the turn.
+
+---
+
+### RC-10 — The active v3 system prompt contains no MCP flow guidance
+
+The "discover before you call" instruction exists only in the **legacy v2**
+builder:
+
+`backend/app/ai/agents/planner/prompt_builder.py:142`
+
+```
+MCP/API TOOLS (if <mcp_tools> section is present in context)
+- Use search_mcps to discover available external tools and get their full input schemas before calling execute_mcp.
+- Use execute_mcp to invoke an external tool. ...
+- Flow: search_mcps → execute_mcp → (optional: write_csv) → create_data for visualization.
+```
+
+`prompt_builder_v3.py` — **the default path** (`agent_v2.py:592-601` selects
+`PlannerV3` unless `BOW_PLANNER` says otherwise) — has none of it. Grepping v3
+for `execute_mcp` returns exactly one hit, and it is about the cosmetic `title`
+argument (`prompt_builder_v3.py:400`).
+
+The only surviving nudges are the `search_mcps` tool description and the
+`<note>` inside `<mcp_tools>`. The system prompt gives the flow no priority at
+all.
+
+---
+
+### RC-11 — Schema staleness
+
+`ConnectionTool.input_schema` is a snapshot taken by
+`ConnectionService.refresh_tools` (`connection_service.py:1786-1884`), triggered
+only on connect, OAuth callback, explicit route, or the indexing service. There
+is no TTL and no `tools/list_changed` subscription. When monday ships a schema
+change, the agent faithfully follows a schema the server no longer accepts — and
+the failure looks identical to a model error.
+
+---
+
+## Why "even Sonnet" fails
+
+Because it isn't a reasoning failure. With a native tool schema the provider
+constrains sampling — emitting an object where the schema says `string` is
+largely *unreachable*. With `Dict[str, Any]` there is no grammar, and correctness
+depends entirely on recall of a schema that (RC-2) arrived as prose, (RC-3) may
+have been deleted from context, and (RC-6) may have been unresolvable `$ref`s
+when it was there.
+
+Stronger models push the failure rate down. They cannot remove a missing
+constraint.
+
+---
+
+## Recommended direction
+
+Not implemented — proposed, tiered by leverage against effort.
+
+### Tier 1 — Native tool registration (highest leverage)
+
+Expand each allowed `ConnectionTool` into a `ToolSpec` in the v3 catalog:
+
+- name: `mcp__{connection_slug}__{tool_name}`, sanitized to `[a-zA-Z0-9_-]`,
+  truncated to the provider's 64-char limit with a stable hash suffix on
+  collision (OpenCode's `McpCatalog.sanitize`/`toolName` is the model).
+- `input_schema`: `ConnectionTool.input_schema`, passed through
+  `filter_locked_from_schema` (already exists,
+  `mcp_context_injection.py:266-288`) then a normalization pass.
+- Dispatch: route by name prefix straight into the existing
+  `ConnectionToolGateway` — policy enforcement, identity forwarding, CSV/JSON
+  materialization, and audit all stay exactly as they are.
+
+Needs alongside it:
+- A schema normalization pass: force `type: "object"`, default
+  `properties: {}`, keep `$defs` intact for Anthropic, inline/lower per provider
+  where required (the `google_client` ref-inliner is the seed).
+- A catalog-size budget. Keep `execute_mcp` + `search_mcps` as the fallback path
+  for agents with large tool counts, and register natively below the threshold.
+
+This alone should remove the large majority of the reported failures.
+
+### Tier 2 — Native `tool_use` / `tool_result` transcript
+
+Make the agent loop maintain a real message array instead of rebuilding one user
+message per iteration. Bigger refactor, but it fixes tool fidelity, error
+attribution, and prompt caching for **every** tool, not just MCP. The client
+layer already supports it (`anthropic_client.py:191-204`) — the gap is entirely
+in `PromptBuilderV3` / `PlannerV3` / `agent_v2`.
+
+### Tier 3 — Cheap fixes worth doing regardless of Tier 1
+
+1. **Validate `arguments` against `ConnectionTool.input_schema` before the network
+   call** (`jsonschema`), and return a path-based error
+   (`columnValues: expected string, got object`) plus the resolved schema.
+   Converts a slow, vague remote failure into an instant, precise local one.
+2. **Add `tools` and `input_schema` to `_OBS_KEEP_KEYS`** — or better, pin the
+   most recent `search_mcps` result so schemas never fall out of context.
+3. **Keep `tool_input` on minified observations for failed calls**, so the model
+   can diff its previous attempt.
+4. **Resolve `$ref`/`$defs` before rendering any schema into a prompt.**
+5. **Inline schemas into `<mcp_tools>` for small catalogs** (say < 15 tools) —
+   the two-hop discovery step disappears entirely for most connectors.
+6. **Restore the MCP flow guidance in the v3 system prompt**, with an explicit
+   note that some servers expect JSON-encoded *strings* for structured fields.
+7. **Pool/persist the MCP client per connection for the duration of a run**, and
+   subscribe to `tools/list_changed`.
+8. **Deepen `_failure_payload`** to render nested properties, enums, and formats
+   rather than one flat level.
+
+---
+
+## How to verify any fix
+
+Build a small eval harness against the preset catalog (monday, Notion, Linear,
+Atlassian, Sentry) measuring, per connector:
+
+- **first-call argument validity** — fraction of `execute_mcp` calls that pass
+  local schema validation on the first attempt (the headline metric);
+- **calls-to-success** — round trips needed to complete a task;
+- **remote 4xx rate** — argument errors that reach the server at all;
+- **schema-in-context rate** — how often the tool's schema was actually present
+  in the prompt at generation time (this one will be damning today).
+
+Track it per model so the "is it the model or is it us" question stops being a
+matter of opinion.
+
+---
+
+## Files referenced
+
+| Concern | Path |
+|---|---|
+| Gateway tool schema (RC-1) | `backend/app/ai/tools/schemas/execute_mcp.py` |
+| Gateway execution (RC-5, RC-8) | `backend/app/ai/tools/implementations/execute_mcp.py` |
+| Discovery tool (RC-2) | `backend/app/ai/tools/implementations/search_mcps.py` |
+| `<mcp_tools>` rendering (RC-2) | `backend/app/ai/context/sections/tables_schema_section.py:338-377` |
+| Observation compaction (RC-3) | `backend/app/ai/agents/planner/prompt_builder.py:17-27, 543-586` |
+| Single-user-message prompt (RC-4, RC-10) | `backend/app/ai/agents/planner/prompt_builder_v3.py` |
+| Native block support (unused) | `backend/app/ai/llm/clients/anthropic_client.py:174-231` |
+| Wrapper-only validation (RC-5, RC-9) | `backend/app/ai/runner/tool_runner.py:32-83` |
+| Per-call session (RC-8) | `backend/app/data_sources/clients/mcp_client.py:211-247, 355-391` |
+| Schema snapshot (RC-11) | `backend/app/services/connection_service.py:1786-1884` |
+| Presets | `backend/app/schemas/data_source_registry.py:1564-1669` |
+
+### External references
+
+- OpenCode MCP → tool conversion: `sst/opencode`, `packages/opencode/src/mcp/catalog.ts`
+- OpenCode provider schema lowering: `packages/opencode/src/provider/transform.ts` (`ProviderTransform.schema`)
+- OpenCode tool-call repair: `packages/opencode/src/session/llm.ts` (`experimental_repairToolCall`)
+- monday.com `columnValues` is a JSON-encoded string: <https://developer.monday.com/api-reference/docs/change-item-column-values>


### PR DESCRIPTION
## What this is

Investigation into why agent calls to customer-configured MCP connectors fail on argument types/values, plus the first round of fixes and the sandbox harness used to measure them.

Two commits: an RCA doc, and the code changes it pointed at.

## The finding that changed the plan

I built a 10-tool mock MCP server with deliberately hard schemas — JSON-encoded string fields (the monday.com `columnValues` shape), integer enums, `$ref`/`$defs` nesting, unix-epoch integers, arrays of objects, pattern-constrained strings. The server validates every call against its own declared schema and records each attempt, so it scores argument fidelity directly.

**The baseline did not reproduce the reported failure.** Sonnet 4.5 scored 19/19 first-call argument validity (10 isolated cases + 9 under context pressure). Stripping the type hints out of the tool descriptions to make it harder changed nothing — still 9/9.

The planner-context dump shows why: the agent called `search_mcps` before nearly every tool call, so the schema was never more than one turn old. The `<mcp_tools>` block listed tool names only and explicitly told it to go fetch the schema first, and it complied every time.

So the measurable cost of the current design here is **turn amplification, not wrong arguments**. The RCA's ranking was wrong on one point: an unconstrained `arguments` dict is survivable when the schema is fresh.

## Root cause addressed

`_build_mcp_tools` loads full `ConnectionTool` rows — which carry `input_schema` — and then drops it, because `MCPToolItem` had no field for it. The schema was one attribute access away and thrown out, so `<mcp_tools>` could only render names and descriptions.

That forced a discovery round trip whose result then gets minified out of context after `_RECENT_OBS_FULL=5` tool calls (`tools` was not in `_OBS_KEEP_KEYS`), which in turn encouraged re-discovery before every call.

## Changes

- `MCPToolItem` carries `input_schema`; `schema_context_builder` passes it through `filter_locked_from_schema` so admin-locked fields stay hidden from the model.
- `<mcp_tools>` renders the full argument shape inline as `<arg>` elements for catalogs under 40 tools, and tells the agent to call `execute_mcp` directly. This block is rebuilt every turn, so a schema here never ages out of context.
- New `app/ai/tools/mcp_schema.py`: `$ref`/`$defs` inlining, compact XML schema rendering, and local argument validation.
- `execute_mcp` validates arguments against the tool's own schema **before** the network call. Failures return path-qualified errors (`columnValues: expected string, got object`) plus the resolved schema, instead of a terse vendor string after a round trip.
- `_failure_payload` renders the full nested shape rather than one flat level — nested objects, array item shape and enums are exactly where agents go wrong.
- `_OBS_KEEP_KEYS` keeps `input_schema`; minified observations retain `tool_input` for failed calls so the agent can diff its previous attempt.
- v3 system prompt gains MCP flow guidance — it only existed in the legacy v2 builder, and v3 is the default planner.
- `planner_v3` gains an env-gated planner-input dump (`BOW_PLANNER_DUMP_FILE`, off by default) for verifying what the planner actually saw.

## Results

Pressure scenario — 9 sequential MCP calls in one agent run, identical prompt, mock, and model (Sonnet 4.5):

| | before | after |
|---|---|---|
| planner turns | 21 | **11** (−48%) |
| context bytes | 346K | **197K** (−43%) |
| first-call argument validity | 9/9 | 9/9 |

Roughly half the LLM turns and half the tokens for identical work. Accuracy is unchanged because it had no room to improve in this scenario.

The 10-case suite is 10/10 before and after.

### Context diff

`<mcp_tools>` goes from 1,200 bytes of names to 5,088 bytes carrying the real shape:

Before
```xml
<tool name="issue_create">Create a new issue in a team's backlog.</tool>
<note>Only tool names and descriptions are shown above, not their argument schemas.
Call search_mcps to get a tool's full input schema before calling execute_mcp…</note>
```

After
```xml
<tool name="issue_create">
Create a new issue in a team's backlog.
  <arg name="teamId" type="string" required="true"/>
  <arg name="priority" type="integer" required="true" enum="0,1,2,3,4">0=None, 1=Urgent…</arg>
  <arg name="estimate" type="object">
    <arg name="value" type="number" required="true"/>
    <arg name="unit" type="string" required="true" enum="points,hours,days"/>
  </arg>
</tool>
```

## Testing

- 77 existing MCP unit tests pass.
- New harness: `backend/tests/mocks/complex_schema_mcp_server.py` (oracle) and `backend/tests/mocks/mcp_argument_fidelity_eval.py` (two modes — `cases` for isolated tasks, `pressure` for nine sequential calls in one run). Both are runnable standalone; usage is in the module docstrings.

## What this does not do

No native per-tool registration (wave 1 in the RCA), and no native `tool_use`/`tool_result` transcript (wave 2). I'd hold wave 1 until we know why production fails when this test doesn't — the leading hypothesis is catalog size, since customers likely exceed the 40-tool inline threshold and would still take the discovery path. A real failing transcript from the monday connection would settle it quickly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWxEM7nTfjCNEAJ3GPwQJh)_