### PR TITLE
Wire the Priority ERP query guide into the codegen prompt

### DIFF
--- a/backend/app/data_sources/clients/priority_erp_client.py
+++ b/backend/app/data_sources/clients/priority_erp_client.py
@@ -73,6 +73,10 @@ _DEFAULT_FORMS = [
 _METADATA_TIMEOUT = 190
 _QUERY_TIMEOUT = 120
 
+# Detects a SQL statement handed to `execute_query`. Priority form names are
+# bare identifiers, so a leading SELECT/WITH can only be a dialect mix-up.
+_SQL_PREFIX_RE = re.compile(r"^\s*(select|with)\b", re.IGNORECASE)
+
 
 class _RateLimiter:
     """Token-bucket over a sliding 60s window.
@@ -428,6 +432,18 @@ class PriorityErpClient(DataSourceClient):
             raise ValueError("A Priority form name (optionally with OData query options) is required.")
         target = target.lstrip("/")
 
+        # A SQL string would otherwise be percent-encoded into the URL path and
+        # come back as an opaque HTTP 400. Naming the mismatch gives the codegen
+        # retry loop something it can actually act on.
+        if _SQL_PREFIX_RE.match(target):
+            raise ValueError(
+                "Priority is queried with OData, not SQL. Pass a form name with OData query "
+                "options instead of a SELECT statement — e.g. "
+                "\"CUSTOMERS?$select=CUSTNAME,CDES&$top=10\" or "
+                "\"ORDERS?$filter=CUSTNAME eq '1011'&$orderby=CURDATE desc\". "
+                "Supported options: $filter, $select, $expand, $orderby, $top, $skip, $since."
+            )
+
         path, _, query_string = target.partition("?")
         params: Dict[str, str] = {}
         if max_rows and "$top" not in query_string:
@@ -461,8 +477,15 @@ class PriorityErpClient(DataSourceClient):
 
     @property
     def description(self) -> str:
+        # `description` is the ONLY channel that carries per-connector query
+        # guidance into the code-generation prompt (it is read as-is in
+        # build_codegen_context and rendered under <connection_clients>).
+        # Without the guide appended, the coder falls back to the prompt's
+        # SQL-shaped defaults and emits SELECT statements, which this client
+        # then percent-encodes into the OData URL path.
         company = self._company() or "unknown company"
-        return f"Priority ERP (OData) — company '{company}' at {self.service_root}"
+        text = f"Priority ERP (OData) — company '{company}' at {self.service_root}"
+        return text + "\n\n" + self.system_prompt()
 
     def system_prompt(self) -> str:
         return """
@@ -470,6 +493,12 @@ class PriorityErpClient(DataSourceClient):
 
 Query Priority ERP forms over the OData v4 REST API. Each schema table is a
 Priority **form** (ORDERS, CUSTOMERS, PART …) and each column is a form column.
+
+**This is NOT a SQL data source.** `execute_query` takes an OData URL fragment,
+not SQL — the string is appended to the service root as a URL path. Any
+`SELECT ... FROM ...` is percent-encoded into the URL and fails with HTTP 400.
+`execute_query` takes exactly one positional argument; there is no
+`query_params`, no bind parameters, and no second argument.
 
 ### How to Execute Queries
 
@@ -482,6 +511,17 @@ ORDERS?$filter=CUSTNAME eq '1011'&$top=50
 ORDERS?$select=ORDNAME,CUSTNAME,CURDATE&$orderby=CURDATE desc
 ORDERS?$expand=ORDERITEMS_SUBFORM($select=PARTNAME,PRICE)
 ```
+
+**Always push `$select` and `$top` into the query.** A bare form name
+(`execute_query("CUSTOMERS")`) downloads every row of every column before any
+pandas filtering runs — on a real tenant that is minutes of transfer for ten
+rows. Ask the server for what you need:
+
+```
+CUSTOMERS?$select=CUSTNAME,CDES,PHONE,EMAIL&$top=10
+```
+
+Never fetch a whole form and then `.head(n)` it in pandas.
 
 ### Supported query options
 

--- a/backend/tests/unit/test_priority_erp_client.py
+++ b/backend/tests/unit/test_priority_erp_client.py
@@ -315,3 +315,43 @@ def test_system_prompt_states_the_aggregation_limitation(client):
 
 def test_description_names_the_company(client):
     assert "demo" in client.description
+
+
+def test_description_carries_the_query_guide(client):
+    """`description` is the only channel into the codegen prompt.
+
+    The guide lived in `system_prompt()` but was never concatenated in, so the
+    coder saw no OData guidance and fell back to the prompt's SQL defaults.
+    """
+    text = client.description
+    assert "demo" in text
+    assert "NOT a SQL data source" in text
+    assert "$select" in text and "$top" in text
+    assert "$apply" in text
+
+
+def test_system_prompt_pushes_select_and_top(client):
+    """A bare form name pulls the whole form before pandas ever filters."""
+    prompt = client.system_prompt()
+    assert "$select" in prompt and "$top" in prompt
+    assert "query_params" in prompt
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT TOP 10 CUSTNAME, EMAIL FROM CUSTOMERS",
+    "  select * from ORDERS",
+    "WITH x AS (SELECT 1) SELECT * FROM x",
+])
+def test_execute_query_rejects_sql_with_an_actionable_message(client, sql):
+    """A SELECT would otherwise be URL-encoded into the path and 400."""
+    with pytest.raises(ValueError) as exc:
+        client.execute_query(sql)
+    msg = str(exc.value)
+    assert "OData, not SQL" in msg
+    assert "$select" in msg and "$filter" in msg
+
+
+def test_execute_query_still_accepts_odata(client):
+    """The guard must not catch legitimate form names or query options."""
+    df = client.execute_query("CUSTOMERS?$select=CUSTNAME&$top=2")
+    assert "CUSTNAME" in df.columns


### PR DESCRIPTION
## Problem

A Priority ERP query for "10 customers" took 165s and three attempts:

| Attempt | Outcome |
|---|---|
| 1 | `SELECT TOP 10 CUSTNAME, ...` → percent-encoded into the OData URL path → HTTP 400 |
| 2 | `execute_query(..., query_params=...)` → `unexpected keyword argument 'query_params'` |
| 3 | `execute_query("CUSTOMERS")` → succeeded, 152.7s |

## Root cause

`PriorityErpClient.system_prompt()` — the entire OData v4 query guide — was never reachable by the agent.

A client's `description` property is the **only** channel that carries per-connector query guidance into the code-generation prompt:

`ds_clients` → `build_codegen_context` reads `getattr(client, "description")` verbatim (`backend/app/ai/prompt_formatters.py:121-136`) → `CodeGenContext.data_sources_context` → rendered under `<connection_clients>` (`backend/app/ai/agents/coder/coder.py:666-669`).

24 of the 25 clients that define `system_prompt()` append it to `description`. Priority returned only a one-line summary, so its guide was dead code — no production caller anywhere in `backend/app`.

Two things let this ship unnoticed:

- `system_prompt` is not part of the `DataSourceClient` ABC (`base.py:67-111`); it is a convention with no framework contract.
- The existing test asserted the *string's contents* rather than its reachability, so it passed while the prompt was unreachable.

With no OData guidance the coder fell back to the prompt's SQL-shaped defaults (`coder.py:749`: *"For SQL data sources, 'SOME QUERY' should be SQL code"*), which explains attempts 1 and 2. `query_params` appears nowhere in the codebase — it was the model improvising a parameterized-SQL API with nothing to correct it.

Attempt 3 succeeded because a bare form name is the one shape that cannot fail — but with `max_rows` unset no `$top` is added, so it downloads every row of every column and filters in pandas afterward. The 152.7s is transfer time, not query time.

## Changes

`backend/app/data_sources/clients/priority_erp_client.py`

- **`description` now appends `system_prompt()`** — the actual fix, matching the pattern every other guide-carrying connector uses.
- **Hardened the guide** against the generic prompt's SQL framing: states up front that this is not a SQL source and that `execute_query` takes one positional OData fragment (no `query_params`, no bind parameters, no second argument); requires `$select`/`$top` pushdown rather than fetching a form and `.head()`-ing it.
- **Guard in `execute_query`** — a `SELECT`/`WITH` string now raises a `ValueError` naming the correct OData shape instead of being percent-encoded into the URL. The codegen retry loop feeds errors back to the model, so this yields an actionable correction even if prompt guidance is ever bypassed.

`backend/tests/unit/test_priority_erp_client.py` — 6 new tests. The load-bearing one asserts the guide is reachable *through* `description`, closing the gap the original test left open. Others cover `$select`/`$top` guidance, SQL rejection across three statement shapes, and that legitimate OData queries still pass the guard.

## Verification

```
tests/unit/test_priority_erp_client.py — 38 passed (was 32)
```

Driven against `tools/priority/mock_server.py` over real HTTP in a background uvicorn thread.

`tests/unit/test_connection_oauth.py` has 2 failures (`test_ms_fabric`, `test_obo_exchange_ms_fabric`). Both were confirmed to fail identically on clean `HEAD` via `git stash` — pre-existing and unrelated to this change. Not touched here.

## Not addressed

The SQL-defaulted framing in `coder.py` is generic across all connectors, with Power BI as the only hardcoded non-SQL carve-out. Any future non-SQL connector that omits the `description` wiring fails the same way, silently. Promoting `system_prompt` to the `DataSourceClient` ABC would turn the convention into a contract — a cross-connector change left out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfFb5aThhfitcBzoPzFgod

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfFb5aThhfitcBzoPzFgod)_