### PR TITLE
Add Markdown export functionality for instructions

### DIFF
--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -580,6 +580,9 @@
                 <UIcon name="i-heroicons-clock" class="w-4 h-4" />
               </button>
               <template v-if="!editing && !diff">
+                <button v-if="!creating" class="h-7 w-7 rounded-md flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800/70 transition-colors" :title="$t('agentsPage.tipDownloadMarkdown')" @click="downloadMarkdown">
+                  <UIcon name="i-heroicons-arrow-down-tray" class="w-4 h-4" />
+                </button>
                 <button class="h-7 px-3 rounded-md border border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 text-xs font-medium hover:bg-gray-50 dark:hover:bg-gray-800/50" @click="startEdit">{{ $t('agentsPage.edit') }}</button>
               </template>
               <template v-else-if="!diff">
@@ -2977,6 +2980,34 @@ const restore = async (v: any) => {
 // Tree/list rows carry `preview` instead of the body; the detail pane still has
 // the full `text` once an instruction is opened.
 const displayTitle = (ins: Instruction) => instructionRowLabel(ins)
+
+// ── Markdown export ─────────────────────────────────────
+// The body is already markdown; the title and description live in their own
+// fields, so they get promoted to a heading and a lead paragraph to make the
+// downloaded file a standalone document. `draft` mirrors `detail` while not
+// editing, so it is the right source in both states.
+const instructionMarkdown = () => {
+  const parts = [draft.title.trim() ? `# ${draft.title.trim()}` : '', draft.description.trim(), draft.text.trim()]
+  return parts.filter(Boolean).join('\n\n') + '\n'
+}
+// Strip path/filesystem-hostile characters while keeping non-Latin scripts
+// (Hebrew/Arabic) intact, so a translated title still yields a readable name.
+const mdFileName = () => {
+  const base = (draft.title || (detail.value ? displayTitle(detail.value) : '')).replace(/[^\w\d֐-׿؀-ۿ -]+/g, '').trim()
+  return `${base || 'instruction'}.md`
+}
+const downloadMarkdown = () => {
+  if (!detail.value) return
+  const blob = new Blob([instructionMarkdown()], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = mdFileName()
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
 const refLabel = (ref: any) => ref.display_text || ref.object?.name || ref.object_type
 const _df = useFormatDate()
 const fmtDate = (s?: string) => { if (!s) return ''; try { return _df.format(s, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) } catch { return s } }

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "غير مُفعّل بعد — بانتظار موافقة المسؤول.",
     "saving": "جارٍ الحفظ…",
     "tipVersionHistory": "سجل الإصدارات",
+    "tipDownloadMarkdown": "تنزيل بصيغة Markdown",
     "deleting": "جارٍ الحذف…",
     "delete": "حذف",
     "tipDeleteInstruction": "حذف هذه التعليمة",

--- a/locales/de.json
+++ b/locales/de.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Noch nicht aktiv – wartet auf Freigabe durch einen Administrator.",
     "saving": "Wird gespeichert…",
     "tipVersionHistory": "Versionsverlauf",
+    "tipDownloadMarkdown": "Als Markdown herunterladen",
     "deleting": "Wird gelöscht…",
     "delete": "Löschen",
     "tipDeleteInstruction": "Diese Anweisung löschen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -135,6 +135,7 @@
     "pendingApprovalHint": "Not live yet — waiting for an admin to approve.",
     "saving": "Saving…",
     "tipVersionHistory": "Version history",
+    "tipDownloadMarkdown": "Download as Markdown",
     "deleting": "Deleting…",
     "delete": "Delete",
     "tipDeleteInstruction": "Delete this instruction",

--- a/locales/es.json
+++ b/locales/es.json
@@ -121,6 +121,7 @@
     "pendingApprovalHint": "Aún no activo: esperando la aprobación de un administrador.",
     "saving": "Guardando…",
     "tipVersionHistory": "Historial de versiones",
+    "tipDownloadMarkdown": "Descargar como Markdown",
     "deleting": "Eliminando…",
     "delete": "Eliminar",
     "tipDeleteInstruction": "Eliminar esta instrucción",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Pas encore actif — en attente de l’approbation d’un administrateur.",
     "saving": "Enregistrement…",
     "tipVersionHistory": "Historique des versions",
+    "tipDownloadMarkdown": "Télécharger en Markdown",
     "deleting": "Suppression…",
     "delete": "Supprimer",
     "tipDeleteInstruction": "Supprimer cette instruction",

--- a/locales/he.json
+++ b/locales/he.json
@@ -121,6 +121,7 @@
     "pendingApprovalHint": "עדיין לא פעיל — ממתין לאישור מנהל.",
     "saving": "שומר…",
     "tipVersionHistory": "היסטוריית גרסאות",
+    "tipDownloadMarkdown": "הורדה כ-Markdown",
     "deleting": "מוחק…",
     "delete": "מחיקה",
     "tipDeleteInstruction": "מחק הנחיה זו",

--- a/locales/it.json
+++ b/locales/it.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Non ancora attivo — in attesa dell’approvazione di un amministratore.",
     "saving": "Salvataggio…",
     "tipVersionHistory": "Cronologia versioni",
+    "tipDownloadMarkdown": "Scarica come Markdown",
     "deleting": "Eliminazione…",
     "delete": "Elimina",
     "tipDeleteInstruction": "Elimina questa istruzione",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Ainda não ativo — aguardando aprovação de um administrador.",
     "saving": "Salvando…",
     "tipVersionHistory": "Histórico de versões",
+    "tipDownloadMarkdown": "Baixar como Markdown",
     "deleting": "Excluindo…",
     "delete": "Excluir",
     "tipDeleteInstruction": "Excluir esta instrução",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Ещё не активно — ожидает одобрения администратора.",
     "saving": "Сохранение…",
     "tipVersionHistory": "История версий",
+    "tipDownloadMarkdown": "Скачать как Markdown",
     "deleting": "Удаление…",
     "delete": "Удалить",
     "tipDeleteInstruction": "Удалить эту инструкцию",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -109,6 +109,7 @@
     "pendingApprovalHint": "Inte aktiv än – väntar på godkännande av en administratör.",
     "saving": "Sparar…",
     "tipVersionHistory": "Versionshistorik",
+    "tipDownloadMarkdown": "Ladda ner som Markdown",
     "deleting": "Raderar…",
     "delete": "Radera",
     "tipDeleteInstruction": "Radera denna instruktion",


### PR DESCRIPTION
## Summary
This PR adds the ability to download instructions as Markdown files from the Knowledge Explorer component. Users can now export the full instruction (title, description, and body) as a standalone Markdown document with a single click.

## Key Changes
- **UI Enhancement**: Added a download button in the instruction detail pane toolbar that appears when not in edit or diff mode and not creating a new instruction
- **Export Logic**: Implemented three new functions:
  - `instructionMarkdown()`: Combines title (as H1 heading), description, and body text into a properly formatted Markdown document
  - `mdFileName()`: Generates a safe filename from the instruction title, preserving non-Latin scripts (Hebrew/Arabic) while removing filesystem-hostile characters
  - `downloadMarkdown()`: Handles the client-side download using Blob and URL APIs
- **Internationalization**: Added tooltip text `tipDownloadMarkdown` across 11 language locales (English, Spanish, French, German, Italian, Portuguese, Russian, Swedish, Hebrew, and Arabic)

## Implementation Details
- The download button is conditionally rendered only when viewing an instruction (not during creation, editing, or diff viewing)
- The exported Markdown uses the current draft state, ensuring consistency with what the user sees
- Filename sanitization intelligently handles Unicode ranges for Hebrew (U+05C0–U+05FF) and Arabic (U+0600–U+06FF) to maintain readability in translated titles
- The implementation uses standard browser APIs for file download without external dependencies

https://claude.ai/code/session_01K9mHFx6QzexDmdzEGBZuwm