### PR TITLE
Guard against swallowed query errors in generated code

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -183,6 +183,46 @@ class QueryTimeoutError(AppError):
         self.sql = sql
 
 
+class SwallowedQueryError(AppError):
+    """Raised when a query failed but the generated code returned an empty frame.
+
+    Generated code that wraps `execute_query` in `try/except` and falls back to
+    an empty DataFrame turns a hard failure into a successful-looking 0-row
+    answer: the step is marked `success`, the retry loop never fires, and the
+    widget renders correct-looking headers over no data. Worse, the step is then
+    recorded as a successful use of those tables (`emit_table_usage_*` reads
+    `step.status`), so the broken code becomes a "similar successful snippet"
+    fed back into later codegen for the same tables.
+
+    The prompts ask the model not to do this, but a prompt cannot be relied on
+    to hold. This makes the swallow structurally impossible: the wrapper already
+    records every failed query in `captured_timings`, so an empty result plus a
+    failed query is caught here and raised, feeding the real error back into the
+    retry loop.
+
+    Deliberate trade-off: code that legitimately recovers from a failed query
+    and then legitimately returns zero rows is also caught. That is the correct
+    bias — when a query has failed, an empty result cannot be distinguished from
+    a broken one, and a retry costs less than silently reporting "no data".
+    """
+
+    def __init__(self, errors: List[str]) -> None:
+        detail = "; ".join(errors[:3])
+        message = (
+            "A query failed but the code returned an empty DataFrame instead of "
+            f"letting the error surface. Underlying error(s): {detail}. "
+            "Do NOT wrap execute_query in try/except that falls back to an empty "
+            "DataFrame — fix the failing call so the query actually runs."
+        )
+        super().__init__(
+            ErrorCode.QUERY_FAILED_SILENTLY,
+            message,
+            status_code=422,
+            params={"query_errors": list(errors[:3])},
+        )
+        self.errors = list(errors)
+
+
 def resolve_query_timeout(client, organization_settings) -> int:
     """Per-connection timeout resolution.
 
@@ -1034,7 +1074,34 @@ class StreamingCodeExecutor:
                 stdout_capture.close()
             span.set_attribute("code_execution.query_count", len(executed_queries))
             span.set_attribute("code_execution.stdout_chars", len(output_log or ""))
+            # An empty result on top of a failed query means the code swallowed
+            # the error. Raise so the retry loop sees it instead of shipping a
+            # 0-row "success". Checked after stdout is unbound so the model's own
+            # printed error still reaches the execution log.
+            self._raise_if_query_errors_were_swallowed(df, _timings, span=span)
             return df, output_log, executed_queries
+
+    @staticmethod
+    def _raise_if_query_errors_were_swallowed(df, timings: List[dict], span=None) -> None:
+        """Turn a silently-empty result into a real failure.
+
+        Only fires when BOTH hold: the returned frame is empty, and at least one
+        `execute_query` call recorded an error. Either alone is legitimate — a
+        query can correctly return no rows, and code can recover from a failed
+        query and go on to return real data.
+        """
+        if df is None or not isinstance(df, pd.DataFrame) or not df.empty:
+            return
+        errors = [
+            str(t.get("error"))
+            for t in (timings or [])
+            if isinstance(t, dict) and t.get("error")
+        ]
+        if not errors:
+            return
+        if span is not None:
+            span.set_attribute("code_execution.swallowed_query_errors", len(errors))
+        raise SwallowedQueryError(errors)
 
     def _build_http_client(self) -> Optional[SafeHttpClient]:
         """Return a SafeHttpClient when `enable_web_fetch` is on, else None."""

--- a/backend/app/errors/codes.py
+++ b/backend/app/errors/codes.py
@@ -55,3 +55,4 @@ class ErrorCode(str, Enum):
 
     # Data execution
     QUERY_TIMEOUT = "query.timeout"
+    QUERY_FAILED_SILENTLY = "query.failed_silently"

--- a/backend/tests/unit/test_swallowed_query_error.py
+++ b/backend/tests/unit/test_swallowed_query_error.py
@@ -1,0 +1,219 @@
+"""Generated code must not turn a failed query into a successful empty answer.
+
+The contract: when `execute_query` raises and the returned frame is empty, the
+execution fails loudly and carries the underlying error, so the retry loop can
+fix the code. When either half is absent — a query that legitimately returned no
+rows, or a failure the code genuinely recovered from — execution succeeds.
+
+Everything here goes through the public `execute_code` surface; the guard's
+internals are deliberately not asserted on.
+"""
+import pandas as pd
+import pytest
+
+from app.ai.code_execution.code_execution import (
+    StreamingCodeExecutor,
+    SwallowedQueryError,
+)
+from app.errors.codes import ErrorCode
+
+
+class _StubClient:
+    """Stands in for a real driver: execute_query takes a query string only."""
+
+    def __init__(self, result=None, raises=None):
+        self._result = pd.DataFrame({"n": [7]}) if result is None else result
+        self._raises = raises
+        self._bow_connection_id = None
+
+    def execute_query(self, query):
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+def _run(code, client, **kwargs):
+    return StreamingCodeExecutor(organization_settings=None).execute_code(
+        code=code, ds_clients={"main": client}, excel_files=[], **kwargs
+    )
+
+
+# ---------------------------------------------------------------------------
+# A swallowed failure becomes a real failure
+# ---------------------------------------------------------------------------
+
+# Distinct failure modes, none of which should reach the caller as "0 rows".
+# Values deliberately differ from the incident that prompted this guard.
+SWALLOWED_FAILURES = [
+    pytest.param(
+        """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    try:
+        return ds_clients["main"].execute_query("SELECT 1", scope=["a"])
+    except Exception:
+        return pd.DataFrame(columns=["c"])
+""",
+        _StubClient(),
+        "unexpected keyword argument",
+        id="unsupported_kwarg",
+    ),
+    pytest.param(
+        """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    try:
+        return ds_clients["main"].execute_query("SELECT * FROM missing_view")
+    except Exception:
+        return pd.DataFrame(columns=["c"])
+""",
+        _StubClient(raises=RuntimeError("Invalid object name 'missing_view'")),
+        "missing_view",
+        id="bad_object_name",
+    ),
+    pytest.param(
+        """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    frames = []
+    for q in ("SELECT a FROM t1", "SELECT b FROM t2"):
+        try:
+            frames.append(ds_clients["main"].execute_query(q))
+        except Exception:
+            pass
+    return pd.concat(frames) if frames else pd.DataFrame(columns=["a"])
+""",
+        _StubClient(raises=ValueError("permission denied for relation t1")),
+        "permission denied",
+        id="loop_swallowing_every_query",
+    ),
+]
+
+
+@pytest.mark.parametrize("code,client,expected_fragment", SWALLOWED_FAILURES)
+def test_swallowed_query_failure_raises(code, client, expected_fragment):
+    with pytest.raises(SwallowedQueryError) as excinfo:
+        _run(code, client)
+
+    err = excinfo.value
+    assert err.error_code == ErrorCode.QUERY_FAILED_SILENTLY.value
+    # The underlying driver error must survive onto the exception: the retry
+    # loop feeds it back to codegen, and without it the model cannot fix the call.
+    assert any(expected_fragment in e for e in err.errors)
+
+
+def test_underlying_error_reaches_the_retry_loop_message():
+    """The retry loop stringifies the exception, so the cause must be in there."""
+    code = """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    try:
+        return ds_clients["main"].execute_query("SELECT 1")
+    except Exception:
+        return pd.DataFrame()
+"""
+    with pytest.raises(SwallowedQueryError) as excinfo:
+        _run(code, _StubClient(raises=RuntimeError("login timeout expired")))
+    assert "login timeout expired" in str(excinfo.value)
+
+
+def test_stdout_error_print_is_not_what_we_rely_on():
+    """The guard fires even when the code swallows silently, printing nothing."""
+    code = """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    try:
+        return ds_clients["main"].execute_query("SELECT 1")
+    except Exception:
+        return pd.DataFrame(columns=["x"])
+"""
+    with pytest.raises(SwallowedQueryError):
+        _run(code, _StubClient(raises=RuntimeError("boom")))
+
+
+# ---------------------------------------------------------------------------
+# Legitimate outcomes stay untouched
+# ---------------------------------------------------------------------------
+
+def test_empty_result_without_query_failure_succeeds():
+    """Zero rows is a valid answer when nothing failed."""
+    df, _log, _q = _run(
+        """
+def generate_df(ds_clients, excel_files):
+    return ds_clients["main"].execute_query("SELECT * FROM t WHERE 1=0")
+""",
+        _StubClient(result=pd.DataFrame(columns=["a", "b"])),
+    )
+    assert df.empty
+    assert list(df.columns) == ["a", "b"]
+
+
+def test_recovered_failure_returning_rows_succeeds():
+    """A failure the code genuinely recovered from is not a swallow."""
+
+    class _FailsFirst(_StubClient):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def execute_query(self, query):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient reset")
+            return pd.DataFrame({"n": [1, 2, 3]})
+
+    df, _log, _q = _run(
+        """
+def generate_df(ds_clients, excel_files):
+    client = ds_clients["main"]
+    try:
+        return client.execute_query("SELECT primary_source")
+    except Exception:
+        return client.execute_query("SELECT fallback_source")
+""",
+        _FailsFirst(),
+    )
+    assert len(df) == 3
+
+
+def test_successful_query_succeeds():
+    """Baseline: the happy path is unchanged."""
+    df, _log, _q = _run(
+        """
+def generate_df(ds_clients, excel_files):
+    return ds_clients["main"].execute_query("SELECT COUNT(*) AS n FROM t")
+""",
+        _StubClient(result=pd.DataFrame({"n": [42]})),
+    )
+    assert df.iloc[0]["n"] == 42
+
+
+def test_unhandled_query_failure_still_propagates_unchanged():
+    """Code that does not swallow keeps surfacing the driver's own exception."""
+    code = """
+def generate_df(ds_clients, excel_files):
+    return ds_clients["main"].execute_query("SELECT 1")
+"""
+    with pytest.raises(Exception) as excinfo:
+        _run(code, _StubClient(raises=RuntimeError("connection refused")))
+    assert not isinstance(excinfo.value, SwallowedQueryError)
+    assert "connection refused" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "returned",
+    ["None", "'a string'", "{'k': 1}"],
+    ids=["none", "string", "dict"],
+)
+def test_non_dataframe_results_are_left_to_the_caller(returned):
+    """The guard only judges DataFrames; other shapes are the caller's problem."""
+    code = f"""
+def generate_df(ds_clients, excel_files):
+    try:
+        ds_clients["main"].execute_query("SELECT 1")
+    except Exception:
+        pass
+    return {returned}
+"""
+    result, _log, _q = _run(code, _StubClient(raises=RuntimeError("boom")))
+    assert not isinstance(result, pd.DataFrame)

--- a/locales/en.json
+++ b/locales/en.json
@@ -2651,7 +2651,8 @@
     "integration.not_found": "Integration not found",
     "resource.conflict": "Resource already exists or conflicts with existing state",
     "resource.duplicate": "Duplicate resource",
-    "setting.update_failed": "Failed to update setting"
+    "setting.update_failed": "Failed to update setting",
+    "query.failed_silently": "A query failed but the generated code returned an empty result instead of reporting it"
   },
   "email": {
     "dashboardShare": {


### PR DESCRIPTION
## Summary
Add a safety guard to detect when generated code silently swallows query failures by catching exceptions and returning empty DataFrames. This prevents broken code from being marked as successful and fed back into the retry loop.

## Key Changes
- **New `SwallowedQueryError` exception class**: Raised when a query fails but the generated code returns an empty DataFrame instead of propagating the error. Includes the underlying error details so the retry loop can feed them back to codegen for fixing.

- **Query error detection in `execute_code`**: Added `_raise_if_query_errors_were_swallowed()` method that checks if both conditions hold:
  - The returned DataFrame is empty
  - At least one `execute_query` call recorded an error in `captured_timings`
  
  When both are true, raises `SwallowedQueryError` with all captured error messages.

- **Comprehensive test suite**: 219 lines of tests covering:
  - Multiple failure modes that should be caught (unsupported kwargs, bad object names, permission errors, etc.)
  - Legitimate outcomes that should pass through unchanged (empty results without failures, recovered failures returning data, unhandled exceptions)
  - Edge cases (non-DataFrame returns, silent swallowing without stdout output)

- **Error code and localization**: Added `QUERY_FAILED_SILENTLY` error code and English localization string.

## Implementation Details
- The guard fires **after** stdout is unbound so the model's own printed errors still reach the execution log
- Deliberately biased toward false positives: code that legitimately recovers from a failed query and returns zero rows will also be caught, but this is acceptable since a retry costs less than silently reporting "no data"
- Only judges DataFrames; other return types are left to the caller
- Captures up to 3 error messages in the exception for the retry loop
- Sets a span attribute tracking the number of swallowed errors for observability

https://claude.ai/code/session_01G9AvFdkBjM2M95s8ZJM5rg