### PR TITLE
Fix artifact opening on mobile devices

### DIFF
--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -4011,10 +4011,19 @@ async function handleAddWidgetFromPreview(payload: { widget?: any, step?: any, v
 
 // Handle opening an artifact from CreateArtifactTool
 function handleOpenArtifact(payload: { artifactId?: string; loading?: boolean }) {
-	// Switch to artifact view and ensure split screen is open
-	if (!isSplitScreen.value) toggleSplitScreen()
-	// Switch to artifact panel
-	rightPanelView.value = 'artifact'
+	if (isMobile.value) {
+		// On mobile there is no split layout — surface the dashboard as a
+		// full-screen tab. Set the view directly (not via toggleSplitScreen,
+		// which toggles): reports with a dashboard pre-set isSplitScreen=true
+		// on load, so the old `if (!isSplitScreen) toggleSplitScreen()` guard
+		// never fired here and tapping the artifact card did nothing.
+		mobileView.value = 'dashboard'
+	} else {
+		// Switch to artifact view and ensure split screen is open
+		if (!isSplitScreen.value) toggleSplitScreen()
+		// Switch to artifact panel
+		rightPanelView.value = 'artifact'
+	}
 	// If artifactId provided, dispatch event to ArtifactFrame to select this artifact
 	// If loading is true, just open the pane - ArtifactFrame will show loading state
 	// and artifact:created event will trigger selection when ready


### PR DESCRIPTION
## Summary
Fixed an issue where tapping an artifact card on mobile devices had no effect. The problem was that the artifact opening logic didn't account for mobile's different layout structure, which uses a `mobileView` property instead of split-screen panels.

## Key Changes
- Added mobile-specific handling in `handleOpenArtifact()` to set `mobileView.value = 'dashboard'` instead of attempting to toggle split screen
- Wrapped existing split-screen logic in an `else` block for non-mobile devices
- Added explanatory comments clarifying why the mobile path is necessary (reports pre-set `isSplitScreen=true` on load, so the previous guard never fired on mobile)

## Implementation Details
The fix recognizes that mobile and desktop layouts are fundamentally different:
- **Mobile**: Uses a full-screen tab-based view controlled by `mobileView`
- **Desktop**: Uses a split-screen layout with `isSplitScreen` and `rightPanelView`

The previous code only handled the desktop case, causing artifact selection to silently fail on mobile devices.

https://claude.ai/code/session_01He52Gdw6GdBx9Rqei538Zp