### PR TITLE
Allow sharing reports with groups, not just individual members

### DIFF
--- a/backend/alembic/versions/rsgrp0001_report_share_groups.py
+++ b/backend/alembic/versions/rsgrp0001_report_share_groups.py
@@ -1,0 +1,44 @@
+"""allow sharing reports with groups
+
+Revision ID: rsgrp0001
+Revises: fccfb9232670
+Create Date: 2026-07-30 00:00:00.000000
+
+Adds group_id to report_shares so a report's artifact/conversation can be
+shared with a whole group, not just individual members. user_id becomes
+nullable — each row now names exactly one principal (user OR group).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'rsgrp0001'
+down_revision: Union[str, None] = 'fccfb9232670'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('report_shares', schema=None) as batch_op:
+        batch_op.alter_column('user_id', existing_type=sa.String(36), nullable=True)
+        batch_op.add_column(sa.Column('group_id', sa.String(36), nullable=True))
+        batch_op.create_foreign_key(
+            'fk_report_shares_group_id', 'groups', ['group_id'], ['id']
+        )
+        batch_op.create_unique_constraint(
+            'uq_report_share_group', ['report_id', 'group_id', 'share_type']
+        )
+    op.create_index('ix_report_shares_group_id', 'report_shares', ['group_id'])
+
+
+def downgrade() -> None:
+    # Group share rows cannot survive a non-null user_id; drop them first.
+    op.execute("DELETE FROM report_shares WHERE user_id IS NULL")
+    op.drop_index('ix_report_shares_group_id', table_name='report_shares')
+    with op.batch_alter_table('report_shares', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_report_share_group', type_='unique')
+        batch_op.drop_constraint('fk_report_shares_group_id', type_='foreignkey')
+        batch_op.drop_column('group_id')
+        batch_op.alter_column('user_id', existing_type=sa.String(36), nullable=False)

--- a/backend/app/models/report_share.py
+++ b/backend/app/models/report_share.py
@@ -5,22 +5,26 @@ from app.models.base import BaseSchema
 
 class ReportShare(BaseSchema):
     """
-    Per-user sharing grants for reports.
+    Sharing grants for reports.
 
-    Each row grants a specific user access to either the artifact (dashboard)
-    or the conversation of a report, depending on share_type.
+    Each row grants a principal — a specific user OR a whole group — access to
+    either the artifact (dashboard) or the conversation of a report, depending
+    on share_type. Exactly one of user_id / group_id is set per row.
 
     share_type: 'artifact' | 'conversation'
     """
     __tablename__ = 'report_shares'
 
     report_id = Column(String(36), ForeignKey('reports.id'), nullable=False, index=True)
-    user_id = Column(String(36), ForeignKey('users.id'), nullable=False, index=True)
+    user_id = Column(String(36), ForeignKey('users.id'), nullable=True, index=True)
+    group_id = Column(String(36), ForeignKey('groups.id'), nullable=True, index=True)
     share_type = Column(String(20), nullable=False, index=True)  # 'artifact' or 'conversation'
 
     report = relationship("Report", back_populates="shares", lazy="selectin")
     user = relationship("User", lazy="selectin")
+    group = relationship("Group", lazy="selectin")
 
     __table_args__ = (
         UniqueConstraint('report_id', 'user_id', 'share_type', name='uq_report_share'),
+        UniqueConstraint('report_id', 'group_id', 'share_type', name='uq_report_share_group'),
     )

--- a/backend/app/routes/organization.py
+++ b/backend/app/routes/organization.py
@@ -189,6 +189,16 @@ async def get_organization_members(db: AsyncSession = Depends(get_async_db), cur
     return await organization_service.get_organization_members(db, current_user, organization)
 
 
+@router.get("/organization/groups")
+async def get_organization_groups(db: AsyncSession = Depends(get_async_db), current_user: User = Depends(current_user), organization: Organization = Depends(get_current_organization)):
+    """Minimal group directory (id, name, member count) for share pickers.
+
+    Deliberately lighter than the RBAC groups endpoints: any org member can
+    address a group by name when sharing, without manage_members access.
+    """
+    return await organization_service.get_organization_groups(db, organization)
+
+
 @router.put("/organization", response_model=OrganizationSchema)
 @requires_permission('manage_settings')
 async def update_organization(

--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -216,6 +216,7 @@ async def set_report_visibility(
         db, report_id, share_type, payload.visibility,
         payload.shared_user_ids, current_user, organization,
         run_identity=payload.run_identity,
+        shared_group_ids=payload.shared_group_ids,
     )
 
 

--- a/backend/app/schemas/report_schema.py
+++ b/backend/app/schemas/report_schema.py
@@ -83,6 +83,8 @@ class ReportSchema(ReportBase):
     has_user_scoped: bool = False
     artifact_shared_user_ids: List[str] = []
     conversation_shared_user_ids: List[str] = []
+    artifact_shared_group_ids: List[str] = []
+    conversation_shared_group_ids: List[str] = []
     # Artifact modes (page, slides) that exist for this report
     artifact_modes: List[str] = []
     # Thumbnail URL for the main artifact
@@ -158,6 +160,9 @@ class ReportVisibilityUpdate(BaseModel):
     """Update visibility for either artifact or conversation sharing."""
     visibility: VISIBILITY_LITERAL
     shared_user_ids: Optional[List[str]] = None  # required when visibility == 'shared'
+    # Group grants: every member of a listed group can view. None = leave
+    # the current group shares unchanged (mirrors shared_user_ids semantics).
+    shared_group_ids: Optional[List[str]] = None
     # Artifact sharing only: whose credentials viewer-triggered runs use.
     # Omitted = leave unchanged.
     run_identity: Optional[Literal["viewer", "creator"]] = None

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -778,6 +778,40 @@ class OrganizationService:
         users = result.scalars().all()
         return [UserSchema.from_orm(user) for user in users]
 
+    async def get_organization_groups(self, db: AsyncSession, organization: Organization) -> List[dict]:
+        """Minimal group directory for share pickers: id, name, member count."""
+        from app.models.group import Group
+        from app.models.group_membership import GroupMembership
+
+        groups = (await db.execute(
+            select(Group).where(
+                Group.organization_id == str(organization.id),
+                Group.deleted_at.is_(None),
+            ).order_by(Group.name)
+        )).scalars().all()
+        if not groups:
+            return []
+
+        count_rows = (await db.execute(
+            select(GroupMembership.group_id, func.count(GroupMembership.id))
+            .where(
+                GroupMembership.group_id.in_([str(g.id) for g in groups]),
+                GroupMembership.deleted_at.is_(None),
+            )
+            .group_by(GroupMembership.group_id)
+        )).all()
+        counts = {str(gid): cnt for gid, cnt in count_rows}
+
+        return [
+            {
+                "id": str(g.id),
+                "name": g.name,
+                "description": g.description,
+                "member_count": counts.get(str(g.id), 0),
+            }
+            for g in groups
+        ]
+
     # ------------------------------------------------------------------
     # Excel / CSV import of memberships
     # ------------------------------------------------------------------

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -115,19 +115,41 @@ class ReportService:
             if str(user.id) == str(report.user_id):
                 return
             share_type = 'artifact' if visibility_field == 'artifact_visibility' else 'conversation'
-            stmt = select(ReportShare).where(
+            # Granted directly, or through membership of a shared group.
+            user_group_ids = self._user_group_ids_subquery(user.id, report.organization_id)
+            stmt = select(ReportShare.id).where(
                 ReportShare.report_id == report.id,
-                ReportShare.user_id == user.id,
                 ReportShare.share_type == share_type,
                 ReportShare.deleted_at.is_(None),
-            )
+                or_(
+                    ReportShare.user_id == user.id,
+                    ReportShare.group_id.in_(user_group_ids),
+                ),
+            ).limit(1)
             result = await db.execute(stmt)
             if not result.scalar_one_or_none():
                 raise HTTPException(status_code=403, detail="Access denied")
             return
 
+    @staticmethod
+    def _user_group_ids_subquery(user_id, organization_id):
+        """Selectable of group ids the user belongs to within an org."""
+        from app.models.group import Group
+        from app.models.group_membership import GroupMembership
+        return (
+            select(GroupMembership.group_id)
+            .join(Group, Group.id == GroupMembership.group_id)
+            .where(
+                GroupMembership.user_id == str(user_id),
+                GroupMembership.deleted_at.is_(None),
+                Group.organization_id == str(organization_id),
+                Group.deleted_at.is_(None),
+            )
+        )
+
     async def _emit_share_event(
         self, db, *, report, share_type, visibility, shared_user_ids, current_user,
+        shared_group_ids=None,
     ) -> None:
         """Emit a silent report_shared / artifact_shared (or the unshared/off
         counterpart) event when sharing changes. share_type ∈ {conversation,
@@ -147,6 +169,12 @@ class ReportService:
                         select(_User.name, _User.email).where(_User.id.in_([str(u) for u in shared_user_ids]))
                     )).all()
                     names = [(n or e) for (n, e) in rows]
+                if shared_group_ids:
+                    from app.models.group import Group as _Group
+                    group_rows = (await db.execute(
+                        select(_Group.name).where(_Group.id.in_([str(g) for g in shared_group_ids]))
+                    )).all()
+                    names.extend([f"the {n} group" for (n,) in group_rows])
                 shared_with = names or ['specific people']
             elif visibility == 'public':
                 shared_with = ['anyone with the link']
@@ -180,21 +208,40 @@ class ReportService:
         current_user: User,
         organization: Organization,
         run_identity: str | None = None,
+        shared_group_ids: list[str] | None = None,
     ) -> dict:
         """Set visibility for artifact or conversation sharing.
 
         share_type: 'artifact' or 'conversation'
         visibility: 'none', 'shared', 'internal', 'public'
         shared_user_ids: list of user IDs (required when visibility == 'shared')
+        shared_group_ids: list of group IDs whose members can view; like
+        shared_user_ids, None leaves the existing group grants unchanged
         run_identity: artifact only — whose credentials viewer-triggered runs
         use ('viewer' | 'creator'); None leaves the current setting unchanged
         """
         from app.models.report_share import ReportShare
+        from app.models.group import Group
 
         result = await db.execute(select(Report).filter(Report.id == report_id))
         report = result.scalar_one_or_none()
         if not report:
             raise HTTPException(status_code=404, detail="Report not found")
+
+        # Group grants must reference groups of the report's own organization.
+        if shared_group_ids:
+            shared_group_ids = [str(g) for g in shared_group_ids]
+            valid_rows = (await db.execute(
+                select(Group.id).where(
+                    Group.id.in_(shared_group_ids),
+                    Group.organization_id == str(organization.id),
+                    Group.deleted_at.is_(None),
+                )
+            )).all()
+            valid_ids = {str(r[0]) for r in valid_rows}
+            unknown = [g for g in shared_group_ids if g not in valid_ids]
+            if unknown:
+                raise HTTPException(status_code=400, detail="Unknown group in shared_group_ids")
 
         field = 'artifact_visibility' if share_type == 'artifact' else 'conversation_visibility'
         setattr(report, field, visibility)
@@ -225,35 +272,65 @@ class ReportService:
             else:
                 report.conversation_share_enabled = False
 
-        # Update shares list
+        # Update shares list. User and group grants are replaced independently:
+        # a None list leaves that principal kind untouched (so e.g. the
+        # run-identity-only PUT, which sends neither list, changes nothing).
         newly_added_user_ids: list[str] = []
-        if visibility == 'shared' and shared_user_ids is not None:
-            # Snapshot who already had this share so we only notify *new* recipients.
-            existing_rows = (await db.execute(
-                select(ReportShare.user_id).where(
-                    ReportShare.report_id == report_id,
-                    ReportShare.share_type == share_type,
-                    ReportShare.deleted_at.is_(None),
+        newly_added_group_ids: list[str] = []
+        if visibility == 'shared':
+            if shared_user_ids is not None:
+                # Snapshot who already had this share so we only notify *new* recipients.
+                existing_rows = (await db.execute(
+                    select(ReportShare.user_id).where(
+                        ReportShare.report_id == report_id,
+                        ReportShare.share_type == share_type,
+                        ReportShare.user_id.isnot(None),
+                        ReportShare.deleted_at.is_(None),
+                    )
+                )).all()
+                existing_uids = {str(r[0]) for r in existing_rows}
+                # Remove existing user shares for this type
+                await db.execute(
+                    delete(ReportShare).where(
+                        ReportShare.report_id == report_id,
+                        ReportShare.share_type == share_type,
+                        ReportShare.user_id.isnot(None),
+                    )
                 )
-            )).all()
-            existing_uids = {str(r[0]) for r in existing_rows}
-            # Remove existing shares for this type
-            await db.execute(
-                delete(ReportShare).where(
-                    ReportShare.report_id == report_id,
-                    ReportShare.share_type == share_type,
+                # Add new shares
+                for uid in shared_user_ids:
+                    share = ReportShare(
+                        report_id=report_id,
+                        user_id=uid,
+                        share_type=share_type,
+                    )
+                    db.add(share)
+                newly_added_user_ids = [str(u) for u in shared_user_ids if str(u) not in existing_uids]
+            if shared_group_ids is not None:
+                existing_group_rows = (await db.execute(
+                    select(ReportShare.group_id).where(
+                        ReportShare.report_id == report_id,
+                        ReportShare.share_type == share_type,
+                        ReportShare.group_id.isnot(None),
+                        ReportShare.deleted_at.is_(None),
+                    )
+                )).all()
+                existing_gids = {str(r[0]) for r in existing_group_rows}
+                await db.execute(
+                    delete(ReportShare).where(
+                        ReportShare.report_id == report_id,
+                        ReportShare.share_type == share_type,
+                        ReportShare.group_id.isnot(None),
+                    )
                 )
-            )
-            # Add new shares
-            for uid in shared_user_ids:
-                share = ReportShare(
-                    report_id=report_id,
-                    user_id=uid,
-                    share_type=share_type,
-                )
-                db.add(share)
-            newly_added_user_ids = [str(u) for u in shared_user_ids if str(u) not in existing_uids]
-        elif visibility != 'shared':
+                for gid in shared_group_ids:
+                    db.add(ReportShare(
+                        report_id=report_id,
+                        group_id=gid,
+                        share_type=share_type,
+                    ))
+                newly_added_group_ids = [g for g in shared_group_ids if g not in existing_gids]
+        else:
             # Clear shares if moving away from shared mode
             await db.execute(
                 delete(ReportShare).where(
@@ -283,6 +360,7 @@ class ReportService:
             await self._emit_share_event(
                 db, report=report, share_type=share_type, visibility=visibility,
                 shared_user_ids=shared_user_ids, current_user=current_user,
+                shared_group_ids=shared_group_ids,
             )
         except Exception:
             pass
@@ -290,12 +368,33 @@ class ReportService:
         # Notify-first: the durable in-app notification is the canonical record of
         # "shared with you" — created here on the share grant itself (email stays
         # the explicit opt-in action). Non-fatal: sharing must not depend on it.
-        if newly_added_user_ids:
+        notify_user_ids = list(newly_added_user_ids)
+        if newly_added_group_ids:
+            # A newly shared group notifies its registered members too.
+            try:
+                from app.models.group_membership import GroupMembership
+                member_rows = (await db.execute(
+                    select(GroupMembership.user_id).where(
+                        GroupMembership.group_id.in_(newly_added_group_ids),
+                        GroupMembership.user_id.isnot(None),
+                        GroupMembership.deleted_at.is_(None),
+                    )
+                )).all()
+                seen = set(notify_user_ids)
+                seen.add(str(report.user_id))
+                seen.add(str(current_user.id))
+                for (uid,) in member_rows:
+                    if str(uid) not in seen:
+                        notify_user_ids.append(str(uid))
+                        seen.add(str(uid))
+            except Exception:
+                logger.warning("failed to expand group members for share notification", exc_info=True)
+        if notify_user_ids:
             try:
                 from app.services.inbox_service import inbox_service
                 await inbox_service.notify_share(
                     db, report=report, share_type=share_type,
-                    user_ids=newly_added_user_ids, actor_user=current_user,
+                    user_ids=notify_user_ids, actor_user=current_user,
                 )
             except Exception:
                 logger.warning("share in-app notification failed", exc_info=True)
@@ -337,6 +436,7 @@ class ReportService:
             "share_type": share_type,
             "visibility": visibility,
             "shared_user_ids": shared_user_ids or [],
+            "shared_group_ids": shared_group_ids or [],
             "shared_run_identity": report.shared_run_identity,
             "conversation_share_token": report.conversation_share_token if share_type == 'conversation' and visibility != 'none' else None,
         }
@@ -347,12 +447,13 @@ class ReportService:
         report_id: str,
         share_type: str,
     ) -> list[dict]:
-        """Get list of users a report is shared with for a given share_type."""
+        """Get the users and groups a report is shared with for a share_type."""
         from app.models.report_share import ReportShare
+        from app.models.group_membership import GroupMembership
 
         stmt = (
             select(ReportShare)
-            .options(selectinload(ReportShare.user))
+            .options(selectinload(ReportShare.user), selectinload(ReportShare.group))
             .where(
                 ReportShare.report_id == report_id,
                 ReportShare.share_type == share_type,
@@ -362,17 +463,36 @@ class ReportService:
         result = await db.execute(stmt)
         shares = result.scalars().all()
 
-        return [
-            {
+        # Member counts for group entries, one grouped query.
+        group_ids = [str(s.group_id) for s in shares if s.group_id]
+        member_counts: dict[str, int] = {}
+        if group_ids:
+            count_rows = (await db.execute(
+                select(GroupMembership.group_id, func.count(GroupMembership.id))
+                .where(
+                    GroupMembership.group_id.in_(group_ids),
+                    GroupMembership.deleted_at.is_(None),
+                )
+                .group_by(GroupMembership.group_id)
+            )).all()
+            member_counts = {str(gid): cnt for gid, cnt in count_rows}
+
+        out = []
+        for s in shares:
+            entry = {
                 "id": str(s.id),
-                "user_id": str(s.user_id),
+                "principal_type": "group" if s.group_id else "user",
+                "user_id": str(s.user_id) if s.user_id else None,
                 "user_name": s.user.name if s.user else None,
                 "user_email": s.user.email if s.user else None,
+                "group_id": str(s.group_id) if s.group_id else None,
+                "group_name": s.group.name if s.group else None,
+                "member_count": member_counts.get(str(s.group_id), 0) if s.group_id else None,
                 "share_type": s.share_type,
                 "created_at": s.created_at.isoformat() if s.created_at else None,
             }
-            for s in shares
-        ]
+            out.append(entry)
+        return out
 
     async def _detect_app_version(self, db: AsyncSession, report_id: str) -> str:
         """Detect app version for routing decisions based on agent execution data."""
@@ -495,11 +615,19 @@ class ReportService:
             shared_run_identity=getattr(report, "shared_run_identity", "viewer") or "viewer",
             artifact_shared_user_ids=[
                 str(s.user_id) for s in (report.shares or [])
-                if s.share_type == 'artifact' and s.deleted_at is None
+                if s.share_type == 'artifact' and s.user_id and s.deleted_at is None
             ],
             conversation_shared_user_ids=[
                 str(s.user_id) for s in (report.shares or [])
-                if s.share_type == 'conversation' and s.deleted_at is None
+                if s.share_type == 'conversation' and s.user_id and s.deleted_at is None
+            ],
+            artifact_shared_group_ids=[
+                str(s.group_id) for s in (report.shares or [])
+                if s.share_type == 'artifact' and s.group_id and s.deleted_at is None
+            ],
+            conversation_shared_group_ids=[
+                str(s.group_id) for s in (report.shares or [])
+                if s.share_type == 'conversation' and s.group_id and s.deleted_at is None
             ],
             # Scheduled rerun notification subscribers
             notification_subscribers=getattr(report, "notification_subscribers", None),
@@ -1796,11 +1924,18 @@ class ReportService:
                 )
                 base_conditions.append(Report.project_id == str(target_project.id))
 
-            # Shared visibility: reports the user has been explicitly shared with
+            # Shared visibility: reports shared with the user directly or via
+            # a group they belong to.
             from app.models.report_share import ReportShare
+            user_group_ids = self._user_group_ids_subquery(
+                current_user.id, organization.id
+            )
             shared_with_user = Report.id.in_(
                 select(ReportShare.report_id).where(
-                    ReportShare.user_id == current_user.id,
+                    or_(
+                        ReportShare.user_id == current_user.id,
+                        ReportShare.group_id.in_(user_group_ids),
+                    ),
                     ReportShare.deleted_at.is_(None),
                 )
             )

--- a/backend/tests/e2e/rbac/test_report_group_sharing.py
+++ b/backend/tests/e2e/rbac/test_report_group_sharing.py
@@ -1,0 +1,237 @@
+"""
+E2E tests for sharing a report's artifact/conversation with a group.
+
+Group members get the same access a direct per-user share grants, resolved
+through group membership at read time:
+- PUT /reports/{id}/visibility/{type} accepts shared_group_ids
+- GET /reports/{id}/shares/{type} lists group entries (principal_type=group)
+- /r/{id} honors group membership; non-members stay blocked
+- GET /reports?filter=shared surfaces group-shared reports
+- GET /organization/groups exposes the share-picker group directory
+"""
+import uuid
+
+import pytest
+
+
+def _headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+@pytest.fixture
+def group_share_cast(
+    enterprise_license, test_client, create_user, login_user, whoami,
+    invite_user_to_org, create_group, add_user_to_group,
+):
+    """Admin org with a group containing one member and one outsider member."""
+    admin = create_user()
+    admin_token = login_user(admin["email"], admin["password"])
+    org_id = whoami(admin_token)["organizations"][0]["id"]
+
+    member = invite_user_to_org(org_id=org_id, admin_token=admin_token)
+    outsider = invite_user_to_org(org_id=org_id, admin_token=admin_token)
+
+    group_resp = create_group(
+        name=f"Analysts {uuid.uuid4().hex[:6]}", user_token=admin_token, org_id=org_id
+    )
+    assert group_resp.status_code == 200, group_resp.json()
+    group = group_resp.json()
+
+    add_resp = add_user_to_group(
+        group_id=group["id"], user_id=member["user_id"],
+        user_token=admin_token, org_id=org_id,
+    )
+    assert add_resp.status_code in (200, 201), add_resp.json()
+
+    return {
+        "admin_token": admin_token,
+        "org_id": org_id,
+        "group": group,
+        "member": member,
+        "outsider": outsider,
+    }
+
+
+@pytest.mark.e2e
+def test_share_with_group_lists_group_entry(
+    group_share_cast, create_report, set_visibility, get_shares, get_report,
+):
+    cast = group_share_cast
+    report = create_report(
+        title="Group Shared", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+
+    resp = set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_user_ids=[], shared_group_ids=[cast["group"]["id"]],
+    )
+    data = resp.json()
+    assert data["visibility"] == "shared"
+    assert cast["group"]["id"] in data["shared_group_ids"]
+
+    shares = get_shares(report["id"], "artifact", user_token=cast["admin_token"], org_id=cast["org_id"])
+    assert len(shares) == 1
+    entry = shares[0]
+    assert entry["principal_type"] == "group"
+    assert entry["group_id"] == cast["group"]["id"]
+    assert entry["group_name"] == cast["group"]["name"]
+    assert entry["member_count"] == 1
+    assert entry["user_id"] is None
+
+    fetched = get_report(report["id"], user_token=cast["admin_token"], org_id=cast["org_id"])
+    assert fetched["artifact_shared_group_ids"] == [cast["group"]["id"]]
+    assert fetched["artifact_shared_user_ids"] == []
+
+
+@pytest.mark.e2e
+def test_group_member_can_view_shared_artifact(
+    group_share_cast, test_client, create_report, set_visibility,
+):
+    cast = group_share_cast
+    report = create_report(
+        title="Group Access", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_user_ids=[], shared_group_ids=[cast["group"]["id"]],
+    )
+
+    # Group member can view
+    resp = test_client.get(
+        f"/api/r/{report['id']}",
+        headers={"Authorization": f"Bearer {cast['member']['token']}"},
+    )
+    assert resp.status_code == 200
+
+    # Org member outside the group is blocked
+    resp = test_client.get(
+        f"/api/r/{report['id']}",
+        headers={"Authorization": f"Bearer {cast['outsider']['token']}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.e2e
+def test_group_shared_report_appears_in_shared_list(
+    group_share_cast, test_client, create_report, set_visibility,
+):
+    cast = group_share_cast
+    report = create_report(
+        title="Group List Entry", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_user_ids=[], shared_group_ids=[cast["group"]["id"]],
+    )
+
+    def _shared_ids(token):
+        resp = test_client.get(
+            "/api/reports?filter=shared",
+            headers=_headers(token, cast["org_id"]),
+        )
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+        reports = body["reports"] if isinstance(body, dict) and "reports" in body else body
+        return {r["id"] for r in reports}
+
+    assert report["id"] in _shared_ids(cast["member"]["token"])
+    assert report["id"] not in _shared_ids(cast["outsider"]["token"])
+
+
+@pytest.mark.e2e
+def test_remove_group_share_revokes_access(
+    group_share_cast, test_client, create_report, set_visibility, get_shares,
+):
+    cast = group_share_cast
+    report = create_report(
+        title="Group Revoke", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_user_ids=[], shared_group_ids=[cast["group"]["id"]],
+    )
+
+    # Remove the group by re-setting with an empty group list
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_group_ids=[],
+    )
+    shares = get_shares(report["id"], "artifact", user_token=cast["admin_token"], org_id=cast["org_id"])
+    assert shares == []
+
+    resp = test_client.get(
+        f"/api/r/{report['id']}",
+        headers={"Authorization": f"Bearer {cast['member']['token']}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.e2e
+def test_user_shares_survive_group_only_update(
+    group_share_cast, create_report, set_visibility, get_shares,
+):
+    """Omitting shared_user_ids while updating groups leaves user grants intact."""
+    cast = group_share_cast
+    report = create_report(
+        title="Independent Lists", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_user_ids=[cast["outsider"]["user_id"]],
+    )
+    set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_group_ids=[cast["group"]["id"]],
+    )
+
+    shares = get_shares(report["id"], "artifact", user_token=cast["admin_token"], org_id=cast["org_id"])
+    types = sorted(s["principal_type"] for s in shares)
+    assert types == ["group", "user"]
+
+
+@pytest.mark.e2e
+def test_share_with_foreign_group_rejected(
+    group_share_cast, create_user, login_user, whoami, create_report, set_visibility,
+):
+    """A group from another organization cannot be granted access."""
+    cast = group_share_cast
+    report = create_report(
+        title="Foreign Group", user_token=cast["admin_token"],
+        org_id=cast["org_id"], data_sources=[],
+    )
+
+    resp = set_visibility(
+        report["id"], "artifact", "shared",
+        user_token=cast["admin_token"], org_id=cast["org_id"],
+        shared_group_ids=[str(uuid.uuid4())],
+        expect_status=400,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.e2e
+def test_organization_groups_directory(group_share_cast, test_client):
+    """Any org member can list groups (id, name, member_count) for the picker."""
+    cast = group_share_cast
+    resp = test_client.get(
+        "/api/organization/groups",
+        headers=_headers(cast["member"]["token"], cast["org_id"]),
+    )
+    assert resp.status_code == 200, resp.json()
+    groups = resp.json()
+    entry = next((g for g in groups if g["id"] == cast["group"]["id"]), None)
+    assert entry is not None
+    assert entry["name"] == cast["group"]["name"]
+    assert entry["member_count"] == 1

--- a/backend/tests/fixtures/report.py
+++ b/backend/tests/fixtures/report.py
@@ -221,7 +221,7 @@ def get_public_report(test_client):
 
 @pytest.fixture
 def set_visibility(test_client):
-    def _set_visibility(report_id, share_type, visibility, user_token=None, org_id=None, shared_user_ids=None, expect_status=200):
+    def _set_visibility(report_id, share_type, visibility, user_token=None, org_id=None, shared_user_ids=None, shared_group_ids=None, expect_status=200):
         if user_token is None:
             pytest.fail("User token is required for set_visibility")
         if org_id is None:
@@ -235,6 +235,8 @@ def set_visibility(test_client):
         body = {"visibility": visibility}
         if shared_user_ids is not None:
             body["shared_user_ids"] = shared_user_ids
+        if shared_group_ids is not None:
+            body["shared_group_ids"] = shared_group_ids
 
         response = test_client.put(
             f"/api/reports/{report_id}/visibility/{share_type}",

--- a/frontend/components/ShareModal.vue
+++ b/frontend/components/ShareModal.vue
@@ -90,59 +90,64 @@
                 <label class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2 block">{{ $t('share.shareWith') }}</label>
                 <div class="flex items-start gap-2 mb-4">
                     <div class="flex-1 flex flex-wrap items-center gap-1.5 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-1.5 min-h-[32px] focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500 bg-white dark:bg-gray-900">
-                        <span v-for="(user, idx) in pendingUsers" :key="user.id || user.email"
+                        <span v-for="(principal, idx) in pendingPrincipals" :key="principal.kind + ':' + (principal.id || principal.email)"
                             class="inline-flex items-center gap-1 bg-blue-50 dark:bg-blue-950 text-blue-700 text-xs px-2 py-0.5 rounded-full whitespace-nowrap">
-                            {{ user.name || user.email }}
-                            <button @click="removePendingUser(idx)" class="hover:text-red-500 outline-none">
+                            <Icon v-if="principal.kind === 'group'" name="heroicons:user-group" class="w-3 h-3" />
+                            {{ principal.name || principal.email }}
+                            <button @click="removePendingPrincipal(idx)" class="hover:text-red-500 outline-none">
                                 <Icon name="heroicons:x-mark" class="w-3 h-3" />
                             </button>
                         </span>
                         <div class="relative flex-1 min-w-[120px]">
                             <input ref="inputRef" v-model="inputValue" type="text"
                                 class="w-full border-none outline-none text-xs bg-transparent p-0"
-                                :placeholder="$t('share.nameOrEmail')"
+                                :placeholder="groups.length > 0 ? $t('share.nameEmailOrGroup') : $t('share.nameOrEmail')"
                                 @keydown.enter.prevent="handleEnter"
                                 @keydown.,.prevent="handleComma"
                                 @keydown.backspace="handleBackspace"
                                 @input="onInput"
                                 @focus="showDropdown = true"
                                 @blur="onBlur" />
-                            <div v-if="showDropdown && filteredMembers.length > 0"
+                            <div v-if="showDropdown && filteredOptions.length > 0"
                                 class="absolute start-0 top-full mt-1 w-64 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-40 overflow-y-auto">
-                                <button v-for="member in filteredMembers" :key="member.id"
+                                <button v-for="option in filteredOptions" :key="option.kind + ':' + option.id"
                                     class="w-full text-start px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-2.5"
-                                    @mousedown.prevent="addMember(member)">
+                                    @mousedown.prevent="addPrincipal(option)">
                                     <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-xs font-medium text-gray-600 dark:text-gray-400 flex-shrink-0">
-                                        {{ (member.name || member.email).charAt(0).toUpperCase() }}
+                                        <Icon v-if="option.kind === 'group'" name="heroicons:user-group" class="w-3.5 h-3.5" />
+                                        <template v-else>{{ (option.name || option.email).charAt(0).toUpperCase() }}</template>
                                     </div>
                                     <div class="flex flex-col min-w-0">
-                                        <span class="text-gray-900 dark:text-white truncate">{{ member.name || member.email }}</span>
-                                        <span v-if="member.name" class="text-xs text-gray-400 truncate">{{ member.email }}</span>
+                                        <span class="text-gray-900 dark:text-white truncate">{{ option.name || option.email }}</span>
+                                        <span v-if="option.kind === 'group'" class="text-xs text-gray-400 truncate">{{ $t('share.groupMembers', option.memberCount || 0) }}</span>
+                                        <span v-else-if="option.name" class="text-xs text-gray-400 truncate">{{ option.email }}</span>
                                     </div>
                                 </button>
                             </div>
                         </div>
                     </div>
-                    <button @click="inviteUsers" :disabled="pendingUsers.length === 0 || isSaving"
+                    <button @click="invitePrincipals" :disabled="pendingPrincipals.length === 0 || isSaving"
                         class="flex-shrink-0 px-3 h-[32px] text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed">
                         {{ $t('share.share') }}
                     </button>
                 </div>
 
-                <!-- People with access -->
-                <div v-if="sharedUsers.length > 0" class="space-y-0.5">
-                    <div v-for="user in sharedUsers" :key="user.user_id"
+                <!-- People and groups with access -->
+                <div v-if="sharedEntries.length > 0" class="space-y-0.5">
+                    <div v-for="entry in sharedEntries" :key="entry.id"
                         class="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 group">
                         <div class="flex items-center gap-2.5">
                             <div class="w-7 h-7 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center text-xs font-medium text-gray-600 dark:text-gray-400">
-                                {{ (user.user_name || user.user_email || '?').charAt(0).toUpperCase() }}
+                                <Icon v-if="entry.principal_type === 'group'" name="heroicons:user-group" class="w-4 h-4" />
+                                <template v-else>{{ (entry.user_name || entry.user_email || '?').charAt(0).toUpperCase() }}</template>
                             </div>
                             <div class="flex flex-col">
-                                <span class="text-sm text-gray-700 dark:text-gray-300">{{ user.user_name || user.user_email }}</span>
-                                <span v-if="user.user_name && user.user_email" class="text-xs text-gray-400">{{ user.user_email }}</span>
+                                <span class="text-sm text-gray-700 dark:text-gray-300">{{ entry.principal_type === 'group' ? entry.group_name : (entry.user_name || entry.user_email) }}</span>
+                                <span v-if="entry.principal_type === 'group'" class="text-xs text-gray-400">{{ $t('share.groupMembers', entry.member_count || 0) }}</span>
+                                <span v-else-if="entry.user_name && entry.user_email" class="text-xs text-gray-400">{{ entry.user_email }}</span>
                             </div>
                         </div>
-                        <button @click="removeSharedUser(user)"
+                        <button @click="removeSharedEntry(entry)"
                             class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity p-1">
                             <Icon name="heroicons:x-mark" class="w-3.5 h-3.5" />
                         </button>
@@ -180,8 +185,9 @@ const isSaving = ref(false)
 const inputRef = ref<HTMLInputElement | null>(null)
 const inputValue = ref('')
 const showDropdown = ref(false)
-const pendingUsers = ref<{ id?: string; name?: string; email: string }[]>([])
-const sharedUsers = ref<any[]>([])
+// Pending picks not yet saved: individual users or whole groups
+const pendingPrincipals = ref<{ kind: 'user' | 'group'; id?: string; name?: string; email?: string; memberCount?: number }[]>([])
+const sharedEntries = ref<any[]>([])
 const copied = ref(false)
 
 const currentVisibility = ref('none')
@@ -236,8 +242,9 @@ const shareUrl = computed(() => {
     return token ? `${window.location.origin}/c/${token}` : ''
 })
 
-// Org members for autocomplete
+// Org members and groups for autocomplete
 const members = ref<{ id: string; name: string; email: string }[]>([])
+const groups = ref<{ id: string; name: string; memberCount: number }[]>([])
 const fetchMembers = async () => {
     try {
         const res = await useMyFetch('/organization/members')
@@ -251,25 +258,46 @@ const fetchMembers = async () => {
     } catch { /* silent */ }
 }
 
-const filteredMembers = computed(() => {
+const fetchGroups = async () => {
+    try {
+        const res = await useMyFetch('/organization/groups')
+        if (res.data.value) {
+            groups.value = (res.data.value as any[]).map((g: any) => ({
+                id: g.id,
+                name: g.name || '',
+                memberCount: g.member_count || 0,
+            }))
+        }
+    } catch { /* silent */ }
+}
+
+const filteredOptions = computed(() => {
     const q = inputValue.value.toLowerCase().trim()
     if (!q) return []
-    const existingIds = new Set([
-        ...sharedUsers.value.map(u => u.user_id),
-        ...pendingUsers.value.map(u => u.id),
+    const existingUserIds = new Set([
+        ...sharedEntries.value.filter(e => e.principal_type !== 'group').map(e => e.user_id),
+        ...pendingPrincipals.value.filter(p => p.kind === 'user').map(p => p.id),
     ])
-    return members.value.filter(
-        m => !existingIds.has(m.id) &&
+    const existingGroupIds = new Set([
+        ...sharedEntries.value.filter(e => e.principal_type === 'group').map(e => e.group_id),
+        ...pendingPrincipals.value.filter(p => p.kind === 'group').map(p => p.id),
+    ])
+    const groupMatches = groups.value.filter(
+        g => !existingGroupIds.has(g.id) && g.name.toLowerCase().includes(q)
+    ).map(g => ({ kind: 'group' as const, id: g.id, name: g.name, email: '', memberCount: g.memberCount }))
+    const userMatches = members.value.filter(
+        m => !existingUserIds.has(m.id) &&
             m.id !== props.report?.user?.id &&
             (m.email.toLowerCase().includes(q) || m.name.toLowerCase().includes(q))
-    ).slice(0, 6)
+    ).map(m => ({ kind: 'user' as const, id: m.id, name: m.name, email: m.email, memberCount: 0 }))
+    return [...groupMatches, ...userMatches].slice(0, 6)
 })
 
 const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
 
-const addMember = (member: { id: string; name: string; email: string }) => {
-    if (!pendingUsers.value.find(u => u.id === member.id)) {
-        pendingUsers.value.push({ id: member.id, name: member.name, email: member.email })
+const addPrincipal = (option: { kind: 'user' | 'group'; id: string; name: string; email?: string; memberCount?: number }) => {
+    if (!pendingPrincipals.value.find(p => p.kind === option.kind && p.id === option.id)) {
+        pendingPrincipals.value.push({ kind: option.kind, id: option.id, name: option.name, email: option.email, memberCount: option.memberCount })
     }
     inputValue.value = ''
     showDropdown.value = false
@@ -277,20 +305,26 @@ const addMember = (member: { id: string; name: string; email: string }) => {
 
 const addEmailAsPending = (email: string) => {
     const clean = email.trim().toLowerCase()
-    if (!clean || !isValidEmail(clean)) return
+    if (!clean) return
+    if (!isValidEmail(clean)) {
+        // Not an email — maybe an exact group name was typed.
+        const group = groups.value.find(g => g.name.toLowerCase() === clean)
+        if (group) addPrincipal({ kind: 'group', ...group })
+        return
+    }
     const member = members.value.find(m => m.email.toLowerCase() === clean)
     if (member) {
-        addMember(member)
+        addPrincipal({ kind: 'user', ...member })
     } else {
         toast.add({ title: t('share.userNotFound'), color: 'orange' })
     }
 }
 
-const removePendingUser = (idx: number) => pendingUsers.value.splice(idx, 1)
+const removePendingPrincipal = (idx: number) => pendingPrincipals.value.splice(idx, 1)
 
 const handleEnter = () => {
-    if (filteredMembers.value.length > 0) {
-        addMember(filteredMembers.value[0])
+    if (filteredOptions.value.length > 0) {
+        addPrincipal(filteredOptions.value[0])
     } else {
         addEmailAsPending(inputValue.value)
     }
@@ -299,7 +333,7 @@ const handleEnter = () => {
 const handleComma = () => addEmailAsPending(inputValue.value)
 
 const handleBackspace = () => {
-    if (!inputValue.value && pendingUsers.value.length > 0) pendingUsers.value.pop()
+    if (!inputValue.value && pendingPrincipals.value.length > 0) pendingPrincipals.value.pop()
 }
 
 const onInput = () => { showDropdown.value = true }
@@ -336,16 +370,24 @@ const fetchShares = async () => {
     try {
         const res = await useMyFetch(`/reports/${props.report.id}/shares/${props.shareType}`)
         if (res.data.value) {
-            sharedUsers.value = res.data.value as any[]
+            sharedEntries.value = res.data.value as any[]
         }
     } catch { /* silent */ }
 }
 
-const saveVisibility = async (visibility: string, userIds?: string[]) => {
+const sharedUserIds = () => sharedEntries.value
+    .filter(e => e.principal_type !== 'group')
+    .map(e => e.user_id)
+const sharedGroupIds = () => sharedEntries.value
+    .filter(e => e.principal_type === 'group')
+    .map(e => e.group_id)
+
+const saveVisibility = async (visibility: string, userIds?: string[], groupIds?: string[]) => {
     isSaving.value = true
     try {
         const body: any = { visibility }
         if (userIds) body.shared_user_ids = userIds
+        if (groupIds) body.shared_group_ids = groupIds
         const res = await useMyFetch(`/reports/${props.report.id}/visibility/${props.shareType}`, {
             method: 'PUT',
             body,
@@ -401,39 +443,45 @@ const onVisibilityChange = async (value: string) => {
     const prev = props.report?.[visibilityField.value] || 'none'
     if (value === prev) return
 
-    const userIds = value === 'shared'
-        ? sharedUsers.value.map(u => u.user_id)
-        : undefined
-    await saveVisibility(value, userIds)
+    const userIds = value === 'shared' ? sharedUserIds() : undefined
+    const groupIds = value === 'shared' ? sharedGroupIds() : undefined
+    await saveVisibility(value, userIds, groupIds)
 }
 
-const inviteUsers = async () => {
-    if (pendingUsers.value.length === 0) return
+const invitePrincipals = async () => {
+    if (pendingPrincipals.value.length === 0) return
 
     if (currentVisibility.value === 'none') {
         currentVisibility.value = 'shared'
     }
 
     const allUserIds = [
-        ...sharedUsers.value.map(u => u.user_id),
-        ...pendingUsers.value.map(u => u.id).filter(Boolean),
+        ...sharedUserIds(),
+        ...pendingPrincipals.value.filter(p => p.kind === 'user').map(p => p.id).filter(Boolean),
+    ]
+    const allGroupIds = [
+        ...sharedGroupIds(),
+        ...pendingPrincipals.value.filter(p => p.kind === 'group').map(p => p.id).filter(Boolean),
     ]
 
-    await saveVisibility(currentVisibility.value === 'shared' ? 'shared' : currentVisibility.value, allUserIds)
+    await saveVisibility(currentVisibility.value === 'shared' ? 'shared' : currentVisibility.value, allUserIds, allGroupIds)
     await fetchShares()
-    pendingUsers.value = []
+    pendingPrincipals.value = []
 }
 
-const removeSharedUser = async (user: any) => {
-    const remaining = sharedUsers.value
-        .filter(u => u.user_id !== user.user_id)
-        .map(u => u.user_id)
+const removeSharedEntry = async (entry: any) => {
+    const remainingUsers = sharedEntries.value
+        .filter(e => e.id !== entry.id && e.principal_type !== 'group')
+        .map(e => e.user_id)
+    const remainingGroups = sharedEntries.value
+        .filter(e => e.id !== entry.id && e.principal_type === 'group')
+        .map(e => e.group_id)
 
-    if (remaining.length === 0 && currentVisibility.value === 'shared') {
+    if (remainingUsers.length === 0 && remainingGroups.length === 0 && currentVisibility.value === 'shared') {
         currentVisibility.value = 'none'
         await saveVisibility('none')
     } else {
-        await saveVisibility('shared', remaining)
+        await saveVisibility('shared', remainingUsers, remainingGroups)
     }
 
     await fetchShares()
@@ -454,7 +502,7 @@ const openModal = async () => {
     currentVisibility.value = props.report?.[visibilityField.value] || 'none'
     conversationShareToken.value = props.report?.conversation_share_token ?? null
     runAsCreator.value = props.report?.shared_run_identity === 'creator'
-    await Promise.all([fetchMembers(), fetchVisibility(), fetchShares()])
+    await Promise.all([fetchMembers(), fetchGroups(), fetchVisibility(), fetchShares()])
 }
 
 // Keep button in sync when report data loads/changes (e.g. after page reload)

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -2101,6 +2101,8 @@
     "access": "الوصول",
     "shareWith": "مشاركة مع",
     "nameOrEmail": "الاسم أو البريد الإلكتروني…",
+    "nameEmailOrGroup": "الاسم أو البريد الإلكتروني أو المجموعة…",
+    "groupMembers": "{n} عضو | {n} أعضاء",
     "visibilityPrivate": "خاص",
     "visibilityPrivateDesc": "أنت فقط من يمكنه الوصول",
     "visibilityShared": "أشخاص محددون",

--- a/locales/de.json
+++ b/locales/de.json
@@ -2101,6 +2101,8 @@
     "access": "Zugriff",
     "shareWith": "Teilen mit",
     "nameOrEmail": "Name oder E-Mail …",
+    "nameEmailOrGroup": "Name, E-Mail oder Gruppe…",
+    "groupMembers": "{n} Mitglied | {n} Mitglieder",
     "visibilityPrivate": "Privat",
     "visibilityPrivateDesc": "Nur Sie haben Zugriff",
     "visibilityShared": "Bestimmte Personen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -2509,6 +2509,8 @@
     "access": "Access",
     "shareWith": "Share with",
     "nameOrEmail": "Name or email…",
+    "nameEmailOrGroup": "Name, email, or group…",
+    "groupMembers": "{n} member | {n} members",
     "visibilityPrivate": "Private",
     "visibilityPrivateDesc": "Only you can access",
     "visibilityShared": "Specific people",

--- a/locales/es.json
+++ b/locales/es.json
@@ -2321,6 +2321,8 @@
     "access": "Acceso",
     "shareWith": "Compartir con",
     "nameOrEmail": "Nombre o correo…",
+    "nameEmailOrGroup": "Nombre, correo o grupo…",
+    "groupMembers": "{n} miembro | {n} miembros",
     "visibilityPrivate": "Privado",
     "visibilityPrivateDesc": "Solo tú puedes acceder",
     "visibilityShared": "Personas específicas",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2101,6 +2101,8 @@
     "access": "Accès",
     "shareWith": "Partager avec",
     "nameOrEmail": "Nom ou e-mail…",
+    "nameEmailOrGroup": "Nom, e-mail ou groupe…",
+    "groupMembers": "{n} membre | {n} membres",
     "visibilityPrivate": "Privé",
     "visibilityPrivateDesc": "Vous seul pouvez accéder",
     "visibilityShared": "Personnes spécifiques",

--- a/locales/he.json
+++ b/locales/he.json
@@ -2321,6 +2321,8 @@
     "access": "גישה",
     "shareWith": "שיתוף עם",
     "nameOrEmail": "שם או דוא״ל…",
+    "nameEmailOrGroup": "שם, אימייל או קבוצה…",
+    "groupMembers": "חבר אחד | {n} חברים",
     "visibilityPrivate": "פרטי",
     "visibilityPrivateDesc": "רק אתם יכולים לגשת",
     "visibilityShared": "אנשים מסוימים",

--- a/locales/it.json
+++ b/locales/it.json
@@ -2101,6 +2101,8 @@
     "access": "Accesso",
     "shareWith": "Condividi con",
     "nameOrEmail": "Nome o e-mail…",
+    "nameEmailOrGroup": "Nome, e-mail o gruppo…",
+    "groupMembers": "{n} membro | {n} membri",
     "visibilityPrivate": "Privato",
     "visibilityPrivateDesc": "Solo tu puoi accedere",
     "visibilityShared": "Persone specifiche",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -2101,6 +2101,8 @@
     "access": "Acesso",
     "shareWith": "Compartilhar com",
     "nameOrEmail": "Nome ou e-mail…",
+    "nameEmailOrGroup": "Nome, e-mail ou grupo…",
+    "groupMembers": "{n} membro | {n} membros",
     "visibilityPrivate": "Privado",
     "visibilityPrivateDesc": "Apenas você pode acessar",
     "visibilityShared": "Pessoas específicas",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -2101,6 +2101,8 @@
     "access": "Доступ",
     "shareWith": "Поделиться с",
     "nameOrEmail": "Имя или электронная почта…",
+    "nameEmailOrGroup": "Имя, эл. почта или группа…",
+    "groupMembers": "{n} участник | {n} участников",
     "visibilityPrivate": "Приватный",
     "visibilityPrivateDesc": "Только вы имеете доступ",
     "visibilityShared": "Конкретные люди",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -2101,6 +2101,8 @@
     "access": "Åtkomst",
     "shareWith": "Dela med",
     "nameOrEmail": "Namn eller e-post…",
+    "nameEmailOrGroup": "Namn, e-post eller grupp…",
+    "groupMembers": "{n} medlem | {n} medlemmar",
     "visibilityPrivate": "Privat",
     "visibilityPrivateDesc": "Endast du har åtkomst",
     "visibilityShared": "Specifika personer",


### PR DESCRIPTION
Report artifact/conversation shares previously accepted only user
principals. This adds group grants end to end:

- report_shares gains a nullable group_id (user_id now nullable too);
  each row names exactly one principal. New migration rsgrp0001.
- PUT /reports/{id}/visibility/{type} accepts shared_group_ids; user and
  group lists are replaced independently so omitting one leaves it
  untouched. Group ids are validated against the report's organization.
- Read gates (_check_visibility) and the reports list query resolve
  access through group membership. GET shares returns typed entries
  (principal_type user|group) with group name and member count.
- New GET /organization/groups: minimal group directory (id, name,
  member count) so any member can address a group by name when sharing,
  without manage_members access.
- ShareModal picker now offers matching groups alongside members,
  renders group chips/rows with member counts, and newly shared groups
  notify their registered members in-app.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0132bi8htTJyVTHWRhm1nRnJ