### PR TITLE
Improve Monaco editor loading UX and unify catalog count labels

### DIFF
--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -202,6 +202,7 @@ import GitRepoModalComponent from '@/components/GitRepoModalComponent.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import GitBranchIcon from '~/components/icons/GitBranchIcon.vue'
 import InstructionEditor from '~/components/instructions/InstructionEditor.vue'
+import { connectionCatalogLabel } from '~/composables/useCatalogCount'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits<{
@@ -257,22 +258,17 @@ interface Connection {
   name: string
   type: string
   connector_key?: string | null
+  // Registry data_shape (tables | files | objects | tools) — drives which noun
+  // the catalog count uses. Sent by GET /connections.
+  data_shape?: string
   table_count?: number
   tool_count?: number
   agent_count?: number
 }
 
-// Tool-provider connections (MCP / custom API) expose tools, not tables, so
-// their catalog count is meaningless — show the tool count instead.
-const TOOL_PROVIDER_TYPES = ['mcp', 'custom_api']
-function connectionCountLabel(conn: Connection): string {
-  if (TOOL_PROVIDER_TYPES.includes(conn.type)) {
-    const n = conn.tool_count || 0
-    return `${n} tool${n === 1 ? '' : 's'}`
-  }
-  const n = conn.table_count || 0
-  return `${n} table${n === 1 ? '' : 's'}`
-}
+// "11 files" / "3 tools" / "12 tables" — the noun follows the connection's
+// data_shape rather than a hardcoded type list.
+const connectionCountLabel = connectionCatalogLabel
 
 const connections = ref<Connection[]>([])
 const loadingConnections = ref(true)

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -213,29 +213,47 @@
                     </button>
                   </div>
 
-                  <!-- Code editor with Monaco -->
+                  <!-- Code editor with Monaco.
+                       MonacoEditor has a top-level `await useMonaco()` in its
+                       setup, so mounting it suspends until the monaco chunk has
+                       loaded — with no boundary of its own the Code tab just
+                       rendered an empty box for that beat. The local Suspense
+                       gives that wait a spinner; ClientOnly's fallback covers
+                       the SSR/hydration pass before it. -->
                   <div class="relative h-[250px] rounded overflow-hidden border border-gray-200 dark:border-gray-700">
                     <ClientOnly>
-                      <MonacoEditor
-                        :modelValue="displayedCode"
-                        :lang="codeLanguage"
-                        :options="{
-                          theme: 'vs',
-                          readOnly: true,
-                          automaticLayout: true,
-                          minimap: { enabled: false },
-                          wordWrap: 'on',
-                          scrollBeyondLastLine: false,
-                          fontSize: 12,
-                          lineNumbers: 'off',
-                          folding: false,
-                          renderLineHighlight: 'none',
-                          overviewRulerLanes: 0,
-                          hideCursorInOverviewRuler: true,
-                          scrollbar: { vertical: 'auto', horizontal: 'hidden' }
-                        }"
-                        style="height: 100%"
-                      />
+                      <Suspense>
+                        <MonacoEditor
+                          :modelValue="displayedCode"
+                          :lang="codeLanguage"
+                          :options="{
+                            theme: 'vs',
+                            readOnly: true,
+                            automaticLayout: true,
+                            minimap: { enabled: false },
+                            wordWrap: 'on',
+                            scrollBeyondLastLine: false,
+                            fontSize: 12,
+                            lineNumbers: 'off',
+                            folding: false,
+                            renderLineHighlight: 'none',
+                            overviewRulerLanes: 0,
+                            hideCursorInOverviewRuler: true,
+                            scrollbar: { vertical: 'auto', horizontal: 'hidden' }
+                          }"
+                          style="height: 100%"
+                        />
+                        <template #fallback>
+                          <div class="flex items-center justify-center w-full h-full">
+                            <Spinner class="w-5 h-5 text-gray-400" />
+                          </div>
+                        </template>
+                      </Suspense>
+                      <template #fallback>
+                        <div class="flex items-center justify-center w-full h-full">
+                          <Spinner class="w-5 h-5 text-gray-400" />
+                        </div>
+                      </template>
                     </ClientOnly>
                   </div>
                 </div>

--- a/frontend/composables/useCatalogCount.ts
+++ b/frontend/composables/useCatalogCount.ts
@@ -38,11 +38,32 @@ export interface CatalogCount {
   shouldShow: boolean
 }
 
-function nounFor(shape: string | undefined): { sing: string; plural: string } {
+export function nounFor(shape: string | undefined): { sing: string; plural: string } {
   if (shape === 'files') return { sing: 'file', plural: 'files' }
   if (shape === 'objects') return { sing: 'collection', plural: 'collections' }
   if (shape === 'tools') return { sing: 'tool', plural: 'tools' }
   return { sing: 'table', plural: 'tables' }
+}
+
+/**
+ * "11 files" / "3 tools" / "12 tables" for a SINGLE connection.
+ *
+ * The noun follows the registry `data_shape` the /connections payload already
+ * carries — a files-shaped connection (network_dir, SharePoint, S3…) keeps its
+ * catalog entries in the same `connection_tables` rows a database does, so
+ * `table_count` is really "catalog entries" and only the noun differs. Branching
+ * on a hardcoded type list instead got every non-database connection labelled
+ * "N tables".
+ */
+export function connectionCatalogLabel(conn: {
+  data_shape?: string
+  table_count?: number
+  tool_count?: number
+} | null | undefined): string {
+  const shape = conn?.data_shape || 'tables'
+  const noun = nounFor(shape)
+  const n = (shape === 'tools' ? conn?.tool_count : conn?.table_count) || 0
+  return `${n} ${n === 1 ? noun.sing : noun.plural}`
 }
 
 export function useCatalogCount() {

--- a/frontend/pages/agents/new/index.vue
+++ b/frontend/pages/agents/new/index.vue
@@ -127,6 +127,7 @@ import { useCan } from '~/composables/usePermissions'
 import Spinner from '~/components/Spinner.vue'
 import WizardSteps from '@/components/datasources/WizardSteps.vue'
 import AddConnectionModal from '~/components/AddConnectionModal.vue'
+import { connectionCatalogLabel } from '~/composables/useCatalogCount'
 
 const route = useRoute()
 
@@ -135,22 +136,17 @@ interface Connection {
   name: string
   type: string
   connector_key?: string | null
+  // Registry data_shape (tables | files | objects | tools) — drives which noun
+  // the catalog count uses. Sent by GET /connections.
+  data_shape?: string
   table_count?: number
   tool_count?: number
   agent_count?: number
 }
 
-// Tool-provider connections (MCP / custom API) expose tools, not tables, so
-// their catalog count is meaningless — show the tool count instead.
-const TOOL_PROVIDER_TYPES = ['mcp', 'custom_api']
-function connectionCountLabel(conn: Connection): string {
-  if (TOOL_PROVIDER_TYPES.includes(conn.type)) {
-    const n = conn.tool_count || 0
-    return `${n} tool${n === 1 ? '' : 's'}`
-  }
-  const n = conn.table_count || 0
-  return `${n} table${n === 1 ? '' : 's'}`
-}
+// "11 files" / "3 tools" / "12 tables" — the noun follows the connection's
+// data_shape rather than a hardcoded type list.
+const connectionCountLabel = connectionCatalogLabel
 
 const connections = ref<Connection[]>([])
 const loadingConnections = ref(true)


### PR DESCRIPTION
## Summary
This PR improves the user experience when loading the Monaco code editor and consolidates duplicate catalog count labeling logic across multiple components.

## Key Changes

- **Monaco Editor Loading State**: Wrapped the MonacoEditor component with a `Suspense` boundary inside `ClientOnly` to display a spinner while the Monaco chunk loads, preventing an empty box during the initial load. Added detailed comments explaining the suspension behavior and fallback handling for both SSR/hydration and async loading phases.

- **Centralized Catalog Count Logic**: Extracted the `connectionCatalogLabel` function to `useCatalogCount.ts` composable and exported the `nounFor` helper. This replaces duplicate `connectionCountLabel` implementations in `NewAgentWizardModal.vue` and `agents/new/index.vue`.

- **Data Shape-Driven Labels**: Updated the labeling logic to use the connection's `data_shape` field (sent by the API) instead of a hardcoded type list (`TOOL_PROVIDER_TYPES`). This allows the system to correctly label connections as "files", "collections", "tools", or "tables" based on their actual data shape rather than connector type.

- **Type Improvements**: Added `data_shape?: string` field to the Connection interface in both components to support the new labeling approach.

## Implementation Details

The new `connectionCatalogLabel` function intelligently selects between `table_count` and `tool_count` based on the connection's `data_shape`, ensuring accurate catalog descriptions across different connection types (databases, file systems, object storage, tool providers, etc.).

https://claude.ai/code/session_01MHuvVzd1EHKQmViRktKo8q