### PR TITLE
Sidebar: shrink the loading spinner to match the status dots

### DIFF
--- a/frontend/components/ReportStatusDot.vue
+++ b/frontend/components/ReportStatusDot.vue
@@ -1,6 +1,6 @@
 <template>
   <UTooltip v-if="visual" :text="visual.label">
-    <Spinner v-if="visual.kind === 'spinner'" class="w-3 h-3 shrink-0 text-blue-500" />
+    <Spinner v-if="visual.kind === 'spinner'" class="w-2 h-2 shrink-0 text-blue-500" />
     <span v-else class="w-1.5 h-1.5 rounded-full shrink-0 inline-block" :class="visual.cls"></span>
   </UTooltip>
   <!-- Idle / no-activity. Opt-in (show-idle) so surfaces that render the dot in


### PR DESCRIPTION
Follow-up to #855.

The running-state spinner in `ReportStatusDot` was `w-3` (12px) while the status dots are `w-1.5` (6px), so a loading row's indicator looked noticeably larger than its idle/unread neighbors in the sidebar. Shrink the spinner to `w-2` (8px) so it sits flush with the dots while staying legible as an animated ring.

Component-level change, so it also aligns the spinner with the dots everywhere `ReportStatusDot` is used (/reports, projects, home cards).

If you'd prefer it *identical* to the dots I can drop it to `w-1.5`, but a true 6px spinner gets hard to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMPPh1keVgwwBDsnT89sMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMPPh1keVgwwBDsnT89sMk)_