### PR TITLE
Parse @mentions against known names so multi-word names survive

### DIFF
--- a/backend/app/ai/agents/data_source/data_source.py
+++ b/backend/app/ai/agents/data_source/data_source.py
@@ -6,16 +6,27 @@ import pandas as pd
 import json
 from app.models.llm_model import LLMModel
 from app.dependencies import async_session_maker
+from app.utils.mentions import format_mention
 
 """
 """
 
 class DataSourceAgent:
 
-    def __init__(self, data_source: DataSource, schema: str, model: LLMModel):
+    def __init__(
+        self,
+        data_source: DataSource,
+        schema: str,
+        model: LLMModel,
+        mentionable_names: list[str] | None = None,
+    ):
         self.data_source = data_source
         self.llm = LLM(model, usage_session_maker=async_session_maker)
         self.schema = schema
+        # Exact display names the instruction may @mention. Resolution happens
+        # against these afterwards, so a name the model paraphrases or
+        # snake_cases cannot be linked — hence handing over the literal list.
+        self.mentionable_names = mentionable_names or []
 
     def generate_summary(self):
         prompt = f"""
@@ -83,6 +94,26 @@ Do not add prefix ``` or markdown or anything. just the list of conversation sta
     def generate_context(self):
         pass
 
+    def _mention_rules(self) -> str:
+        """Mention-writing rules for the instruction prompt.
+
+        Mentions are resolved back to real objects by matching display names, so
+        a name must be reproduced exactly — paraphrasing "Sales Orders" as
+        "@sales_orders" links to nothing. Names carrying spaces, dots or dashes
+        are quoted so they stay unambiguous even without the name dictionary.
+        """
+        lines = [
+            "- Reference tables and tools by writing their name after an @",
+            '- Write the name EXACTLY as listed below — never rename, snake_case or abbreviate it',
+            '- If the name contains a space, dot or dash, wrap it in quotes: @"Sales Orders", @"dbo.fact_sales"',
+            "- Otherwise write it bare: @orders, @search_products",
+            "- Only mention names that appear in this list; never invent one",
+        ]
+        if self.mentionable_names:
+            listed = "\n".join(f"  {format_mention(n)}" for n in sorted(self.mentionable_names))
+            lines.append(f"\nMentionable names (write them exactly like this):\n{listed}")
+        return "\n".join(lines)
+
     def generate_datasource_instruction(self) -> dict:
         """Generate a single comprehensive overview instruction for this data source.
 
@@ -114,8 +145,7 @@ Rules:
 - Write as direct instructions to the AI analyst ("Use X to...", "Always join on...", "Note that...")
 - Plain prose with short bullet points where helpful
 - 150–300 words
-- When referencing a table from the schema, write its name as @TableName (e.g. @orders, @customers)
-- When referencing an MCP tool from the schema, write its name as @tool_name (e.g. @search_products)
+{self._mention_rules()}
 
 Return JSON only:
 {{"title": "{title}", "text": "...", "category": "general", "load_mode": "always", "confidence": 0.95}}"""

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -921,6 +921,56 @@ class DataSourceService:
 
         return response
 
+    async def _get_mentionable_objects(self, db: AsyncSession, data_source_id: str) -> list[dict]:
+        """Everything an instruction on this data source may @mention.
+
+        Shaped like `InstructionService.get_available_references` rows
+        ({id, type, name}) so the same resolver works on both, but queried
+        directly by data source: this runs during onboarding where there is no
+        acting user to resolve per-user access against, and the instruction is
+        scoped to this data source anyway.
+        """
+        from app.models.datasource_table import DataSourceTable
+        from app.models.metadata_resource import MetadataResource
+        from app.models.connection import Connection
+        from app.models.connection_tool import ConnectionTool
+        from app.models.domain_connection import domain_connection
+
+        items: list[dict] = []
+
+        tables = await db.execute(
+            select(DataSourceTable.id, DataSourceTable.name)
+            .filter(DataSourceTable.datasource_id == data_source_id)
+            .filter(DataSourceTable.is_active == True)  # noqa: E712
+        )
+        items.extend(
+            {"id": str(tid), "type": "datasource_table", "name": name}
+            for tid, name in tables.all() if name
+        )
+
+        resources = await db.execute(
+            select(MetadataResource.id, MetadataResource.name)
+            .filter(MetadataResource.data_source_id == data_source_id)
+        )
+        items.extend(
+            {"id": str(rid), "type": "metadata_resource", "name": name}
+            for rid, name in resources.all() if name
+        )
+
+        tools = await db.execute(
+            select(ConnectionTool.id, ConnectionTool.name)
+            .select_from(ConnectionTool)
+            .join(Connection, ConnectionTool.connection_id == Connection.id)
+            .join(domain_connection, domain_connection.c.connection_id == Connection.id)
+            .filter(domain_connection.c.data_source_id == data_source_id)
+        )
+        items.extend(
+            {"id": str(cid), "type": "connection_tool", "name": name}
+            for cid, name in tools.all() if name
+        )
+
+        return items
+
     async def llm_sync(self, db: AsyncSession, data_source_id: str, organization: Organization, current_user: User | None = None) -> dict:
         """Run LLM onboarding generators for a data source.
         Returns a dict of generated fields.
@@ -977,8 +1027,17 @@ class DataSourceService:
                 db=db, data_sources=[data_source], organization=organization, report=None
             ).build(with_stats=False)
             schema = schema_ctx.render() if schema_ctx else await self._get_prompt_schema(db=db, data_source=data_source, organization=organization, current_user=current_user or User())
+            # The exact set of names the instruction may mention. Given to the
+            # model so it writes them verbatim, and used afterwards to resolve
+            # those mentions back to real objects.
+            mentionables = await self._get_mentionable_objects(db, data_source_id)
             from app.ai.agents.data_source.data_source import DataSourceAgent
-            agent = DataSourceAgent(data_source=data_source, schema=schema, model=model)
+            agent = DataSourceAgent(
+                data_source=data_source,
+                schema=schema,
+                model=model,
+                mentionable_names=[m["name"] for m in mentionables],
+            )
             # Offload — sync `generate_datasource_instruction` calls
             # `LLM.inference` whose pre-call usage-limit check can't run
             # from an active event loop without `loop` set.
@@ -992,6 +1051,25 @@ class DataSourceService:
             if text and title:
                 instruction_service = InstructionService()
                 from app.models.instruction import Instruction, instruction_data_source_association
+                from app.schemas.instruction_reference_schema import InstructionReferenceCreate
+                from app.utils.mentions import canonicalize_mentions, resolve_mentions
+
+                # Resolve the generated @mentions against the real objects, once,
+                # here — rather than re-deriving them from display names on every
+                # render. Multi-word names ("@Sales Orders") only survive because
+                # the resolver matches against the known-name dictionary.
+                # Canonicalizing first fixes casing and quotes anything a bare
+                # parse could not delimit.
+                text = canonicalize_mentions(text, mentionables)
+                references = [
+                    InstructionReferenceCreate(**ref)
+                    for ref in resolve_mentions(text, mentionables)
+                ]
+                if references:
+                    logger.info(
+                        "Resolved %d @mention(s) in onboarding instruction for data source %s",
+                        len(references), data_source_id,
+                    )
 
                 # Reuse existing onboarding draft if present (avoids FK cascade issues from old builds)
                 existing_q = await db.execute(
@@ -1011,6 +1089,9 @@ class DataSourceService:
                     existing.title = title
                     existing.category = category
                     existing.load_mode = load_mode
+                    await instruction_service.reference_service.replace_for_instruction(
+                        db, str(existing.id), references, organization, [data_source_id]
+                    )
                     await db.commit()
                     await db.refresh(existing)
                     result["onboarding_instruction"] = {"id": str(existing.id), "title": title}
@@ -1024,6 +1105,7 @@ class DataSourceService:
                         ai_source="onboarding",
                         data_source_ids=[data_source_id],
                         status="draft",
+                        references=references,
                     )
                     created = await instruction_service.create_instruction(
                         db=db,

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -1669,7 +1669,24 @@ class InstructionService:
                 "completion_id": (trace or {}).get("completion_id"),
                 "hunks": shown,
             })
-        return {"main_version_id": main_vid, "main_text": main_text, "suggestions": suggestions}
+        # Display names of this instruction's references, so the review UI can
+        # chip multi-word @mentions ("@Sales Orders") the same way the read-only
+        # instruction view does — parsing them needs the set of known names.
+        from app.models.instruction_reference import InstructionReference
+        reference_names = [
+            name for (name,) in (await db.execute(
+                select(InstructionReference.display_text)
+                .where(InstructionReference.instruction_id == instruction_id)
+                .where(InstructionReference.display_text.isnot(None))
+            )).all()
+            if name
+        ]
+        return {
+            "main_version_id": main_vid,
+            "main_text": main_text,
+            "suggestions": suggestions,
+            "reference_names": reference_names,
+        }
 
     async def get_pending_change_instruction_ids(
         self,

--- a/backend/app/utils/mentions.py
+++ b/backend/app/utils/mentions.py
@@ -1,0 +1,247 @@
+"""@mention resolution.
+
+A mention is ``@`` followed by the *display name* of a referenced object. Display
+names are not identifiers: tables, semantic models and MCP tools routinely carry
+spaces, slashes and dots — "Sales Orders", "Microsoft Fabric / dbo.sales".
+
+A regex therefore cannot delimit a mention on its own. In ``@Sales Orders by
+region`` nothing in the string says whether the name is "Sales", "Sales Orders"
+or "Sales Orders by region" — that depends entirely on which names exist.
+Matching ``[A-Za-z0-9_]+`` just takes the first word and silently truncates every
+multi-word name.
+
+So mentions are parsed against a dictionary of known names, longest match wins
+(maximum munch — the same rule lexers use). The dictionary is held in a trie, so
+a lookup costs O(length of the matched name) rather than O(number of names): an
+agent with 5k tables parses at the same speed as one with five.
+
+This mirrors ``frontend/utils/mentions.ts``; the two must stay in step, so the
+behavioural cases are pinned by tests/unit/test_mentions.py.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+# Identifier-shaped fallback: what a mention looks like with no dictionary.
+_BARE_MENTION_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*")
+
+# A name needs quoting when its own characters would not survive a bare parse.
+_NEEDS_QUOTES_RE = re.compile(r"[\s\-.\"]")
+
+# A dictionary match must end on a word boundary, so "Sales" does not chip the
+# head of "@SalesForce".
+_WORD_CHAR_RE = re.compile(r"[A-Za-z0-9_]")
+
+
+@dataclass
+class _TrieNode:
+    children: dict = field(default_factory=dict)
+    name: Optional[str] = None  # canonical display name; set on terminal nodes
+
+
+class MentionMatcher:
+    """Display names indexed for longest-prefix lookup.
+
+    Matching is case-insensitive; the canonical casing from the dictionary is
+    returned, so a resolved mention carries the object's real name regardless of
+    how it was written.
+    """
+
+    def __init__(self, names: Iterable[Optional[str]]):
+        self._root = _TrieNode()
+        self._size = 0
+        for raw in names:
+            name = (raw or "").strip()
+            if not name:
+                continue
+            node = self._root
+            for ch in name.lower():
+                nxt = node.children.get(ch)
+                if nxt is None:
+                    nxt = _TrieNode()
+                    node.children[ch] = nxt
+                node = nxt
+            # First writer wins, so a stable dictionary order gives stable casing.
+            if node.name is None:
+                node.name = name
+                self._size += 1
+
+    def __len__(self) -> int:
+        return self._size
+
+    def match_at(self, text: str, pos: int) -> Optional[Tuple[str, int]]:
+        """Longest dictionary name matching ``text`` at ``pos``.
+
+        Returns ``(canonical_name, chars_consumed)`` or None. Walks the trie one
+        character at a time, keeping the last terminal seen — so the longest
+        candidate wins and the scan stops as soon as no name can extend further.
+        """
+        node = self._root
+        best: Optional[Tuple[str, int]] = None
+        for i in range(pos, len(text)):
+            nxt = node.children.get(text[i].lower())
+            if nxt is None:
+                break
+            node = nxt
+            if node.name is not None:
+                after = text[i + 1] if i + 1 < len(text) else ""
+                if not after or not _WORD_CHAR_RE.match(after):
+                    best = (node.name, i + 1 - pos)
+        return best
+
+
+EMPTY_MATCHER = MentionMatcher([])
+
+
+@dataclass
+class MentionSegment:
+    """A run of the source text: literal when ``label`` is None."""
+
+    text: str
+    label: Optional[str] = None
+
+
+def parse_mention_segments(
+    text: str, matcher: Optional[MentionMatcher] = None
+) -> List[MentionSegment]:
+    """Split ``text`` into literal runs and mentions.
+
+    Resolution order at each ``@``:
+      1. a quoted label — ``@"Sales Orders"`` — always wins, it is self-delimiting;
+      2. the longest name in ``matcher``;
+      3. the identifier-shaped fallback, so undictionaried text still resolves.
+    """
+    src = text or ""
+    out: List[MentionSegment] = []
+    buffer: List[str] = []
+
+    def flush() -> None:
+        if buffer:
+            out.append(MentionSegment("".join(buffer)))
+            buffer.clear()
+
+    i = 0
+    n = len(src)
+    while i < n:
+        if src[i] == "@":
+            rest = src[i + 1 :]
+
+            # 1. Quoted mention.
+            if rest[:1] == '"':
+                end = rest.find('"', 1)
+                if end != -1:
+                    label = rest[1:end]
+                    flush()
+                    out.append(MentionSegment(f'@"{label}"', label))
+                    i += 1 + end + 1
+                    continue
+
+            # 2. Longest known display name.
+            hit = matcher.match_at(src, i + 1) if matcher is not None else None
+            if hit is not None:
+                name, length = hit
+                flush()
+                out.append(MentionSegment("@" + src[i + 1 : i + 1 + length], name))
+                i += 1 + length
+                continue
+
+            # 3. Identifier-shaped fallback.
+            word = _BARE_MENTION_RE.match(rest)
+            if word:
+                flush()
+                out.append(MentionSegment("@" + word.group(0), word.group(0)))
+                i += 1 + len(word.group(0))
+                continue
+
+        buffer.append(src[i])
+        i += 1
+
+    flush()
+    return out
+
+
+def extract_mention_labels(
+    text: str, matcher: Optional[MentionMatcher] = None
+) -> List[str]:
+    """Distinct mention labels in ``text``, in order of first appearance."""
+    seen = set()
+    out: List[str] = []
+    for seg in parse_mention_segments(text, matcher):
+        if seg.label is None:
+            continue
+        key = seg.label.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(seg.label)
+    return out
+
+
+def mention_needs_quotes(name: Optional[str]) -> bool:
+    """True when ``name`` must be written ``@"name"`` to survive a bare parse."""
+    return bool(name) and bool(_NEEDS_QUOTES_RE.search(name))
+
+
+def format_mention(name: str) -> str:
+    """Canonical source form for a mention of ``name``."""
+    return f'@"{name.replace(chr(34), "")}"' if mention_needs_quotes(name) else f"@{name}"
+
+
+def resolve_mentions(
+    text: str, candidates: Sequence[dict]
+) -> List[dict]:
+    """Resolve the @mentions in ``text`` against ``candidates``.
+
+    ``candidates`` are dicts as returned by
+    ``InstructionService.get_available_references`` — each carrying at least
+    ``id``, ``type`` and ``name``. Returns one entry per distinct resolved
+    mention, in order of first appearance, shaped for
+    ``InstructionReferenceCreate``.
+
+    Unresolvable mentions are dropped: they name something that does not exist,
+    so there is nothing to link them to.
+    """
+    by_name: dict = {}
+    for cand in candidates or []:
+        name = (cand.get("name") or "").strip()
+        if not name:
+            continue
+        by_name.setdefault(name.lower(), cand)
+
+    matcher = MentionMatcher(c.get("name") for c in (candidates or []))
+
+    out: List[dict] = []
+    for label in extract_mention_labels(text, matcher):
+        cand = by_name.get(label.lower())
+        if not cand:
+            continue
+        out.append(
+            {
+                "object_type": cand.get("type"),
+                "object_id": str(cand.get("id")),
+                "relation_type": "mention",
+                "display_text": cand.get("name"),
+            }
+        )
+    return out
+
+
+def canonicalize_mentions(text: str, candidates: Sequence[dict]) -> str:
+    """Rewrite every resolvable mention in ``text`` to its canonical source form.
+
+    ``@sales orders`` becomes ``@"Sales Orders"`` — right casing, and quoted so
+    the text stays unambiguous for any reader that lacks the dictionary. Text
+    that resolves to nothing is left exactly as written.
+    """
+    matcher = MentionMatcher(c.get("name") for c in (candidates or []))
+    known = {(c.get("name") or "").lower() for c in (candidates or [])}
+    parts: List[str] = []
+    for seg in parse_mention_segments(text, matcher):
+        if seg.label is not None and seg.label.lower() in known:
+            parts.append(format_mention(seg.label))
+        else:
+            parts.append(seg.text)
+    return "".join(parts)

--- a/backend/tests/unit/test_mentions.py
+++ b/backend/tests/unit/test_mentions.py
@@ -1,0 +1,227 @@
+"""@mention parsing.
+
+Pins the behaviour that `frontend/utils/mentions.ts` must mirror — the two
+implementations are read by the same stored instruction text, so they have to
+agree on where a mention starts and ends.
+"""
+
+import time
+
+import pytest
+
+from app.utils.mentions import (
+    MentionMatcher,
+    canonicalize_mentions,
+    extract_mention_labels,
+    format_mention,
+    mention_needs_quotes,
+    parse_mention_segments,
+    resolve_mentions,
+)
+
+
+DICT = MentionMatcher([
+    "Sales Orders",
+    "Sales",
+    "customers",
+    "Microsoft Fabric / dbo.sales",
+    "Total Revenue (USD)",
+    "search_products",
+    "הזמנות מכירה",
+])
+
+
+def chips(text, matcher=DICT):
+    return [s.label for s in parse_mention_segments(text, matcher) if s.label is not None]
+
+
+class TestMultiWordNames:
+    """The bug: a name with spaces was truncated to its first word."""
+
+    def test_multi_word_name_resolves_whole(self):
+        assert chips("Use @Sales Orders for revenue.") == ["Sales Orders"]
+
+    def test_without_dictionary_only_first_word(self):
+        # Documents the fallback: with no known names there is nothing to
+        # delimit against, so the identifier-shaped match is all that is left.
+        assert chips("Use @Sales Orders for revenue.", None) == ["Sales"]
+
+    def test_longest_match_wins_over_prefix_name(self):
+        assert chips("@Sales Orders") == ["Sales Orders"]
+
+    def test_shorter_name_when_longer_does_not_apply(self):
+        assert chips("@Sales figures rose") == ["Sales"]
+
+    def test_slashes_and_dots(self):
+        assert chips("Join @Microsoft Fabric / dbo.sales here.") == [
+            "Microsoft Fabric / dbo.sales"
+        ]
+
+    def test_parens(self):
+        assert chips("Track @Total Revenue (USD) monthly.") == ["Total Revenue (USD)"]
+
+    def test_rtl_name(self):
+        assert chips("ראה @הזמנות מכירה בבקשה") == ["הזמנות מכירה"]
+
+
+class TestDelimiting:
+    def test_quoted_wins_without_dictionary(self):
+        assert chips('Use @"Sales Orders" now.', None) == ["Sales Orders"]
+
+    def test_quoted_unknown_name_still_parses(self):
+        assert chips('Use @"Not A Table" now.') == ["Not A Table"]
+
+    def test_canonical_casing_returned(self):
+        assert chips("@sales orders rocks") == ["Sales Orders"]
+
+    def test_word_boundary_protects_longer_token(self):
+        # "Sales" is a known name but must not chip the head of "SalesForce".
+        assert chips("@SalesForce is a CRM") == ["SalesForce"]
+
+    def test_prose_is_not_swallowed(self):
+        segs = parse_mention_segments("@Sales Orders are late.", DICT)
+        rebuilt = "".join(f"[{s.label}]" if s.label else s.text for s in segs)
+        assert rebuilt == "[Sales Orders] are late."
+
+    def test_unknown_mention_falls_back_to_identifier(self):
+        assert chips("@unknown_table matters") == ["unknown_table"]
+
+    def test_segments_reconstruct_source_exactly(self):
+        for text in [
+            "Use @Sales Orders and @customers.",
+            'Quoted @"Sales Orders" plus @search_products.',
+            "no mentions at all",
+            "email a@b and @@ and @",
+        ]:
+            segs = parse_mention_segments(text, DICT)
+            assert "".join(s.text for s in segs) == text
+
+
+class TestHelpers:
+    def test_extract_labels_dedupes_case_insensitively(self):
+        assert extract_mention_labels("@Sales Orders and @sales orders", DICT) == [
+            "Sales Orders"
+        ]
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Sales Orders", '@"Sales Orders"'),
+            ("dbo.sales", '@"dbo.sales"'),
+            ("fact-table", '@"fact-table"'),
+            ("customers", "@customers"),
+            ("search_products", "@search_products"),
+        ],
+    )
+    def test_format_mention(self, name, expected):
+        assert format_mention(name) == expected
+
+    def test_mention_needs_quotes(self):
+        assert mention_needs_quotes("Sales Orders")
+        assert not mention_needs_quotes("customers")
+        assert not mention_needs_quotes(None)
+
+
+CANDIDATES = [
+    {"id": "t1", "type": "datasource_table", "name": "Sales Orders"},
+    {"id": "t2", "type": "datasource_table", "name": "customers"},
+    {"id": "r1", "type": "metadata_resource", "name": "Revenue Model"},
+    {"id": "c1", "type": "connection_tool", "name": "search_products"},
+]
+
+
+class TestResolveMentions:
+    def test_resolves_multi_word_to_object(self):
+        refs = resolve_mentions("Use @Sales Orders with @customers.", CANDIDATES)
+        assert [(r["object_type"], r["object_id"], r["display_text"]) for r in refs] == [
+            ("datasource_table", "t1", "Sales Orders"),
+            ("datasource_table", "t2", "customers"),
+        ]
+
+    def test_relation_type_is_mention(self):
+        refs = resolve_mentions("@Revenue Model", CANDIDATES)
+        assert refs[0]["relation_type"] == "mention"
+
+    def test_unknown_mentions_are_dropped(self):
+        assert resolve_mentions("@nothing_here at all", CANDIDATES) == []
+
+    def test_deduplicates_repeat_mentions(self):
+        refs = resolve_mentions("@Sales Orders then @Sales Orders again", CANDIDATES)
+        assert len(refs) == 1
+
+    def test_resolves_quoted_form(self):
+        refs = resolve_mentions('Use @"Sales Orders".', CANDIDATES)
+        assert refs[0]["object_id"] == "t1"
+
+    def test_empty_candidates_resolve_nothing(self):
+        assert resolve_mentions("@Sales Orders", []) == []
+
+
+class TestCanonicalizeMentions:
+    def test_quotes_multi_word_names(self):
+        assert canonicalize_mentions(
+            "Use @Sales Orders now.", CANDIDATES
+        ) == 'Use @"Sales Orders" now.'
+
+    def test_fixes_casing(self):
+        assert canonicalize_mentions("@sales orders", CANDIDATES) == '@"Sales Orders"'
+
+    def test_leaves_identifiers_bare(self):
+        assert canonicalize_mentions("@customers rock", CANDIDATES) == "@customers rock"
+
+    def test_leaves_unresolvable_text_untouched(self):
+        text = "@not_a_table and plain @words here"
+        assert canonicalize_mentions(text, CANDIDATES) == text
+
+    def test_is_idempotent(self):
+        once = canonicalize_mentions("Use @Sales Orders now.", CANDIDATES)
+        assert canonicalize_mentions(once, CANDIDATES) == once
+
+
+class TestScale:
+    """Lookup must not degrade on agents carrying thousands of tables.
+
+    The trie makes a match cost O(len(name)) instead of O(number of names); this
+    pins that so a future 'simplification' back to a linear scan is caught here
+    rather than as UI jank on a large agent.
+    """
+
+    NAMES = [
+        f"Enterprise Data Warehouse Fact Table Sales Orders Region {i}"
+        for i in range(5000)
+    ]
+
+    def test_resolves_correctly_at_5k_names(self):
+        matcher = MentionMatcher(self.NAMES + ["customers"])
+        text = "Use @Enterprise Data Warehouse Fact Table Sales Orders Region 4999 daily."
+        assert chips(text, matcher) == [
+            "Enterprise Data Warehouse Fact Table Sales Orders Region 4999"
+        ]
+
+    def test_parse_cost_is_independent_of_dictionary_size(self):
+        doc = " ".join(
+            f"Use @Enterprise Data Warehouse Fact Table Sales Orders Region {i * 250} "
+            "joining on customer_id before aggregation."
+            for i in range(20)
+        )
+        big = MentionMatcher(self.NAMES)
+        small = MentionMatcher(["customers", "Sales Orders"])
+
+        assert len([s for s in parse_mention_segments(doc, big) if s.label]) == 20
+
+        def timed(matcher, iters=50):
+            start = time.perf_counter()
+            for _ in range(iters):
+                parse_mention_segments(doc, matcher)
+            return (time.perf_counter() - start) / iters
+
+        timed(big, 5)  # warm up
+        big_ms = timed(big) * 1000
+        small_ms = timed(small) * 1000
+
+        # 2500x the names must not cost anywhere near 2500x the time. Generous
+        # bound so the test is not flaky on a loaded CI box; a linear scan
+        # regression lands orders of magnitude above it.
+        assert big_ms < max(small_ms * 10, 5.0), (
+            f"5k-name parse took {big_ms:.3f} ms vs {small_ms:.3f} ms for 2 names"
+        )

--- a/frontend/components/InstructionGlobalCreateComponent.vue
+++ b/frontend/components/InstructionGlobalCreateComponent.vue
@@ -840,6 +840,7 @@
 <script setup lang="ts">
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import Spinner from '~/components/Spinner.vue'
+import { buildMentionMatcher, extractMentionLabels } from '~/utils/mentions'
 import InstructionText from '~/components/instructions/InstructionText.vue'
 import InstructionEditor from '~/components/instructions/InstructionEditor.vue'
 import InstructionLabelFormModal from '~/components/InstructionLabelFormModal.vue'
@@ -1949,19 +1950,14 @@ const syncReferencesWithMentions = (text: string) => {
         return
     }
 
-    // Extract all mentions from text
-    const mentionRegex = /@([A-Za-z_][A-Za-z0-9_]*|"[^"]+")/g
-    const mentionedNames = new Set<string>()
-
-    let match
-    while ((match = mentionRegex.exec(text)) !== null) {
-        let name = match[1]
-        // Remove quotes if present
-        if (name.startsWith('"') && name.endsWith('"')) {
-            name = name.slice(1, -1)
-        }
-        mentionedNames.add(name.toLowerCase())
-    }
+    // Extract all mentions from text. Parsed against the names that actually
+    // exist, so a multi-word reference ("@Sales Orders") is recognised whole —
+    // an identifier-shaped regex reads it as "Sales", finds no match, and
+    // silently drops the reference the user just attached.
+    const matcher = buildMentionMatcher([...selectedReferences.value, ...mentionableOptions.value])
+    const mentionedNames = new Set(
+        extractMentionLabels(text, matcher).map(name => name.toLowerCase())
+    )
 
     // Keep only references that are still mentioned in text
     selectedReferences.value = selectedReferences.value.filter(ref => {

--- a/frontend/components/instructions/InstructionEditor.vue
+++ b/frontend/components/instructions/InstructionEditor.vue
@@ -112,6 +112,13 @@ import MarkdownIt from 'markdown-it'
 import { useI18n } from 'vue-i18n'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import { firstStrongDir, RTL_LOCALES } from '~/utils/textDirection'
+import {
+  buildMentionMatcher,
+  replaceMentions,
+  mentionNeedsQuotes,
+  EMPTY_MENTION_MATCHER,
+  type MentionMatcher,
+} from '~/utils/mentions'
 
 interface MentionItem {
   id: string
@@ -131,6 +138,8 @@ const props = defineProps<{
   dataSourceIds?: string[]
   isAllDataSources?: boolean
   editable?: boolean
+  /** Extra mentionable display names, when the host already has them loaded. */
+  knownNames?: string[]
 }>()
 
 const isEditable = computed(() => props.editable !== false)
@@ -150,16 +159,10 @@ const { organization } = useOrganization()
 const md = new MarkdownIt({ html: true, breaks: false, linkify: false })
 
 function convertMentions(text: string): string {
-  return text.replace(
-    /@([A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*|"[^"]+")/g,
-    (_, captured) => {
-      const label = captured.startsWith('"') && captured.endsWith('"')
-        ? captured.slice(1, -1)
-        : captured
-      const safe = label.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
-      return `<span data-type="mention" data-id="${safe}" data-label="${safe}"></span>`
-    }
-  )
+  return replaceMentions(text, mentionMatcher.value, (label) => {
+    const safe = label.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+    return `<span data-type="mention" data-id="${safe}" data-label="${safe}"></span>`
+  })
 }
 
 // Convert @mentions to mention spans, but NEVER inside code (fenced blocks or
@@ -177,7 +180,7 @@ function preprocessMentions(text: string): string {
 function normalizeMentionHtml(text: string): string {
   const toAt = (raw: string): string => {
     const label = (raw || '').replace(/&quot;/g, '"').replace(/&amp;/g, '&').trim()
-    return /[\s\-."]/.test(label) ? `@"${label.replace(/"/g, '')}"` : `@${label}`
+    return mentionNeedsQuotes(label) ? `@"${label.replace(/"/g, '')}"` : `@${label}`
   }
   return text
     .replace(/`?\s*<span[^>]*data-type=["']mention["'][^>]*data-label=["']([^"']*)["'][^>]*>\s*<\/span>\s*`?/g, (_, l) => toAt(l))
@@ -239,7 +242,9 @@ function serializeNode(node: any): string {
       return '\n'
     case 'mention': {
       const label = node.attrs?.label || node.attrs?.id || ''
-      return /[\s\-.]/.test(label) ? `@"${label}"` : `@${label}`
+      // Quote names that a bare parse could not delimit, so the markdown stays
+      // unambiguous even for a reader without the mention dictionary.
+      return mentionNeedsQuotes(label) ? `@"${label}"` : `@${label}`
     }
     case 'text':
       return serializeInlineMarks(node.text || '', node.marks || [])
@@ -294,6 +299,56 @@ async function fetchMentionSuggestions(query: string): Promise<MentionItem[]> {
     return []
   }
 }
+
+// ─── Mention dictionary ───────────────────────────────────────────────────────
+// Stored markdown holds display names, not ids, so turning `@Sales Orders` back
+// into one chip needs the set of names that exist. Fetched once per editor (the
+// same endpoint the typeahead uses, unfiltered) and held as a trie.
+
+const mentionMatcher = shallowRef<MentionMatcher>(EMPTY_MENTION_MATCHER)
+
+async function loadMentionDictionary() {
+  const seeded = props.knownNames?.length ? props.knownNames : null
+  if (seeded) mentionMatcher.value = buildMentionMatcher(seeded.map(name => ({ name })))
+  try {
+    const params = new URLSearchParams()
+    params.set('types', 'instruction,datasource_table,metadata_resource,connection_tool')
+    if (!props.isAllDataSources && props.dataSourceIds?.length) {
+      params.set('data_source_filter', props.dataSourceIds.join(','))
+    }
+    const data = await $fetch<any[]>(
+      `${config.public.baseURL}/instructions/available-references?${params}`,
+      {
+        headers: {
+          Authorization: token.value || '',
+          'X-Organization-Id': organization.value?.id || '',
+        }
+      }
+    )
+    if (!data?.length) return
+    mentionMatcher.value = buildMentionMatcher([
+      ...data,
+      ...(seeded || []).map(name => ({ name })),
+    ])
+  } catch {
+    // Keep whatever we have; the parser degrades to identifier-shaped mentions.
+  }
+}
+
+// Re-chip once the dictionary lands. Only while unfocused: re-setting content
+// under the caret would move it mid-typing, and an editor being typed into has
+// already been chipped by the suggestion plugin anyway.
+watch(mentionMatcher, () => {
+  const e = editor.value
+  if (!e || e.isFocused) return
+  const currentMd = docToMarkdown(e.getJSON())
+  const rechipped = markdownToHtml(currentMd)
+  if (rechipped !== markdownToHtmlCache) {
+    markdownToHtmlCache = rechipped
+    e.commands.setContent(rechipped, false)
+  }
+})
+let markdownToHtmlCache = ''
 
 // ─── Mention suggestion state ─────────────────────────────────────────────────
 
@@ -477,6 +532,7 @@ const editorOptions = () => ({
 // construction throws, flip to the raw-markdown fallback so the instruction
 // text is still readable/editable instead of a blank pane.
 onMounted(() => {
+  loadMentionDictionary()
   try {
     editor.value = new Editor(editorOptions() as any)
     // Apply editable state explicitly, to avoid stale state from HMR / component reuse

--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -48,6 +48,12 @@ import MarkdownIt from 'markdown-it'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import DocMermaid from '~/components/dashboard/DocMermaid.vue'
 import { firstStrongDir } from '~/utils/textDirection'
+import {
+  buildMentionMatcher,
+  parseMentionSegments,
+  replaceMentions,
+  type MentionMatcher,
+} from '~/utils/mentions'
 
 interface RawReference {
   id?: string
@@ -97,73 +103,19 @@ interface Segment {
   raw?: string
 }
 
-// Reference display names sorted longest-first, so multi-word mentions like
-// "Microsoft Fabric / dbo.sales" win over the bare leading word ("Microsoft").
-const refMatchers = computed(() =>
-  normalizedRefs.value
-    .filter(r => r.name)
-    .map(r => ({ name: r.name as string, ref: r }))
-    .sort((a, b) => b.name.length - a.name.length)
+// The instruction's own references double as the mention dictionary: their
+// display names are exactly the labels that may appear after an '@'. Indexed as
+// a trie so lookup cost tracks the matched name's length, not the number of
+// references (see utils/mentions.ts).
+const mentionMatcher = computed(() => buildMentionMatcher(normalizedRefs.value))
+
+const segments = computed((): Segment[] =>
+  parseMentionSegments(props.text || '', mentionMatcher.value).map((seg): Segment => {
+    if (seg.type === 'text') return { text: seg.value }
+    const ref = refByName.value.get(seg.label.toLowerCase())
+    return ref ? { ref, raw: seg.label } : { mention: seg.label }
+  })
 )
-
-const segments = computed((): Segment[] => {
-  const text = props.text || ''
-  const result: Segment[] = []
-  let buffer = ''
-  const flush = () => {
-    if (buffer) {
-      result.push({ text: buffer })
-      buffer = ''
-    }
-  }
-
-  let i = 0
-  while (i < text.length) {
-    if (text[i] === '@') {
-      const rest = text.slice(i + 1)
-
-      // 1. Quoted mention: @"some label with spaces"
-      if (rest[0] === '"') {
-        const end = rest.indexOf('"', 1)
-        if (end !== -1) {
-          const label = rest.slice(1, end)
-          flush()
-          const ref = refByName.value.get(label.toLowerCase())
-          result.push(ref ? { ref, raw: label } : { mention: label })
-          i += 1 + end + 1
-          continue
-        }
-      }
-
-      // 2. Longest matching reference display name (handles spaces, slashes,
-      //    dots — e.g. data-source tables like "Microsoft Fabric / dbo.sales").
-      const match = refMatchers.value.find(m => rest.startsWith(m.name))
-      if (match) {
-        flush()
-        result.push({ ref: match.ref, raw: match.name })
-        i += 1 + match.name.length
-        continue
-      }
-
-      // 3. Fallback: a plain identifier word (optionally dotted/dashed).
-      const word = rest.match(/^[A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*/)
-      if (word) {
-        flush()
-        const w = word[0]
-        const ref = refByName.value.get(w.toLowerCase())
-        result.push(ref ? { ref, raw: w } : { mention: w })
-        i += 1 + w.length
-        continue
-      }
-    }
-
-    buffer += text[i]
-    i++
-  }
-
-  flush()
-  return result
-})
 
 // ─── Markdown rendering ──────────────────────────────────────────────────────
 // Mirrors InstructionEditor's pipeline so read-only and edit views render identically.
@@ -198,22 +150,18 @@ md.core.ruler.push('block_dir', (state) => {
   }
 })
 
-function preprocessMentions(text: string): string {
-  return text.replace(
-    /@([A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*|"[^"]+")/g,
-    (_, captured) => {
-      const label = captured.startsWith('"') && captured.endsWith('"')
-        ? captured.slice(1, -1)
-        : captured
-      const safe = label.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
-      return `<span class="instruction-mention">@${safe}</span>`
-    }
-  )
+// Same dictionary-driven parse as the plain-text branch above, so a multi-word
+// mention chips identically whether the instruction renders as markdown or not.
+function preprocessMentions(text: string, matcher: MentionMatcher | null): string {
+  return replaceMentions(text, matcher, (label) => {
+    const safe = label.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+    return `<span class="instruction-mention">@${safe}</span>`
+  })
 }
 
-function renderProse(text: string): string {
+function renderProse(text: string, matcher: MentionMatcher | null): string {
   if (!text.trim()) return ''
-  return md.render(preprocessMentions(text))
+  return md.render(preprocessMentions(text, matcher))
 }
 
 // Split the markdown into prose blocks and ```mermaid diagram blocks, so a
@@ -228,8 +176,9 @@ const blocks = computed<Block[]>(() => {
   const lines = (props.text || '').split('\n')
   const out: Block[] = []
   let buffer: string[] = []
+  const matcher = mentionMatcher.value
   const flush = () => {
-    const html = renderProse(buffer.join('\n'))
+    const html = renderProse(buffer.join('\n'), matcher)
     if (html.trim()) out.push({ type: 'html', html })
     buffer = []
   }

--- a/frontend/components/instructions/InstructionTrackedChanges.vue
+++ b/frontend/components/instructions/InstructionTrackedChanges.vue
@@ -78,7 +78,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, shallowRef, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import {
+  buildMentionMatcher,
+  parseMentionSegments,
+  EMPTY_MENTION_MATCHER,
+  type MentionMatcher,
+} from '~/utils/mentions'
 
 const props = defineProps<{ instructionId: string; canApprove?: boolean; compact?: boolean; collapseContext?: boolean; hideHeader?: boolean }>()
 const emit = defineEmits<{ (e: 'changed'): void; (e: 'empty'): void; (e: 'state', s: { total: number; busy: boolean }): void }>()
@@ -145,25 +151,18 @@ const fmtWhen = (s?: string) => { if (!s) return ''; try { return _df.format(s, 
 
 // Split text into plain runs + @mention chips so references render like the
 // normal instruction view. Handles both `@name` / `@"label"` and the TipTap
-// `<span data-type="mention" label="x">` HTML form.
-const MENTION_RE = /@([A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*|"[^"]+")/g
+// `<span data-type="mention" label="x">` HTML form. Multi-word names are
+// resolved against the instruction's own reference names (see utils/mentions.ts).
+const mentionMatcher = shallowRef<MentionMatcher>(EMPTY_MENTION_MATCHER)
+
 function mentionParts(text: string): Array<{ t?: string; mention?: string }> {
   const norm = (text || '')
     .replace(/<span[^>]*data-type=["']mention["'][^>]*label=["']([^"']+)["'][^>]*>\s*<\/span>/g, '@$1')
     .replace(/<span[^>]*data-type=["']mention["'][^>]*>([^<]*)<\/span>/g, '@$1')
   if (!norm.includes('@')) return [{ t: norm }]
-  const parts: Array<{ t?: string; mention?: string }> = []
-  let last = 0, m: RegExpExecArray | null
-  MENTION_RE.lastIndex = 0
-  while ((m = MENTION_RE.exec(norm))) {
-    if (m.index > last) parts.push({ t: norm.slice(last, m.index) })
-    let label = m[1]
-    if (label.startsWith('"')) label = label.slice(1, -1)
-    parts.push({ mention: label })
-    last = MENTION_RE.lastIndex
-  }
-  if (last < norm.length) parts.push({ t: norm.slice(last) })
-  return parts
+  return parseMentionSegments(norm, mentionMatcher.value).map(seg =>
+    seg.type === 'mention' ? { mention: seg.label } : { t: seg.value }
+  )
 }
 
 // Interleave every suggestion's hunks (server-positioned by char offset) onto the
@@ -235,6 +234,7 @@ async function load(opts: { silent?: boolean } = {}) {
     mainText.value = d.main_text || ''
     mainVersionId.value = d.main_version_id || null
     suggestions.value = d.suggestions || []
+    mentionMatcher.value = buildMentionMatcher((d.reference_names || []).map((name: string) => ({ name })))
   } finally { if (!opts.silent) loading.value = false }
   if (!totalHunks.value) emit('empty')
 }

--- a/frontend/pages/agents/new/[id]/context.vue
+++ b/frontend/pages/agents/new/[id]/context.vue
@@ -117,6 +117,7 @@ import GitRepoModalComponent from '@/components/GitRepoModalComponent.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import GitBranchIcon from '~/components/icons/GitBranchIcon.vue'
 import Spinner from '~/components/Spinner.vue'
+import { buildMentionMatcher, parseMentionSegments, extractMentionLabels, formatMention } from '~/utils/mentions'
 
 const route = useRoute()
 const router = useRouter()
@@ -241,29 +242,47 @@ watch(() => mentionState.value.query, (q) => {
   mentionFetchTimeout = setTimeout(() => fetchMentionItems(q), 150)
 })
 
-const isKnownMention = (text: string) => {
-  const lower = text.toLowerCase()
-  return allMentionItems.value.some(item => {
-    if (item.name?.toLowerCase() === lower) return true
-    if (item.type === 'instruction' && item.textPreview) {
-      if ((item.textPreview.slice(0, 30) + '...').toLowerCase() === lower) return true
-    }
-    return false
-  })
-}
+// Mentionable display names, indexed for longest-match lookup. Table / semantic
+// model / tool names routinely contain spaces, so "@Sales Orders" can only be
+// delimited by knowing which names exist (see utils/mentions.ts).
+const mentionMatcher = computed(() =>
+  buildMentionMatcher([
+    ...allMentionItems.value.map(item => ({ name: item.name })),
+    // Instructions with no title are mentioned by a truncated text preview.
+    ...allMentionItems.value
+      .filter(item => item.type === 'instruction' && !item.name && item.textPreview)
+      .map(item => ({ name: item.textPreview!.slice(0, 30) + '...' })),
+  ])
+)
 
+const knownMentionNames = computed(() => {
+  const set = new Set<string>()
+  for (const item of allMentionItems.value) {
+    if (item.name) set.add(item.name.toLowerCase())
+    if (item.type === 'instruction' && item.textPreview) {
+      set.add((item.textPreview.slice(0, 30) + '...').toLowerCase())
+    }
+  }
+  return set
+})
+
+const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+// The backdrop sits behind the textarea, so every character must land in the
+// same place — each segment is re-emitted verbatim, only wrapped.
 const highlightedText = computed(() => {
   const text = instructionText.value
   if (!text) return ''
-  let html = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  html = html.replace(/@([A-Za-z_][A-Za-z0-9_]*|"[^"]+")/g, (match, captured) => {
-    let name = captured
-    if (name.startsWith('"') && name.endsWith('"')) name = name.slice(1, -1)
-    if (isKnownMention(name)) {
-      return `<mark style="background-color: rgba(99,102,241,0.12); color: transparent; border-radius: 3px; padding: 0;">${match}</mark>`
-    }
-    return match
-  })
+  const html = parseMentionSegments(text, mentionMatcher.value)
+    .map(seg => {
+      if (seg.type === 'text') return escapeHtml(seg.value)
+      const source = escapeHtml('@' + seg.raw)
+      return knownMentionNames.value.has(seg.label.toLowerCase())
+        ? `<mark style="background-color: rgba(99,102,241,0.12); color: transparent; border-radius: 3px; padding: 0;">${source}</mark>`
+        : source
+    })
+    .join('')
   return html + '\n'
 })
 
@@ -325,20 +344,13 @@ const handleTextareaKeydown = (e: KeyboardEvent) => {
 
 const handleTextareaBlur = () => setTimeout(() => { mentionState.value.active = false }, 150)
 
-const needsQuotes = (name: string | null) => name && /[\s\-.]/.test(name)
-
 const selectMention = (item: MentionItem) => {
   const ta = textareaRef.value
   if (!ta) return
   const { startPos, query } = mentionState.value
-  let mentionText: string
-  if (!item.name) {
-    mentionText = `@"${item.textPreview?.slice(0, 30)}..."`
-  } else if (needsQuotes(item.name)) {
-    mentionText = `@"${item.name}"`
-  } else {
-    mentionText = `@${item.name}`
-  }
+  const mentionText = item.name
+    ? formatMention(item.name)
+    : `@"${item.textPreview?.slice(0, 30)}..."`
   const before = instructionText.value.slice(0, startPos)
   const after = instructionText.value.slice(startPos + 1 + query.length)
   instructionText.value = before + mentionText + ' ' + after
@@ -351,18 +363,42 @@ const selectMention = (item: MentionItem) => {
 }
 
 // ── Save ──────────────────────────────────────────────────────────────────────
+
+// Resolve the @mentions in the text to the objects they name, so the saved
+// instruction carries real references (ids) rather than only display names in
+// prose. Without this every reader has to re-derive references by matching
+// names, and the read-only view — which parses against the instruction's own
+// references — has no dictionary to work with.
+function resolveReferences(text: string) {
+  const byName = new Map(
+    allMentionItems.value
+      .filter(item => item.name)
+      .map(item => [item.name!.toLowerCase(), item])
+  )
+  const out: Array<{ object_type: string; object_id: string; column_name: null; relation_type: string }> = []
+  const seen = new Set<string>()
+  for (const label of extractMentionLabels(text, mentionMatcher.value)) {
+    const item = byName.get(label.toLowerCase())
+    if (!item || seen.has(item.id)) continue
+    seen.add(item.id)
+    out.push({ object_type: item.type, object_id: item.id, column_name: null, relation_type: 'mention' })
+  }
+  return out
+}
+
 async function handleSave() {
   if (saving.value) return
   saving.value = true
   try {
     const text = instructionText.value.trim()
+    const references = resolveReferences(text)
     let primaryInstructionId: string | null = null
 
     if (draftInstructionId.value) {
       if (text) {
         await useMyFetch(`/instructions/${draftInstructionId.value}`, {
           method: 'PUT',
-          body: { text, status: 'published' },
+          body: { text, status: 'published', references },
         })
         primaryInstructionId = draftInstructionId.value
       } else {
@@ -379,6 +415,7 @@ async function handleSave() {
           can_user_toggle: true,
           load_mode: 'always',
           data_source_ids: [dsId.value],
+          references,
         },
       })
       primaryInstructionId = (data as any)?.value?.id || null

--- a/frontend/utils/mentions.ts
+++ b/frontend/utils/mentions.ts
@@ -1,0 +1,239 @@
+/**
+ * @mention parsing.
+ *
+ * A mention is `@` followed by the *display name* of a referenced object. Display
+ * names are not identifiers: tables, semantic models and MCP tools routinely carry
+ * spaces, slashes and dots — "Sales Orders", "Microsoft Fabric / dbo.sales".
+ *
+ * A regex therefore cannot delimit a mention on its own. Given the text
+ * `@Sales Orders by region`, nothing in the string says whether the name is
+ * "Sales", "Sales Orders" or "Sales Orders by region" — that depends entirely on
+ * which names exist. Matching `[A-Za-z0-9_]+` just takes the first word and
+ * silently truncates every multi-word name.
+ *
+ * So mentions are parsed against a dictionary of known names, longest match wins
+ * (maximum munch — the same rule lexers use for `>>` vs `>`). The dictionary lives
+ * in a trie, so a lookup costs O(length of the matched name) instead of
+ * O(number of names): an agent with 5k tables parses at the same speed as one with
+ * five. Without a dictionary the parser degrades to the historical
+ * identifier-shaped match, so callers that have no name list still work.
+ *
+ * Quoted mentions (`@"Sales Orders"`) are always honored, dictionary or not —
+ * that is the form the mention picker inserts, and it is self-delimiting.
+ */
+
+/** Identifier-shaped fallback: what a mention looks like with no dictionary. */
+const BARE_MENTION_RE = /^[A-Za-z_][A-Za-z0-9_]*(?:[.\-][A-Za-z0-9_]+)*/
+
+/** A name needs quoting when its own characters would not survive a bare parse. */
+const NEEDS_QUOTES_RE = /[\s\-."]/
+
+/** Characters that may not immediately follow a dictionary match — a match must
+ *  end on a word boundary, so "Sales" does not chip the head of "@SalesForce". */
+const WORD_CHAR_RE = /[A-Za-z0-9_]/
+
+interface TrieNode {
+  children: Map<string, TrieNode>
+  /** Canonical display name, set on terminal nodes. */
+  name?: string
+}
+
+export interface MentionMatch {
+  /** Canonical name as it appears in the dictionary (original casing). */
+  name: string
+  /** Characters consumed from the text (may differ in case from `name`). */
+  length: number
+}
+
+/**
+ * A dictionary of mentionable display names, indexed for longest-prefix lookup.
+ *
+ * Matching is case-insensitive; the canonical casing from the dictionary is
+ * returned so a chip renders the object's real name regardless of how it was
+ * typed.
+ */
+export class MentionMatcher {
+  private root: TrieNode = { children: new Map() }
+  readonly size: number
+
+  constructor(names: Iterable<string | null | undefined>) {
+    let size = 0
+    for (const raw of names) {
+      const name = (raw || '').trim()
+      if (!name) continue
+      let node = this.root
+      const lower = name.toLowerCase()
+      for (const ch of lower) {
+        let next = node.children.get(ch)
+        if (!next) {
+          next = { children: new Map() }
+          node.children.set(ch, next)
+        }
+        node = next
+      }
+      // First writer wins, so a stable dictionary order gives stable casing.
+      if (node.name === undefined) {
+        node.name = name
+        size++
+      }
+    }
+    this.size = size
+  }
+
+  get isEmpty(): boolean {
+    return this.size === 0
+  }
+
+  /**
+   * Longest dictionary name matching `text` at `pos`, or null.
+   *
+   * Walks the trie one character at a time, remembering the last terminal node
+   * seen — so the longest candidate wins and the scan stops as soon as no name
+   * can extend further. Cost is bounded by the longest name in the dictionary,
+   * not by its size.
+   */
+  matchAt(text: string, pos: number): MentionMatch | null {
+    let node = this.root
+    let best: MentionMatch | null = null
+    for (let i = pos; i < text.length; i++) {
+      const next = node.children.get(text[i].toLowerCase())
+      if (!next) break
+      node = next
+      if (node.name !== undefined) {
+        const after = text[i + 1]
+        // Require a word boundary so a short name cannot chip the head of a
+        // longer bare token ("Sales" inside "@SalesForce").
+        if (after === undefined || !WORD_CHAR_RE.test(after)) {
+          best = { name: node.name, length: i + 1 - pos }
+        }
+      }
+    }
+    return best
+  }
+}
+
+/** Empty dictionary — parses with the identifier fallback only. */
+export const EMPTY_MENTION_MATCHER = new MentionMatcher([])
+
+/**
+ * Build a matcher from whatever reference-ish objects a caller has on hand.
+ * Accepts the shapes returned by `/instructions/available-references` and by an
+ * instruction's own `references` array.
+ */
+export function buildMentionMatcher(
+  refs: Array<{ name?: string | null; display_text?: string | null } | null | undefined> | null | undefined,
+): MentionMatcher {
+  if (!refs?.length) return EMPTY_MENTION_MATCHER
+  return new MentionMatcher(refs.map(r => r?.name || r?.display_text || null))
+}
+
+export type MentionSegment =
+  | { type: 'text'; value: string }
+  | { type: 'mention'; label: string; /** consumed source text, without the `@` */ raw: string }
+
+/**
+ * Split `text` into literal runs and mentions.
+ *
+ * Resolution order at each `@`:
+ *   1. a quoted label — `@"Sales Orders"` — always wins, it is self-delimiting;
+ *   2. the longest name in `matcher`;
+ *   3. the identifier-shaped fallback, so undictionaried text still chips.
+ */
+export function parseMentionSegments(
+  text: string,
+  matcher: MentionMatcher | null = null,
+): MentionSegment[] {
+  const src = text || ''
+  const out: MentionSegment[] = []
+  let buffer = ''
+  const flush = () => {
+    if (buffer) {
+      out.push({ type: 'text', value: buffer })
+      buffer = ''
+    }
+  }
+
+  let i = 0
+  while (i < src.length) {
+    if (src[i] === '@') {
+      const rest = src.slice(i + 1)
+
+      // 1. Quoted mention.
+      if (rest[0] === '"') {
+        const end = rest.indexOf('"', 1)
+        if (end !== -1) {
+          const label = rest.slice(1, end)
+          flush()
+          out.push({ type: 'mention', label, raw: `"${label}"` })
+          i += 1 + end + 1
+          continue
+        }
+      }
+
+      // 2. Longest known display name.
+      const match = matcher?.matchAt(src, i + 1)
+      if (match) {
+        flush()
+        out.push({ type: 'mention', label: match.name, raw: src.substr(i + 1, match.length) })
+        i += 1 + match.length
+        continue
+      }
+
+      // 3. Identifier-shaped fallback.
+      const word = rest.match(BARE_MENTION_RE)
+      if (word) {
+        flush()
+        out.push({ type: 'mention', label: word[0], raw: word[0] })
+        i += 1 + word[0].length
+        continue
+      }
+    }
+
+    buffer += src[i]
+    i++
+  }
+
+  flush()
+  return out
+}
+
+/** Distinct mention labels in `text`, in order of first appearance. */
+export function extractMentionLabels(
+  text: string,
+  matcher: MentionMatcher | null = null,
+): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const seg of parseMentionSegments(text, matcher)) {
+    if (seg.type !== 'mention') continue
+    const key = seg.label.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(seg.label)
+  }
+  return out
+}
+
+/**
+ * Rewrite every mention in `text` through `render`, leaving literal runs alone.
+ * Used to turn stored markdown into chip markup.
+ */
+export function replaceMentions(
+  text: string,
+  matcher: MentionMatcher | null,
+  render: (label: string) => string,
+): string {
+  return parseMentionSegments(text, matcher)
+    .map(seg => (seg.type === 'mention' ? render(seg.label) : seg.value))
+    .join('')
+}
+
+/** True when `name` must be written as `@"name"` to survive a bare parse. */
+export function mentionNeedsQuotes(name: string | null | undefined): boolean {
+  return !!name && NEEDS_QUOTES_RE.test(name)
+}
+
+/** Canonical source form for a mention of `name`. */
+export function formatMention(name: string): string {
+  return mentionNeedsQuotes(name) ? `@"${name.replace(/"/g, '')}"` : `@${name}`
+}


### PR DESCRIPTION
## Problem

Table, semantic-model and MCP-tool display names routinely contain spaces — `Sales Orders`, `Microsoft Fabric / dbo.sales`, `Total Revenue (USD)`. Mentions were matched with an identifier-shaped regex that stops at the first non-word character, so `@Sales Orders` chipped as `@Sales` and left ` Orders` as prose. Names like `@Customer Support Tickets` went unhighlighted entirely.

Most visible on the new-agent wizard's last screen, where the generated instruction is full of mentions — but it affected every mention surface.

## Why not just widen the regex

Nothing in `@Sales Orders by region` says where the name ends. `Sales`, `Sales Orders`, and `Sales Orders by region` are all plausible; which is right depends entirely on which names exist. An unbounded space-tolerant pattern would swallow prose (`@revenue is computed from...`).

So mentions are now parsed against a **dictionary of known display names, longest match wins** (maximum munch — the rule lexers use for `>>` vs `>`). The dictionary is a trie, so a lookup costs `O(len(name))` instead of `O(number of names)`.

## Changes

- **`frontend/utils/mentions.ts` + `backend/app/utils/mentions.py`** — one parser each side, replacing five drifted copies of the regex. Quoted mentions (`@"Sales Orders"`) and the identifier fallback still work, so callers without a dictionary are unaffected.
- **Mentions resolve to `InstructionReference` rows at save time**, rather than being re-derived from display names on every render. The agent wizard previously dropped references entirely; it now sends them.
- **`review-hunks` returns `reference_names`** so the tracked-changes view can chip multi-word mentions too.
- **Instruction-generation prompt** gets the literal list of mentionable names plus the quoting rule, and the output is canonicalized. Longest-match cannot rescue a name the model never wrote verbatim, so this still earns its keep.

Also fixes a silent data loss: `syncReferencesWithMentions` used the same regex to *prune* references, so editing an instruction dropped every multi-word reference attached to it.

## Verification

**Correctness** — 34 pytest cases in `backend/tests/unit/test_mentions.py` (runs in CI), covering longest-match vs. prefix names, word boundaries (`@SalesForce` must not chip as `@Sales`), casing, RTL names, and exact source reconstruction.

**End to end** — booted a local sandbox, seeded tables with spaces in their names, and typed the mention by hand through the real UI. Verified at every layer:

```
POST references: 4 × {object_type: datasource_table, relation_type: mention}
DB rows:         ('datasource_table', 'Sales Orders', 'mention') … ×4
read-only chips: ["@Sales Orders","@customers","@Customer Support Tickets","@Total Revenue (USD)"]
tiptap chips:    same
```

Before: only `@Sales` highlighted. After: all four full names. Editor round-trip promotes them to the canonical `@"Sales Orders"` form and re-renders identically — no truncation, appended text preserved.

**Scale — 5,008 tables**, seeded and driven through the real UI:

| | 8 tables | 5,008 tables |
|---|---|---|
| keystroke → highlight repaint (mean, 80 edits) | 0.25 ms | **0.32 ms** |
| p95 / max | 0.50 / 1.70 ms | 0.60 / 2.60 ms |
| dictionary fetch | — | 5,009 refs in 346 ms |

A 60-character mention (`@Enterprise Data Warehouse Fact Table Sales Orders Region 4999`) resolves whole, and longest-match correctly distinguishes it from `Region 12` in the same sentence.

The trie is what keeps that flat. Isolated parse benchmark on the same 5k dictionary: **0.071 ms** vs **23.4 ms** for the linear longest-first scan previously in `InstructionText` — 327×. At 5k tables that scan would have been visible jank on every keystroke, so it was worth replacing regardless of the spaces bug.

## Known limitation

`InstructionReference` stores no offsets, so chip *positions* are still recovered by matching names against the text. Rename a table and the stored text stops matching. Rename-proofing needs an inline token carrying the id (`@[Sales Orders](ref_id)`) — a migration deliberately left out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpy8eKEm5ZVj5Pu2S4Uwag)_