### PR TITLE
Emit run_stopped session event when a user stops a run

### DIFF
--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -2877,7 +2877,8 @@ class CompletionService:
         # broadcast signals the agent to break its current sub-loop at its next
         # cooperative checkpoint.
         completion.sigkill = datetime.now()
-        if completion.status == 'in_progress':
+        was_in_progress = completion.status == 'in_progress'
+        if was_in_progress:
             completion.status = 'stopped'
 
         # Also update all in_progress completion blocks to stopped — regardless of the
@@ -2900,6 +2901,23 @@ class CompletionService:
 
         await db.commit()
         await db.refresh(completion)
+
+        # Silent session event so the deliberate interruption is visible in the
+        # report's context on the next agent turn (and as a UI strip). Only when
+        # we actually stopped an in-progress run — if the analysis had already
+        # finished, sigkill merely signals a background sub-loop to break and the
+        # user-facing answer stands, so "Run was stopped" would be misleading.
+        if was_in_progress:
+            from types import SimpleNamespace
+            from app.services.session_event_service import SessionEventService
+            from app.ai.context.session_events import RUN_STOPPED
+            await SessionEventService.emit_safe(
+                db,
+                report=SimpleNamespace(id=completion.report_id),
+                kind=RUN_STOPPED,
+                user=current_user,
+                meta={"completion_id": str(completion.id)},
+            )
 
         # Audit log
         if current_user and organization:

--- a/backend/tests/unit/test_session_events.py
+++ b/backend/tests/unit/test_session_events.py
@@ -304,6 +304,65 @@ async def test_feedback_service_hook_emits_events(db):
 
 
 @pytest.mark.asyncio
+async def test_sigkill_hook_emits_run_stopped_event(db):
+    """Stopping an in-progress run emits a run_stopped event keyed to the
+    completion, so the deliberate interruption is visible in later context."""
+    from app.services.completion_service import CompletionService
+    from app.ai.context.session_events import RUN_STOPPED
+
+    org, report, user = await _seed_report(db)
+    await _add_turn(db, report, user, role="user", content="crunch this", minute=0)
+    sys = await _add_turn(db, report, user, role="system", content="", minute=1)
+    sys.status = "in_progress"
+    await db.commit()
+
+    # organization=None keeps the (EE) audit-log branch out of this unit test;
+    # the session-event emit is what we're exercising.
+    await CompletionService().update_completion_sigkill(
+        db, str(sys.id), current_user=user, organization=None
+    )
+
+    rows = (await db.execute(
+        select(Completion).where(
+            Completion.report_id == str(report.id),
+            Completion.role == EVENT_ROLE,
+        )
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].message_type == RUN_STOPPED
+    assert rows[0].prompt["content"] == "Run was stopped"
+    assert rows[0].prompt["meta"]["completion_id"] == str(sys.id)
+    # And the stopped run is now LLM-visible in the report context.
+    text = await (MessageContextBuilder(db, org, report)).build_context(max_messages=20)
+    assert "Run was stopped" in text
+
+
+@pytest.mark.asyncio
+async def test_sigkill_on_finished_run_emits_no_event(db):
+    """If the analysis already left in_progress (success/error), sigkill only
+    signals a background sub-loop to break — the user-facing answer stands, so
+    no "Run was stopped" event is emitted."""
+    from app.services.completion_service import CompletionService
+
+    org, report, user = await _seed_report(db)
+    await _add_turn(db, report, user, role="user", content="q", minute=0)
+    sys = await _add_turn(db, report, user, role="system", content="a", minute=1)
+    assert sys.status == "success"  # already finished
+
+    await CompletionService().update_completion_sigkill(
+        db, str(sys.id), current_user=user, organization=None
+    )
+
+    rows = (await db.execute(
+        select(Completion).where(
+            Completion.report_id == str(report.id),
+            Completion.role == EVENT_ROLE,
+        )
+    )).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
 async def test_llm_changed_emitted_on_report_model_override_change(db):
     """emit_report_model_changed fires only when the report's model override
     (report.model_id) actually changes — the explicit user pick — and reads the


### PR DESCRIPTION
Stopping a report run (sigkill) stamped the completion and wrote an audit
log, but recorded nothing in the report's conversation ledger. The
run_stopped event kind was fully defined and plumbed through the context
builder, UI, and compaction pipeline — but no code path ever emitted it,
so a deliberate user interruption was invisible to the agent on its next
turn.

Wire the one missing emit at the existing sigkill hook point: emit a
silent role='event' completion via SessionEventService.emit_safe, gated on
the run actually having been in_progress. When the analysis had already
finished (sigkill only signals a background sub-loop to break), no event is
emitted, so a completed answer is never mislabeled "Run was stopped".

Add unit coverage for both cases: the in-progress stop emits a run_stopped
event keyed to the completion and renders in report context, and the
already-finished stop emits nothing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VLcMPMGzFSWtDzYwnN9buM