### PR TITLE
Make language directive user-driven, always emit for all locales

### DIFF
--- a/.agents/skills/localization/SKILL.md
+++ b/.agents/skills/localization/SKILL.md
@@ -58,10 +58,13 @@ Hebrew vocabulary conventions: "הנחיות" (never "הוראות"), "גלרי�
 - Emails: `app/services/email_renderer.py` + `email_strings.py`, shared Jinja
   templates in `app/templates/emails/*.jinja2` honoring `lang`/`dir`. Keep
   substitutions HTML-escaped — `description` in `share.html.jinja2` is `| safe`.
-- LLM prompts: `app/ai/prompt_language.py` injects a "respond in {language}"
-  directive for **conversational** agents only (planner/answer/judge/reporter/
-  suggest_instructions). Code/artifact agents stay English so SQL, identifiers,
-  and JSON fields never get translated. Returns `""` for `en`.
+- LLM prompts: `app/ai/prompt_language.py` injects a "mirror the user's
+  language" directive for **conversational** agents only (planner/answer/judge/
+  reporter/suggest_instructions) — reply in the language of the user's latest
+  message, overriding tool/page/schema/instruction languages; org locale is the
+  ambiguous-message fallback. Always emitted, including the `en` default.
+  Code/artifact agents stay English so SQL, identifiers, and JSON fields never
+  get translated.
 - Public boot config: `GET /api/config/i18n`.
 
 ## Procedures

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -90,10 +90,15 @@ Concise overview of `@backend/` with emphasis on the `app` library layout and ho
   HTML-escaped at the substitution layer — the `description` field in
   `share.html.jinja2` is `| safe`, so never feed it raw user input.
 - **LLM prompts** (`app/ai/prompt_language.py`): `build_language_directive`
-  injects a "respond in {language}" snippet for **conversational** agents
-  only (planner / answer / judge / reporter / suggest_instructions).
-  Code/artifact agents (coder, dashboard_designer, excel, doc,
-  data_source) stay English so identifiers, SQL, and JSON fields don't
-  get translated. Returns empty string for `en` to save tokens.
+  injects a "mirror the user's language" snippet for **conversational**
+  agents only (planner / answer / judge / reporter / suggest_instructions).
+  The rule is user-driven: reply in the language of the user's most recent
+  message, overriding the language of tool output, fetched pages, schemas,
+  and org instructions; the org locale is only the fallback for ambiguous
+  messages. Always emitted (including the `en` default) — the empty-string
+  shortcut was removed because that was exactly when the model drifted into
+  the content's language. Code/artifact agents (coder, dashboard_designer,
+  excel, doc, data_source) stay English so identifiers, SQL, and JSON
+  fields don't get translated.
 
 See `docs/design/i18n.md` for the full design and authoring rules.

--- a/backend/app/ai/prompt_language.py
+++ b/backend/app/ai/prompt_language.py
@@ -49,18 +49,33 @@ def resolve_locale(organization_settings: Optional[OrganizationSettingsConfig]) 
 
 
 def build_language_directive(organization_settings: Optional[OrganizationSettingsConfig]) -> str:
-    """Return a system-prompt snippet that asks the model to reply in the org locale.
+    """Return a system-prompt snippet that pins the response language.
 
-    Returns an empty string when the locale resolves to English so we don't
-    waste tokens on the default case.
+    The rule is user-driven: always mirror the language of the user's most
+    recent message, regardless of the language of tool output, fetched pages,
+    database content, or organization instructions. The org locale is only a
+    fallback for messages too short or ambiguous to detect a language from.
+
+    This snippet is always emitted (including for the English default) because
+    the failure mode it prevents — the model drifting into the language of
+    tool/page/schema content instead of the user's — happens precisely when no
+    directive is present.
     """
     locale = resolve_locale(organization_settings)
-    if locale == "en":
-        return ""
-    language = _LOCALE_NAMES.get(locale, locale)
+    fallback = _LOCALE_NAMES.get(locale, locale)
     return (
         f"\n\n**Language**:\n"
-        f"Respond to the user in {language}. Translate any English phrasing in "
-        f"your narrative prose and headings into {language}. Keep code, SQL, "
-        f"column names, identifiers, and JSON field names in English.\n"
+        f"ALWAYS respond in the same language as the user's most recent message. "
+        f"Detect the language from the user's message itself and reply in that "
+        f"language. This takes priority over the language of everything else in "
+        f"context: tool output, fetched web pages, database rows, table and "
+        f"column names, schemas, and any organization instructions written in "
+        f"another language. If the user writes in Hebrew, respond in Hebrew, even "
+        f"when the data or page content is in English; if the user writes in "
+        f"English, respond in English, even when the data or page content is in "
+        f"another language. If the user switches languages mid-conversation, "
+        f"switch with them. When the user's message is too short or ambiguous to "
+        f"determine a language (for example a bare number or a URL), default to "
+        f"{fallback}. Always keep code, SQL, column names, identifiers, and JSON "
+        f"field names in English.\n"
     )

--- a/backend/tests/unit/test_prompt_language.py
+++ b/backend/tests/unit/test_prompt_language.py
@@ -1,0 +1,46 @@
+"""Unit tests for the response-language directive.
+
+The directive must be user-driven: it always instructs the model to mirror the
+language of the user's most recent message, overriding the language of tool
+output / page content / schemas. Regression guard for the bug where an English
+request against a Hebrew page produced a Hebrew reply (and vice versa) because
+no directive was emitted for the English default.
+"""
+
+from types import SimpleNamespace
+
+from app.ai.prompt_language import build_language_directive, resolve_locale
+
+
+def test_directive_is_always_emitted_even_for_english_default():
+    # None org settings -> resolves to the system default (English), but the
+    # directive must still be present so the model has an explicit rule.
+    directive = build_language_directive(None)
+    assert directive.strip(), "directive must never be empty"
+    assert "**Language**" in directive
+
+
+def test_directive_mirrors_the_user_not_a_fixed_language():
+    directive = build_language_directive(None).lower()
+    # It anchors on the user's message, not on a single hard-coded language.
+    assert "most recent message" in directive
+    # It explicitly overrides other context languages.
+    assert "priority" in directive
+    assert "tool output" in directive
+
+
+def test_directive_keeps_code_in_english():
+    directive = build_language_directive(None).lower()
+    assert "code" in directive and "sql" in directive
+
+
+def test_org_locale_is_only_the_ambiguous_fallback():
+    # An explicitly non-English org locale should appear only as the fallback
+    # for ambiguous input, not as an override of the user's language.
+    he_org = SimpleNamespace(locale="he")
+    directive = build_language_directive(he_org)
+    if resolve_locale(he_org) == "he":
+        # Fallback language named for ambiguous messages...
+        assert "Hebrew" in directive
+        # ...but the primary rule still mirrors the user.
+        assert "most recent message" in directive.lower()


### PR DESCRIPTION
## Summary
Changed the LLM language directive from a fixed org-locale response to a user-driven approach that mirrors the language of the user's most recent message. The directive is now always emitted (including for English) to prevent the model from drifting into the language of tool output, fetched pages, or database content.

## Key Changes
- **Rewrote `build_language_directive()`** to emit a comprehensive rule that:
  - Prioritizes the user's message language over all other context (tool output, pages, schemas, org instructions)
  - Uses org locale only as a fallback for ambiguous/short messages (bare numbers, URLs)
  - Explicitly preserves English for code, SQL, identifiers, and JSON field names
  - Is always emitted, removing the previous empty-string optimization for English

- **Added comprehensive unit tests** (`test_prompt_language.py`) covering:
  - Directive is never empty, even for English default
  - Directive mirrors user language, not a fixed language
  - Code/SQL remain in English
  - Org locale serves only as ambiguous-message fallback

- **Updated documentation** in `AGENTS.md` and `SKILL.md` to reflect the new user-driven behavior and explain why the directive is always emitted

## Implementation Details
The new directive explicitly instructs the model to detect language from the user's message and respond in that language, with clear examples (Hebrew user → Hebrew response even with English data; English user → English response even with non-English data). This addresses a regression where the model would produce responses in the wrong language when no directive was present to override the language of surrounding context.

https://claude.ai/code/session_01Gi89paSXvQHHiWhHnGRcuq