### PR TITLE
Fix MCP ask-policy approvals dying on the first poll; show who allowed/denied

### DIFF
--- a/backend/app/ai/tools/implementations/execute_mcp.py
+++ b/backend/app/ai/tools/implementations/execute_mcp.py
@@ -907,6 +907,14 @@ Do not use when:
                     await confirmations.expire(db, confirmation_id)
 
             approved = bool(response and response.get("approved"))
+            # Who decided. The DB-poll path only carries the resolver's id, but
+            # may_respond restricts responding to the run's own user, so their
+            # name is the correct display fallback whenever a decision exists.
+            resolved_by_name = None
+            if response is not None:
+                resolved_by_name = response.get("resolved_by_name") or (
+                    getattr(user, "name", None) if user else None
+                )
             # Persist the user's decision on the tool output so the planner's
             # conversation digest (and the rehydrated UI) can see what the
             # user chose, not just that the call failed.
@@ -914,6 +922,7 @@ Do not use when:
                 "approved": approved,
                 "remember": bool(response and response.get("remember")),
                 "timed_out": response is None,
+                "resolved_by_name": resolved_by_name,
             }
             await log_tool_audit(
                 runtime_ctx,

--- a/backend/app/routes/completion.py
+++ b/backend/app/routes/completion.py
@@ -384,7 +384,13 @@ async def respond_to_mcp_tool_confirmation(
     # Same-worker fast path: wakes the run now instead of on its next poll.
     # A False here just means the run is on another worker, which is the norm.
     resolved_locally = resolve_confirmation(
-        confirmation_id, {"approved": approved, "remember": remember}
+        confirmation_id,
+        {
+            "approved": approved,
+            "remember": remember,
+            "resolved_by_user_id": str(current_user.id),
+            "resolved_by_name": getattr(current_user, "name", None) or None,
+        },
     )
     if row is None and not resolved_locally:
         raise HTTPException(status_code=404, detail="Confirmation not found or expired")

--- a/backend/app/services/tool_confirmation_service.py
+++ b/backend/app/services/tool_confirmation_service.py
@@ -160,15 +160,22 @@ class ToolConfirmationService:
         try:
             async with async_session_maker() as session:
                 row = await self.get(session, confirmation_id)
+                # Read the columns while the row is still attached. rollback()
+                # expires every loaded instance regardless of expire_on_commit,
+                # so touching row.status after it (or after the session closes)
+                # raises DetachedInstanceError — which killed the waiting run on
+                # its first poll and made the Allow/Deny buttons appear dead.
+                status = row.status if row is not None else None
+                remember = bool(row.remember) if row is not None else False
+                resolved_by = row.resolved_by_user_id if row is not None else None
                 await session.rollback()
         except Exception as e:
             logger.warning(f"ToolConfirmation {confirmation_id}: poll failed: {e!r}")
             return None
-        if row is None or row.status == ToolConfirmation.STATUS_PENDING:
-            return None
-        if row.status == ToolConfirmation.STATUS_EXPIRED:
+        if status in (None, ToolConfirmation.STATUS_PENDING, ToolConfirmation.STATUS_EXPIRED):
             return None
         return {
-            "approved": row.status == ToolConfirmation.STATUS_APPROVED,
-            "remember": bool(row.remember),
+            "approved": status == ToolConfirmation.STATUS_APPROVED,
+            "remember": remember,
+            "resolved_by_user_id": str(resolved_by) if resolved_by else None,
         }

--- a/backend/tests/unit/test_tool_confirmation_service.py
+++ b/backend/tests/unit/test_tool_confirmation_service.py
@@ -1,0 +1,75 @@
+"""Regression tests for ToolConfirmationService.poll_decision.
+
+The waiting 'ask' run polls the tool_confirmations row every few seconds on a
+fresh short-lived session. poll_decision used to read ``row.status`` AFTER
+``session.rollback()`` and after the ``async with`` block closed the session —
+rollback expires every loaded instance (regardless of expire_on_commit), so the
+very first poll raised DetachedInstanceError ("Instance <ToolConfirmation> is
+not bound to a Session"), the tool errored out after its retry, and the
+Allow/Deny buttons in the report did nothing no matter what the user clicked.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.services.tool_confirmation_service import ToolConfirmationService
+
+
+async def _create_pending(svc: ToolConfirmationService) -> str:
+    cid = str(uuid4())
+    async with async_session_maker() as db:
+        await svc.create(
+            db,
+            confirmation_id=cid,
+            tool_name="echo",
+            arguments={"message": "hi"},
+        )
+    return cid
+
+
+@pytest.mark.asyncio
+async def test_poll_decision_pending_returns_none_without_raising():
+    svc = ToolConfirmationService()
+    cid = await _create_pending(svc)
+    assert await svc.poll_decision(cid) is None
+
+
+@pytest.mark.asyncio
+async def test_poll_decision_reads_resolved_row_after_its_session_closed():
+    """The other-worker path: the decision is only visible via the DB row."""
+    svc = ToolConfirmationService()
+    cid = await _create_pending(svc)
+
+    # Resolve on a separate session, the way the approval POST's worker does.
+    resolver = str(uuid4())
+    async with async_session_maker() as db:
+        await svc.resolve(
+            db, confirmation_id=cid, approved=True, remember=True, user_id=resolver
+        )
+
+    assert await svc.poll_decision(cid) == {
+        "approved": True, "remember": True, "resolved_by_user_id": resolver,
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_decision_denied_and_expired():
+    svc = ToolConfirmationService()
+
+    denied = await _create_pending(svc)
+    async with async_session_maker() as db:
+        await svc.resolve(
+            db, confirmation_id=denied, approved=False, remember=False, user_id=None
+        )
+    assert await svc.poll_decision(denied) == {
+        "approved": False, "remember": False, "resolved_by_user_id": None,
+    }
+
+    expired = await _create_pending(svc)
+    async with async_session_maker() as db:
+        await svc.expire(db, expired)
+    assert await svc.poll_decision(expired) is None
+
+    assert await svc.poll_decision(str(uuid4())) is None

--- a/frontend/components/tools/MCPTool.vue
+++ b/frontend/components/tools/MCPTool.vue
@@ -84,6 +84,19 @@
       <span class="break-words">{{ errorMessage }}</span>
     </div>
 
+    <!-- 'ask' policy outcome: who allowed or denied this call. Persisted on
+         the tool output, so it survives rehydration; right after a click the
+         local decision renders as "by you" until the output arrives. -->
+    <div
+      v-if="approvalOutcome"
+      class="mt-1 flex items-center gap-1 text-[10px]"
+      :class="approvalOutcome.approved ? 'text-gray-400 dark:text-gray-500' : 'text-amber-600 dark:text-amber-500'"
+      data-testid="mcp-approval-outcome"
+    >
+      <Icon :name="approvalOutcome.approved ? 'heroicons-check-circle' : 'heroicons-no-symbol'" class="w-3 h-3 shrink-0" />
+      <span class="truncate">{{ approvalOutcomeLabel }}</span>
+    </div>
+
     <!-- Auto policy verdict ('auto' policy): small-model review outcome -->
     <div
       v-if="autoPolicy"
@@ -185,6 +198,26 @@ const showApprovalCard = computed(() =>
   ['awaiting_confirmation', 'awaiting_approval'].includes(progressStage.value)
 )
 
+// The clicker's own decision, kept so the outcome shows instantly ("by you")
+// while the run resumes and before the persisted output arrives.
+const localDecision = ref<{ approved: boolean } | null>(null)
+
+// Persisted 'ask' outcome from the tool output (survives rehydration), with
+// the local click as fallback. A timed-out approval is not a decision.
+const approvalOutcome = computed(() => {
+  const a = (resultJson.value as any).approval
+  if (a && !a.timed_out) return { approved: !!a.approved, name: a.resolved_by_name || '' }
+  if (localDecision.value) return { approved: localDecision.value.approved, name: '' }
+  return null
+})
+
+const approvalOutcomeLabel = computed(() => {
+  const o = approvalOutcome.value
+  if (!o) return ''
+  if (o.name) return o.approved ? t('tools.mcp.allowedBy', { name: o.name }) : t('tools.mcp.deniedBy', { name: o.name })
+  return o.approved ? t('tools.mcp.allowedByYou') : t('tools.mcp.deniedByYou')
+})
+
 const confirmationArgs = computed(() => {
   const a = confirmation.value?.arguments
   if (!a || !Object.keys(a).length) return ''
@@ -222,6 +255,7 @@ async function respond(approved: boolean, remember: boolean) {
         : t('tools.mcp.approvalFailed')
     } else {
       answered.value = true
+      localDecision.value = { approved }
     }
   } catch (e) {
     console.warn('Failed to respond to tool approval', e)

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (محظور بموجب السياسة)",
       "autoDeclinedLabel": "{name} (مرفوض تلقائيًا)",
       "autoApproved": "تمت الموافقة تلقائيًا بمراجعة السياسة",
-      "autoDenied": "مرفوض بمراجعة السياسة"
+      "autoDenied": "مرفوض بمراجعة السياسة",
+      "allowedBy": "سُمح بواسطة {name}",
+      "deniedBy": "رُفض بواسطة {name}",
+      "allowedByYou": "سمحت به",
+      "deniedByYou": "رفضته"
     },
     "answerQuestion": {
       "thought": "فكّر في الإجابة"

--- a/locales/de.json
+++ b/locales/de.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (durch Richtlinie blockiert)",
       "autoDeclinedLabel": "{name} (automatisch abgelehnt)",
       "autoApproved": "Automatisch durch Richtlinienprüfung genehmigt",
-      "autoDenied": "Durch Richtlinienprüfung abgelehnt"
+      "autoDenied": "Durch Richtlinienprüfung abgelehnt",
+      "allowedBy": "Erlaubt von {name}",
+      "deniedBy": "Abgelehnt von {name}",
+      "allowedByYou": "Von dir erlaubt",
+      "deniedByYou": "Von dir abgelehnt"
     },
     "answerQuestion": {
       "thought": "Über Antwort nachgedacht"

--- a/locales/en.json
+++ b/locales/en.json
@@ -1047,7 +1047,11 @@
       "blockedByPolicy": "{name} (blocked by policy)",
       "autoDeclinedLabel": "{name} (auto-declined)",
       "autoApproved": "Auto-approved by policy review",
-      "autoDenied": "Declined by policy review"
+      "autoDenied": "Declined by policy review",
+      "allowedBy": "Allowed by {name}",
+      "deniedBy": "Denied by {name}",
+      "allowedByYou": "Allowed by you",
+      "deniedByYou": "Denied by you"
     },
     "answerQuestion": {
       "thought": "Thought about answer"

--- a/locales/es.json
+++ b/locales/es.json
@@ -998,7 +998,11 @@
       "blockedByPolicy": "{name} (bloqueado por política)",
       "autoDeclinedLabel": "{name} (rechazado automáticamente)",
       "autoApproved": "Aprobado automáticamente por revisión de política",
-      "autoDenied": "Rechazado por revisión de política"
+      "autoDenied": "Rechazado por revisión de política",
+      "allowedBy": "Permitido por {name}",
+      "deniedBy": "Denegado por {name}",
+      "allowedByYou": "Permitido por ti",
+      "deniedByYou": "Denegado por ti"
     },
     "answerQuestion": {
       "thought": "Pensó la respuesta"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (bloqué par la politique)",
       "autoDeclinedLabel": "{name} (refusé automatiquement)",
       "autoApproved": "Approuvé automatiquement par l'examen de politique",
-      "autoDenied": "Refusé par l'examen de politique"
+      "autoDenied": "Refusé par l'examen de politique",
+      "allowedBy": "Autorisé par {name}",
+      "deniedBy": "Refusé par {name}",
+      "allowedByYou": "Autorisé par vous",
+      "deniedByYou": "Refusé par vous"
     },
     "answerQuestion": {
       "thought": "Pensée sur la réponse"

--- a/locales/he.json
+++ b/locales/he.json
@@ -998,7 +998,11 @@
       "blockedByPolicy": "{name} (חסום לפי מדיניות)",
       "autoDeclinedLabel": "{name} (נדחה אוטומטית)",
       "autoApproved": "אושר אוטומטית בבדיקת מדיניות",
-      "autoDenied": "נדחה בבדיקת מדיניות"
+      "autoDenied": "נדחה בבדיקת מדיניות",
+      "allowedBy": "אושר על ידי {name}",
+      "deniedBy": "נדחה על ידי {name}",
+      "allowedByYou": "אושר על ידך",
+      "deniedByYou": "נדחה על ידך"
     },
     "answerQuestion": {
       "thought": "חשב על התשובה"

--- a/locales/it.json
+++ b/locales/it.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (bloccato dalla policy)",
       "autoDeclinedLabel": "{name} (rifiutato automaticamente)",
       "autoApproved": "Approvato automaticamente dalla revisione della policy",
-      "autoDenied": "Rifiutato dalla revisione della policy"
+      "autoDenied": "Rifiutato dalla revisione della policy",
+      "allowedBy": "Consentito da {name}",
+      "deniedBy": "Negato da {name}",
+      "allowedByYou": "Consentito da te",
+      "deniedByYou": "Negato da te"
     },
     "answerQuestion": {
       "thought": "Ha riflettuto sulla risposta"

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (bloqueado por política)",
       "autoDeclinedLabel": "{name} (negado automaticamente)",
       "autoApproved": "Aprovado automaticamente pela revisão de política",
-      "autoDenied": "Negado pela revisão de política"
+      "autoDenied": "Negado pela revisão de política",
+      "allowedBy": "Permitido por {name}",
+      "deniedBy": "Negado por {name}",
+      "allowedByYou": "Permitido por você",
+      "deniedByYou": "Negado por você"
     },
     "answerQuestion": {
       "thought": "Pensou na resposta"

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (заблокировано политикой)",
       "autoDeclinedLabel": "{name} (автоматически отклонено)",
       "autoApproved": "Автоматически одобрено проверкой политики",
-      "autoDenied": "Отклонено проверкой политики"
+      "autoDenied": "Отклонено проверкой политики",
+      "allowedBy": "Разрешено: {name}",
+      "deniedBy": "Отклонено: {name}",
+      "allowedByYou": "Разрешено вами",
+      "deniedByYou": "Отклонено вами"
     },
     "answerQuestion": {
       "thought": "Размышление об ответе"

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -948,7 +948,11 @@
       "blockedByPolicy": "{name} (blockerad av policy)",
       "autoDeclinedLabel": "{name} (auto-nekad)",
       "autoApproved": "Auto-godkänd av policygranskning",
-      "autoDenied": "Nekad av policygranskning"
+      "autoDenied": "Nekad av policygranskning",
+      "allowedBy": "Tillåtet av {name}",
+      "deniedBy": "Nekat av {name}",
+      "allowedByYou": "Tillåtet av dig",
+      "deniedByYou": "Nekat av dig"
     },
     "answerQuestion": {
       "thought": "Tänkte på svaret"


### PR DESCRIPTION
## What

Fixes the reported "allow/deny MCP tools does nothing" bug and adds a minimal, persisted "Allowed by {name} / Denied by {name}" outcome line to the approval card's tool row.

## Root cause (verified against the reported production report)

Both failing runs in the reported report errored ~7s in with:

```
Instance <ToolConfirmation ...> is not bound to a Session; attribute refresh operation cannot proceed
```

`ToolConfirmationService.poll_decision` — the loop the waiting `ask` run uses to see the user's decision — read `row.status` **after** `session.rollback()` and after the `async with` session closed. `rollback()` expires every loaded instance regardless of `expire_on_commit=False`, so the **first** 3-second poll of a still-pending confirmation raised `DetachedInstanceError`. The tool errored after its one retry, before/regardless of any click, so Allow and Deny both appeared dead.

## Changes

- `backend/app/services/tool_confirmation_service.py`: read the row's columns while it is still attached, before `rollback()`; also return `resolved_by_user_id`.
- `backend/app/routes/completion.py`: the same-worker fast path now carries the resolver's id/name in the future response.
- `backend/app/ai/tools/implementations/execute_mcp.py`: persists `resolved_by_name` on the approval output (`result_json.approval`), falling back to the run owner's name on the DB-poll path (`may_respond` restricts responding to the run's own user).
- `frontend/components/tools/MCPTool.vue`: renders a minimal outcome line — "Allowed by {name}" / "Denied by {name}" (amber for denied), with a "by you" fallback immediately after clicking; survives rehydration via `result_json.approval`.
- `locales/*.json`: `allowedBy` / `deniedBy` / `allowedByYou` / `deniedByYou` in all 10 locales.

## Tests

New `backend/tests/unit/test_tool_confirmation_service.py` calls `poll_decision` against pending / approved / denied / expired rows after the writing session closed — all of them raised before the fix (verified by stashing the fix), all pass with it:

```
3 passed  (uv run pytest tests/unit/test_tool_confirmation_service.py --db=sqlite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Det5ZV23TTrwhjDJqvUULA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Det5ZV23TTrwhjDJqvUULA)_