### PR TITLE
Power BI: keep user-contributed semantic models queryable

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1595,12 +1595,27 @@ class ConnectionService:
             return
         try:
             from app.models.connection_table import ConnectionTable
+            from app.models.datasource_table import DataSourceTable
 
             rows = (await db.execute(
                 select(ConnectionTable.name, ConnectionTable.metadata_json).where(
                     ConnectionTable.connection_id == str(connection.id)
                 )
             )).all()
+            # The service-principal catalog can be EMPTY and the connection still
+            # perfectly usable: an SP gets 401 on every RLS-protected model, so in
+            # a fully RLS tenant it indexes nothing and ConnectionTable stays bare.
+            # Models contributed by users' own discovery live on DataSourceTable
+            # instead — include them so the connect test has something to probe
+            # and does not reject a member who can genuinely query.
+            ds_ids = [str(ds.id) for ds in (connection.data_sources or [])]
+            if ds_ids:
+                rows += (await db.execute(
+                    select(DataSourceTable.name, DataSourceTable.metadata_json).where(
+                        DataSourceTable.datasource_id.in_(ds_ids),
+                        DataSourceTable.connection_table_id.is_(None),
+                    )
+                )).all()
             client.attach_table_metadata(
                 [{"name": name, "metadata_json": metadata_json} for name, metadata_json in rows]
             )

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2417,23 +2417,30 @@ class DataSourceService:
             from app.models.datasource_table import DataSourceTable
             from app.models.connection_table import ConnectionTable
 
+            # Rows linked to THIS connection, plus every unlinked row. Unlinked
+            # covers two cases that both need query-time metadata:
+            #   - legacy rows indexed before the connection_table link existed
+            #   - user-contributed rows: a semantic model the service principal
+            #     cannot see (every RLS model — SPs get 401 on those) enters the
+            #     catalog through a user's own discovery and never gets a
+            #     ConnectionTable link. An inner join dropped them, so the client
+            #     could not resolve their dataset GUID and every query against
+            #     them failed with "Could not resolve Power BI dataset".
+            # Attaching an unlinked row to a sibling connection's client is
+            # harmless — resolution is by name, and a name it does not own simply
+            # will not match (this is what the old no-rows fallback already did).
             rows = (await db.execute(
                 select(DataSourceTable.name, DataSourceTable.metadata_json)
-                .join(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
+                .outerjoin(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
                 .where(
                     DataSourceTable.datasource_id == str(data_source.id),
                     DataSourceTable.is_active == True,
-                    ConnectionTable.connection_id == str(connection.id),
+                    or_(
+                        ConnectionTable.connection_id == str(connection.id),
+                        DataSourceTable.connection_table_id.is_(None),
+                    ),
                 )
             )).all()
-            if not rows:
-                # Legacy rows indexed before the connection_table link existed
-                rows = (await db.execute(
-                    select(DataSourceTable.name, DataSourceTable.metadata_json).where(
-                        DataSourceTable.datasource_id == str(data_source.id),
-                        DataSourceTable.is_active == True,
-                    )
-                )).all()
             client.attach_table_metadata(
                 [{"name": name, "metadata_json": metadata_json} for name, metadata_json in rows]
             )

--- a/backend/tests/e2e/test_powerbi_user_contributed_query_metadata.py
+++ b/backend/tests/e2e/test_powerbi_user_contributed_query_metadata.py
@@ -1,0 +1,142 @@
+"""User-contributed semantic models must stay QUERYABLE, not just visible.
+
+A service principal gets 401 on every RLS-protected semantic model, so those
+models can only enter the catalog through a user's own discovery — and such rows
+carry NO `connection_table_id` (there is no service-principal ConnectionTable row
+to link to).
+
+`_attach_stored_table_metadata` gives the Power BI client the dataset GUIDs it
+needs to address `executeQueries`. It used to INNER JOIN ConnectionTable, which
+silently dropped every user-contributed row, with a whole-catalog fallback that
+only fired when there were ZERO linked rows. So in a MIXED tenant — some models
+the SP can index, some it cannot — the user-contributed ones resolved to nothing
+and every query against them failed:
+
+    ValueError: Could not resolve Power BI dataset for table 'rls_sales/Sales'
+
+Caught live (docs/feedback-loops/powerbi-obo-rls.md): a member could see the
+model in their catalog and had permission to query it, but the agent could not
+execute against it.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_powerbi_user_contributed_query_metadata.py -v
+"""
+import asyncio
+import uuid
+
+from app.dependencies import async_session_maker
+from app.models.connection import Connection
+from app.models.connection_table import ConnectionTable
+from app.models.data_source import DataSource
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+from app.models.organization import Organization
+from app.models.user import User
+from app.services.data_source_service import DataSourceService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _pbi_meta(ds_id, ws_id, model, table):
+    return {"powerbi": {"datasetId": ds_id, "workspaceId": ws_id,
+                        "datasetName": model, "tableName": table}}
+
+
+class _Recorder:
+    """Stands in for PowerBIClient — records what metadata it was handed."""
+
+    def __init__(self):
+        self.attached = None
+
+    def attach_table_metadata(self, tables):
+        self.attached = {t["name"]: t["metadata_json"] for t in tables}
+
+
+async def _seed():
+    """A delegated Power BI connection holding both row shapes: one model the
+    service principal indexed (ConnectionTable-linked) and one only a user could
+    see (unlinked)."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        org = Organization(name=f"RLS Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        owner = User(name="Owner", email=f"owner-{suffix}@example.com", hashed_password="x",
+                     is_active=True, is_superuser=False, is_verified=True)
+        db.add(owner)
+        await db.flush()
+
+        conn = Connection(
+            organization_id=org.id, name=f"PBI {suffix}", type="powerbi",
+            config={}, auth_policy="user_required", allowed_user_auth_modes=["oauth"],
+        )
+        conn.encrypt_credentials({"tenant_id": "t", "client_id": "c", "client_secret": "s"})
+        db.add(conn)
+        await db.flush()
+
+        ds = DataSource(name=f"PBI DS {suffix}", organization_id=org.id,
+                        is_active=True, owner_user_id=owner.id)
+        db.add(ds)
+        await db.flush()
+        await db.execute(domain_connection.insert().values(
+            data_source_id=ds.id, connection_id=conn.id))
+
+        # SP-indexed model: ConnectionTable row + linked DataSourceTable row.
+        ct = ConnectionTable(name="SalesPush/Sales", connection_id=conn.id,
+                             columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[],
+                             no_rows=0, metadata_json=_pbi_meta("ds-sp", "ws-sp", "SalesPush", "Sales"))
+        db.add(ct)
+        await db.flush()
+        db.add(DataSourceTable(
+            name="SalesPush/Sales", datasource_id=ds.id, connection_table_id=ct.id,
+            is_active=True, metadata_json=_pbi_meta("ds-sp", "ws-sp", "SalesPush", "Sales"),
+            columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0))
+
+        # RLS model the SP cannot see — contributed by a user's own discovery,
+        # so there is no ConnectionTable row and the link stays NULL.
+        db.add(DataSourceTable(
+            name="rls_sales/Sales", datasource_id=ds.id, connection_table_id=None,
+            is_active=True,
+            metadata_json={**_pbi_meta("ds-rls", "ws-rls", "rls_sales", "Sales"),
+                           "discovered_by": "user"},
+            columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0))
+
+        await db.commit()
+        return str(ds.id), str(conn.id)
+
+
+def test_user_contributed_model_gets_query_metadata():
+    ds_id, conn_id = _run(_seed())
+
+    async def _check():
+        async with async_session_maker() as db:
+            from sqlalchemy import select
+            from sqlalchemy.orm import selectinload
+            ds = (await db.execute(
+                select(DataSource).options(selectinload(DataSource.connections))
+                .where(DataSource.id == ds_id))).scalar_one()
+            conn = (await db.execute(
+                select(Connection).where(Connection.id == conn_id))).scalar_one()
+            rec = _Recorder()
+            await DataSourceService()._attach_stored_table_metadata(db, rec, ds, conn)
+            return rec.attached
+
+    attached = _run(_check())
+
+    # The SP-indexed model still resolves (no regression).
+    assert "SalesPush/Sales" in attached
+    assert attached["SalesPush/Sales"]["powerbi"]["datasetId"] == "ds-sp"
+
+    # The user-contributed RLS model must resolve too — without this the client
+    # raises "Could not resolve Power BI dataset" for every query against it.
+    assert "rls_sales/Sales" in attached, (
+        "user-contributed model missing from query metadata — it is visible in "
+        "the catalog but unqueryable"
+    )
+    assert attached["rls_sales/Sales"]["powerbi"]["datasetId"] == "ds-rls"
+    assert attached["rls_sales/Sales"]["powerbi"]["workspaceId"] == "ws-rls"

--- a/docs/feedback-loops/powerbi-obo-rls.md
+++ b/docs/feedback-loops/powerbi-obo-rls.md
@@ -122,6 +122,56 @@ IDs to probe.
 
 Screenshots: `assets/powerbi-obo-rls-*.png`.
 
+## Round 2 — RLS roles assigned, filtering proven end to end
+
+The roles could not be assigned programmatically (see below), so a human
+assigned them in the portal: demo1 → `USOnly`, demo2 → `EMEAOnly`, and demo1 was
+demoted from workspace Member to **Viewer** so RLS applies to them at all.
+Final topology: demo1 = Viewer + Build + `USOnly`; demo2 = Build only (no
+workspace role) + `EMEAOnly`.
+
+| | `/groups` sees ws | group-scoped | tenant-level | rows returned |
+|---|---|---|---|---|
+| demo1 (Viewer + Build + `USOnly`) | yes | 200 | 200 | **3 rows, US only, 9 000** |
+| demo2 (Build only + `EMEAOnly`) | **no** | 401 | **200** | **3 rows, EMEA only, 4 600** |
+
+Disjoint slices of the same 6-row / 13 600 model, each filtered to that user's
+role — through BOW's own client stack, not just raw REST. RLS works, and the
+tenant-level fallback is what makes demo2's half possible at all.
+
+Two findings from this round:
+
+- **`COLUMNSTATISTICS` works fine for an RLS-restricted identity** (200, 4
+  columns, tenant-level). The residual hole flagged in round 1 — "a model whose
+  only readers are RLS Viewers can be contributed by nobody" — **does not
+  exist**. Such users can introspect and contribute the model themselves.
+- **Power BI caches user permissions.** After demoting demo1 Member → Viewer,
+  they still saw all 6 rows (RLS not applied) until
+  `POST /v1.0/myorg/RefreshUserPermissions` was called with their token; the
+  very next query returned the correct 3. The Get Groups docs warn about this
+  ("User permissions for workspaces take time to get updated"). Anyone testing
+  a permission change — us or a customer — will otherwise measure stale
+  behavior and conclude RLS is broken. Worth considering calling it before a
+  per-user overlay sync.
+
+### Bug found and fixed in this round
+
+demo2 could SEE `rls_sales/Sales` in their catalog and had permission to query
+it, but the agent could not execute against it:
+
+    ValueError: Could not resolve Power BI dataset for table 'rls_sales/Sales'
+
+`_attach_stored_table_metadata` supplies the dataset GUIDs the client needs, and
+it INNER JOINed `ConnectionTable` — which drops every user-contributed row,
+since those have no service-principal row to link to. The whole-catalog fallback
+only fired when there were ZERO linked rows, so the bug is invisible in a pure
+tenant and bites in a MIXED one (some models SP-visible, some not). Now an outer
+join includes unlinked rows alongside this connection's own. Pinned by
+`tests/e2e/test_powerbi_user_contributed_query_metadata.py` (fails without the
+fix). `ConnectionService._attach_connection_table_metadata` gained the same
+union, so the connect gate still has something to probe in a tenant where the SP
+indexed nothing at all.
+
 ## Still open
 
 - **RLS role membership cannot be automated.** It is a service-layer
@@ -129,10 +179,9 @@ Screenshots: `assets/powerbi-obo-rls-*.png`.
   create and rejects it on update (`Workload_FailedToParseFile`), and the
   Power BI portal is unreachable from the sandbox (Chromium gets
   `ERR_CONNECTION_RESET` against `app.powerbi.com` — the egress proxy rejects
-  its TLS handshake, same as the prior OBO loop). So the fixture proves the
-  *routing and discovery* paths but not row-level filtering itself; that is
-  Power BI's own behavior, and `rls_sales` has roles `EMEAOnly` / `USOnly`
-  ready for a human to assign in the portal to finish that leg.
+  its TLS handshake, same as the prior OBO loop). Assigning roles is therefore a
+  manual portal step: workspace item → **… → Security** → pick the role → add
+  the member.
 - **User-contributed catalog rows land inactive.** `_upsert_user_overlay`
   creates them with `is_active=False` for delegated connections, so a model
   only a user can see needs an admin to select it before it reaches the agent's


### PR DESCRIPTION
Follow-up to #807, found while verifying the full RLS topology against a live tenant — this time with RLS roles actually assigned in the portal, which #807 could not do.

## The bug

A member could **see** an RLS model in their catalog and had permission to query it, but the agent failed:

```
ValueError: Could not resolve Power BI dataset for table 'rls_sales/Sales'
```

`_attach_stored_table_metadata` supplies the dataset GUIDs the client needs to address `executeQueries`, and it INNER JOINed `ConnectionTable`. Models a service principal cannot see — which is **every** RLS-protected model, since SPs get 401 on those — enter the catalog through a user's own discovery and carry no `ConnectionTable` link, so the join dropped them.

The whole-catalog fallback only fired when there were **zero** linked rows, which is why this was invisible until now: it works by accident in a pure tenant (SP indexes nothing → fallback fires → everything attached) and breaks in a **mixed** one (some models SP-visible, some not). The test tenant is mixed; the customer's may become mixed the moment one non-RLS model appears.

An outer join now includes unlinked rows alongside the connection's own. `ConnectionService._attach_connection_table_metadata` gains the same union so the connect gate still has candidates to probe where the SP indexed nothing at all.

## Verification — RLS proven end to end

With roles assigned (demo1 → `USOnly`, demo2 → `EMEAOnly`) and demo1 demoted from workspace Member to **Viewer** so RLS applies to them:

| Identity | `/groups` sees ws | group-scoped | tenant-level | rows through BOW |
|---|---|---|---|---|
| demo1 (Viewer + Build + `USOnly`) | yes | 200 | 200 | **3 rows, US only, 9 000** |
| demo2 (Build only, **no ws role** + `EMEAOnly`) | **no** | 401 | **200** | **3 rows, EMEA only, 4 600** |

Disjoint slices of the same 6-row / 13 600 model, each filtered to that user's role, through the product's own client stack. demo2's half only works because of the tenant-level fallback from #807.

## Two findings recorded in the feedback loop

- **`COLUMNSTATISTICS` works fine for an RLS-restricted identity** (200, tenant-level). The residual hole flagged in #807 — "a model whose only readers are RLS Viewers can be contributed by nobody" — **does not exist**. Good news; nothing further needed there.
- **Power BI caches user permissions.** After demoting demo1 Member → Viewer they still saw all 6 rows until `POST /v1.0/myorg/RefreshUserPermissions` was called with their token; the next query returned the correct 3. Anyone testing a permission change will otherwise measure stale behavior and conclude RLS is broken. Worth considering calling it before a per-user overlay sync — not done here.

## Tests

- `backend/tests/e2e/test_powerbi_user_contributed_query_metadata.py` — pins both row shapes (SP-linked and user-contributed); **verified to fail without the fix**
- 20 passing across the new test plus `test_powerbi_item_level_access`, `test_shared_catalog_union_per_user`, `test_powerbi_overlay_intersection_repro`

## Still open (unchanged)

User-contributed catalog rows land `is_active=False`, so a model only a user can see needs admin activation before it reaches the agent. Activation itself is safe — a gate, not a grant, verified in #807 — but in a fully RLS tenant that's every model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012q6jXXABTZDgC2FEvoRsRg)_