### PR TITLE
Add verify_ssl toggle to ServiceNow data source

### DIFF
--- a/backend/app/data_sources/clients/servicenow_client.py
+++ b/backend/app/data_sources/clients/servicenow_client.py
@@ -110,6 +110,7 @@ class ServiceNowClient(DataSourceClient):
         tables: Optional[str] = None,
         discover_all: bool = False,
         display_values: bool = True,
+        verify_ssl: bool = True,
     ):
         self.instance_url = (instance_url or "").rstrip("/")
         self.username = username
@@ -122,6 +123,7 @@ class ServiceNowClient(DataSourceClient):
         self.tables = [t.strip() for t in tables.split(",") if t.strip()] if tables else None
         self.discover_all = discover_all
         self.display_values = display_values
+        self.verify_ssl = bool(verify_ssl)
 
     # ── connection ──────────────────────────────────────────────────────────
 
@@ -132,6 +134,7 @@ class ServiceNowClient(DataSourceClient):
                 "ServiceNow client has no credentials: provide username/password or sign in with OAuth."
             )
         session = requests.Session()
+        session.verify = self.verify_ssl
         session.headers.update({"Accept": "application/json"})
         if self.access_token:
             session.headers["Authorization"] = f"Bearer {self.access_token}"

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -532,6 +532,12 @@ class ServiceNowConfig(BaseModel):
         description="Return human-readable display values for reference and choice fields.",
         json_schema_extra={"ui:type": "boolean"}
     )
+    verify_ssl: bool = Field(
+        True,
+        title="Verify SSL",
+        description="Verify the server TLS certificate. Disable only for internal CAs the backend host does not trust.",
+        json_schema_extra={"ui:type": "boolean"}
+    )
 
 
 # Priority ERP (Priority Software) — OData v4 REST API, cloud and on-premise.


### PR DESCRIPTION
The ServiceNow client built a bare requests.Session(), so TLS verification always used the default certifi trust store with no way to override it. In environments where egress is TLS-inspected by an internal CA, or where the instance is self-hosted behind an internal CA, connections fail with "SSL: CERTIFICATE_VERIFY_FAILED" and there was no config escape hatch.

Add the verify_ssl field already present on the other HTTP-based connectors (Priority ERP, Prometheus, Zabbix, Qlik Sense, Power BI Report Server, ...) and apply it to the session, mirroring the Priority ERP client.


Claude-Session: https://claude.ai/code/session_01Y7GSYGR55AJShRn3SXSvm4