### PR TITLE
Don't auto-route when the user picked a model

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -2076,6 +2076,23 @@ class AgentV2:
                 if t.name not in denied_tools
             ]
 
+    def _user_picked_model(self) -> bool:
+        """True when the user explicitly chose the model for this run.
+
+        Either per-message (``prompt.model_id``, the picker on the message) or
+        pinned on the conversation (``report.model_id``). Mirrors the top of
+        ``CompletionService._resolve_completion_models``'s precedence ladder —
+        an explicit pick always wins, so the Auto router must stay out of the
+        run entirely rather than re-deciding what the user already decided.
+        """
+        try:
+            prompt = getattr(self.head_completion, "prompt", None) or {}
+            if isinstance(prompt, dict) and prompt.get("model_id"):
+                return True
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return bool(getattr(self.report, "model_id", None))
+
     async def _setup_model_routing(self) -> None:
         """Resolve routing candidates and wire the route_model tool for this run.
 
@@ -2084,6 +2101,10 @@ class AgentV2:
         those models (with the admin's hints), and a RoutingController is bound
         so the tool can escalate. Otherwise route_model is removed from the
         planner catalog so it's never advertised or attempted.
+
+        An explicit user pick (message model or report-pinned model) disables
+        routing outright: the resolver already handed us the user's model, and
+        advertising route_model would let the planner switch away from it.
         """
         from app.ai.model_router import (
             RoutingController,
@@ -2095,11 +2116,17 @@ class AgentV2:
         has_tool = any(t.name == "route_model" for t in catalog)
 
         routing_on = False
-        try:
-            cfg = self.organization_settings.get_config("model_routing") if self.organization_settings else None
-            routing_on = bool(getattr(cfg, "value", False))
-        except Exception:
-            routing_on = False
+        if self._user_picked_model():
+            logger.info(
+                "[routing] disabled: user picked %s explicitly",
+                getattr(self.model, "name", None),
+            )
+        else:
+            try:
+                cfg = self.organization_settings.get_config("model_routing") if self.organization_settings else None
+                routing_on = bool(getattr(cfg, "value", False))
+            except Exception:
+                routing_on = False
 
         candidates = []
         if routing_on and self.db and self.organization:

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -3179,13 +3179,14 @@ class CompletionService:
                     org_settings = await organization.get_settings(session)
 
                     prompt = head.prompt or {}
-                    if prompt.get('model_id'):
-                        model = await self.llm_service.get_model_by_id(session, organization, user, prompt['model_id'])
-                    else:
-                        model = await self.llm_service.get_default_model_for_user(session, organization, user)
+                    # Same precedence ladder + Auto-router decision as the
+                    # streaming path, so a queued turn honours the report-pinned
+                    # model and gets routing attribution identically.
+                    model, small_model, routing_meta = await self._resolve_completion_models(
+                        session, organization, user, report, prompt.get('model_id'),
+                    )
                     if not model:
                         raise RuntimeError("No default LLM model configured")
-                    small_model = await self.llm_service.get_default_model(session, organization, user, is_small=True)
                     if not small_model:
                         small_model = model
 
@@ -3224,6 +3225,7 @@ class CompletionService:
                         event_queue=event_queue,
                         clients=clients,
                         session_maker=session_factory,
+                        routing_meta=routing_meta,
                     )
                     await agent.main_execution()
                     await event_queue.put(SSEEvent(

--- a/backend/tests/unit/test_model_router.py
+++ b/backend/tests/unit/test_model_router.py
@@ -251,3 +251,76 @@ def test_savings_nets_escalation_overhead_negative_when_actual_exceeds_baseline(
     rec = _usage(True, "base", prompt=1_000_000, completion=0, total_cost=5.0)
     # baseline = $1; actual = $5 → -4.
     assert compute_routing_savings_usd([rec], rates) == pytest.approx(-4.0)
+
+
+# ── explicit user pick disables routing entirely ───────────────────────────
+
+def _routing_self(*, prompt=None, report_model_id=None, routing_on=True):
+    """Light stand-in carrying only what _setup_model_routing reads."""
+    from app.ai.agent_v2 import AgentV2
+
+    tool = types.SimpleNamespace(name="route_model", schema=None)
+    other = types.SimpleNamespace(name="create_data", schema={})
+    fake_self = types.SimpleNamespace(
+        planner=types.SimpleNamespace(tool_catalog=[tool, other]),
+        organization_settings=types.SimpleNamespace(
+            get_config=lambda key: types.SimpleNamespace(value=routing_on)
+        ),
+        organization=types.SimpleNamespace(id="org1"),
+        db=object(),
+        model=_model("gpt-big", "GPT Big", default=True, db_id="b1"),
+        report=types.SimpleNamespace(model_id=report_model_id),
+        head_completion=types.SimpleNamespace(prompt=prompt, user=None),
+        _routing_controller=None,
+    )
+    fake_self._user_picked_model = lambda: AgentV2._user_picked_model(fake_self)
+    return fake_self
+
+
+async def _run_setup(fake_self, monkeypatch, candidates):
+    from app.ai import model_router
+    from app.ai.agent_v2 import AgentV2
+
+    async def _fake_resolve(db, organization, user, **kwargs):
+        return candidates
+
+    monkeypatch.setattr(model_router, "resolve_routing_candidates", _fake_resolve)
+    await AgentV2._setup_model_routing(fake_self)
+    return [t.name for t in fake_self.planner.tool_catalog]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prompt,report_model_id",
+    [
+        ({"content": "hi", "model_id": "b1"}, None),   # per-message pick
+        ({"content": "hi"}, "b1"),                      # report-pinned model
+        (None, "b1"),                                   # pinned, no prompt dict
+    ],
+)
+async def test_explicit_user_pick_removes_route_model_tool(prompt, report_model_id, monkeypatch):
+    """The router must never switch away from a model the user chose.
+
+    The resolver already bypasses routing for explicit picks, but the agent
+    wired route_model purely off the org toggle — so a pinned report could
+    still be routed elsewhere mid-run. Advertising the tool at all is the bug.
+    """
+    fake_self = _routing_self(prompt=prompt, report_model_id=report_model_id)
+    small = _model("gpt-small", "GPT Small", small=True, hint="simple lookups", db_id="s1")
+
+    names = await _run_setup(fake_self, monkeypatch, [small])
+
+    assert "route_model" not in names
+    assert fake_self._routing_controller is None
+
+
+@pytest.mark.asyncio
+async def test_no_pick_keeps_route_model_tool_wired(monkeypatch):
+    """Control: with nothing picked and the toggle on, routing stays active."""
+    fake_self = _routing_self(prompt={"content": "hi"}, report_model_id=None)
+    small = _model("gpt-small", "GPT Small", small=True, hint="simple lookups", db_id="s1")
+
+    names = await _run_setup(fake_self, monkeypatch, [small])
+
+    assert "route_model" in names
+    assert fake_self._routing_controller is not None

--- a/docs/design/auto-model-routing.md
+++ b/docs/design/auto-model-routing.md
@@ -18,7 +18,11 @@ it fails closed so a config left over from an active license can't keep routing.
 
 - **Explicit user choice always wins.** The router only acts when the user
   picked nothing — no `prompt.model_id`, no `report.model_id`. Router
-  decisions are per-run, never persisted into any default.
+  decisions are per-run, never persisted into any default. This is enforced
+  twice: `_resolve_completion_models` starts an explicit pick on the user's
+  model, and `AgentV2._setup_model_routing` drops `route_model` from the
+  planner catalog entirely for such runs — otherwise the planner could
+  escalate away from a model the user deliberately chose.
 - **Route down on evidence, up on need.** Start small only where failure is
   detectable or recoverable; escalation is always available and one-way.
 - **Extremely simple for the user.** The model picker gains no new options.


### PR DESCRIPTION
## Problem

The Auto router is documented as never overriding an explicit user choice, and `CompletionService._resolve_completion_models` honours that: an explicit `prompt.model_id` or a report-pinned `report.model_id` starts the run on the user's model and returns empty routing metadata.

But `AgentV2._setup_model_routing` wired the `route_model` tool purely off the org's `model_routing` toggle plus candidate availability — it never looked at *how* the model was chosen. A report pinned to one model therefore started on that model correctly and then handed the planner a tool to switch away from it mid-run. In the transcript this reads as "Model was switched to X" immediately followed by "Routed to Y".

## Changes

- **`backend/app/ai/agent_v2.py`** — new `_user_picked_model()` (per-message `prompt.model_id` or conversation-pinned `report.model_id`), checked at the top of `_setup_model_routing`. On an explicit pick, `route_model` is dropped from the planner catalog and no `RoutingController` is bound. Dropping the tool also removes the escalation instruction from the planner prompt, since `prompt_builder_v3` keys off the tool's presence.
- **`backend/app/services/completion_service.py`** — the queued/dispatched turn (`_run_dispatched_agent`) had its own resolution ladder: `prompt.model_id` > *user* default, skipping the report pin entirely, and it never passed `routing_meta`. It now goes through `_resolve_completion_models` like the streaming path, so a pinned report is honoured there too and routed runs on that path get savings attribution.
- **`docs/design/auto-model-routing.md`** — notes that "explicit choice wins" is now enforced at both the resolver and the agent.

## Tests

New cases in `backend/tests/unit/test_model_router.py`: three parametrized picks (per-message, report-pinned, pinned with no prompt dict) asserting `route_model` is removed and no controller bound, plus a control confirming routing still wires up when nothing is picked.

```
pytest tests/unit/test_model_router.py tests/e2e/rbac/test_auto_model_routing.py \
       tests/unit/test_session_events.py -m "e2e or not e2e" --db=sqlite   → 39 passed
pytest tests/e2e/test_completion_queue_steer.py -m "e2e or not e2e" --db=sqlite → 4 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011BiuGHxSr6TBUEHUV3fo9y)_