### PR TITLE
Fix concurrent table resolution race in parallel tool batches

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1739,6 +1739,11 @@ class AgentV2:
                         "context_view": view,
                         "context_hub": self.context_hub,
                         "ds_clients": self.codegen_clients,
+                        # Serializes tool-side reads of the shared long-lived DB
+                        # session (schema resolution in create_data/inspect_data/
+                        # write_csv) so parallel tool batches don't use the
+                        # non-concurrency-safe AsyncSession at the same time.
+                        "tool_db_lock": self._tool_db_lock,
                         "usage_limit_context": self.usage_limit_context,
                         "training_build_id": self.training_build_id,
                         "agent_execution_id": str(self.current_execution.id) if self.current_execution else None,
@@ -4805,6 +4810,10 @@ class AgentV2:
                                         "context_view": _view,
                                         "context_hub": self.context_hub,
                                         "ds_clients": self.codegen_clients,
+                                        # See note at the other runtime_ctx build
+                                        # site: serialize tool-side shared-session
+                                        # reads across parallel tool batches.
+                                        "tool_db_lock": self._tool_db_lock,
                                         "loaded_agent_ids": self.loaded_agent_ids,
                                         "used_agent_ids": self.used_agent_ids,
                                         "_file_enum_seen": self._file_enum_seen,

--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import re
 import time as _time
+from contextlib import nullcontext
 from typing import AsyncIterator, Dict, Any, Type, Optional, List, Union
 from pydantic import BaseModel
 from app.core.otel import get_tracer
@@ -68,6 +69,13 @@ ALLOWED_VIZ_TYPES = {
     "table","bar_chart","line_chart","pie_chart","area_chart","count","metric_card",
     "heatmap","map","candlestick","treemap","radar_chart","scatter_plot",
 }
+
+
+# Tags a table-resolution warning that came from a raised exception (e.g.
+# concurrent AsyncSession use) rather than a genuine "no table matched this
+# name" miss. Lets the failure path report the real cause instead of a
+# misleading name-mismatch message. See CreateDataTool._resolve_active_tables.
+_RESOLUTION_INTERNAL_ERROR_MARKER = "Table resolution internal error"
 
 
 def _extract_json_object(text: Optional[str]) -> Optional[Dict[str, Any]]:
@@ -1156,6 +1164,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
         tables_by_source: List[Any],
         schema_builder,
         data_sources: Optional[List[Any]] = None,
+        db_lock: Optional["asyncio.Lock"] = None,
     ) -> tuple[List[Dict[str, Any]], List[str]]:
         """Resolve table patterns to active tables only.
 
@@ -1163,13 +1172,29 @@ Do not use generic placeholders like "value" unless that is the actual column na
             tables_by_source: List of TablesBySource with table names/patterns
             schema_builder: SchemaContextBuilder instance
             data_sources: Optional list of data sources to get all ds_ids
+            db_lock: Optional asyncio.Lock serializing access to the shared
+                long-lived DB session. ``schema_builder.build`` issues
+                ``await self.db.execute(...)`` on the agent's single AsyncSession,
+                which is NOT safe for concurrent use. When several tool calls run
+                in one parallel batch (e.g. multiple create_data), their
+                resolution reads overlap on that one session and all-but-one
+                raise — previously swallowed below as "no active tables matched".
+                Holding this lock (the agent's ``_tool_db_lock``) around the build
+                removes the contention; the read is fast, so the LLM/codegen work
+                of sibling calls still overlaps freely. ``None`` (tests / direct
+                callers with no shared session) skips locking.
 
         Returns:
             (resolved_tables_by_source, warnings) where:
             - resolved_tables_by_source: List of dicts with resolved active table names
-            - warnings: List of warning messages for patterns with no matches
+            - warnings: List of warning messages for patterns with no matches.
+              An internal failure (a raised exception, e.g. concurrent session
+              use) is tagged with ``_RESOLUTION_INTERNAL_ERROR_MARKER`` so the
+              caller can distinguish it from a genuine name mismatch.
         """
         import re
+
+        _guard = db_lock if db_lock is not None else nullcontext()
 
         with tracer.start_as_current_span("create_data.resolve_active_tables") as span:
             span.set_attribute("tables_by_source.count", len(tables_by_source or []))
@@ -1203,11 +1228,12 @@ Do not use generic placeholders like "value" unless that is the actual column na
                 # Resolve via schema_builder (only returns active tables)
                 try:
                     _t0 = _time.perf_counter()
-                    ctx = await schema_builder.build(
-                        with_stats=False,
-                        data_source_ids=[ds_id] if ds_id else None,
-                        name_patterns=name_patterns,
-                    )
+                    async with _guard:
+                        ctx = await schema_builder.build(
+                            with_stats=False,
+                            data_source_ids=[ds_id] if ds_id else None,
+                            name_patterns=name_patterns,
+                        )
                     logger.info(
                         "create_data.schema_build stage=resolve_active ds_id=%s elapsed_ms=%.0f patterns=%d",
                         ds_id,
@@ -1246,7 +1272,19 @@ Do not use generic placeholders like "value" unless that is the actual column na
                             warnings.append(f"No active tables matched patterns {input_tables} across any data source")
 
                 except Exception as e:
-                    warnings.append(f"Failed to resolve tables {input_tables}: {str(e)}")
+                    # A raise here is an INTERNAL failure (most often concurrent
+                    # use of the shared AsyncSession — see db_lock above), NOT
+                    # "these table names don't exist". Log it and tag the warning
+                    # so it can never again be silently reported to the planner as
+                    # a plain "no active tables matched" name mismatch.
+                    logger.exception(
+                        "create_data._resolve_active_tables raised for %s (ds_id=%s)",
+                        input_tables, ds_id,
+                    )
+                    warnings.append(
+                        f"{_RESOLUTION_INTERNAL_ERROR_MARKER} for {input_tables}: "
+                        f"{type(e).__name__}: {e}"
+                    )
 
             span.set_attribute("tables.resolved_count", sum(len(g.get("tables", [])) for g in resolved))
             return resolved, warnings
@@ -1434,6 +1472,7 @@ Do not use generic placeholders like "value" unless that is the actual column na
                 resolved_tables, resolution_warnings = await self._resolve_active_tables(
                     data.tables_by_source,
                     context_hub.schema_builder,
+                    db_lock=runtime_ctx.get("tool_db_lock"),
                 )
         
         # Check if we have any data sources (tables or files)
@@ -1449,11 +1488,47 @@ Do not use generic placeholders like "value" unless that is the actual column na
             web_fetch_enabled = False
 
         if total_resolved == 0 and not has_files and not web_fetch_enabled:
-            # No tables resolved AND no files available - fail
+            # No tables resolved AND no files available - fail. Distinguish the
+            # three ways we land here so the planner (and any human reading the
+            # step) sees the real cause instead of one flattened message:
+            #   1. resolution raised internally (concurrent session use, etc.)
+            #   2. the tool was called with no source at all (tables_by_source
+            #      empty AND no file) — a planner slip, corrected by re-calling
+            #      with tables; it is NOT a name mismatch.
+            #   3. table names genuinely matched nothing active.
             _requested = [
                 {"data_source_id": str(g.data_source_id), "tables": g.tables}
                 for g in (data.tables_by_source or [])
             ] if data.tables_by_source else []
+            _had_internal_error = any(
+                _RESOLUTION_INTERNAL_ERROR_MARKER in (w or "")
+                for w in (resolution_warnings or [])
+            )
+            _had_table_request = bool(data.tables_by_source)
+            if _had_internal_error:
+                _no_ds_type = "table_resolution_error"
+                _no_ds_summary = "Table resolution failed (internal error)"
+                _no_ds_message = (
+                    "Table resolution failed due to an internal error, not a "
+                    "table-name mismatch (see warnings). This is transient — "
+                    "re-run the same create_data call."
+                )
+            elif not _had_table_request:
+                _no_ds_type = "no_source_specified"
+                _no_ds_summary = "No data source specified for create_data"
+                _no_ds_message = (
+                    "create_data was called with no tables_by_source and no file. "
+                    "Pass tables_by_source (a data_source_id plus the table names "
+                    "to query), or attach a file, then call create_data again."
+                )
+            else:
+                _no_ds_type = "no_data_sources"
+                _no_ds_summary = "No data sources available - no tables matched and no files uploaded"
+                _no_ds_message = (
+                    "No active tables matched the requested patterns and no files "
+                    "are available. Either provide valid table names in "
+                    "tables_by_source or upload files."
+                )
             await log_tool_audit(
                 runtime_ctx,
                 action="tool.table_resolution_failed",
@@ -1478,10 +1553,10 @@ Do not use generic placeholders like "value" unless that is the actual column na
                         "errors": [],
                     },
                     "observation": {
-                        "summary": "No data sources available - no tables matched and no files uploaded",
+                        "summary": _no_ds_summary,
                         "error": {
-                            "type": "no_data_sources",
-                            "message": "No active tables matched the requested patterns and no files are available. Either provide valid table names in tables_by_source or upload files.",
+                            "type": _no_ds_type,
+                            "message": _no_ds_message,
                             "warnings": resolution_warnings,
                             "requested_tables": [
                                 {"data_source_id": g.data_source_id, "tables": g.tables}
@@ -1504,6 +1579,11 @@ Do not use generic placeholders like "value" unless that is the actual column na
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "data_sources_resolved", "mode": mode, "tables_count": total_resolved, "files_count": len(excel_files)})
         
         # Build schemas excerpt using resolved active tables (skip if file-only mode)
+        # Same shared-AsyncSession hazard as _resolve_active_tables: this
+        # schema_builder.build runs concurrently with sibling tool calls, so
+        # serialize the DB read on the agent's lock.
+        _excerpt_lock = runtime_ctx.get("tool_db_lock")
+        _excerpt_guard = _excerpt_lock if _excerpt_lock is not None else nullcontext()
         if total_resolved > 0:
             try:
                 # Collect all resolved table names for schema building
@@ -1513,18 +1593,19 @@ Do not use generic placeholders like "value" unless that is the actual column na
                     if group.get("data_source_id"):
                         ds_ids.append(group["data_source_id"])
                     all_resolved_names.extend(group.get("tables", []))
-                
+
                 ds_scope = list(set(ds_ids)) if ds_ids else None
                 # Use exact name patterns for resolved tables
                 import re
                 name_patterns = [f"(?i)(?:^|\\.){re.escape(n)}$" for n in all_resolved_names] if all_resolved_names else None
-                
+
                 _t0 = _time.perf_counter()
-                ctx = await context_hub.schema_builder.build(
-                    with_stats=True,
-                    data_source_ids=ds_scope,
-                    name_patterns=name_patterns,
-                )
+                async with _excerpt_guard:
+                    ctx = await context_hub.schema_builder.build(
+                        with_stats=True,
+                        data_source_ids=ds_scope,
+                        name_patterns=name_patterns,
+                    )
                 logger.info(
                     "create_data.schema_build stage=final_excerpt elapsed_ms=%.0f ds_count=%d patterns=%d",
                     (_time.perf_counter() - _t0) * 1000.0,
@@ -1535,7 +1616,8 @@ Do not use generic placeholders like "value" unless that is the actual column na
             except Exception as e:
                 # Fallback to keyword-based excerpt if resolution-based build fails
                 raw_text = (data.interpreted_prompt or data.user_prompt or "")
-                schemas_excerpt = await self._build_schemas_excerpt(context_hub, context_view, raw_text, top_k=10)
+                async with _excerpt_guard:
+                    schemas_excerpt = await self._build_schemas_excerpt(context_hub, context_view, raw_text, top_k=10)
         else:
             # File-only mode: no database schemas needed
             schemas_excerpt = ""

--- a/backend/app/ai/tools/implementations/inspect_data.py
+++ b/backend/app/ai/tools/implementations/inspect_data.py
@@ -153,7 +153,8 @@ Queries are subject to a per-connection timeout.
             from app.ai.tools.implementations.create_data import CreateDataTool
             resolved_tables, _ = await CreateDataTool._resolve_active_tables(
                 data.tables_by_source,
-                context_hub.schema_builder
+                context_hub.schema_builder,
+                db_lock=runtime_ctx.get("tool_db_lock"),
             )
 
         # 2. Build Context

--- a/backend/app/ai/tools/implementations/write_csv.py
+++ b/backend/app/ai/tools/implementations/write_csv.py
@@ -109,6 +109,7 @@ Do not use when:
             resolved_tables, _ = await CreateDataTool._resolve_active_tables(
                 data.tables_by_source,
                 context_hub.schema_builder,
+                db_lock=runtime_ctx.get("tool_db_lock"),
             )
 
         # 2. Build context

--- a/backend/tests/unit/test_create_data_resolve_concurrency.py
+++ b/backend/tests/unit/test_create_data_resolve_concurrency.py
@@ -1,0 +1,140 @@
+"""Regression: concurrent table resolution must not collide on the shared session.
+
+Production failure class (traced from a real report): the planner emitted a
+parallel batch of ``create_data`` calls in one turn. Each resolves its tables
+via ``schema_builder.build()``, which runs ``await self.db.execute(...)`` on the
+agent's ONE long-lived SQLAlchemy ``AsyncSession``. That session is not safe for
+concurrent use, so the overlapping reads raised ("another operation is in
+progress"); ``_resolve_active_tables`` swallowed the exception and the tool
+failed with the generic "No active tables matched" — the *same* table names that
+failed in the batch succeeded when re-run serially.
+
+These tests reproduce the race deterministically with a fake builder that mimics
+the session's no-concurrent-ops rule, and prove that passing the agent's
+``_tool_db_lock`` (``db_lock=``) serializes the reads so every call resolves.
+"""
+import asyncio
+
+import pytest
+
+from app.ai.tools.implementations.create_data import (
+    CreateDataTool,
+    _RESOLUTION_INTERNAL_ERROR_MARKER,
+)
+
+
+class _Info:
+    def __init__(self, id):
+        self.id = id
+
+
+class _Tbl:
+    def __init__(self, name):
+        self.name = name
+
+
+class _DS:
+    def __init__(self, id, names):
+        self.info = _Info(id)
+        self.tables = [_Tbl(n) for n in names]
+
+
+class _Ctx:
+    def __init__(self, data_sources):
+        self.data_sources = data_sources
+
+
+class _Group:
+    """Stand-in for a TablesBySource entry (attribute access, like the real one)."""
+
+    def __init__(self, data_source_id, tables):
+        self.data_source_id = data_source_id
+        self.tables = tables
+
+
+class SharedSessionSchemaBuilder:
+    """Fake SchemaContextBuilder bound to a single AsyncSession.
+
+    Reproduces the exact hazard: if two ``build()`` calls overlap — as they do
+    under ``asyncio.gather`` on one session — the second raises the way
+    SQLAlchemy does for concurrent operations. Serialized callers never collide.
+    """
+
+    def __init__(self, ds_id, table_names):
+        self.ds_id = ds_id
+        self.table_names = list(table_names)
+        self._active = 0
+        self.max_concurrency = 0
+
+    async def build(self, *, with_stats=False, data_source_ids=None,
+                    name_patterns=None, **kwargs):
+        self._active += 1
+        self.max_concurrency = max(self.max_concurrency, self._active)
+        try:
+            if self._active > 1:
+                raise RuntimeError(
+                    "another operation is in progress (concurrent AsyncSession use)"
+                )
+            await asyncio.sleep(0.005)  # widen the overlap window
+            return _Ctx([_DS(self.ds_id, self.table_names)])
+        finally:
+            self._active -= 1
+
+
+_TABLES = ["dbo.Reports", "dbo.Employees"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resolution_races_without_lock():
+    """Without the lock, the shared builder is entered concurrently and at least
+    one call fails to resolve — surfacing the INTERNAL-ERROR marker rather than a
+    silent, misleading name-mismatch. (Guards that the fix is actually needed.)"""
+    builder = SharedSessionSchemaBuilder("ds-1", _TABLES)
+    groups = [_Group("ds-1", list(_TABLES))]
+
+    results = await asyncio.gather(*[
+        CreateDataTool._resolve_active_tables(groups, builder)  # no db_lock
+        for _ in range(6)
+    ])
+
+    assert builder.max_concurrency > 1, "expected the reads to overlap on one session"
+    all_warnings = [w for _resolved, warns in results for w in warns]
+    assert any(_RESOLUTION_INTERNAL_ERROR_MARKER in w for w in all_warnings), (
+        "a raised resolution must be tagged as an internal error, not swallowed "
+        "into a plain 'no active tables matched'"
+    )
+    assert any(len(resolved) == 0 for resolved, _warns in results), (
+        "at least one concurrent resolution should have failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resolution_serialized_with_lock():
+    """With the agent's _tool_db_lock, build() runs strictly serially, so every
+    concurrent call resolves its tables and none hits the internal-error path."""
+    builder = SharedSessionSchemaBuilder("ds-1", _TABLES)
+    groups = [_Group("ds-1", list(_TABLES))]
+    lock = asyncio.Lock()
+
+    results = await asyncio.gather(*[
+        CreateDataTool._resolve_active_tables(groups, builder, db_lock=lock)
+        for _ in range(6)
+    ])
+
+    assert builder.max_concurrency == 1, "the lock must keep the session reads serial"
+    for resolved, warns in results:
+        assert not any(_RESOLUTION_INTERNAL_ERROR_MARKER in w for w in warns)
+        assert resolved and resolved[0]["tables"] == _TABLES
+
+
+@pytest.mark.asyncio
+async def test_no_lock_single_call_still_resolves():
+    """Sanity: db_lock is optional — a lone call (tests / direct callers with no
+    shared session) resolves exactly as before."""
+    builder = SharedSessionSchemaBuilder("ds-1", _TABLES)
+    groups = [_Group("ds-1", list(_TABLES))]
+
+    resolved, warns = await CreateDataTool._resolve_active_tables(groups, builder)
+
+    assert resolved == [{"data_source_id": "ds-1", "tables": _TABLES}]
+    assert warns == []


### PR DESCRIPTION
## Summary

Fixes a production issue where parallel `create_data` tool calls in a single batch would race on the agent's shared long-lived SQLAlchemy `AsyncSession`, causing table resolution to fail silently. The session is not safe for concurrent use, so overlapping `schema_builder.build()` calls would raise "another operation is in progress" exceptions that were swallowed and reported as misleading "no tables matched" errors.

## Key Changes

- **Added `db_lock` parameter to `_resolve_active_tables()`**: Accepts an optional `asyncio.Lock` that serializes access to the shared DB session. When provided, the lock wraps the `schema_builder.build()` call to prevent concurrent access.

- **Introduced `_RESOLUTION_INTERNAL_ERROR_MARKER`**: Tags resolution warnings that came from raised exceptions (e.g., concurrent session use) rather than genuine table name mismatches. This allows the failure path to distinguish between transient internal errors and actual name mismatches.

- **Enhanced error reporting in `_run_stream_traced()`**: When no data sources are available, the tool now distinguishes between three failure modes:
  - Internal resolution errors (transient, should retry)
  - No source specified (planner slip, needs tables_by_source)
  - No matching tables (genuine name mismatch)

- **Passed `tool_db_lock` through runtime context**: Modified `agent_v2.py` to include the agent's `_tool_db_lock` in the `runtime_ctx` passed to all tool implementations, enabling them to serialize their DB reads.

- **Applied lock to schema excerpt building**: The final schema excerpt build in `create_data` also uses the lock to prevent concurrent session access.

- **Updated dependent tools**: `inspect_data.py` and `write_csv.py` now pass the `db_lock` when calling `_resolve_active_tables()`.

## Implementation Details

- Uses `contextlib.nullcontext()` as a no-op guard when no lock is provided, maintaining backward compatibility with tests and direct callers that don't share a session.
- The lock is held only during the fast DB read operation, allowing LLM/codegen work in sibling tool calls to overlap freely.
- Comprehensive regression tests verify that concurrent resolution fails without the lock and succeeds with it, and that single calls work correctly in both cases.

https://claude.ai/code/session_01EYWgzU8ciBfbZN19CxipQd