### PR TITLE
Fix silent stalls when loading report conversation history (scroll-to-top pagination)

### DIFF
--- a/backend/app/schemas/completion_v2_schema.py
+++ b/backend/app/schemas/completion_v2_schema.py
@@ -217,9 +217,10 @@ class CompletionsV2Response(BaseModel):
     total_steps_created: int
     earliest_completion: Optional[datetime] = None
     latest_completion: Optional[datetime] = None
-    # Cursor pagination
+    # Cursor pagination. next_before is an opaque cursor ("<ISO8601>~<completion id>")
+    # the client echoes back verbatim as the `before` query param.
     has_more: bool = False
-    next_before: Optional[datetime] = None
+    next_before: Optional[str] = None
     # Rolling-compaction state so the transcript can place the divider on load
     compaction: Optional[CompactionStateSchema] = None
 

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -990,8 +990,9 @@ class CompletionService:
         """Assemble v2 completions response efficiently with batched queries.
 
         Returns the last `limit` completions (user+system) in reverse chronological order,
-        then sorted ascending for UI render. If `before` is provided (ISO8601), fetches
-        items strictly before that timestamp (cursor pagination).
+        then sorted ascending for UI render. If `before` is provided (the response's
+        opaque `next_before` cursor: "<ISO8601>~<completion id>", or a bare ISO8601
+        timestamp from older clients), fetches items strictly before that position.
         """
         from app.ai.llm.pii.display import display_redaction
         from app.dependencies import async_session_maker
@@ -1023,14 +1024,29 @@ class CompletionService:
             ),
         )
         if before:
+            # Cursor is "<iso timestamp>~<completion id>" (see next_before below).
+            # The id tiebreaker keeps pagination exact when several completions
+            # share a created_at (bulk inserts, webhook bursts): a plain
+            # `created_at < ts` cursor either skips those rows or re-serves the
+            # same page forever. Bare ISO cursors (older clients) still work.
             try:
                 from datetime import datetime as _dt
-                before_dt = _dt.fromisoformat(before)
-                completions_stmt = completions_stmt.where(Completion.created_at < before_dt)
+                ts_part, _, before_id = before.partition('~')
+                before_dt = _dt.fromisoformat(ts_part)
+                if before_id:
+                    completions_stmt = completions_stmt.where(
+                        (Completion.created_at < before_dt)
+                        | ((Completion.created_at == before_dt) & (Completion.id < before_id))
+                    )
+                else:
+                    completions_stmt = completions_stmt.where(Completion.created_at < before_dt)
             except Exception:
-                pass
-        # Order newest first, fetch one extra to determine has_more
-        completions_stmt = completions_stmt.order_by(Completion.created_at.desc()).limit(limit + 1)
+                logger.warning(f"Ignoring unparseable completions cursor {before!r} for report {report_id}")
+        # Order newest first (id desc as tiebreaker for identical timestamps so
+        # page boundaries are deterministic), fetch one extra to determine has_more
+        completions_stmt = completions_stmt.order_by(
+            Completion.created_at.desc(), Completion.id.desc()
+        ).limit(limit + 1)
         completions_res = await db.execute(completions_stmt)
         fetched_desc = completions_res.scalars().all()
         has_more = len(fetched_desc) > limit
@@ -1479,7 +1495,9 @@ class CompletionService:
             earliest_completion=earliest,
             latest_completion=latest,
             has_more=has_more,
-            next_before=earliest,
+            # Compound cursor: oldest row of this page. '~' is URL-unreserved and
+            # appears in neither ISO timestamps nor UUIDs.
+            next_before=f"{all_completions[0].created_at.isoformat()}~{all_completions[0].id}",
             compaction=compaction_state,
         )
 

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -3222,19 +3222,27 @@ class ReportService:
         # Build query with pagination - fetch newest first, then reverse for display
         completions_query = select(Completion).where(Completion.report_id == report.id)
         
-        # If 'before' cursor provided, fetch older completions
+        # If 'before' cursor provided, fetch older completions. The id
+        # tiebreaker keeps pagination exact when several completions share a
+        # created_at (bulk inserts, webhook bursts): a plain `created_at < ts`
+        # filter either skips those rows or re-serves the same page forever.
         if before:
             cursor_result = await db.execute(select(Completion).where(Completion.id == before))
             cursor_completion = cursor_result.scalar_one_or_none()
             if cursor_completion:
                 completions_query = completions_query.where(
-                    Completion.created_at < cursor_completion.created_at
+                    (Completion.created_at < cursor_completion.created_at)
+                    | (
+                        (Completion.created_at == cursor_completion.created_at)
+                        & (Completion.id < cursor_completion.id)
+                    )
                 )
-        
-        # Order by newest first, limit, then we'll reverse
+
+        # Order by newest first (id desc as tiebreaker for identical timestamps
+        # so page boundaries are deterministic), limit, then we'll reverse
         completions_stmt = (
             completions_query
-            .order_by(Completion.created_at.desc())
+            .order_by(Completion.created_at.desc(), Completion.id.desc())
             .limit(limit + 1)  # Fetch one extra to check if there are more
         )
         completions_res = await db.execute(completions_stmt)

--- a/backend/tests/e2e/test_completions_v2_pagination.py
+++ b/backend/tests/e2e/test_completions_v2_pagination.py
@@ -1,0 +1,167 @@
+"""
+Regression guard for completions cursor pagination (reports/{id} transcript).
+
+Scrolling a conversation to the top pages through GET /api/reports/{id}/completions
+with a `before` cursor. The cursor used to be the bare `created_at` of the oldest
+row on the page with a strict `<` filter and no ORDER BY tiebreaker, so
+completions sharing a created_at (bulk inserts, webhook bursts, fork imports)
+were either skipped (silently missing history) or re-served forever (the client
+deduped them to nothing and the scroll stalled with no signal).
+
+The fixed cursor is "<ISO8601>~<completion id>" with (created_at, id) ordering,
+which pages exactly once over ties. Bare ISO cursors from older clients must
+keep working.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/test_pagination.db \
+      .venv/bin/python -m pytest tests/e2e/test_completions_v2_pagination.py -v -s
+"""
+import asyncio
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.report import Report
+from app.models.completion import Completion
+from app.services.completion_service import CompletionService
+
+
+N_TURNS = 30  # 60 completions total
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed(collide: bool):
+    suffix = uuid.uuid4().hex[:8]
+    base = datetime(2026, 1, 1, 10, 0, 0)
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Pag Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        user = User(
+            name="Pag User",
+            email=f"pag-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        db.add(user)
+        await db.flush()
+
+        report = Report(
+            title=f"Pag Report {suffix}",
+            slug=f"pag-report-{suffix}",
+            status="draft",
+            user_id=user.id,
+            organization_id=org.id,
+        )
+        db.add(report)
+        await db.flush()
+
+        ids = []
+        for i in range(N_TURNS):
+            if collide:
+                # groups of 4 completions share the exact same created_at,
+                # deliberately straddling the limit=10 page boundaries
+                t_user = t_sys = base + timedelta(minutes=(i // 2) * 5)
+            else:
+                t_user = base + timedelta(minutes=i * 5, microseconds=i * 137)
+                t_sys = t_user + timedelta(seconds=2)
+
+            u = Completion(
+                prompt={"content": f"q{i}"}, completion=None, status="success",
+                role="user", report_id=report.id, user_id=user.id, turn_index=i,
+            )
+            u.created_at = u.updated_at = t_user
+            s = Completion(
+                prompt=None, completion={"content": f"a{i}"}, status="success",
+                role="system", report_id=report.id, turn_index=i,
+            )
+            s.created_at = s.updated_at = t_sys
+            db.add_all([u, s])
+            await db.flush()
+            ids.extend([str(u.id), str(s.id)])
+
+        await db.commit()
+        return {"org": org, "user": user, "report_id": str(report.id), "ids": set(ids)}
+
+
+async def _walk_pages(svc, seeded, limit=10, max_pages=20):
+    seen, dups, pages = set(), 0, 0
+    before = None
+    async with async_session_maker() as db:
+        while True:
+            resp = await svc.get_completions_v2(
+                db, seeded["report_id"], seeded["org"], seeded["user"],
+                limit=limit, before=before,
+            )
+            pages += 1
+            for c in resp.completions:
+                if c.id in seen:
+                    dups += 1
+                seen.add(c.id)
+            if not resp.has_more or pages >= max_pages:
+                return seen, dups, pages, resp
+            assert resp.next_before, "has_more without a next_before cursor"
+            assert resp.next_before != before, "cursor did not advance"
+            before = resp.next_before
+
+
+@pytest.mark.e2e
+def test_cursor_pages_exactly_once_over_identical_timestamps():
+    async def scenario():
+        svc = CompletionService()
+        for collide in (False, True):
+            seeded = await _seed(collide=collide)
+            seen, dups, pages, _ = await _walk_pages(svc, seeded)
+            label = "collide" if collide else "distinct"
+            print(f"[pagination:{label}] pages={pages} unique={len(seen)} dups={dups}")
+            assert dups == 0, f"{label}: {dups} completions served twice"
+            assert seen == seeded["ids"], (
+                f"{label}: {len(seeded['ids'] - seen)} completions never served "
+                f"(silently lost history)")
+            assert pages == (2 * N_TURNS) // 10, f"{label}: unexpected page count {pages}"
+
+    _run(scenario())
+
+
+@pytest.mark.e2e
+def test_cursor_format_and_legacy_iso_cursor_still_work():
+    async def scenario():
+        svc = CompletionService()
+        seeded = await _seed(collide=False)
+
+        async with async_session_maker() as db:
+            first = await svc.get_completions_v2(
+                db, seeded["report_id"], seeded["org"], seeded["user"], limit=10)
+            assert first.has_more
+            # compound "<iso>~<id>" cursor, pointing at the oldest row served
+            ts_part, sep, id_part = first.next_before.partition("~")
+            assert sep == "~" and id_part == first.completions[0].id
+            datetime.fromisoformat(ts_part)  # parseable timestamp
+
+            # an old client sending the bare ISO timestamp still pages backwards
+            legacy = await svc.get_completions_v2(
+                db, seeded["report_id"], seeded["org"], seeded["user"],
+                limit=10, before=ts_part)
+            assert legacy.completions, "legacy ISO cursor returned nothing"
+            first_ids = {c.id for c in first.completions}
+            assert all(c.id not in first_ids for c in legacy.completions)
+
+            # unparseable cursor is ignored (serves the newest page) instead of 500ing
+            junk = await svc.get_completions_v2(
+                db, seeded["report_id"], seeded["org"], seeded["user"],
+                limit=10, before="not-a-cursor")
+            assert {c.id for c in junk.completions} == first_ids
+
+    _run(scenario())

--- a/backend/tests/e2e/test_completions_v2_pagination.py
+++ b/backend/tests/e2e/test_completions_v2_pagination.py
@@ -136,6 +136,48 @@ def test_cursor_pages_exactly_once_over_identical_timestamps():
 
 
 @pytest.mark.e2e
+def test_public_share_cursor_pages_exactly_once_over_identical_timestamps():
+    """Same tie-safety guard for GET /api/c/{token} (public shared conversation),
+    whose cursor is a completion id resolved server-side."""
+    async def scenario():
+        from app.services.report_service import ReportService
+        svc = ReportService()
+        for collide in (False, True):
+            seeded = await _seed(collide=collide)
+            token = f"tok-{uuid.uuid4().hex}"
+            async with async_session_maker() as db:
+                report = await db.get(Report, seeded["report_id"])
+                report.conversation_share_token = token
+                report.conversation_visibility = "public"
+                await db.commit()
+
+            seen, dups, pages = set(), 0, 0
+            before = None
+            async with async_session_maker() as db:
+                while True:
+                    resp = await svc.get_public_conversation(db, token, limit=10, before=before)
+                    pages += 1
+                    for c in resp["completions"]:
+                        cid = str(c["id"] if isinstance(c, dict) else c.id)
+                        if cid in seen:
+                            dups += 1
+                        seen.add(cid)
+                    if not resp["has_more"] or pages >= 20:
+                        break
+                    assert resp["next_before"], "has_more without a next_before cursor"
+                    before = str(resp["next_before"])
+
+            label = "collide" if collide else "distinct"
+            print(f"[public-pagination:{label}] pages={pages} unique={len(seen)} dups={dups}")
+            assert dups == 0, f"{label}: {dups} completions served twice"
+            assert seen == seeded["ids"], (
+                f"{label}: {len(seeded['ids'] - seen)} completions never served "
+                f"(silently lost history)")
+
+    _run(scenario())
+
+
+@pytest.mark.e2e
 def test_cursor_format_and_legacy_iso_cursor_still_work():
     async def scenario():
         svc = CompletionService()

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1278,6 +1278,7 @@ const pageLimit = 10
 const hasMore = ref<boolean>(true)
 const isLoadingMore = ref<boolean>(false)
 const cursorBefore = ref<string | null>(null)
+let initialLoadRetries = 0
 const promptText = ref<string>('')
 const isStreaming = ref<boolean>(false)
 // Tracks whether the main completion (analysis) is still running.
@@ -3586,8 +3587,19 @@ function onReportFilesChanged() {
 
 async function loadCompletions({ skipEstimate = false } = {}) {
 	try {
-		const { data } = await useMyFetch(`/reports/${report_id}/completions?limit=${pageLimit}`)
+		const { data, error } = await useMyFetch(`/reports/${report_id}/completions?limit=${pageLimit}`)
 		const response = data.value as any
+		if (error?.value || !response) {
+			// useMyFetch resolves with { error } instead of throwing on the client.
+			// A transient failure must not fall through as an empty response — that
+			// would wipe the rendered transcript (and reset the pagination cursor).
+			console.error('Error loading completions:', error?.value)
+			if (messages.value.length === 0 && initialLoadRetries < 3) {
+				initialLoadRetries++
+				window.setTimeout(() => loadCompletions({ skipEstimate: true }), 1000 * initialLoadRetries)
+			}
+			return
+		}
 		const list = response?.completions || []
 		messages.value = list.map((c: any) => {
 			// Override status if sigkill timestamp exists - this means it was stopped
@@ -3688,6 +3700,12 @@ async function loadCompletions({ skipEstimate = false } = {}) {
 	// Lazily hydrate step data for whatever tool cards are already on screen
 	await nextTick()
 	observeStepContainers()
+	// If the first page doesn't fill the viewport the container can't scroll, so
+	// the top trigger would never fire — top up until scrollable or exhausted.
+	if (hasMore.value) {
+		const c = scrollContainer.value
+		if (c && c.scrollHeight <= c.clientHeight) loadPreviousCompletions()
+	}
 }
 
 // === Lazy step-data hydration ===
@@ -3767,16 +3785,50 @@ function observeStepContainers() {
 }
 
 // Load previous page (older completions) and prepend while preserving scroll anchor
+let loadMoreFailures = 0
+let loadMoreTopUpTimer: number | null = null
+
+// While the viewport sits at the very top no further scroll events fire, so an
+// attempt that failed (transient 5xx/network) or prepended nothing would strand
+// the user — hasMore still true, spinner gone, and nothing left to re-trigger
+// the load short of scrolling down and back up. After every attempt, if the
+// user is still pinned near the top, keep going: immediately after progress,
+// with backoff after failures.
+function scheduleTopUpIfPinned(progressed: boolean) {
+    const container = scrollContainer.value
+    if (!container || !hasMore.value) return
+    if (container.scrollTop > 64) return
+    // Success but no progress means the server isn't advancing the cursor —
+    // don't spin on it; a later scroll can retry.
+    if (!progressed && loadMoreFailures === 0) return
+    if (loadMoreFailures > 5) return
+    const delay = loadMoreFailures > 0 ? Math.min(500 * 2 ** (loadMoreFailures - 1), 8000) : 50
+    if (loadMoreTopUpTimer !== null) clearTimeout(loadMoreTopUpTimer)
+    loadMoreTopUpTimer = window.setTimeout(() => {
+        loadMoreTopUpTimer = null
+        loadPreviousCompletions()
+    }, delay)
+}
+
 async function loadPreviousCompletions() {
     if (isLoadingMore.value || !hasMore.value) return
     const container = scrollContainer.value
     if (!container) return
     isLoadingMore.value = true
     const prevHeight = container.scrollHeight
+    let progressed = false
     try {
         const qs = cursorBefore.value ? `&before=${encodeURIComponent(cursorBefore.value)}` : ''
-        const { data } = await useMyFetch(`/reports/${report_id}/completions?limit=${pageLimit}${qs}`)
+        const { data, error } = await useMyFetch(`/reports/${report_id}/completions?limit=${pageLimit}${qs}`)
         const response = data.value as any
+        if (error?.value || !response) {
+            // useMyFetch resolves with { error } instead of throwing on the
+            // client, so a failure reaching the cursor updates below would
+            // clobber hasMore/cursorBefore and silently kill pagination.
+            loadMoreFailures++
+            return
+        }
+        loadMoreFailures = 0
         const list: any[] = response?.completions || []
         const newItems: ChatMessage[] = list.map((c: any) => {
             let status = c.status as ChatStatus
@@ -3843,21 +3895,26 @@ async function loadPreviousCompletions() {
         const existingIds = new Set(messages.value.map(m => m.id))
         const toPrepend = newItems.filter(m => !existingIds.has(m.id))
         if (toPrepend.length > 0) {
+            progressed = true
             messages.value = [...toPrepend, ...messages.value]
             await nextTick()
             // Keep viewport anchored to previous items
             const newHeight = container.scrollHeight
             container.scrollTop = newHeight - prevHeight
         }
+        const prevCursor = cursorBefore.value
         hasMore.value = !!response?.has_more
         cursorBefore.value = response?.next_before || null
+        if (cursorBefore.value !== prevCursor) progressed = true
         // Observe the newly prepended tool cards for lazy step-data hydration
         await nextTick()
         observeStepContainers()
     } catch (e) {
-        // keep hasMore as-is on error
+        // keep hasMore/cursorBefore as-is on error
+        loadMoreFailures++
     } finally {
         isLoadingMore.value = false
+        scheduleTopUpIfPinned(progressed)
     }
 }
 
@@ -4119,6 +4176,7 @@ onUnmounted(() => {
 	document.body.style.userSelect = 'auto'
     window.removeEventListener('resize', safeScrollToBottom)
 	try { scrollContainer.value?.removeEventListener('scroll', onScroll) } catch {}
+	if (loadMoreTopUpTimer !== null) { clearTimeout(loadMoreTopUpTimer); loadMoreTopUpTimer = null }
 	// Cancel any pending animation frame for scroll
 	if (scrollRAF !== null && typeof window !== 'undefined') {
 		window.cancelAnimationFrame(scrollRAF)


### PR DESCRIPTION
## Problem

Loading older messages on `/reports/{id}` by scrolling the transcript to the top was flaky — it sometimes stopped with no signal (no spinner, no error, no retry), leaving older history unreachable.

Reproduced end-to-end with mocked completion data (no LLM) via Playwright: after two consecutive transient failures on one page fetch (a single 500 self-heals because ofetch silently retries GETs once), the transcript was permanently stuck at 10/60 messages no matter how much the user scrolled.

## Root causes

1. **Error path masquerading as success** (`frontend/pages/reports/[id]/index.vue`): `useMyFetch` never throws on the client — it resolves with `{ data: ref(null), error }`. `loadPreviousCompletions` assumed errors throw (its `catch` said "keep hasMore as-is"), so a transient failure fell through the success path and ran `hasMore = !!null?.has_more` → `false`, `cursorBefore = null` — pagination permanently disabled, silently. The same flaw in `loadCompletions` wiped the whole rendered transcript on a failed background poll.
2. **No re-trigger while pinned at the top**: at `scrollTop 0` no scroll events fire, so even with the cursor preserved nothing could restart loading after a failed or all-duplicate page — and if the first page didn't fill the viewport, the top trigger could never fire at all.
3. **Cursor unsafe on timestamp ties** (backend): both the authed endpoint (`created_at < before`, bare ISO cursor) and the public share endpoint `GET /api/c/{token}` used a strict timestamp filter with no `ORDER BY` tiebreaker. Completions sharing a `created_at` (bulk inserts, webhook bursts, imports) were either skipped — silently missing history — or re-served page after page, which the client deduped to nothing (another silent stall).

## Fixes

**Frontend** (`reports/[id]/index.vue`):
- Check `error`/null response before touching any pagination state; only a successful response updates `hasMore`/`cursorBefore`.
- While the user is still pinned near the top after an attempt, keep loading — immediately after progress, with exponential backoff (capped) after failures.
- Top up after the initial load until the container is scrollable (under-filled viewport case).
- Bounded retry when the initial transcript load itself fails; a failed reload no longer wipes the rendered transcript.

**Backend**:
- Authed cursor is now `"<ISO8601>~<completion id>"` with `(created_at DESC, id DESC)` ordering — pages exactly once over ties. The cursor is opaque to the client; bare ISO cursors from older clients still parse, and unparseable cursors log a warning instead of silently returning page 1.
- Public share endpoint gets the same `(created_at, id)` tie-safe filter and ordering; its cursor format (completion id) is unchanged.

## Verification

All verified against a live sandbox with seeded mock data (60 completions), driven through the real UI with Playwright:

- Pre-fix code stalls silently at 10/60 after 2 injected 500s; fixed code recovers in the identical scenario and loads all 60 (also verified with a 5×500 burst).
- Colliding-timestamp data loads 60/60 in exactly 6 pages — no lost rows, no duplicate pages — on both the authed page and the public share page.
- Under-filled viewport auto-tops-up with zero user interaction.
- Legacy bare-ISO cursor confirmed working against the live API.
- New regression tests in `backend/tests/e2e/test_completions_v2_pagination.py`: exactly-once paging over identical timestamps (authed + public), cursor format, legacy-cursor compatibility, junk-cursor tolerance — 4/4 e2e completions tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V2ExLjz2vx8TktFopPKAM

---
_Generated by [Claude Code](https://claude.ai/code/session_011V2ExLjz2vx8TktFopPKAM)_