### PR TITLE
Fix 404 opening a dashboard that lives in a project

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1894,6 +1894,11 @@ class ReportService:
                     lazyload("*"),
                     selectinload(DataSource.connections).options(lazyload("*")),
                 ),
+                # ReportSchema serializes `project`. It is lazy="joined" on the
+                # mapper, but the wildcard above turned that off — without an
+                # explicit load, serializing a report that sits inside a project
+                # lazy-loads on the async session and raises MissingGreenlet.
+                selectinload(Report.project).options(lazyload("*")),
             )
             .filter(Report.id == report_id)
         )

--- a/backend/tests/e2e/test_public_report_in_project.py
+++ b/backend/tests/e2e/test_public_report_in_project.py
@@ -1,0 +1,59 @@
+"""Regression: GET /api/r/{id} for a report that lives inside a project.
+
+The published-dashboard page (/r/{id}) is what the project page's dashboard
+cards link to. ``Report.project`` is a ``lazy="joined"`` to-one, and the
+public loader turns eager loading off wholesale with ``lazyload("*")`` — so
+serializing ``ReportSchema.project`` used to lazy-load on an async session
+and blow up (MissingGreenlet -> 500), but only for reports that actually
+carry a ``project_id``. The frontend maps any non-401/403 failure to
+/not_found, which is why the card read as a 404.
+"""
+import uuid
+
+import pytest
+
+
+def _owner(create_user, login_user, whoami):
+    email = f"pub_proj_{uuid.uuid4().hex[:6]}@test.com"
+    create_user(email=email, password="test123")
+    token = login_user(email=email, password="test123")
+    org_id = whoami(token)["organizations"][0]["id"]
+    return token, org_id
+
+
+@pytest.mark.e2e
+def test_public_report_endpoint_serves_report_inside_project(
+    create_user, login_user, whoami, create_project, create_report, test_client,
+):
+    token, org_id = _owner(create_user, login_user, whoami)
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    project = create_project(name="Aviv", user_token=token, org_id=org_id)
+    report = create_report(
+        title="Dashboard in a project",
+        user_token=token,
+        org_id=org_id,
+        project_id=project["id"],
+    )
+
+    resp = test_client.get(f"/api/r/{report['id']}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == report["id"]
+    assert body["project_id"] == project["id"]
+    assert (body.get("project") or {}).get("id") == project["id"]
+
+
+@pytest.mark.e2e
+def test_public_report_endpoint_serves_report_without_project(
+    create_user, login_user, whoami, create_report, test_client,
+):
+    """The no-project case must keep working (it always did)."""
+    token, org_id = _owner(create_user, login_user, whoami)
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    report = create_report(title="Rootless report", user_token=token, org_id=org_id)
+
+    resp = test_client.get(f"/api/r/{report['id']}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project"] is None

--- a/backend/tests/e2e/test_public_report_in_project.py
+++ b/backend/tests/e2e/test_public_report_in_project.py
@@ -1,12 +1,13 @@
 """Regression: GET /api/r/{id} for a report that lives inside a project.
 
-The published-dashboard page (/r/{id}) is what the project page's dashboard
-cards link to. ``Report.project`` is a ``lazy="joined"`` to-one, and the
-public loader turns eager loading off wholesale with ``lazyload("*")`` — so
-serializing ``ReportSchema.project`` used to lazy-load on an async session
-and blow up (MissingGreenlet -> 500), but only for reports that actually
-carry a ``project_id``. The frontend maps any non-401/403 failure to
-/not_found, which is why the card read as a 404.
+The published-dashboard page (/r/{id}) is what every dashboard card links
+to — the project page, /dashboards, and the home page all render
+RecentReportCard in 'org' view mode. ``Report.project`` is a
+``lazy="joined"`` to-one, and the public loader turns eager loading off
+wholesale with ``lazyload("*")`` — so serializing ``ReportSchema.project``
+used to lazy-load on an async session and blow up (MissingGreenlet -> 500),
+but only for reports that actually carry a ``project_id``. The frontend maps
+any non-401/403 failure to /not_found, which is why the card read as a 404.
 """
 import uuid
 
@@ -42,6 +43,48 @@ def test_public_report_endpoint_serves_report_inside_project(
     assert body["id"] == report["id"]
     assert body["project_id"] == project["id"]
     assert (body.get("project") or {}).get("id") == project["id"]
+
+
+@pytest.mark.e2e
+def test_public_report_endpoint_serves_project_collaborator(
+    create_user, login_user, whoami, create_project, create_report,
+    upsert_project_member, test_client,
+):
+    """A read-only collaborator reaches the same card from /dashboards.
+
+    Their access comes from project membership, not from artifact_visibility,
+    so they take the same serialization path as the owner.
+    """
+    owner_token, org_id = _owner(create_user, login_user, whoami)
+
+    member_email = f"pub_proj_m_{uuid.uuid4().hex[:6]}@test.com"
+    test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": member_email, "role": "member"},
+        headers={"Authorization": f"Bearer {owner_token}", "X-Organization-Id": str(org_id)},
+    )
+    create_user(email=member_email, password="test123")
+    member_token = login_user(email=member_email, password="test123")
+    member_id = whoami(member_token)["id"]
+
+    project = create_project(name="Aviv", user_token=owner_token, org_id=org_id)
+    upsert_project_member(
+        project["id"], member_id, permissions=["view"],
+        user_token=owner_token, org_id=org_id,
+    )
+    report = create_report(
+        title="Shared dashboard",
+        user_token=owner_token,
+        org_id=org_id,
+        project_id=project["id"],
+    )
+
+    resp = test_client.get(
+        f"/api/r/{report['id']}",
+        headers={"Authorization": f"Bearer {member_token}", "X-Organization-Id": str(org_id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == project["id"]
 
 
 @pytest.mark.e2e

--- a/frontend/pages/projects/[id]/index.vue
+++ b/frontend/pages/projects/[id]/index.vue
@@ -65,7 +65,7 @@
                                         <NuxtLink :to="automationLink(auto)" class="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800/60 cursor-pointer">
                                             <UIcon :name="automationIcon(auto)" class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500" />
                                             <span class="flex-1 truncate text-[13px] text-gray-800 dark:text-gray-200">{{ auto.label }}</span>
-                                            <span class="hidden sm:block text-[11px] font-mono text-gray-400 dark:text-gray-500">{{ auto.cron_schedule }}</span>
+                                            <span class="hidden sm:block text-[11px] text-gray-400 dark:text-gray-500">{{ getCronLabel(auto.cron_schedule) }}</span>
                                             <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="auto.is_active ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
                                         </NuxtLink>
                                     </li>
@@ -430,10 +430,11 @@ const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const { fetchActivity, sortByActivity } = useReportActivity()
+// Schedules read as prose ("Daily at 7:00 AM"), not as a raw cron expression.
+const { getCronLabel } = useCronLabel()
 const toast = useToast()
 const { data: currentUser } = useAuth()
 const { fetchProjects, updateProject, deleteProject } = useProjects()
-const { selectedAgentObjects } = useAgent()
 const { organization } = useOrganization()
 
 const projectId = computed(() => String(route.params.id))
@@ -753,13 +754,19 @@ const createReportInProject = async () => {
     if (creating.value) return
     creating.value = true
     try {
-        const dataSourceIds = selectedAgentObjects.value.map((a: any) => a.id)
+        // No data_sources: the backend copies the project's default agents onto
+        // a report created inside a project, and only when the caller didn't
+        // pick agents explicitly. Sending the global selection here defeated
+        // that — useAgent's selection is workspace-wide and falls back to
+        // *every* org agent when nothing is selected, so new project reports
+        // were created with the whole org attached instead of the project's
+        // agents (which is what the rail promises).
         const resp: any = await useMyFetch('/reports', {
             method: 'POST',
             body: JSON.stringify({
                 title: 'untitled report',
                 files: [],
-                data_sources: dataSourceIds,
+                data_sources: [],
                 project_id: projectId.value,
             }),
         })


### PR DESCRIPTION
Opening a dashboard card 404'd whenever the report lived inside a project. Two smaller project-page fixes ride along.

## 1. The 404 — `GET /api/r/{id}` returned 500 for any report in a project

Every dashboard card links to `/r/{id}`: the project page, `/dashboards`, and the home page all render `RecentReportCard` in `org` view mode.

`get_public_report` builds its query with `.options(lazyload("*"))`. That wildcard is deliberate — `Report`'s relationships are `lazy="selectin"`, so without it, rendering report metadata hydrates the whole report graph (every step version's data JSON, every artifact version, the chat history). The method then re-adds explicit loads for what it serializes: `user`, `external_platform`, `widgets`, `dashboard_layout_versions`, `data_sources`.

`project` was missed. `Report.project` is `lazy="joined"` on the mapper, so it normally rides along in the same query and never needed an explicit option — but the wildcard turns that off too.

So Pydantic reads `report.project` at serialization time, the attribute isn't loaded, SQLAlchemy emits a lazy SELECT, and on an `AsyncSession` that raises:

```
MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here
```

Pydantic wraps it as `ValidationError: 1 validation error for ReportSchema / project / Error extracting attribute`, which leaves the route unhandled → 500.

Only reports with a `project_id` were affected: for a many-to-one with a NULL FK, SQLAlchemy's lazy loader short-circuits to `None` without touching the database, so root-level reports always worked.

The user saw **404**, not 500, because `/r/[id]/index.vue`'s `loadReport` maps 401 → sign-in, 403 → access denied, and everything else → `navigateTo('/not_found')`, whose entire body is `<h1>404</h1>`.

Fix: load `Report.project` explicitly, exactly as the authenticated `get_report` already does.

## 2. "New report" in a project ignored the project's default agents

The page sent `useAgent()`'s workspace-wide selection as `data_sources`. The backend treats an explicit selection as an override of the project defaults rather than a union (`report_service.py:737`) — and that selection falls back to **every org agent** when nothing is selected. New project reports were created with the whole org attached instead of the project's agents, contradicting the rail's "Copied onto every new report created in this project."

Now it sends no agents and lets the backend copy the defaults.

## 3. Automations row printed a raw cron expression

`0 7 * * *` rendered verbatim in a mono span. It now goes through the existing `useCronLabel()` helper — "Daily at 7:00 AM" — matching the scheduled-tasks list and the automations page, and translated in every locale via the existing `scheduled.*` keys.

## Testing

New `backend/tests/e2e/test_public_report_in_project.py` — written first and confirmed failing with the exact `MissingGreenlet` error, then green after the fix:

- report inside a project, opened by the owner
- same report opened by a read-only project collaborator (access via project membership, not `artifact_visibility` — the case `/dashboards` surfaces)
- report with no project, which always worked and must keep working

64 existing tests across `test_report.py`, `test_report_sharing.py`, `test_projects.py`, `test_project_collaboration.py` pass. The project-defaults contract in fix 2 is already covered by `test_project_default_agents_override_not_union`.

The two frontend changes were verified by reading, not by running — this environment has no `node_modules`, so no build or click-through. Worth a quick look in a running app.

## Not addressed

`/r/[id]` funnels every non-401/403 failure into a bare 404 page. That's what disguised this 500 as "not found," and it will disguise the next one. Out of scope here; happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNMhHg3bk94zfx3CmjGT2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNMhHg3bk94zfx3CmjGT2c)_