### PR TITLE
Learn from MCP tool failures; register MCP tools natively behind a flag

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -3023,6 +3023,10 @@ class AgentV2:
             # Early scoring will be launched as a background task using an isolated session
             await self._apply_tool_permission_filter()
             await self._apply_email_availability_filter()
+            # Add native MCP tools AFTER the permission/availability filters so
+            # they are never stripped by a filter that doesn't know about them,
+            # and before routing/fallback so the catalog is final by loop start.
+            await self._register_native_mcp_tools()
             await self._setup_model_routing()
             await self._setup_llm_fallback()
             _mlog(f"loop_starting step_limit={step_limit}")
@@ -3968,6 +3972,15 @@ class AgentV2:
                             """
                             tool_name = action.name
                             tool_input = action.arguments
+
+                            # A natively-registered MCP tool is rewritten into the
+                            # equivalent execute_mcp call before anything else runs.
+                            # Everything downstream — policy, identity forwarding,
+                            # materialization, audit, and the persisted
+                            # ToolExecution row — then behaves exactly as it does on
+                            # the gateway path, so native registration changes how
+                            # the model SEES the tool, not how we execute it.
+                            tool_name, tool_input = self._rewrite_native_mcp_action(tool_name, tool_input)
 
                             # Validate tool availability for chosen plan_type
                             if not self._validate_tool_for_plan_type(tool_name, decision.plan_type):
@@ -5284,6 +5297,75 @@ class AgentV2:
             return hosts[:20]
         except Exception:
             return []
+
+    def _rewrite_native_mcp_action(self, tool_name: str, tool_input):
+        """Translate a native MCP tool call into its execute_mcp equivalent.
+
+        Native registration exposes each MCP tool under its own name and schema
+        (``mcp__<connection>__<tool>``) so the provider can constrain decoding
+        against the server's real schema. Execution is unchanged: the call is
+        rewritten here into the gateway's argument shape, so tool policy,
+        per-user identity forwarding, result materialization and audit all keep
+        running exactly once, on one code path.
+
+        A side benefit worth preserving: the persisted ToolExecution row still
+        records ``execute_mcp`` with a ``connection_id``, which is what the
+        mcp_failed_then_fixed instruction trigger keys on. Native registration
+        therefore does not blind that trigger.
+
+        Unknown ``mcp__`` names pass through untouched and fail normal tool
+        resolution, which is the correct outcome for a hallucinated name.
+        """
+        routing = getattr(self, "_native_mcp_routing", None)
+        if not routing or not isinstance(tool_name, str) or not tool_name.startswith("mcp__"):
+            return tool_name, tool_input
+        route = routing.get(tool_name)
+        if not route:
+            return tool_name, tool_input
+
+        args = tool_input if isinstance(tool_input, dict) else {}
+        # Every key here belongs to the MCP server: a native tool's schema is
+        # the server's own, so nothing is lifted out. In particular `title` must
+        # NOT be treated as execute_mcp's cosmetic label the way it is on the
+        # gateway path — plenty of real tools take a `title` argument
+        # (issue_create requires one), and stripping it makes every such call
+        # fail validation for a missing required field.
+        rewritten = {
+            "connection_id": route["connection_id"],
+            "tool_name": route["tool_name"],
+            "arguments": dict(args),
+            "title": f"Running {route['tool_name']}",
+        }
+        logger.info("[agent] native mcp call %s -> execute_mcp(%s)", tool_name, route["tool_name"])
+        return "execute_mcp", rewritten
+
+    async def _register_native_mcp_tools(self) -> None:
+        """Add one planner tool per MCP/custom-API tool, when the flag is on.
+
+        Runs in the async post-init phase (``__init__`` is sync and has no DB
+        access), alongside the other catalog adjustments. Off by default; on
+        failure the catalog is left untouched and the gateway path serves.
+        """
+        from app.ai.tools.mcp_tool_registry import build_native_mcp_tools, native_tools_enabled
+
+        self._native_mcp_routing = {}
+        if not native_tools_enabled() or not self.report:
+            return
+        try:
+            user = self.user if hasattr(self, "user") else None
+            descriptors, routing = await build_native_mcp_tools(
+                self.db, self.report, user or getattr(self.head_completion, "user", None)
+            )
+            if not descriptors:
+                return
+            existing = {t.name for t in (self.planner.tool_catalog or [])}
+            added = [ToolDescriptor(**d) for d in descriptors if d["name"] not in existing]
+            self.planner.tool_catalog = (self.planner.tool_catalog or []) + added
+            self._native_mcp_routing = routing
+            logger.info("[agent] registered %d native MCP tool(s)", len(added))
+        except Exception as e:
+            logger.warning("[agent] native MCP tool registration skipped: %s", e)
+            self._native_mcp_routing = {}
 
     def _validate_tool_for_plan_type(self, tool_name: str, plan_type: str) -> bool:
         """Validate that tool is available for the chosen plan type.

--- a/backend/app/ai/agents/suggest_instructions/trigger.py
+++ b/backend/app/ai/agents/suggest_instructions/trigger.py
@@ -27,6 +27,25 @@ CORRECTION_KEYWORDS = [
     "exclude", "remove", "without", "skip", "omit", "drop",
 ]
 
+# Error text that means "try again later", not "you called this wrong".
+#
+# An MCP call can fail for two very different reasons, and only one of them is
+# worth writing down. A rate limit, an expired token or a gateway blip says
+# nothing durable about how the tool should be called — turning one into a
+# permanent instruction would be actively harmful, since the rule outlives the
+# outage. Anything matching here is excluded from the failed-then-fixed trigger.
+TRANSIENT_ERROR_PATTERNS = [
+    r"\b429\b", r"\brate.?limit", r"\btoo many requests\b",
+    r"\b50[0-9]\b", r"\bserver error\b", r"\bbad gateway\b",
+    r"\bservice unavailable\b", r"\bgateway timeout\b",
+    r"\btimed?.?out\b", r"\btimeout\b",
+    r"\b401\b", r"\b403\b", r"\bunauthorized\b", r"\bforbidden\b",
+    r"\btoken (has )?expired\b", r"\bexpired token\b",
+    r"\binvalid.{0,10}credential", r"\bauthentication failed\b",
+    r"\bconnection (refused|reset|error)\b", r"\bnetwork\b",
+    r"\btemporarily unavailable\b", r"\btry again\b",
+]
+
 # Patterns that suggest user provided code
 CODE_PATTERNS = [
     r"```",                          # Markdown code blocks
@@ -40,6 +59,17 @@ CODE_PATTERNS = [
     r"\bpd\.\w+",                    # Pandas
     r"\bdf\[",                       # DataFrame indexing
 ]
+
+
+def _json_preview(value: object, limit: int = 220) -> str:
+    """Compact JSON for embedding tool arguments in a trigger hint."""
+    import json
+
+    try:
+        text = json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        text = str(value)
+    return text if len(text) <= limit else text[:limit] + "…"
 
 
 class TriggerCondition:
@@ -194,8 +224,9 @@ class InstructionTriggerEvaluator:
                 condition_d = await self._check_failed_then_fixed()
                 condition_e = await self._check_user_provided_code(prev_tool_name_before_last_user)
                 condition_f = await self._check_inspect_then_create_data()
+                condition_i = await self._check_mcp_failed_then_fixed()
 
-                for condition in [condition_a, condition_b, condition_c, condition_d, condition_e, condition_f]:
+                for condition in [condition_a, condition_b, condition_c, condition_d, condition_e, condition_f, condition_i]:
                     if condition.met:
                         met_conditions.append(condition.to_dict())
 
@@ -448,6 +479,130 @@ class InstructionTriggerEvaluator:
                 elif prev_tables or current_tables:
                     # If we can't compare tables, still trigger if there was a recent failure
                     condition.met = True
+                    return condition
+
+            return condition
+
+        except Exception:
+            return condition
+
+    @staticmethod
+    def _is_transient_error(error_message: Optional[str]) -> bool:
+        """True when an error says 'retry later' rather than 'you called it wrong'."""
+        if not error_message:
+            return True  # No detail to learn from — treat as not worth capturing.
+        text = error_message.lower()
+        return any(re.search(p, text) for p in TRANSIENT_ERROR_PATTERNS)
+
+    async def _check_mcp_failed_then_fixed(self) -> TriggerCondition:
+        """Condition I: an execute_mcp call failed against a connection, and a
+        later call to that same connection succeeded.
+
+        This is the MCP twin of ``_check_failed_then_fixed``, with two
+        deliberate differences.
+
+        First, it matches WITHIN one execution as well as across executions. The
+        SQL version requires a user turn between the failure and the fix, because
+        a human normally supplies the missing knowledge. MCP failures are not
+        like that: the server states its own constraint in the error, and the
+        agent recovers unaided in the same run. Requiring a user turn would miss
+        the common case entirely.
+
+        Second, it filters transient errors. A rate limit or expired token is not
+        a fact about how the tool should be called, and recording it as an
+        instruction would leave a stale rule behind once the outage clears.
+
+        The learning is the delta between the rejected arguments and the accepted
+        ones, explained by the server's own error text — a durable fact about a
+        server whose declared schema under-specifies its real contract.
+        """
+        condition = TriggerCondition(
+            name="mcp_failed_then_fixed",
+            hint=(
+                "An MCP/API tool call failed and a later call to the same connection "
+                "succeeded. Capture what the server actually requires."
+            ),
+        )
+
+        try:
+            if not self.current_execution_id or not self.report_id:
+                return condition
+
+            # All execute_mcp calls for this report, oldest first, so a failure
+            # can be paired with a later success.
+            stmt = (
+                select(
+                    ToolExecution.arguments_json,
+                    ToolExecution.success,
+                    ToolExecution.status,
+                    ToolExecution.error_message,
+                    ToolExecution.started_at,
+                )
+                .join(AgentExecution, AgentExecution.id == ToolExecution.agent_execution_id)
+                .where(AgentExecution.report_id == self.report_id)
+                .where(ToolExecution.tool_name == "execute_mcp")
+                .order_by(ToolExecution.started_at.asc())
+                .limit(40)
+            )
+            rows = (await self.db.execute(stmt)).all()
+            if len(rows) < 2:
+                return condition
+
+            def _conn_of(args: Optional[dict]) -> Optional[str]:
+                return (args or {}).get("connection_id") if isinstance(args, dict) else None
+
+            def _tool_of(args: Optional[dict]) -> Optional[str]:
+                return (args or {}).get("tool_name") if isinstance(args, dict) else None
+
+            for i, (args, success, status, error_message, _ts) in enumerate(rows):
+                failed = (success is False) or (status == "error")
+                if not failed:
+                    continue
+                if self._is_transient_error(error_message):
+                    continue
+                conn = _conn_of(args)
+                if not conn:
+                    continue
+
+                # Any LATER successful call on the same connection is the fix —
+                # whether the agent retried the same tool with corrected
+                # arguments or switched to a sibling tool that does the job.
+                for later_args, later_success, later_status, _e, _t in rows[i + 1:]:
+                    if not ((later_success is True) or (later_status == "success")):
+                        continue
+                    if _conn_of(later_args) != conn:
+                        continue
+
+                    failed_tool = _tool_of(args) or "unknown"
+                    fixed_tool = _tool_of(later_args) or "unknown"
+                    same_tool = failed_tool == fixed_tool
+                    err = (error_message or "").strip()
+                    if len(err) > 300:
+                        err = err[:300] + "…"
+
+                    condition.met = True
+                    condition.hint = (
+                        "MCP failed-then-fixed flow: the tool "
+                        f"'{failed_tool}' was called and the server REJECTED it with: "
+                        f"\"{err}\". A later call "
+                        + (
+                            f"to the same tool with different arguments succeeded."
+                            if same_tool
+                            else f"to '{fixed_tool}' succeeded instead."
+                        )
+                        + " The rejected arguments were: "
+                        f"{_json_preview(args)}. The accepted arguments were: "
+                        f"{_json_preview(later_args)}.\n"
+                        "Capture the GENERAL RULE this reveals about the server — a requirement "
+                        "its declared input schema does not express (e.g. 'this tool needs at "
+                        "least one filter argument', 'this field must be a JSON-encoded string', "
+                        "'use tool X rather than Y to list all records'). "
+                        "Write it as a reusable rule about the tool, naming the tool and the "
+                        "requirement. Do NOT record the specific ids, emails or values used in "
+                        "this run — those are record-level facts, not rules. "
+                        "FIRST call search_instructions to check whether this rule is already "
+                        "captured; if it is, do nothing rather than creating a near-duplicate."
+                    )
                     return condition
 
             return condition

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -357,8 +357,18 @@ class TablesSchemaContext(ContextSection):
             # Inline argument schemas when the catalog is small enough to
             # afford it. Above the threshold the block would dominate the
             # prompt every turn, so those fall back to search_mcps discovery.
+            #
+            # When native registration is on, each tool already carries its
+            # schema in the request's tools array. Inlining here as well would
+            # pay for the same bytes twice, every turn, so the block degrades to
+            # an index and the note points at the real tools.
             total_tools = sum(len(v) for v in groups.values())
-            inline_schemas = total_tools <= self._MCP_INLINE_SCHEMA_MAX
+            try:
+                from app.ai.tools.mcp_tool_registry import native_tools_enabled
+                native_on = native_tools_enabled()
+            except Exception:
+                native_on = False
+            inline_schemas = (not native_on) and total_tools <= self._MCP_INLINE_SCHEMA_MAX
 
             conn_parts = []
             has_gated = False
@@ -401,6 +411,14 @@ class TablesSchemaContext(ContextSection):
                     "call execute_mcp directly; do NOT call search_mcps first. Match the declared type "
                     "exactly: an arg typed \"string\" takes a string even when its content is JSON "
                     "(serialize it), and an arg typed \"integer\" takes a number, not a formatted date.</note>"
+                )
+            elif native_on:
+                conn_parts.append(
+                    "<note>Each tool above is also available to you directly as a tool named "
+                    "mcp__&lt;connection&gt;__&lt;tool&gt;, carrying its own argument schema — call it "
+                    "directly rather than going through execute_mcp, and do not call search_mcps "
+                    "for it. Use search_mcps + execute_mcp only for a tool listed here that has no "
+                    "matching mcp__ tool available.</note>"
                 )
             else:
                 conn_parts.append(

--- a/backend/app/ai/tools/mcp_tool_registry.py
+++ b/backend/app/ai/tools/mcp_tool_registry.py
@@ -1,0 +1,262 @@
+"""Native registration of MCP / custom-API tools as first-class planner tools.
+
+Default path today is the ``execute_mcp`` gateway: one tool whose ``arguments``
+field is an unconstrained object, so the provider never sees the real schema and
+cannot constrain decoding against it. The agent compensates by calling
+``search_mcps`` to fetch the schema, which costs a planner turn and a tool round
+trip per call.
+
+This module builds the alternative: one ``ToolDescriptor`` per allowed
+``ConnectionTool``, each carrying the server's own JSON Schema. The schema then
+travels in the request's ``tools`` array, which means it is present at every
+generation, sits in the cacheable prefix, and constrains sampling. It is the
+pattern used by opencode (``McpCatalog.convertTool``) and OpenClaw
+(``agent-bundle-mcp-materialize``).
+
+Dispatch stays on the existing path: a native call is rewritten into the same
+``execute_mcp`` arguments, so tool policy, per-user identity forwarding, CSV/JSON
+materialization and audit are unchanged.
+
+Gated by ``BOW_MCP_NATIVE_TOOLS`` (default off) and capped by
+``BOW_MCP_NATIVE_TOOLS_MAX`` — above the cap the gateway path is kept, because a
+very large catalog costs more as permanent tool definitions than it saves in
+discovery round trips.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Anthropic and OpenAI both cap tool names at 64 characters.
+_MAX_TOOL_NAME = 64
+_PREFIX = "mcp__"
+
+_DEFAULT_MAX_NATIVE_TOOLS = 60
+
+
+def native_tools_enabled() -> bool:
+    return os.environ.get("BOW_MCP_NATIVE_TOOLS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def native_tools_budget() -> int:
+    try:
+        return int(os.environ.get("BOW_MCP_NATIVE_TOOLS_MAX", _DEFAULT_MAX_NATIVE_TOOLS))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_NATIVE_TOOLS
+
+
+def sanitize(value: str) -> str:
+    """Reduce a name to the character set every provider accepts."""
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", value or "")
+
+
+def build_tool_name(connection_slug: str, tool_name: str, taken: set) -> str:
+    """``mcp__<connection>__<tool>``, sanitized, unique, and within the 64-char cap.
+
+    Truncation happens on the TOOL half rather than the connection half, so two
+    tools from different connections can never collide after trimming. A short
+    content hash is appended whenever the name had to be shortened or would
+    otherwise duplicate one already issued — a stable suffix, so the same tool
+    keeps the same name across runs (important for prompt caching).
+    """
+    conn = sanitize(connection_slug)[:20].strip("_") or "conn"
+    tool = sanitize(tool_name)
+    base = f"{_PREFIX}{conn}__{tool}"
+
+    if len(base) <= _MAX_TOOL_NAME and base.lower() not in taken:
+        taken.add(base.lower())
+        return base
+
+    digest = hashlib.sha1(f"{connection_slug}:{tool_name}".encode()).hexdigest()[:6]
+    room = _MAX_TOOL_NAME - len(_PREFIX) - len(conn) - len("____") - len(digest)
+    trimmed = tool[: max(room, 1)]
+    name = f"{_PREFIX}{conn}__{trimmed}__{digest}"[:_MAX_TOOL_NAME]
+
+    # A collision here would require the same connection+tool pair twice, which
+    # the caller already de-duplicates; loop defensively rather than assume.
+    counter = 0
+    while name.lower() in taken:
+        counter += 1
+        suffix = f"{digest}{counter}"
+        room = _MAX_TOOL_NAME - len(_PREFIX) - len(conn) - len("____") - len(suffix)
+        name = f"{_PREFIX}{conn}__{tool[: max(room, 1)]}__{suffix}"[:_MAX_TOOL_NAME]
+    taken.add(name.lower())
+    return name
+
+
+def normalize_schema(schema: Any) -> Dict[str, Any]:
+    """Make an MCP input schema safe to send as a provider tool schema.
+
+    Servers emit schemas of varying quality: missing ``type``, absent
+    ``properties``, a stray ``$schema`` draft marker. Providers reject some of
+    these outright. ``$ref``/``$defs`` are inlined so the shape is literal at the
+    point of use, matching what the ``<mcp_tools>`` renderer already does.
+    """
+    from app.ai.tools.mcp_schema import resolve_refs
+
+    if not isinstance(schema, dict) or not schema:
+        return {"type": "object", "properties": {}}
+
+    try:
+        resolved = resolve_refs(schema)
+    except Exception:
+        resolved = schema
+    if not isinstance(resolved, dict):
+        return {"type": "object", "properties": {}}
+
+    out = {k: v for k, v in resolved.items() if k != "$schema"}
+    out["type"] = "object"
+    if not isinstance(out.get("properties"), dict):
+        out["properties"] = {}
+    if "required" in out and not isinstance(out["required"], list):
+        out.pop("required")
+    return out
+
+
+def parse_native_tool_name(name: str) -> Optional[str]:
+    """True-ish check: is this one of ours? Returns the raw name if so."""
+    return name if isinstance(name, str) and name.startswith(_PREFIX) else None
+
+
+async def build_native_mcp_tools(
+    db, report, user=None
+) -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, str]]]:
+    """Build native tool descriptors for a report's MCP / custom-API tools.
+
+    Returns ``(descriptor_dicts, routing)`` where routing maps the generated tool
+    name to ``{"connection_id", "tool_name"}`` for dispatch. Mirrors the
+    discovery, policy and locked-field filtering that ``search_mcps`` performs,
+    so a tool hidden there is hidden here too.
+
+    Returns empty on any failure — the gateway path remains available, so a
+    problem here degrades to today's behavior rather than breaking the run.
+    """
+    from sqlalchemy import select
+    from app.models.connection import Connection
+    from app.models.connection_tool import ConnectionTool
+    from app.models.data_source_connection_tool import DataSourceConnectionTool
+    from app.models.domain_connection import domain_connection
+    from app.models.report_data_source_association import report_data_source_association
+    from app.services.mcp_context_injection import filter_locked_from_schema
+    from app.services.tool_policy_service import ToolPolicyService, resolve_effective_policy
+
+    try:
+        conns = (await db.execute(
+            select(Connection)
+            .join(domain_connection, domain_connection.c.connection_id == Connection.id)
+            .join(
+                report_data_source_association,
+                report_data_source_association.c.data_source_id == domain_connection.c.data_source_id,
+            )
+            .where(
+                report_data_source_association.c.report_id == str(report.id),
+                Connection.type.in_(["mcp", "custom_api"]),
+            )
+        )).scalars().all()
+        if not conns:
+            return [], {}
+
+        import json as _json
+        conn_by_id = {}
+        for c in conns:
+            cfg = c.config
+            if isinstance(cfg, str):
+                try:
+                    cfg = _json.loads(cfg)
+                except Exception:
+                    cfg = {}
+            conn_by_id[str(c.id)] = {"name": c.name, "config": cfg or {}}
+
+        tools = (await db.execute(
+            select(ConnectionTool).where(
+                ConnectionTool.connection_id.in_(list(conn_by_id.keys()))
+            )
+        )).scalars().all()
+        if not tools:
+            return [], {}
+
+        ds_ids = [str(r[0]) for r in (await db.execute(
+            select(domain_connection.c.data_source_id)
+            .join(
+                report_data_source_association,
+                report_data_source_association.c.data_source_id == domain_connection.c.data_source_id,
+            )
+            .where(
+                report_data_source_association.c.report_id == str(report.id),
+                domain_connection.c.connection_id.in_(list(conn_by_id.keys())),
+            )
+        )).all()]
+
+        overlays = {}
+        if ds_ids:
+            rows = (await db.execute(
+                select(DataSourceConnectionTool).where(
+                    DataSourceConnectionTool.data_source_id.in_(ds_ids),
+                    DataSourceConnectionTool.connection_tool_id.in_([str(t.id) for t in tools]),
+                )
+            )).scalars().all()
+            overlays = {str(o.connection_tool_id): o for o in rows}
+
+        user_prefs = {}
+        if user is not None:
+            user_prefs = await ToolPolicyService().get_user_preferences(
+                db, str(user.id), [str(t.id) for t in tools]
+            )
+
+        descriptors: List[Dict[str, Any]] = []
+        routing: Dict[str, Dict[str, str]] = {}
+        taken: set = set()
+        budget = native_tools_budget()
+
+        for t in tools:
+            overlay = overlays.get(str(t.id))
+            if not (overlay.is_enabled if overlay else t.is_enabled):
+                continue
+            admin_policy = overlay.policy if overlay else t.policy
+            effective = resolve_effective_policy(admin_policy, user_prefs.get(str(t.id)))
+            if effective == "deny":
+                continue
+
+            cid = str(t.connection_id)
+            info = conn_by_id.get(cid) or {}
+            try:
+                visible = filter_locked_from_schema(t.input_schema, info.get("config", {}))
+            except Exception:
+                visible = t.input_schema
+
+            name = build_tool_name(info.get("name") or cid, t.name, taken)
+            desc = (t.description or f"Tool '{t.name}' on {info.get('name') or 'connection'}.").strip()
+            if effective in ("ask", "auto"):
+                desc += (
+                    f"\n\n(Policy: {effective} — this call is reviewed before it runs "
+                    "and may be declined.)"
+                )
+
+            descriptors.append({
+                "name": name,
+                "description": desc,
+                "schema": normalize_schema(visible),
+                "category": "both",
+                "research_accessible": True,
+                "is_active": True,
+            })
+            routing[name] = {"connection_id": cid, "tool_name": t.name}
+
+            if len(descriptors) >= budget:
+                logger.info(
+                    "native mcp tools: budget %d reached; %d tool(s) remain on the "
+                    "execute_mcp gateway path", budget, len(tools) - len(descriptors),
+                )
+                break
+
+        return descriptors, routing
+
+    except Exception as e:
+        logger.warning("native mcp tool registration failed, falling back to gateway: %s", e)
+        return [], {}

--- a/backend/tests/mocks/complex_schema_mcp_server.py
+++ b/backend/tests/mocks/complex_schema_mcp_server.py
@@ -317,7 +317,102 @@ TOOLS: list[dict[str, Any]] = [
             "additionalProperties": False,
         },
     },
+    {
+        # FAILURE MODE: the schema LIES BY OMISSION. Every property is optional
+        # — there is no `required` key at all — but the server rejects a call
+        # that supplies only pagination. Copied from the real Intercom
+        # search_contacts tool, which produced exactly this failure in
+        # production: `{"per_page": 50}` is schema-valid and still 400s.
+        #
+        # This is the case neither inline schemas nor native registration can
+        # catch, because there is nothing in the schema to validate against. It
+        # exists to exercise the mcp_failed_then_fixed instruction trigger.
+        "name": "contacts_search",
+        "description": "Search for contacts using multiple filter criteria.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "contact_ids": {"type": "array", "items": {"type": "string"}},
+                "name": {"type": "string", "description": "Search contacts by name (partial match)."},
+                "email": {"type": "string", "description": "Search contacts by exact email address."},
+                "email_domain": {"type": "string"},
+                "phone": {"type": "string"},
+                "per_page": {"type": "number", "default": 5, "description": "Results per page (max 150)."},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        # The recovery path — deliberately NOT an obvious "list_all". Intercom
+        # has no list-contacts tool; the only way to enumerate is a search DSL
+        # whose entry point is easy to overlook. An obviously-named listing tool
+        # here would let the agent sidestep the failure entirely and the trigger
+        # would never be exercised (it did exactly that on the first attempt).
+        "name": "workspace_query",
+        "description": (
+            "Run a workspace query using the Query DSL. The query MUST start with "
+            "object_type:contacts or object_type:conversations to select which API to "
+            "call, followed by optional space-separated key[:op]:value filters. "
+            "Example: 'object_type:contacts' returns all contacts."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Query DSL string."},
+                "per_page": {"type": "number", "default": 50},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    },
 ]
+
+# Tools whose runtime contract is stricter than their declared schema. The value
+# is (predicate over arguments, error message) — when the predicate holds, the
+# call is rejected even though it validates. Real servers do this constantly;
+# modelling it is the only way to test the failure class honestly.
+UNDECLARED_CONSTRAINTS = {
+    "contacts_search": (
+        lambda a: not any(
+            k in a for k in ("contact_ids", "name", "email", "email_domain", "phone")
+        ),
+        "At least one search parameter must be provided",
+    ),
+}
+
+# Optional filler so the catalog can be pushed past the <mcp_tools> inline-schema
+# threshold (40). Above it, the gateway path stops inlining schemas and the agent
+# must rediscover them via search_mcps — which is the regime real customers with
+# monday/Atlassian-sized catalogs are actually in, and the one where native
+# registration is supposed to earn its keep. Set MOCK_MCP_PAD_TOOLS=N.
+def _padding_tools(n: int) -> list[dict[str, Any]]:
+    domains = ["orders", "invoices", "tickets", "assets", "vendors",
+               "shipments", "budgets", "policies", "incidents", "reviews"]
+    verbs = ["list", "get", "search", "update", "archive"]
+    out: list[dict[str, Any]] = []
+    for i in range(n):
+        domain = domains[i % len(domains)]
+        verb = verbs[(i // len(domains)) % len(verbs)]
+        out.append({
+            "name": f"{domain}_{verb}_{i}",
+            "description": f"{verb.capitalize()} {domain} records in the workspace.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "recordId": {"type": "string", "description": f"The {domain} record id."},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 200},
+                    "includeArchived": {"type": "boolean", "default": False},
+                },
+                "required": ["recordId"],
+                "additionalProperties": False,
+            },
+        })
+    return out
+
+
+_PAD = int(os.environ.get("MOCK_MCP_PAD_TOOLS", "0") or 0)
+if _PAD > 0:
+    TOOLS.extend(_padding_tools(_PAD))
 
 TOOLS_BY_NAME = {t["name"]: t for t in TOOLS}
 
@@ -400,13 +495,27 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.ContentB
         raise ValueError(f"Unknown tool: {name}")
 
     violations = _violations(name, arguments)
+
+    # A schema-valid call can still be refused by the server's real contract.
+    # Recorded separately so scoring can distinguish "the agent broke the
+    # schema" from "the schema never described the rule".
+    undeclared = None
+    if not violations and name in UNDECLARED_CONSTRAINTS:
+        predicate, message = UNDECLARED_CONSTRAINTS[name]
+        if predicate(arguments):
+            undeclared = message
+
     _capture({
         "tool": name,
         "arguments": arguments,
         "valid": not violations,
         "violations": violations,
+        "undeclared_constraint": undeclared,
         "ts": datetime.now(timezone.utc).isoformat(),
     })
+
+    if undeclared:
+        raise ValueError(undeclared)
 
     if violations:
         # Deliberately terse and vendor-flavoured: a real server tells you

--- a/backend/tests/mocks/mcp_argument_fidelity_eval.py
+++ b/backend/tests/mocks/mcp_argument_fidelity_eval.py
@@ -157,8 +157,14 @@ def run_case(c: httpx.Client, seed: dict, case: dict, timeout_s: int = 240) -> d
         rr = c.get(f"/reports/{report_id}/completions", headers=H)
         if rr.status_code != 200:
             continue
-        comps = rr.json()
-        sys_comps = [x for x in comps if x.get("role") == "system"]
+        body = rr.json()
+        # The endpoint returns {"completions": [...]} on some builds and a bare
+        # list on others; a bare dict iterates as its KEYS (strings), which is
+        # how this silently crashed rather than just polling.
+        comps = body.get("completions", []) if isinstance(body, dict) else body
+        if not isinstance(comps, list):
+            continue
+        sys_comps = [x for x in comps if isinstance(x, dict) and x.get("role") == "system"]
         if sys_comps and sys_comps[-1].get("status") in ("success", "error"):
             status = sys_comps[-1]["status"]
             break

--- a/backend/tests/mocks/mcp_trigger_eval.py
+++ b/backend/tests/mocks/mcp_trigger_eval.py
@@ -1,0 +1,103 @@
+"""End-to-end check for the mcp_failed_then_fixed instruction trigger.
+
+Drives the real agent at the mock's Intercom-shaped tool (`contacts_search`,
+whose schema declares nothing required but whose server refuses filter-less
+calls), then asks two questions:
+
+  1. Did the run fail-then-recover, as production did?
+  2. Did the knowledge harness draft an instruction capturing the rule?
+
+Usage (from backend/, backend + mock running)::
+
+    uv run python tests/mocks/mcp_trigger_eval.py --label t1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import httpx
+
+BASE = "http://localhost:8000/api"
+SEED = "/tmp/bow-agent/seed.json"
+
+PROMPT = "Using MockOps, show me a list of contacts."
+
+
+def session():
+    seed = json.load(open(SEED))
+    tok = httpx.post(
+        f"{BASE}/auth/jwt/login",
+        data={"username": seed["email"], "password": "TestPassword123!"},
+        timeout=60,
+    ).json()["access_token"]
+    h = {"Authorization": f"Bearer {tok}", "X-Organization-Id": seed["org_id"]}
+    return seed, h
+
+
+def run_turn(c, h, seed, prompt, timeout_s=420):
+    r = c.post("/reports", headers=h, json={"title": "trigger-eval", "data_sources": [seed["ds_id"]]})
+    r.raise_for_status()
+    rid = r.json()["id"]
+    c.post(f"/reports/{rid}/completions", headers=h, json={"prompt": {"content": prompt}, "stream": False})
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        time.sleep(5)
+        rr = c.get(f"/reports/{rid}/completions", headers=h)
+        if rr.status_code != 200:
+            continue
+        body = rr.json()
+        comps = body.get("completions", body) if isinstance(body, dict) else body
+        if not isinstance(comps, list):
+            continue
+        sysc = [x for x in comps if isinstance(x, dict) and x.get("role") == "system"]
+        if sysc and sysc[-1].get("status") in ("success", "error"):
+            return rid, sysc[-1].get("status")
+    return rid, "timeout"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", default="t1")
+    args = ap.parse_args()
+
+    def drafts(c, h):
+        """Harness output lands as draft instructions inside a submitted AI
+        build — it is NOT in the default (published) instruction list, so the
+        status filter is required or this silently reports zero."""
+        r = c.get("/instructions", headers=h, params={"status": "draft"})
+        if r.status_code != 200:
+            return []
+        body = r.json()
+        return body.get("items", []) if isinstance(body, dict) else (body or [])
+
+    seed, h = session()
+    with httpx.Client(base_url=BASE, timeout=600) as c:
+        n_before = len(drafts(c, h))
+        print("pending instruction drafts before:", n_before)
+
+        rid, status = run_turn(c, h, seed, PROMPT)
+        print("report:", rid, "status:", status)
+
+        # The harness runs after the answer streams; give it room to finish.
+        time.sleep(45)
+
+        items = drafts(c, h)
+        print("pending instruction drafts after:", len(items))
+        for it in items:
+            if not isinstance(it, dict):
+                print("-", str(it)[:200])
+                continue
+            txt = it.get("text") or it.get("content") or it.get("new_text") or ""
+            print("-" * 70)
+            print("status:", it.get("status"), "| category:", it.get("category"))
+            print(txt[:600])
+
+    json.dump({"report": rid, "status": status, "instructions": items},
+              open(f"/tmp/bow-agent/trigger_{args.label}.json", "w"), indent=2, default=str)
+    print("\nwrote /tmp/bow-agent/trigger_%s.json" % args.label)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_mcp_failed_then_fixed_trigger.py
+++ b/backend/tests/unit/test_mcp_failed_then_fixed_trigger.py
@@ -1,0 +1,168 @@
+"""Unit tests for the MCP failed-then-fixed instruction trigger.
+
+The negative controls matter as much as the positive one here: a trigger that
+fires on a rate limit would mint a permanent instruction describing a temporary
+outage, and that rule would outlive the outage.
+"""
+import pytest
+
+from app.ai.agents.suggest_instructions.trigger import InstructionTriggerEvaluator
+
+
+class _Row(tuple):
+    """Mimics a SQLAlchemy row of (arguments_json, success, status, error_message, started_at)."""
+
+
+def _row(args, success, status, error=None, ts=0):
+    return _Row((args, success, status, error, ts))
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._rows)
+
+
+def _evaluator(rows):
+    ev = InstructionTriggerEvaluator.__new__(InstructionTriggerEvaluator)
+    ev.db = _FakeDB(rows)
+    ev.current_execution_id = "exec-1"
+    ev.report_id = "report-1"
+    return ev
+
+
+CONN = "conn-intercom"
+
+
+# ── transient-error classifier ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("msg", [
+    "429 Too Many Requests",
+    "Rate limit exceeded, try again in 30s",
+    "503 Service Unavailable",
+    "upstream request timed out",
+    "401 Unauthorized",
+    "token has expired",
+    "connection refused",
+    None,
+    "",
+])
+def test_transient_errors_are_excluded(msg):
+    assert InstructionTriggerEvaluator._is_transient_error(msg) is True
+
+
+@pytest.mark.parametrize("msg", [
+    "At least one search parameter must be provided",
+    "invalid value for 'columnValues'",
+    "field 'from' must be a unix timestamp",
+    "unknown column id 'status9'",
+])
+def test_deterministic_errors_are_capturable(msg):
+    assert InstructionTriggerEvaluator._is_transient_error(msg) is False
+
+
+# ── the trigger ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fires_on_intercom_shaped_failure_then_recovery():
+    """The real production case: schema-valid call rejected at runtime, then a
+    sibling tool succeeds — all inside one execution, no user turn."""
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "search_contacts",
+              "arguments": {"per_page": 50}},
+             False, "error", "At least one search parameter must be provided", 1),
+        _row({"connection_id": CONN, "tool_name": "search",
+              "arguments": {"query": "object_type:contacts"}},
+             True, "success", None, 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is True
+    assert "search_contacts" in cond.hint
+    assert "At least one search parameter" in cond.hint
+    assert "search_instructions" in cond.hint       # dedupe is mandated
+    assert "GENERAL RULE" in cond.hint              # pushes away from record-level facts
+
+
+@pytest.mark.asyncio
+async def test_fires_when_same_tool_retried_with_fixed_arguments():
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "board_change_column_values",
+              "arguments": {"columnValues": {"status": "Done"}}},
+             False, "error", "invalid value for 'columnValues'", 1),
+        _row({"connection_id": CONN, "tool_name": "board_change_column_values",
+              "arguments": {"columnValues": "{\"status\": \"Done\"}"}},
+             True, "success", None, 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is True
+    assert "same tool with different arguments" in cond.hint
+
+
+@pytest.mark.asyncio
+async def test_does_not_fire_on_rate_limit():
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "search_contacts", "arguments": {}},
+             False, "error", "429 Too Many Requests", 1),
+        _row({"connection_id": CONN, "tool_name": "search_contacts", "arguments": {}},
+             True, "success", None, 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is False
+
+
+@pytest.mark.asyncio
+async def test_does_not_fire_on_expired_token():
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "get_contact", "arguments": {}},
+             False, "error", "401 Unauthorized: token has expired", 1),
+        _row({"connection_id": CONN, "tool_name": "get_contact", "arguments": {}},
+             True, "success", None, 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is False
+
+
+@pytest.mark.asyncio
+async def test_does_not_fire_without_a_recovery():
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "search_contacts", "arguments": {}},
+             False, "error", "At least one search parameter must be provided", 1),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is False
+
+
+@pytest.mark.asyncio
+async def test_does_not_pair_across_different_connections():
+    """A failure on Intercom is not explained by a success on monday."""
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "search_contacts", "arguments": {}},
+             False, "error", "At least one search parameter must be provided", 1),
+        _row({"connection_id": "conn-monday", "tool_name": "get_board", "arguments": {}},
+             True, "success", None, 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is False
+
+
+@pytest.mark.asyncio
+async def test_success_before_failure_does_not_count():
+    """Ordering matters: the fix must come after the failure."""
+    rows = [
+        _row({"connection_id": CONN, "tool_name": "search", "arguments": {}},
+             True, "success", None, 1),
+        _row({"connection_id": CONN, "tool_name": "search_contacts", "arguments": {}},
+             False, "error", "At least one search parameter must be provided", 2),
+    ]
+    cond = await _evaluator(rows)._check_mcp_failed_then_fixed()
+    assert cond.met is False

--- a/backend/tests/unit/test_mcp_tool_registry.py
+++ b/backend/tests/unit/test_mcp_tool_registry.py
@@ -1,0 +1,193 @@
+"""Unit tests for native MCP tool naming and schema normalization."""
+import pytest
+
+from app.ai.tools.mcp_tool_registry import (
+    build_tool_name, normalize_schema, parse_native_tool_name, sanitize,
+    native_tools_enabled, native_tools_budget,
+)
+
+MAX = 64
+
+
+def test_sanitize_strips_unsupported_characters():
+    assert sanitize("Intercom (Prod)!") == "Intercom__Prod__"
+    assert sanitize("search-contacts_v2") == "search-contacts_v2"
+
+
+def test_basic_name_shape():
+    name = build_tool_name("Intercom", "search_contacts", set())
+    assert name == "mcp__Intercom__search_contacts"
+    assert parse_native_tool_name(name) == name
+
+
+def test_non_native_names_are_not_claimed():
+    assert parse_native_tool_name("create_data") is None
+    assert parse_native_tool_name(None) is None
+
+
+def test_same_tool_name_on_two_connections_does_not_collide():
+    taken = set()
+    a = build_tool_name("Intercom", "search", taken)
+    b = build_tool_name("Notion", "search", taken)
+    assert a != b
+    assert a.lower() in taken and b.lower() in taken
+
+
+def test_names_are_capped_at_provider_limit():
+    taken = set()
+    name = build_tool_name("a-very-long-connection-name-indeed", "b" * 120, taken)
+    assert len(name) <= MAX
+    assert name.startswith("mcp__")
+
+
+def test_long_names_from_different_connections_stay_distinct():
+    """Truncation must not merge two tools into one name — the connection half
+    is preserved and a stable hash disambiguates the trimmed tool half."""
+    taken = set()
+    a = build_tool_name("connection-alpha-long", "z" * 120, taken)
+    b = build_tool_name("connection-bravo-long", "z" * 120, taken)
+    assert a != b
+    assert len(a) <= MAX and len(b) <= MAX
+
+
+def test_name_is_stable_across_runs():
+    """Prompt caching depends on tool names not moving between runs."""
+    first = build_tool_name("Intercom", "x" * 120, set())
+    second = build_tool_name("Intercom", "x" * 120, set())
+    assert first == second
+
+
+def test_duplicate_registration_gets_distinct_names():
+    taken = set()
+    a = build_tool_name("Intercom", "search", taken)
+    b = build_tool_name("Intercom", "search", taken)
+    assert a != b
+
+
+# ── schema normalization ───────────────────────────────────────────────────
+
+def test_empty_schema_becomes_valid_object():
+    assert normalize_schema(None) == {"type": "object", "properties": {}}
+    assert normalize_schema({}) == {"type": "object", "properties": {}}
+
+
+def test_missing_type_and_properties_are_filled():
+    out = normalize_schema({"required": ["a"]})
+    assert out["type"] == "object"
+    assert out["properties"] == {}
+
+
+def test_draft_marker_is_stripped():
+    out = normalize_schema({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+    })
+    assert "$schema" not in out
+    assert out["properties"]["q"]["type"] == "string"
+
+
+def test_refs_are_inlined():
+    out = normalize_schema({
+        "type": "object",
+        "properties": {"estimate": {"$ref": "#/$defs/Estimate"}},
+        "$defs": {"Estimate": {
+            "type": "object",
+            "properties": {"value": {"type": "number"}},
+            "required": ["value"],
+        }},
+    })
+    est = out["properties"]["estimate"]
+    assert est["type"] == "object"
+    assert est["properties"]["value"]["type"] == "number"
+    assert "$ref" not in str(out)
+
+
+def test_malformed_required_is_dropped():
+    out = normalize_schema({"type": "object", "properties": {}, "required": "a"})
+    assert "required" not in out
+
+
+def test_intercom_shaped_schema_survives_normalization():
+    """The real search_contacts schema: no `required` at all. Normalization must
+    not invent one — the whole point is that the server under-declares, and
+    fabricating requiredness here would make valid calls fail locally."""
+    out = normalize_schema({
+        "type": "object",
+        "properties": {"per_page": {"type": "number"}, "email": {"type": "string"}},
+        "additionalProperties": False,
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    })
+    assert "required" not in out
+    assert out["additionalProperties"] is False
+
+
+# ── flag plumbing ──────────────────────────────────────────────────────────
+
+def test_flag_defaults_off(monkeypatch):
+    monkeypatch.delenv("BOW_MCP_NATIVE_TOOLS", raising=False)
+    assert native_tools_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_flag_accepts_truthy_values(monkeypatch, val):
+    monkeypatch.setenv("BOW_MCP_NATIVE_TOOLS", val)
+    assert native_tools_enabled() is True
+
+
+def test_budget_defaults_and_overrides(monkeypatch):
+    monkeypatch.delenv("BOW_MCP_NATIVE_TOOLS_MAX", raising=False)
+    assert native_tools_budget() == 60
+    monkeypatch.setenv("BOW_MCP_NATIVE_TOOLS_MAX", "12")
+    assert native_tools_budget() == 12
+    monkeypatch.setenv("BOW_MCP_NATIVE_TOOLS_MAX", "not-a-number")
+    assert native_tools_budget() == 60
+
+
+# ── dispatch rewrite ───────────────────────────────────────────────────────
+
+class _FakeAgent:
+    """Minimal stand-in exposing just the rewrite helper."""
+    from app.ai.agent_v2 import AgentV2
+    _rewrite_native_mcp_action = AgentV2._rewrite_native_mcp_action
+
+    def __init__(self, routing):
+        self._native_mcp_routing = routing
+
+
+ROUTING = {"mcp__conn__issue_create": {"connection_id": "c1", "tool_name": "issue_create"}}
+
+
+def test_rewrite_maps_to_execute_mcp():
+    name, args = _FakeAgent(ROUTING)._rewrite_native_mcp_action(
+        "mcp__conn__issue_create", {"teamId": "t", "title": "Fix login", "priority": 1}
+    )
+    assert name == "execute_mcp"
+    assert args["connection_id"] == "c1"
+    assert args["tool_name"] == "issue_create"
+
+
+def test_rewrite_preserves_a_tool_argument_named_title():
+    """Regression: `title` is execute_mcp's cosmetic label on the gateway path,
+    but on a native call every key belongs to the server — and issue_create
+    REQUIRES a `title`. Stripping it made every such call fail validation for a
+    missing required field, three retries deep, without reaching the server."""
+    _, args = _FakeAgent(ROUTING)._rewrite_native_mcp_action(
+        "mcp__conn__issue_create", {"teamId": "t", "title": "Fix login", "priority": 1}
+    )
+    assert args["arguments"]["title"] == "Fix login"
+
+
+def test_unknown_native_name_passes_through():
+    name, args = _FakeAgent(ROUTING)._rewrite_native_mcp_action("mcp__conn__nope", {"a": 1})
+    assert name == "mcp__conn__nope" and args == {"a": 1}
+
+
+def test_non_native_tool_untouched():
+    name, args = _FakeAgent(ROUTING)._rewrite_native_mcp_action("create_data", {"a": 1})
+    assert name == "create_data" and args == {"a": 1}
+
+
+def test_rewrite_noop_when_routing_absent():
+    name, args = _FakeAgent({})._rewrite_native_mcp_action("mcp__conn__issue_create", {"a": 1})
+    assert name == "mcp__conn__issue_create"


### PR DESCRIPTION
Two changes attacking MCP connector reliability from opposite ends, plus the sandbox evidence for both.

Follows #792 (inline schemas + local validation), which is already on `main` and deployed.

## Why these two

A production Intercom trace showed a failure that **neither** inline schemas nor native registration can prevent:

```
search_contacts({"per_page": 50})
  → "At least one search parameter must be provided"
```

The real `search_contacts` schema declares **no `required` key at all** — every property is optional. So that call is schema-valid, local validation correctly passes it, and native registration would pass it too. The contract lives in the server's runtime, not its schema.

That's the gap item 1 closes. Item 2 closes a different one: large catalogs, where inline schemas fall back to `search_mcps` rediscovery.

## 1. `mcp_failed_then_fixed` instruction trigger

`_check_mcp_failed_then_fixed` is the MCP twin of the existing `_check_failed_then_fixed`, with two deliberate differences:

- **Matches within one execution**, not only across them. The SQL version requires a user turn between failure and fix, because a human normally supplies the missing knowledge. MCP servers state their own constraint in the error and the agent recovers unaided in the same run — requiring a user turn would miss the common case entirely.
- **Filters transient errors.** A 429, timeout or expired token says nothing durable about how a tool should be called, and an instruction minted from one would outlive the outage.

The learning flows through the existing knowledge harness into a draft instruction, scoped to the agent via `instruction_data_source_association`, human-reviewed before going live.

Verified end-to-end against a mock reproducing the Intercom shape. The agent hit `contacts_search {"per_page": 150}` — the exact production shape — recovered, and the harness drafted:

> **MockOps `contacts_search` tool requirement**: requires **at least one search filter parameter** — one of `contact_ids`, `name`, `email`, `email_domain`, `phone`. The `per_page` argument alone is not sufficient… Do not call with only `per_page` — the server will reject it.

General rule, no record-level facts, `status: draft`. That's the shape we want.

## 2. Native MCP tool registration (`BOW_MCP_NATIVE_TOOLS`, default off)

One planner tool per `ConnectionTool`, named `mcp__<connection>__<tool>`, carrying the server's own schema so the provider constrains decoding against it. Same pattern as opencode's `McpCatalog.convertTool` and OpenClaw's `agent-bundle-mcp-materialize`.

Dispatch rewrites a native call into the equivalent `execute_mcp` call before anything else runs, so **policy, per-user identity forwarding, materialization and audit stay on one code path**. A useful side effect: the persisted `ToolExecution` row still records `execute_mcp` with a `connection_id`, so item 1's trigger keeps working under native registration.

Capped by `BOW_MCP_NATIVE_TOOLS_MAX` (default 60); beyond the cap tools stay on the gateway. `<mcp_tools>` drops its inline schemas when native is on rather than paying for the same bytes twice.

## Results

Pressure scenario — 9 sequential MCP calls in one run, Sonnet 4.5, identical prompt:

**12-tool catalog** (below the 40-tool inline threshold):

| | first-call valid | turns | ctx bytes |
|---|---|---|---|
| gateway | 9/9 | 10 | 188K |
| native | 9/9 | 11 | 165K |

A wash — expected, since #792 already inlines schemas there.

**60-tool catalog** (above it — the regime real customers with monday/Atlassian-sized catalogs are in):

| | first-call valid | turns | ctx bytes | `search_mcps` refs |
|---|---|---|---|---|
| gateway | 9/9 | 20 | 422K | 227 |
| native | 9/9 | **10** | **181K** | 20 |

**Half the planner turns, 57% fewer context bytes.** This is the experiment that justifies the feature, and it's why the catalog budget exists — the benefit is entirely in the large-catalog regime.

Argument validity is 9/9 in every arm. This harness has never once produced a wrong-argument failure, which remains the most important caveat here.

## Testing

- 126 unit tests pass (47 new).
- Negative controls on the trigger: rate limit, expired token, no-recovery, cross-connection, and success-before-failure all correctly do **not** fire.
- Regression test for a bug this sandbox caught: the dispatch rewrite initially stripped `title` as execute_mcp's cosmetic label, but `title` is a **required argument** of `issue_create`. Every such call failed validation three retries deep without reaching the server.
- Harness additions: `contacts_search` (Intercom shape), `workspace_query` (non-obvious recovery), `MOCK_MCP_PAD_TOOLS` to push past the inline threshold. Fixed a polling bug that silently iterated a dict's keys instead of completions.

## Rollout

Item 1 is on by default — it only adds a trigger condition, and its output is human-gated. Item 2 is off by default; enable per-environment with `BOW_MCP_NATIVE_TOOLS=true`.

## Caveats

The trigger is built from **one** production sample. Negative controls show the mechanism is safe; only volume will show whether it's worth it. A wider slice of execution history — the console endpoint returned only 10 reports — or the monday transcripts would let us calibrate against a real distribution rather than one anecdote.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWxEM7nTfjCNEAJ3GPwQJh)_