### PR TITLE
Replace retired Google model ids and refresh the Anthropic presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 0.0.520 (August 3, 2026)
+- **Gemini works again** — every Google model on offer had been retired by Google, so each question came back with "this model is no longer available" and switching models just produced the same error on the next one; the list is now Gemini 3.6 Flash, Gemini 3.1 Pro and Gemini 3.5 Flash-Lite, and existing workspaces are moved off the dead models automatically
+- **Claude Opus 5 is available**, replacing Claude 4.6 Sonnet in the model list
+
 ## Version 0.0.519 (August 3, 2026)
 - **The AI remembers what it already did** — every tool result is now part of the conversation the model actually sees, so it stops re-reading files it just opened and re-running work it just finished; a file it pulls from a connection stays usable for the whole report instead of going stale after one step, and those background fetches no longer show up as attachments in your message box
 

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -118,6 +118,19 @@ LLM_MODEL_DETAILS = [
         "output_cost_per_million_tokens_usd": 15.00
     },
     {
+        "name": "Claude Opus 5",
+        "model_id": "claude-opus-5",
+        "provider_type": "anthropic",
+        "is_preset": True,
+        "is_enabled": True,
+        "is_default": False,
+        "supports_vision": True,
+        "context_window_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "input_cost_per_million_tokens_usd": 5.00,
+        "output_cost_per_million_tokens_usd": 25.00
+    },
+    {
         "name": "Claude Opus 4.8",
         "model_id": "claude-opus-4-8",
         "provider_type": "anthropic",
@@ -128,18 +141,6 @@ LLM_MODEL_DETAILS = [
         "context_window_tokens": 1000000,
         "input_cost_per_million_tokens_usd": 5.00,
         "output_cost_per_million_tokens_usd": 25.00
-    },
-    {
-        "name": "Claude 4.6 Sonnet",
-        "model_id": "claude-sonnet-4-6",
-        "provider_type": "anthropic",
-        "is_preset": True,
-        "is_enabled": True,
-        "is_default": False,
-        "supports_vision": True,
-        "context_window_tokens": 1000000,
-        "input_cost_per_million_tokens_usd": 3.00,
-        "output_cost_per_million_tokens_usd": 15.00
     },
     {
         "name": "Claude 4.5 Haiku",
@@ -154,40 +155,52 @@ LLM_MODEL_DETAILS = [
         "input_cost_per_million_tokens_usd": 1,
         "output_cost_per_million_tokens_usd": 5.00
     },
+    # Google retires model ids aggressively, and a retired id is a hard 404
+    # ("This model models/X is no longer available to new users") that no retry
+    # or fallback can heal. gemini-3-pro-preview was shut down outright;
+    # gemini-2.5-pro / gemini-2.5-flash still appear in Google's model list but
+    # reject any project that had not already used them, which is every new
+    # install. Prefer stable ids over preview ones for the defaults.
     {
-        "name": "Gemini 3 Pro Preview",
-        "model_id": "gemini-3-pro-preview",
+        "name": "Gemini 3.6 Flash",
+        "model_id": "gemini-3.6-flash",
+        "provider_type": "google",
+        "is_preset": True,
+        "is_enabled": True,
+        "is_default": True,
+        "supports_vision": True,
+        "context_window_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "input_cost_per_million_tokens_usd": 1.50,
+        "output_cost_per_million_tokens_usd": 7.50
+    },
+    {
+        # Preview channel — the pro tier has no stable id right now. Selectable,
+        # but deliberately not a default: a preview id is what got shut down.
+        "name": "Gemini 3.1 Pro Preview",
+        "model_id": "gemini-3.1-pro-preview",
         "provider_type": "google",
         "is_preset": True,
         "is_enabled": True,
         "is_default": False,
         "is_small_default": False,
         "supports_vision": True,
-        "context_window_tokens": 200000,
+        "context_window_tokens": 1048576,
+        "max_output_tokens": 65536,
+        # Tiered: $4.00 / $18.00 above a 200k-token prompt.
         "input_cost_per_million_tokens_usd": 2.00,
         "output_cost_per_million_tokens_usd": 12.00
     },
     {
-        "name": "Gemini 2.5 Pro",
-        "model_id": "gemini-2.5-pro",
-        "provider_type": "google",
-        "is_preset": True,
-        "is_enabled": True,
-        "is_default": True,
-        "supports_vision": True,
-        "context_window_tokens": 1047576,
-        "input_cost_per_million_tokens_usd": 1.25,
-        "output_cost_per_million_tokens_usd": 10.00
-    },
-    {
-        "name": "Gemini 2.5 Flash",
-        "model_id": "gemini-2.5-flash",
+        "name": "Gemini 3.5 Flash-Lite",
+        "model_id": "gemini-3.5-flash-lite",
         "provider_type": "google",
         "is_preset": True,
         "is_enabled": True,
         "is_small_default": True,
         "supports_vision": True,
-        "context_window_tokens": 1047576,
+        "context_window_tokens": 1048576,
+        "max_output_tokens": 65536,
         "input_cost_per_million_tokens_usd": 0.30,
         "output_cost_per_million_tokens_usd": 2.50
     },

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -2004,7 +2004,20 @@ class LLMService:
 
         for model in provider_models:
             model_data = catalog_by_id.get(model.model_id)
-            if not model_data or not model.is_preset:
+            if not model.is_preset:
+                continue
+            # Preset row whose id left the catalog: the provider retired the
+            # model, so every call to it is a permanent 404 that no retry or
+            # fallback can heal. Disable it and surrender the default flags —
+            # the promotion below then moves the org onto the catalog's current
+            # default instead of leaving it pinned to a dead id. Custom models
+            # (skipped above) stay untouched; the row itself is kept so history
+            # and usage records still resolve.
+            if not model_data:
+                model.is_enabled = False
+                model.is_default = False
+                model.is_small_default = False
+                db.add(model)
                 continue
 
             self._apply_catalog_model_details(model, model_data, sync_enabled=True)

--- a/backend/tests/e2e/test_cost_metrics_attribution.py
+++ b/backend/tests/e2e/test_cost_metrics_attribution.py
@@ -80,7 +80,7 @@ async def _seed():
         await db.flush()
 
         m_claude = LLMModel(organization_id=org.id, provider_id=prov_a.id,
-                            name="Claude 4.6 Sonnet", model_id="claude-sonnet-4-6")
+                            name="Claude Opus 5", model_id="claude-opus-5")
         m_gpt = LLMModel(organization_id=org.id, provider_id=prov_o.id,
                          name="GPT-5.5", model_id="gpt-5.5")
         db.add_all([m_claude, m_gpt])

--- a/backend/tests/e2e/test_llm_context_window_override.py
+++ b/backend/tests/e2e/test_llm_context_window_override.py
@@ -22,7 +22,7 @@ from app.dependencies import async_session_maker
 from app.models.llm_model import LLMModel
 from app.models.llm_provider import LLMProvider
 
-# Catalog value for claude-sonnet-4-6 in LLM_MODEL_DETAILS.
+# Catalog value for claude-opus-5 in LLM_MODEL_DETAILS.
 CATALOG_CONTEXT_WINDOW = 1_000_000
 
 
@@ -33,7 +33,7 @@ def _run(coro):
 async def _seed_anthropic_preset(org_id):
     """Seed a preset Anthropic provider with a catalog model.
 
-    claude-sonnet-4-6 has context_window_tokens=1_000_000 in LLM_MODEL_DETAILS,
+    claude-opus-5 has context_window_tokens=1_000_000 in LLM_MODEL_DETAILS,
     so any direct edit to the row is clobbered on the next catalog re-sync —
     exactly the case the override closes.
     """
@@ -53,8 +53,8 @@ async def _seed_anthropic_preset(org_id):
             LLMModel(
                 organization_id=org_id,
                 provider_id=provider.id,
-                name="Claude 4.6 Sonnet",
-                model_id="claude-sonnet-4-6",
+                name="Claude Opus 5",
+                model_id="claude-opus-5",
                 is_preset=True,
                 is_enabled=True,
                 is_default=True,
@@ -84,8 +84,8 @@ async def _seed_bedrock_custom(org_id):
             LLMModel(
                 organization_id=org_id,
                 provider_id=provider.id,
-                name="anthropic.claude-sonnet-4-6",
-                model_id="anthropic.claude-sonnet-4-6",
+                name="anthropic.claude-opus-5",
+                model_id="anthropic.claude-opus-5",
                 is_preset=False,
                 is_custom=True,
                 is_enabled=True,
@@ -112,7 +112,7 @@ def test_context_window_override_persists_across_catalog_resync(
     _run(_seed_anthropic_preset(org_id))
 
     # Baseline: catalog value is exposed.
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["context_window_tokens"] == CATALOG_CONTEXT_WINDOW
     assert model.get("context_window_tokens_override") is None
     model_id = model["id"]
@@ -127,7 +127,7 @@ def test_context_window_override_persists_across_catalog_resync(
 
     # GET re-syncs preset providers from the catalog. The override must win:
     # effective value stays 100k even though the catalog says 1M.
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["context_window_tokens"] == 100_000, (
         "override was clobbered by catalog re-sync"
     )
@@ -138,7 +138,7 @@ def test_context_window_override_persists_across_catalog_resync(
         f"/api/llm/models/{model_id}/set_context_window", headers=headers
     )
     assert resp.status_code == 200, resp.text
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["context_window_tokens"] == CATALOG_CONTEXT_WINDOW
     assert model["context_window_tokens_override"] is None
 
@@ -155,7 +155,7 @@ def test_context_window_settable_on_custom_model(
 
     _run(_seed_bedrock_custom(org_id))
 
-    model = _find(get_models(token, org_id), "anthropic.claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "anthropic.claude-opus-5")
     assert model["context_window_tokens"] is None
     model_id = model["id"]
 
@@ -166,7 +166,7 @@ def test_context_window_settable_on_custom_model(
     )
     assert resp.status_code == 200, resp.text
 
-    model = _find(get_models(token, org_id), "anthropic.claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "anthropic.claude-opus-5")
     assert model["context_window_tokens"] == 100_000
     assert model["context_window_tokens_override"] == 100_000
 
@@ -177,7 +177,7 @@ def test_context_window_settable_on_custom_model(
         headers=headers,
     )
     assert resp.status_code in (400, 422), resp.text
-    model = _find(get_models(token, org_id), "anthropic.claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "anthropic.claude-opus-5")
     assert model["context_window_tokens"] == 100_000
 
 

--- a/backend/tests/e2e/test_llm_vision_toggle.py
+++ b/backend/tests/e2e/test_llm_vision_toggle.py
@@ -31,7 +31,7 @@ def _run(coro):
 async def _seed_anthropic_preset(org_id):
     """Seed a preset Anthropic provider with a vision-capable catalog model.
 
-    claude-sonnet-4-6 is `supports_vision=True` in LLM_MODEL_DETAILS, so this is
+    claude-opus-5 is `supports_vision=True` in LLM_MODEL_DETAILS, so this is
     exactly the case that regressed before the override existed.
     """
     async with async_session_maker() as db:
@@ -50,8 +50,8 @@ async def _seed_anthropic_preset(org_id):
             LLMModel(
                 organization_id=org_id,
                 provider_id=provider.id,
-                name="Claude 4.6 Sonnet",
-                model_id="claude-sonnet-4-6",
+                name="Claude Opus 5",
+                model_id="claude-opus-5",
                 is_preset=True,
                 is_enabled=True,
                 is_default=True,
@@ -78,7 +78,7 @@ def test_vision_toggle_persists_across_catalog_resync(
     _run(_seed_anthropic_preset(org_id))
 
     # Baseline: catalog says this model is vision-capable.
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["supports_vision"] is True
     assert model["supports_vision_override"] in (None, False, True)
     model_id = model["id"]
@@ -91,7 +91,7 @@ def test_vision_toggle_persists_across_catalog_resync(
 
     # GET re-syncs preset providers from the catalog. The override must win:
     # effective flag stays OFF even though the catalog says True.
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["supports_vision"] is False, "override was clobbered by catalog re-sync"
     assert model["supports_vision_override"] is False
 
@@ -100,7 +100,7 @@ def test_vision_toggle_persists_across_catalog_resync(
         f"/api/llm/models/{model_id}/toggle_vision", params={"enabled": True}, headers=headers
     )
     assert resp.status_code == 200, resp.text
-    model = _find(get_models(token, org_id), "claude-sonnet-4-6")
+    model = _find(get_models(token, org_id), "claude-opus-5")
     assert model["supports_vision"] is True
     assert model["supports_vision_override"] is True
 

--- a/backend/tests/evals/conftest.py
+++ b/backend/tests/evals/conftest.py
@@ -248,7 +248,7 @@ def _install_llm_provider_from_detail(
     # prefer Sonnet 4.6. Order: explicit preference → provider small default
     # → provider default (always distinct from the model under test).
     _JUDGE_PREFERENCE = {
-        "anthropic": ["claude-sonnet-4-6"],
+        "anthropic": ["claude-opus-5"],
     }
     # EVAL_JUDGE_MODEL overrides the judge/small-default pick — used to run
     # the knowledge harness on a specific model (e.g. claude-sonnet-5 as the

--- a/backend/tests/evals/test_evals.py
+++ b/backend/tests/evals/test_evals.py
@@ -9,7 +9,7 @@ Per-case failure produces a human-readable rule-by-rule report. Every
 case also appends one JSON line to ``BOW_EVAL_REPORT`` (default
 ``/tmp/bow_eval_report.jsonl``) so you can post-process a multi-LLM matrix:
 
-    Case                                 anthropic/claude-sonnet-4-6  openai/gpt-5.4
+    Case                                 anthropic/claude-opus-5  openai/gpt-5.4
     Sanity · Smoke/count_tracks          pass                          pass
     Sanity · Clarify/vague_show_data     fail                          pass
 """

--- a/backend/tests/fixtures/llm.py
+++ b/backend/tests/fixtures/llm.py
@@ -87,7 +87,7 @@ def create_bedrock_provider_and_models(test_client):
 
 @pytest.fixture
 def create_anthropic_provider_and_models(test_client):
-    """Create an Anthropic provider + Claude 4.6 Sonnet and Haiku models.
+    """Create an Anthropic provider + Claude Opus 5 and Haiku models.
 
     Uses ``ANTHROPIC_API_KEY_TEST`` from env. Sets Sonnet as default and
     Haiku as the small default so the judge and planner use sensible
@@ -111,8 +111,8 @@ def create_anthropic_provider_and_models(test_client):
                 "credentials": {"api_key": str(anthropic_api_key)},
                 "models": [
                     {
-                        "model_id": "claude-sonnet-4-6",
-                        "name": "Claude 4.6 Sonnet",
+                        "model_id": "claude-opus-5",
+                        "name": "Claude Opus 5",
                         "is_custom": False,
                     },
                     {

--- a/tools/agent/run_concurrency_probe.py
+++ b/tools/agent/run_concurrency_probe.py
@@ -69,8 +69,8 @@ def provider_spec(provider, stub_base_url=None):
         return {
             "provider_type": "google",
             "credentials": {"api_key": _env("GEMINI_API_KEY", "GOOGLE_API_KEY")},
-            "model_id": os.environ.get("GEMINI_MODEL_ID", "gemini-2.5-flash"),
-            "model_name": "Gemini 2.5 Flash",
+            "model_id": os.environ.get("GEMINI_MODEL_ID", "gemini-3.6-flash"),
+            "model_name": "Gemini 3.6 Flash",
         }
     if provider == "bedrock":
         return {


### PR DESCRIPTION
Every Google preset in the catalog is unusable for a new API key, which is why the chat returned `google returned an error (404): This model models/X is no longer available` on each model the user picked:

| Old `model_id` | Real status |
|---|---|
| `gemini-3-pro-preview` | Listed under "Previous models — Shut down" |
| `gemini-2.5-pro` | Still in Google's model list, but the API 404s any project with no prior usage |
| `gemini-2.5-flash` | Same |

The 404 classifies as `provider_error` (`backend/app/ai/llm/errors.py:264`), which is both façade-retryable and fallback-eligible — so the retry and the fallback chain both walk to sibling Google models that are equally retired.

## Changes

**`backend/app/models/llm_model.py`** — Google presets replaced with ids verified against Google's model and pricing pages:

- `gemini-3.6-flash` — stable, 1,048,576 ctx, $1.50/$7.50 — now the provider default
- `gemini-3.1-pro-preview` — $2.00/$12.00 (tiered above a 200k prompt), selectable but not a default
- `gemini-3.5-flash-lite` — $0.30/$2.50 — small default

The pro tier has no stable id right now, so the default deliberately sits on a stable flash id rather than a preview one — a preview id is exactly what got shut down.

Anthropic: dropped Claude 4.6 Sonnet, added Claude Opus 5 (`claude-opus-5`, 1M ctx, 128K output, $5/$25, vision). The org default stays on Claude Sonnet 5.

**`backend/app/services/llm_service.py`** — removing ids from the catalog alone fixes nothing for existing installs: `_sync_provider_with_latest_models` skipped rows it couldn't find in the catalog, so dead presets stayed enabled and still held `is_default`. Preset rows whose id has left the catalog are now disabled and surrender their default flags, which lets the existing promotion step move the org onto the new default. Reports pinned to a retired model already fall back to the org default, since `get_default_model_for_report` filters on `is_enabled`.

Tests repointed off `claude-sonnet-4-6` to `claude-opus-5` (same 1M context and vision, so the assertions hold); concurrency probe default updated; changelog entry added.

## Verification

Catalog invariants pass — unique ids, at most one default and one small default per provider, all prices > 0.

111 LLM-related unit tests pass: fallback, error classification, model router, Google tool-schema and message translation, image generation, usage metering. The full `tests/unit` run exceeds the 900s container timeout, so I scoped it to the suites covering this change rather than leaving it half-run.

Sources: [Gemini models](https://ai.google.dev/gemini-api/docs/models), [Gemini pricing](https://ai.google.dev/gemini-api/docs/pricing), [forum report on the 2.5 404](``https://discuss.ai.google.dev/t/gemini-2-5-pro-returns-no-longer-available-to-new-users-contradicts-official-deprecation-date-oct-16-2026/176380).``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8KuRKZ4xCh7yJoTKxRNGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8KuRKZ4xCh7yJoTKxRNGJ)_