### PR TITLE
Cap cell width in data previews and stats

### DIFF
--- a/backend/app/ai/context/builders/query_context_builder.py
+++ b/backend/app/ai/context/builders/query_context_builder.py
@@ -11,6 +11,7 @@ from app.models.query import Query
 from app.models.step import Step
 from app.models.visualization import Visualization
 from app.ai.context.sections.queries_section import QueriesSection, QueryObservation, QueryVisualizationSummary
+from app.ai.context.data_preview import MAX_CELL_CHARS, clamp_scalar, clamp_stats
 
 from app.settings.logging_config import get_logger
 
@@ -54,11 +55,17 @@ def _preview_table(column_names: List[str], rows: Any) -> Optional[str]:
         header = " | ".join(column_names)
         lines.append(header)
         lines.append("-" * len(header))
+        # Row count is capped at 5, but cell width was unbounded: a single
+        # multi-MB cell rendered this section at ~156k tokens. Same clamp the
+        # tool-observation previews use.
         for row in rows[:5]:
             if isinstance(row, dict):
-                lines.append(" | ".join(str(row.get(col, "N/A")) for col in column_names))
+                lines.append(" | ".join(
+                    str(clamp_scalar(row.get(col, "N/A"), MAX_CELL_CHARS))
+                    for col in column_names
+                ))
             else:
-                lines.append(str(row))
+                lines.append(str(clamp_scalar(row, MAX_CELL_CHARS)))
         return "\n".join(lines)
     except Exception:
         return None
@@ -306,7 +313,9 @@ class QueryContextBuilder:
                     obs.data_model = data_model
                 info = default_step.get("info")
                 if isinstance(info, dict):
-                    obs.stats = info
+                    # describe()-derived top/min/max are verbatim cells — for a
+                    # wide column that reproduces the payload the preview clamps.
+                    obs.stats = clamp_stats(info)
                     try:
                         obs.row_count = int(info.get("total_rows") or 0)
                     except Exception:

--- a/backend/app/ai/context/data_preview.py
+++ b/backend/app/ai/context/data_preview.py
@@ -30,7 +30,7 @@ MAX_CELL_CHARS = 1_000
 _ELISION = "…[truncated {dropped} chars]"
 
 
-def _clamp_scalar(value: Any, max_chars: int) -> Any:
+def clamp_scalar(value: Any, max_chars: int) -> Any:
     """Clamp one cell/stat value to *max_chars*, leaving non-strings that are
     already short (numbers, bools, None) untouched."""
     if value is None or isinstance(value, (bool, int, float)):
@@ -48,10 +48,10 @@ def _clamp_scalar(value: Any, max_chars: int) -> Any:
 
 def _clamp_row(row: Any, max_chars: int) -> Any:
     if isinstance(row, dict):
-        return {k: _clamp_scalar(v, max_chars) for k, v in row.items()}
+        return {k: clamp_scalar(v, max_chars) for k, v in row.items()}
     if isinstance(row, list):
-        return [_clamp_scalar(v, max_chars) for v in row]
-    return _clamp_scalar(row, max_chars)
+        return [clamp_scalar(v, max_chars) for v in row]
+    return clamp_scalar(row, max_chars)
 
 
 def clamp_stats(info: Dict[str, Any], max_chars: int = MAX_CELL_CHARS) -> Dict[str, Any]:
@@ -68,9 +68,9 @@ def clamp_stats(info: Dict[str, Any], max_chars: int = MAX_CELL_CHARS) -> Dict[s
     cols_out: Dict[str, Any] = {}
     for col, ci in (info.get("column_info") or {}).items():
         cols_out[col] = (
-            {k: _clamp_scalar(v, max_chars) for k, v in ci.items()}
+            {k: clamp_scalar(v, max_chars) for k, v in ci.items()}
             if isinstance(ci, dict)
-            else _clamp_scalar(ci, max_chars)
+            else clamp_scalar(ci, max_chars)
         )
     if "column_info" in info:
         out["column_info"] = cols_out

--- a/backend/app/ai/context/data_preview.py
+++ b/backend/app/ai/context/data_preview.py
@@ -19,6 +19,63 @@ DEFAULT_PREVIEW_BUDGET_BYTES = 48_000
 # Rows kept when an older observation is compacted to a sample.
 SAMPLE_ROWS = 3
 
+# Max characters kept for any single cell value. The row budget above bounds how
+# many rows are shown, but nothing bounded how *wide* one value could be: a
+# result of 1 row x 5 cols whose cell holds a multi-MB JSON payload sailed past
+# the byte budget (the first row is admitted unconditionally, see below) and put
+# ~1.1M tokens into one observation. Cells are clamped first so both the row
+# budget and the mandatory-first-row guarantee stay bounded.
+MAX_CELL_CHARS = 1_000
+
+_ELISION = "…[truncated {dropped} chars]"
+
+
+def _clamp_scalar(value: Any, max_chars: int) -> Any:
+    """Clamp one cell/stat value to *max_chars*, leaving non-strings that are
+    already short (numbers, bools, None) untouched."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    text = value if isinstance(value, str) else None
+    if text is None:
+        try:
+            text = json.dumps(value, default=str, ensure_ascii=False)
+        except Exception:
+            text = str(value)
+    if len(text) <= max_chars:
+        return value if isinstance(value, str) else text
+    return text[:max_chars] + _ELISION.format(dropped=len(text) - max_chars)
+
+
+def _clamp_row(row: Any, max_chars: int) -> Any:
+    if isinstance(row, dict):
+        return {k: _clamp_scalar(v, max_chars) for k, v in row.items()}
+    if isinstance(row, list):
+        return [_clamp_scalar(v, max_chars) for v in row]
+    return _clamp_scalar(row, max_chars)
+
+
+def clamp_stats(info: Dict[str, Any], max_chars: int = MAX_CELL_CHARS) -> Dict[str, Any]:
+    """Clamp verbatim cell values echoed by ``df.describe(include='all')``.
+
+    ``column_info`` carries ``top``/``min``/``max``/percentiles, which are raw
+    cells — for a wide column that reproduces the very payload the preview just
+    clamped. gate_stats_for_privacy only runs when allow_llm_see_data is off, so
+    without this the stats block is unbounded on the common path.
+    """
+    if not isinstance(info, dict):
+        return info
+    out = {k: v for k, v in info.items() if k != "column_info"}
+    cols_out: Dict[str, Any] = {}
+    for col, ci in (info.get("column_info") or {}).items():
+        cols_out[col] = (
+            {k: _clamp_scalar(v, max_chars) for k, v in ci.items()}
+            if isinstance(ci, dict)
+            else _clamp_scalar(ci, max_chars)
+        )
+    if "column_info" in info:
+        out["column_info"] = cols_out
+    return out
+
 
 def _row_bytes(row: Any) -> int:
     # +2 accounts for the inter-row ", " separator in the serialized list, so the
@@ -92,6 +149,7 @@ def build_data_preview(
     *,
     budget_bytes: int = DEFAULT_PREVIEW_BUDGET_BYTES,
     allow_llm_see_data: bool = True,
+    max_cell_chars: int = MAX_CELL_CHARS,
 ) -> Dict[str, Any]:
     """Build a budgeted, self-describing preview from a ``format_df_for_widget`` dict.
 
@@ -106,17 +164,23 @@ def build_data_preview(
         - ``note`` (truncated only): human-readable description of the cut.
     """
     columns = formatted.get("columns", []) or []
-    rows = formatted.get("rows", []) or []
+    raw_rows = formatted.get("rows", []) or []
     info = formatted.get("info", {}) or {}
     total = info.get("total_rows")
     if not isinstance(total, int):
-        total = len(rows)
+        total = len(raw_rows)
+
+    # Clamp cell width before any byte accounting: the row budget below bounds
+    # row *count*, and the head loop admits the first row unconditionally, so an
+    # unclamped wide cell escapes the budget entirely.
+    rows = [_clamp_row(r, max_cell_chars) for r in raw_rows]
+    cells_truncated = rows != raw_rows
 
     if not allow_llm_see_data:
         return {
             "columns": [{"field": c.get("field")} for c in columns if isinstance(c, dict)],
             "row_count": total,
-            "stats": gate_stats_for_privacy(info),
+            "stats": clamp_stats(gate_stats_for_privacy(info), max_cell_chars),
             "data_hidden": True,
             "note": (
                 "Row-level data is hidden by organization policy "
@@ -134,12 +198,21 @@ def build_data_preview(
         if used > budget_bytes:
             break
     else:
-        return {
+        out = {
             "columns": columns,
             "rows": rows,
             "row_count": total,
             "truncated": False,
+            "cells_truncated": cells_truncated,
         }
+        if cells_truncated:
+            # Say so explicitly: without a note the planner reads a clipped cell
+            # as the whole value and reasons from a truncated payload.
+            out["note"] = (
+                f"all {total} rows shown; long cell values clipped to "
+                f"{max_cell_chars} chars"
+            )
+        return out
 
     # Truncated: keep head (~75% of budget) + tail (remainder). create_data
     # results are usually sorted, so the tail carries as much signal as the head.
@@ -152,6 +225,14 @@ def build_data_preview(
         b = _row_bytes(row)
         if head_rows and used + b > head_budget:
             break
+        if not head_rows and b > budget_bytes:
+            # The first row is always admitted so a preview is never empty, but a
+            # very wide row (many columns, each at the cell cap) must not blow the
+            # budget through that door — re-clamp it to a share of the budget.
+            n_fields = len(row) if isinstance(row, (dict, list)) and row else 1
+            row = _clamp_row(row, max(64, budget_bytes // n_fields))
+            b = _row_bytes(row)
+            cells_truncated = True
         head_rows.append(row)
         used += b
 
@@ -172,10 +253,13 @@ def build_data_preview(
         note = f"showing first {head_n} and last {tail_n} of {total} rows"
     else:
         note = f"showing first {head_n} of {total} rows"
+    if cells_truncated:
+        note += f"; long cell values clipped to {max_cell_chars} chars"
     return {
         "columns": columns,
         "rows": preview_rows,
         "row_count": total,
         "truncated": True,
+        "cells_truncated": cells_truncated,
         "note": note,
     }

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -24,7 +24,7 @@ from app.ai.tools.schemas import (
 )
 from app.ai.agents.coder.coder import Coder
 from app.ai.code_execution.code_execution import StreamingCodeExecutor
-from app.ai.context.data_preview import build_data_preview, gate_stats_for_privacy
+from app.ai.context.data_preview import build_data_preview, clamp_stats, gate_stats_for_privacy
 from app.ai.llm import LLM
 from app.ai.llm.types import Message, TextDeltaEvent
 from app.dependencies import async_session_maker
@@ -1890,7 +1890,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
         observation = {
             "summary": result_summary,
             "data_preview": data_preview,
-            "stats": info if allow_llm_see_data else gate_stats_for_privacy(info),
+            "stats": clamp_stats(info) if allow_llm_see_data else clamp_stats(gate_stats_for_privacy(info)),
             "analysis_complete": False,
             "final_answer": None,
         }

--- a/backend/app/ai/tools/implementations/read_query.py
+++ b/backend/app/ai/tools/implementations/read_query.py
@@ -10,7 +10,7 @@ from typing import AsyncIterator, Dict, Any, Type, List, Optional
 from pydantic import BaseModel
 from sqlalchemy import select
 
-from app.ai.context.data_preview import build_data_preview, gate_stats_for_privacy
+from app.ai.context.data_preview import build_data_preview, clamp_stats, gate_stats_for_privacy
 from app.ai.tools.base import Tool
 from app.ai.tools.metadata import ToolMetadata
 from app.ai.tools.schemas import (
@@ -255,7 +255,7 @@ class ReadQueryTool(Tool):
             r = succeeded[0]
             observation["data_preview"] = r.data_preview
             info = r.data.get("info", {}) if r.data and isinstance(r.data, dict) else {}
-            observation["stats"] = info if allow_llm_see_data else gate_stats_for_privacy(info)
+            observation["stats"] = clamp_stats(info) if allow_llm_see_data else clamp_stats(gate_stats_for_privacy(info))
             if r.data_model:
                 observation["data_model"] = r.data_model
             if r.view:

--- a/backend/tests/unit/test_data_preview_cell_cap.py
+++ b/backend/tests/unit/test_data_preview_cell_cap.py
@@ -1,0 +1,182 @@
+"""Unit tests for cell-width capping in data previews / stats.
+
+Regression coverage for a real context-window blowout: a `create_data` result of
+1 row x 5 cols, where one cell held a ~2 MB JSON payload, produced a single tool
+observation of ~1.1M tokens and killed the turn with a provider
+context-window error.
+
+The preview already had a 48 KB *row* budget, but two doors bypassed it:
+  1. the head loop admits the first row unconditionally, so one wide row escaped
+     the budget entirely;
+  2. `stats` (df.describe-derived `top`/`min`/`max`) echoed the same raw cell and
+     was only sanitized when `allow_llm_see_data` was off.
+
+Pure-Python: no DB, no LLM.
+"""
+import json
+
+from app.ai.context.data_preview import (
+    DEFAULT_PREVIEW_BUDGET_BYTES,
+    MAX_CELL_CHARS,
+    build_data_preview,
+    clamp_stats,
+    gate_stats_for_privacy,
+)
+
+HUGE = "x" * 2_000_000
+
+
+def _sz(obj) -> int:
+    return len(json.dumps(obj, default=str, ensure_ascii=False))
+
+
+def _wide_cell_formatted():
+    """The shape that caused the incident: 1 row, 5 cols, one giant cell."""
+    return {
+        "rows": [{
+            "payload_json": HUGE,
+            "payload_row_count": 2240,
+            "payload_min_month": "2021-01",
+            "payload_max_month": "2025-12",
+            "payload_description": "full dashboard payload",
+        }],
+        "columns": [{"field": f, "headerName": f} for f in (
+            "payload_json", "payload_row_count", "payload_min_month",
+            "payload_max_month", "payload_description",
+        )],
+        "info": {
+            "total_rows": 1,
+            "total_columns": 5,
+            "column_info": {
+                "payload_json": {"dtype": "str", "count": 1, "unique": 1,
+                                 "top": HUGE, "freq": 1},
+                "payload_row_count": {"dtype": "int64", "count": 1, "mean": 2240.0},
+            },
+        },
+    }
+
+
+def test_single_wide_row_stays_within_budget():
+    """The unconditional first row must not smuggle a 2 MB cell past the budget."""
+    preview = build_data_preview(_wide_cell_formatted())
+    assert _sz(preview) < DEFAULT_PREVIEW_BUDGET_BYTES
+    # The incident payload was ~2.25 MB; anything in that league means no cap.
+    assert _sz(preview) < 50_000
+
+
+def test_wide_cell_is_clipped_but_row_and_columns_survive():
+    """Clipping is per-cell: the row, all column names and the count remain."""
+    preview = build_data_preview(_wide_cell_formatted())
+    row = preview["rows"][0]
+    assert set(row) == {
+        "payload_json", "payload_row_count", "payload_min_month",
+        "payload_max_month", "payload_description",
+    }
+    assert preview["row_count"] == 1
+    assert len(row["payload_json"]) < len(HUGE)
+    assert row["payload_json"].startswith("xxx")
+    assert "truncated" in row["payload_json"]
+    # Narrow cells in the same row are untouched.
+    assert row["payload_row_count"] == 2240
+    assert row["payload_min_month"] == "2021-01"
+
+
+def test_clipping_is_disclosed_to_the_model():
+    """A clipped cell the planner reads as complete is worse than a small one."""
+    preview = build_data_preview(_wide_cell_formatted())
+    assert preview["cells_truncated"] is True
+    assert "clipped" in (preview.get("note") or "")
+
+
+def test_stats_do_not_echo_the_raw_cell():
+    """describe()'s `top` reproduces a verbatim cell — cap it on the visible path too."""
+    info = _wide_cell_formatted()["info"]
+    capped = clamp_stats(info)
+    assert _sz(capped) < 50_000
+    assert len(capped["column_info"]["payload_json"]["top"]) < len(HUGE)
+    # Structure and aggregates are preserved.
+    assert capped["total_rows"] == 1
+    assert capped["column_info"]["payload_row_count"]["mean"] == 2240.0
+
+
+def test_privacy_path_also_capped():
+    """allow_llm_see_data=False still returns stats — they must be capped too."""
+    preview = build_data_preview(_wide_cell_formatted(), allow_llm_see_data=False)
+    assert preview["data_hidden"] is True
+    assert "rows" not in preview
+    assert _sz(preview) < 50_000
+    # gate_stats_for_privacy drops `top` entirely; capping must not resurrect it.
+    assert "top" not in preview["stats"]["column_info"]["payload_json"]
+
+
+def test_many_wide_columns_cannot_blow_the_budget():
+    """200 columns each at the cell cap would exceed the budget via the first row."""
+    row = {f"c{i}": HUGE for i in range(200)}
+    preview = build_data_preview({
+        "rows": [row],
+        "columns": [{"field": f"c{i}"} for i in range(200)],
+        "info": {"total_rows": 1, "total_columns": 200},
+    })
+    assert _sz(preview) < DEFAULT_PREVIEW_BUDGET_BYTES * 2
+    assert len(preview["rows"][0]) == 200
+
+
+def test_normal_results_are_unchanged():
+    """The common case must not regress: no clipping, no note, all rows kept."""
+    formatted = {
+        "rows": [{"id": i, "name": f"customer {i}", "revenue": i * 10.5}
+                 for i in range(20)],
+        "columns": [{"field": f} for f in ("id", "name", "revenue")],
+        "info": {"total_rows": 20, "total_columns": 3},
+    }
+    preview = build_data_preview(formatted)
+    assert preview["truncated"] is False
+    assert preview["cells_truncated"] is False
+    assert preview.get("note") is None
+    assert preview["rows"] == formatted["rows"]
+
+
+def test_cell_cap_boundary():
+    """A cell exactly at the cap is kept verbatim; one char over is clipped."""
+    at = build_data_preview({
+        "rows": [{"v": "y" * MAX_CELL_CHARS}], "columns": [{"field": "v"}],
+        "info": {"total_rows": 1},
+    })
+    assert at["rows"][0]["v"] == "y" * MAX_CELL_CHARS
+    assert at["cells_truncated"] is False
+
+    over = build_data_preview({
+        "rows": [{"v": "y" * (MAX_CELL_CHARS + 1)}], "columns": [{"field": "v"}],
+        "info": {"total_rows": 1},
+    })
+    assert over["cells_truncated"] is True
+    assert len(over["rows"][0]["v"]) < MAX_CELL_CHARS + len("…[truncated 1 chars]") + 1
+
+
+def test_row_budget_truncation_still_works():
+    """Cell capping must not disturb the existing head+tail row truncation."""
+    formatted = {
+        "rows": [{"id": i, "blob": "z" * 500} for i in range(1000)],
+        "columns": [{"field": "id"}, {"field": "blob"}],
+        "info": {"total_rows": 1000, "total_columns": 2},
+    }
+    preview = build_data_preview(formatted)
+    assert preview["truncated"] is True
+    assert preview["row_count"] == 1000
+    assert len(preview["rows"]) < 1000
+    assert _sz(preview) < DEFAULT_PREVIEW_BUDGET_BYTES * 2
+    # head+tail: first and last source rows both represented
+    assert preview["rows"][0]["id"] == 0
+    assert preview["rows"][-1]["id"] == 999
+
+
+def test_non_string_cells_are_left_alone():
+    """Numbers/bools/None must keep their type — the planner reasons on them."""
+    preview = build_data_preview({
+        "rows": [{"n": 42, "f": 1.5, "b": True, "z": None}],
+        "columns": [{"field": f} for f in ("n", "f", "b", "z")],
+        "info": {"total_rows": 1},
+    })
+    row = preview["rows"][0]
+    assert row == {"n": 42, "f": 1.5, "b": True, "z": None}
+    assert preview["cells_truncated"] is False

--- a/backend/tests/unit/test_data_preview_cell_cap.py
+++ b/backend/tests/unit/test_data_preview_cell_cap.py
@@ -170,6 +170,33 @@ def test_row_budget_truncation_still_works():
     assert preview["rows"][-1]["id"] == 999
 
 
+def test_query_section_preview_table_clamps_cells():
+    """The queries section had the same rows[:5]-but-unbounded-cell shape.
+
+    It renders at ~156k tokens for one wide cell. It does not currently reach
+    the planner prompt, but it is built and rendered on every warm refresh.
+    """
+    from app.ai.context.builders.query_context_builder import _preview_table
+
+    cols = ["payload_json", "payload_row_count"]
+    rendered = _preview_table(cols, [{"payload_json": HUGE, "payload_row_count": 2240}])
+    assert len(rendered) < 5_000
+    assert "truncated" in rendered
+    # Header, separator and the narrow cell all survive.
+    assert "payload_json | payload_row_count" in rendered
+    assert "2240" in rendered
+
+
+def test_query_section_preview_table_normal_case_unchanged():
+    from app.ai.context.builders.query_context_builder import _preview_table
+
+    rows = [{"id": i, "name": f"c{i}"} for i in range(3)]
+    rendered = _preview_table(["id", "name"], rows)
+    assert "truncated" not in rendered
+    for r in rows:
+        assert f"{r['id']} | {r['name']}" in rendered
+
+
 def test_non_string_cells_are_left_alone():
     """Numbers/bools/None must keep their type — the planner reasons on them."""
     preview = build_data_preview({


### PR DESCRIPTION
## The bug

A `create_data` result of **1 row × 5 cols**, where one cell held a ~2 MB JSON payload, produced a single tool observation of **~1.1M tokens** and killed the turn with:

```
LLM v2 streaming failed (provider=openai, model=gpt-5.6-sol):
Your input exceeds the context window of this model.
```

The observation was JSON-dumped verbatim into `<last_observation>` on the next planner iteration.

`build_data_preview` already had a 48 KB **row** budget, but two doors bypassed it:

1. **`data_preview.py:153`** — the head loop admits the first row unconditionally (so a preview is never empty), and the budget is measured per *row*, never per *cell*. One wide row escaped the budget by ~47×.
2. **`create_data.py:1893` / `read_query.py:258`** — `stats` (the `df.describe(include='all')`-derived `top`/`min`/`max`) echoed the same raw cell, and `gate_stats_for_privacy` only runs when `allow_llm_see_data` is **off**. On the common path the payload was reproduced a second time.

Measured on the failing execution's snapshot — the caps are on rows/columns, so the *pathological* shape is the small one:

| | rows × cols | `data_preview` | `stats` |
|---|---|---|---|
| Healthy step | 2240 × 34 | 4,923 chars | 7,686 chars |
| Pathological step | **1 × 5** | **2,251,516 chars** | **2,251,981 chars** |

## The fix

- Clamp individual cell values to `MAX_CELL_CHARS` (1,000) **before** any byte accounting, so both the row budget and the mandatory-first-row guarantee stay bounded.
- Add `clamp_stats()` for the `describe()`-derived values, applied on **both** the visible and privacy paths.
- Re-clamp the mandatory first row to a share of the budget, so a row with very many columns can't blow it through that door either.
- Disclose clipping via `cells_truncated` and a `note` — a clipped cell the planner reads as complete is worse than a small one.

Verified against the actual payload from the failing execution:

```
data_preview: 2,251,516 ->  1,947 chars
stats       : 2,251,981 ->  2,355 chars
OBSERVATION : 4,503,497 ->  4,234 chars   (~1,125,874 tok -> ~1,058 tok)
```

All 5 column names, the row count, and the head of the payload are preserved. The healthy 2240×34 result is unchanged (stats byte-identical, no note emitted).

## Testing

New `backend/tests/unit/test_data_preview_cell_cap.py` — 11 tests: budget containment for a single wide row, per-cell clipping with row/column survival, disclosure to the model, stats not echoing the raw cell, the privacy path, many-wide-columns, normal results unchanged, cap boundary, existing row-budget truncation intact, and non-string cells keeping their type.

- New tests + existing `test_data_preview_privacy.py`: **17 passed**.
- Full `tests/unit/` before and after the change produce an **identical failure set** (pre-existing, all from optional connector deps missing in this sandbox — none touch `data_preview` / `create_data` / `read_query`).

## Note on scope

This fixes the payload that blew the window. It does not address two adjacent findings from the same investigation, which are separate changes:

- `errors.py:180` doesn't match OpenAI's *"Your input exceeds the context window of this model"* wording, so the failure classified as `unknown` rather than `context_length`.
- Compaction couldn't have prevented this: it is conversation-history-only, and with `PROTECT_LAST_MIN = 12` a 6-completion report has an empty compaction scope (`can_compact: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8BniW7LMTRYx94sbuykZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8BniW7LMTRYx94sbuykZN)_