### PR TITLE
README: tighten the query acceleration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-An agent issues many queries to answer one question, and several agents can be doing that at once. Custom queries let an admin define that SQL up front on a connection: BOW runs it on a schedule and keeps the result in an encrypted local copy that agents query instead of the source. Reads come from local disk in a few milliseconds, concurrent requests do not queue behind an on-prem database, and a consumption-priced warehouse is scanned once per refresh rather than once per question.
+Agents answer in a few milliseconds instead of seconds. Many concurrent requests no longer reach an on-prem database, and a consumption-priced warehouse is scanned once per refresh rather than once per question.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-Agents do not ask once. They explore, refine, and re-check, many of them at the same time. Define the queries worth exposing on a connection and BOW re-runs them on a schedule into an encrypted local copy that agents query instead of the source: answers in milliseconds, no repeated scan bill on consumption-priced warehouses, and no agent traffic reaching a database that was never built to absorb it.
+An agent issues many queries to answer one question, and several agents can be doing that at once. Custom queries let an admin define that SQL up front on a connection: BOW runs it on a schedule and keeps the result in an encrypted local copy that agents query instead of the source. Reads come from local disk in a few milliseconds, concurrent requests do not queue behind an on-prem database, and a consumption-priced warehouse is scanned once per refresh rather than once per question.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-Agents answer in a few milliseconds instead of seconds. Many concurrent requests no longer reach an on-prem database, and a consumption-priced warehouse is scanned once per refresh rather than once per question.
+A query that takes seconds against the source returns in milliseconds from the cache. That is what makes agent workloads practical: agents ask the same question many ways, many of them at once — a pattern that is slow against a legacy on-prem database and expensive against a warehouse that bills per scan. Cached, it is neither.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />

--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-An agent exploring a question does not ask once — it tries a grouping, refines it, checks a total. That burst lands on a database built for the application that owns it, and on a consumption-priced warehouse it is billed every time.
-
-Define the queries worth exposing as custom queries on a connection, and BOW re-runs them on a schedule into an encrypted local copy that agents query instead of the source. A six-query agent workload went from 24 statements against the source to none. Agents get full SQL over the copy — joins, CTEs, and window functions regardless of what the source supports — and are told when it was last refreshed and when it refreshes next, so they can say how current a figure is.
+Agents do not ask once. They explore, refine, and re-check, many of them at the same time. Define the queries worth exposing on a connection and BOW re-runs them on a schedule into an encrypted local copy that agents query instead of the source: answers in milliseconds, no repeated scan bill on consumption-priced warehouses, and no agent traffic reaching a database that was never built to absorb it.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />
@@ -113,9 +111,7 @@ Define the queries worth exposing as custom queries on a connection, and BOW re-
   <img src="./media/readme/final/query-latency-onprem.png" alt="Query latency on PostgreSQL, SQL Server, and Oracle, live versus the cached copy" width="100%" />
 </div>
 
-A refresh is a full run of your SQL, so a copy refreshed more often than it is queried costs more than it saves — the break-even is about 1.8 agent questions per refresh on BigQuery and 1.0 on Snowflake. One copy is shared by every agent that activates it, and row-level security can filter it per person against their profile attributes, groups, or roles.
-
-Available for PostgreSQL, MySQL/MariaDB, SQLite, SQL Server, Oracle, Snowflake, and BigQuery. Microsoft Fabric and Sybase SQL Anywhere are implemented but not yet verified against a live server. Beta — an admin turns it on under **Custom queries** in AI settings. See the [caching documentation](https://docs.bagofwords.com/bow-fast/overview).
+A refresh is a full run of your SQL, so a copy refreshed more often than it is queried costs more than it saves — the break-even is about 1.8 agent questions per refresh on BigQuery and 1.0 on Snowflake. One copy is shared by every agent that activates it, and row-level security can filter it per person against their profile attributes, groups, or roles. See the [caching documentation](https://docs.bagofwords.com/bow-fast/overview).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-A query that takes seconds against the source returns in milliseconds from the cache. That is what makes agent workloads practical: agents ask the same question many ways, many of them at once — a pattern that is slow against a legacy on-prem database and expensive against a warehouse that bills per scan. Cached, it is neither.
+Analytical queries are slow — often a second or more on Snowflake or SQL Server — and an agent runs several of them before it can answer. That breaks the conversation speed people expect from an agent. Cached, the same queries return in milliseconds.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create agents for teams, systems, and business domains. Scope their data, tools,
 
 ### Speed up analytical queries with an auto-updating cache
 
-Analytical queries are slow — often a second or more on Snowflake or SQL Server — and an agent runs several of them before it can answer. That breaks the conversation speed people expect from an agent. Cached, the same queries return in milliseconds.
+Query acceleration with caching lets agents query a warehouse or database at speed, improving the experience for users while reducing load and cost on the source. Admins choose what to cache — whole tables or specific queries — and BOW keeps it refreshed on a schedule.
 
 <div align="center">
   <img src="./media/readme/final/query-latency-cloud.png" alt="Query latency on BigQuery and Snowflake, live versus the cached copy" width="100%" />


### PR DESCRIPTION
Follow-up to #838. Three paragraphs of prose around two charts was more than the section earned.

**Above the images** is now one paragraph covering what the feature is and why it suits agent workloads — many concurrent questions, instant answers, no repeated scan bill, no traffic on a database that was never built to absorb it.

**Drops the per-connector availability paragraph** entirely. Its docs link moves to the end of the remaining paragraph so it isn't lost.

## One thing that moves rather than disappears

That paragraph carried three facts: the supported connector list, the beta gate, and the note that Microsoft Fabric and Sybase SQL Anywhere are implemented but not verified against a live server. All three now live only on the docs page.

That is a reasonable place for them — someone deciding whether to adopt this will be on the docs, not the README — but it does mean the unverified-connector caveat is one click further away than it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB3Y3XF3bibPirGCpQmQxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB3Y3XF3bibPirGCpQmQxE)_