### PR TITLE
feat(custom-queries): accelerate Sybase SQL Anywhere via a native pyodbc extraction source

### DIFF
--- a/backend/app/data_sources/clients/sybase_client.py
+++ b/backend/app/data_sources/clients/sybase_client.py
@@ -15,6 +15,12 @@ FREETDS_CUSTOM_CONF = "/tmp/freetds.conf"
 QUERY_TIMEOUT_SECONDS = 60
 
 
+def _sybase_extraction_source(client):
+    from app.data_sources.fast.sybase_source import SybaseSource
+
+    return SybaseSource(client)
+
+
 class SybaseClient(DataSourceClient):
     def __init__(self, host, port, database, user, password):
         self.host = host
@@ -24,6 +30,10 @@ class SybaseClient(DataSourceClient):
         self.password = password
         self._freetds_section = f"{self.host}_{self.port}_{self.database}"
         self._freetds_ready = False
+
+    # SQLAlchemy 2.0 has no SQL Anywhere dialect, so extraction drives the raw
+    # pyodbc connection natively. Resolved lazily by fast/sources.source_for.
+    EXTRACTION_SOURCE = staticmethod(_sybase_extraction_source)
 
     def _ensure_freetds_entry(self):
         """Register a freetds.conf entry so FreeTDS can select the correct SQL Anywhere database."""

--- a/backend/app/data_sources/fast/sybase_source.py
+++ b/backend/app/data_sources/fast/sybase_source.py
@@ -1,0 +1,170 @@
+"""Materializing from Sybase SQL Anywhere over raw pyodbc.
+
+SQL Anywhere cannot take the SQLAlchemy path: SQLAlchemy 2.0 removed its
+Sybase dialect, and the client speaks to the server through FreeTDS with a
+raw pyodbc connection. So this is a native `ExtractionSource`, the same shape
+BigQuery uses — the protocol's three questions answered directly against the
+driver.
+
+The dialect quirks that matter here:
+
+* **Estimating.** SQL Anywhere has no SHOWPLAN_XML. `GRAPHICAL_PLAN('<sql>')`
+  compiles the statement without executing it and returns the optimizer's plan
+  as XML, which carries estimated row counts. The XML schema is not publicly
+  pinned down, so the parse is deliberately permissive (several known spellings
+  of the estimate attribute) and degrades to an unsupported estimate — falling
+  back to the hard caps — rather than guessing.
+* **Bounding.** The fetch is stopped rather than the SQL rewritten, for the
+  same reasons as every other source (a wrapped ORDER BY changes meaning).
+* **Cancelling.** pyodbc's `Cursor.cancel()` (SQLCancel) asks the server to
+  stop the statement. Best effort: FreeTDS support varies, so failure is
+  logged and the cursor is closed regardless.
+
+Sybase sits in UNVERIFIED_TYPES until this file has been run against a live
+SQL Anywhere engine — GRAPHICAL_PLAN's XML shape and SQLCancel-over-FreeTDS
+are exactly the kind of thing a fake cannot prove (the SQL Server KILL bug is
+the cautionary tale).
+"""
+
+import logging
+import re
+from typing import Iterator, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# The client's default 60s statement timeout protects live agent queries; an
+# extraction is a deliberate full read and gets the extractor's wall-clock
+# budget instead (see extractor.DEFAULT_MAX_SECONDS).
+EXTRACTION_TIMEOUT_SECONDS = 1800
+
+# GRAPHICAL_PLAN's XML schema is not documented as stable. These are the
+# spellings of "estimated rows" worth looking for; first hit wins.
+_EST_ROWS_PATTERNS = (
+    re.compile(r'EstRowCount\s*=\s*"([\d.eE+]+)"'),
+    re.compile(r'est_rows\s*=\s*"([\d.eE+]+)"'),
+    re.compile(r'Estimated\s+rows[^\d]*([\d.eE+]+)', re.IGNORECASE),
+)
+
+
+class SybaseSource:
+    """Extraction over the Sybase client's raw pyodbc connection."""
+
+    def __init__(self, client):
+        self.client = client
+
+    # -- the protocol -----------------------------------------------------
+
+    def estimate(self, sql: str):
+        """Estimated result rows from GRAPHICAL_PLAN, without executing.
+
+        Width is assumed, not reported — SQL Anywhere's plan does not carry
+        one — so the byte ceiling has something to bite on and the note says
+        it is a guess.
+        """
+        from app.data_sources.fast.extractor import Estimate
+        from app.data_sources.fast.sql_dialect import (
+            ASSUMED_ROW_WIDTH_BYTES,
+            strip_trailing_semicolon,
+        )
+
+        stmt = strip_trailing_semicolon(sql).replace("'", "''")
+        try:
+            with self.client.connect() as conn:
+                cursor = conn.cursor()
+                try:
+                    cursor.execute(f"SELECT GRAPHICAL_PLAN('{stmt}')")
+                    row = cursor.fetchone()
+                finally:
+                    cursor.close()
+        except Exception as e:
+            return Estimate(supported=False, note=f"sybase GRAPHICAL_PLAN failed: {e}")
+
+        plan = row[0] if row else None
+        rows = _estimated_rows(plan)
+        if rows is None:
+            return Estimate(supported=False,
+                            note="sybase plan had no recognizable row estimate")
+        return Estimate(rows=rows, width_bytes=ASSUMED_ROW_WIDTH_BYTES,
+                        note="row width estimated (GRAPHICAL_PLAN reports none)")
+
+    def preview(self, sql: str, limit: int) -> Tuple[List[dict], List[list]]:
+        """First `limit` rows, stopping the fetch rather than wrapping the SQL."""
+        from app.data_sources.fast.sql_dialect import strip_trailing_semicolon
+
+        with self.client.connect() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(strip_trailing_semicolon(sql))
+                cols = _columns(cursor)
+                rows = [list(r) for r in cursor.fetchmany(limit)]
+                if len(rows) == limit:
+                    # There may be more; ask the server to stop instead of
+                    # draining the rest of the result down the wire.
+                    _cancel(cursor)
+            finally:
+                cursor.close()
+        return cols, rows
+
+    def stream_batches(self, sql: str, batch_rows: int) -> Iterator["object"]:
+        """Yield pyarrow.Table batches covering the whole result."""
+        from app.data_sources.fast.sources import arrow_table
+
+        with self.client.connect() as conn:
+            # A full extraction may legitimately outlive the client's 60s
+            # statement timeout; give it the refresh budget instead.
+            try:
+                conn.timeout = EXTRACTION_TIMEOUT_SECONDS
+            except Exception:
+                pass
+            cursor = conn.cursor()
+            try:
+                cursor.execute(sql)
+                colnames = [c["name"] for c in _columns(cursor)]
+                emitted = False
+                while True:
+                    batch = cursor.fetchmany(batch_rows)
+                    if not batch:
+                        break
+                    emitted = True
+                    yield arrow_table(
+                        {name: [r[i] for r in batch] for i, name in enumerate(colnames)}
+                    )
+                if not emitted:
+                    # Zero rows: still emit the shape so the relation exists.
+                    yield arrow_table({c: [] for c in colnames})
+            except GeneratorExit:
+                # The extractor stopped early — a cap was breached. The
+                # statement is still running on the source; ask it to stop.
+                _cancel(cursor)
+                raise
+            finally:
+                cursor.close()
+
+
+def _columns(cursor) -> List[dict]:
+    """(name, dtype) pairs from a pyodbc cursor description."""
+    return [
+        {"name": d[0], "dtype": getattr(d[1], "__name__", None)}
+        for d in (cursor.description or [])
+    ]
+
+
+def _cancel(cursor) -> None:
+    """Best-effort SQLCancel; FreeTDS support varies and failure is not fatal."""
+    try:
+        cursor.cancel()
+    except Exception:
+        logger.debug("Sybase statement cancel failed", exc_info=True)
+
+
+def _estimated_rows(plan) -> "int | None":
+    if not isinstance(plan, str) or not plan:
+        return None
+    for pattern in _EST_ROWS_PATTERNS:
+        m = pattern.search(plan)
+        if m:
+            try:
+                return int(float(m.group(1)))
+            except (TypeError, ValueError):
+                continue
+    return None

--- a/backend/app/services/custom_query_service.py
+++ b/backend/app/services/custom_query_service.py
@@ -41,11 +41,14 @@ logger = logging.getLogger(__name__)
 # (`fast/sources.py`) and is unit-tested; only the first group has been run
 # against a live server end to end.
 #
-# Fabric is the only one left unverified, and it is the reason this still ships
-# behind `enable_custom_queries`. It speaks T-SQL through an Entra token, so it
-# borrows the SQL Server dialect without ever having proven that Fabric's SQL
-# analytics endpoint supports SHOWPLAN_XML or permits KILL — and its SQL port is
-# unreachable from the build environment, so that cannot be checked here.
+# The unverified two are why this still ships behind `enable_custom_queries`.
+# Fabric speaks T-SQL through an Entra token, so it borrows the SQL Server
+# dialect without ever having proven that Fabric's SQL analytics endpoint
+# supports SHOWPLAN_XML or permits KILL — and its SQL port is unreachable from
+# the build environment, so that cannot be checked here. Sybase SQL Anywhere
+# has a native pyodbc extraction source (fast/sybase_source.py) whose
+# GRAPHICAL_PLAN estimator and SQLCancel-over-FreeTDS early-stop are untested
+# against a live engine — no SQL Anywhere instance was reachable either.
 #
 # SQL Server and Oracle graduated once they were run against real engines
 # (SQL Server 2022 and Oracle Free 23ai in Docker). That run was worth doing:
@@ -55,7 +58,7 @@ logger = logging.getLogger(__name__)
 # caught it.
 VERIFIED_TYPES = {"postgresql", "mariadb", "mysql", "sqlite", "snowflake",
                   "bigquery", "mssql", "oracledb"}
-UNVERIFIED_TYPES = {"ms_fabric"}
+UNVERIFIED_TYPES = {"ms_fabric", "sybase"}
 ACCELERABLE_TYPES = VERIFIED_TYPES | UNVERIFIED_TYPES
 
 

--- a/backend/tests/unit/test_fast_sql_dialect.py
+++ b/backend/tests/unit/test_fast_sql_dialect.py
@@ -262,14 +262,17 @@ def test_every_accelerable_type_has_an_explainer():
         "snowflake": "snowflake",
         "ms_fabric": "mssql",     # Fabric speaks T-SQL
     }
-    # BigQuery does not go through the SQL dialect table at all — it has a
-    # native extraction source instead. Assert that explicitly rather than
-    # letting it fall through the map lookup.
+    # BigQuery and Sybase do not go through the SQL dialect table at all —
+    # each has a native extraction source instead. Assert that explicitly
+    # rather than letting them fall through the map lookup.
     from app.data_sources.fast.bigquery_source import BigQuerySource
+    from app.data_sources.fast.sybase_source import SybaseSource
     assert "bigquery" in ACCELERABLE_TYPES
     assert hasattr(BigQuerySource, "estimate")
+    assert "sybase" in ACCELERABLE_TYPES
+    assert hasattr(SybaseSource, "estimate")
     for conn_type in ACCELERABLE_TYPES:
-        if conn_type == "bigquery":
+        if conn_type in ("bigquery", "sybase"):
             continue
         dialect = type_to_dialect[conn_type]
         assert dialect in sql_dialect.EXPLAINERS, conn_type

--- a/backend/tests/unit/test_sybase_source.py
+++ b/backend/tests/unit/test_sybase_source.py
@@ -1,0 +1,200 @@
+"""Sybase SQL Anywhere native extraction source.
+
+The driver (pyodbc over FreeTDS) is the boundary, so it is faked; everything
+above it — resolution, fetch-bounding, batch shaping, estimate degradation —
+runs real. What a fake cannot prove (GRAPHICAL_PLAN's XML on a live engine,
+SQLCancel over FreeTDS) is exactly why the type sits in UNVERIFIED_TYPES.
+"""
+
+from contextlib import contextmanager
+
+from app.data_sources.fast.sybase_source import SybaseSource
+
+
+# --------------------------------------------------------------------------
+# Fakes at the pyodbc boundary
+# --------------------------------------------------------------------------
+
+class FakeCursor:
+    def __init__(self, rows, description):
+        self._rows = list(rows)
+        self.description = description
+        self.executed = []
+        self.cancelled = False
+        self.closed = False
+
+    def execute(self, sql):
+        self.executed.append(sql)
+        return self
+
+    def fetchone(self):
+        return self._rows.pop(0) if self._rows else None
+
+    def fetchmany(self, n):
+        out, self._rows = self._rows[:n], self._rows[n:]
+        return out
+
+    def cancel(self):
+        self.cancelled = True
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.timeout = 60
+
+    def cursor(self):
+        return self._cursor
+
+
+class FakeSybaseClient:
+    def __init__(self, cursor):
+        self.connection = FakeConnection(cursor)
+
+    @contextmanager
+    def connect(self):
+        yield self.connection
+
+
+def _source(rows, description=(("id", int), ("name", str))):
+    cursor = FakeCursor(rows, description)
+    return SybaseSource(FakeSybaseClient(cursor)), cursor
+
+
+# --------------------------------------------------------------------------
+# Resolution & gating
+# --------------------------------------------------------------------------
+
+def test_the_sybase_client_resolves_to_its_native_source():
+    from app.data_sources.clients.sybase_client import SybaseClient
+    from app.data_sources.fast.sources import source_for
+
+    client = SybaseClient(host="h", port=2638, database="d", user="u", password="p")
+    assert isinstance(source_for(client), SybaseSource)
+
+
+def test_sybase_is_an_accelerable_but_unverified_type():
+    from app.services.custom_query_service import (
+        ACCELERABLE_TYPES,
+        UNVERIFIED_TYPES,
+        is_accelerable_type,
+    )
+
+    assert "sybase" in ACCELERABLE_TYPES
+    assert "sybase" in UNVERIFIED_TYPES
+    assert is_accelerable_type("sybase")
+
+
+# --------------------------------------------------------------------------
+# Preview — bound the fetch, never rewrite the SQL
+# --------------------------------------------------------------------------
+
+def test_preview_returns_at_most_the_limit_and_stops_the_source():
+    src, cursor = _source([(i, f"r{i}") for i in range(10)])
+    cols, rows = src.preview("SELECT * FROM t", 3)
+    assert [c["name"] for c in cols] == ["id", "name"]
+    assert len(rows) == 3
+    assert cursor.cancelled, "a partially-read statement must be stopped at the source"
+    assert cursor.closed
+
+
+def test_preview_of_a_small_result_does_not_cancel():
+    src, cursor = _source([(1, "a")])
+    _, rows = src.preview("SELECT * FROM t", 100)
+    assert len(rows) == 1
+    assert not cursor.cancelled
+
+
+def test_preview_runs_the_sql_as_written():
+    """Wrapping would break ORDER BY / duplicate-column queries — the bound
+    lives in the fetch, so the statement must reach the driver untouched."""
+    src, cursor = _source([])
+    src.preview("SELECT a.id, b.id FROM a, b ORDER BY a.id DESC;", 5)
+    assert cursor.executed == ["SELECT a.id, b.id FROM a, b ORDER BY a.id DESC"]
+
+
+# --------------------------------------------------------------------------
+# Streaming — batches cover the result, zero rows still emit the shape
+# --------------------------------------------------------------------------
+
+def test_stream_batches_covers_the_whole_result_in_batch_sized_pieces():
+    src, _ = _source([(i, f"r{i}") for i in range(5)])
+    batches = list(src.stream_batches("SELECT * FROM t", batch_rows=2))
+    assert [b.num_rows for b in batches] == [2, 2, 1]
+    assert sum(b.num_rows for b in batches) == 5
+    assert batches[0].column_names == ["id", "name"]
+
+
+def test_a_zero_row_result_still_emits_the_relation_shape():
+    src, _ = _source([])
+    batches = list(src.stream_batches("SELECT * FROM t WHERE 1=0", batch_rows=10))
+    assert len(batches) == 1
+    assert batches[0].num_rows == 0
+    assert batches[0].column_names == ["id", "name"]
+
+
+def test_an_abandoned_stream_cancels_the_statement_on_the_source():
+    src, cursor = _source([(i, f"r{i}") for i in range(100)])
+    gen = src.stream_batches("SELECT * FROM t", batch_rows=10)
+    next(gen)
+    gen.close()  # extractor breached a cap and stopped consuming
+    assert cursor.cancelled
+    assert cursor.closed
+
+
+def test_extraction_lifts_the_statement_timeout_to_the_refresh_budget():
+    """The client's 60s timeout protects live agent queries; a deliberate full
+    extraction gets the extractor's wall-clock budget instead."""
+    from app.data_sources.fast.sybase_source import EXTRACTION_TIMEOUT_SECONDS
+
+    src, _ = _source([(1, "a")])
+    list(src.stream_batches("SELECT * FROM t", batch_rows=10))
+    assert src.client.connection.timeout == EXTRACTION_TIMEOUT_SECONDS
+
+
+# --------------------------------------------------------------------------
+# Estimation — permissive parse, honest degradation
+# --------------------------------------------------------------------------
+
+def test_estimate_reads_rows_from_a_graphical_plan():
+    plan = '<plan><node EstRowCount="1234.5" cost="1"/></plan>'
+    src, cursor = _source([(plan,)])
+    est = src.estimate("SELECT * FROM t;")
+    assert est.supported
+    assert est.rows == 1234
+    assert est.width_bytes is not None, "byte ceiling needs a width to bite on"
+    # The statement is compiled inside a string literal, quotes escaped, and
+    # never executed as-is.
+    assert "GRAPHICAL_PLAN" in cursor.executed[0]
+
+
+def test_estimate_escapes_quotes_inside_the_admins_sql():
+    src, cursor = _source([(None,)])
+    src.estimate("SELECT * FROM t WHERE name = 'o''brien'")
+    sent = cursor.executed[0]
+    assert "GRAPHICAL_PLAN('" in sent
+    assert "o''''brien" in sent
+
+
+def test_an_unrecognizable_plan_degrades_to_unsupported():
+    """Falling back to the hard caps is the honest outcome; inventing a row
+    count is not."""
+    src, _ = _source([("<plan>nothing useful here</plan>",)])
+    est = src.estimate("SELECT 1")
+    assert est.supported is False
+    assert est.note
+
+
+def test_a_driver_error_during_estimate_degrades_rather_than_raising():
+    class BrokenClient:
+        @contextmanager
+        def connect(self):
+            raise RuntimeError("no GRAPHICAL_PLAN permission")
+            yield
+
+    est = SybaseSource(BrokenClient()).estimate("SELECT 1")
+    assert est.supported is False
+    assert "GRAPHICAL_PLAN" in est.note


### PR DESCRIPTION
Adds Sybase SQL Anywhere to the accelerable connector types with a native `ExtractionSource` driving its raw pyodbc/FreeTDS connection.
It was needed because SQLAlchemy 2.0 removed its Sybase dialect, so SQL Anywhere could never take the standard SQLAlchemy extraction path that every other SQL connector uses — and the connector was excluded from custom queries entirely.

## Executive summary

Sybase SQL Anywhere customers run exactly the environment custom queries were built for: legacy on-prem, enterprise-licensed databases that cannot absorb agentic query load — the connector already carries a 60-second statement timeout and prompt-level warnings begging the agent to query gently. Yet these customers were locked out of the one feature that would take that load off their box. With this change an admin on a Sybase connection can author a custom query, have it materialized locally on a schedule, and agents answer from the local cached copy at local-disk latency — the production SQL Anywhere server sees one scheduled refresh instead of every exploratory agent query.

## Product impact (before → after)

```mermaid
flowchart LR
    subgraph Before
        A1[Admin connects SQL Anywhere] --> B1[No Add Custom option:<br/>type not accelerable]
        B1 --> C1[Every agent question hits the<br/>legacy box live, 60s timeout races]
        style C1 fill:#7f1d1d,color:#fff
    end
    subgraph After
        A2[Admin connects SQL Anywhere] --> B2[Custom queries available,<br/>materialized on a schedule]
        B2 --> C2[Agents query the local cached<br/>relation; source sees one refresh]
        style C2 fill:#14532d,color:#fff
    end
```

## Technical mechanism

```mermaid
flowchart TD
    C[SybaseClient - raw pyodbc over FreeTDS] -->|no SQLAlchemy 2.0 dialect| X[SqlAlchemySource impossible]
    style X fill:#7f1d1d,color:#fff
    C -->|EXTRACTION_SOURCE declaration| S[SybaseSource - native, like BigQuery]
    style S fill:#14532d,color:#fff
    S --> E["estimate: GRAPHICAL_PLAN('sql')<br/>compiles without executing"]
    S --> P["preview: run SQL as written,<br/>bound the fetch, cancel remainder"]
    S --> B["stream_batches: Arrow batches,<br/>zero-row shape, cancel on abandon"]
```

The `ExtractionSource` protocol (`fast/sources.py`) was designed for exactly this case — BigQuery proved a client with no SQLAlchemy engine can answer the extractor's three questions natively. Key dialect decisions:

- **Estimate** uses `GRAPHICAL_PLAN('<sql>')`, which compiles the statement server-side without executing. The XML schema isn't publicly pinned, so the row-estimate parse tries several known spellings and **degrades to `supported=False`** (falling back to the hard row/byte/wall-clock caps) rather than inventing a number. Width is assumed at the shared `ASSUMED_ROW_WIDTH_BYTES`, and the note says so — same treatment as MySQL.
- **Preview** executes the admin's SQL exactly as written and bounds the *fetch*, then issues a best-effort `Cursor.cancel()` (SQLCancel) so a partially-read statement stops at the source — the same never-rewrite rule every other source follows.
- **Streaming** lifts the client's 60s statement timeout to the extractor's 30-minute refresh budget on the extraction connection only; live agent queries keep their 60s protection.

## Reviewer decision box

| | |
|---|---|
| **Risk** | Low-medium — all new code is behind three gates: the `enable_custom_queries` beta flag (off by default), the per-connection `system_only` requirement, and per-agent activation. No existing code path changes behavior. |
| **Blast radius** | New file `fast/sybase_source.py`; 2-line wiring in `sybase_client.py`; `"sybase"` added to `UNVERIFIED_TYPES`. Nothing else touched. |
| **Behavior change (intended)** | Sybase connections report `custom_queries_supported=true` and can host materialized custom queries. |
| **Verified ✅** | 55 unit tests pass locally covering the fast path (incl. 13 new); mutation check confirms the cancel test fails when the cancel is removed; full unit suite run — see Evidence. |
| **NOT verified ⚠️** | No live SQL Anywhere engine was reachable: GRAPHICAL_PLAN's real XML shape and SQLCancel-over-FreeTDS behavior are unproven — hence `UNVERIFIED_TYPES`, mirroring Fabric. |
| **Where to look first** | `backend/app/data_sources/fast/sybase_source.py` — especially `estimate()`'s permissive parse and `stream_batches()`'s cancel-on-abandon. |

## Evidence

| Check | Result |
|---|---|
| New unit tests (`test_sybase_source.py`) | 13/13 pass locally |
| Fast-path suite (`test_sybase_source.py` + `test_fast_sql_dialect.py`) | 55/55 pass |
| Mutation check (repo test rule 6) | Removing the preview cancel makes `test_preview_returns_at_most_the_limit_and_stops_the_source` fail for the right reason; restored |
| Full unit suite (sqlite, xdist) | 16 failures, **all pre-existing on clean `main`** (verified by stashing this change and re-running the same tests — identical failures) |
| Failures attributable to this PR | **0** |

### Pre-existing failure attribution appendix

All 16 were re-run serially on a clean checkout of `main` (`dbb7e25`, this change stashed) and failed identically, so none are caused by this PR. Grouped by file, all labeled `pre-existing-defect` (or environment-sensitive) with that stash-run as the shared evidence: `test_connection_oauth.py` (2: ms_fabric OAuth scopes/OBO — expect `api.fabric.microsoft.com` scopes, code returns `database.windows.net`, likely from PR #833's OAuth changes), `test_notification_service.py` (6), `test_eval_draft_helpers.py` (3), `test_permissions_registry.py` (2), `test_data_source_member_email.py` (1), `test_notify_service.py` (1), `test_whatsapp_webhook_route.py` (1). None import or exercise any file this PR touches.

## Context map

- `backend/app/data_sources/fast/sybase_source.py` — the native source (new)
- `backend/app/data_sources/clients/sybase_client.py` — `EXTRACTION_SOURCE` wiring (the same lazy-resolver shape as BigQuery's)
- `backend/app/services/custom_query_service.py` — `"sybase"` in `UNVERIFIED_TYPES`; the comment block records exactly what live verification must prove
- `backend/tests/unit/test_sybase_source.py` — fakes at the pyodbc boundary only, per `tests/AGENTS.md`
- `backend/tests/unit/test_fast_sql_dialect.py` — the every-accelerable-type sweep now treats Sybase like BigQuery (native source, not dialect table)
- **Convention established:** a connector without a SQLAlchemy dialect accelerates via a native `ExtractionSource` declared with `EXTRACTION_SOURCE`, not by forcing a pseudo-dialect through the SQL table.
- Follow-up (the graduation path): run against a live SQL Anywhere — confirm GRAPHICAL_PLAN's XML (adjust `_EST_ROWS_PATTERNS` to the real attribute), confirm SQLCancel over FreeTDS, then move `"sybase"` to `VERIFIED_TYPES`.

## Deep detail

**Roads not taken.**
- *Borrow the mssql dialect* (as Fabric does) — wrong: SQL Anywhere speaks Watcom SQL, not T-SQL; SHOWPLAN_XML and KILL don't exist there. Fabric borrows mssql because it genuinely is T-SQL.
- *Add a third-party SQLAlchemy dialect* (`sqlalchemy-sqlany`) — unmaintained against SQLAlchemy 2.0 and a new dependency for one connector; the native protocol is less code.
- *Skip the estimator entirely* (as SQLite does) — SQLite gets away with it because it's a local file; SQL Anywhere is a shared server, the thing the pre-flight refusal protects. A degradable estimator is strictly better than none.

**Radical honesty.** The unverified parts are named in `UNVERIFIED_TYPES`' comment and above: GRAPHICAL_PLAN's XML attribute names are parsed permissively because no live engine was reachable to observe the real output, and `Cursor.cancel()` support under FreeTDS is assumed-best-effort (failure is logged, never fatal). The repo's own history (SQL Server's KILL failing silently until run against a real engine) is why this ships unverified-behind-the-beta-flag rather than claiming a green it hasn't earned. The e2e/playwright CI jobs will exercise the unchanged surrounding paths; no CI job runs against a real SQL Anywhere.

**Automated review** — pending; will be resolved on this PR as comments arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNjYBQXUDy6HC8bVSNvdy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNjYBQXUDy6HC8bVSNvdy5)_