### PR TITLE
Fix "Pending review" badges surviving reject-all on drifted suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Unreleased
+- **Rejecting suggested instruction changes now clears the "Pending review" badges immediately and durably** — a suggestion whose change was already contained in the live text could previously keep an instruction flagged as pending forever (rejecting did nothing and refreshing brought the badge back), and the "N pending" count now drops without a page refresh
+
 ## Version 0.0.499 (July 30, 2026)
 - MCP tool approvals now resolve reliably, show who allowed or denied each call, and a one-time deny no longer blocks the tool forever
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -62,6 +62,11 @@ logger = logging.getLogger(__name__)
 # saturate the worker even from a thread. Small on purpose.
 _HUNK_CPU = asyncio.Semaphore(2)
 
+# Sentinel key for the "settled" marker rows stored in a build's rejected_hunks
+# (see _settle_resolved_suggestion_rows). Real hunk keys are 16-char sha1 hex,
+# so this can never collide with one.
+SETTLED_HUNK_KEY = "__settled__"
+
 
 class InstructionService:
     def __init__(self):
@@ -1563,6 +1568,11 @@ class InstructionService:
             base_id = str(build.base_build_id) if getattr(build, "base_build_id", None) else None
             if base_id and base_vid_by_build.get(base_id) == str(proposed_vid):
                 continue
+            # Settled suggestions (fully resolved by an accept/reject while main
+            # and the proposal were exactly these versions) yield no unrejected
+            # hunks by construction — skip the rebase instead of re-proving it.
+            if self._settled_marker_matches(build, str(instruction_id), main_vid, proposed_vid):
+                continue
             base_text = base_text_by_build.get(base_id, "") if base_id else ""
             live_rows.append((build, proposed_text, proposed_vid, base_text))
 
@@ -1795,12 +1805,12 @@ class InstructionService:
                 base_key = (str(build.base_build_id), str(iid))
                 if base_version.get(base_key) == str(proposed_vid):
                     continue
-            changed_rows.append((iid, build, proposed))
+            changed_rows.append((iid, build, proposed, proposed_vid))
         sug_rows = changed_rows
         if not sug_rows:
             return set()
 
-        cand_ids = list({str(iid) for iid, _b, _t in sug_rows})
+        cand_ids = list({str(iid) for iid, _b, _t, _v in sug_rows})
 
         # (3) Live main text per candidate (authoritative is_main build content).
         #     Mirrors _main_text_of(): a candidate absent from the org's main
@@ -1810,8 +1820,9 @@ class InstructionService:
         #     the proposal against its own text and hide it. The row fallback
         #     only applies to legacy orgs that predate main-build content.
         main_text: dict = {}
-        for iid, t in (await db.execute(
-            select(BuildContent.instruction_id, _IV.text)
+        main_vid: dict = {}
+        for iid, vid, t in (await db.execute(
+            select(BuildContent.instruction_id, BuildContent.instruction_version_id, _IV.text)
             .join(InstructionBuild, InstructionBuild.id == BuildContent.build_id)
             .join(_IV, _IV.id == BuildContent.instruction_version_id)
             .where(and_(
@@ -1822,6 +1833,7 @@ class InstructionService:
             ))
         )).all():
             main_text[str(iid)] = t or ""
+            main_vid[str(iid)] = str(vid) if vid else None
         missing_main = [i for i in cand_ids if i not in main_text]
         if missing_main:
             has_main_build = (await db.execute(
@@ -1832,10 +1844,12 @@ class InstructionService:
                 )).limit(1)
             )).scalar_one_or_none()
             if not has_main_build:
-                for iid, txt in (await db.execute(
-                    select(Instruction.id, Instruction.text).where(Instruction.id.in_(missing_main))
+                for iid, vid, txt in (await db.execute(
+                    select(Instruction.id, Instruction.current_version_id, Instruction.text)
+                    .where(Instruction.id.in_(missing_main))
                 )).all():
                     main_text[str(iid)] = txt or ""
+                    main_vid[str(iid)] = str(vid) if vid else None
 
         # (4) Pure-Python pass — no awaits in the loop.
         # Process conclusive unchanged-main suggestions first. Once one such row
@@ -1843,7 +1857,7 @@ class InstructionService:
         # is skipped below. This avoids paying for an older/stale diff merely because
         # the database happened to return it before the cheap conclusive row.
         def _is_conclusive_pending(row) -> bool:
-            row_iid, row_build, row_proposed = row
+            row_iid, row_build, row_proposed, _row_pvid = row
             row_iid = str(row_iid)
             row_base = (
                 base_text.get((str(row_build.base_build_id), row_iid), "")
@@ -1864,9 +1878,17 @@ class InstructionService:
             # rows are still exact; the drifted remainder is reported pending
             # without confirming the hunk survives, and resolves on open.
             cheap_cache = RebasedHunkCache()
-            for iid, build, proposed in sug_rows:
+            for iid, build, proposed, proposed_vid in sug_rows:
                 iid = str(iid)
                 if iid in pending:
+                    continue
+                # A row the per-hunk review fully settled (see
+                # _settle_resolved_suggestion_rows) is conclusively not pending
+                # while main and the proposal are the versions it was settled
+                # against — without this, a drifted suggestion whose hunks all
+                # collapsed would fall through to the optimistic branch below
+                # and read "pending review" forever after a reject-all.
+                if self._settled_marker_matches(build, iid, main_vid.get(iid), proposed_vid):
                     continue
                 bt = base_text.get((str(build.base_build_id), iid), "") if build.base_build_id else ""
                 mt = main_text.get(iid, "")
@@ -1887,9 +1909,13 @@ class InstructionService:
             return pending
 
         diff_cache = RebasedHunkCache()
-        for iid, build, proposed in sug_rows:
+        for iid, build, proposed, proposed_vid in sug_rows:
             iid = str(iid)
             if iid in pending:
+                continue
+            # Settled rows skip the (quadratic) rebase: the marker certifies the
+            # exact same answer was already computed for this state.
+            if self._settled_marker_matches(build, iid, main_vid.get(iid), proposed_vid):
                 continue
             rejected = self._rejected_keys(build, iid)
             bt = base_text.get((str(build.base_build_id), iid), "") if build.base_build_id else ""
@@ -1955,6 +1981,11 @@ class InstructionService:
         # stays resolved even if main later drifts around its anchor (the build's
         # content snapshot is untouched — this is review metadata only).
         await self._record_resolved_hunk(db, build, instruction_id, hunk_key, "accept")
+        # If that was the suggestion's last live hunk it is fully resolved —
+        # stamp it settled so the badge sweep stops counting it.
+        await self._settle_resolved_suggestion_rows(
+            db, instruction, organization=organization, build_ids={str(build_id)},
+        )
         return await self.get_instruction(db, instruction.id, organization, current_user), "ok"
 
     async def _record_resolved_hunk(self, db: AsyncSession, build, instruction_id: str, hunk_key: str, action: str, *, commit: bool = True):
@@ -1966,6 +1997,79 @@ class InstructionService:
             flag_modified(build, "rejected_hunks")
             if commit:
                 await db.commit()
+
+    @staticmethod
+    def _settled_marker_matches(build, instruction_id: str,
+                                main_version_id: Optional[str],
+                                proposed_version_id: Optional[str]) -> bool:
+        """True when `build` carries a settled marker for this instruction that
+        was stamped against exactly this (main version, proposed version) pair —
+        i.e. nothing has moved since the review concluded there was nothing
+        live, so the row is conclusively not pending, no diff required."""
+        mv = str(main_version_id) if main_version_id else None
+        pv = str(proposed_version_id) if proposed_version_id else None
+        for r in (getattr(build, "rejected_hunks", None) or []):
+            if r.get("instruction_id") == str(instruction_id) and r.get("key") == SETTLED_HUNK_KEY:
+                return r.get("main_version_id") == mv and r.get("proposed_version_id") == pv
+        return False
+
+    async def _settle_resolved_suggestion_rows(self, db: AsyncSession, instruction, *,
+                                               organization: Organization,
+                                               build_ids: Optional[set] = None) -> None:
+        """Stamp every pending suggestion build that no longer has a live,
+        unrejected hunk for `instruction` as SETTLED against the current main
+        and proposed versions.
+
+        This is what makes an explicit accept/reject DURABLE on the badge
+        surfaces. The badge sweep (get_pending_change_instruction_ids
+        verify=False) never diffs, so a drifted suggestion with no recorded
+        resolutions is reported pending optimistically — and a suggestion whose
+        hunks all collapsed in the rebase (already applied / anchors gone)
+        records NOTHING in a reject-all, because there is no live hunk to
+        reject. Its build then kept the instruction counting as "pending
+        review" forever: the review pane empties, the user rejects everything,
+        and the amber "Pending review" badge survives every refresh. The
+        settled marker gives the sweep a conclusive, zero-diff answer instead.
+
+        The marker is review metadata only (it rides ``rejected_hunks``, whose
+        keys never collide with real hunk keys) — the build's content snapshot
+        is untouched, so publish/merge semantics don't change. It binds the
+        exact main and proposed version ids: if either moves (main drifts
+        again, or the build stages a new proposed version), the marker stops
+        matching and the row is re-evaluated like any other. Carry-over rows
+        (proposed text == base text) are skipped, and ``build_ids`` scopes the
+        pass to the builds a resolution actually touched so a build-scoped
+        reject can't settle a sibling suggestion.
+        """
+        from sqlalchemy.orm.attributes import flag_modified
+        from app.services.text_hunks import has_live_hunk_against_main, RebasedHunkCache
+        iid = str(instruction.id)
+        main_text, main_vid, _meta = await self._main_text_of(db, instruction)
+        mv = str(main_vid) if main_vid else None
+        cache = RebasedHunkCache()
+        changed = False
+        for build, proposed_text, proposed_vid in await self._pending_suggestion_builds(db, iid, organization):
+            if build_ids is not None and str(build.id) not in build_ids:
+                continue
+            pt = proposed_text or ""
+            base_text = await self._build_base_text(db, build, iid)
+            if pt == (base_text or ""):
+                continue  # carry-over: no intended change to settle
+            pv = str(proposed_vid) if proposed_vid else None
+            if self._settled_marker_matches(build, iid, mv, pv):
+                continue  # already stamped for this exact state
+            if has_live_hunk_against_main(base_text, pt, main_text,
+                                          self._rejected_keys(build, iid), cache=cache):
+                continue  # still something to review — keep proposing it
+            rej = [r for r in (build.rejected_hunks or [])
+                   if not (r.get("instruction_id") == iid and r.get("key") == SETTLED_HUNK_KEY)]
+            rej.append({"instruction_id": iid, "key": SETTLED_HUNK_KEY, "action": "settle",
+                        "main_version_id": mv, "proposed_version_id": pv})
+            build.rejected_hunks = rej
+            flag_modified(build, "rejected_hunks")
+            changed = True
+        if changed:
+            await db.commit()
 
     async def accept_all_hunks(self, db: AsyncSession, instruction_id: str, *,
                                against_main_version_id: Optional[str], organization: Organization, current_user: User,
@@ -1999,6 +2103,14 @@ class InstructionService:
                 new_text = new_text[:h["start"]] + h["after"] + new_text[h["end"]:]
                 accepted.append((build, h["key"]))
         if not accepted or new_text == main_text:
+            # Nothing live to apply. Suggestions in scope whose hunks all
+            # collapsed in the rebase are still settled by this review pass —
+            # stamp them so the badge sweep stops counting them (builds that DO
+            # carry a live hunk are left untouched by the settle check).
+            await self._settle_resolved_suggestion_rows(
+                db, instruction, organization=organization,
+                build_ids={str(b.id) for b, _t, _v in rows},
+            )
             return await self.get_instruction(db, instruction.id, organization, current_user), "noop"
         new_version = await self.version_service.create_version_from_data(
             db, instruction_id=instruction.id, text=new_text,
@@ -2020,6 +2132,13 @@ class InstructionService:
         for build, key in accepted:
             await self._record_resolved_hunk(db, build, instruction_id, key, "accept", commit=False)
         await db.commit()
+        # Main now carries the accepted changes — suggestions in scope with
+        # nothing live left (accepted, rejected, or collapsed in the rebase)
+        # are settled; stamp them so the badge sweep stops counting them.
+        await self._settle_resolved_suggestion_rows(
+            db, instruction, organization=organization,
+            build_ids={str(b.id) for b, _t, _v in rows},
+        )
         return await self.get_instruction(db, instruction.id, organization, current_user), "ok"
 
     async def _void_pending_suggestions(self, db: AsyncSession, instruction, *, organization: Organization) -> None:
@@ -2069,6 +2188,15 @@ class InstructionService:
                     continue
                 await self._record_resolved_hunk(db, build, instruction_id, h["key"], "reject", commit=False)
         await db.commit()
+        # Every live hunk in scope is now rejected — nothing is left to propose,
+        # so stamp the settled rows. Without this a build whose hunks all
+        # collapsed in the rebase (nothing live to record a rejection against)
+        # keeps the instruction "pending review" in the non-diffing badge sweep
+        # forever, surviving any refresh.
+        await self._settle_resolved_suggestion_rows(
+            db, instruction, organization=organization,
+            build_ids={str(b.id) for b, _t, _v in rows},
+        )
         try:
             # Build-scoped rejection may leave sibling suggestions live — only
             # clear the Review-feed item when nothing remains pending.
@@ -2091,6 +2219,13 @@ class InstructionService:
         if not build or str(build.organization_id) != str(organization.id) or build.is_main:
             return None, "not_found"
         await self._record_resolved_hunk(db, build, instruction_id, hunk_key, "reject")
+        # Rejecting the build's LAST live hunk fully resolves that suggestion —
+        # stamp it settled so the badge sweep stops counting it.
+        instruction = await self._get_instruction_by_id(db, instruction_id, organization)
+        if instruction:
+            await self._settle_resolved_suggestion_rows(
+                db, instruction, organization=organization, build_ids={str(build_id)},
+            )
         # If nothing remains pending for this instruction across all builds, clear
         # it from the Review feed.
         try:

--- a/backend/tests/e2e/test_instruction.py
+++ b/backend/tests/e2e/test_instruction.py
@@ -1533,3 +1533,176 @@ def test_new_instruction_reject_all_resolves_everywhere(
     # Not live: the row stays a draft and main gained no content for it.
     detail = get_instruction(iid, user_token=token, org_id=org_id)
     assert detail["status"] == "draft"
+
+
+def _pending_badge_state(test_client, headers):
+    """The three badge surfaces the /agents page renders from: the counts badge
+    (chip + per-row dots), the org-wide sweep, and the pending_only list."""
+    counts = test_client.get("/api/instructions/counts", headers=headers)
+    assert counts.status_code == 200, counts.json()
+    counts = counts.json()
+    sweep = test_client.get("/api/instructions/pending-changes", headers=headers)
+    assert sweep.status_code == 200, sweep.json()
+    plist = test_client.get(
+        "/api/instructions",
+        params={"pending_only": "true", "include_own": "true",
+                "include_drafts": "true", "include_archived": "true", "limit": 200},
+        headers=headers,
+    )
+    assert plist.status_code == 200, plist.json()
+    return {
+        "pending_total": counts["pending_total"],
+        "pending_ids": set(counts.get("pending_instruction_ids", [])),
+        "sweep_ids": set(sweep.json()["instruction_ids"]),
+        "list_ids": {r["id"] for r in plist.json()["items"]},
+    }
+
+
+@pytest.mark.e2e
+def test_reject_all_clears_pending_badges_without_refresh(
+    test_client,
+    create_global_instruction,
+    get_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """The reported flow on the /agents page: reject every suggested change,
+    then look at the tree. Every badge surface — the "N pending" chip
+    (counts.pending_total), the per-row dots (pending_instruction_ids /
+    /pending-changes), and the "Pending changes" list (pending_only) — must
+    agree the instruction is resolved, with no refresh required and nothing
+    for a refresh to bring back."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="alpha beta gamma delta", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    _inject_suggestion_build(org_id, iid, "alpha beta gamma delta epsilon")
+
+    state = _pending_badge_state(test_client, headers)
+    assert state["pending_total"] == 1
+    assert iid in state["pending_ids"] and iid in state["sweep_ids"] and iid in state["list_ids"]
+
+    resp = test_client.post(f"/api/instructions/{iid}/hunks/reject-all", json={}, headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    state = _pending_badge_state(test_client, headers)
+    assert state["pending_total"] == 0, "the 'N pending' chip must drop after reject-all"
+    assert iid not in state["pending_ids"]
+    assert iid not in state["sweep_ids"]
+    assert iid not in state["list_ids"]
+    assert get_instruction(iid, user_token=token, org_id=org_id)["text"] == "alpha beta gamma delta"
+
+
+@pytest.mark.e2e
+def test_reject_all_settles_drifted_noop_suggestion(
+    test_client,
+    create_global_instruction,
+    update_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Regression: the badge nobody could clear.
+
+    The badge sweep never diffs (verify=False), so a DRIFTED suggestion — main
+    moved since it forked — is reported pending optimistically. When the drift
+    already contains the suggestion's change, the authoritative per-hunk review
+    finds no live hunks, so reject-all had nothing to record a rejection
+    against: the review pane showed nothing to review, yet the optimistic sweep
+    kept the amber "Pending review" badge forever, surviving reject-all AND any
+    page refresh. Rejecting must settle the suggestion durably."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="alpha beta delta", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    # Suggestion forked from main("alpha beta delta") proposing one word swap...
+    _inject_suggestion_build(org_id, iid, "alpha BETA delta")
+    # ...then main moves PAST it: the swap is already contained in main, but
+    # the proposed text still differs from both base and main.
+    update_instruction(instruction_id=iid, text="alpha BETA delta extra",
+                       user_token=token, org_id=org_id)
+
+    # The phantom: the authoritative review has nothing to show, while the
+    # optimistic (non-diffing) badge surfaces still count it as pending.
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert review["main_text"] == "alpha BETA delta extra"
+    assert review["suggestions"] == []
+    state = _pending_badge_state(test_client, headers)
+    assert iid in state["pending_ids"], "precondition: the optimistic sweep flags the drifted no-op"
+
+    # Reject-all — the review has no live hunks, so before the settle marker
+    # this recorded nothing and the badge was unkillable.
+    resp = test_client.post(f"/api/instructions/{iid}/hunks/reject-all", json={}, headers=headers)
+    assert resp.status_code == 200, resp.json()
+
+    state = _pending_badge_state(test_client, headers)
+    assert state["pending_total"] == 0, "reject-all must settle a drifted no-op suggestion"
+    assert iid not in state["pending_ids"]
+    assert iid not in state["sweep_ids"]
+    assert iid not in state["list_ids"]
+
+
+@pytest.mark.e2e
+def test_partial_reject_keeps_pending_badges(
+    test_client,
+    create_global_instruction,
+    create_user,
+    login_user,
+    whoami,
+):
+    """Guard against over-settling: rejecting ONE of two hunks resolves only
+    that hunk — the other stays live, so every badge surface must keep the
+    instruction pending and the review must keep offering the survivor."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    instr = create_global_instruction(
+        text="one two three four", user_token=token, org_id=org_id, status="published",
+    )
+    iid = instr["id"]
+    bid = _inject_suggestion_build(org_id, iid, "one TWO three four five")
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    hunks = review["suggestions"][0]["hunks"]
+    assert len(hunks) == 2, hunks
+    replaced = next(h for h in hunks if "TWO" in h["after"])
+
+    resp = test_client.post(
+        f"/api/instructions/{iid}/hunks/reject",
+        json={"build_id": bid, "hunk_key": replaced["key"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+
+    review = test_client.get(f"/api/instructions/{iid}/review-hunks", headers=headers).json()
+    assert len(review["suggestions"]) == 1
+    assert len(review["suggestions"][0]["hunks"]) == 1
+    state = _pending_badge_state(test_client, headers)
+    assert state["pending_total"] == 1, "a live hunk remains — the badge must stay"
+    assert iid in state["pending_ids"] and iid in state["sweep_ids"]
+
+    # Rejecting the LAST live hunk settles the suggestion everywhere.
+    survivor = review["suggestions"][0]["hunks"][0]
+    resp = test_client.post(
+        f"/api/instructions/{iid}/hunks/reject",
+        json={"build_id": bid, "hunk_key": survivor["key"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    state = _pending_badge_state(test_client, headers)
+    assert state["pending_total"] == 0
+    assert iid not in state["pending_ids"]
+    assert iid not in state["sweep_ids"]

--- a/docs/feedback-loops/agents-pending-review-clearing.md
+++ b/docs/feedback-loops/agents-pending-review-clearing.md
@@ -1,0 +1,68 @@
+# Agents page — "Pending review" badges survive reject-all (and refresh)
+
+Reported flow: on the **Agents** page a reviewer rejects every suggested change,
+yet the amber **Pending review** row badges and the **"N pending"** chip keep
+showing. Refreshing the page doesn't clear them either — for some rows nothing
+can.
+
+## Root cause
+
+Two layers, both downstream of the deliberate perf trade documented in
+`agents-pending-reconciliation-perf.md`: the badge surfaces
+(`GET /instructions/counts`, `GET /instructions/pending-changes`, the
+`pending_only` list) answer from the **non-diffing** tier of
+`get_pending_change_instruction_ids(verify=False)`, which reports a *drifted*
+suggestion (its base no longer matches main) as pending **optimistically**,
+without confirming any hunk survives the rebase.
+
+1. **Backend — the badge nobody could clear.** `hunks/reject-all` (and the
+   other per-hunk resolutions) only record resolutions for hunks that are
+   currently **live**. A drifted suggestion whose change is already contained
+   in main rebases to *zero* live hunks — the review pane rightly shows nothing
+   to review — so reject-all recorded **nothing** for it. With no recorded
+   resolution, the optimistic sweep kept reporting the row as pending on every
+   page load, forever: not clearable by rejecting, not by refreshing.
+
+2. **Frontend — the clear that un-cleared itself.** Opening an instruction runs
+   the authoritative per-hunk pass (`/review-hunks`); when it comes back empty,
+   `KnowledgeExplorer.loadPending` cleared the row's dot locally. But every
+   mutation then runs `refreshLists → fetchCounts`, which **replaces**
+   `pendingInstrIds` wholesale with the server's optimistic set — resurrecting
+   the badge the user just watched clear.
+
+## Fix
+
+- **Settled markers** (`instruction_service.py`). When a per-hunk resolution
+  (accept/reject, single or all) leaves a suggestion build with **no live,
+  unrejected hunk** for the instruction, `_settle_resolved_suggestion_rows`
+  stamps a `__settled__` marker into the build's `rejected_hunks` metadata,
+  bound to the exact `(main version, proposed version)` pair it was verified
+  against. The sweep (both tiers) and `review_hunks` treat a matching marker as
+  a conclusive, **zero-diff** "not pending"; if main drifts again or the build
+  stages a new proposed version, the marker stops matching and the row is
+  re-evaluated like any other. The marker is review metadata only — the build's
+  content snapshot is untouched, so publish/merge semantics don't change (a
+  `remove_from_build` here would have read as "deleted" if e.g. a git build was
+  later published wholesale). As a bonus, fully-rejected drifted rows no longer
+  pay the quadratic exact check on every counts call.
+
+- **Sticky authoritative verdicts** (`KnowledgeExplorer.vue`). Rows the
+  authoritative pass proved empty are remembered in `verifiedNotPending` and
+  excluded from `isPending`, the "N pending" chip and the Pending-changes list
+  even after `fetchCounts` overwrites the optimistic set; a row leaves the set
+  the moment the authoritative pass finds a real pending change again. The
+  Pending-changes flat list also refetches after mutations while it is open.
+
+## Tests
+
+`backend/tests/e2e/test_instruction.py`:
+
+- `test_reject_all_clears_pending_badges_without_refresh` — the reported flow:
+  after reject-all, counts / sweep / pending_only all agree, nothing for a
+  refresh to bring back.
+- `test_reject_all_settles_drifted_noop_suggestion` — the previously unkillable
+  badge: drifted suggestion, zero live hunks, optimistically pending; verified
+  to FAIL before the settle marker and pass after.
+- `test_partial_reject_keeps_pending_badges` — guard against over-settling:
+  one of two hunks rejected keeps every surface pending; rejecting the last
+  hunk settles everywhere.

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -1555,6 +1555,13 @@ const startTreeResize = (e: MouseEvent) => {
 const pendingBuilds = ref<any[]>([])
 // True while GET /instructions/{id}/review-hunks is in flight for the open row.
 const reviewLoading = ref(false)
+// Rows the AUTHORITATIVE per-hunk pass (/review-hunks, via loadPending) proved
+// have nothing left to review this session. The counts sweep never diffs, so a
+// drifted suggestion can still read "pending" there — when fetchCounts replaces
+// pendingInstrIds wholesale, these verdicts must survive the overwrite, or the
+// badge the user just watched clear pops straight back. An id leaves this set
+// the moment the authoritative pass finds a real pending change again.
+const verifiedNotPending = ref<Set<string>>(new Set())
 // Global set of instruction ids that have a REAL pending change (a build that
 // intentionally changed them vs its base, not stale-snapshot inheritance). The
 // backend computes this so the count/dots match the per-instruction review.
@@ -1592,7 +1599,9 @@ const loadPendingChanges = async () => {
 // and icon so the flat list reads like the tree's agent sections.
 const pendingGroups = computed(() => {
   const map = new Map<string, { id: string; name: string; type?: string; connector_key?: string; rows: Instruction[] }>()
-  for (const ins of pendingRows.value) {
+  // The pending_only list is served by the same optimistic sweep as the dots —
+  // hide rows the authoritative pass has since proven resolved.
+  for (const ins of pendingRows.value.filter(r => !verifiedNotPending.value.has(r.id))) {
     const dss = ins.data_sources || []
     if (!dss.length) {
       const key = '__global__'
@@ -1794,9 +1803,15 @@ const loadPending = async (id: string) => {
   finally { if (selectedId.value === id || !selectedId.value) reviewLoading.value = false }
   // The tree's dots come from a deliberately cheap check that never runs the
   // per-hunk rebase, so a suggestion whose change is already applied can still
-  // carry a dot. This IS the authoritative answer for this row — when it comes
-  // back empty, clear the dot and the badge instead of leaving the tree
-  // disagreeing with what the user is looking at.
+  // carry a dot. This IS the authoritative answer for this row — remember the
+  // verdict (verifiedNotPending) so the next fetchCounts overwrite of
+  // pendingInstrIds can't resurrect a badge this pass just cleared, and clear
+  // the dot/badge now instead of leaving the tree disagreeing with what the
+  // user is looking at.
+  const verified = new Set(verifiedNotPending.value)
+  if (pendingBuilds.value.length) verified.delete(id)
+  else verified.add(id)
+  verifiedNotPending.value = verified
   if (!pendingBuilds.value.length && pendingInstrIds.value.has(id)) {
     const next = new Set(pendingInstrIds.value)
     next.delete(id)
@@ -2311,8 +2326,13 @@ const fetchAll = async () => {
 }
 // Refresh badges + pending dots + visible rows after a mutation. fetchAll() runs
 // fetchCounts(), which also refreshes the per-row pending-dot set — so no extra
-// /pending-changes sweep is needed here.
-const refreshLists = async () => { await fetchAll() }
+// /pending-changes sweep is needed here. While the "Pending changes" view is
+// open its flat list is refreshed too, so a just-resolved instruction drops out
+// instead of lingering until the next enter.
+const refreshLists = async () => {
+  await fetchAll()
+  if (pendingView.value) await loadPendingChanges()
+}
 const fetchAgents = async () => {
   try {
     // include_unconnected=true so members also see user_required (OBO) agents
@@ -2425,12 +2445,19 @@ const openFile = async (f: any, agentId?: string) => {
 }
 
 // ── Counts ──────────────────────────────────────────────
-// Authoritative: an instruction is "pending" iff it has a real pending change
-// (from /pending-changes). Avoids the old over-count from inherited/stale rows.
-const isPending = (ins: Instruction) => pendingInstrIds.value.has(ins.id)
+// An instruction is "pending" iff the cheap sweep flags it AND the
+// authoritative per-hunk pass hasn't already proven this session that nothing
+// is left to review (the sweep is optimistic for drifted suggestions).
+const isPending = (ins: Instruction) => pendingInstrIds.value.has(ins.id) && !verifiedNotPending.value.has(ins.id)
 // Badges read from the aggregate `counts` (not from the lazy row cache), so they
-// are correct even before a group's rows have been loaded.
-const pendingCount = computed(() => counts.value?.pending_total || 0)
+// are correct even before a group's rows have been loaded. The "N pending" chip
+// subtracts rows the authoritative pass has since proven resolved — the server
+// total comes from the optimistic sweep and may still be counting them.
+const pendingCount = computed(() => {
+  let n = counts.value?.pending_total || 0
+  for (const id of verifiedNotPending.value) if (pendingInstrIds.value.has(id)) n--
+  return Math.max(0, n)
+})
 const globalCount = computed(() => counts.value?.global || 0)
 const skillCount = computed(() => counts.value?.skills || 0)
 const agentCount = (id: string) => counts.value?.by_agent?.[id] || 0
@@ -2699,7 +2726,7 @@ const InstrLeaf = defineComponent({
     return () => {
       const ins = props.ins
       const sel = selectedId.value === ins.id
-      const pending = pendingInstrIds.value.has(ins.id)
+      const pending = isPending(ins)
       // Inactive (draft/archived) rows stay muted even while a change is
       // pending: the amber dot flags the pending review, a second gray dot
       // keeps the live lifecycle state visible, and the title never turns


### PR DESCRIPTION
## Summary

Fixes a bug where "Pending review" badges on the Agents page would persist indefinitely after rejecting all suggested changes, particularly for drifted suggestions (where the proposed change was already contained in the live text). The badges would survive page refreshes and couldn't be cleared by any user action.

## Root Cause

The badge surfaces (`/instructions/counts`, `/instructions/pending-changes`, `pending_only` list) use an optimistic, non-diffing sweep that reports drifted suggestions as pending without confirming hunks survive the rebase. When a suggestion's hunks all collapsed (change already applied), `reject-all` recorded no resolutions (nothing live to reject), leaving the optimistic sweep to report the row as pending forever.

## Key Changes

**Backend (`instruction_service.py`)**
- Added `SETTLED_HUNK_KEY` sentinel to mark fully-resolved suggestions in `rejected_hunks` metadata
- Implemented `_settled_marker_matches()` to check if a suggestion build has been conclusively resolved against specific main/proposed version pairs
- Implemented `_settle_resolved_suggestion_rows()` to stamp settled markers when a suggestion has no remaining live, unrejected hunks
- Updated `review_hunks()` to skip rebasing for settled suggestions (optimization)
- Updated `get_pending_change_instruction_ids()` to:
  - Track main and proposed version IDs alongside suggestion rows
  - Skip settled suggestions in both the conclusive and diffing passes
  - Avoid quadratic exact checks for fully-rejected drifted rows
- Added settle calls to `accept_hunk()`, `accept_all_hunks()`, `reject_all_hunks()`, and `reject_hunk()` to durably mark resolved suggestions

**Frontend (`KnowledgeExplorer.vue`)**
- Added `verifiedNotPending` set to remember rows the authoritative per-hunk pass proved have no pending changes
- Updated `isPending()` to exclude rows in `verifiedNotPending` from the pending count
- Updated `pendingCount` computed property to subtract verified-resolved rows from the server's optimistic count
- Updated `pendingGroups` to filter out verified-resolved rows from the pending-changes flat list
- Modified `loadPending()` to populate `verifiedNotPending` with the authoritative verdict
- Updated `refreshLists()` to refetch the pending-changes list while it's open, so resolved instructions drop out immediately

**Tests (`test_instruction.py`)**
- Added `_pending_badge_state()` helper to verify consistency across all three badge surfaces
- Added `test_reject_all_clears_pending_badges_without_refresh()` to verify the reported flow works end-to-end
- Added `test_reject_all_settles_drifted_noop_suggestion()` regression test for the previously unkillable badge
- Added `test_partial_reject_keeps_pending_badges()` guard test to ensure partial rejections don't over-settle

## Implementation Details

The settled marker is review metadata only (stored in `rejected_hunks` with a non-colliding key), so it doesn't affect publish/merge semantics. The marker binds to exact version IDs: if main drifts or the build stages a new proposed version, the marker stops matching and the row is re-evaluated. This provides a zero-diff conclusive answer for the optimistic sweep while remaining resilient to future changes.

https://claude.ai/code/session_01XxS1LvQwnQmRkKH5S1HSim