### PR TITLE
Decide suggestion containment with a linear scan, not a quadratic diff

### DIFF
--- a/backend/app/services/suggestion_merge.py
+++ b/backend/app/services/suggestion_merge.py
@@ -13,7 +13,6 @@ We instead detect the relationship by *content*: if one suggestion's text is the
 other's text plus pure insertions, the smaller is an intermediate the larger
 already covers, and only the larger (cumulative) suggestion should surface.
 """
-import difflib
 from typing import List
 
 
@@ -22,18 +21,50 @@ def covers(small: str, big: str) -> bool:
     character of ``small`` is preserved in ``big`` (no deletions/replacements).
 
     That makes ``big`` a strict cumulative superset of ``small``, so a suggestion
-    proposing ``big`` already contains everything ``small`` proposes."""
+    proposing ``big`` already contains everything ``small`` proposes.
+
+    "Preserved, in order, with only insertions between" is precisely "``small``
+    is a subsequence of ``big``", which one left-to-right scan decides in
+    O(len(small) + len(big)).
+
+    This used to ask ``difflib.SequenceMatcher(None, small, big, autojunk=False)``
+    for a full character-level alignment and then discard everything except
+    whether any ``delete``/``replace`` opcode appeared. That is quadratic, and
+    ``autojunk=False`` disables the popular-element heuristic that keeps difflib
+    usable on repetitive text — exactly what a system-prompt style instruction
+    (many near-identical rule lines) is. Measured on a customer workspace: one
+    call on a 20k-character instruction took 66.7s and was 100% of
+    ``GET /api/instructions/{id}`` (SQL: 0.025s). Because this runs on the event
+    loop, it also starved every other request on the worker — an unrelated
+    instruction-list query went 0.076s idle -> 55.7s alongside it.
+
+    The scan answers the docstring's question exactly; difflib only approximated
+    it. Its greedy longest-match alignment can emit a ``delete`` even when a
+    subsequence embedding exists, so it could answer False where the contract
+    says True — never the reverse, since an alignment with no delete/replace
+    leaves every character of ``small`` in an ``equal`` block, which *is* a
+    subsequence. So this can only ever return True where difflib returned False
+    (a suggestion main already contains being correctly recognised as covered),
+    and 1,000 randomised edit pairs (insert / append / delete / replace /
+    line-reorder / identical) produced no disagreement at all. Cost on the
+    pathological pair above: 66.7s -> 0.7ms.
+
+    See ``docs/feedback-loops/agents-pending-reconciliation-perf.md`` for the
+    sibling diff in ``text_hunks`` — capped at ``MAX_DIFF_TOKENS`` and run off
+    the event loop. Neither guard reached here: this one compares raw characters
+    rather than word tokens, and no caller offloads it."""
     small = small or ""
     big = big or ""
     if small == big:
         return False
     if not small:
         return True  # the empty proposal is contained in anything non-empty
-    sm = difflib.SequenceMatcher(None, small, big, autojunk=False)
-    for tag, *_ in sm.get_opcodes():
-        if tag in ("delete", "replace"):
-            return False
-    return True
+    if len(small) > len(big):
+        return False  # a longer string cannot be a subsequence of a shorter one
+    # `ch in it` consumes the iterator up to the match, so each character of
+    # `big` is visited at most once across the whole comprehension.
+    it = iter(big)
+    return all(ch in it for ch in small)
 
 
 def superseded_by_containment(items: dict) -> set:
@@ -49,7 +80,13 @@ def superseded_by_containment(items: dict) -> set:
 
     Requiring ``a`` to be additive over its base is what keeps a deletion-only
     suggestion safe: it is never silently dropped just because some unrelated
-    additive sibling's text happens to contain its (shorter) text."""
+    additive sibling's text happens to contain its (shorter) text.
+
+    This is O(candidates^2) in ``covers`` calls, which was ruinous while each one
+    was a quadratic character diff. Each is now a linear scan, and the length
+    test below prunes the pairs that cannot match to O(1): ``b`` must be strictly
+    longer than ``a`` to add anything, since a subsequence of equal length is the
+    string itself (which ``covers`` reports as False)."""
     ids: List[str] = list(items.keys())
     superseded = set()
     for a in ids:
@@ -63,6 +100,8 @@ def superseded_by_containment(items: dict) -> set:
             if a == b or b in superseded:
                 continue
             b_text, _b_base = items[b]
+            if len(b_text or "") <= len(a_text or ""):
+                continue  # cannot be a strict superset — skip before scanning
             if covers(a_text or "", b_text or ""):   # b ⊋ a → a is intermediate
                 superseded.add(a)
                 break

--- a/backend/tests/unit/test_suggestion_merge.py
+++ b/backend/tests/unit/test_suggestion_merge.py
@@ -1,0 +1,169 @@
+"""Unit tests for app.services.suggestion_merge.
+
+`covers()` decides whether a pending suggestion is already fully contained in
+another text (main, or a later sibling suggestion), which is how the review
+surfaces skip already-applied proposals and collapse intermediate snapshots.
+
+It used to answer that with a character-level `difflib.SequenceMatcher`, which is
+quadratic and degenerates on repetitive text — one call on a customer's 20k-char
+instruction took 66.7s and was 100% of `GET /api/instructions/{id}`. It is now a
+linear subsequence scan. These tests pin both halves of that change: the answers
+must not move, and the pathological input must stay fast.
+"""
+import difflib
+import random
+import time
+
+import pytest
+
+from app.services.suggestion_merge import covers, superseded_by_containment
+
+
+def _covers_difflib(small: str, big: str) -> bool:
+    """The pre-change implementation, kept here as the differential oracle."""
+    small = small or ""
+    big = big or ""
+    if small == big:
+        return False
+    if not small:
+        return True
+    sm = difflib.SequenceMatcher(None, small, big, autojunk=False)
+    return not any(tag in ("delete", "replace") for tag, *_ in sm.get_opcodes())
+
+
+RULE = (
+    "- Table HR_FACT_{i}: one row per employee per day. Columns employee_id, "
+    "work_date, hours_worked, absence_code, cost_center. Exclude approved_flag = 0.\n"
+)
+
+
+def _doc(n_lines: int) -> str:
+    """A system-prompt shaped instruction: many near-identical rule lines. This
+    repetition is what makes the old character diff degenerate."""
+    return "".join(RULE.format(i=i) for i in range(n_lines))
+
+
+# ---------------------------------------------------------------- contract ---
+
+def test_pure_insertion_is_covered():
+    base = _doc(5)
+    assert covers(base, base + "\nAlso cap the lookback window to 24 months.\n")
+
+
+def test_insertion_in_the_middle_is_covered():
+    base = _doc(5)
+    cut = len(base) // 2
+    assert covers(base, base[:cut] + "\nNew mid-document rule.\n" + base[cut:])
+
+
+def test_identical_text_is_not_covered():
+    # Nothing was added, so `big` is not a *cumulative* superset.
+    assert covers(_doc(4), _doc(4)) is False
+
+
+def test_deletion_is_not_covered():
+    base = _doc(6)
+    assert covers(base, base[:200] + base[400:]) is False
+
+
+def test_replacement_is_not_covered():
+    base = _doc(6)
+    assert covers(base, base[:200] + "TOTALLY DIFFERENT TEXT" + base[400:]) is False
+
+
+def test_reordering_is_not_covered():
+    lines = _doc(8).splitlines(True)
+    assert covers("".join(lines), "".join(reversed(lines))) is False
+
+
+def test_longer_small_is_not_covered():
+    assert covers(_doc(6), _doc(2)) is False
+
+
+def test_empty_and_none_handling():
+    assert covers("", "anything") is True      # empty proposal is in everything
+    assert covers("", "") is False             # ...but not in nothing
+    assert covers(None, None) is False
+    assert covers("abc", None) is False
+
+
+# ------------------------------------------------------------ differential ---
+
+@pytest.mark.parametrize("seed", [1, 7, 11, 23])
+def test_matches_the_previous_difflib_implementation(seed):
+    """Randomised edits across every shape the review surfaces produce: the new
+    scan must agree with the old alignment on all of them."""
+    rng = random.Random(seed)
+    for _ in range(120):
+        base = _doc(rng.randint(3, 20))
+        kind = rng.choice(["insert", "append", "delete", "replace", "reorder", "identical"])
+        if kind == "insert":
+            p = rng.randrange(len(base))
+            big = base[:p] + "\nCap the lookback window to 24 months.\n" + base[p:]
+        elif kind == "append":
+            big = base + "\nAppended rule.\n"
+        elif kind == "delete":
+            p = rng.randrange(0, max(1, len(base) - 200))
+            big = base[:p] + base[p + 150:]
+        elif kind == "replace":
+            p = rng.randrange(0, max(1, len(base) - 200))
+            big = base[:p] + "DIFFERENT TEXT HERE" + base[p + 150:]
+        elif kind == "reorder":
+            lines = base.splitlines(True)
+            rng.shuffle(lines)
+            big = "".join(lines)
+        else:
+            big = base
+        assert covers(base, big) == _covers_difflib(base, big), f"disagreement on {kind}"
+
+
+def test_never_reports_covered_where_difflib_reported_uncovered_the_other_way():
+    """The one-way guarantee the swap rests on: an alignment with no
+    delete/replace leaves every character of `small` in an `equal` block, so
+    difflib=True implies subsequence=True. Drift can therefore only ever go the
+    other direction (difflib wrongly saying False), never towards *hiding* less."""
+    rng = random.Random(99)
+    for _ in range(200):
+        base = _doc(rng.randint(2, 12))
+        p = rng.randrange(len(base))
+        big = base[:p] + rng.choice(["\nX\n", "", " extra "]) + base[p:]
+        if _covers_difflib(base, big):
+            assert covers(base, big)
+
+
+# -------------------------------------------------------------------- perf ---
+
+def test_pathological_pair_is_not_quadratic():
+    """The customer shape: two ~20k-char repetitive instructions differing by a
+    rewritten section. The old implementation took tens of seconds on this pair
+    (66.7s on their real text) with the request holding the event loop."""
+    small = _doc(140)
+    big = small[:9000] + "REWRITTEN SECTION " * 20 + small[9600:]
+    started = time.perf_counter()
+    assert covers(small, big) is False
+    assert time.perf_counter() - started < 1.0
+
+
+# ---------------------------------------------------- superseded_by_containment ---
+
+def test_intermediate_snapshot_is_superseded_by_the_cumulative_one():
+    base = "Lorem ipsum."
+    a = base + " lorem"
+    b = base + " lorem hello"
+    assert superseded_by_containment({"a": (a, base), "b": (b, base)}) == {"a"}
+
+
+def test_deletion_only_suggestion_is_never_dropped():
+    """`a` removes text rather than adding it, so it is not an intermediate even
+    if a longer unrelated sibling happens to contain its text."""
+    base = "Alpha beta gamma."
+    a = "Alpha gamma."                      # a deletion over its own base
+    b = "Alpha gamma. Plus more content."   # contains `a`, but `a` isn't additive
+    assert superseded_by_containment({"a": (a, base), "b": (b, base)}) == set()
+
+
+def test_unrelated_siblings_are_both_kept():
+    base = "Shared preamble."
+    a = base + " alpha"
+    b = base + " beta"
+    assert superseded_by_containment({"a": (a, base), "b": (b, base)}) == set()


### PR DESCRIPTION
Instruction saves and opens were taking minutes. Profiling one `GET /api/instructions/{id}` on a sandbox reproducing the reported shape (48 instructions, 8 agents, 12 pending, system-prompt sized bodies): **wall 66.9s, of which 66.7s was a single `difflib` call and 0.025s was SQL.**

## Root cause

`suggestion_merge.covers()` asks whether a pending suggestion is already fully contained in another text. It computed a full character-level alignment and then discarded everything except whether any `delete`/`replace` opcode appeared:

```python
sm = difflib.SequenceMatcher(None, small, big, autojunk=False)
for tag, *_ in sm.get_opcodes():
    if tag in ("delete", "replace"):
        return False
```

That is quadratic, and `autojunk=False` disables the popular-element heuristic that keeps difflib usable on repetitive input — which a system-prompt instruction (many near-identical rule lines) is:

| instruction size | `covers()` |
|---|---|
| 2.5k chars | 0.056 s |
| 5k | 0.250 s |
| 10k | 0.831 s |
| 20k | 3.2 s |
| 40k | 15.1 s |
| the customer's real 20k pair | **66.7 s** |

## Why the earlier fix didn't cover it

`docs/feedback-loops/agents-pending-reconciliation-perf.md` (PR #813) capped the sibling diff in `text_hunks` at `MAX_DIFF_TOKENS = 2000` and moved it off the event loop behind `_HUNK_CPU`. Neither guard reaches this one:

| | `text_hunks` rebase | `suggestion_merge.covers()` |
|---|---|---|
| size cap | `MAX_DIFF_TOKENS` | none |
| unit compared | word tokens (~5k for a 20k-char doc) | raw characters (20k) — ~16× the work |
| off the event loop | `asyncio.to_thread` + semaphore | no |

And it sits on the **detail** path — where that fix deliberately routed the authoritative check ("resolves the moment the instruction is opened") — plus the review panel and the response of every `PUT`.

## The change

"Every character preserved, in order, with only insertions between" is exactly *"`small` is a subsequence of `big`"*, which one left-to-right scan decides in O(n+m).

The scan answers the docstring's question **exactly**; difflib only approximated it. Its greedy longest-match can emit a `delete` even where an embedding exists, so it could answer False where the contract says True — never the reverse, since an alignment with no delete/replace leaves every character of `small` in an `equal` block, which *is* a subsequence. 1,000 randomised edit pairs (insert / append / delete / replace / line-reorder / identical) produced no disagreement in either direction.

`superseded_by_containment` calls it O(candidates²) times; the length test added there prunes pairs that cannot match to O(1), since `b` must be strictly longer than `a` to add anything.

## Measured

Same sandbox, same data, before → after:

| request | before | after |
|---|---|---|
| `GET /instructions/{id}` | 68.1 s | **0.05 s** |
| `GET /instructions/{id}/versions` | 3.3 s | **0.05 s** |
| `GET /instructions/{id}/resolved-evals` | 2.9 s | **0.05 s** |
| `GET /instructions/{id}/pending-builds` | 204.8 s | **0.09 s** |
| `PUT /instructions/{id}` (save) | 70.5 s / 133.7 s | **0.19 s** |

Because it ran on the event loop it also starved the worker — the same mechanism the earlier PR described. An unrelated instruction-list query, unchanged:

```
idle                                    0.076 s
alongside one detail request  before   55.7 s
                              after     0.13 s
```

Results are unchanged: the same 12 pending ids out of 48 instructions, and the same suggestion returned by the review panel.

## Tests

- `backend/tests/unit/test_suggestion_merge.py` (new, 17 tests): the contract cases, a differential check against the previous difflib implementation over randomised edits, the one-way-implication guarantee the swap rests on, a perf guard asserting the pathological 20k-char pair stays under 1 s, and the `superseded_by_containment` behaviours including the deletion-only suggestion that must never be dropped.
- Existing suites: `test_instruction.py`, `test_build.py`, `test_instruction_light_view.py`, `test_instruction_resolve.py`, `test_instruction_edit_anchors.py`, `test_search_instructions_pending.py`, `test_instruction_main_build_integrity.py` — 92 passed.

## Not included

Three separate findings from the same investigation, left for their own changes:

1. Every save creates a build snapshotting **every** instruction in the org (`BuildService._copy_build_contents`) — ~1.5 s and 4,000 inserted rows per save at 4k instructions, and `build_contents` grows unboundedly.
2. `AgentReliabilityService._run_build_fanout` derives `has_global` from the whole snapshot rather than the changed rows, so essentially every save fans out to every agent in the org (reproduced: editing one DS-scoped instruction recorded 6 `global_change` runs).
3. Concurrent saves can truncate the main build — `get_or_create_draft_build` can hand out a build another request is still copying into, the collision is swallowed by `create_build`'s `except Exception`, and in a 5-way burst the sandbox's main build went from 4,000 instructions to 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBz5PkzdbnUMC5A9W9wWxE)_