### PR TITLE
Scope standing instructions to roster focus, gate intelligent by query match

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -7,7 +7,7 @@ import time as _time
 import uuid as _uuid_mod
 from datetime import datetime
 from contextlib import asynccontextmanager
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from pydantic import ValidationError
 from opentelemetry.trace import StatusCode
 
@@ -1012,6 +1012,52 @@ class AgentV2:
             except Exception:
                 pass
 
+    def _resolve_instruction_scope_ids(self) -> Optional[List[str]]:
+        """Data-source scope for the standing <instructions> block.
+
+        Mirrors the agent roster/focus policy (``decide_focus_mode``) so a report
+        attached to many agents does not force-load every agent's always-on
+        instructions before any of those agents is in play. The instruction
+        builder always keeps GLOBAL (no-agent) instructions regardless of scope;
+        this only bounds the agent-attached ones:
+
+          - Few agents (roster "all" mode): full attached scope (unchanged).
+          - Many agents / explicit focus ("pick"/"focus"): globals + the focused
+            and run-loaded agents only. An empty list scopes to globals alone —
+            i.e. nothing agent-specific loads until an agent is picked (an agent's
+            always-on rules then ride in with its schema).
+
+        Returns the list of data-source ids to scope to. Falls back to the full
+        attached scope on any error (never widens beyond attached agents).
+        """
+        try:
+            from app.ai.context.agent_roster import decide_focus_mode
+
+            # Roster = attached agents, merged the same way _render_schemas_with_roster
+            # does (self.data_sources may miss an agent attached mid-run).
+            roster_sources = list(self.data_sources or [])
+            known = {str(d.id) for d in roster_sources}
+            if self.report:
+                for ds in (getattr(self.report, "data_sources", None) or []):
+                    if str(ds.id) not in known:
+                        roster_sources.append(ds)
+                        known.add(str(ds.id))
+            roster_ids = {str(d.id) for d in roster_sources}
+            full_scope = sorted(roster_ids)
+
+            explicit = (
+                [str(x) for x in (getattr(self.report, "focused_data_source_ids", None) or [])]
+                if self.report else []
+            )
+            focus_ids, mode = decide_focus_mode(roster_ids, explicit, len(roster_ids))
+            if mode == "all":
+                return full_scope
+            loaded = {str(x) for x in (getattr(self, "loaded_agent_ids", ()) or ())}
+            return sorted((set(focus_ids) | loaded) & roster_ids)
+        except Exception:
+            logger.exception("instruction scope resolve failed; using full attached scope")
+            return [str(d.id) for d in (self.data_sources or [])] or None
+
     async def _render_schemas_with_roster(self, schemas_ctx):
         """Render the schema block, applying the agent roster/focus policy.
 
@@ -1311,6 +1357,15 @@ class AgentV2:
     async def estimate_prompt_tokens(self) -> dict:
         """Approximate the total planner prompt tokens without executing tools."""
         try:
+            # Match the real run's instruction scope so the estimate reflects the
+            # roster-focused <instructions> block, not every agent's rules.
+            try:
+                if getattr(self.context_hub, "instruction_builder", None) is not None:
+                    self.context_hub.instruction_builder.data_source_ids = (
+                        self._resolve_instruction_scope_ids()
+                    )
+            except Exception:
+                logger.exception("estimate instruction scope failed; leaving full scope")
             await self.context_hub.prime_static()
             await self.context_hub.refresh_warm()
             try:
@@ -3529,6 +3584,18 @@ class AgentV2:
                 _model_default_effort,
             )
 
+            # Scope the standing <instructions> block to the roster's focus
+            # BEFORE priming, so a report over many agents doesn't force-load
+            # every agent's always-on instructions on a trivial turn. Globals are
+            # always kept by the builder; this only bounds agent-attached ones.
+            try:
+                if getattr(self.context_hub, "instruction_builder", None) is not None:
+                    self.context_hub.instruction_builder.data_source_ids = (
+                        self._resolve_instruction_scope_ids()
+                    )
+            except Exception:
+                logger.exception("initial instruction scope failed; leaving full scope")
+
             # Prime static and refresh warm in parallel for faster startup
             # Pass prompt_text to enable intelligent instruction search
             with tracer.start_as_current_span("agent.context_initial_load") as span:
@@ -3834,10 +3901,15 @@ class AgentV2:
                             # describe_tables calls).
                             try:
                                 from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
+                                # Scope to the roster's focus (now including any
+                                # agent focused/loaded this run), so a mid-run
+                                # added agent's always-on rules become visible
+                                # while other agents' rules stay deferred.
+                                _instr_scope = self._resolve_instruction_scope_ids()
                                 _ib = InstructionContextBuilder(
                                     self.db, self.organization,
                                     current_user=getattr(self.head_completion, "user", None) if self.head_completion else None,
-                                    data_source_ids=[str(d.id) for d in (self.report.data_sources or [])] if self.report else None,
+                                    data_source_ids=_instr_scope,
                                     mode=self.mode,
                                 )
                                 instructions = (await _ib.build(query=None)).render(include_catalog=True)
@@ -3846,9 +3918,7 @@ class AgentV2:
                                 # call, so without this a mid-run added agent's
                                 # rules never reach the coder either.
                                 if getattr(self.context_hub, "instruction_builder", None) is not None and self.report:
-                                    self.context_hub.instruction_builder.data_source_ids = [
-                                        str(d.id) for d in (self.report.data_sources or [])
-                                    ]
+                                    self.context_hub.instruction_builder.data_source_ids = _instr_scope
                             except Exception:
                                 logger.exception("instruction re-scope on focus change failed")
                             self._rendered_focus_key = _focus_key

--- a/backend/app/ai/context/agent_roster.py
+++ b/backend/app/ai/context/agent_roster.py
@@ -33,6 +33,38 @@ from sqlalchemy import func, select
 DEFAULT_INDEX_THRESHOLD = int(os.environ.get("BOW_AGENT_INDEX_THRESHOLD", "4"))
 
 
+def decide_focus_mode(
+    roster_ids,
+    explicit,
+    n: int,
+    *,
+    threshold: int = DEFAULT_INDEX_THRESHOLD,
+) -> Tuple[List[str], str]:
+    """Single source of truth for the roster gate.
+
+    Given the set of attached agent ids, the caller's explicit
+    ``report.focused_data_source_ids``, and the attached-agent count ``n``,
+    decide how much to pre-load. Returns ``(focus_ids, mode)``:
+
+      - ``([], "all")``       few agents, no explicit focus → render everything
+                              (behavior identical to before the roster feature).
+      - ``(explicit, "focus")`` explicit report focus honored.
+      - ``([], "pick")``      many agents, nothing picked → roster only; the
+                              model must choose (search_agents/set_report_agents).
+
+    Used by both the schema roster (``build_focus_and_roster``) and the standing
+    <instructions> scope so the two never disagree about which agents are "in
+    play" for a turn.
+    """
+    roster = set(roster_ids or ())
+    explicit = [str(x) for x in (explicit or []) if str(x) in roster]
+    if not explicit and n <= threshold:
+        return [], "all"
+    if explicit:
+        return explicit, "focus"
+    return [], "pick"
+
+
 # Connection types whose tools are the EMAIL family (search_email/read_email/
 # list_emails) — file tools reject them, and the model can't tell from the
 # item count alone (mailboxes render as file scopes). Surfacing this in the
@@ -286,21 +318,20 @@ async def build_focus_and_roster(
     roster_ids = {str(ds.id) for ds in (data_sources or [])}
     n = len(data_sources or [])
 
-    explicit = [str(x) for x in (report_focused_ids or []) if str(x) in roster_ids]
-    if not explicit and n <= threshold:
+    focus_ids, mode = decide_focus_mode(
+        roster_ids, report_focused_ids, n, threshold=threshold
+    )
+    if mode == "all":
         return None, None, "all"
 
-    # One grouped query; ranks the roster's top-K lines (and search results).
+    # Many agents, nothing picked yet ("pick"): render the roster ONLY — no
+    # schema is pre-loaded; the model must pick (search_agents →
+    # set_report_agents) before data work. usage informs its ranking, not the
+    # choice. One grouped query ranks the roster's top-K lines (and search
+    # results).
     usage = await rank_agents_for_user(
         db, str(organization.id), str(user.id) if user else None, list(roster_ids)
     )
-    if explicit:
-        focus_ids, mode = explicit, "focus"
-    else:
-        # Many agents, nothing picked yet: render the roster ONLY — no schema
-        # is pre-loaded. The model must pick (search_agents → set_report_agents)
-        # before doing data work; usage informs its ranking, not the choice.
-        focus_ids, mode = [], "pick"
 
     count_map, kind_map = _counts_from_sections(schema_sections)
     one_liners = await load_agent_one_liners(db, data_sources)

--- a/backend/app/ai/context/builders/instruction_context_builder.py
+++ b/backend/app/ai/context/builders/instruction_context_builder.py
@@ -33,9 +33,12 @@ class InstructionContextBuilder:
 
     Load behavior:
     1. Load ALL 'always' instructions first
-    2. Fill remaining capacity with 'intelligent' instructions (keyword-matched)
+    2. Fill remaining capacity with 'intelligent' instructions that MATCH the
+       query (keyword score > 0). Non-matching intelligent instructions are
+       advertised in the catalog, not force-loaded (a query-less build has
+       nothing to judge, so it fills by usage rank instead).
     3. Skip 'disabled' instructions
-    
+
     The max_instructions_in_context setting (default 50) controls total capacity.
     'Always' instructions take priority and can exceed the limit.
     """
@@ -632,10 +635,11 @@ class InstructionContextBuilder:
 
         Load behavior:
         1. Load ALL 'always' instructions (they take priority)
-        2. Fill remaining capacity with 'intelligent' instructions ranked by
-           keyword score, then aggregated usage (zero-score candidates are not
-           dropped — they fill remaining slots)
-        3. Advertise over-capacity intelligent instructions as catalog entries
+        2. Fill remaining capacity with 'intelligent' instructions that MATCH
+           the query (score > 0), ranked by score then usage. With no query
+           keywords to judge, fall back to filling by usage rank.
+        3. Advertise non-loaded intelligent instructions (zero-score matches and
+           over-capacity ones) as catalog entries
         4. Skip 'disabled' instructions
 
         Returns (loaded_items, catalog_entries), or None if no build is
@@ -827,9 +831,21 @@ class InstructionContextBuilder:
         ranked = [entry for entry in ranked if entry[0].id in accessible_ids]
 
         remaining_slots = max(0, max_instructions - len(always_items))
-        intelligent_items = [it for it, _, _ in ranked[:remaining_slots]]
+        # Relevance gate: when we have query keywords to judge against, only
+        # LOAD intelligent instructions that actually matched (score > 0). The
+        # rest are advertised in <available_instructions> and pulled on demand
+        # via search_instructions/read_instruction — they are NOT force-loaded to
+        # pad the context. Without a query (a query-less context build) there is
+        # nothing to judge, so fall back to filling slots by usage rank.
+        if keywords:
+            loadable = [entry for entry in ranked if entry[1] > 0][:remaining_slots]
+        else:
+            loadable = ranked[:remaining_slots]
+        intelligent_items = [it for it, _, _ in loadable]
 
-        # Over-capacity intelligent instructions are advertised, not dropped.
+        # Everything not loaded — zero-score matches AND over-capacity ones — is
+        # advertised (not dropped), so the model can still reach it on demand.
+        loaded_intelligent_ids = {it.id for it in intelligent_items}
         catalog: List[SkillCatalogItem] = [
             self._catalog_entry(
                 inst_id=it.id,
@@ -840,8 +856,9 @@ class InstructionContextBuilder:
                 table_refs=it.table_refs,
                 usage_count=it.usage_count,
             )
-            for it, _, version in ranked[remaining_slots:remaining_slots + self.CATALOG_LIMIT]
-        ]
+            for it, _, version in ranked
+            if it.id not in loaded_intelligent_ids
+        ][: self.CATALOG_LIMIT]
 
         items = always_items + intelligent_items
 
@@ -891,8 +908,12 @@ class InstructionContextBuilder:
         # Calculate remaining slots for intelligent instructions
         remaining_slots = max(0, max_instructions - len(always_instructions))
 
-        # Rank intelligent instructions: top of the ranking fills remaining
-        # slots, the rest (up to CATALOG_LIMIT) is advertised as catalog entries.
+        # Rank intelligent instructions. When we have query keywords to judge,
+        # only LOAD those that matched (score > 0); the rest are advertised as
+        # catalog entries (reachable via search_instructions), not force-loaded
+        # to pad the context. With no query keywords, fall back to filling by
+        # usage rank.
+        keywords = self._extract_keywords(query) if query else set()
         intelligent_ranked: List[Tuple[Instruction, float]] = await self.search_instructions(
             query or "",
             limit=remaining_slots + self.CATALOG_LIMIT,
@@ -900,8 +921,14 @@ class InstructionContextBuilder:
             category=category,
             categories=categories,
         )
-        intelligent_results = intelligent_ranked[:remaining_slots]
-        catalog_candidates = intelligent_ranked[remaining_slots:]
+        if keywords:
+            intelligent_results = [(i, s) for i, s in intelligent_ranked if s > 0][:remaining_slots]
+        else:
+            intelligent_results = intelligent_ranked[:remaining_slots]
+        loaded_intelligent_ids = {str(i.id) for i, _ in intelligent_results}
+        catalog_candidates = [
+            (i, s) for i, s in intelligent_ranked if str(i.id) not in loaded_intelligent_ids
+        ]
 
         # Collect all instruction IDs for batch stats loading
         all_instruction_ids = [str(inst.id) for inst in always_instructions]

--- a/backend/app/ai/context/context_hub.py
+++ b/backend/app/ai/context/context_hub.py
@@ -718,12 +718,17 @@ class ContextHub:
 
         # Same identity component as the schema cache: instructions are filtered
         # by per-user table accessibility, so they must not cross users either.
+        # The builder's data_source_ids scope is part of the key: it is narrowed
+        # to the roster focus per turn (globals only until an agent is picked),
+        # so two turns with different focus must not share a cache entry.
+        instr_scope = getattr(self.instruction_builder, "data_source_ids", None)
         instr_key = (
             org_id,
             ds_ids,
             str(self.build_id) if self.build_id else None,
             str(instr_query or ""),
             self._schema_identity_key(),
+            tuple(sorted(instr_scope)) if instr_scope is not None else None,
         )
         instr_cached = _INSTRUCTIONS_CACHE.get(instr_key)
 

--- a/backend/tests/e2e/test_instruction_catalog.py
+++ b/backend/tests/e2e/test_instruction_catalog.py
@@ -1,10 +1,14 @@
-"""E2E tests: intelligent instructions fill capacity and overflow to a catalog.
+"""E2E tests: intelligent instructions are relevance-gated, overflow to a catalog.
 
 InstructionContextBuilder.build() must:
-  - fill remaining capacity with intelligent instructions even when they have
-    ZERO keyword overlap with the query (ranked last, load_reason='fill'),
-  - advertise over-capacity intelligent instructions in
-    section.available_instructions instead of dropping them,
+  - LOAD only intelligent instructions that MATCH the query (keyword score > 0)
+    when a query is present; zero-score ones are advertised, not force-loaded to
+    pad the context (this is what stops a trivial turn from dragging in every
+    intelligent instruction),
+  - with NO query keywords to judge, fall back to filling capacity by usage
+    rank (load_reason='fill') — a query-less build has nothing to gate on,
+  - advertise every non-loaded intelligent instruction (zero-score matches and
+    over-capacity ones) in section.available_instructions instead of dropping it,
   - render the catalog as <available_instructions> ONLY when
     render(include_catalog=True) is passed (the planner path) — tool-less
     consumers (coder/answer) keep the default render without it.
@@ -46,9 +50,10 @@ def _settings(max_instructions: int):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_zero_score_intelligent_fills_capacity(create_user, login_user, whoami, test_client):
-    """A query with no token overlap must no longer make intelligent
-    instructions invisible while capacity remains."""
+async def test_zero_score_intelligent_goes_to_catalog_not_loaded(create_user, login_user, whoami, test_client):
+    """With a query present, an intelligent instruction that does NOT match is
+    advertised in the catalog, not force-loaded — even though capacity remains.
+    This is the fix for a trivial turn pulling in every intelligent rule."""
     from app.dependencies import async_session_maker
     from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
 
@@ -63,16 +68,42 @@ async def test_zero_score_intelligent_fills_capacity(create_user, login_user, wh
         builder = InstructionContextBuilder(db, SimpleNamespace(id=org_id))
         section = await builder.build(query="completely unrelated marketing words")
 
+    loaded_ids = {it.id for it in section.items}
+    catalog_ids = {c.id for c in section.available_instructions}
+    assert inst["id"] not in loaded_ids, "zero-score intelligent must not be force-loaded"
+    assert inst["id"] in catalog_ids, "zero-score intelligent must stay reachable via catalog"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_no_query_fills_intelligent_by_usage(create_user, login_user, whoami, test_client):
+    """A query-less build has nothing to gate on, so it still fills remaining
+    capacity with intelligent instructions (load_reason='fill')."""
+    from app.dependencies import async_session_maker
+    from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
+
+    token, org_id = _new_admin(create_user, login_user, whoami)
+    inst = _create(
+        test_client, token, org_id,
+        text="Fiscal year starts in February.", title="Fiscal year",
+        load_mode="intelligent",
+    )
+
+    async with async_session_maker() as db:
+        builder = InstructionContextBuilder(db, SimpleNamespace(id=org_id))
+        section = await builder.build(query=None)
+
     loaded = {it.id: it for it in section.items}
-    assert inst["id"] in loaded, "zero-score intelligent instruction was dropped"
+    assert inst["id"] in loaded, "query-less build should still fill from intelligent"
     assert loaded[inst["id"]].load_reason == "fill"
 
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_overflow_intelligent_lands_in_catalog(create_user, login_user, whoami, test_client):
-    """With capacity 3, higher-scoring intelligent instructions load and the
-    rest are advertised in available_instructions (not dropped)."""
+    """With a query present and capacity 3, only the query-matching intelligent
+    instruction loads; the non-matching rest are advertised in
+    available_instructions (not dropped, and NOT padded into the free slots)."""
     from app.dependencies import async_session_maker
     from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
 
@@ -108,8 +139,10 @@ async def test_overflow_intelligent_lands_in_catalog(create_user, login_user, wh
     # Everything is either loaded or advertised — nothing vanished
     all_ids = {match["id"], *[o["id"] for o in others]}
     assert all_ids == loaded_ids | catalog_ids
-    assert len(loaded_ids) == 3
-    assert len(catalog_ids) == 3
+    # Only the matching instruction loads (free slots are NOT padded with
+    # irrelevant intelligent rules); the five zero-score ones are all advertised.
+    assert loaded_ids == {match["id"]}
+    assert catalog_ids == {o["id"] for o in others}
 
     # Catalog renders only for the planner (include_catalog=True)
     assert "<available_instructions>" not in section.render()

--- a/backend/tests/e2e/test_instruction_roster_scope.py
+++ b/backend/tests/e2e/test_instruction_roster_scope.py
@@ -1,0 +1,89 @@
+"""Roster-scoped instruction loading (the fix for "trivial turn over many agents
+loads every agent's always-on rules").
+
+The agent scopes the standing <instructions> block to the roster's focus by
+setting ``InstructionContextBuilder.data_source_ids``:
+
+  - full attached scope  → every attached agent's always-on rules load ("all"
+    mode: few agents),
+  - empty list           → GLOBAL always-on rules only, agent-attached ones
+    deferred ("pick" mode: many agents, nothing picked yet),
+  - focus subset         → globals + the picked/loaded agents' rules ("focus").
+
+Global (no-agent) instructions always load regardless of scope; only
+agent-attached ones are bounded.
+"""
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_SQLITE_DB = (Path(__file__).resolve().parent.parent / "config" / "chinook.sqlite").resolve()
+
+
+def _auth(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _new_admin(create_user, login_user, whoami):
+    email = f"rscope_{uuid.uuid4().hex[:6]}@test.com"
+    create_user(email=email, password="test123")
+    token = login_user(email=email, password="test123")
+    me = whoami(token)
+    return token, me["organizations"][0]["id"]
+
+
+def _create(test_client, token, org_id, **fields):
+    resp = test_client.post(
+        "/api/instructions", json={"status": "published", **fields}, headers=_auth(token, org_id)
+    )
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_agent_always_instruction_respects_roster_scope(
+    create_user, login_user, whoami, test_client, create_data_source
+):
+    from app.dependencies import async_session_maker
+    from app.ai.context.builders.instruction_context_builder import InstructionContextBuilder
+
+    token, org_id = _new_admin(create_user, login_user, whoami)
+    ds = create_data_source(
+        name="ds_scope", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+
+    global_inst = _create(
+        test_client, token, org_id,
+        text="Always format currency with a leading symbol.", title="Currency",
+        load_mode="always",
+    )
+    agent_inst = _create(
+        test_client, token, org_id,
+        text="For this agent, quarters start in February.", title="Agent quarters",
+        load_mode="always", data_source_ids=[ds["id"]],
+    )
+
+    org = SimpleNamespace(id=org_id)
+
+    # "pick" scope (empty list): globals only — the agent's always-on rule is
+    # deferred even though it is 'always'.
+    async with async_session_maker() as db:
+        section = await InstructionContextBuilder(
+            db, org, data_source_ids=[]
+        ).build(query="hello")
+    loaded = {it.id for it in section.items}
+    assert global_inst["id"] in loaded, "global always-on rule must always load"
+    assert agent_inst["id"] not in loaded, "agent always-on rule must NOT load until its agent is in play"
+
+    # "focus" scope (agent picked): both load.
+    async with async_session_maker() as db:
+        section = await InstructionContextBuilder(
+            db, org, data_source_ids=[ds["id"]]
+        ).build(query="hello")
+    loaded = {it.id for it in section.items}
+    assert global_inst["id"] in loaded
+    assert agent_inst["id"] in loaded, "agent always-on rule must load once its agent is focused"

--- a/backend/tests/unit/test_decide_focus_mode.py
+++ b/backend/tests/unit/test_decide_focus_mode.py
@@ -1,0 +1,58 @@
+"""The roster gate (``decide_focus_mode``) is the single source of truth for how
+much a report pre-loads, shared by the schema roster and the standing
+<instructions> scope. These pin the three regimes:
+
+  - few agents, no explicit focus  → "all"   (render/scope everything)
+  - explicit report focus           → "focus" (honor the pick)
+  - many agents, nothing picked      → "pick"  (roster only; globals-only for
+                                                instructions until an agent is picked)
+"""
+from app.ai.context.agent_roster import decide_focus_mode, DEFAULT_INDEX_THRESHOLD
+
+
+def _roster(n):
+    return {f"a{i}" for i in range(n)}
+
+
+def test_few_agents_no_focus_is_all():
+    ids = _roster(3)  # <= DEFAULT_INDEX_THRESHOLD (4)
+    focus, mode = decide_focus_mode(ids, [], len(ids))
+    assert mode == "all"
+    assert focus == []
+
+
+def test_at_threshold_is_still_all():
+    ids = _roster(DEFAULT_INDEX_THRESHOLD)
+    focus, mode = decide_focus_mode(ids, [], len(ids))
+    assert mode == "all"
+
+
+def test_many_agents_nothing_picked_is_pick():
+    ids = _roster(DEFAULT_INDEX_THRESHOLD + 1)
+    focus, mode = decide_focus_mode(ids, [], len(ids))
+    assert mode == "pick"
+    assert focus == []  # nothing pre-loaded; instruction scope becomes globals-only
+
+
+def test_explicit_focus_wins_even_below_threshold():
+    ids = _roster(2)
+    focus, mode = decide_focus_mode(ids, ["a1"], len(ids))
+    assert mode == "focus"
+    assert focus == ["a1"]
+
+
+def test_explicit_focus_is_filtered_to_roster():
+    ids = _roster(10)
+    # "ghost" is not attached; it must be dropped so scope never references a
+    # non-attached agent.
+    focus, mode = decide_focus_mode(ids, ["a1", "ghost"], len(ids))
+    assert mode == "focus"
+    assert focus == ["a1"]
+
+
+def test_explicit_all_ghosts_falls_back_to_pick():
+    ids = _roster(10)
+    focus, mode = decide_focus_mode(ids, ["ghost1", "ghost2"], len(ids))
+    # Every explicit id was filtered out → treated as "nothing picked".
+    assert mode == "pick"
+    assert focus == []


### PR DESCRIPTION
## Summary

This PR fixes two performance issues with instruction loading:

1. **Roster-scoped instructions**: Standing `<instructions>` blocks now respect the agent roster focus policy, preventing a report over many agents from force-loading every agent's always-on rules before any agent is selected.

2. **Query-gated intelligent instructions**: Intelligent instructions are now only loaded if they match the query (keyword score > 0). Non-matching instructions are advertised in the catalog instead of being force-loaded to pad remaining context capacity.

## Key Changes

- **`InstructionContextBuilder`**: 
  - Added `data_source_ids` parameter to scope agent-attached instructions to the roster focus
  - Global (no-agent) instructions always load regardless of scope
  - Intelligent instructions now require keyword match (score > 0) to load when a query is present
  - Query-less builds still fill capacity by usage rank (fallback behavior)
  - Non-loaded intelligent instructions are advertised in `available_instructions` catalog

- **`AgentV2`**:
  - Added `_resolve_instruction_scope_ids()` method that mirrors the roster focus policy (`decide_focus_mode`)
  - Scopes instructions before initial context prime and on focus changes during runs
  - Applies scope to both token estimation and mid-run instruction re-scoping
  - Handles graceful fallback to full attached scope on errors

- **`agent_roster.py`**:
  - Extracted `decide_focus_mode()` as single source of truth for roster gating
  - Shared by both schema roster and instruction scope to ensure consistency
  - Three modes: "all" (few agents), "focus" (explicit pick), "pick" (many agents, nothing selected)

- **Context caching**:
  - Instruction cache key now includes `data_source_ids` scope to prevent cross-turn cache collisions

## Implementation Details

The instruction scope follows three regimes:
- **Few agents (≤ threshold), no explicit focus** → "all" mode: full attached scope loads (unchanged behavior)
- **Explicit report focus** → "focus" mode: globals + focused agents' rules
- **Many agents, nothing picked** → "pick" mode: globals only until an agent is selected (empty list scope)

When an agent is focused or loaded mid-run, its always-on rules become visible while other agents' rules remain deferred. This prevents trivial turns from dragging in irrelevant instructions while keeping them reachable via catalog search.

## Tests

- Added `test_instruction_roster_scope.py`: E2E tests for roster-scoped instruction loading
- Added `test_decide_focus_mode.py`: Unit tests for the roster gate logic
- Updated `test_instruction_catalog.py`: Tests now verify query-gated loading and catalog advertising behavior

https://claude.ai/code/session_01NYQNcj5n88oekCxcrMkbVQ