### PR TITLE
Use wall-clock span for block group duration instead of sum

### DIFF
--- a/frontend/composables/useBlockGrouping.ts
+++ b/frontend/composables/useBlockGrouping.ts
@@ -164,9 +164,13 @@ export interface BlockGroup {
   id: string
   blockIds: string[]
   count: number
+  /** Elapsed wall-clock across the run (earliest member start -> latest member
+      end), so inter-step LLM planning time is included. Falls back to the sum
+      of per-tool self-times only when members carry no timestamps. */
   durationMs: number
-  /** True when every non-failed member reported a duration — otherwise the
-      header omits the misleading partial figure. */
+  /** True when the figure covers the whole run (span with every member ended,
+      or — in the fallback — every non-failed member reported a duration).
+      Otherwise the header omits the misleading partial figure. */
   durationComplete: boolean
   /** Handled-error members absorbed into this group (amber count on header). */
   issueCount: number
@@ -197,6 +201,28 @@ function llmTitle(block: any): string {
   return typeof t === 'string' ? t.trim() : ''
 }
 
+/** Parse an ISO/epoch timestamp to epoch ms, or null if absent/unparseable.
+    Backend serializes timestamps as UTC ISO strings with a `Z` suffix, so
+    Date.parse resolves them unambiguously. */
+function toEpochMs(v: any): number | null {
+  if (v === null || v === undefined || v === '') return null
+  const t = typeof v === 'number' ? v : Date.parse(v)
+  return Number.isFinite(t) ? t : null
+}
+
+/** Earliest start of a member: prefer the block span (which brackets this
+    step's LLM planning + tool run — block.started_at is the plan decision's
+    creation), falling back to the tool execution's own start. */
+function memberStartMs(b: any): number | null {
+  return toEpochMs(b?.started_at) ?? toEpochMs(b?.tool_execution?.started_at)
+}
+
+/** Latest end of a member: block completion mirrors the tool's completion;
+    fall back to the tool execution's own end. */
+function memberEndMs(b: any): number | null {
+  return toEpochMs(b?.completed_at) ?? toEpochMs(b?.tool_execution?.completed_at)
+}
+
 // Family labels are stored as plurals; explicit singulars — a regex
 // singularizer produced "1 note updat".
 const SINGULAR: Record<string, string> = {
@@ -213,24 +239,37 @@ const SINGULAR: Record<string, string> = {
 function buildGroup(run: any[]): BlockGroup {
   const famCounts = new Map<string, number>()
   const toolNames: string[] = []
-  let durationMs = 0
-  let durationKnown = 0
+  // Sum of per-tool self-times — the fallback when members carry no
+  // timestamps (older reports / unit fixtures).
+  let sumMs = 0
+  let sumKnown = 0
   let okMembers = 0
   let lastTitle = ''
   let active = false
   let runningLabel = ''
   let issueCount = 0
+  // Wall-clock span material: earliest member start -> latest member end.
+  let minStart = Infinity
+  let maxEnd = -Infinity
+  let startsKnown = 0
+  let endsKnown = 0
   for (const b of run) {
     const name = b?.tool_execution?.tool_name || ''
     if (name && !toolNames.includes(name)) toolNames.push(name)
     const fam = verbFamily(name)
     famCounts.set(fam, (famCounts.get(fam) || 0) + 1)
+    // Every member (including a handled-error probe) counts toward the span —
+    // it consumed elapsed time before the run moved on.
+    const s = memberStartMs(b)
+    const e = memberEndMs(b)
+    if (s !== null) { startsKnown += 1; if (s < minStart) minStart = s }
+    if (e !== null) { endsKnown += 1; if (e > maxEnd) maxEnd = e }
     if (isBlockFailed(b)) {
       issueCount += 1
     } else {
       okMembers += 1
       const d = Number(b?.tool_execution?.duration_ms || 0)
-      if (d > 0) { durationMs += d; durationKnown += 1 }
+      if (d > 0) { sumMs += d; sumKnown += 1 }
       const t = llmTitle(b)
       if (t) lastTitle = t
       if (!isBlockSettled(b)) {
@@ -238,6 +277,25 @@ function buildGroup(run: any[]): BlockGroup {
         runningLabel = t || humanToolLabel(name)
       }
     }
+  }
+  // Prefer elapsed wall-clock over the sum of per-tool self-times. duration_ms
+  // measures only each tool's own execution and excludes the LLM planning
+  // between steps, so summing it makes a several-second group read as "1s".
+  // The span from the first member's start to the last member's end includes
+  // those inter-step gaps — the time the user actually waited. Fall back to the
+  // sum only when members carry no usable timestamps.
+  const spanValid = startsKnown === run.length && endsKnown > 0 && maxEnd >= minStart
+  let durationMs: number
+  let durationComplete: boolean
+  if (spanValid) {
+    durationMs = maxEnd - minStart
+    // Trust the span's end only when every member reported one. A missing end
+    // means a member is still in flight — but then `active` is true and the
+    // duration isn't rendered anyway.
+    durationComplete = endsKnown === run.length
+  } else {
+    durationMs = sumMs
+    durationComplete = okMembers > 0 && sumKnown === okMembers
   }
   const verbSummary = Array.from(famCounts.entries())
     .sort((a, b) => b[1] - a[1])
@@ -248,7 +306,7 @@ function buildGroup(run: any[]): BlockGroup {
     blockIds: run.map((b) => String(b?.id ?? '')),
     count: run.length,
     durationMs,
-    durationComplete: okMembers > 0 && durationKnown === okMembers,
+    durationComplete,
     issueCount,
     verbSummary,
     lastTitle,

--- a/frontend/tests/unit/useBlockGrouping.mjs
+++ b/frontend/tests/unit/useBlockGrouping.mjs
@@ -163,6 +163,54 @@ assert.equal(
   assert.equal(g2.headerAt[missing[0].id].durationComplete, false)
 }
 
+// wall-clock span: when members carry timestamps, durationMs is the elapsed
+// time from the first member's start to the last member's end (which includes
+// the inter-step LLM planning gaps), NOT the sum of per-tool self-times.
+{
+  // Three 300ms tools (sum = 900ms) but spread over ~5s of wall-clock because
+  // the model spent seconds planning between each step. The header must show
+  // the ~5s the user waited, not "1s".
+  const t0 = Date.parse('2026-08-01T00:00:00.000Z')
+  const iso = (ms) => new Date(t0 + ms).toISOString()
+  const spanChip = (startMs, endMs) => chip('read_file', {
+    te: { duration_ms: endMs - startMs, started_at: iso(startMs), completed_at: iso(endMs) },
+    block: { started_at: iso(startMs), completed_at: iso(endMs) },
+  })
+  const blocks = [
+    spanChip(0, 300),      // step 1 runs 0.0-0.3s
+    spanChip(2300, 2600),  // ~2s of planning, then step 2
+    spanChip(4700, 5000),  // ~2s of planning, then step 3
+  ]
+  const g = computeBlockGroups(blocks)
+  const group = g.headerAt[blocks[0].id]
+  assert.ok(group)
+  assert.equal(group.durationMs, 5000)        // span, not 900 (the sum)
+  assert.equal(group.durationComplete, true)
+}
+
+// span falls back to the summed self-times when members carry no timestamps
+{
+  const blocks = [chip('read_file'), chip('read_file'), chip('read_file')]
+  const g = computeBlockGroups(blocks)
+  assert.equal(g.headerAt[blocks[0].id].durationMs, 3000) // 3 * 1000ms fallback
+  assert.equal(g.headerAt[blocks[0].id].durationComplete, true)
+}
+
+// mixed: if any member lacks a start timestamp the span can't be trusted, so
+// it falls back to the sum rather than undercounting from a later start
+{
+  const t0 = Date.parse('2026-08-01T00:00:00.000Z')
+  const iso = (ms) => new Date(t0 + ms).toISOString()
+  const timed = chip('read_file', {
+    te: { duration_ms: 1000, started_at: iso(4000), completed_at: iso(5000) },
+    block: { started_at: iso(4000), completed_at: iso(5000) },
+  })
+  const untimed = chip('read_file') // duration_ms 1000, no timestamps
+  const g = computeBlockGroups([untimed, timed])
+  // startsKnown (1) !== run.length (2) -> fallback to sum = 2000ms
+  assert.equal(g.headerAt[untimed.id].durationMs, 2000)
+}
+
 // breakBefore forces a boundary (steering interleave): 2 + 2 -> two groups
 // instead of one of four
 {


### PR DESCRIPTION
## Summary
Changed block group duration calculation to use the elapsed wall-clock time (from earliest member start to latest member end) instead of summing per-tool self-times. This provides more accurate duration reporting that includes inter-step LLM planning time.

## Key Changes
- **Duration calculation logic**: Replaced simple summation of `duration_ms` with a wall-clock span calculation that tracks the earliest start and latest end across all group members
- **Timestamp parsing**: Added `toEpochMs()` helper to safely parse ISO 8601 timestamps and epoch milliseconds from block data
- **Member timing helpers**: Added `memberStartMs()` and `memberEndMs()` functions to extract timestamps from blocks, preferring the block-level timestamps (which bracket the full step including LLM planning) over tool execution timestamps
- **Fallback mechanism**: When members lack usable timestamps (older reports or test fixtures), the implementation falls back to the original sum-of-self-times approach
- **Completeness tracking**: Updated `durationComplete` logic to reflect whether the span covers the entire run (all members have end timestamps) or falls back to the sum (all non-failed members reported durations)
- **Documentation**: Updated JSDoc comments to clarify the new behavior and fallback strategy

## Implementation Details
- The span is only considered valid when all members have start timestamps and at least one has an end timestamp
- The span's end is only marked complete when every member reported an end timestamp (indicating no members are still in flight)
- Added comprehensive test cases covering: wall-clock span calculation with inter-step gaps, fallback to sum when timestamps are absent, and mixed scenarios with partial timestamps

https://claude.ai/code/session_01YDUz2hmRDYyiowEsixRqFA