### PR TITLE
Publish the live row when a harness suggestion is accepted

### DIFF
--- a/backend/app/services/build_service.py
+++ b/backend/app/services/build_service.py
@@ -1047,6 +1047,17 @@ class BuildService:
         # on instructions the user never touched. Filtering to rows whose live
         # `current_version_id` differs shrinks the loop from O(instructions in
         # the org) to the handful genuinely promoted in this build.
+        #
+        # The version pointer alone is not a sufficient test, though: a brand-new
+        # AI-suggested instruction is created with `current_version_id` already
+        # pointing at the staged version (see instruction_service.create_instruction),
+        # while the live row stays `draft` until promotion flips it. Matching on
+        # the pointer only would skip exactly those rows, leaving accepted
+        # knowledge-harness suggestions stuck at `draft` — invisible to every
+        # context loader (they filter `status == "published"`) and labelled
+        # "Inactive" in the UI. So also take rows whose staged version is
+        # `published` while the live row is not: precisely the set the status
+        # flip below acts on.
         rows = await db.execute(
             select(
                 BuildContent.instruction_id,
@@ -1070,8 +1081,14 @@ class BuildService:
             )
             .where(BuildContent.build_id == build_id)
             .where(
-                BuildContent.instruction_version_id.is_distinct_from(
-                    Instruction.current_version_id
+                or_(
+                    BuildContent.instruction_version_id.is_distinct_from(
+                        Instruction.current_version_id
+                    ),
+                    and_(
+                        InstructionVersion.status == "published",
+                        Instruction.status.is_distinct_from("published"),
+                    ),
                 )
             )
         )

--- a/backend/tests/e2e/test_training_multi_instruction_accept.py
+++ b/backend/tests/e2e/test_training_multi_instruction_accept.py
@@ -33,6 +33,7 @@ from app.dependencies import async_session_maker
 from app.models.organization import Organization
 from app.models.user import User
 from app.models.membership import Membership
+from app.models.instruction import Instruction
 from app.services.build_service import BuildService
 from app.services.instruction_service import InstructionService
 from app.schemas.instruction_schema import InstructionCreate
@@ -447,3 +448,118 @@ def test_accept_staged_then_reject_sibling(
     assert test_client.get(
         f"/api/instructions/{iids[1]}", headers=_hdr(token, org_id),
     ).status_code in (403, 404)
+
+
+# ---------------------------------------------------------------------------
+# Loop C — an accepted suggestion must actually go LIVE, not just land in main
+#
+# Regression: promote_build only syncs rows whose staged version differs from
+# Instruction.current_version_id. A brand-new AI instruction is created with
+# current_version_id already pointing at the staged version, so those rows were
+# skipped and never had status flipped draft -> published. Membership in main
+# looked right (_is_live passed) while every context loader — which filters
+# `Instruction.status == "published"` — still ignored the instruction, and the
+# UI rendered it as "Inactive".
+# ---------------------------------------------------------------------------
+
+async def _status_of(db, instruction_id):
+    row = (await db.execute(
+        select(Instruction.status).where(Instruction.id == instruction_id)
+    )).first()
+    return row[0] if row else None
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_accept_staged_publishes_the_live_row():
+    """accept-staged (the harness tool-card Accept) must leave the instruction
+    `published`, not `draft` — otherwise the agent never loads it."""
+    org_id, user_id, build_id, iids = await _seed_training_draft(2)
+    instruction_service = InstructionService()
+
+    async with async_session_maker() as db:
+        for iid in iids:
+            assert await _status_of(db, iid) == "draft", "staged suggestion starts as draft"
+
+    async with async_session_maker() as db:
+        org = await db.get(Organization, org_id)
+        user = await db.get(User, user_id)
+        await instruction_service.accept_staged_instruction(
+            db, iids[0], build_id=build_id, organization=org, current_user=user,
+        )
+
+    async with async_session_maker() as db:
+        assert await _is_live(db, org_id, iids[0])
+        assert await _status_of(db, iids[0]) == "published", (
+            "accepted instruction must be published; a draft row is filtered out "
+            "by every instruction loader and shows as 'Inactive' in the UI"
+        )
+        # The untouched sibling is unaffected.
+        assert await _status_of(db, iids[1]) == "draft"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_publish_build_publishes_the_live_row():
+    """The other accept path (KnowledgeGroup / training-build approve, which
+    POSTs /builds/{id}/publish) must flip the live row too."""
+    org_id, user_id, build_id, iids = await _seed_training_draft(1)
+    build_service = BuildService()
+
+    async with async_session_maker() as db:
+        await build_service.publish_build(db, build_id, user_id, instruction_ids=[iids[0]])
+
+    async with async_session_maker() as db:
+        assert await _is_live(db, org_id, iids[0])
+        assert await _status_of(db, iids[0]) == "published"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_promote_does_not_publish_user_drafts():
+    """Guard the other direction: a user-authored draft (version snapshotted as
+    'draft') stays draft through promotion. Only versions explicitly staged as
+    'published' — the AI-suggestion flows — flip the live row."""
+    suffix = uuid.uuid4().hex[:8]
+    build_service = BuildService()
+    instruction_service = InstructionService()
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Draft Org {suffix}")
+        db.add(org)
+        await db.flush()
+        admin = User(
+            name="Admin", email=f"draft-{suffix}@example.com",
+            hashed_password="x", is_active=True, is_superuser=False, is_verified=True,
+        )
+        db.add(admin)
+        await db.flush()
+        db.add(Membership(user_id=admin.id, organization_id=org.id, role="admin"))
+        await db.commit()
+        await db.refresh(org)
+        await db.refresh(admin)
+        org_id, user_id = str(org.id), str(admin.id)
+
+        build = await build_service.get_or_create_draft_build(
+            db=db, org_id=org_id, source="user", user_id=user_id,
+        )
+        build_id = str(build.id)
+        inst = await instruction_service.create_instruction(
+            db=db,
+            instruction_data=InstructionCreate(
+                text="A user draft that is not ready to go live.",
+                title="User draft", category="general", load_mode="always",
+                data_source_ids=[], references=[], status="draft",
+            ),
+            current_user=admin, organization=org, force_global=True,
+            build=build, auto_finalize=False,
+        )
+        iid = str(inst.id)
+
+    async with async_session_maker() as db:
+        await build_service.publish_build(db, build_id, user_id, instruction_ids=[iid])
+
+    async with async_session_maker() as db:
+        assert await _status_of(db, iid) == "draft", (
+            "a user draft must not be published as a side effect of promotion"
+        )


### PR DESCRIPTION
Accepting an instruction suggested by the knowledge harness left it at
status='draft' — rendered as "Inactive" in the UI and, worse, skipped by every
context loader (they all filter Instruction.status == "published"), so an
accepted suggestion never reached the agent.

promote_build is the only place that flips the live row to 'published' (for
versions staged as published by the AI tools). Since 281cc1c that loop only
visits rows whose staged version differs from Instruction.current_version_id.
A brand-new AI instruction is created with current_version_id already pointing
at the staged version (instruction_service.create_instruction), so those rows
were filtered out and the flip never ran. Both accept paths were affected:
/instructions/{id}/accept-staged (harness tool card) and /builds/{id}/publish
(KnowledgeGroup + training-build approve). Edits were unaffected, since
edit_instruction stages a new version without moving the pointer.

Widen the filter to also take rows whose staged version is 'published' while
the live row is not — exactly the set the status flip acts on. The latency win
from 281cc1c is preserved: a copy-from-main draft's already-live rows still
match on neither branch. Status changes made by users always create a new
version (status is in the version content hash), so the live row and its
current version never disagree outside the AI-create flow — no risk of
re-publishing something a user set inactive.

Tests: assert the live row is published after accept-staged and after
publish_build, plus a guard that a user-authored draft stays draft through
promotion. The first two fail without the fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EyFRa3BHuo45Bp8JhPgoAP