### PR TITLE
Gate custom-query RLS behind enterprise license

### DIFF
--- a/backend/app/ee/license.py
+++ b/backend/app/ee/license.py
@@ -35,6 +35,7 @@ TIER_FEATURES = {
         "model_routing",
         "llm_fallback",
         "pii_protection",
+        "rls",
     ],
 }
 

--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -1187,6 +1187,7 @@ async def custom_query_rls_options(
     make that impossible rather than diagnosable.
     """
     await custom_query_service.ensure_enabled(db, organization)
+    custom_query_service.ensure_rls_licensed()
     await connection_service.get_connection(db, connection_id, organization)
 
     from app.models.group import Group

--- a/backend/app/services/custom_query_service.py
+++ b/backend/app/services/custom_query_service.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.scheduler import scheduler
 from app.data_sources.fast import artifacts, extractor, rls
+from app.ee.license import has_feature
 from app.data_sources.fast.fast_client import FastQueryClient, FastRelation
 from app.models.connection import Connection
 from app.models.connection_table import KIND_BOW, KIND_TABLE, ConnectionTable
@@ -130,6 +131,28 @@ class CustomQueryService:
                 detail=(
                     "Custom queries are in beta and disabled for this organization. "
                     "An admin can enable them in Settings."
+                ),
+            )
+
+    @staticmethod
+    def ensure_rls_licensed() -> None:
+        """Enterprise gate on AUTHORING row policies — not on enforcing them.
+
+        Query acceleration (custom queries) is a community feature; row-level
+        security on top of it is enterprise. The asymmetry is deliberate:
+        enabling, editing or previewing a policy requires the license, but a
+        policy that is already saved keeps filtering even if the license
+        lapses — an expired license must fail closed, never widen anyone's
+        row visibility. Disabling a policy is likewise allowed without a
+        license, so a lapsed org is not stuck with a filter it can no longer
+        administer.
+        """
+        if not has_feature("rls"):
+            raise HTTPException(
+                status_code=402,
+                detail=(
+                    "Row-level security requires an enterprise license. "
+                    "Set BOW_LICENSE_KEY to enable."
                 ),
             )
 
@@ -692,6 +715,9 @@ class CustomQueryService:
         Save rather than by wondering why a report came back empty.
         """
         if rls_enabled:
+            # Enterprise-only to enable or edit; turning OFF stays open so a
+            # lapsed license never traps an org behind its own policy.
+            self.ensure_rls_licensed()
             columns = [
                 c.get("name") for c in (cq.columns or []) if isinstance(c, dict)
             ]
@@ -730,6 +756,8 @@ class CustomQueryService:
         applied the filter differently would be able to disagree with reality,
         which is the one thing a preview must not do.
         """
+        self.ensure_rls_licensed()
+
         from app.models.user import User as UserModel
         from app.services.rls_identity_service import resolve_identity
 
@@ -783,7 +811,12 @@ class CustomQueryService:
 
     @staticmethod
     def compile_rls(row: ConnectionTable, identity: rls.Identity) -> Optional[rls.Filter]:
-        """The filter to apply to `row` for `identity`, or None if unprotected."""
+        """The filter to apply to `row` for `identity`, or None if unprotected.
+
+        Deliberately NOT license-checked: a saved policy is enforced whether or
+        not the enterprise license is still active. Skipping the filter on a
+        lapsed license would turn a billing event into a data leak.
+        """
         if not getattr(row, "rls_enabled", False):
             return None
         return rls.compile_policy(

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -40,6 +40,7 @@ def _e2e_force_enterprise_license():
             "ldap",
             "usage_limits",
             "pii_protection",
+            "rls",
         ],
         license_id="e2e-fake",
     )

--- a/backend/tests/unit/test_custom_query_permissions.py
+++ b/backend/tests/unit/test_custom_query_permissions.py
@@ -125,6 +125,101 @@ def test_the_beta_gate_is_checked_by_every_custom_query_route():
 
 
 @pytest.mark.asyncio
+async def test_enabling_a_row_policy_requires_an_enterprise_license(monkeypatch):
+    """Acceleration is community; the row policies on top of it are enterprise.
+    The check runs before the policy is even validated, so a community instance
+    cannot store one."""
+    from fastapi import HTTPException
+
+    from app.services import custom_query_service as svc_mod
+
+    monkeypatch.setattr(svc_mod, "has_feature", lambda feature: False)
+
+    with pytest.raises(HTTPException) as e:
+        await svc_mod.custom_query_service.set_rls(
+            None, object(), rls_enabled=True,
+            rls_policy={"column": "region", "source": "user.email", "op": "in"},
+        )
+    assert e.value.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_disabling_a_row_policy_needs_no_license(monkeypatch):
+    """A lapsed license must not trap an org behind a policy it can no longer
+    administer — turning RLS off stays open."""
+    from app.services import custom_query_service as svc_mod
+
+    monkeypatch.setattr(svc_mod, "has_feature", lambda feature: False)
+
+    class _Db:
+        async def commit(self):
+            pass
+
+        async def refresh(self, obj):
+            pass
+
+    class _Cq:
+        rls_enabled = True
+        rls_mode = "attribute"
+        rls_policy = {"column": "region"}
+        rls_default_deny = True
+        columns = [{"name": "region"}]
+
+    cq = await svc_mod.custom_query_service.set_rls(_Db(), _Cq(), rls_enabled=False)
+    assert cq.rls_enabled is False
+    assert cq.rls_policy is None
+
+
+@pytest.mark.asyncio
+async def test_preview_as_user_requires_an_enterprise_license(monkeypatch):
+    from fastapi import HTTPException
+
+    from app.services import custom_query_service as svc_mod
+
+    monkeypatch.setattr(svc_mod, "has_feature", lambda feature: False)
+
+    with pytest.raises(HTTPException) as e:
+        await svc_mod.custom_query_service.preview_as_user(None, None, None, "u1")
+    assert e.value.status_code == 402
+
+
+def test_a_saved_policy_keeps_filtering_without_a_license(monkeypatch):
+    """Enforcement never consults the license. If it did, an expired license
+    would silently hand every user the full table — a billing event becoming a
+    data leak."""
+    from app.data_sources.fast.rls import Identity
+    from app.services import custom_query_service as svc_mod
+
+    monkeypatch.setattr(svc_mod, "has_feature", lambda feature: False)
+
+    class _Row:
+        rls_enabled = True
+        rls_mode = "attribute"
+        rls_policy = {"column": "region", "source": "profile.officeLocation", "op": "in"}
+        rls_default_deny = True
+        columns = [{"name": "region"}]
+
+    f = svc_mod.CustomQueryService.compile_rls(
+        _Row(), Identity(user_id="u1", profile_attributes={"officeLocation": "EMEA"})
+    )
+    assert f is not None
+    assert f.allowed_values == ["EMEA"]
+
+
+def test_rls_options_route_checks_the_license():
+    """set_rls and preview_as_user are gated inside the service; rls-options is
+    a plain read with no service call, so the route body must check itself."""
+    from app.routes import connection
+
+    src = inspect.getsource(connection)
+    body = next(
+        b for b in src.split("@router.")
+        if b.splitlines() and "rls-options" in b.splitlines()[0]
+    )
+    assert "ensure_rls_licensed" in body
+
+
+@pytest.mark.asyncio
 async def test_the_service_gate_fails_closed():
     """If the settings lookup itself breaks, the answer must be 'disabled'."""
     from fastapi import HTTPException

--- a/docs/design/custom-query-rls.md
+++ b/docs/design/custom-query-rls.md
@@ -7,6 +7,13 @@ at read time against **who is asking**.
 
 Status: design. Depends on the custom-queries beta (`enable_custom_queries`).
 
+Licensing: RLS is an **enterprise** feature (`rls` in `TIER_FEATURES`), while
+query acceleration itself stays community. The gate sits on *authoring* —
+enabling or editing a policy, the options endpoint, preview-as-user — not on
+*enforcement*: a saved policy keeps filtering even if the license lapses
+(fail closed, never wider), and disabling a policy needs no license so a
+lapsed org isn't stuck behind its own filter.
+
 ## Why this is the unlock, not a nice-to-have
 
 Custom queries are gated on `auth_policy == 'system_only'` today. That excludes

--- a/frontend/components/datasources/CustomQueryModal.vue
+++ b/frontend/components/datasources/CustomQueryModal.vue
@@ -261,7 +261,20 @@
 
       <!-- ============ RLS ============ -->
       <div v-show="tab === 'rls'">
-        <div v-if="!editing" class="text-sm text-gray-500 dark:text-gray-400 py-8 text-center">
+        <!-- Enterprise gate: acceleration is community, row policies are not. -->
+        <div v-if="!rlsLicensed" data-testid="cq-rls-upgrade"
+             class="max-w-xl mx-auto my-8 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 p-5">
+          <div class="flex items-center gap-2 font-medium text-amber-800 dark:text-amber-300">
+            <UIcon name="heroicons-sparkles" class="w-5 h-5" />
+            Row-level security is an Enterprise feature
+          </div>
+          <p class="text-sm text-amber-700 dark:text-amber-400 mt-2">
+            Filter the cached copy per user — by profile attribute, group or role —
+            so each person sees only their own rows. Available with an enterprise
+            license.
+          </p>
+        </div>
+        <div v-else-if="!editing" class="text-sm text-gray-500 dark:text-gray-400 py-8 text-center">
           Save the query first — a row policy filters on its result columns.
         </div>
         <div v-else class="flex gap-5">
@@ -459,6 +472,7 @@
 
 <script setup lang="ts">
 import DataSourceIcon from '@/components/DataSourceIcon.vue'
+import { useEnterprise } from '~/ee/composables/useEnterprise'
 const ROW_LIMIT = 100
 
 const props = defineProps<{
@@ -592,6 +606,9 @@ function close() { isOpen.value = false }
 // not a nicety — it is how an admin confirms the rule does what they meant
 // before anyone depends on it, and it runs the same code path an agent does.
 
+const { hasFeature } = useEnterprise()
+const rlsLicensed = computed(() => hasFeature('rls'))
+
 const rls = reactive({
   enabled: false,
   column: '',
@@ -708,7 +725,7 @@ async function onPreviewAsUser() {
 }
 
 watch(tab, (t) => {
-  if (t !== 'rls' || !editing.value) return
+  if (t !== 'rls' || !editing.value || !rlsLicensed.value) return
   if (!rlsOptions.members.length) loadRlsOptions()
 })
 


### PR DESCRIPTION
Query acceleration (custom queries) stays community; the row-level
security layered on top becomes an enterprise feature ('rls' in
TIER_FEATURES). The gate sits on authoring only: enabling or editing a
policy, the rls-options endpoint, and preview-as-user all require the
license (402), while an already-saved policy keeps filtering even if
the license lapses — fail closed, never wider — and disabling a policy
needs no license so a lapsed org isn't stuck behind its own filter.

Frontend shows the standard enterprise upsell in the modal's RLS tab
when unlicensed instead of the policy editor.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011rsW2r52f6wo4Fsg6T7U1Z