### PR TITLE
Merge the three alembic heads left by parallel migrations

### DIFF
--- a/backend/alembic/versions/mrgheads03_merge_indexing_mainbuild_toolconf.py
+++ b/backend/alembic/versions/mrgheads03_merge_indexing_mainbuild_toolconf.py
@@ -1,0 +1,26 @@
+"""merge connection-indexing-user-scope, one-main-build and tool-confirmations heads
+
+Revision ID: mrgheads03
+Revises: idxuser01, mainbuild01, toolconf01
+Create Date: 2026-07-26 13:10:00.000000
+
+No schema change — three features branched off entraprof01 and landed in
+parallel (per-user connection indexing scope, the one-main-build-per-org
+constraint, and the tool_confirmations table), leaving three heads so
+`alembic upgrade head` failed with MultipleHeads and every test that builds a
+schema errored. This unifies them; the three can be applied in any order.
+"""
+from typing import Sequence, Union
+
+revision: str = "mrgheads03"
+down_revision: Union[str, Sequence[str], None] = ("idxuser01", "mainbuild01", "toolconf01")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
`main` currently has **three alembic heads**, so `alembic upgrade head` fails and the per-test schema fixture errors before any test runs — the AI and E2E jobs are red on main, not just on a branch:

```
alembic.util.exc.CommandError: Multiple head revisions are present for given
argument 'head'; ... idxuser01, mainbuild01, toolconf01
```

All three declare `down_revision = "entraprof01"` and landed within a couple of hours of each other:

| revision | from |
|---|---|
| `idxuser01` | per-user connection indexing scope (#789) |
| `mainbuild01` | one main instruction build per org (#791) |
| `toolconf01` | `tool_confirmations` table (#793) |

## Change

One empty merge revision, `mrgheads03`, revising all three — the same shape as `mrgheads02` for an earlier parallel landing. No schema change, and the three parents can be applied in any order.

Re-pointing one of the three `down_revision`s instead would rewrite migrations already merged to main: a database stamped at one of them would then treat its new ancestor as applied and silently skip it.

## Verification

- `alembic heads` resolves to `mrgheads03` alone.
- A fresh SQLite DB upgrades through all three parents and then the merge.
- `downgrade base` walks every branch. As with `mrgheads02`, `downgrade -1` from a merge point is ambiguous by design; the test fixtures only ever upgrade (`command.upgrade(..., "head")`).
- 55 MCP / tool-policy tests pass on this branch (`test_tool_policy_resolution`, `test_rbac_tool_policies`, `test_mcp_agent_tools`, `test_mcp_tools`, `test_custom_api_tools`).

Failing run that surfaced this: https://github.com/bagofwords1/bagofwords/actions/runs/30203066924/job/89796287332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMdeDeERW4QoUghoTm9FxH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMdeDeERW4QoUghoTm9FxH)_