### PR TITLE
Add ui-audit skill: control-level, role-aware UI bug sweeps

### DIFF
--- a/.agents/skills/ui-audit/SKILL.md
+++ b/.agents/skills/ui-audit/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: ui-audit
+description: Exhaustively audit the UI control by control and role by role — enumerate every button, link, and input on a set of pages, write down what each is supposed to do (derived from the handler code and the RBAC matrix), then drive a real browser as each role and record what it actually does, filing every mismatch as a finding. Use whenever the user wants to hunt UI bugs broadly rather than fix one known bug — "go through every page and every button", "we have lots of weird UI bugs", "sweep the app for breakage", "check that these controls actually work", "verify what admins vs members can see", or when producing a bug inventory for triage.
+---
+
+# UI audit — control-level sweep
+
+Compare intent to behavior, one control at a time, and write down both.
+
+## Which skill is this?
+
+Three skills overlap here; picking the wrong one wastes a sandbox boot.
+
+| Skill | Unit of work | Use when |
+|---|---|---|
+| **`qa`** | User flows ("invite a member, they can sign in") | Release QA, post-merge smoke, "QA this area". Breadth across journeys. |
+| **`ui-audit`** (this) | Individual controls | Hunting unknown bugs. Depth within pages — every button, including ones no flow touches. |
+| **`sandbox-feedback-loop`** | One known bug | You already know what's broken and are fixing it. |
+
+Findings from this skill feed `sandbox-feedback-loop` — audit, then fix, never both at once.
+Once you start fixing you stop looking, and the pages after the first bug get a worse audit
+than the pages before it.
+
+## Why the phases are ordered the way they are
+
+An LLM given a browser reports that everything works. Not from carelessness — from ordering.
+It navigates, sees a page render, and forms its expectation *after* seeing the result, so
+whatever happened becomes what was supposed to happen. A button that silently does nothing is
+indistinguishable from a button that correctly did nothing.
+
+So:
+
+> **Write the expectation to disk before opening the browser**, derived from the handler code
+> rather than the rendered page. The comparison then becomes a diff against a committed
+> artifact instead of a judgment call made while looking at the answer.
+
+That is the whole method. Phases 2 and 3 must not be interleaved.
+
+## Phase 0 — Scope, roles, and boot
+
+Pick a **page group** of 3–6 related routes, not the whole app. One group audited end to end
+beats every page half-covered, and a group shares fixture state.
+`references/bow-surface.md` lists the groups, the permission gating, and the traps — read it
+before choosing.
+
+Then pick the **roles** you will audit as. Most of this app's UI is permission-gated, so a
+page audited only as admin is audited in its easiest state, and the whole class of "the UI
+offered a control the backend forbids" goes unseen. `references/roles.md` has the matrix,
+where it actually lives in the code, and verified seeding recipes. At minimum use admin plus
+one non-admin; add a single-permission custom role when a finding hinges on one gate.
+
+**Boot via the `sandbox-feedback-loop` skill** — it owns sandbox setup for this repo and
+already encodes the traps (sqlite URL, onboarding dismissal, LLM provider seeding). Read it
+and follow it rather than re-deriving. In short, it lands on the standard agent stack:
+
+```bash
+tools/agent/boot_stack.sh --dev              # backend :8000 + frontend :3000; --stop to tear down
+cd backend && uv run python ../tools/agent/seed_org.py --demo
+ANTHROPIC_API_KEY=$ANTHROPIC_KEY uv run python ../tools/agent/setup_haiku_llm.py   # only if auditing chat/report pages
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+```
+
+Seeded admin is `admin@example.com` / `Password123!`. Seeding a second role needs the manual
+recipe in `references/roles.md` — `seed_org.py --invite` currently 422s.
+
+Logs land in `/tmp/bow-agent/{backend,frontend}.log` — keep the backend log open, it explains
+most "the UI did nothing" findings, and it is where a silent 403 shows up. The database is
+`backend/db/agent.db`, disposable by design, which matters because **this skill clicks
+destructive controls**. Never point an audit at a database whose contents you care about.
+
+## Phase 1 — Inventory (browser, read-only)
+
+`scripts/sweep.mjs` visits each route without clicking anything and records the final URL
+after redirects, every interactive control with a verified selector, console errors, uncaught
+exceptions, and failed `/api/` responses.
+
+```bash
+node .agents/skills/ui-audit/scripts/sweep.mjs \
+  --routes /settings/general,/settings/members,/settings/models \
+  --login --out audit/settings
+```
+
+`--login` signs in through the UI and dismisses onboarding, caching the session for reuse.
+Run with `--help` for the rest; `--storage none` sweeps logged out, which is how you audit
+the auth pages.
+
+**Sweep once per role**, into separate output directories — the session cache is per-`--out`,
+so reusing one directory silently sweeps the first role twice and yields a confident, wrong
+comparison:
+
+```bash
+BOW_EMAIL=member@example.com BOW_PASSWORD='Password123!' \
+  node .agents/skills/ui-audit/scripts/sweep.mjs --routes /agents --login --out audit/agents-member
+node .agents/skills/ui-audit/scripts/diff-roles.mjs audit/agents audit/agents-member
+```
+
+`diff-roles.mjs` reports controls present for one role and absent for the other. Admin-only
+controls are usually correct gating; anything present for the *lower*-privileged role and not
+for admin is almost always a bug in the gate's condition.
+
+Three findings fall out before you click anything, and they cost nothing:
+
+- **Route bounced** — you asked for `/x` and landed elsewhere. Either the route is dead or a
+  guard is wrong. Check `references/bow-surface.md` first: an unverified user or undismissed
+  onboarding redirects *everything*, and that is a broken fixture, not thirty bugs.
+- **Console errors or uncaught exceptions on load** — a page that throws on mount is broken
+  even when it looks fine.
+- **Failed API calls during load** — a 4xx/5xx is a defect regardless of appearance, and if
+  the UI doesn't surface it, that silence is the second and usually worse finding.
+
+## Phase 2 — Expectation (code, no browser)
+
+For each control, open the `.vue` file, find the bound handler, and follow it far enough to
+name an observable outcome: a navigation, an API call, a modal, a toast, a mutated list.
+Record one row per control in `expectations.md` and **commit it before Phase 3.**
+
+```markdown
+| # | Control | Selector | Expected | Source |
+|---|---------|----------|----------|--------|
+| 1 | "Save Provider" | `button:has-text("Save Provider")` | POST /api/llm/providers, success toast, modal closes, row appears in list | pages/settings/models.vue:214 |
+| 2 | "Test Connection" | `[data-testid="test-connection"]` | POST .../test, shows "Successfully connected to LLM" | pages/settings/models.vue:188 |
+```
+
+Four cases carry most of the value:
+
+- **No handler bound.** Expected outcome is "nothing". If it looks clickable to a user,
+  that is already a finding — record it now and confirm in Phase 3.
+- **Handler fires but ignores the result.** Expected is "no visible change"; the finding is
+  that failures are invisible. This is a recurring bug class in this codebase.
+- **Expectation depends on state** — empty vs populated. Write both rows. Empty states are
+  the richest vein here and the least covered by the existing suite.
+- **Expectation depends on role.** Add a `Role` column and one row per role whose answer
+  differs. Take the expected answer from `permission_resolver.py` and the route's
+  `definePageMeta`, never from what the UI renders — the UI's copy of the matrix is the thing
+  under test. `references/roles.md` explains why that distinction has teeth.
+
+Write `UNCLEAR` rather than guessing when the code doesn't answer in a couple of minutes. An
+honest `UNCLEAR` is worth more than a fabricated expectation, and a control whose purpose
+isn't legible from its own handler is worth flagging on those grounds alone.
+
+## Phase 3 — Reality (browser, clicking)
+
+Work down the table in order. Click, observe, fill the `Actual` column with what you saw —
+not what it means. "Nothing happened, no network request, no console output" is an
+observation; "the handler is probably missing" is a diagnosis that belongs in the finding.
+Merging them is how a wrong root cause gets locked in early.
+
+- **Confirm the click landed** before believing a no-op. A locator that matches a stale
+  element clicks nothing at all and looks exactly like a broken button — the single most
+  common false finding in an automated sweep.
+- **Check the network and the backend log**, not just the DOM. A button that "does nothing"
+  but fires a successful POST is a rendering bug; one that fires nothing is a wiring bug.
+  Different owner, different fix, and this sweep is the only place separating them is free.
+- **Destructive controls last**, on entities you created for the purpose — deleting fixture
+  data mid-sweep invalidates every row after it.
+- **Screenshot mismatches only.** A screenshot of correct behavior is noise. Use
+  `tools/agent/capture.mjs` for one-off evidence outside the sweep.
+- **Time-box to ~90 minutes per group.** Bug-finding accuracy falls off after that, and a
+  tired sweep produces confident wrong rows that cost more to disprove than they were worth.
+
+Run the role rows as the role, in its own browser context. When a control 403s for a
+non-admin, the audit is not over: a 403 means the backend refused something the UI chose to
+show, so the finding is the affordance, not the refusal. Check whether the UI surfaced
+anything to the user — a silent 403 is worse than a rejected one.
+
+## Phase 4 — Findings
+
+Only rows where expected ≠ actual become findings; the rest stay in the table as proof of
+coverage. Severity rules, the write-up template, and worked examples are in
+`references/findings-format.md`.
+
+| | |
+|---|---|
+| **P1** | Data loss, unrecoverable state, the page crashes, or a user acts beyond their permissions |
+| **P2** | Control is broken: no-op, wrong destination, unhandled API error, endless spinner |
+| **P3** | Works but wrong: stale data, wrong label, error swallowed, state not refreshed, a control offered to a role the backend forbids |
+| **P4** | Cosmetic: layout, copy, untranslated string |
+
+Write each finding in the `sandbox-feedback-loop` format — symptom → reproduction → suspected
+root cause with `file:line` — so a confirmed one can be picked up and driven to a fix without
+re-deriving it. That skill owns the fix; this one owns the finding.
+
+## Deliverable
+
+Follow the repo's report convention — file at `docs/feedback-loops/ui-audit-<date>-<group>.md`
+alongside the existing feedback-loop docs, with the raw artifacts beside it:
+
+```
+docs/feedback-loops/ui-audit-<date>-<group>.md   # findings, P1 first
+audit/<group>/expectations.md                    # every row, passes included
+audit/<group>/routes/*.json                      # sweep output
+audit/<group>/screenshots/                       # mismatches only
+audit/<group>/state.json                         # session JWT — gitignored, never commit
+```
+
+`--login` banks a real session token in `state.json`. It is gitignored along with the raw
+sweep output; keep it that way and commit only the markdown.
+
+Lead the report with P1s and P2s. A reader who stops after the first screen should have seen
+the worst thing you found; coverage goes last. Report the mismatch count and the P1/P2 list
+in your message to the user, and don't fix anything unless asked — a triageable findings
+document is the deliverable.

--- a/.agents/skills/ui-audit/references/bow-surface.md
+++ b/.agents/skills/ui-audit/references/bow-surface.md
@@ -1,0 +1,142 @@
+# Bag of Words UI surface
+
+Route inventory, access gating, and the traps that make a naive sweep produce wrong findings.
+Regenerate the route list with `find frontend/pages -type f -name '*.vue' | sort` — the file
+tree is the router.
+
+## Contents
+
+- [Page groups](#page-groups) — pick one per audit session
+- [Access gating](#access-gating) — what redirects where, and why a route may bounce
+- [Traps](#traps) — app-specific behavior that fakes a bug or hides one
+- [Existing coverage](#existing-coverage) — what the current suite already asserts
+
+## Page groups
+
+Audit one group per session. Groups are ordered roughly by user-facing value.
+
+### Core app
+
+| Route | Notes |
+|---|---|
+| `/` | Home. Requires `view_reports`. Report creation entry point. |
+| `/reports`, `/reports/[id]` | The chat/report surface. Richest control set in the app; also the most stateful — expect to hand-drive rather than sweep. |
+| `/queries`, `/queries/[id]` | Saved queries. |
+| `/dashboards` | |
+| `/projects`, `/projects/[id]` | |
+| `/agents`, `/agents/new`, `/agents/new/[id]/{context,schema}` | Data source agents. Multi-step wizard — audit as a flow, not as independent pages. |
+| `/files` | |
+| `/automations`, `/scheduled-tasks` | |
+| `/instructions` | |
+| `/evals`, `/evals/runs/[id]` | |
+| `/monitoring`, `/monitoring/cost`, `/monitoring/diagnosis` | The two subpages need `manage_settings`. |
+| `/excel` | |
+
+### Settings and admin
+
+All under the `settings` layout. Permission from `definePageMeta`:
+
+| Route | Required permission |
+|---|---|
+| `/settings/general`, `/settings/overview`, `/settings/pii`, `/settings/smtp`, `/settings/license`, `/settings/integrations` | `manage_settings` |
+| `/settings/models` | `manage_llm` |
+| `/settings/members` | `view_members` |
+| `/settings/audit` | `view_audit_logs` |
+| `/settings/instructions` | `manage_instructions` |
+| `/settings/identity-provider` | `manage_identity_providers` |
+| `/settings/integrations/verify/[verify_code]` | `create_reports`, and `default` layout — the odd one out |
+
+Credential-gated: SMTP, identity-provider, license, and OAuth integrations cannot be
+exercised end to end without real external credentials. Audit them up to the point where the
+form would submit, and record that boundary rather than reporting a failure.
+
+### Auth and onboarding
+
+`/users/sign-up`, `/users/sign-in`, `/users/verify`, `/users/forgot-password`,
+`/users/reset-password`, `/organizations/new`, `/onboarding`, `/onboarding/llm`,
+`/onboarding/data`, `/onboarding/data/[ds_id]/{context,schema}`.
+
+These need a **logged-out** sweep (`--storage none`) — with an admin session they redirect.
+Highest blast radius in the app; also partly covered by the existing suite.
+
+### Out of scope by default
+
+- `/old_agents/*` (11 routes) — superseded, but still linked from `layouts/data.vue`, so
+  reachable. Confirm with the user before spending time here.
+- `/reports/[id]/legacy`, `/i18n-smoke` — legacy and test fixture respectively.
+- `/r/[id]`, `/c/[token]` — public share links, need a shared resource to exist first.
+
+## Access gating
+
+Three global middlewares run on every navigation (`frontend/middleware/`). A route that
+bounces is usually one of these, not a bug — check before writing it up:
+
+**`auth.global.ts`** — an authenticated but unverified user is pinned to `/users/verify`.
+If every route in your sweep redirects there, your seeded user was never verified; fix the
+fixture rather than filing 30 findings.
+
+**`onboarding.global.ts`** — admins with incomplete, undismissed onboarding are redirected to
+`/onboarding` from everywhere except `/users/*`, `/organizations/new`, `/r/*`. Non-admins are
+never nudged. This is the single most common cause of a bogus "page redirects to onboarding"
+finding. `sweep.mjs --login` dismisses it and warns if the dismissal did not take; if you
+build a session another way, click "Skip onboarding" and wait for the URL to change
+(`frontend/tests/fixtures/auth.ts` and `tools/agent/login_and_capture.mjs` both show it).
+
+**`permissions.global.ts`** — enforces `meta.permissions` and `meta.resourcePermissionAny`.
+Note it **deliberately does not block when permissions have not loaded yet**. A page can
+therefore render briefly and then redirect once permissions arrive. If a route's outcome
+differs between runs, this race is the first thing to suspect — raise `--settle` and re-run
+before calling it flaky.
+
+## Traps
+
+**`networkidle` never fires.** The app holds polling and websocket connections. Use
+`waitUntil: 'load'` plus an explicit settle delay. The existing `global.setup.ts` comments on
+this; `sweep.mjs` already does it.
+
+**Pages spin until `/api/settings` resolves.** A form is not present at DOM-ready. Wait for a
+specific element, not for the page.
+
+**The message input is `[contenteditable="true"]`, not a textarea.** Fill it by typing, not
+`fill()`.
+
+**Send in the report view gates on multiple conditions** — non-empty text, a data source or
+uploaded file, no upload in flight, a selected model. A disabled send button is usually
+correct; check all four before reporting it. The draft does not survive a reload.
+
+**Escape closes modals by eating the draft.** Click the page background instead
+(`page.mouse.click(60, 60)`).
+
+**Provider names must be unique including soft-deleted ones** — a 409 on a name you just
+"deleted" is existing behavior, not a new bug (though whether the UI explains that is fair
+game).
+
+**Model checkboxes have no accessible label.** Resolve them by walking ancestors until the
+text contains `Model ID:`.
+
+**Empty states are undertested.** Most of this app's pages have only ever been exercised with
+data present. Sweeping a fresh database is where the yield is highest — and it means the
+order of your audit matters: sweep empty first, then seed, then sweep again.
+
+## Existing coverage
+
+`frontend/tests/` runs under `playwright.config.ts` as a dependency chain: `setup` (creates
+admin, writes `tests/config/admin.json`) → `onboarding` → `members` and `features` in
+parallel → `visibility`.
+
+For an audit, prefer the agent stack (`boot_stack.sh` + `seed_org.py`) and `sweep.mjs
+--login` — it is the same setup the `qa` and `ui-evidence` skills use, and `seed_org.py`
+gives you a member account for permission checks that the Playwright `setup` project does
+not. `tests/config/admin.json` works as a session source if that suite has already run.
+Either way, do not write a third login flow.
+
+Coverage is thin and partly hollow — e.g. `tests/home/home-menu.spec.ts` navigates and
+asserts nothing. Treat the presence of a spec as weak evidence that an area works. Two
+helpers in `tests/utils/helpers.ts` reference `/users/login`, which is not a route in
+`pages/` (the page is `users/sign-in.vue`); anything calling `login()` from there is broken
+or unused. Worth confirming during an auth-group audit.
+
+Only 22 components carry `data-testid`, concentrated in custom queries, projects, triggers,
+and webhooks. Everywhere else you are selecting by role and text, which is why `sweep.mjs`
+records a selector per control up front — deriving them twice invites drift between the
+expectation table and the click run.

--- a/.agents/skills/ui-audit/references/findings-format.md
+++ b/.agents/skills/ui-audit/references/findings-format.md
@@ -1,0 +1,116 @@
+# Findings format
+
+How to write up a mismatch so someone can triage it without re-running the audit.
+
+## The rule
+
+A finding needs three things: what you expected and where that expectation came from, what
+actually happened, and enough detail for someone else to see it again. Missing the source
+makes it an opinion; missing the reproduction makes it a rumor.
+
+## Template
+
+```markdown
+### [P2] "Save Provider" silently discards the form on a 409
+
+**Route:** `/settings/models`
+**Control:** `button:has-text("Save Provider")` (expectation row #7)
+
+**Expected:** POST `/api/llm/providers`, success toast, modal closes, provider appears in
+the list. — `frontend/pages/settings/models.vue:214`
+
+**Actual:** POST returns 409 (duplicate name, including soft-deleted providers). The modal
+closes anyway, no toast appears, and the list is unchanged. The user sees a form that
+submitted successfully and a list that did not update.
+
+**Reproduce:**
+1. `/settings/models` → "Integrate Models" → "New Provider" → anthropic
+2. Name it `Anthropic` (any name previously used and deleted)
+3. Fill the API key, click "Save Provider"
+
+**Evidence:** `screenshots/settings-models-save-409.png`, `inventory/settings_models.json`
+**Note:** The 409 itself is expected behavior (names are unique across soft-deleted rows).
+The finding is that the failure is invisible.
+```
+
+The `Note` line is where an audit earns its keep: separating "the backend is right and the UI
+lies about it" from "the backend is wrong" is most of the triage work, and you are the only
+one who saw both layers.
+
+## Severity
+
+Assign from consequence to the user, not from how surprising the bug is.
+
+**P1 — Data loss, unrecoverable state, or crash.** Work is destroyed, the user is locked out,
+or the page throws and stops rendering. A destructive action that fires without confirmation
+is P1 even if it "worked".
+
+**P2 — The control is broken.** No-op, wrong destination, an API error that the UI never
+surfaces, a spinner that never resolves, a form that cannot be submitted. The user cannot
+complete the task the control exists for.
+
+**P3 — Works but wrong.** The action succeeds and something about the result is incorrect:
+stale list after a mutation, wrong label, a count that does not update, an error surfaced in
+a way that misdescribes it. The task completes; the user is misinformed.
+
+**P4 — Cosmetic.** Layout, overflow, copy, untranslated strings. Real, but nobody is blocked.
+
+Two calls that come up constantly:
+
+- **A disabled control is not a bug** unless the conditions for enabling it are met. Check
+  the gating logic in the handler before filing. (See the send-button gating in
+  `bow-surface.md`.)
+- **A console error with no user-visible effect is P3, not P2** — but do file it. These are
+  the leading indicator for the P1 that shows up later under different data.
+
+## Not findings
+
+Recording these as bugs makes the document harder to act on, which costs more than the
+coverage gains:
+
+- Features that are visibly unbuilt (empty page, "coming soon").
+- Flows that stop at a credential wall you cannot pass — record the boundary, not a failure.
+- Dev-server console noise: HMR, Vue devtools hints, source map warnings.
+- Anything caused by your own fixture being wrong (unverified user, undismissed onboarding).
+  Fix the fixture and re-run.
+- Behavior you disagree with but that matches the code and has no user-facing defect. If it
+  is worth saying, put it in a short "Observations" section at the end, clearly separated
+  from the findings.
+
+## Document structure
+
+```markdown
+# UI audit — <group> — <date>
+
+## Summary
+<n> controls checked across <n> routes. <n> mismatches: <n> P1, <n> P2, <n> P3, <n> P4.
+
+## P1
+## P2
+## P3
+## P4
+
+## Observations
+Non-defect notes worth someone's attention.
+
+## Coverage
+Routes swept, routes skipped and why, controls marked UNCLEAR in Phase 2.
+```
+
+Lead with P1 and P2. A reader who stops after the first screen should have seen the worst
+thing you found. Coverage goes last — it proves the audit was real, but nobody opens a bug
+document to read about what was fine.
+
+## Worked example: a no-op
+
+The most common real finding, and the easiest to get wrong:
+
+> **Expected:** Opens the schema editor modal. — `pages/agents/index.vue:88`
+> **Actual:** Click registers (button shows its active style), no modal, no network request,
+> no console output. Repeated on reload and in a fresh session.
+
+Note what makes this credible: the click was confirmed to land (active style), three
+observation channels were checked (DOM, network, console), and it was reproduced twice. A
+no-op report without those is indistinguishable from a missed selector — which is the single
+most common false finding in an automated sweep, because a locator that matches a stale
+element silently clicks nothing at all.

--- a/.agents/skills/ui-audit/references/roles.md
+++ b/.agents/skills/ui-audit/references/roles.md
@@ -1,0 +1,152 @@
+# Roles and permissions — what to audit each page as
+
+A page audited only as admin is a page audited in its easiest state. Most of this app's UI is
+permission-gated, so a control's correctness is not "does it work" but "does it work, and is
+it visible, for the right people".
+
+## Contents
+
+- [The matrix](#the-matrix) — where truth lives, and the built-in roles
+- [Three layers of gating](#three-layers-of-gating) — org perms, resource grants, groups
+- [The drift risk](#the-drift-risk-why-this-phase-exists) — why role auditing finds real bugs
+- [Seeding roles](#seeding-the-roles-you-need) — verified recipes
+- [What to compare](#what-to-compare-across-roles)
+
+## The matrix
+
+`backend/app/core/permission_resolver.py` is the authority. Do not infer the matrix from the
+UI — the UI is the thing under test.
+
+Two built-in system roles ship (`roles` rows with `organization_id IS NULL`, `is_system=1`):
+
+| Role | Permissions |
+|---|---|
+| `admin` | `["full_admin_access"]` — the `FULL_ADMIN` wildcard, passes every org-level check |
+| `member` | `view_reports`, `create_reports`, `update_reports`, `delete_reports`, `publish_reports`, `manage_files`, `view_members` |
+
+Read them live rather than trusting this table, which will age:
+
+```bash
+cd backend && uv run python -c "
+import sqlite3; [print(r) for r in sqlite3.connect('db/agent.db').execute(
+  'select name, is_system, organization_id, permissions from roles order by is_system desc, name')]"
+```
+
+Orgs can also define **custom roles** (`is_system=0`, org-scoped) with any permission subset,
+via `rbac_service`. A custom role holding exactly one permission is the sharpest audit
+instrument available — it isolates a single gate.
+
+## Three layers of gating
+
+A user's effective permissions are the union of every role assigned directly or through a
+group, then expanded by two implication tables. All four layers can hide or show a control:
+
+1. **Org-level role permissions** — e.g. `manage_settings`, `manage_llm`, `view_audit_logs`.
+   Routes declare these in `definePageMeta({ permissions: [...] })`.
+2. **Resource grants** (`ResourceGrant`) — per data source / connection, e.g.
+   `data_source:<id> → ["manage"]`. Routes declare these via `meta.resourcePermissionAny`.
+3. **Groups** (`Group`, `GroupMembership`) — roles assigned to a group flow to its members.
+   A user with no direct role can still hold permissions. Easy to forget when seeding.
+4. **Implications** — `ORG_PERM_IMPLIES_RESOURCE` (holding `manage_instructions` at org level
+   grants `manage_instructions` on *every* data source) and `RESOURCE_PERM_IMPLIES` (a
+   `manage` grant on a data source is the owner tier, implying `manage_instructions`,
+   `create_entities`, `manage_evals`, `manage_members`, `view`, `view_schema`).
+
+The implication rules are where intuition fails. A user with no admin role and a single
+`manage` grant on one agent sees most of that agent's management UI — and must see none of it
+on any other agent. That asymmetry is worth a row in the expectations table.
+
+## The drift risk (why this phase exists)
+
+`frontend/composables/usePermissions.ts` **hand-mirrors** both implication tables from
+`permission_resolver.py`. Its own comments say so: *"Mirror of backend
+ORG_PERM_IMPLIES_RESOURCE in app/core/permission_resolver.py."*
+
+Two hand-maintained copies of one matrix drift. When they do, you get one of two bugs, and
+only a role-aware audit finds either:
+
+- **Visible but forbidden** — the UI's copy is more generous, so it renders a control the
+  backend rejects. The user clicks and gets a 403, usually silently. This is the serious
+  direction: it looks like a broken button, and it is really a permission bug.
+- **Hidden but permitted** — the UI's copy is stricter, so a capability the user legitimately
+  holds is unreachable. Nobody files this one, because the affordance was never seen.
+
+So when a control 403s for a non-admin, do not stop at "permission denied, working as
+intended". Ask why the UI offered it at all — that is the finding.
+
+## Seeding the roles you need
+
+**Admin** comes from `seed_org.py` (`admin@example.com` / `Password123!`).
+
+**Member** — `seed_org.py --invite` is currently broken: it posts
+`{"email", "role_id"}` but `MembershipCreate`
+(`backend/app/schemas/organization_schema.py:27-32`) requires `organization_id` and names the
+field `role`, so the invite 422s. Until that is fixed, invite by hand:
+
+```bash
+cd backend && uv run python - <<'PY'
+import httpx, sqlite3
+c = httpx.Client(base_url="http://localhost:8000", timeout=30)
+tok = c.post("/api/auth/jwt/login",
+             data={"username": "admin@example.com", "password": "Password123!"}).json()["access_token"]
+org = c.get("/api/organizations", headers={"Authorization": f"Bearer {tok}"}).json()[0]["id"]
+H = {"Authorization": f"Bearer {tok}", "X-Organization-Id": org}
+r = c.post(f"/api/organizations/{org}/members",
+           json={"organization_id": org, "email": "member@example.com", "role": "member"}, headers=H)
+print("invite:", r.status_code, r.text[:200])
+row = sqlite3.connect("db/agent.db").execute(
+    "select invite_token from memberships order by rowid desc limit 1").fetchone()
+token = row[0] if row else None
+print("register:", c.post("/api/auth/register", json={
+    "email": "member@example.com", "password": "Password123!",
+    "name": "Member", "invite_token": token}).status_code)
+PY
+```
+
+**A custom role** isolating one permission — create it through `/api/organizations/{org}/roles`
+(see `backend/app/routes/rbac.py`) and assign it instead of `member`. Use this when a finding
+depends on exactly one gate; `member` holds seven permissions and confounds the result.
+
+Then sweep as each identity:
+
+```bash
+BOW_EMAIL=member@example.com BOW_PASSWORD='Password123!' \
+  node .agents/skills/ui-audit/scripts/sweep.mjs --routes /agents --login --out audit/agents-member
+```
+
+`--login` caches per `--out` directory, so give each role its own directory or the second run
+silently reuses the first role's session — which produces a confident, entirely wrong role
+comparison.
+
+## What to compare across roles
+
+Diff the control inventories, not the screenshots. For each control present for admin:
+
+| Present for admin | Present for role X | Read as |
+|---|---|---|
+| yes | yes, and it works | Fine — but confirm X *should* have it |
+| yes | yes, and it 403s | **Finding.** UI offered what the backend forbids |
+| yes | no | Expected gating — confirm against the matrix, not against intuition |
+| yes | yes, but disabled with no explanation | P3 at least: the user cannot tell whether it is broken or forbidden |
+
+The reverse direction matters too: a control that appears for a **lower**-privileged role and
+not for admin is almost always a bug in the gate's condition.
+
+Record the role in every expectations row where the answer differs by role. A row that reads
+the same for all roles does not need one.
+
+### Reading the diff without being fooled
+
+**Expect two false positives from the user menu.** Controls are matched by accessible name, so
+the signed-in user's own name (`A Agent Admin` vs `M Member`) always appears as a difference in
+both directions. Ignore that pair; it is the identity, not a gate.
+
+**A big count difference is usually one modal, not many gates.** A page that auto-opens a
+dialog for one role and not the other shifts dozens of controls at once. Find the dialog before
+concluding the page is wildly different — and then ask why it opened, because "this role sees a
+list filtered to empty, and empty is treated as *nothing exists yet*" is a bug pattern this app
+repeats.
+
+**The diff cannot see the worst case.** A control present for both roles that renders fine and
+then 403s on click looks identical in both inventories. Only Phase 3, run as the lower role,
+finds it. Treat the diff as a map of where to click, not as the result.

--- a/.agents/skills/ui-audit/scripts/diff-roles.mjs
+++ b/.agents/skills/ui-audit/scripts/diff-roles.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * ui-audit role diff — compare two sweeps of the same routes taken as different
+ * identities, and report which controls each role can see.
+ *
+ * Gating differences are the point of the comparison, but they are not all
+ * equal. Admin-only controls are usually correct. A control visible to the
+ * LOWER-privileged role and not to admin is nearly always a bug in the gate's
+ * condition, so it is called out separately rather than left in a symmetric
+ * diff for someone to notice.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const HELP = `
+ui-audit diff-roles — diff control inventories between two role sweeps.
+
+Usage:
+  node diff-roles.mjs <higher-privilege-dir> <lower-privilege-dir> [--json]
+
+Both arguments are sweep.mjs --out directories. Order matters: put the more
+privileged identity first, so "only in B" can be flagged as suspicious.
+
+  node sweep.mjs --routes /agents --login --out audit/agents-admin
+  BOW_EMAIL=member@example.com node sweep.mjs --routes /agents --login --out audit/agents-member
+  node diff-roles.mjs audit/agents-admin audit/agents-member
+`
+
+const args = process.argv.slice(2)
+if (args.includes('--help') || args.includes('-h') || args.length < 2) {
+  console.log(HELP)
+  process.exit(args.length < 2 ? 2 : 0)
+}
+const asJson = args.includes('--json')
+const [dirA, dirB] = args.filter(a => !a.startsWith('--'))
+
+const loadRoutes = dir => {
+  const routesDir = path.join(dir, 'routes')
+  if (!fs.existsSync(routesDir)) {
+    console.error(`Not a sweep output directory (no routes/): ${dir}`)
+    process.exit(1)
+  }
+  const out = new Map()
+  for (const f of fs.readdirSync(routesDir).filter(f => f.endsWith('.json'))) {
+    const r = JSON.parse(fs.readFileSync(path.join(routesDir, f), 'utf8'))
+    out.set(r.route, r)
+  }
+  return out
+}
+
+// Identity for matching a control across two runs. Deliberately not the
+// selector: headless-ui ids and DOM order shift between renders, and a control
+// that merely moved is not a gating difference.
+const key = c => `${c.tag}${c.role ? `[${c.role}]` : ''}:${(c.name || '').trim() || '(unnamed)'}`
+
+const A = loadRoutes(dirA)
+const B = loadRoutes(dirB)
+const report = []
+
+for (const route of [...new Set([...A.keys(), ...B.keys()])].sort()) {
+  const a = A.get(route)
+  const b = B.get(route)
+  const entry = { route, onlyInA: [], onlyInB: [], reachable: { a: !!a, b: !!b } }
+
+  if (!a || !b) {
+    entry.note = `route only swept in ${a ? dirA : dirB}`
+    report.push(entry)
+    continue
+  }
+
+  // A route the lower-privileged identity gets bounced off is gating working at
+  // the router level, not a missing control — report it as such and move on.
+  const finalA = a.finalUrl && new URL(a.finalUrl).pathname
+  const finalB = b.finalUrl && new URL(b.finalUrl).pathname
+  if (finalA !== finalB) {
+    entry.note = `redirect differs: ${dirA} -> ${finalA}, ${dirB} -> ${finalB}`
+  }
+
+  const visible = r => (r.controls || []).filter(c => c.visible)
+  const mapA = new Map(visible(a).map(c => [key(c), c]))
+  const mapB = new Map(visible(b).map(c => [key(c), c]))
+  for (const [k, c] of mapA) if (!mapB.has(k)) entry.onlyInA.push({ key: k, selector: c.selector, destructive: c.destructive })
+  for (const [k, c] of mapB) if (!mapA.has(k)) entry.onlyInB.push({ key: k, selector: c.selector, destructive: c.destructive })
+  report.push(entry)
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ higher: dirA, lower: dirB, routes: report }, null, 2))
+  process.exit(0)
+}
+
+console.log(`\nhigher privilege: ${dirA}\nlower privilege:  ${dirB}\n`)
+let suspicious = 0
+for (const e of report) {
+  console.log(`── ${e.route}`)
+  if (e.note) console.log(`   note: ${e.note}`)
+  if (!e.onlyInA.length && !e.onlyInB.length && !e.note) {
+    console.log('   identical visible controls')
+  }
+  if (e.onlyInA.length) {
+    console.log(`   gated away from the lower role (${e.onlyInA.length}) — expected if the matrix says so:`)
+    for (const c of e.onlyInA) console.log(`     - ${c.key}${c.destructive ? '  [destructive]' : ''}`)
+  }
+  if (e.onlyInB.length) {
+    suspicious += e.onlyInB.length
+    console.log(`   !! visible ONLY to the lower role (${e.onlyInB.length}) — check the gate condition:`)
+    for (const c of e.onlyInB) console.log(`     - ${c.key}${c.destructive ? '  [destructive]' : ''}`)
+  }
+  console.log('')
+}
+
+console.log(`${suspicious} control(s) visible only to the lower-privileged role.`)
+console.log('Controls present for BOTH roles still need clicking as the lower role:')
+console.log('a control that renders and then 403s is the bug this diff cannot see.')

--- a/.agents/skills/ui-audit/scripts/sweep.mjs
+++ b/.agents/skills/ui-audit/scripts/sweep.mjs
@@ -1,0 +1,476 @@
+#!/usr/bin/env node
+/**
+ * ui-audit route sweep — Phase 1 inventory.
+ *
+ * Visits routes WITHOUT clicking anything and records, per route:
+ *   - the final URL after redirects (a bounce is itself a finding)
+ *   - every interactive control, with accessible name and a stable selector
+ *   - console errors and uncaught page exceptions
+ *   - failed /api/ responses during load
+ *   - a full-page screenshot
+ *
+ * Read-only by design: it never clicks, submits, or navigates via UI. Safe to
+ * run against any environment you can log into. Phase 3 does the clicking.
+ */
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const HELP = `
+ui-audit sweep — enumerate controls and load-time errors for a set of routes.
+
+Usage:
+  node sweep.mjs --routes <list|@file> [options]
+
+Required:
+  --routes <list>       Comma-separated routes, or @path/to/file with one route per line
+                        (blank lines and # comments ignored).
+
+Session (pick one):
+  --login               Sign in through the UI and dismiss onboarding, then cache the
+                        session at <out>/state.json and reuse it on later runs.
+                        Credentials from $BOW_EMAIL / $BOW_PASSWORD, defaulting to the
+                        seed_org.py admin (admin@example.com / Password123!).
+  --storage <path>      Use an existing Playwright storageState JSON instead.
+                        --storage none sweeps logged out (for the auth pages).
+  --fresh-login         With --login, ignore a cached state.json and sign in again.
+                        Use after reseeding the database.
+
+Options:
+  --out <dir>           Output directory. Default: ./audit-inventory
+  --base-url <url>      Default: $PLAYWRIGHT_BASE_URL or http://localhost:3000
+  --settle <ms>         Idle time to wait after hydration before reading the DOM.
+                        Default 1500. Raise it for slow/animated pages.
+  --hydrate-timeout <ms> How long to wait for the client to render anything at all.
+                        Default 45000 — a cold "nuxt dev" compiles routes on demand
+                        and a large page can take ~30s on its first hit.
+  --timeout <ms>        Per-route navigation timeout. Default 30000.
+  --viewport <WxH>      Default 1440x900.
+  --headed              Run with a visible browser (needs a display).
+  --help                This message.
+
+Output: <out>/routes/<slug>.json, <out>/screenshots/<slug>.png, <out>/summary.json
+`
+
+function parseArgs (argv) {
+  const opts = {
+    routes: null,
+    storage: undefined,
+    out: 'audit-inventory',
+    baseUrl: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    settle: 1500,
+    hydrateTimeout: 45000,
+    timeout: 30000,
+    viewport: '1440x900',
+    headed: false,
+    login: false,
+    freshLogin: false
+  }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    const next = () => {
+      const v = argv[++i]
+      if (v === undefined) throw new Error(`${a} requires a value`)
+      return v
+    }
+    switch (a) {
+      case '--help': case '-h': console.log(HELP); process.exit(0); break
+      case '--routes': opts.routes = next(); break
+      case '--storage': opts.storage = next(); break
+      case '--out': opts.out = next(); break
+      case '--base-url': opts.baseUrl = next(); break
+      case '--settle': opts.settle = Number(next()); break
+      case '--hydrate-timeout': opts.hydrateTimeout = Number(next()); break
+      case '--timeout': opts.timeout = Number(next()); break
+      case '--viewport': opts.viewport = next(); break
+      case '--headed': opts.headed = true; break
+      case '--login': opts.login = true; break
+      case '--fresh-login': opts.login = true; opts.freshLogin = true; break
+      default: throw new Error(`Unknown argument: ${a}\n${HELP}`)
+    }
+  }
+  if (!opts.routes) throw new Error(`--routes is required.\n${HELP}`)
+  return opts
+}
+
+function resolveRoutes (spec) {
+  const raw = spec.startsWith('@')
+    ? fs.readFileSync(spec.slice(1), 'utf8').split('\n')
+    : spec.split(',')
+  const routes = raw
+    .map(r => r.trim())
+    .filter(r => r && !r.startsWith('#'))
+    .map(r => (r.startsWith('/') ? r : `/${r}`))
+  if (!routes.length) throw new Error('No routes resolved from --routes')
+  return routes
+}
+
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), '../../../../..')
+
+/** Playwright lives in frontend/node_modules, not at the repo root. */
+function loadChromium () {
+  const frontendPkg = path.join(repoRoot, 'frontend', 'package.json')
+  if (!fs.existsSync(frontendPkg)) {
+    throw new Error(`Cannot find ${frontendPkg} — run this from the bagofwords repo, or install playwright-core somewhere resolvable.`)
+  }
+  const require = createRequire(frontendPkg)
+  try {
+    return require('playwright-core').chromium
+  } catch {
+    return require('@playwright/test').chromium
+  }
+}
+
+/**
+ * The bundled playwright version and the sandbox's chromium build can disagree,
+ * which makes Playwright try to download a browser it cannot reach. Point it at
+ * whatever is already installed instead.
+ */
+function findChrome () {
+  if (process.env.PW_CHROME) return process.env.PW_CHROME
+  const base = process.env.PLAYWRIGHT_BROWSERS_PATH || '/opt/pw-browsers'
+  if (!fs.existsSync(base)) return undefined
+  const candidates = fs.readdirSync(base)
+    .filter(d => d.startsWith('chromium') && !d.includes('headless_shell'))
+    .sort()
+    .reverse()
+    .map(d => path.join(base, d, 'chrome-linux', 'chrome'))
+  candidates.push(path.join(base, 'chromium'))
+  return candidates.find(p => fs.existsSync(p) && fs.statSync(p).isFile())
+}
+
+const slug = route => (route === '/' ? 'root' : route.replace(/^\//, '').replace(/[^a-zA-Z0-9]+/g, '_'))
+
+/**
+ * Sign in through the UI and bank the session, mirroring
+ * tools/agent/login_and_capture.mjs. Doing it through the UI rather than by
+ * forging a token means a broken sign-in page fails here loudly instead of
+ * quietly producing a sweep of redirect pages.
+ */
+async function login (browser, opts, statePath) {
+  const email = process.env.BOW_EMAIL || 'admin@example.com'
+  const password = process.env.BOW_PASSWORD || 'Password123!'
+  const context = await browser.newContext({ viewport: opts.viewportSize })
+  const page = await context.newPage()
+
+  await page.goto(`${opts.baseUrl}/users/sign-in`, { waitUntil: 'load', timeout: opts.timeout })
+  // The form is behind a spinner until /api/settings resolves, so a timeout here
+  // usually means the backend is down rather than the sign-in page being broken.
+  try {
+    await page.waitForSelector('#email', { state: 'visible', timeout: opts.timeout })
+  } catch {
+    await context.close()
+    throw new Error(`no sign-in form at ${opts.baseUrl}/users/sign-in after ${opts.timeout}ms. Is the stack up? tools/agent/boot_stack.sh --status`)
+  }
+  await page.fill('#email', email)
+  await page.fill('#password', password)
+  await page.click('button[type=submit]')
+
+  // Wait for the navigation rather than sleeping a fixed interval: on a cold
+  // `nuxt dev` the post-login route still has to compile, so a short fixed wait
+  // reports a working login as "sign-in failed" and sends you off seeding an
+  // org that is already fine.
+  const left = await page.waitForURL(u => !u.pathname.includes('/users/sign-in'), { timeout: opts.hydrateTimeout })
+    .then(() => true).catch(() => false)
+
+  if (!left) {
+    const err = await page.locator('.text-red-500').first().textContent().catch(() => null)
+    await context.close()
+    throw new Error(
+      err
+        ? `sign-in rejected for ${email}: ${err.trim()}`
+        : `sign-in for ${email} did not navigate within ${opts.hydrateTimeout}ms. If the credentials are right, the dev server may still be compiling — retry, or raise --hydrate-timeout. Seed with: cd backend && uv run python ../tools/agent/seed_org.py --demo`
+    )
+  }
+  await page.waitForTimeout(1500)
+
+  // A fresh org lands on the onboarding wizard, which gates every other page.
+  // Leaving it undismissed makes the whole sweep look like a redirect bug.
+  if (page.url().includes('/onboarding')) {
+    const skip = page.getByText('Skip onboarding', { exact: false }).first()
+    await skip.click({ timeout: 8000 }).catch(() => {})
+    await page.waitForTimeout(2000)
+  }
+  if (page.url().includes('/onboarding')) {
+    console.warn('warning: still on /onboarding after skip — routes will redirect and findings will be noise')
+  }
+
+  await context.storageState({ path: statePath })
+  await context.close()
+  console.log(`signed in as ${email}, session cached at ${statePath}`)
+  return statePath
+}
+
+/**
+ * Runs in the page. Collects interactive controls in one DOM pass — far cheaper
+ * than round-tripping per element, and it keeps the snapshot internally
+ * consistent (a Vue re-render mid-enumeration would otherwise mix two states).
+ */
+function collectControls () {
+  const SELECTOR = [
+    'button',
+    'a[href]',
+    'input:not([type="hidden"])',
+    'select',
+    'textarea',
+    '[contenteditable="true"]',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="tab"]',
+    '[role="menuitem"]',
+    '[role="switch"]',
+    '[role="checkbox"]'
+  ].join(',')
+
+  const norm = s => (s || '').replace(/\s+/g, ' ').trim().slice(0, 120)
+
+  // Approximates the accessible name: the text a user would call this control.
+  const accessibleName = el => {
+    const aria = el.getAttribute('aria-label')
+    if (aria) return norm(aria)
+    const labelledby = el.getAttribute('aria-labelledby')
+    if (labelledby) {
+      const parts = labelledby.split(/\s+/)
+        .map(id => document.getElementById(id)?.innerText)
+        .filter(Boolean)
+      if (parts.length) return norm(parts.join(' '))
+    }
+    if (el.id) {
+      const label = document.querySelector(`label[for="${CSS.escape(el.id)}"]`)
+      if (label) return norm(label.innerText)
+    }
+    const text = norm(el.innerText || el.textContent)
+    if (text) return text
+    return norm(el.getAttribute('placeholder') || el.getAttribute('title') || el.value || '')
+  }
+
+  // Prefer a selector that survives a re-render: testid > id > aria-label > own text.
+  //
+  // Order matters more than it looks. `:has-text()` matches *rendered text*, so
+  // building it from the accessible name is wrong whenever that name came from
+  // an aria-label, a <label for>, or a placeholder — the selector then matches
+  // nothing, Phase 3 clicks nothing, and the audit reports a no-op bug that does
+  // not exist. Only ever build has-text from the element's own visible text.
+  const stableSelector = el => {
+    const esc = s => s.replace(/"/g, '\\"')
+    const testid = el.getAttribute('data-testid')
+    if (testid) return `[data-testid="${testid}"]`
+    // Headless UI ids are generated per render (`headlessui-popover-button-v-0-1`)
+    // and renumber when anything above them changes, so they look stable and are
+    // not. Fall through to name-based selection instead.
+    if (el.id && !/^headlessui-/.test(el.id)) return `#${el.id}`
+
+    const tag = el.tagName.toLowerCase()
+    const aria = el.getAttribute('aria-label')
+    if (aria) return `${tag}[aria-label="${esc(aria)}"]`
+
+    const ownText = norm(el.innerText)
+    if (ownText && ownText.length < 40) {
+      if (tag === 'button' || tag === 'a') return `${tag}:has-text("${esc(ownText)}")`
+      const role = el.getAttribute('role')
+      if (role) return `[role="${role}"]:has-text("${esc(ownText)}")`
+    }
+    if (el.getAttribute('contenteditable') === 'true') return '[contenteditable="true"]'
+    return null // Phase 3 will need to derive one by position or context.
+  }
+
+  const controls = []
+  const seen = new Set()
+  for (const el of document.querySelectorAll(SELECTOR)) {
+    if (seen.has(el)) continue
+    seen.add(el)
+    const rect = el.getBoundingClientRect()
+    const style = getComputedStyle(el)
+    const visible = rect.width > 0 && rect.height > 0 &&
+      style.visibility !== 'hidden' && style.display !== 'none' && style.opacity !== '0'
+    const type = el.getAttribute('type')
+    controls.push({
+      tag: el.tagName.toLowerCase(),
+      type: type || undefined,
+      role: el.getAttribute('role') || undefined,
+      name: accessibleName(el),
+      selector: stableSelector(el),
+      testid: el.getAttribute('data-testid') || undefined,
+      href: el.getAttribute('href') || undefined,
+      disabled: el.disabled === true || el.getAttribute('aria-disabled') === 'true',
+      visible,
+      // Destructive-looking controls get clicked last in Phase 3; flagging them
+      // here means the auditor sees the risk before planning the click order.
+      destructive: /\b(delete|remove|revoke|reset|disconnect|uninstall|clear|destroy|archive)\b/i
+        .test(accessibleName(el))
+    })
+  }
+  return {
+    controls,
+    title: document.title,
+    // A page whose body is nearly empty after load is usually a silent render failure.
+    bodyTextLength: (document.body?.innerText || '').trim().length
+  }
+}
+
+async function sweepRoute (context, route, opts) {
+  const page = await context.newPage()
+  const consoleErrors = []
+  const pageErrors = []
+  const apiFailures = []
+  const apiCalls = []
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 500))
+  })
+  page.on('pageerror', err => pageErrors.push(String(err.message || err).slice(0, 500)))
+  page.on('response', res => {
+    const url = res.url()
+    if (!url.includes('/api/')) return
+    const entry = { url: url.replace(opts.baseUrl, ''), status: res.status(), method: res.request().method() }
+    apiCalls.push(entry)
+    if (res.status() >= 400) apiFailures.push(entry)
+  })
+
+  const result = { route, requestedUrl: opts.baseUrl + route }
+  try {
+    // 'load' rather than 'networkidle': this app holds long-lived polling and
+    // websocket connections, so networkidle can never resolve.
+    await page.goto(opts.baseUrl + route, { waitUntil: 'load', timeout: opts.timeout })
+    // The app is client-rendered: `load` fires on an empty SSR shell. Waiting a
+    // fixed interval and reading whatever is there reports a blank page with no
+    // console errors — indistinguishable from a genuinely broken route. Wait for
+    // hydration to put something on the page, and record when it never arrives
+    // so that reads as its own finding rather than "zero controls".
+    result.hydrated = await page.waitForFunction(
+      () => document.body && document.body.innerText.trim().length > 0,
+      { timeout: opts.hydrateTimeout }
+    ).then(() => true).catch(() => false)
+    await page.waitForTimeout(opts.settle)
+
+    const finalUrl = page.url()
+    const finalPath = new URL(finalUrl).pathname
+    result.finalUrl = finalUrl
+    result.redirected = finalPath.replace(/\/$/, '') !== route.replace(/\/$/, '')
+
+    const collected = await page.evaluate(collectControls)
+    Object.assign(result, collected)
+
+    const shotPath = path.join(opts.out, 'screenshots', `${slug(route)}.png`)
+    await page.screenshot({ path: shotPath, fullPage: true })
+    result.screenshot = path.relative(opts.out, shotPath)
+    result.ok = true
+  } catch (err) {
+    result.ok = false
+    result.error = String(err.message || err).split('\n')[0]
+  }
+
+  result.consoleErrors = consoleErrors
+  result.pageErrors = pageErrors
+  result.apiFailures = apiFailures
+  result.apiCallCount = apiCalls.length
+  await page.close()
+  return result
+}
+
+async function main () {
+  const opts = parseArgs(process.argv)
+  const routes = resolveRoutes(opts.routes)
+  opts.out = path.resolve(opts.out)
+  fs.mkdirSync(path.join(opts.out, 'routes'), { recursive: true })
+  fs.mkdirSync(path.join(opts.out, 'screenshots'), { recursive: true })
+
+  if (opts.login && opts.storage) {
+    throw new Error('--login and --storage are mutually exclusive: pick one session source.')
+  }
+
+  const [width, height] = opts.viewport.split('x').map(Number)
+  opts.viewportSize = { width, height }
+  const chromium = loadChromium()
+  const executablePath = findChrome()
+  const browser = await chromium.launch({ headless: !opts.headed, executablePath })
+
+  let storage
+  if (opts.login) {
+    const statePath = path.join(opts.out, 'state.json')
+    storage = (!opts.freshLogin && fs.existsSync(statePath))
+      ? statePath
+      : await login(browser, opts, statePath)
+  } else if (opts.storage === undefined) {
+    // No session named. Fall back to the Playwright suite's admin state if it
+    // happens to exist, otherwise say so rather than silently sweeping logged
+    // out — a logged-out sweep of app routes is 100% redirects and 0% signal.
+    const fallback = path.join(repoRoot, 'frontend', 'tests', 'config', 'admin.json')
+    if (fs.existsSync(fallback)) {
+      storage = fallback
+    } else {
+      await browser.close()
+      throw new Error('No session source. Pass --login (after tools/agent/seed_org.py), --storage <state.json>, or --storage none for the logged-out auth pages.')
+    }
+  } else {
+    storage = opts.storage
+    if (storage !== 'none' && !fs.existsSync(storage)) {
+      await browser.close()
+      throw new Error(`storageState not found: ${storage}`)
+    }
+  }
+
+  const context = await browser.newContext({
+    viewport: { width, height },
+    storageState: storage === 'none' ? undefined : storage
+  })
+
+  console.log(`Sweeping ${routes.length} route(s) against ${opts.baseUrl}`)
+  console.log(`Session: ${storage === 'none' ? 'logged out' : storage}\n`)
+
+  const summary = []
+  for (const route of routes) {
+    const result = await sweepRoute(context, route, opts)
+    fs.writeFileSync(
+      path.join(opts.out, 'routes', `${slug(route)}.json`),
+      JSON.stringify(result, null, 2)
+    )
+
+    // Flag the three things worth acting on before any clicking happens.
+    const flags = []
+    if (!result.ok) flags.push('LOAD FAILED')
+    if (result.redirected) flags.push(`REDIRECTED -> ${result.finalUrl && new URL(result.finalUrl).pathname}`)
+    if (result.pageErrors?.length) flags.push(`${result.pageErrors.length} uncaught`)
+    if (result.consoleErrors?.length) flags.push(`${result.consoleErrors.length} console err`)
+    if (result.apiFailures?.length) flags.push(`${result.apiFailures.length} api fail`)
+    if (result.ok && result.hydrated === false) flags.push(`NEVER HYDRATED (${opts.hydrateTimeout}ms)`)
+    else if (result.ok && (result.bodyTextLength ?? 0) < 50) flags.push('NEARLY EMPTY')
+
+    const n = result.controls?.length ?? 0
+    const visible = result.controls?.filter(c => c.visible).length ?? 0
+    console.log(
+      `${flags.length ? '!' : ' '} ${route.padEnd(34)} ${String(visible).padStart(3)}/${String(n).padEnd(3)} controls` +
+      (flags.length ? `  [${flags.join(', ')}]` : '')
+    )
+
+    summary.push({
+      route,
+      ok: result.ok,
+      redirected: result.redirected,
+      finalUrl: result.finalUrl,
+      controlsTotal: n,
+      controlsVisible: visible,
+      destructiveControls: result.controls?.filter(c => c.destructive).length ?? 0,
+      consoleErrors: result.consoleErrors.length,
+      pageErrors: result.pageErrors.length,
+      apiFailures: result.apiFailures.length,
+      flags
+    })
+  }
+
+  fs.writeFileSync(path.join(opts.out, 'summary.json'), JSON.stringify(summary, null, 2))
+  await browser.close()
+
+  const flagged = summary.filter(s => s.flags.length)
+  console.log(`\nWrote ${opts.out}`)
+  console.log(`${flagged.length}/${summary.length} route(s) flagged before any interaction.`)
+  if (flagged.length) {
+    console.log('These are Phase 1 findings — write them up before starting Phase 2.')
+  }
+}
+
+main().catch(err => {
+  console.error(`\nsweep failed: ${err.message}`)
+  process.exit(1)
+})

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ frontend/login*.mjs
 frontend/evidence*.mjs
 frontend/diag*.mjs
 frontend/.agent-tmp/
+
+# ui-audit run artifacts. state.json holds a live session JWT — never commit it.
+# The written-up expectations/findings markdown is kept.
+audit/**/state.json
+audit/**/screenshots/
+audit/**/routes/
+audit/**/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ one of these tasks:
   any bug/feature; reports land in `docs/feedback-loops/`.
 - **qa** — map all user-facing functionality (`docs/qa/functionality-map.md`),
   then live-test flows against a running stack.
+- **ui-audit** — sweep a page group control by control (every button, link,
+  input) and role by role, recording expected-from-code vs actual-in-browser
+  and filing the mismatches. Use for open-ended UI bug hunts and for verifying
+  RBAC gating in the UI; `qa` covers flows, this covers the controls no flow
+  touches.
 - **ui-evidence** — capture the **mandatory** before/after screenshots (and
   GIFs/videos for flows) for any change touching
   `frontend/{pages,components,layouts,assets}/**`.


### PR DESCRIPTION
## What

A new agent skill at `.agents/skills/ui-audit/` for open-ended UI bug hunts. The `qa` skill tests user *flows*; nothing covered the controls no flow touches, and nothing checked those controls against the RBAC matrix.

Skill only — no product code changes.

## Why the phases are ordered the way they are

An agent given a browser reports that everything works. Not from carelessness, from ordering: it navigates, sees a page render, and forms its expectation *after* seeing the result — so whatever happened becomes what was supposed to happen, and a silently broken button is indistinguishable from a button that correctly did nothing.

The skill's whole method is the fix: **the expectation table is derived from handler code and `permission_resolver.py`, and committed to disk before the browser opens.** The comparison is then a diff against a fixed artifact rather than a judgment call made while looking at the answer. Phase 2 and Phase 3 must not interleave.

## Why roles are part of it

`frontend/composables/usePermissions.ts` hand-mirrors both implication tables from `backend/app/core/permission_resolver.py` — its own comments say so. Two hand-maintained copies of one matrix drift, and drift produces one of two bugs:

- **Hidden but permitted** — the UI's copy is stricter; a capability the user holds is unreachable. Nobody files it, because the affordance was never seen.
- **Visible but forbidden** — the UI's copy is more generous; it renders a control the backend rejects. The user clicks, gets a silent 403, and it reads as a broken button when it is really a permission bug.

Only a role-aware sweep finds either. So the skill sweeps as each role and diffs the inventories.

## Contents

| File | Purpose |
|---|---|
| `SKILL.md` | The four phases, and when to use this vs `qa` vs `sandbox-feedback-loop` |
| `scripts/sweep.mjs` | Read-only route sweep: final URL after redirects, every control with a verified selector, console errors, uncaught exceptions, failed `/api/` responses |
| `scripts/diff-roles.mjs` | Diffs two role sweeps; separates expected gating from controls visible only to the lower-privileged role |
| `references/roles.md` | The matrix and where it lives, the gating layers plus implications, verified seeding recipes, how to read the diff without being fooled |
| `references/bow-surface.md` | Route groups, per-route permissions from `definePageMeta`, and the traps that fake a bug |
| `references/findings-format.md` | Severity rules and the write-up template |

Boot defers to the **`sandbox-feedback-loop`** skill rather than inventing a parallel setup, and findings are written in that skill's format so a confirmed one can be driven to a fix without re-deriving it. `.gitignore` covers the run artifacts — `--login` banks a live session JWT in `state.json`.

## Validation

Run for real against `/agents` and `/agents/new`, as admin and as member. Three things that run corrected in the tooling itself:

- **Headless-ui ids were preferred as "stable" selectors.** They renumber per render, so a selector that looked stable matched nothing — which is indistinguishable from a broken button, the exact false finding the skill warns about.
- **A fixed settle window read a cold `nuxt dev` route as a blank page.** `/agents` takes ~30s to first-compile; the sweep saw zero controls and no console errors, identical to a genuinely broken route. It now waits for hydration and flags a route that never arrives.
- **Login treated a slow post-submit navigation as a failed sign-in**, sending you off to re-seed an org that was already fine.

## Note for reviewers

`tools/agent/seed_org.py --invite` is currently broken — it posts `{email, role_id}` where `MembershipCreate` (`backend/app/schemas/organization_schema.py:27-32`) requires `organization_id` and names the field `role`, so the invite 422s and no member account is created. Both `qa` and this skill ask you to verify member behavior, so this blocks role coverage today. `references/roles.md` documents it with a verified manual recipe alongside; the script fix is not in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011R7bX5xEHAznE1FZhiYdHm)_