### PR TITLE
Fix NameError on every connection delete (regression from #814)

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -682,11 +682,18 @@ class ConnectionService:
                     extra={"connection_id": str(connection_id)},
                 )
 
-        _invalidate_engine_pool(connection)
-
         async def _load_and_delete(org: Organization) -> tuple[str, int, list]:
             connection = await self.get_connection(db, connection_id, org)
             connection_name = connection.name
+
+            # Drop this connection's pooled engines while the row is still
+            # readable — building the pool key needs its config and
+            # credentials, and after the delete they are gone. Without this a
+            # live pool keeps a handful of authenticated sessions open against
+            # a source the user believes they disconnected, until it ages out.
+            # Idempotent, which matters because the caller retries this whole
+            # function on a concurrent-write FK violation.
+            _invalidate_engine_pool(connection)
 
             agent_count = len(connection.data_sources) if connection.data_sources else 0
             deleted_agent_names: list = []


### PR DESCRIPTION
`main` is red. #814 added `_invalidate_engine_pool(connection)` to `delete_connection` at the outer function level, but `connection` only exists inside the nested `_load_and_delete(org)` closure that loads it. Every connection delete raises `NameError`.

13 e2e tests fail: [`e2e-tests (sqlite)`](https://github.com/bagofwords1/bagofwords/actions/runs/30433786440/job/90516776270), across `test_connection.py`, `test_domains.py`, `test_schema_drift.py` and `test_connection_delete_race_repro.py`.

```
app/services/connection_service.py:685: NameError: name 'connection' is not defined
```

## Fix

Moved the call inside `_load_and_delete`, right after the row is loaded. That is also where it has to be: building the pool key reads the connection's config and credentials, so it must run while the row is still readable. It is idempotent, which matters because that function is retried on a concurrent-write FK violation.

## Verification

`pytest -m e2e --db=sqlite` over the four affected files: **29 passed**, no `NameError`.

## How it got through

Worth recording, since the fix is trivial but the gap isn't:

- The tests I wrote for #814 were all unit tests. `delete_connection` is only covered by `pytest -m e2e`, which I did not run — I checked the suites I added rather than the ones my changes could break.
- Ruff with pyflakes is already configured in `pyproject.toml` and flags this in seconds, but CI never invokes ruff:

  ```
  $ ruff check app/services/connection_service.py --select F821
  app/services/connection_service.py:685:33: F821 Undefined name `connection`
  ```

  I have since run that across all 43 Python files #814 touched. Clean apart from 15 pre-existing hits elsewhere in the repo (mostly forward-reference annotations, plus two real-looking ones in `external_platform_service.py` and `review_producers.py`) — none in code from that PR.

A `ruff check --select F821` step scoped to changed files would have caught this before merge. Not included here to keep this diff to the regression; happy to open it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB3Y3XF3bibPirGCpQmQxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB3Y3XF3bibPirGCpQmQxE)_