### PR TITLE
Power BI: flush the user permission cache on delegated crawls

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -98,6 +98,13 @@ class PowerBIClient(DataSourceClient):
 
         self._access_token: Optional[str] = access_token
         self._http: Optional[requests.Session] = None
+        # A delegated (per-user OBO) identity was handed a token at construction;
+        # the service principal is built from client_id/secret and mints its own.
+        # Only a delegated identity has user-cached permissions worth flushing.
+        self._delegated: bool = access_token is not None
+        # RefreshUserPermissions is account-wide and idempotent — fire it at most
+        # once per client instance (guarded here, invoked from get_schemas).
+        self._perms_refreshed: bool = False
 
         # Persisted schema metadata injected via attach_table_metadata():
         # schema table name ("Dataset/Table") -> the table's `powerbi` metadata
@@ -196,6 +203,36 @@ class PowerBIClient(DataSourceClient):
 
         self._access_token = token
         self._http = requests.Session()
+
+    def refresh_user_permissions(self) -> bool:
+        """Force Power BI to re-evaluate THIS user's cached permissions.
+
+        Power BI serves workspace/dataset permissions from a replicated cache,
+        so a grant or revocation made in the portal lags by an unbounded window
+        — the Get Groups reference warns "user permissions for workspaces take
+        time to get updated and may not be immediately available". During that
+        window a just-revoked user still reads rows they should not, and a
+        just-granted user sees nothing. This is Microsoft's documented flush.
+
+        Fired once per client, only for a delegated (per-user) identity: a
+        service principal has no user permission cache, and the effect is
+        account-wide so repeating it is waste. Best-effort — a failure here must
+        never break discovery, so the caller proceeds regardless. Note the flush
+        is asynchronous on Microsoft's side; it reliably freshens the user's
+        NEXT queries (the security-critical path) and usually the crawl that
+        follows it in this same request.
+        """
+        if not self._delegated or self._perms_refreshed:
+            return False
+        self._perms_refreshed = True
+        try:
+            self.connect()
+            resp = self._request(
+                "POST", f"{self.BASE_URL}/RefreshUserPermissions", timeout=30
+            )
+            return resp.status_code < 300
+        except Exception:
+            return False
 
     def test_connection(self) -> Dict:
         """
@@ -858,6 +895,15 @@ class PowerBIClient(DataSourceClient):
 
         if self._schemas_cache is not None and not force_refresh:
             return self._schemas_cache
+
+        # A delegated crawl only happens on OBO sign-in and manual reload — the
+        # two moments a user's access may just have changed. Flush Power BI's
+        # permission cache first so this crawl (and the queries that follow) see
+        # the current grants, not a stale snapshot. No-op for the service
+        # principal and fires at most once per client. The query path never
+        # reaches here (it resolves dataset IDs from attached metadata), so this
+        # never adds a RefreshUserPermissions call to a hot query.
+        self.refresh_user_permissions()
 
         # Fresh crawl → reset per-run diagnostics.
         self.discovery_diagnostics = []

--- a/backend/tests/unit/test_powerbi_refresh_user_permissions.py
+++ b/backend/tests/unit/test_powerbi_refresh_user_permissions.py
@@ -1,0 +1,138 @@
+"""Power BI caches user permissions; we flush it on delegated crawls.
+
+Power BI serves workspace/dataset permissions from a replicated cache, so a
+grant or revocation made in the portal lags by an unbounded window (measured
+live: a Member→Viewer demotion still returned unfiltered rows until
+RefreshUserPermissions was called). We flush it via POST /myorg/
+RefreshUserPermissions at the two moments a user's access may just have changed
+and we are about to build their catalog: OBO sign-in and manual reload. Both go
+through get_schemas on a delegated client, so that is where the flush is wired.
+
+Rules pinned here:
+  - a delegated crawl flushes exactly once,
+  - the service principal never flushes (it has no user permission cache),
+  - the flush never fires on the query path (dataset IDs resolve from attached
+    metadata; get_schemas is not reached),
+  - a flush failure never breaks discovery.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from app.data_sources.clients.powerbi_client import PowerBIClient
+
+
+def _resp(status: int, payload=None):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload if payload is not None else {}
+    r.headers = {}
+    r.text = json.dumps(payload) if payload else ""
+    return r
+
+
+class _Tenant:
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+        self._routes: list[tuple[str, str, object]] = []
+
+    def route(self, method, sub, response):
+        self._routes.append((method.upper(), sub, response))
+
+    def _dispatch(self, method, url):
+        self.calls.append((method.upper(), url))
+        matches = [(len(s), r) for m, s, r in self._routes if m == method.upper() and s in url]
+        if matches:
+            return max(matches, key=lambda x: x[0])[1]
+        return _resp(404, {"error": {"code": "PowerBIEntityNotFound"}})
+
+    def request(self, method, url, json=None, headers=None, timeout=None):
+        return self._dispatch(method, url)
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        return self._dispatch("POST", url)
+
+    def get(self, url, headers=None, timeout=None):
+        return self._dispatch("GET", url)
+
+    def count(self, method, sub):
+        return sum(1 for m, u in self.calls if m == method.upper() and sub in u)
+
+
+def _delegated(tenant):
+    c = PowerBIClient(tenant_id="t", client_id="c", client_secret="s", access_token="user-tok")
+    c._http = tenant
+    return c
+
+
+def _service_principal(tenant):
+    c = PowerBIClient(tenant_id="t", client_id="c", client_secret="s")
+    c._http = tenant
+    c._access_token = "sp-tok"  # pretend client-credentials already ran
+    return c
+
+
+REFRESH = "/v1.0/myorg/RefreshUserPermissions"
+
+
+def _empty_listing(tenant):
+    tenant.route("GET", "/groups", _resp(200, {"value": []}))
+
+
+def test_delegated_crawl_flushes_permissions_once():
+    t = _Tenant()
+    _empty_listing(t)
+    t.route("POST", REFRESH, _resp(200))
+
+    c = _delegated(t)
+    c.get_schemas()
+    c.get_schemas()          # cached — no second crawl
+    c.get_schemas(force_refresh=True)   # re-crawl, but flush already spent
+
+    assert t.count("POST", REFRESH) == 1
+
+
+def test_service_principal_never_flushes():
+    t = _Tenant()
+    _empty_listing(t)
+    t.route("POST", REFRESH, _resp(200))
+
+    _service_principal(t).get_schemas()
+
+    assert t.count("POST", REFRESH) == 0
+
+
+def test_flush_failure_does_not_break_discovery():
+    t = _Tenant()
+    tables = {
+        "m/T": {"columns": [{"name": "id", "dtype": "int64"}], "pks": [], "fks": [],
+                "metadata_json": {"powerbi": {"datasetId": "ds1", "workspaceId": "ws1",
+                                              "datasetName": "m", "tableName": "T"}}}
+    }
+    # /groups returns the workspace so the model is discovered the normal way.
+    t.route("GET", "/groups", _resp(200, {"value": [{"id": "ws1", "name": "m"}]}))
+    t.route("GET", "/groups/ws1/datasets", _resp(200, {"value": [{"id": "ds1", "name": "m"}]}))
+    t.route("GET", "/groups/ws1/reports", _resp(200, {"value": []}))
+    t.route("POST", REFRESH, _resp(500))   # flush fails
+
+    out = _delegated(t).get_schemas(prior_tables=tables)
+
+    assert [x.name for x in out] == ["m/T"]
+
+
+def test_query_path_does_not_flush():
+    """execute_query resolves the dataset from attached metadata and never calls
+    get_schemas, so a hot query must not trigger a permission flush."""
+    t = _Tenant()
+    meta = {"powerbi": {"datasetId": "ds1", "workspaceId": "ws1",
+                        "datasetName": "m", "tableName": "T"}}
+    t.route("POST", "/groups/ws1/datasets/ds1/executeQueries",
+            _resp(200, {"results": [{"tables": [{"rows": [{"T[id]": 1}]}]}]}))
+    t.route("POST", REFRESH, _resp(200))
+
+    c = _delegated(t)
+    c.attach_table_metadata([{"name": "m/T", "metadata_json": meta}])
+    c.execute_query("EVALUATE T", "m/T")
+
+    assert t.count("POST", REFRESH) == 0

--- a/docs/feedback-loops/powerbi-obo-rls.md
+++ b/docs/feedback-loops/powerbi-obo-rls.md
@@ -151,8 +151,39 @@ Two findings from this round:
   very next query returned the correct 3. The Get Groups docs warn about this
   ("User permissions for workspaces take time to get updated"). Anyone testing
   a permission change — us or a customer — will otherwise measure stale
-  behavior and conclude RLS is broken. Worth considering calling it before a
-  per-user overlay sync.
+  behavior and conclude RLS is broken. **Now handled** (see below).
+
+## Round 3 — flush the permission cache on delegated crawls
+
+The staleness runs *permissive*: a just-revoked user keeps reading rows they
+should not until the cache catches up, over an unbounded window. So this is a
+correctness issue, not just UX. `PowerBIClient.refresh_user_permissions()` now
+issues the documented flush, wired into `get_schemas` and gated so it fires:
+
+- **only for a delegated identity** — the service principal has no user
+  permission cache; `_delegated` is set from whether a token was handed in at
+  construction;
+- **at most once per client** (`_perms_refreshed`); the effect is account-wide;
+- **only on a crawl** — `get_schemas` is the catalog-build entry, reached on OBO
+  sign-in and manual reload (the two moments access may just have changed) but
+  NOT on the query path, which resolves dataset IDs from attached metadata and
+  never calls `get_schemas`. So no `RefreshUserPermissions` is ever added to a
+  hot query.
+
+Best-effort: a failed flush never breaks discovery. The flush is asynchronous
+on Microsoft's side — it reliably freshens the user's next queries (the
+security-critical path) and usually the crawl in the same request.
+
+Verified e2e against the live tenant:
+
+| Path | RefreshUserPermissions fired? |
+|---|---|
+| demo2 OBO sign-in / overlay sync (delegated crawl) | **yes — HTTP 200**, then 8 tables |
+| demo2 DAX query through BOW | **no** (0 calls), still 3 EMEA rows |
+| service-principal reindex | **no** (0 calls), indexing completed |
+
+Pinned by `tests/unit/test_powerbi_refresh_user_permissions.py` (flush-once,
+SP-never, query-never, failure-safe).
 
 ### Bug found and fixed in this round
 


### PR DESCRIPTION
Third and final follow-up in the Power BI OBO/RLS series (after #807, #818).

## The problem

Power BI serves workspace/dataset permissions from a **replicated cache**, so a grant or revocation made in the portal lags by an unbounded window. The Get Groups reference warns about it directly ("user permissions for workspaces take time to get updated and may not be immediately available").

Measured live while verifying #818: after demoting a user Member → Viewer, they **kept reading unfiltered rows** (6 of 6, RLS not applied) until `POST /v1.0/myorg/RefreshUserPermissions` was called with their token — the very next query returned the correct 3. The staleness runs **permissive**, so this is a correctness/security concern, not just UX.

## The fix

`PowerBIClient.refresh_user_permissions()` issues Microsoft's documented flush, wired into `get_schemas` and gated so it fires:

- **only for a delegated identity** — the service principal has no user permission cache (`_delegated` is set from whether a token was handed in at construction);
- **at most once per client** (`_perms_refreshed`) — the effect is account-wide;
- **only on a crawl** — `get_schemas` is the catalog-build entry, reached on OBO sign-in and manual reload (the two moments access may just have changed) but **never on the query path**, which resolves dataset IDs from attached metadata. No `RefreshUserPermissions` is ever added to a hot query.

Best-effort: a failed flush never breaks discovery. The flush is asynchronous on Microsoft's side — it reliably freshens the user's **next** queries (the security-critical path) and usually the crawl in the same request.

## Verification — live tenant

| Path | RefreshUserPermissions fired? |
|---|---|
| demo2 OBO sign-in / overlay sync (delegated crawl) | **yes — HTTP 200**, then 8 tables |
| demo2 DAX query through BOW | **no** (0 calls), still 3 EMEA rows |
| service-principal reindex | **no** (0 calls), indexing completed |

## Tests

`backend/tests/unit/test_powerbi_refresh_user_permissions.py` — flush-once, SP-never, query-never, failure-safe. 65 passing across the Power BI unit + e2e suites.

## Note for operators

This shortens but does not eliminate the window (the flush is async upstream). Two things still worth telling customers: a permission change may need a reload to fully take effect, and our own per-user overlay persists table **names** until the next sync — actual data stays fail-closed (the token is evaluated live at query time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012q6jXXABTZDgC2FEvoRsRg)_