### PR TITLE
Route a bare file-source id to the agent's file connection in read_file

### DIFF
--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -104,6 +104,37 @@ async def resolve_file_data_source(
     )
 
 
+def attached_file_connections(runtime_ctx: Dict[str, Any]) -> list:
+    """``[(data_source, connection), ...]`` for every ACTIVE file-source
+    connection on the current report's ACTIVE data sources.
+
+    This is the allow-list every file tool resolves against: a disabled agent
+    or connection is never a valid target, and nothing outside the report the
+    caller is running in can appear here. Empty when there's no report scope.
+    """
+    report = runtime_ctx.get("report")
+    if not report:
+        return []
+    out: list = []
+    for ds in (report.data_sources or []):
+        if not getattr(ds, "is_active", True):
+            continue
+        for conn in (ds.connections or []):
+            if conn.type in FILE_SOURCE_TYPES and getattr(conn, "is_active", True):
+                out.append((ds, conn))
+    return out
+
+
+def describe_file_connections(attached: list) -> str:
+    """`'Name' (id: …), 'Other' (id: …)` — the retry hint every file tool shows
+    when a selection didn't resolve, so the model can name a real source
+    instead of guessing (or re-listing in a loop)."""
+    return ", ".join(
+        f"'{(getattr(conn, 'name', '') or '').strip()}' (id: {conn.id})"
+        for _, conn in attached
+    ) or "(none attached)"
+
+
 async def resolve_file_client(
     runtime_ctx: Dict[str, Any],
     connection_id: str,
@@ -133,18 +164,9 @@ async def resolve_file_client(
     # The agent's attached file-source connections form the allow-list AND the
     # resolution target. We only ever resolve to something on this list, so the
     # forgiving fallbacks below can never reach a connection the current report
-    # isn't already built on. Restrict to ACTIVE connections on ACTIVE data
-    # sources — a disabled agent/connection is not a valid target.
-    attached: list = []  # (ds, conn)
-    if report:
-        for ds in (report.data_sources or []):
-            if not getattr(ds, "is_active", True):
-                continue
-            for conn in (ds.connections or []):
-                if conn.type in FILE_SOURCE_TYPES and getattr(conn, "is_active", True):
-                    attached.append((ds, conn))
+    # isn't already built on.
+    attached = attached_file_connections(runtime_ctx)  # (ds, conn)
 
-    attached_conn_ids = {str(conn.id) for _, conn in attached}
     sid = str(connection_id or "").strip()
     sid_l = sid.lower()
 
@@ -194,10 +216,7 @@ async def resolve_file_client(
             # model retries with a valid identifier instead of telling the user
             # the source is disconnected (these connections are attached and
             # remain connected — auth is checked separately, below).
-            choices = ", ".join(
-                f"'{(getattr(conn, 'name', '') or '').strip()}' (id: {conn.id})"
-                for _, conn in attached
-            ) or "(none attached)"
+            choices = describe_file_connections(attached)
             return None, (
                 f"Invalid file-source selection: '{connection_id}' does not match any "
                 f"file source attached to this agent. This is NOT a disconnection — "

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import re
 from typing import Any, AsyncIterator, Dict, Optional, Type
 
 from pydantic import BaseModel
@@ -24,13 +26,30 @@ from ._file_tool_common import (
     SessionFileClient,
     allow_llm_see_data,
     attach_drive_file_to_session,
+    attached_file_connections,
     audit_file_access_denied,
+    describe_file_connections,
     render_file_images,
     render_file_payload,
     render_pdf_pages_images,
     resolve_file_client,
     resolve_session_file,
 )
+
+logger = logging.getLogger(__name__)
+
+# Session file ids are uuid4 (File.id). Connector ids never are: Graph items are
+# opaque base32 tokens ('01LZCX…'), network_dir/S3 ids are paths. The shape is
+# what lets a failed session lookup tell "stale/foreign attachment" (report it)
+# apart from "the model pasted a list_files id" (route it to the connection).
+_SESSION_FILE_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+
+
+def _looks_like_session_file_id(file_id: str) -> bool:
+    return bool(_SESSION_FILE_ID_RE.match(str(file_id or "").strip()))
+
 
 # The planner consumes the OBSERVATION, not the tool output — so the content a
 # read is supposed to deliver to the model must be rendered into
@@ -171,14 +190,34 @@ class ReadFileTool(Tool):
         if not (data.connection_id or "").strip():
             session_file = resolve_session_file(runtime_ctx, data.file_id)
             if session_file is None:
-                err = (
-                    f"'{data.file_id}' is not a file attached to this conversation. "
-                    "Pass a session file id from <files>, or a connection_id + "
-                    "file id from list_files/search_files for a file source."
+                # Not in the report's own space. The overwhelmingly common cause
+                # is a file-source id carried straight from list_files/search_files
+                # with connection_id left empty — so when the agent has exactly one
+                # file connection, read from it instead of failing. Access is NOT
+                # assumed: resolve_file_client re-checks that this user can reach
+                # the data source (and that it declares the capability) exactly as
+                # it does for an explicitly named connection.
+                fallback = self._implicit_connection(runtime_ctx, data.file_id)
+                if fallback is None:
+                    yield self._fail_read(data, self._unresolved_error(runtime_ctx, data.file_id))
+                    return
+                client, err = await resolve_file_client(
+                    runtime_ctx, str(fallback.id), self._required_capability
                 )
-                yield self._fail_read(data, err)
-                return
-            client = SessionFileClient(session_file)
+                if err:
+                    yield self._fail_read(data, err)
+                    return
+                # Own the choice: the cache key, the output and the UI all read
+                # connection_id, and a blank one would misreport a connector read
+                # as a conversation attachment.
+                data.connection_id = str(fallback.id)
+                logger.info(
+                    "%s: '%s' matched no session file; reading it from the agent's "
+                    "only file connection %s (%s).",
+                    self._operation_name, data.file_id, fallback.id, fallback.name,
+                )
+            else:
+                client = SessionFileClient(session_file)
         else:
             client, err = await resolve_file_client(
                 runtime_ctx, data.connection_id, self._required_capability
@@ -581,6 +620,48 @@ class ReadFileTool(Tool):
             )
 
         yield ToolEndEvent(type="tool.end", payload={"output": output, "observation": observation})
+
+    def _implicit_connection(self, runtime_ctx: Dict[str, Any], file_id: str):
+        """The connection to read `file_id` from when the model named none, or
+        None when the id must be reported as unresolved.
+
+        Only ever the agent's SINGLE attached file connection: with two or more,
+        guessing could read the wrong source, so the error names them instead.
+        A uuid4 id is a conversation-attachment id by construction — if it isn't
+        in this report's space it is stale or from another report, and probing a
+        connector with it would swap a precise error for a provider 404.
+        """
+        if _looks_like_session_file_id(file_id):
+            return None
+        attached = attached_file_connections(runtime_ctx)
+        return attached[0][1] if len(attached) == 1 else None
+
+    def _unresolved_error(self, runtime_ctx: Dict[str, Any], file_id: str) -> str:
+        """Error for an id that resolved to nothing — written so the model's next
+        move is a corrected call, not another list_files. The old text ended at
+        'not a file attached to this conversation', which reads as 'your id is
+        wrong'; re-listing returns the same id, so the agent could loop."""
+        attached = attached_file_connections(runtime_ctx)
+        if not attached:
+            return (
+                f"'{file_id}' is not a file attached to this conversation, and no "
+                "file source is attached to this agent. Pass a file id from the "
+                "<files> block."
+            )
+        choices = describe_file_connections(attached)
+        if _looks_like_session_file_id(file_id):
+            return (
+                f"'{file_id}' is not a file attached to this conversation (it may "
+                "belong to another report). Pass a file id from the <files> block, "
+                "or a file-source id from list_files/search_files together with "
+                f"connection_id — attached source(s): {choices}."
+            )
+        return (
+            f"'{file_id}' is not a file attached to this conversation — it looks "
+            "like a file-source id. The id is probably fine: re-issue this SAME "
+            f"{self._operation_name} call with connection_id set to the source it "
+            f"came from. Do NOT re-run list_files. Attached source(s): {choices}."
+        )
 
     def _fail_read(self, data, err: str) -> ToolEndEvent:
         return ToolEndEvent(type="tool.end", payload={

--- a/backend/tests/unit/test_read_file_connection_fallback.py
+++ b/backend/tests/unit/test_read_file_connection_fallback.py
@@ -1,0 +1,243 @@
+"""read_file: a file-source id passed WITHOUT connection_id.
+
+Production trace this came from — the agent ran list_files on a SharePoint
+connection, got back Graph item ids, then called read_file with only
+`file_id='01LZCX…'`. An empty connection_id routes to the report's own file
+space (uploads / attach_file results), the Graph id isn't there, and the read
+failed with "is not a file attached to this conversation". The model read that
+as "my id is wrong", re-ran list_files, got the same id back, and looped.
+
+The id was fine — only the source was unnamed. So: fall through to the agent's
+file connection when there is exactly one, WITHOUT relaxing any access check
+(the user must still be able to reach that data source, and it must declare the
+capability), and when a fallback isn't safe, say which connections exist so the
+next call names one instead of re-listing.
+"""
+from __future__ import annotations
+
+import json
+import uuid as _uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.data_sources.clients.base import Capability
+
+
+# A real Microsoft Graph driveItem id — opaque base32, no dots or slashes, and
+# emphatically not a uuid4. This is the shape the fallback keys on.
+GRAPH_ID = "01LZCX6LHDIF2ODN4WMRDIZQRZ72A77RUD"
+
+
+class _StubClient:
+    """Minimal file client: enough surface for a whole-file text read."""
+
+    def __init__(self, text: str = "ITURAN-REVENUE-2026", caps=None):
+        self.capabilities = {Capability.READ_FILE} if caps is None else caps
+        self.text = text
+        self.reads: list = []
+
+    async def afile_version(self, file_id: str):
+        return None  # no cheap version → skip the content cache entirely
+
+    async def aread_file(self, file_id: str, **kwargs):
+        self.reads.append(file_id)
+        return self.text
+
+
+def _conn(conn_id: str, name: str, conn_type: str = "sharepoint"):
+    c = MagicMock()
+    c.id = conn_id
+    c.name = name
+    c.type = conn_type
+    c.is_active = True
+    c.auth_policy = "system"
+    c.allowed_user_auth_modes = []
+    return c
+
+
+def _ctx(*conns, files=None):
+    ds = MagicMock()
+    ds.id = "DS-1"
+    ds.name = "Company Files"
+    ds.is_active = True
+    ds.connections = list(conns)
+
+    report = MagicMock()
+    report.id = "REP-1"
+    report.data_sources = [ds] if conns else []
+    report.files = files or []
+
+    org = MagicMock()
+    org.id = "ORG-1"
+    org.settings = None
+
+    return {
+        "db": AsyncMock(),
+        "organization": org,
+        "report": report,
+        "user": MagicMock(id="USER-1"),
+        "model": MagicMock(supports_vision=False),
+    }
+
+
+async def _run_read(tool_input, runtime_ctx, client=None):
+    """Drive ReadFileTool with ConnectionService stubbed out. Returns the final
+    payload; the caller inspects `client.reads` to see if the connector was hit."""
+    from app.ai.tools.implementations.read_file import ReadFileTool
+
+    with patch("app.services.connection_service.ConnectionService") as svc_cls, patch(
+        "app.ai.tools.implementations.read_file.attach_drive_file_to_session",
+        new=AsyncMock(return_value="SESSION-1"),
+    ):
+        svc_cls.return_value.construct_client = AsyncMock(return_value=client)
+        events = [e async for e in ReadFileTool().run_stream(tool_input, runtime_ctx)]
+    return events[-1].payload
+
+
+# --------------------------------------------------------------- fallback
+
+
+class TestImplicitConnectionFallback:
+    @pytest.mark.asyncio
+    async def test_graph_id_without_connection_id_reads_the_only_connection(self):
+        client = _StubClient()
+        ctx = _ctx(_conn("CONN-1", "Employees SharePoint"))
+        payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, ctx, client)
+
+        out = payload["output"]
+        assert out["success"] is True, out.get("error")
+        assert client.reads == [GRAPH_ID]
+        # The read reports the connection it actually came from — a blank id here
+        # would misfile a connector read as a conversation attachment (and would
+        # poison the content cache key).
+        assert out["connection_id"] == "CONN-1"
+        assert "ITURAN-REVENUE-2026" in (payload["observation"].get("details") or "")
+
+    @pytest.mark.asyncio
+    async def test_path_shaped_id_also_falls_through(self):
+        """network_dir / S3 ids are paths, not opaque tokens — same fallback."""
+        client = _StubClient()
+        ctx = _ctx(_conn("CONN-1", "Shared drive", conn_type="network_dir"))
+        payload = await _run_read(
+            {"connection_id": "", "file_id": "reports/q3/ituran.txt"}, ctx, client
+        )
+        assert payload["output"]["success"] is True
+        assert client.reads == ["reports/q3/ituran.txt"]
+
+
+# ----------------------------------------------------------- access guards
+
+
+class TestFallbackStillChecksAccess:
+    @pytest.mark.asyncio
+    async def test_user_without_data_source_access_is_denied(self):
+        """The fallback picks the connection; it does NOT grant reach to it.
+        A user who can't access the data source gets nothing back."""
+        client = _StubClient(text="CONFIDENTIAL-PAYROLL")
+        ctx = _ctx(_conn("CONN-1", "HR SharePoint"))
+        with patch(
+            "app.core.permission_resolver.user_can_access_data_source",
+            new=AsyncMock(return_value=False),
+        ):
+            payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, ctx, client)
+
+        out = payload["output"]
+        assert out["success"] is False
+        assert "do not have access" in out["error"]
+        assert client.reads == []  # never reached the provider
+        assert "CONFIDENTIAL-PAYROLL" not in json.dumps(payload)
+
+    @pytest.mark.asyncio
+    async def test_capability_is_still_required(self):
+        client = _StubClient(caps={Capability.LIST_FILES})
+        ctx = _ctx(_conn("CONN-1", "Employees SharePoint"))
+        payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, ctx, client)
+
+        assert payload["output"]["success"] is False
+        assert "does not support read_file" in payload["output"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_inactive_connection_is_not_a_fallback_target(self):
+        conn = _conn("CONN-1", "Employees SharePoint")
+        conn.is_active = False
+        client = _StubClient()
+        payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, _ctx(conn), client)
+
+        assert payload["output"]["success"] is False
+        assert client.reads == []
+
+
+# -------------------------------------------------------- unresolved errors
+
+
+class TestUnresolvedErrorGuidesTheRetry:
+    @pytest.mark.asyncio
+    async def test_two_connections_are_named_instead_of_guessed(self):
+        client = _StubClient()
+        ctx = _ctx(
+            _conn("CONN-1", "Employees SharePoint"),
+            _conn("CONN-2", "Finance OneDrive", conn_type="onedrive"),
+        )
+        payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, ctx, client)
+
+        err = payload["output"]["error"]
+        assert payload["output"]["success"] is False
+        assert client.reads == []  # ambiguous — must not pick one at random
+        # The retry the model should make is spelled out, with real ids.
+        assert "connection_id" in err
+        assert "CONN-1" in err and "CONN-2" in err
+        assert "Employees SharePoint" in err and "Finance OneDrive" in err
+        # ...and the move that caused the production loop is ruled out.
+        assert "NOT re-run list_files" in err
+
+    @pytest.mark.asyncio
+    async def test_stale_session_uuid_does_not_probe_the_connector(self):
+        """A uuid4 is a conversation-attachment id by construction. If it isn't
+        in this report's space it's stale or foreign — reporting that beats a
+        provider 404 from a connector that was never going to hold it."""
+        client = _StubClient()
+        ctx = _ctx(_conn("CONN-1", "Employees SharePoint"))
+        payload = await _run_read(
+            {"connection_id": "", "file_id": str(_uuid.uuid4())}, ctx, client
+        )
+
+        assert payload["output"]["success"] is False
+        assert client.reads == []
+        assert "another report" in payload["output"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_file_source_attached_says_so(self):
+        payload = await _run_read({"connection_id": "", "file_id": GRAPH_ID}, _ctx(), None)
+
+        err = payload["output"]["error"]
+        assert payload["output"]["success"] is False
+        assert "no file source is attached" in err
+        assert "<files>" in err
+
+
+# --------------------------------------------------------------- precedence
+
+
+class TestSessionSpaceStillWins:
+    @pytest.mark.asyncio
+    async def test_attached_file_beats_the_connection(self, tmp_path):
+        """The report's own space is still checked first — a session file must
+        not be re-fetched from a connector just because one is attached."""
+        path = tmp_path / "notes.txt"
+        path.write_bytes(b"SESSION-SIDE-CONTENT")
+        f = MagicMock()
+        f.id = str(_uuid.uuid4())
+        f.filename = "notes.txt"
+        f.path = str(path)
+        f.organization_id = "ORG-1"
+
+        client = _StubClient()
+        ctx = _ctx(_conn("CONN-1", "Employees SharePoint"), files=[f])
+        payload = await _run_read({"connection_id": "", "file_id": f.id}, ctx, client)
+
+        out = payload["output"]
+        assert out["success"] is True, out.get("error")
+        assert client.reads == []
+        assert out["file_name"] == "notes.txt"
+        assert "SESSION-SIDE-CONTENT" in (payload["observation"].get("details") or "")


### PR DESCRIPTION
read_file picks its source by whether connection_id is set: empty means the
report's own file space (uploads / attach_file results). An agent that ran
list_files and then called read_file with only the returned id — a Graph
driveItem id like '01LZCX…' — hit the session lookup, missed, and failed with
"is not a file attached to this conversation". The id was fine; only the source
was unnamed. Worse, the error reads as "your id is wrong", so the model re-ran
list_files, got the same id back, and looped.

When the session lookup misses and the agent has exactly one attached file
connection, read from it. The fallback goes through resolve_file_client, so the
per-user data-source access check, the active-connection filter and the
capability check all apply exactly as they do for an explicitly named
connection — it picks the source, it does not grant reach to it. With two or
more connections nothing is guessed, and a uuid4 id (a conversation attachment
by construction) never probes a connector, so a stale or foreign attachment
still reports precisely instead of returning a provider 404.

The unresolved-id error now names the attached connections with their ids and
spells out the retry, so the next call sets connection_id instead of re-listing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lwbcm6ix2ZFVepe77X83qz