### PR TITLE
Fix agent file uploads failing silently when uploads/files is missing

### DIFF
--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 from fastapi import UploadFile
 from sqlalchemy.orm import Session
@@ -40,6 +41,12 @@ class FileService:
         # Generate a unique filename to prevent overwriting existing files
         unique_filename = f"{uuid.uuid4()}_{file.filename}"
         file_location = f"uploads/files/{unique_filename}"
+
+        # The image pre-creates uploads/files, but a volume mounted over
+        # uploads/ hides it: Docker seeds a fresh named volume from the image,
+        # Kubernetes mounts an empty PVC/emptyDir and shadows the subdirectory.
+        # Without this every upload raised FileNotFoundError under k8s.
+        os.makedirs(os.path.dirname(file_location), exist_ok=True)
 
         # Async file writing
         async with aiofiles.open(file_location, "wb") as buffer:
@@ -136,11 +143,12 @@ class FileService:
         writes to disk, creates the row, optionally links to a report, and
         generates a preview. Returns the ``File`` ORM object.
         """
-        import os as _os
-
-        safe_name = _os.path.basename(filename or "attachment") or "attachment"
+        safe_name = os.path.basename(filename or "attachment") or "attachment"
         unique_filename = f"{uuid.uuid4()}_{safe_name}"
         file_location = f"uploads/files/{unique_filename}"
+
+        # Same shadowed-mount hazard as upload_file — see the note there.
+        os.makedirs(os.path.dirname(file_location), exist_ok=True)
 
         async with aiofiles.open(file_location, "wb") as buffer:
             await buffer.write(content)

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -1458,6 +1458,13 @@ const uploadingAgent = ref<string | null>(null)
 const uploadTargetAgent = ref<string | null>(null)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 const triggerUpload = (agentId: string) => { uploadTargetAgent.value = agentId; nextTick(() => fileInputRef.value?.click()) }
+// A proxy-level rejection (413) carries no JSON body, so name it rather than
+// surfacing a bare status code.
+const uploadErrorText = (e: any) => {
+  const status = e?.statusCode || e?.response?.status
+  if (status === 413) return t('agentsPage.uploadTooLarge')
+  return e?.data?.detail || e?.statusMessage || e?.message || `HTTP ${status || '?'}`
+}
 const onUploadInput = async (e: Event) => {
   const input = e.target as HTMLInputElement
   const files = Array.from(input.files || [])
@@ -1465,11 +1472,21 @@ const onUploadInput = async (e: Event) => {
   if (!files.length || !agentId) return
   uploadingAgent.value = agentId
   try {
+    // useMyFetch resolves rather than throws on the client — it hands the
+    // failure back in `error`. The try/catch below never fires for a rejected
+    // upload, so check per file; otherwise a 500 still reported "Uploaded 1
+    // file(s)" and the file simply never appeared in the tree.
+    let ok = 0
     for (const file of files) {
       const fd = new FormData(); fd.append('file', file)
-      await useMyFetch(`/data_sources/${agentId}/files`, { method: 'POST', body: fd })
+      const { error } = await useMyFetch(`/data_sources/${agentId}/files`, { method: 'POST', body: fd })
+      if (error.value) {
+        toast.add({ title: t('agentsPage.toastUploadFailed'), description: `${file.name} — ${uploadErrorText(error.value)}`, color: 'red' })
+        continue
+      }
+      ok++
     }
-    toast.add({ title: t('agentsPage.toastUploaded', { n: files.length }), color: 'green' })
+    if (ok) toast.add({ title: t('agentsPage.toastUploaded', { n: ok }), color: 'green' })
     agentLoaded.value.delete(agentId)
     await loadAgentMeta(agentId)
     if (!isOpen('files:' + agentId)) expand('files:' + agentId)

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "تمت إعادة تحميل الأدوات",
     "toastUploaded": "تم رفع {n} ملف",
     "toastUploadFailed": "فشل الرفع",
+    "uploadTooLarge": "الملف أكبر من حد الرفع المسموح به في الخادم",
     "toastSignInFailed": "تعذّر بدء تسجيل الدخول",
     "toastApplyFailed": "تعذّر تطبيق التغيير",
     "toastApprovedPublished": "تمت الموافقة والنشر",

--- a/locales/de.json
+++ b/locales/de.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Werkzeuge neu geladen",
     "toastUploaded": "{n} Datei(en) hochgeladen",
     "toastUploadFailed": "Hochladen fehlgeschlagen",
+    "uploadTooLarge": "Die Datei überschreitet das Upload-Limit des Servers",
     "toastSignInFailed": "Anmeldung konnte nicht gestartet werden",
     "toastApplyFailed": "Änderung konnte nicht angewendet werden",
     "toastApprovedPublished": "Genehmigt und veröffentlicht",

--- a/locales/en.json
+++ b/locales/en.json
@@ -225,6 +225,7 @@
     "toastToolsReloaded": "Tools reloaded",
     "toastUploaded": "Uploaded {n} file(s)",
     "toastUploadFailed": "Upload failed",
+    "uploadTooLarge": "File is too large for the server's upload limit",
     "toastSignInFailed": "Could not start sign-in",
     "toastApplyFailed": "Couldn’t apply change",
     "toastApprovedPublished": "Approved & published",

--- a/locales/es.json
+++ b/locales/es.json
@@ -225,6 +225,7 @@
     "toastToolsReloaded": "Herramientas recargadas",
     "toastUploaded": "{n} archivo(s) subido(s)",
     "toastUploadFailed": "Error al subir",
+    "uploadTooLarge": "El archivo supera el límite de subida del servidor",
     "toastSignInFailed": "No se pudo iniciar el inicio de sesión",
     "toastApplyFailed": "No se pudo aplicar el cambio",
     "toastApprovedPublished": "Aprobado y publicado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Outils rechargés",
     "toastUploaded": "{n} fichier(s) téléversé(s)",
     "toastUploadFailed": "Échec du téléversement",
+    "uploadTooLarge": "Le fichier dépasse la limite de téléversement du serveur",
     "toastSignInFailed": "Impossible de démarrer la connexion",
     "toastApplyFailed": "Impossible d’appliquer la modification",
     "toastApprovedPublished": "Approuvé et publié",

--- a/locales/he.json
+++ b/locales/he.json
@@ -225,6 +225,7 @@
     "toastToolsReloaded": "הכלים נטענו מחדש",
     "toastUploaded": "הועלו {n} קבצים",
     "toastUploadFailed": "ההעלאה נכשלה",
+    "uploadTooLarge": "הקובץ גדול ממגבלת ההעלאה של השרת",
     "toastSignInFailed": "לא ניתן להתחיל את ההתחברות",
     "toastApplyFailed": "לא ניתן להחיל את השינוי",
     "toastApprovedPublished": "אושר ופורסם",

--- a/locales/it.json
+++ b/locales/it.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Strumenti ricaricati",
     "toastUploaded": "Caricato/i {n} file",
     "toastUploadFailed": "Caricamento non riuscito",
+    "uploadTooLarge": "Il file supera il limite di caricamento del server",
     "toastSignInFailed": "Impossibile avviare l’accesso",
     "toastApplyFailed": "Impossibile applicare la modifica",
     "toastApprovedPublished": "Approvato e pubblicato",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Ferramentas recarregadas",
     "toastUploaded": "{n} arquivo(s) enviado(s)",
     "toastUploadFailed": "Falha no envio",
+    "uploadTooLarge": "O arquivo excede o limite de upload do servidor",
     "toastSignInFailed": "Não foi possível iniciar o login",
     "toastApplyFailed": "Não foi possível aplicar a alteração",
     "toastApprovedPublished": "Aprovado e publicado",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Инструменты перезагружены",
     "toastUploaded": "Загружено файлов: {n}",
     "toastUploadFailed": "Не удалось загрузить",
+    "uploadTooLarge": "Файл превышает лимит загрузки на сервере",
     "toastSignInFailed": "Не удалось начать вход",
     "toastApplyFailed": "Не удалось применить изменение",
     "toastApprovedPublished": "Одобрено и опубликовано",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -213,6 +213,7 @@
     "toastToolsReloaded": "Verktyg omladdade",
     "toastUploaded": "Laddade upp {n} fil(er)",
     "toastUploadFailed": "Uppladdning misslyckades",
+    "uploadTooLarge": "Filen överskrider serverns uppladdningsgräns",
     "toastSignInFailed": "Kunde inte starta inloggning",
     "toastApplyFailed": "Kunde inte tillämpa ändring",
     "toastApprovedPublished": "Godkänd och publicerad",


### PR DESCRIPTION
Users on Kubernetes reported that uploading a file under `/agents` → Files does nothing: no file appears in the tree, no error. Not reproducible locally.

## Root cause

`FileService.upload_file` writes to the relative path `uploads/files/...` without creating the directory:

```python
file_location = f"uploads/files/{unique_filename}"
async with aiofiles.open(file_location, "wb") as buffer:
```

When `<cwd>/uploads/files/` does not exist this raises `FileNotFoundError` and the endpoint returns 500.

Why it depends on the environment:

- The Docker image pre-creates the directory, and Docker Compose keeps it because a fresh **named volume is seeded from the image contents** — the Dockerfile comment says exactly this.
- **Kubernetes has no such seeding.** A PVC or emptyDir mounted at `/app/backend/uploads` starts empty and shadows the image's `files/` subdirectory. Parent exists, `files/` does not, every upload 500s.
- Locally the directory is sticky: `backend/uploads/` is gitignored but gets created by any of the agent file tools that already call `makedirs`, so a long-lived dev checkout always has it. A fresh clone fails the same way k8s does.

Every other writer already guards this — `attach_file.py`, `_file_tool_common.py`, `execute_mcp.py`, `read_excel_as_csv.py`, `report_pdf_service.py`, `thumbnail_service.py` all call `os.makedirs("uploads/files", exist_ok=True)` first. `upload_file` and `save_bytes_as_file` (inbound email attachments, same latent bug) were the two that did not.

## Why it looked like "nothing happened"

`KnowledgeExplorer.onUploadInput` wrapped the call in `try/catch`, but `useMyFetch` resolves rather than throws on the client and returns the failure in `error`. The catch never fired, so a 500 still produced a green **"Uploaded 1 file(s)"** toast while the DB gained no row.

## Changes

- `file_service.py`: `os.makedirs(os.path.dirname(file_location), exist_ok=True)` before the write, in both `upload_file` and `save_bytes_as_file`. Hoisted the function-local `import os as _os` to a module import.
- `KnowledgeExplorer.vue`: check `error` per file, report failures individually, and only report success for files that actually uploaded. A 413 is named explicitly since a proxy rejection carries no JSON body.
- New `agentsPage.uploadTooLarge` string across all 10 locales.

## Verification

Driven through the real UI in a local sandbox (backend + frontend + Playwright), with `uploads/` present but `uploads/files/` absent — the exact k8s mount shape:

| | before | after |
|---|---|---|
| `POST /api/data_sources/{id}/files` | 500 `FileNotFoundError` | 200, directory auto-created, row in `files`, bytes on disk |
| toast | green "Uploaded 1 file(s)" | — (success) |
| forced failure | green "Uploaded 1 file(s)" | red "Upload failed — Internal Server Error" |

`tests/unit/test_file_tools.py` and `tests/unit/test_file_reference_service.py`: 27 passed.

## Note for operators

If your deployment mounts a volume at `/app/backend/uploads`, this fix makes uploads work, but files written before it were lost on every pod restart if no volume was mounted at all. Worth confirming your chart values mount `uploads/` if you want upload persistence — the chart has no such volume by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ScrJESQRhxW7fwNbrfV9W

---
_Generated by [Claude Code](https://claude.ai/code/session_017ScrJESQRhxW7fwNbrfV9W)_