### PR TITLE
Load an agent's whole instruction set instead of a silent first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+- Fixed instruction lists silently showing only part of an agent's instructions — every list, tree and picker asked for one capped page and rendered it as if it were the whole set, so past 200 instructions the oldest ones simply weren't there. Rows now load through a light projection (`GET /instructions?view=light`) that drops the instruction body, and the surfaces page through all of them
+- Fixed "select all" bulk update/delete of instructions silently affecting nothing (the request exceeded the endpoint's page limit and failed)
+
 ## Version 0.0.492 (July 27, 2026)
 - Added **Refresh when opened** to a report's schedule settings — the schedule modal now asks one question ("Refresh data": Off / Recurring / When opened), and a report set to "When opened" reruns the queries behind its dashboard when someone opens its shared page, so a link that gets visited rarely is never showing week-old numbers. Traffic does not become query volume: a report reruns at most once every 5 minutes no matter how many people open it or how often they reload, simultaneous viewers collapse to a single rerun, and a viewer who arrives inside that window simply gets the data already on the page. The refresh runs with the report owner's data-source access (viewers may be anonymous) and only for people who can already view the report
 

--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -35,6 +35,15 @@ from app.schemas.instruction_analysis_schema import (
 )
 
 router = APIRouter(tags=["instructions"])
+
+#: Page ceilings for GET /instructions. The full row carries the instruction
+#: body three ways over (see InstructionListItemSchema), so it stays capped
+#: where it was. The light row is a few hundred bytes, which is what lets a
+#: tree or list load an org's whole instruction set instead of silently
+#: truncating at the cap and showing a partial list as if it were complete.
+FULL_MAX_LIMIT = 200
+LIGHT_MAX_LIMIT = 2000
+
 instruction_service = InstructionService()
 instruction_label_service = InstructionLabelService()
 
@@ -85,7 +94,17 @@ async def create_global_instruction(
 @router.get("/instructions")
 async def get_instructions(
     skip: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1, le=200),
+    limit: int = Query(50, ge=1, le=LIGHT_MAX_LIMIT),
+    view: str = Query(
+        "full",
+        description=(
+            "'full' (default) returns the complete list row. 'light' drops the "
+            "instruction body (text / formatted_content / structured_data) and "
+            "the nested user records, keeping a short `preview` — for list and "
+            "tree surfaces that render a label plus badges. Only 'light' may "
+            f"exceed limit={FULL_MAX_LIMIT}."
+        ),
+    ),
     status: Optional[InstructionStatus] = Query(None),
     kind: Optional[str] = Query(None, description="Filter by instruction kind: 'instruction' or 'skill'"),
     category: Optional[InstructionCategory] = Query(None, description="Single category filter (deprecated, use categories)"),
@@ -115,6 +134,22 @@ async def get_instructions(
     By default, loads instructions from the main build (is_main=True).
     Pass build_id to load from a specific build instead.
     """
+    if view not in ("full", "light"):
+        raise AppError(
+            ErrorCode.VALIDATION,
+            f"Unknown view '{view}'. Expected 'full' or 'light'.",
+        )
+    light = view == "light"
+    # Reject rather than silently clamp: a caller asking for 1000 full rows has
+    # mis-sized its request, and quietly returning 200 of them is exactly the
+    # silent-truncation failure this parameter exists to remove.
+    if not light and limit > FULL_MAX_LIMIT:
+        raise AppError(
+            ErrorCode.VALIDATION,
+            f"limit must be <= {FULL_MAX_LIMIT} for view=full; "
+            f"use view=light for larger pages.",
+        )
+
     # Parse label_ids from comma-separated string
     parsed_label_ids = None
     if label_ids:
@@ -166,6 +201,7 @@ async def get_instructions(
         include_global=include_global,
         global_only=global_only,
         pending_only=pending_only,
+        light=light,
     )
     await release_request_db(db)  # free the pooled connection before serialization (Cause A, Phase 1)
     return result

--- a/backend/app/schemas/instruction_schema.py
+++ b/backend/app/schemas/instruction_schema.py
@@ -202,6 +202,73 @@ class InstructionSchema(InstructionBase):
             return self.title
         return self.text[:100] + "..." if len(self.text) > 100 else self.text
 
+#: How much of an instruction's body the light list projection carries. Long
+#: enough that the tree label (title, else the first line) and the in-page
+#: filter still work on ordinary instructions, short enough that the row stays
+#: a few hundred bytes.
+PREVIEW_CHARS = 280
+
+
+def build_preview(text: Optional[str]) -> Optional[str]:
+    """First `PREVIEW_CHARS` of an instruction body, for the light list."""
+    if not text:
+        return text
+    return text[:PREVIEW_CHARS]
+
+
+class InstructionListItemSchema(BaseModel):
+    """Light projection for list/tree surfaces (`GET /instructions?view=light`).
+
+    The full `InstructionListSchema` carries the whole instruction body three
+    times over — `text`, `formatted_content`, and `structured_data` (which for a
+    git-synced instruction holds the entire source resource: every column, its
+    `sql_content`, AND `raw_data.content`, i.e. the file again). Measured on a
+    half-dbt-synced org that is 6.2 KB per row, of which those three fields are
+    81%, and the nested `UserSchema` repeats the author's record on every row.
+
+    None of it is read by a list or tree, which needs a label, a few badges and
+    the pending marker. Dropping it takes a row to a few hundred bytes, which is
+    what makes "load every instruction" affordable instead of silently
+    truncating at the page limit. Bodies come from `GET /instructions/{id}` when
+    a row is opened; hunks already came from `/review-hunks` that way.
+    """
+    id: str
+    title: Optional[str] = None
+    #: Body prefix — the tree label falls back to it when `title` is unset.
+    preview: Optional[str] = None
+    status: str
+    category: str
+    kind: str = "instruction"
+    load_mode: str = "always"
+    source_type: str = "user"
+    source_file_path: Optional[str] = None
+    source_sync_enabled: bool = True
+    #: Author id only; names resolve from the org member list the client holds.
+    user_id: Optional[str] = None
+    is_seen: bool
+    can_user_toggle: bool
+    ai_source: Optional[str] = None
+    applicable_modes: Optional[List[str]] = None
+    applicable_channels: Optional[List[str]] = None
+
+    # Build system / pending-review markers (drive the amber "Pending review"
+    # dot and the Pending changes view).
+    current_version_id: Optional[str] = None
+    current_build_id: Optional[str] = None
+    current_build_status: Optional[str] = None
+    pending_source: Optional[str] = None
+    pending_created_by: Optional[str] = None
+    pending_created_at: Optional[UTCDatetime] = None
+
+    data_sources: List[DataSourceMinimalSchema] = []
+    labels: List[InstructionLabelSchema] = []
+    created_at: UTCDatetime
+    updated_at: UTCDatetime
+
+    class Config:
+        from_attributes = True
+
+
 class InstructionListSchema(BaseModel):
     """Schema for listing instructions without full relationships"""
     id: str

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -507,6 +507,7 @@ class InstructionService:
         include_global: bool = True,
         global_only: bool = False,
         pending_only: bool = False,
+        light: bool = False,
     ) -> dict:
         """Get instructions with clean permission-based filtering. Returns paginated response.
         
@@ -544,7 +545,7 @@ class InstructionService:
             data_source_ids, source_types, load_modes, label_ids, search,
             build_id=build_id, include_global=include_global,
             current_user=current_user, kind=kind, global_only=global_only,
-            pending_only=pending_only,
+            pending_only=pending_only, light=light,
         )
 
     async def _visible_main_build_conditions(self, db, organization, current_user):
@@ -2991,6 +2992,7 @@ class InstructionService:
         kind: Optional[str] = None,
         global_only: bool = False,
         pending_only: bool = False,
+        light: bool = False,
     ) -> dict:
         """Execute the instructions query with given conditions. Returns paginated response.
 
@@ -3242,14 +3244,17 @@ class InstructionService:
         # that would otherwise fire per loaded Instruction.data_sources.
         # The list response uses DataSourceMinimalSchema (id/name/description
         # only), so DS sub-relationships are pure waste.
+        # The light projection carries only user_id, so the author/reviewer rows
+        # it would otherwise selectin-load per page are skipped entirely.
+        eager = [
+            selectinload(Instruction.data_sources).options(lazyload("*")),
+            selectinload(Instruction.labels),
+        ]
+        if not light:
+            eager += [selectinload(Instruction.user), selectinload(Instruction.reviewed_by)]
         query = (
             select(Instruction)
-            .options(
-                selectinload(Instruction.user),
-                selectinload(Instruction.data_sources).options(lazyload("*")),
-                selectinload(Instruction.reviewed_by),
-                selectinload(Instruction.labels),
-            )
+            .options(*eager)
             .where(and_(*base_conditions))
         )
         
@@ -3275,13 +3280,50 @@ class InstructionService:
         instructions = result.scalars().all()
         
         # Map to list schema
-        from app.schemas.instruction_schema import InstructionListSchema
+        from app.schemas.instruction_schema import (
+            InstructionListItemSchema,
+            InstructionListSchema,
+            build_preview,
+        )
         from app.schemas.data_source_schema import DataSourceMinimalSchema
         from app.schemas.instruction_label_schema import InstructionLabelSchema
-        
-        list_items: List[InstructionListSchema] = []
+
+        list_items: List = []
         for inst in instructions:
             ds_min = [DataSourceMinimalSchema.from_orm(ds) for ds in (inst.data_sources or [])]
+            if light:
+                # Light projection: no body, no nested user records. See
+                # InstructionListItemSchema for why (81% of the full row is the
+                # instruction body repeated three ways).
+                list_items.append(
+                    InstructionListItemSchema(
+                        id=str(inst.id),
+                        title=getattr(inst, "title", None),
+                        preview=build_preview(inst.text),
+                        status=inst.status,
+                        category=inst.category,
+                        kind=getattr(inst, "kind", "instruction") or "instruction",
+                        load_mode=getattr(inst, "load_mode", "always") or "always",
+                        source_type=getattr(inst, "source_type", "user") or "user",
+                        source_file_path=getattr(inst, "source_file_path", None),
+                        source_sync_enabled=(
+                            getattr(inst, "source_sync_enabled", True)
+                            if getattr(inst, "source_sync_enabled", None) is not None else True
+                        ),
+                        user_id=inst.user_id,
+                        is_seen=inst.is_seen,
+                        can_user_toggle=inst.can_user_toggle,
+                        ai_source=getattr(inst, "ai_source", None),
+                        applicable_modes=getattr(inst, "applicable_modes", None),
+                        applicable_channels=getattr(inst, "applicable_channels", None),
+                        current_version_id=getattr(inst, "current_version_id", None),
+                        data_sources=ds_min,
+                        labels=[InstructionLabelSchema.from_orm(l) for l in (inst.labels or [])],
+                        created_at=inst.created_at,
+                        updated_at=inst.updated_at,
+                    )
+                )
+                continue
             list_items.append(
                 InstructionListSchema(
                     id=str(inst.id),

--- a/backend/tests/e2e/test_instruction_light_view.py
+++ b/backend/tests/e2e/test_instruction_light_view.py
@@ -1,0 +1,120 @@
+"""GET /instructions?view=light — the projection list and tree surfaces use.
+
+The full row carries the instruction body three ways over (text,
+formatted_content, structured_data), so it was capped at 200 per page and every
+caller rendered that page as if it were the whole set. The light row drops the
+body and the nested user records, which is what makes loading an org's entire
+instruction set affordable instead of silently truncating it.
+"""
+import uuid
+
+import pytest
+
+from app.routes.instruction import FULL_MAX_LIMIT, LIGHT_MAX_LIMIT
+
+# Fields the light projection must NOT carry — the reason it exists.
+HEAVY_FIELDS = ("text", "formatted_content", "structured_data", "user", "reviewed_by")
+# Fields list/tree surfaces render off each row.
+REQUIRED_FIELDS = ("id", "title", "preview", "status", "category", "kind",
+                   "load_mode", "source_type", "data_sources", "labels",
+                   "created_at", "updated_at")
+
+
+@pytest.fixture
+def agent_with_instructions(create_user, login_user, whoami, create_data_source,
+                            create_instruction):
+    def _make(n=3, body="short rule"):
+        user = create_user()
+        token = login_user(user["email"], user["password"])
+        org_id = str(whoami(token)["organizations"][0]["id"])
+        ds = create_data_source(
+            name=f"agent-{uuid.uuid4().hex[:6]}", type="sqlite",
+            config={"database": ":memory:"}, credentials={},
+            user_token=token, org_id=org_id,
+        )
+        for i in range(n):
+            create_instruction(text=f"{body} {i}", user_token=token, org_id=org_id,
+                               status="published", data_source_ids=[ds["id"]])
+        return {"org_id": org_id, "ds_id": ds["id"], "count": n,
+                "headers": {"Authorization": f"Bearer {token}",
+                            "X-Organization-Id": org_id}}
+    return _make
+
+
+def _get(client, ctx, **params):
+    q = {"data_source_ids": ctx["ds_id"], "include_global": "true",
+         "include_own": "true", "include_drafts": "true"}
+    q.update(params)
+    return client.get("/api/instructions", params=q, headers=ctx["headers"])
+
+
+@pytest.mark.e2e
+def test_light_view_drops_the_body_but_keeps_what_a_list_renders(test_client,
+                                                                 agent_with_instructions):
+    ctx = agent_with_instructions(3)
+    r = _get(test_client, ctx, view="light", limit=200)
+    assert r.status_code == 200, r.text[:400]
+    body = r.json()
+    assert body["total"] == ctx["count"]
+    assert len(body["items"]) == ctx["count"]
+    for item in body["items"]:
+        for f in HEAVY_FIELDS:
+            assert f not in item, f"light row still carries {f}"
+        for f in REQUIRED_FIELDS:
+            assert f in item, f"light row is missing {f}"
+
+
+@pytest.mark.e2e
+def test_preview_carries_enough_for_the_row_label(test_client, agent_with_instructions):
+    """The tree label falls back to the body's first line when there's no title,
+    so the light row has to carry a usable prefix."""
+    long_body = "Reconcile ledgers against the closed period. " * 40
+    ctx = agent_with_instructions(1, body=long_body)
+    item = _get(test_client, ctx, view="light", limit=200).json()["items"][0]
+    assert item["preview"], "no preview to label the row with"
+    assert item["preview"].startswith("Reconcile ledgers")
+    # Bounded — the point is not to ship the body.
+    assert len(item["preview"]) < len(long_body)
+
+
+@pytest.mark.e2e
+def test_full_view_is_unchanged(test_client, agent_with_instructions):
+    """Existing callers keep the complete row."""
+    ctx = agent_with_instructions(2)
+    body = _get(test_client, ctx, limit=200).json()
+    assert body["total"] == ctx["count"]
+    for item in body["items"]:
+        assert "text" in item and item["text"]
+        assert "organization_id" in item
+
+
+@pytest.mark.e2e
+def test_both_views_return_the_same_instructions(test_client, agent_with_instructions):
+    """The projection changes the shape of a row, never which rows come back."""
+    ctx = agent_with_instructions(5)
+    full = _get(test_client, ctx, limit=200).json()
+    light = _get(test_client, ctx, view="light", limit=200).json()
+    assert light["total"] == full["total"]
+    assert [i["id"] for i in light["items"]] == [i["id"] for i in full["items"]]
+
+
+@pytest.mark.e2e
+def test_light_view_may_page_past_the_full_view_ceiling(test_client,
+                                                        agent_with_instructions):
+    """The cap is a property of the heavy row, so only the light view lifts it.
+    A full-view caller asking for more is told, not silently given 200."""
+    ctx = agent_with_instructions(1)
+    over = FULL_MAX_LIMIT + 1
+
+    assert _get(test_client, ctx, view="light", limit=over).status_code == 200
+    assert _get(test_client, ctx, view="light", limit=LIGHT_MAX_LIMIT).status_code == 200
+
+    rejected = _get(test_client, ctx, limit=over)
+    assert rejected.status_code >= 400
+    assert _get(test_client, ctx, view="light", limit=LIGHT_MAX_LIMIT + 1).status_code == 422
+
+
+@pytest.mark.e2e
+def test_unknown_view_is_rejected(test_client, agent_with_instructions):
+    ctx = agent_with_instructions(1)
+    assert _get(test_client, ctx, view="tiny").status_code >= 400

--- a/frontend/components/AgentFlyout.vue
+++ b/frontend/components/AgentFlyout.vue
@@ -547,22 +547,12 @@ const fetchInstructionsForAgent = async (agentId: string) => {
   instructionsLoading.value = true
   instructionsError.value = null
   try {
-    const { data, error } = await useMyFetch('/api/instructions', {
-      method: 'GET',
-      query: {
-        data_source_ids: agentId,
-        include_global: true,
-        limit: 50,
-        include_own: true,
-        include_drafts: false
-      }
+    const { items } = await fetchAllInstructions({
+      data_source_ids: agentId,
+      include_global: true,
+      include_own: true,
+      include_drafts: false,
     })
-    if (error?.value) {
-      instructionsError.value = t('agentFlyout.instructionsLoadFailed')
-      return
-    }
-    const payload: any = (data as any)?.value
-    const items = payload?.items || payload || []
     instructionsCache.value[agentId] = items
   } catch (e) {
     instructionsError.value = t('agentFlyout.instructionsLoadFailed')

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -1494,11 +1494,10 @@ const pendingLoading = ref(false)
 const loadPendingChanges = async () => {
   pendingLoading.value = true
   try {
-    const { data } = await useMyFetch<any>('/api/instructions', {
-      method: 'GET',
-      query: { skip: 0, limit: 200, pending_only: true, include_drafts: true, include_archived: true },
+    const { items } = await fetchAllInstructions({
+      pending_only: true, include_drafts: true, include_archived: true,
     })
-    pendingRows.value = (data.value?.items || []) as Instruction[]
+    pendingRows.value = items as Instruction[]
     // Keep the lazy cache + dot set in sync so opening a row from here behaves
     // identically to opening it from the tree.
     mergeRows(pendingRows.value)
@@ -2191,12 +2190,14 @@ const loadGroup = async (key: string, force = false) => {
   if (loadingGroups.value.has(key)) return
   loadingGroups.value = new Set(loadingGroups.value).add(key)
   try {
-    const query: Record<string, any> = { skip: 0, limit: 200, include_own: true, include_drafts: true, include_archived: true }
+    const query: Record<string, any> = { include_own: true, include_drafts: true, include_archived: true }
     if (key === 'global') query.global_only = true
     else if (key === 'skills') query.kind = 'skill'
     else { query.data_source_ids = key; query.include_global = false }
-    const { data } = await useMyFetch<any>('/api/instructions', { method: 'GET', query })
-    mergeRows(data.value?.items || [])
+    // Pages through every row — the group is only marked loaded on success, so
+    // a failure retries on the next expand instead of caching a partial set.
+    const { items } = await fetchAllInstructions(query)
+    mergeRows(items)
     loadedGroups.value = new Set(loadedGroups.value).add(key)
   } catch (e) { console.error(e) } finally {
     const s = new Set(loadingGroups.value); s.delete(key); loadingGroups.value = s
@@ -2372,8 +2373,13 @@ const activeTables = (agentId: string) => (agentTables.value[agentId] || []).fil
 // ── Detail / create ─────────────────────────────────────
 const openInstruction = async (ins: Instruction) => {
   closePreview(); closeDiff(); closePanel(); closeAgentView(); closeReview(); creating.value = false; bottomTab.value = 'details'
-  selectedId.value = ins.id; detail.value = ins; editing.value = false
-  syncDraft(ins); loadVersions(ins.id)
+  // The row came from the light list, so it has `preview` but no body. Seed the
+  // pane with the preview so it shows the opening lines rather than blank while
+  // GET /instructions/{id} (below) fetches the real text.
+  selectedId.value = ins.id
+  detail.value = { ...ins, text: (ins as any).text ?? (ins as any).preview ?? '' } as Instruction
+  editing.value = false
+  syncDraft(detail.value); loadVersions(ins.id)
   try {
     const { data } = await useMyFetch<Instruction>(`/api/instructions/${ins.id}`, { method: 'GET' })
     if (data.value && selectedId.value === ins.id) {
@@ -2548,7 +2554,9 @@ const restore = async (v: any) => {
 }
 
 // ── Display helpers ─────────────────────────────────────
-const displayTitle = (ins: Instruction) => ins?.title || (ins?.text || '').split('\n')[0].slice(0, 60) || 'Untitled'
+// Tree/list rows carry `preview` instead of the body; the detail pane still has
+// the full `text` once an instruction is opened.
+const displayTitle = (ins: Instruction) => instructionRowLabel(ins)
 const refLabel = (ref: any) => ref.display_text || ref.object?.name || ref.object_type
 const _df = useFormatDate()
 const fmtDate = (s?: string) => { if (!s) return ''; try { return _df.format(s, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) } catch { return s } }

--- a/frontend/components/instructions/PrimaryInstructionMenu.vue
+++ b/frontend/components/instructions/PrimaryInstructionMenu.vue
@@ -75,7 +75,7 @@
                             <span class="text-xs font-medium text-gray-800 dark:text-gray-200 truncate">{{ inst.title || 'Untitled instruction' }}</span>
                             <span v-if="inst.id === currentInstructionId" class="text-[9px] px-1 py-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-700 rounded shrink-0">Current</span>
                         </div>
-                        <div class="text-[11px] text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">{{ inst.text }}</div>
+                        <div class="text-[11px] text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">{{ inst.preview ?? inst.text }}</div>
                     </button>
                 </div>
 
@@ -142,9 +142,13 @@ async function openReplace() {
 async function fetchInstructions() {
     loading.value = true
     try {
+        // Capped on purpose: this picker is search-backed (`query.search` below),
+        // so it shows the top matches rather than everything. `view=light` keeps
+        // the rows from carrying the instruction body they never render.
         const query: Record<string, any> = {
             skip: 0,
             limit: 50,
+            view: 'light',
             status: 'published',
             data_source_ids: props.agentId,
             include_global: true,

--- a/frontend/components/instructions/PrimaryInstructionPicker.vue
+++ b/frontend/components/instructions/PrimaryInstructionPicker.vue
@@ -55,7 +55,7 @@
                         </span>
                     </div>
                     <div class="text-[11px] text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">
-                        {{ inst.text }}
+                        {{ inst.preview ?? inst.text }}
                     </div>
                 </button>
             </div>
@@ -94,9 +94,13 @@ const search = ref('')
 async function fetchInstructions() {
     loading.value = true
     try {
+        // Capped on purpose: this picker is search-backed (`query.search` below),
+        // so it shows the top matches rather than everything. `view=light` keeps
+        // the rows from carrying the instruction body they never render.
         const query: Record<string, any> = {
             skip: 0,
             limit: 50,
+            view: 'light',
             status: 'published',
             data_source_ids: props.agentId,
             include_global: true,

--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -1485,13 +1485,13 @@ async function fetchAvailableMentions() {
 // instruction's content into context server-side (mirrors the FILE path).
 async function fetchInstructionMentions() {
   try {
-    const { data, error } = await useMyFetch('/instructions?limit=50', { method: 'GET' })
-    if (error.value) { instructionCategoryItems.value = []; return }
-    const list = (data.value as any)?.items || []
-    instructionCategoryItems.value = list.map((ins: any) => ({
+    // Every instruction, not the newest 50 — the picker filters client-side on
+    // what you type, so a capped list silently made the rest unmentionable.
+    const { items } = await fetchAllInstructions({})
+    instructionCategoryItems.value = items.map((ins: any) => ({
       id: String(ins.id),
       type: 'instruction' as const,
-      name: ins.title || (ins.text || '').slice(0, 60),
+      name: instructionRowLabel(ins),
       kind: ins.kind || 'instruction',
     } as MentionItem))
   } catch {

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -338,11 +338,12 @@
                   <div class="flex-1 min-w-0">
                     <!-- Title or text preview -->
                     <div class="flex items-center gap-1.5">
-                      <span class="truncate text-gray-800 dark:text-gray-200 font-medium text-xs">{{ inst.title || inst.text?.slice(0, 60) || $t('reportAgent.untitled') }}</span>
+                      <span class="truncate text-gray-800 dark:text-gray-200 font-medium text-xs">{{ inst.title || (inst.preview ?? inst.text)?.slice(0, 60) || $t('reportAgent.untitled') }}</span>
                     </div>
-                    <!-- Text preview if title exists -->
-                    <p v-if="inst.title && inst.text" class="text-[11px] text-gray-500 dark:text-gray-400 truncate mt-0.5 leading-snug">
-                      <InstructionText :text="inst.text.slice(0, 80)" :references="inst.references?.map((r: any) => ({ id: r.object_id, type: r.object_type, name: r.display_text || r.object?.name, data_source_type: r.object?.data_source_type || r.object?.connection_type, data_source_icon: r.data_source_icon }))" />
+                    <!-- Body preview under the title. Rows come from the light
+                         list, which carries `preview` rather than the full text. -->
+                    <p v-if="inst.title && (inst.preview ?? inst.text)" class="text-[11px] text-gray-500 dark:text-gray-400 truncate mt-0.5 leading-snug">
+                      <InstructionText :text="(inst.preview ?? inst.text).slice(0, 80)" :references="inst.references?.map((r: any) => ({ id: r.object_id, type: r.object_type, name: r.display_text || r.object?.name, data_source_type: r.object?.data_source_type || r.object?.connection_type, data_source_icon: r.data_source_icon }))" />
                     </p>
                     <!-- Badges row -->
                     <div class="flex items-center gap-1.5 mt-1 flex-wrap">
@@ -779,10 +780,9 @@ const filteredInstructions = computed(() => {
   let list = instructions.value
   const q = instructionSearch.value.toLowerCase().trim()
   if (q) {
-    list = list.filter((i: any) =>
-      (i.title || '').toLowerCase().includes(q) ||
-      (i.text || '').toLowerCase().includes(q)
-    )
+    // Rows carry a `preview` rather than the whole body (see
+    // useInstructionList), so this matches the title and the body's head.
+    list = list.filter((i: any) => instructionSearchText(i).includes(q))
   }
   if (instructionCategoryFilter.value.length > 0) {
     list = list.filter((i: any) => instructionCategoryFilter.value.includes(i.category))
@@ -921,14 +921,8 @@ async function fetchTabData(agentId: string, tab: string) {
       loading.value = true
       instructionsError.value = null
       try {
-        const { data, error } = await useMyFetch('/api/instructions', {
-          method: 'GET',
-          query: { include_own: true, include_drafts: true, limit: 200 }
-        })
-        if (error?.value) { instructionsError.value = t('reportAgent.loadFailInstructions'); return }
-        const payload: any = (data as any)?.value
-        const all = payload?.items || payload || []
-        instructionsCache.value[agentId] = all.filter((i: any) => !(i.data_sources?.length))
+        const { items } = await fetchAllInstructions({ include_own: true, include_drafts: true })
+        instructionsCache.value[agentId] = items.filter((i: any) => !(i.data_sources?.length))
       } catch { instructionsError.value = t('reportAgent.loadFailInstructions') }
       finally { loading.value = false }
     }
@@ -951,14 +945,10 @@ async function fetchTabData(agentId: string, tab: string) {
     instructionsError.value = null
     try {
       // Fetch instructions scoped to the selected agent AND global (any data source) instructions
-      const { data, error } = await useMyFetch('/api/instructions', {
-        method: 'GET',
-        query: { data_source_ids: agentId, include_global: true, limit: 200, include_own: true, include_drafts: true }
+      const { items } = await fetchAllInstructions({
+        data_source_ids: agentId, include_global: true, include_own: true, include_drafts: true,
       })
-      if (error?.value) { instructionsError.value = t('reportAgent.loadFailInstructions'); return }
-      const payload: any = (data as any)?.value
-      const agentInstructions = payload?.items || payload || []
-      instructionsCache.value[agentId] = agentInstructions
+      instructionsCache.value[agentId] = items
     } catch { instructionsError.value = t('reportAgent.loadFailInstructions') }
     finally { loading.value = false }
   }

--- a/frontend/composables/useInstructionList.ts
+++ b/frontend/composables/useInstructionList.ts
@@ -1,0 +1,70 @@
+// Loading instruction rows for list / tree surfaces.
+//
+// Every caller used to fire a single capped request and render `items` as if it
+// were the whole set — no pagination, and `total` was thrown away. On an org
+// past the cap that silently dropped the oldest instructions with nothing in the
+// UI to say so, which reads as "some of my instructions are just gone".
+//
+// These helpers ask for the light projection (`view=light`: no instruction body,
+// no nested user records, a `preview` prefix instead) and keep paging until
+// `items.length >= total`, so a surface either has every row it is entitled to
+// or throws.
+
+export const INSTRUCTION_PAGE_SIZE = 500
+
+export interface InstructionListResult<T = any> {
+  items: T[]
+  total: number
+}
+
+/**
+ * Fetch every instruction matching `query`, paging through the light list.
+ *
+ * `query` takes the same filters as `GET /instructions` minus paging — `skip`,
+ * `limit` and `view` are managed here and any caller-supplied values for them
+ * are ignored.
+ */
+export async function fetchAllInstructions<T = any>(
+  query: Record<string, any>,
+): Promise<InstructionListResult<T>> {
+  const { skip: _s, limit: _l, view: _v, ...filters } = query || {}
+  const items: T[] = []
+  let total = 0
+
+  for (let skip = 0; ; skip += INSTRUCTION_PAGE_SIZE) {
+    const { data, error } = await useMyFetch<any>('/api/instructions', {
+      method: 'GET',
+      query: { ...filters, view: 'light', skip, limit: INSTRUCTION_PAGE_SIZE },
+    })
+    // Surface the failure instead of returning a short list that looks complete
+    // — a partial result presented as whole is the bug this replaces.
+    if (error?.value) throw error.value
+
+    const payload: any = (data as any)?.value
+    const page: T[] = payload?.items || []
+    total = Number(payload?.total ?? page.length)
+    items.push(...page)
+
+    // An empty page also terminates: without it a `total` that disagrees with
+    // what the filters actually return (a post-query cut such as the per-user
+    // table-accessibility filter) would loop forever.
+    if (!page.length || items.length >= total) break
+  }
+
+  return { items, total }
+}
+
+/** The label a tree/list row shows: title, else the body prefix, else a stub. */
+export function instructionRowLabel(ins: any, max = 60): string {
+  const title = (ins?.title || '').trim()
+  if (title) return title
+  const body = (ins?.preview ?? ins?.text ?? '') as string
+  return body.split('\n')[0].slice(0, max) || 'Untitled'
+}
+
+/** Text a client-side filter can match on. The full body is not loaded here;
+ *  `preview` covers the head of it, and the server `search` filter covers the
+ *  rest for callers that need it. */
+export function instructionSearchText(ins: any): string {
+  return `${ins?.title || ''}\n${ins?.preview ?? ins?.text ?? ''}`.toLowerCase()
+}

--- a/frontend/composables/useInstructions.ts
+++ b/frontend/composables/useInstructions.ts
@@ -2,6 +2,7 @@
  * Composable for fetching and managing instructions with server-side pagination
  */
 import type { Instruction } from './useInstructionHelpers'
+import { fetchAllInstructions } from './useInstructionList'
 
 export interface UseInstructionsOptions {
   dataSourceId?: string | Ref<string | undefined>
@@ -288,10 +289,11 @@ export function useInstructions(options: UseInstructionsOptions = {}) {
       let idsToUpdate: string[] = []
       
       if (selectAllMode.value === 'all') {
-        // Fetch all IDs matching current filters
+        // Fetch all IDs matching current filters. Paged through the light list:
+        // this used to ask for limit=10000, which the endpoint rejects (422), so
+        // the id set came back empty and "select all" silently applied to
+        // nothing.
         const queryParams: Record<string, any> = {
-          skip: 0,
-          limit: 10000, // Get all
           include_own: true,
           include_drafts: true,
           include_archived: filters.status === 'archived'
@@ -304,11 +306,8 @@ export function useInstructions(options: UseInstructionsOptions = {}) {
         if (filters.labelIds.length) queryParams.label_ids = filters.labelIds.join(',')
         if (filters.search?.trim()) queryParams.search = filters.search.trim()
 
-        const { data } = await useMyFetch<PaginatedResponse>('/api/instructions', {
-          method: 'GET',
-          query: queryParams
-        })
-        idsToUpdate = (data.value?.items || []).map((i: Instruction) => i.id)
+        const { items } = await fetchAllInstructions(queryParams)
+        idsToUpdate = items.map((i: any) => i.id)
       } else {
         idsToUpdate = Array.from(selectedIds.value)
       }
@@ -380,10 +379,11 @@ export function useInstructions(options: UseInstructionsOptions = {}) {
       let idsToDelete: string[] = []
       
       if (selectAllMode.value === 'all') {
-        // Fetch all IDs matching current filters
+        // Fetch all IDs matching current filters. Paged through the light list:
+        // this used to ask for limit=10000, which the endpoint rejects (422), so
+        // the id set came back empty and "select all" silently applied to
+        // nothing.
         const queryParams: Record<string, any> = {
-          skip: 0,
-          limit: 10000,
           include_own: true,
           include_drafts: true,
           include_archived: filters.status === 'archived'
@@ -396,11 +396,8 @@ export function useInstructions(options: UseInstructionsOptions = {}) {
         if (filters.labelIds.length) queryParams.label_ids = filters.labelIds.join(',')
         if (filters.search?.trim()) queryParams.search = filters.search.trim()
 
-        const { data } = await useMyFetch<PaginatedResponse>('/api/instructions', {
-          method: 'GET',
-          query: queryParams
-        })
-        idsToDelete = (data.value?.items || []).map((i: Instruction) => i.id)
+        const { items } = await fetchAllInstructions(queryParams)
+        idsToDelete = items.map((i: any) => i.id)
       } else {
         idsToDelete = Array.from(selectedIds.value)
       }


### PR DESCRIPTION
## The problem

Every instruction list, tree and picker fired **one capped request** and rendered `items` as if it were the whole set. `total` came back in the same envelope and was discarded, and none of them paged. Since the list is ordered `created_at DESC`, everything past the cap — the *oldest* instructions — was simply absent, with nothing in the UI saying so.

The Knowledge Explorer contradicted itself most visibly: the agent node's badge comes from `/instructions/counts`, which applies **no limit**, so it read the true count right next to a list that stopped at 200.

| Surface | Was |
|---|---|
| Report agent panel | `limit: 200` (globals shared the budget) |
| Agent flyout | `limit: 50` |
| Knowledge Explorer tree group | `limit: 200`, then marked the group loaded so re-expanding never fetched the rest |
| Knowledge Explorer pending view | `limit: 200` |
| @-mention picker | `limit: 50`, no search — everything older was unmentionable |

## Why the cap existed

The full list row carries the instruction body three ways over: `text`, `formatted_content`, and `structured_data` — which for a git-synced instruction holds the entire source resource, including every column, its `sql_content`, **and `raw_data.content` (the file again)**. Plus a nested `UserSchema` repeated on every row.

Measured on a half-dbt-synced org, that's **6.2 KB per row**, of which those three fields are **81%**:

| field | B/row | % |
|---|---:|---:|
| `structured_data` | 3,650 | 58.8% |
| `text` | 917 | 14.8% |
| `formatted_content` | 476 | 7.7% |
| `user` (nested) | 247 | 4.0% |
| all 33 others | ~914 | 14.7% |

None of it is read by a list that renders a label and some badges.

## The change

**Backend** — `GET /instructions?view=light` returns `InstructionListItemSchema`: no body, no nested user records, and a bounded `preview` prefix instead (the tree label falls back to it when an instruction has no title). Only the light view may exceed the old page limit; a full-view caller asking for more is **rejected**, not quietly handed 200. The light query also skips the author/reviewer eager loads it no longer serializes. `view=full` is the default and is unchanged.

**Frontend** — a `fetchAllInstructions` helper owns the paging and *throws* rather than returning a short list that looks complete. Wired into the report agent panel (agent + global), the agent flyout, the Knowledge Explorer's lazy tree groups and pending-changes view, and the @-mention picker. The two primary-instruction pickers keep their cap — they're search-backed, so "top 50, refine your search" is the intended behaviour — and just take the lighter rows. Surfaces that rendered a body snippet now read `preview`.

**Also fixed**: instruction "select all" bulk update/delete requested `limit=10000`, which the endpoint rejects with 422, so the id set came back empty and the operation **silently affected nothing**. Pre-existing, same family, fixed here since it's the same call path.

## Verified end-to-end on a sandbox

Full stack (FastAPI + Nuxt + real browser), one agent seeded with **451 instructions**, half git-sourced with realistic dbt `structured_data`, driven through the UI with Playwright.

| | request | rows returned | bytes |
|---|---|---:|---:|
| before | `limit=200` (full) | 200 of 451 | 1350 KB |
| after | `view=light&limit=500` | 451 of 451 | 490 KB |

**2.25× the data in 36% of the bytes.**

What the screenshots show:

- **Knowledge Explorer, before** — agent badge **451**, header "451 instructions", but the Instructions node reads **200**. The UI disagreeing with itself.
- **Knowledge Explorer, after** — Instructions node reads **451**; badge and list agree.
- **Report agent panel, after** (the surface from the original report) — tab reads **Instructions (451)**, every row present, labels and preview snippets intact.

Tests: 6 new e2e covering the projection's shape, the `preview` fallback, that both views return the same rows in the same order, the asymmetric limit ceiling, and that `view=full` is unchanged. 93 passed across `test_instruction_light_view`, `test_instruction`, `test_instruction_main_build_integrity`, `test_build`, `test_instruction_label`. SQLite only — Postgres needs Docker, which wasn't available in this environment.

## Notes for review

- **The @-mention picker now loads more than before** (490 KB for all 451 vs 330 KB for the newest 50). That's the cost of making every instruction mentionable. If it proves heavy on report open, the follow-up is server-side search there rather than re-capping it.
- **Client-side filtering in the report panel now matches `title` + `preview`** rather than the full body. The endpoint's `search` param still does full-body matching server-side; wiring the panel's search box to it is a reasonable follow-up.
- `LIGHT_MAX_LIMIT` is 2000. An org past that still pages correctly — it just takes more than one request.
- This does **not** touch the O(n²) diff in the pending-change sweep found earlier. Loading all rows in one request rather than N pages avoids making it worse, but that cost is unchanged and still needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmKSxiniJKW8o2WRPFAK85