### PR TITLE
Fix per-user OAuth connector indexing and tool discovery

### DIFF
--- a/backend/app/routes/connection.py
+++ b/backend/app/routes/connection.py
@@ -823,14 +823,37 @@ async def reindex_connection(
     """
     from datetime import datetime
     connection = await connection_service.get_connection(db, connection_id, organization)
+
+    # A per-user OAuth connector has no credentials of its own to crawl with —
+    # only the OAuth client. Run the discovery as the admin who pressed the
+    # button, using their own token, instead of kicking a system-context run
+    # that can only 401. (Tool catalogs are a flat list, so "this user's view"
+    # and "the connection's view" are the same thing.)
+    from app.schemas.data_source_registry import tool_provider_types
+    from app.services.connection_identity import (
+        get_user_conn_cred_row,
+        catalog_requires_user_sign_in,
+        row_has_token,
+    )
+
+    index_as_user = None
+    if connection.type in tool_provider_types() and catalog_requires_user_sign_in(connection):
+        row = await get_user_conn_cred_row(db, connection, current_user)
+        if row_has_token(row):
+            index_as_user = str(current_user.id)
+        # Nobody has signed in yet: leave it a system-scoped run, which completes
+        # with "discovered when a user signs in" rather than 403-ing on a token
+        # the caller was never asked for.
+
     if force:
-        existing = await indexing_service.get_active(db, connection_id)
+        existing = await indexing_service.get_active(db, connection_id, user_id=index_as_user)
         if existing is not None:
             existing.status = "cancelled"
             existing.finished_at = datetime.utcnow()
             existing.error = "Cancelled by user reindex request"
             await db.commit()
-    row = await indexing_service.start(db=db, connection=connection)
+
+    row = await indexing_service.start(db=db, connection=connection, user_id=index_as_user)
     progress = _indexing_to_progress(row)
     return {
         "message": "Schema indexing started." if row.status == "pending" else "Schema indexing in progress.",

--- a/backend/app/routes/connection_oauth.py
+++ b/backend/app/routes/connection_oauth.py
@@ -437,7 +437,16 @@ async def oauth_callback(
             from app.services.connection_service import ConnectionService as _ToolCS
             await _ToolCS().refresh_tools(db, connection, user)
     except Exception as e:
-        logger.warning(f"Tool refresh after OAuth sign-in failed: {e}")
+        # This is the ONLY path that populates a per-user connector's tool
+        # catalog, so a failure here leaves the connection reading "Connected"
+        # with zero callable tools. Non-fatal (the sign-in itself succeeded and
+        # a Reload recovers it), but never quiet — this went unnoticed once.
+        logger.error(
+            f"Tool refresh after OAuth sign-in failed for connection {connection_id} "
+            f"user {user.id}: {e} — the connection has no discovered tools until "
+            "someone reloads it.",
+            exc_info=True,
+        )
 
     # Kick off the per-user catalog sync in the BACKGROUND.
     #

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -130,6 +130,11 @@ class ConnectionEmbedded(BaseModel):
     # an aggregate over the org's whole catalog). None is "not counted"; 0 still
     # means an empty catalog.
     table_count: Optional[int] = 0
+    # Number of discovered tools, for tool providers (MCP / Custom API). The
+    # connection modal renders this for a `tools` data_shape; without it on the
+    # payload the modal read `undefined || 0` and reported "Tools 0" for a
+    # connection that had a full tool catalog.
+    tool_count: Optional[int] = 0
     # Latest schema indexing run, if any. Frontend derives the "indexing"
     # effective status from this plus user_status.connection.
     indexing: Optional[Dict[str, Any]] = None

--- a/backend/app/services/connection_identity.py
+++ b/backend/app/services/connection_identity.py
@@ -37,6 +37,47 @@ def supports_user_token(connection: Connection) -> bool:
     return "oauth" in modes
 
 
+# Auth modes whose stored connection credentials are an OAuth *client*
+# (client_id/secret + endpoints), never a token: every user signs in for
+# themselves. DCR registers the client dynamically; oauth_app takes an
+# admin-registered one. Either way there is nothing to authenticate WITH
+# outside a signed-in user's session.
+PER_USER_OAUTH_AUTH_TYPES = {"dcr", "oauth_app"}
+
+
+def catalog_requires_user_sign_in(connection: Connection) -> bool:
+    """True when this connection's catalog can ONLY be discovered as a
+    signed-in user, because nothing it stores can authenticate a call made with
+    no user in context.
+
+    `bool(connection.credentials)` does not answer this. A per-user OAuth
+    connector (an MCP/Custom-API tile connected via DCR or an admin OAuth app)
+    stores a full credentials blob — but it holds only the OAuth *client*, so a
+    system-context crawl goes out with no Authorization header at all and the
+    provider answers 401. Callers that run without a user (background indexing,
+    the scheduled reindex sweep) have to ask this, or they schedule a failure
+    that no amount of retrying can fix.
+
+    Deliberately narrow — it asks only about the auth mode the connection was
+    configured with. Everything else keeps indexing admin-side as before:
+    system_only connections, delegated connections carrying real
+    service-principal credentials, and credential-less-but-indexable sources
+    (SQLite/DuckDB/QVD, whose catalog comes from `config`).
+    """
+    if connection.auth_policy != "user_required":
+        return False
+
+    config = connection.config
+    if isinstance(config, str):
+        import json
+
+        try:
+            config = json.loads(config)
+        except (TypeError, ValueError):
+            config = {}
+    return (config or {}).get("auth_type") in PER_USER_OAUTH_AUTH_TYPES
+
+
 def identity_pref_from_row(row: UserConnectionCredentials | None) -> str:
     """Read the stored query-identity preference; defaults to 'self'."""
     if row is not None:

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -31,6 +31,7 @@ from app.models.connection_indexing import (
     ConnectionIndexingStatus,
     TERMINAL_INDEXING_STATUSES,
 )
+from app.services.connection_identity import catalog_requires_user_sign_in
 
 
 logger = logging.getLogger(__name__)
@@ -471,7 +472,18 @@ class ConnectionIndexingService:
                 # used to do inline — a full drive walk on the redirect, with
                 # the browser waiting on it — moved here so sign-in returns at
                 # once and the progress is pollable.
-                if row.user_id:
+                # Tool providers are the exception: their catalog is a flat tool
+                # list, not a per-user schema overlay, so a user-scoped run just
+                # means "discover with THIS user's token" — which is the only way
+                # a per-user OAuth connector (DCR / OAuth app) can be indexed at
+                # all. Fall through to the shared tool path with that identity.
+                index_user = None
+                if row.user_id and is_tool_provider:
+                    from app.models.user import User
+
+                    index_user = await db.get(User, str(row.user_id))
+
+                if row.user_id and not is_tool_provider:
                     await self._run_user_catalog_sync(
                         db=db,
                         new_session=_new_session,
@@ -516,12 +528,43 @@ class ConnectionIndexingService:
                     )
                     return
 
+                # Per-user OAuth connectors (an MCP/Custom-API tile connected via
+                # DCR or an admin OAuth app) hold an OAuth client, never a token.
+                # A run with no user in scope would go out unauthenticated and
+                # come back 401 — on every scheduled sweep, with a red "Indexing
+                # failed" the admin can do nothing about. Say what's actually
+                # true instead: this catalog is discovered when a user signs in.
+                if index_user is None and catalog_requires_user_sign_in(connection):
+                    fresh = await db.get(ConnectionIndexing, indexing_id)
+                    if fresh is None:
+                        return
+                    elapsed_s = round(time.perf_counter() - start, 3)
+                    fresh.status = ConnectionIndexingStatus.COMPLETED.value
+                    fresh.finished_at = datetime.utcnow()
+                    fresh.error = None
+                    fresh.stats_json = {
+                        "table_count": 0,
+                        "awaiting_user_sign_in": True,
+                        "data_shape": data_shape,
+                        "item_noun": noun_sing,
+                        "item_noun_plural": noun_plural,
+                        "elapsed_s": elapsed_s,
+                    }
+                    await db.commit()
+                    await _append_event(
+                        "info", None,
+                        f"This connection signs in per user — {noun_plural} are "
+                        f"discovered with each user's own credentials, so there is "
+                        f"nothing to index with the connection's own.",
+                    )
+                    return
+
                 try:
                     if is_tool_provider:
                         items = await svc.refresh_tools(
                             db=db,
                             connection=connection,
-                            current_user=None,
+                            current_user=index_user,
                         )
                     else:
                         items = await svc.refresh_schema(

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1963,6 +1963,22 @@ class ConnectionService:
                 detail=f"Connection type '{connection.type}' does not support tool discovery",
             )
 
+        # No user in context and nothing to authenticate with: a per-user OAuth
+        # connector (DCR / admin OAuth app) stores an OAuth client, not a token,
+        # so construct_client would build a client with no Authorization header
+        # and the provider would answer 401 — every time, forever. Tools are
+        # discovered when a user signs in; skip cleanly instead of failing.
+        from app.services.connection_identity import catalog_requires_user_sign_in
+
+        if current_user is None and catalog_requires_user_sign_in(connection):
+            logger.info(
+                f"refresh_tools: connection {connection.id} authenticates per user and has no "
+                "system credentials — skipping tool discovery until a user signs in."
+            )
+            self.last_tools_awaiting_sign_in = True
+            return []
+        self.last_tools_awaiting_sign_in = False
+
         try:
             logger.info(f"refresh_tools: Starting for connection {connection.id} (type={connection.type})")
             client = await self.construct_client(db, connection, current_user)

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -273,6 +273,7 @@ class DataSourceService:
         from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
         from app.models.connection_indexing import ConnectionIndexing
         from app.models.connection_table import ConnectionTable
+        from app.models.connection_tool import ConnectionTool
 
         # One query for all connections' latest indexings — avoids N+1 on
         # GET /data_sources/{id} which is polled every ~2s while indexing runs.
@@ -315,6 +316,18 @@ class DataSourceService:
                         "indexing.bulk_lookup_failed",
                         extra={"data_source_id": str(data_source.id)},
                     )
+
+        # Tool counts for tool-provider connections, in one grouped query. The
+        # catalog of an MCP / Custom API connection is its tool list, so this is
+        # the "N items" the UI reports for them — `table_count` is always 0.
+        tool_count_by_conn: dict = {}
+        if connection_ids:
+            tool_rows = await db.execute(
+                select(ConnectionTool.connection_id, func.count(ConnectionTool.id))
+                .where(ConnectionTool.connection_id.in_(connection_ids))
+                .group_by(ConnectionTool.connection_id)
+            )
+            tool_count_by_conn = {str(cid): (n or 0) for cid, n in tool_rows.all()}
 
         connections_list = []
 
@@ -448,6 +461,7 @@ class DataSourceService:
                 last_synced_at=conn.last_synced_at,
                 user_status=user_status,
                 table_count=table_count,
+                tool_count=tool_count_by_conn.get(str(conn.id), 0),
                 indexing=indexing_payload,
                 connector_key=_conn_connector_key(conn),
                 data_shape=data_shape_for(conn.type),
@@ -4234,14 +4248,43 @@ class DataSourceService:
             # keeps exactly one canonical row per table and never creates name-keyed
             # orphans. Per-user catalogs (OneDrive, personal Drive) have no shared
             # catalog and are fetched per user below.
-            shared_conns, per_user_conns = [], []
+            # Tool providers (MCP / Custom API) carry no schema at all — their
+            # catalog is a tool list, discovered by refresh_tools. Routing them
+            # through refresh_schema below reached `McpClient.aget_schemas`,
+            # which does not exist, so an agent-level Reload raised
+            # AttributeError and the user's only recovery action did nothing.
+            from app.schemas.data_source_registry import tool_provider_types
+            _tool_types = tool_provider_types()
+
+            shared_conns, per_user_conns, tool_conns = [], [], []
             for conn in (data_source.connections or []):
+                if conn.type in _tool_types:
+                    tool_conns.append(conn)
+                    continue
                 ownership = "shared"
                 try:
                     ownership = get_entry(conn.type).catalog_ownership
                 except Exception:
                     ownership = "shared"
                 (per_user_conns if ownership == "per_user" else shared_conns).append(conn)
+
+            # Discover with the CALLER's credentials: for a per-user OAuth
+            # connector that is the only identity that has a token at all.
+            for conn in tool_conns:
+                try:
+                    await connection_service.refresh_tools(
+                        db=db, connection=conn, current_user=current_user
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"refresh_data_source_schema: tool refresh failed for connection {conn.id}: {e}"
+                    )
+
+            # Tool-only agent: there is no schema to return, and no legacy
+            # fallback to fall through to (save_or_update_tables would land back
+            # on the same missing aget_schemas).
+            if tool_conns and not shared_conns and not per_user_conns:
+                return []
 
             if shared_conns:
                 # When every shared connection's refresh below runs with the

--- a/backend/app/services/scheduled_reindex.py
+++ b/backend/app/services/scheduled_reindex.py
@@ -87,6 +87,7 @@ async def sweep_due_reindexes() -> None:
 
     from app.dependencies import async_session_maker
     from app.models.connection import Connection
+    from app.services.connection_identity import catalog_requires_user_sign_in
     from app.services.connection_indexing_service import ConnectionIndexingService
     from app.services.connection_service import ConnectionService
 
@@ -132,6 +133,13 @@ async def sweep_due_reindexes() -> None:
             # Per-user catalogs (OneDrive, personal Drive) have no admin-side
             # catalog to re-index — they heal on each user's sign-in. Skip.
             if svc._is_per_user_catalog(conn.type):
+                continue
+            # Per-user OAuth connectors (MCP/Custom API connected via DCR or an
+            # admin OAuth app) hold an OAuth client, not a token — a sweep run
+            # has no identity to crawl as and would 401 on every tick. Their
+            # catalog is discovered when a user signs in, or on an admin's
+            # manual retry, which runs with that admin's own credentials.
+            if catalog_requires_user_sign_in(conn):
                 continue
             tz = await _org_tz(conn.organization_id)
             if _is_due(conn, now, tz):

--- a/backend/tests/mocks/bearer_gated_mcp_server.py
+++ b/backend/tests/mocks/bearer_gated_mcp_server.py
@@ -1,0 +1,98 @@
+"""A streamable-HTTP MCP server that requires a bearer token — a stand-in for
+monday.com's hosted MCP server.
+
+It reproduces the exact failure a per-user OAuth (DCR) connector hits when
+something calls it with no user in context: the request goes out with no
+Authorization header and the server answers
+
+    HTTP 401
+    www-authenticate: Bearer realm="OAuth", error="invalid_token"
+    {"error": "invalid_token", "error_description": "Missing or invalid access token"}
+
+which is byte-for-byte the shape mcp.monday.com returns.
+
+Run standalone::
+
+    MOCK_MCP_TOKEN=secret-user-token \
+        uv run python tests/mocks/bearer_gated_mcp_server.py --port 3399
+
+Then point a ``type=mcp`` connection at ``http://localhost:3399/mcp``
+(transport ``streamable_http``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from mcp.server.fastmcp import FastMCP
+from starlette.responses import JSONResponse
+
+mcp = FastMCP("mock-monday")
+
+# The only token this server accepts. A per-user OAuth connector only ever holds
+# it on a UserConnectionCredentials row — never on the connection itself.
+VALID_TOKEN = os.environ.get("MOCK_MCP_TOKEN", "secret-user-token")
+
+
+@mcp.tool(description="List boards visible to the signed-in user.")
+def get_boards() -> str:
+    return json.dumps([
+        {"id": "1001", "name": "Roadmap"},
+        {"id": "1002", "name": "Support queue"},
+    ])
+
+
+@mcp.tool(description="Fetch the items on a board.")
+def get_board_items(board_id: str) -> str:
+    return json.dumps({"board_id": board_id, "items": [{"id": "i1", "name": "Ship it"}]})
+
+
+@mcp.tool(description="Return the authenticated user.")
+def me() -> str:
+    return json.dumps({"id": "u1", "name": "Sandbox User"})
+
+
+def build_app():
+    """The MCP ASGI app, gated on a bearer token."""
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    app = mcp.streamable_http_app()
+
+    async def require_bearer(request, call_next):
+        auth = request.headers.get("authorization", "")
+        token = auth[7:] if auth.lower().startswith("bearer ") else None
+        if token != VALID_TOKEN:
+            return JSONResponse(
+                {
+                    "error": "invalid_token",
+                    "error_description": "Missing or invalid access token",
+                },
+                status_code=401,
+                headers={
+                    "WWW-Authenticate": (
+                        'Bearer realm="OAuth", error="invalid_token", '
+                        'error_description="Missing or invalid access token"'
+                    )
+                },
+            )
+        return await call_next(request)
+
+    app.add_middleware(BaseHTTPMiddleware, dispatch=require_bearer)
+    return app
+
+
+def main() -> None:
+    import uvicorn
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=3399)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    uvicorn.run(build_app(), host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_per_user_oauth_connector_indexing.py
+++ b/backend/tests/unit/test_per_user_oauth_connector_indexing.py
@@ -1,0 +1,127 @@
+"""A per-user OAuth connector (MCP/Custom API connected via DCR or an admin
+OAuth app) stores an OAuth *client*, never a token. Anything that runs without
+a user in context therefore has nothing to authenticate with, and the provider
+answers 401 — which is how a Monday connector ended up reporting "Indexing
+failed: 401 Unauthorized" on every scheduled sweep, with a Retry button that
+could only reproduce it.
+
+These tests pin the predicate that tells those connections apart from ones with
+real system credentials, and the three call sites that must honour it.
+"""
+import json
+import types
+
+import pytest
+
+from app.services.connection_identity import catalog_requires_user_sign_in
+from app.services.connection_service import ConnectionService
+
+
+def _conn(*, auth_policy="user_required", auth_type="dcr", credentials=True, type="mcp",
+          config_as_str=False):
+    """A stand-in for a Connection row — only the fields the predicate reads."""
+    config = {"server_url": "https://mcp.monday.com/mcp", "transport": "streamable_http"}
+    if auth_type is not None:
+        config["auth_type"] = auth_type
+    return types.SimpleNamespace(
+        id="conn-1",
+        type=type,
+        auth_policy=auth_policy,
+        config=json.dumps(config) if config_as_str else config,
+        # The DCR blob: an OAuth client and endpoints, and no token anywhere.
+        credentials="<encrypted>" if credentials else None,
+        allowed_user_auth_modes=["oauth"] if auth_policy == "user_required" else None,
+    )
+
+
+# ── The predicate ──────────────────────────────────────────────────────────
+
+def test_dcr_connection_needs_a_signed_in_user():
+    # The bug in one assertion: `bool(connection.credentials)` is True here, but
+    # there is no token in that blob, so a user-less call goes out unauthenticated.
+    conn = _conn(auth_type="dcr")
+    assert bool(conn.credentials) is True
+    assert catalog_requires_user_sign_in(conn) is True
+
+
+def test_oauth_app_connection_needs_a_signed_in_user():
+    assert catalog_requires_user_sign_in(_conn(auth_type="oauth_app")) is True
+
+
+def test_config_stored_as_json_string_is_parsed():
+    assert catalog_requires_user_sign_in(_conn(auth_type="dcr", config_as_str=True)) is True
+
+
+def test_system_only_connection_indexes_admin_side():
+    # An admin-supplied bearer/api key lives in the connection credentials and
+    # authenticates fine with no user in context.
+    assert catalog_requires_user_sign_in(
+        _conn(auth_policy="system_only", auth_type="bearer")
+    ) is False
+
+
+def test_user_required_with_shared_secret_still_indexes_admin_side():
+    # user_required + bearer: each user MAY supply their own token, but the
+    # admin's stored one still works for indexing. Not the broken case.
+    assert catalog_requires_user_sign_in(
+        _conn(auth_policy="user_required", auth_type="bearer")
+    ) is False
+
+
+def test_credential_less_but_indexable_source_is_not_gated():
+    """SQLite/DuckDB/QVD index from `config` alone, and an MCP server with no
+    auth needs no token — a user_required one of those must still index
+    admin-side. Gating it here would strand every such catalog at zero items."""
+    assert catalog_requires_user_sign_in(
+        _conn(type="sqlite", auth_policy="user_required", auth_type=None, credentials=False)
+    ) is False
+    assert catalog_requires_user_sign_in(
+        _conn(auth_policy="user_required", auth_type="none", credentials=False)
+    ) is False
+
+
+# ── refresh_tools: skip instead of 401 ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_refresh_tools_without_user_skips_per_user_oauth_connection(monkeypatch):
+    """No user + no system credentials → don't even build a client.
+
+    Before the fix this constructed an McpClient with no Authorization header
+    and let the provider's 401 bubble up as "Failed to refresh tools".
+    """
+    svc = ConnectionService()
+
+    async def _boom(*a, **kw):  # pragma: no cover - must not be reached
+        raise AssertionError("construct_client must not run without credentials")
+
+    monkeypatch.setattr(svc, "construct_client", _boom)
+
+    tools = await svc.refresh_tools(db=None, connection=_conn(), current_user=None)
+
+    assert tools == []
+    assert svc.last_tools_awaiting_sign_in is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_tools_with_a_user_still_runs(monkeypatch):
+    """The same connection IS indexable as a signed-in user — that's the path
+    the OAuth callback and the admin's Retry take."""
+    svc = ConnectionService()
+    built = {}
+
+    class _Client:
+        async def alist_tools(self):
+            return []
+
+    async def _construct(db, connection, current_user, **kw):
+        built["user"] = current_user
+        return _Client()
+
+    monkeypatch.setattr(svc, "construct_client", _construct)
+    # refresh_tools writes ConnectionTool rows; stop at the client call.
+    with pytest.raises(Exception):
+        await svc.refresh_tools(
+            db=None, connection=_conn(), current_user=types.SimpleNamespace(id="u1"),
+        )
+    assert built.get("user") is not None
+    assert svc.last_tools_awaiting_sign_in is False

--- a/frontend/components/ConnectionIndexingProgress.vue
+++ b/frontend/components/ConnectionIndexingProgress.vue
@@ -35,6 +35,13 @@
             <span v-if="indexing?.stats?.per_user_catalog">
                 Each user's {{ itemNounPlural }} are indexed when they sign in
             </span>
+            <!-- Per-user OAuth connectors hold an OAuth client, not a token: there
+                 is no connection-level identity to index with, so say so rather
+                 than reporting a 401 nobody can act on. -->
+            <span v-else-if="indexing?.stats?.awaiting_user_sign_in">
+                {{ itemNounPlural.charAt(0).toUpperCase() + itemNounPlural.slice(1) }}
+                are discovered with each user's own sign-in
+            </span>
             <span v-else>
                 Discovered {{ itemCount }} {{ itemCount === 1 ? itemNoun : itemNounPlural }}
                 <span v-if="indexing?.stats?.elapsed_s != null"> in {{ formatDuration(indexing.stats.elapsed_s) }}</span>


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where per-user OAuth connectors (MCP/Custom API connections using DCR or admin OAuth apps) would repeatedly fail with "401 Unauthorized" during scheduled indexing sweeps, with no way for admins to recover them. The root cause is that these connectors store an OAuth *client* (credentials for registration), not a token—so system-context operations have no credentials to authenticate with.

## Key Changes

- **Added `catalog_requires_user_sign_in()` predicate** (`connection_identity.py`): Identifies connections that can only be indexed as a signed-in user because they hold OAuth clients, not tokens. Checks for `auth_type` in `{"dcr", "oauth_app"}` with `auth_policy="user_required"`.

- **Updated scheduled reindex sweep** (`scheduled_reindex.py`): Skips per-user OAuth connectors entirely, preventing the recurring 401 failures. These catalogs are discovered when users sign in instead.

- **Fixed `refresh_tools()` in ConnectionService** (`connection_service.py`): Returns empty list gracefully when called without a user context on a per-user OAuth connector, instead of attempting an unauthenticated request that fails with 401.

- **Updated connection indexing service** (`connection_indexing_service.py`): 
  - For tool providers, passes the signed-in user's identity to `refresh_tools()` so per-user OAuth connectors can authenticate
  - Marks indexing as completed with `awaiting_user_sign_in=True` when a system-context run encounters a per-user OAuth connector, providing clear messaging instead of an error

- **Enhanced admin reindex action** (`connection.py`): When an admin clicks "Reload" on a per-user OAuth tool connector, runs the discovery as the admin user (if they've signed in) rather than as a system-context operation.

- **Added tool count tracking** (`data_source_service.py`): Queries tool counts for tool-provider connections and includes `tool_count` in connection payloads so the UI correctly reports discovered tools.

- **Improved OAuth callback logging** (`connection_oauth.py`): Elevated tool refresh failures to error level with detailed context, since this is the only path that populates per-user connector tool catalogs.

- **Updated UI messaging** (`ConnectionIndexingProgress.vue`): Shows "discovered with each user's own sign-in" for per-user OAuth connectors instead of reporting indexing failures.

- **Added comprehensive test suite** (`test_per_user_oauth_connector_indexing.py`): Tests the predicate logic and verifies that `refresh_tools()` skips gracefully without a user while still running when a user is present.

- **Added mock MCP server** (`bearer_gated_mcp_server.py`): Reproduces the exact 401 response from monday.com's hosted MCP server for testing.

## Implementation Details

- The fix is deliberately narrow: only per-user OAuth auth types are gated on user sign-in. System-only connections, delegated connections with real service credentials, and credential-less-but-indexable sources (SQLite/DuckDB/QVD) continue indexing admin-side as before.

- Tool providers (MCP/Custom API) are routed through `refresh_tools()` instead of `refresh_schema()` during indexing, with the appropriate user identity passed through.

- The `awaiting_user_sign_in` flag in indexing stats provides clear, actionable messaging to admins about why a connection shows zero items.

https://claude.ai/code/session_01TBDnAkPiL85rjdy5tas5bR