### PR TITLE
Power BI: don't retry the permission-cache flush on 429

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -221,6 +221,13 @@ class PowerBIClient(DataSourceClient):
         is asynchronous on Microsoft's side; it reliably freshens the user's
         NEXT queries (the security-critical path) and usually the crawl that
         follows it in this same request.
+
+        SINGLE ATTEMPT on purpose: this endpoint is aggressively rate-limited
+        (429 with a ~30s Retry-After). Letting the shared `_request` backoff loop
+        retry would block the overlay sync — and thus interactive sign-in /
+        reload — for up to a minute on a call we do not even need to succeed. A
+        429 here just means the cache was flushed recently, which is fine; move
+        on immediately.
         """
         if not self._delegated or self._perms_refreshed:
             return False
@@ -228,7 +235,8 @@ class PowerBIClient(DataSourceClient):
         try:
             self.connect()
             resp = self._request(
-                "POST", f"{self.BASE_URL}/RefreshUserPermissions", timeout=30
+                "POST", f"{self.BASE_URL}/RefreshUserPermissions",
+                timeout=30, max_attempts=1,
             )
             return resp.status_code < 300
         except Exception:

--- a/backend/tests/unit/test_powerbi_refresh_user_permissions.py
+++ b/backend/tests/unit/test_powerbi_refresh_user_permissions.py
@@ -93,6 +93,31 @@ def test_delegated_crawl_flushes_permissions_once():
     assert t.count("POST", REFRESH) == 1
 
 
+def test_flush_does_not_retry_on_429(monkeypatch):
+    """RefreshUserPermissions is aggressively rate-limited (429 + ~30s
+    Retry-After). The flush must NOT ride the shared _request backoff loop — that
+    would block the overlay sync, and thus interactive sign-in, for up to a
+    minute on a best-effort call. One attempt, then move on."""
+    import time as _time
+
+    # Record backoff sleeps rather than raising: the flush's own try/except would
+    # swallow a raised assertion, hiding the retry. _request does a local
+    # `import time`, which returns this same module object.
+    sleeps: list = []
+    monkeypatch.setattr(_time, "sleep", lambda s, *a, **k: sleeps.append(s))
+
+    t = _Tenant()
+    _empty_listing(t)
+    t.route("POST", REFRESH, _resp(429))   # rate limited, every time
+
+    _delegated(t).get_schemas()
+
+    # One attempt, zero backoff sleeps. With the shared retry loop this would be
+    # 3 POSTs and 2 sleeps — up to ~60s of blocking on a best-effort call.
+    assert t.count("POST", REFRESH) == 1
+    assert sleeps == []
+
+
 def test_service_principal_never_flushes():
     t = _Tenant()
     _empty_listing(t)

--- a/docs/feedback-loops/powerbi-obo-rls.md
+++ b/docs/feedback-loops/powerbi-obo-rls.md
@@ -183,9 +183,44 @@ Verified e2e against the live tenant:
 | service-principal reindex | **no** (0 calls), indexing completed |
 
 Pinned by `tests/unit/test_powerbi_refresh_user_permissions.py` (flush-once,
-SP-never, query-never, failure-safe).
+SP-never, query-never, failure-safe, no-429-retry).
 
-### Bug found and fixed in this round
+## Round 4 — full re-verification from a clean rebuild on `main`
+
+After all three rounds merged, the whole stack was rebuilt from zero on `main`
+(fresh DB, connection re-created through the UI, members re-invited) and every
+leg re-run against the live tenant. All green:
+
+| Check | Result |
+|---|---|
+| Power BI unit + e2e suites | **77 passed** |
+| demo1 OBO sign-in (Viewer + Build + `USOnly`) | overlay = 7, incl `rls_sales/Sales`, flush fired |
+| demo2 OBO sign-in (Build only + `EMEAOnly`) | overlay = 8, incl `rls_sales` + `shared_orders`, flush fired |
+| demo1 query `rls_sales` through BOW | **3 rows, US only** (group-scoped) |
+| demo2 query `rls_sales` through BOW | **3 rows, EMEA only** (tenant-level fallback) |
+| demo2 query `shared_orders` (SP-visible) | 6 rows (tenant-level fallback) |
+| per-user visibility (overlay == agent context) | demo1 = 7, demo2 = 8, admin = 8 canonical, no cross-leak |
+
+Two things this round surfaced:
+
+- **The inactive-contributed-model step is real and load-bearing.** On the fresh
+  rebuild, `rls_sales` (user-contributed, so `is_active=False`) was NOT
+  queryable until an admin activated it — `_attach_stored_table_metadata`
+  filters `is_active=True`, and a no-workspace-role user's fallback crawl can't
+  rediscover it without a prior catalog. Once activated, both users query it
+  correctly. This is the documented "still open" item below, confirmed to bite
+  exactly as described; it is not a regression.
+
+- **Latency bug found and fixed: the flush must not retry on 429.**
+  `RefreshUserPermissions` is aggressively rate-limited — back-to-back per-user
+  syncs hit `429` with a ~30s `Retry-After`. The shared `_request` backoff loop
+  then retried 3× (observed live: three 30s-spaced 429s), which would block the
+  overlay sync — and thus interactive sign-in/reload — for up to a minute on a
+  best-effort call. `refresh_user_permissions` now issues a SINGLE attempt
+  (`max_attempts=1`); a 429 just means the cache was flushed recently, so it
+  moves on. Pinned by `test_flush_does_not_retry_on_429`.
+
+### Bug found and fixed in round 2
 
 demo2 could SEE `rls_sales/Sales` in their catalog and had permission to query
 it, but the agent could not execute against it:


### PR DESCRIPTION
Follow-up to #821, found during a full clean-rebuild re-verification of the OBO/RLS stack on `main`.

## The bug

`RefreshUserPermissions` (the permission-cache flush added in #821) is aggressively rate-limited. Back-to-back per-user overlay syncs hit `429` with a ~30s `Retry-After`, and the shared `_request` backoff loop then retried **three times** — observed live as three 30s-spaced 429s:

```
POST /v1.0/myorg/RefreshUserPermissions 429   21:24:45
POST /v1.0/myorg/RefreshUserPermissions 429   21:25:15
POST /v1.0/myorg/RefreshUserPermissions 429   21:25:45
```

That would block the overlay sync — and thus interactive sign-in and reload — for up to a minute, on a best-effort call that never needed to succeed.

## The fix

`refresh_user_permissions` now issues a **single attempt** (`max_attempts=1`). A 429 just means the cache was flushed recently, which is fine — move on immediately. Everything else about the flush (delegated-only, once-per-client, query-path-never, failure-safe) is unchanged.

Pinned by `test_flush_does_not_retry_on_429`, verified to fail without the fix (3 POSTs, 2 backoff sleeps).

## Full re-verification (clean rebuild on main)

The whole stack was rebuilt from zero — fresh DB, connection re-created through the UI, members re-invited — and every leg re-run against the live tenant:

| Check | Result |
|---|---|
| Power BI unit + e2e suites | **77 passed** |
| demo1 query `rls_sales` via BOW (Viewer + Build + `USOnly`) | **3 rows, US only** (group-scoped) |
| demo2 query `rls_sales` via BOW (Build only + `EMEAOnly`) | **3 rows, EMEA only** (tenant-level fallback) |
| demo2 query `shared_orders` (SP-visible) | 6 rows (tenant-level fallback) |
| per-user visibility (overlay == agent context) | demo1 = 7, demo2 = 8, admin = 8 canonical, no cross-leak |

RLS filtering, item-level access, tenant-level fallback, and the permission flush all work end to end.

Details in the round-4 section of `docs/feedback-loops/powerbi-obo-rls.md`.

## Note (unchanged, still open)

User-contributed models (every RLS model, which the service principal cannot index) land `is_active=False` and need admin activation before they are queryable — confirmed on the clean rebuild. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012q6jXXABTZDgC2FEvoRsRg)_