### PR TITLE
Fix eval run execution race, stuck runs, cross-org run listing, and evals UI issues

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1540,7 +1540,9 @@ class AgentV2:
         model distinct from the regular default — self.small_model is resolved
         with a fallback to the regular default, and provider creation often
         flags one model as both defaults, so the flags on the resolved model
-        are what tell a separate small model apart from either case.
+        are what tell a separate small model apart from either case. (Eval
+        runs use the laxer eval_judge_model_allowed gate instead — this one
+        guards every live chat completion.)
         """
         setting = self.organization_settings.get_config("enable_llm_judgement")
         return (

--- a/backend/app/ai/agents/judge/__init__.py
+++ b/backend/app/ai/agents/judge/__init__.py
@@ -1,1 +1,1 @@
-from .judge import Judge, judge_model_allowed
+from .judge import Judge, judge_model_allowed, eval_judge_model_allowed

--- a/backend/app/ai/agents/judge/judge.py
+++ b/backend/app/ai/agents/judge/judge.py
@@ -12,23 +12,40 @@ import asyncio
 
 
 def judge_model_allowed(model) -> bool:
-    """Whether the LLM judge may run on this model.
+    """Whether the BACKGROUND scoring judge may run on this model.
 
-    The judge only runs on an org's designated small-default model, and only
-    when that model is distinct from the regular default. A small default is
-    almost always set — provider creation marks the first enabled model as
-    BOTH default and small default — so the flag alone doesn't prove the org
-    has a separate small model. When the small default is the same row as the
-    regular default it carries both flags, and judging is skipped instead of
-    billed to the org's only (big) model. The is_small_default check also
-    covers resolution's silent fallback (get_default_model(is_small=True)
-    returns the regular default when no small default exists).
+    Gates agent_v2's per-completion judge scoring of live chat traffic. It
+    only runs on an org's designated small-default model, and only when that
+    model is distinct from the regular default. A small default is almost
+    always set — provider creation marks the first enabled model as BOTH
+    default and small default — so the flag alone doesn't prove the org has
+    a separate small model. When the small default is the same row as the
+    regular default it carries both flags, and scoring is skipped instead of
+    billed to the org's only (big) model on every user prompt. The
+    is_small_default check also covers resolution's silent fallback
+    (get_default_model(is_small=True) returns the regular default when no
+    small default exists).
+
+    Explicitly-requested eval runs use eval_judge_model_allowed instead.
     """
     return (
         model is not None
         and bool(getattr(model, "is_small_default", False))
         and not bool(getattr(model, "is_default", False))
     )
+
+
+def eval_judge_model_allowed(model) -> bool:
+    """Whether the EVAL judge may run on this model.
+
+    Eval runs are explicitly requested, so judge rules run on whatever model
+    small-default resolution returns — including a small default that IS the
+    regular default (single-model orgs) and resolution's fallback to the
+    regular default. The strict judge_model_allowed gate here silently
+    disabled every judge rule for single-model orgs; it remains in force
+    only for the background scoring judge on live chat traffic.
+    """
+    return model is not None
 
 
 class Judge:

--- a/backend/app/schemas/test_suite_schema.py
+++ b/backend/app/schemas/test_suite_schema.py
@@ -74,6 +74,13 @@ class TestCaseUpdate(BaseModel):
     data_source_ids_json: Optional[List[str]] = None
 
 
+class TestRunCaseResultBrief(BaseModel):
+    """Per-case status embedded in run listings so clients don't need one
+    /runs/{id}/results request per listed run (the old N+1)."""
+    case_id: str
+    status: str
+
+
 class TestRunSchema(BaseModel):
     id: str
     suite_ids: Optional[str] = None
@@ -90,6 +97,8 @@ class TestRunSchema(BaseModel):
     # True when this response is an already-running identical run returned
     # instead of a duplicate (transient, never persisted).
     deduped: Optional[bool] = None
+    # Populated by list_runs only (transient attribute, never persisted).
+    case_results: Optional[List[TestRunCaseResultBrief]] = None
     created_at: UTCDatetime
     updated_at: UTCDatetime
 

--- a/backend/app/services/test_evaluation_service.py
+++ b/backend/app/services/test_evaluation_service.py
@@ -41,6 +41,14 @@ from app.schemas.completion_v2_schema import CompletionsV2Response
 from app.services.completion_service import CompletionService
 from app.ai.agents.judge.judge import Judge
 
+# Shown on judge rules when the org has no usable judge model. The judge only
+# runs on a small-default model distinct from the regular default (see
+# judge_model_allowed) — the message tells the admin how to enable it.
+JUDGE_UNAVAILABLE_MESSAGE = (
+    "Judge unavailable — enable a small default model distinct from the "
+    "org default to run LLM-judge rules"
+)
+
 
 class TestEvaluationService:
     """
@@ -545,6 +553,16 @@ class TestEvaluationService:
             rule_results.append(RuleResult(ok=False, status="fail", message=message or "Expectation not evaluated (unmet condition)", actual=None, evidence=evidence))
             failed += 1
 
+        def push_soft_skipped(message: Optional[str] = None, evidence: Optional[RuleEvidence] = None):
+            # True skip — the rule could not be evaluated for infrastructure
+            # reasons (e.g. no judge model configured). Unlike push_skipped,
+            # this is not evidence the expectation failed, so it must not
+            # fail the case: single-model orgs used to see every judge case
+            # hard-fail with a bare "Judge unavailable".
+            nonlocal skipped, rule_results
+            rule_results.append(RuleResult(ok=False, status="skipped", message=message or "Rule skipped", actual=None, evidence=evidence))
+            skipped += 1
+
         # Helpers for phase- and turn-scoped rules (phase 3)
         def _phase_of(rule_obj) -> Optional[str]:
             p = getattr(rule_obj, "phase", None)
@@ -596,9 +614,11 @@ class TestEvaluationService:
             # FieldRule(category="judge") path still works and is handled
             # below; prefer this for new YAMLs.
             if isinstance(rule, JudgeRule):
-                ok, reason = False, "Judge unavailable"
-                if judge is not None and organization is not None:
-                    ok, reason = await run_judge(rule.prompt or "")
+                if judge is None or organization is None:
+                    reason = JUDGE_UNAVAILABLE_MESSAGE
+                    push_soft_skipped(reason, evidence=RuleEvidence(type="judge", reasoning=reason))
+                    continue
+                ok, reason = await run_judge(rule.prompt or "")
                 msg = None if ok else (reason or "Judge indicated failure")
                 ev = RuleEvidence(type="judge", reasoning=reason)
                 push(ok, msg, actual=ok, evidence=ev)
@@ -682,12 +702,11 @@ class TestEvaluationService:
                         assertion_text = getattr(rule.matcher, "value", "") or getattr(rule.target, "value", "")
                     except Exception:
                         assertion_text = ""
-                    ok = True
-                    reason = ""
                     if judge is None or organization is None:
-                        ok, reason = False, "Judge unavailable"
-                    else:
-                        ok, reason = await run_judge(assertion_text or "")
+                        reason = JUDGE_UNAVAILABLE_MESSAGE
+                        push_soft_skipped(reason, evidence=RuleEvidence(type="judge", reasoning=reason))
+                        continue
+                    ok, reason = await run_judge(assertion_text or "")
                     msg = None if ok else (reason or "Judge indicated failure")
                     ev = RuleEvidence(type="judge", reasoning=reason)
                     push(ok, msg, actual=ok, evidence=ev)

--- a/backend/app/services/test_evaluation_service.py
+++ b/backend/app/services/test_evaluation_service.py
@@ -41,12 +41,11 @@ from app.schemas.completion_v2_schema import CompletionsV2Response
 from app.services.completion_service import CompletionService
 from app.ai.agents.judge.judge import Judge
 
-# Shown on judge rules when the org has no usable judge model. The judge only
-# runs on a small-default model distinct from the regular default (see
-# judge_model_allowed) — the message tells the admin how to enable it.
+# Shown on judge rules when the org has no usable judge model at all (no
+# model resolved — see eval_judge_model_allowed). The rule is skipped, not
+# failed: judge availability is infrastructure, not evidence.
 JUDGE_UNAVAILABLE_MESSAGE = (
-    "Judge unavailable — enable a small default model distinct from the "
-    "org default to run LLM-judge rules"
+    "Judge unavailable — no LLM model is configured to run LLM-judge rules"
 )
 
 

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -366,6 +366,7 @@ class TestRunService:
         await db.refresh(run)
 
         # Create placeholder TestResult per case (with stub report + head completion)
+        created_results: List[Tuple[TestResult, TestCase]] = []
         for case in cases:
             report_title = f"Test Run · {case.name}"
             report = await self._create_stub_report(db, str(organization.id), str(current_user.id), report_title, ds_ids=case.data_source_ids_json)
@@ -401,7 +402,30 @@ class TestRunService:
                 result_json=result_json,
             )
             db.add(result)
+            created_results.append((result, case))
         await db.commit()
+        for result, _case in created_results:
+            await db.refresh(result)
+
+        # Watchdog: arm the background finalizer at creation. Execution
+        # normally starts when a client opens the run page's stream, but if
+        # that never happens (redirect failed, tab closed, API-created run)
+        # the watcher times out and errors the results instead of leaving
+        # the run in_progress forever. Idempotent with the streamer's own
+        # watcher — _watch_case exits as soon as a result is terminal.
+        asyncio.create_task(self._watch_and_finalize(
+            run_id=str(run.id),
+            organization_id=str(organization.id),
+            user_id=str(current_user.id),
+            watches=[
+                {
+                    "result_id": str(result.id),
+                    "report_id": str(result.report_id),
+                    "expected_turns": 1 + len(list(getattr(case, "additional_turns_json", None) or [])),
+                }
+                for result, case in created_results
+            ],
+        ))
 
         return run
 
@@ -425,29 +449,49 @@ class TestRunService:
         return run
 
     async def list_runs(self, db: AsyncSession, organization_id: str, current_user, suite_id: Optional[str] = None, status: Optional[str] = None, page: int = 1, limit: int = 20) -> List[TestRun]:
-        stmt = select(TestRun)
+        # TestRun has no organization_id column — scope through the
+        # results → cases → suites chain on EVERY branch. The unfiltered
+        # branch used to be a bare select(TestRun), leaking other orgs' run
+        # metadata to anyone with manage_evals in any org.
+        stmt = (
+            select(TestRun)
+            .join(TestResult, TestResult.run_id == TestRun.id)
+            .join(TestCase, TestCase.id == TestResult.case_id)
+            .join(TestSuite, TestSuite.id == TestCase.suite_id)
+            .where(TestSuite.organization_id == str(organization_id))
+        )
         if status:
             stmt = stmt.where(TestRun.status == status)
         if suite_id:
-            # Filter runs that include this suite by joining through results → cases
             await self._get_suite(db, organization_id, suite_id)
-            from sqlalchemy.orm import aliased
-            tr = TestRun
-            tsr = TestResult
-            tc = TestCase
-            stmt = (
-                select(tr).join(tsr, tsr.run_id == tr.id).join(tc, tc.id == tsr.case_id)
-                .where(tc.suite_id == str(suite_id))
-                .order_by(tr.created_at.desc())
-                .offset((page - 1) * limit)
-                .limit(limit)
-                .distinct()
-            )
-            res = await db.execute(stmt)
-            return res.scalars().all()
-        stmt = stmt.order_by(TestRun.created_at.desc()).offset((page - 1) * limit).limit(limit)
+            stmt = stmt.where(TestCase.suite_id == str(suite_id))
+        stmt = (
+            stmt.order_by(TestRun.created_at.desc())
+            .offset((page - 1) * limit)
+            .limit(limit)
+            .distinct()
+        )
         res = await db.execute(stmt)
-        return res.scalars().all()
+        runs = res.scalars().all()
+
+        # Embed per-case statuses (one batched query) so list clients don't
+        # fan out a /runs/{id}/results request per run.
+        if runs:
+            run_ids = [str(r.id) for r in runs]
+            rows = (
+                await db.execute(
+                    select(TestResult.run_id, TestResult.case_id, TestResult.status)
+                    .where(TestResult.run_id.in_(run_ids))
+                )
+            ).all()
+            by_run: Dict[str, List[Dict[str, str]]] = {}
+            for run_id_v, case_id_v, status_v in rows:
+                by_run.setdefault(str(run_id_v), []).append(
+                    {"case_id": str(case_id_v), "status": str(status_v or "")}
+                )
+            for r in runs:
+                r.case_results = by_run.get(str(r.id), [])  # transient, serialized by TestRunSchema
+        return runs
 
     async def list_results(self, db: AsyncSession, organization_id: str, current_user, run_id: str) -> List[TestResult]:
         _ = await self.get_run(db, organization_id, current_user, run_id)
@@ -581,12 +625,15 @@ class TestRunService:
         db.add(run)
         await db.commit()
 
-        # Mark any in-progress results as error for clarity
+        # Mark any non-terminal results as error for clarity. Includes 'init'
+        # results (created but never executed — e.g. the run page was never
+        # opened): leaving them non-terminal kept the run's results stuck
+        # after a stop.
         res_results = await db.execute(select(TestResult).where(TestResult.run_id == str(run.id)))
         results = res_results.scalars().all()
         changed = False
         for r in results:
-            if getattr(r, "status", "") == "in_progress":
+            if getattr(r, "status", "") not in RESULT_TERMINAL_STATUSES:
                 r.status = "error"
                 r.failure_reason = "Stopped by user"
                 db.add(r)
@@ -1600,6 +1647,221 @@ class TestRunService:
         )
 
     # -------- New API: Run-level streaming (start all INIT results and stream status updates) --------
+    async def _execute_result_agent(
+        self,
+        *,
+        central_queue: "asyncio.Queue",
+        eq: CompletionEventQueue,
+        result_id: str,
+        run_id: str,
+        build_id: Optional[str],
+        report_id: str,
+        head_id: str,
+        system_completion_id: str,
+        case_id: str,
+        organization_id: str,
+        user_id: str,
+        model_pk: Optional[str],
+        small_model_pk: Optional[str],
+        prompt_mode: Optional[str],
+    ) -> None:
+        """Run one eval case's agent to completion and evaluate its result.
+
+        Spawned per result by ``stream_run``. Takes only plain ids plus this
+        result's queues: every ORM row is re-loaded in the task's own session.
+        A closure over ``stream_run``'s loop variables late-binds (the task
+        first runs at the loop's next await, after r/head/system_completion
+        have moved on to another result), and sharing the request session's
+        instances across concurrently running tasks crashes with
+        MissingGreenlet on expired-attribute lazy loads.
+        """
+        from app.schemas.sse_schema import SSEEvent
+        from app.models.llm_model import LLMModel
+        from app.models.user import User as _User
+
+        async def _persist_error(reason: str) -> None:
+            # Fresh session — the task session may be in a tainted
+            # transactional state after main_execution raised.
+            try:
+                _sf = create_async_session_factory()
+                async with _sf() as _s:
+                    row = await _s.get(TestResult, str(result_id))
+                    if row is not None and getattr(row, "status", "") not in RESULT_TERMINAL_STATUSES:
+                        row.status = "error"
+                        row.failure_reason = reason
+                        _s.add(row)
+                        await _s.commit()
+            except Exception as pe:
+                logging.warning(f"[stream_run] failed to persist error status for result={result_id}: {pe!r}")
+
+        async def _emit(event: str, data: Dict[str, Any]) -> None:
+            try:
+                await central_queue.put((str(result_id), SSEEvent(
+                    event=event, completion_id=str(system_completion_id), data=data,
+                )))
+            except Exception:
+                pass
+
+        async_session = create_async_session_factory()
+        try:
+            async with async_session() as session:
+                organization = await session.get(Organization, str(organization_id))
+                current_user = await session.get(_User, str(user_id))
+                model = await session.get(LLMModel, str(model_pk)) if model_pk else None
+                small_model = await session.get(LLMModel, str(small_model_pk)) if small_model_pk else None
+                report_obj = await session.get(Report, str(report_id))
+                head_obj = await session.get(Completion, str(head_id))
+                system_obj = await session.get(Completion, str(system_completion_id))
+                if not all([organization, current_user, model, report_obj, head_obj, system_obj]):
+                    await _emit("completion.error", {"result_id": str(result_id), "error": "Failed to initialize agent execution"})
+                    await _persist_error("Failed to initialize agent execution")
+                    await _emit("result.update", {"result_id": str(result_id), "status": "error", "failure_reason": "Failed to initialize agent execution"})
+                    return
+                org_settings = await organization.get_settings(session)
+                # Build clients from report data sources
+                clients = {}
+                for data_source in getattr(report_obj, "data_sources", []):
+                    try:
+                        ds_clients = await self.completions.data_source_service.construct_clients(session, data_source, current_user)
+                        clients.update(ds_clients)
+                    except Exception:
+                        pass
+                # Pre-load files relationship in async context to avoid greenlet error in AgentV2.__init__
+                _ = getattr(report_obj, "files", [])
+                agent = AgentV2(
+                    db=session,
+                    organization=organization,
+                    organization_settings=org_settings,
+                    model=model,
+                    small_model=small_model,
+                    mode=prompt_mode,
+                    report=report_obj,
+                    messages=[],
+                    head_completion=head_obj,
+                    system_completion=system_obj,
+                    widget=None,
+                    step=None,
+                    event_queue=eq,
+                    clients=clients,
+                    build_id=str(build_id) if build_id else None,
+                )
+                await agent.main_execution()
+
+                # Multi-turn: run any follow-up turns on the same report
+                # before evaluating. The evaluator already scans the whole
+                # report, so global expectations cover the entire multi-turn
+                # trace.
+                prev_system = system_obj
+                case_row_multi = await session.get(TestCase, str(case_id))
+                additional_turns = list(getattr(case_row_multi, "additional_turns_json", None) or [])
+                for turn in additional_turns:
+                    tp = (turn or {}).get("prompt") or {}
+                    next_head = Completion(
+                        prompt={
+                            "content": tp.get("content") or "",
+                            "widget_id": None,
+                            "step_id": None,
+                            "mentions": tp.get("mentions"),
+                            "mode": tp.get("mode"),
+                            "model_id": tp.get("model_id"),
+                        },
+                        model=model.model_id,
+                        report_id=report_obj.id,
+                        parent_id=prev_system.id,
+                        turn_index=(prev_system.turn_index or 0) + 1,
+                        message_type="table",
+                        role="user",
+                        status="success",
+                        # Carry user_id from the original head so downstream
+                        # tools (e.g. create_artifact) see a real user and
+                        # don't violate NOT NULL constraints.
+                        user_id=getattr(head_obj, "user_id", None),
+                    )
+                    session.add(next_head)
+                    await session.commit()
+                    await session.refresh(next_head)
+
+                    next_system = Completion(
+                        prompt=None,
+                        completion={"content": ""},
+                        model=model.model_id,
+                        report_id=report_obj.id,
+                        parent_id=next_head.id,
+                        turn_index=next_head.turn_index + 1,
+                        message_type="table",
+                        role="system",
+                        status="in_progress",
+                    )
+                    session.add(next_system)
+                    await session.commit()
+                    await session.refresh(next_system)
+
+                    try:
+                        await central_queue.put((str(result_id), SSEEvent(
+                            event="completion.started",
+                            completion_id=str(next_system.id),
+                            data={
+                                "result_id": str(result_id),
+                                "system_completion_id": str(next_system.id),
+                                "head_completion_id": str(next_head.id),
+                                "turn_index": next_head.turn_index,
+                            },
+                        )))
+                    except Exception:
+                        pass
+
+                    turn_agent = AgentV2(
+                        db=session,
+                        organization=organization,
+                        organization_settings=org_settings,
+                        model=model,
+                        small_model=small_model,
+                        mode=tp.get("mode"),
+                        report=report_obj,
+                        messages=[],
+                        head_completion=next_head,
+                        system_completion=next_system,
+                        widget=None,
+                        step=None,
+                        event_queue=eq,
+                        clients=clients,
+                        build_id=str(build_id) if build_id else None,
+                    )
+                    await turn_agent.main_execution()
+                    prev_system = next_system
+
+                # After the final turn, evaluate assertions and persist the
+                # TestResult (same code path the background watcher uses).
+                try:
+                    status = await self._evaluate_report_result(
+                        session,
+                        run_id=str(run_id),
+                        report_id=str(report_id),
+                        organization=organization,
+                        current_user=current_user,
+                        org_settings=org_settings,
+                        small_model=small_model,
+                    )
+                    if status is not None:
+                        row = await session.get(TestResult, str(result_id))
+                        payload: Dict[str, Any] = {"result_id": str(result_id), "status": status}
+                        rj = getattr(row, "result_json", None) if row is not None else None
+                        if isinstance(rj, dict) and rj:
+                            payload["result_json"] = rj
+                        await _emit("result.update", payload)
+                except Exception as e:
+                    await _persist_error(f"Evaluation failed: {e}")
+                    await _emit("result.update", {"result_id": str(result_id), "status": "error", "failure_reason": str(e)})
+        except Exception as e:
+            await _emit("completion.error", {"result_id": str(result_id), "error": str(e)})
+            await _persist_error(str(e))
+            # ALWAYS emit a terminal result.update, even if the persist above
+            # failed, so the streamer can mark this result finished and close
+            # the stream cleanly instead of hanging until the client times out.
+            await _emit("result.update", {"result_id": str(result_id), "status": "error", "failure_reason": str(e)})
+        finally:
+            eq.finish()
+
     async def stream_run(self, db: AsyncSession, organization, current_user, run_id: str):
         """
         Start execution for any INIT results in a run and stream high-level status updates.
@@ -1636,6 +1898,10 @@ class TestRunService:
                         pass
 
             org_settings = await organization.get_settings(db)
+
+            # Results whose execution this streamer starts (or observes still
+            # in flight) — handed to _watch_and_finalize after the loop.
+            watches: List[Dict[str, Any]] = []
 
             for r in results:
                 # Process results that are not terminal; include both 'init' and 'in_progress'
@@ -1831,7 +2097,16 @@ class TestRunService:
                         await central_queue.put((str(r.id), start_ev))
                     except Exception:
                         pass
-                    # Do not start a duplicate agent; rely on other runner to finish, streamer loop will pick result.update if persisted elsewhere
+                    # Do not start a duplicate agent; rely on the other runner
+                    # to finish. Still watch it: if that runner is gone (e.g.
+                    # a backend restart orphaned the completion), the watcher
+                    # times out and errors the result instead of leaving the
+                    # run in_progress forever.
+                    watches.append({
+                        "result_id": str(r.id),
+                        "report_id": str(head.report_id),
+                        "expected_turns": 1 + len(list(getattr(case, "additional_turns_json", None) or [])),
+                    })
                     continue
 
                 # Otherwise, create system completion linked to the existing head and start agent
@@ -1877,335 +2152,47 @@ class TestRunService:
                 except Exception:
                     pass
 
-                async def run_agent_task():
-                    async_session = create_async_session_factory()
-                    async with async_session() as session:
-                        try:
-                            report_obj = await session.get(Report, head.report_id)
-                            head_obj = await session.get(Completion, head.id)
-                            system_obj = await session.get(Completion, system_completion.id)
-                            if not all([report_obj, head_obj, system_obj]):
-                                err_ev = SSEEvent(
-                                    event="completion.error",
-                                    completion_id=str(system_completion.id),
-                                    data={"result_id": str(r.id), "error": "Failed to initialize agent execution"},
-                                )
-                                await central_queue.put((str(r.id), err_ev))
-                                return
-                            # Build clients from report data sources
-                            clients = {}
-                            for data_source in getattr(report_obj, "data_sources", []):
-                                try:
-                                    ds_clients = await self.completions.data_source_service.construct_clients(session, data_source, current_user)
-                                    clients.update(ds_clients)
-                                except Exception:
-                                    pass
-                            # Pre-load files relationship in async context to avoid greenlet error in AgentV2.__init__
-                            _ = getattr(report_obj, "files", [])
-                            # Get build_id from run
-                            build_id = str(run.build_id) if run.build_id else None
-                            agent = AgentV2(
-                                db=session,
-                                organization=organization,
-                                organization_settings=org_settings,
-                                model=model,
-                                small_model=small_model,
-                                mode=prompt.mode,
-                                report=report_obj,
-                                messages=[],
-                                head_completion=head_obj,
-                                system_completion=system_obj,
-                                widget=None,
-                                step=None,
-                                event_queue=eq,
-                                clients=clients,
-                                build_id=build_id,
-                            )
-                            await agent.main_execution()
-
-                            # Multi-turn: run any follow-up turns on the same
-                            # report before evaluating. The evaluator already
-                            # scans the whole report, so global expectations
-                            # cover the entire multi-turn trace.
-                            prev_system = system_obj
-                            case_row_multi = await session.get(TestCase, str(r.case_id))
-                            additional_turns = list(
-                                getattr(case_row_multi, "additional_turns_json", None) or []
-                            )
-                            for turn in additional_turns:
-                                tp = (turn or {}).get("prompt") or {}
-                                next_head = Completion(
-                                    prompt={
-                                        "content": tp.get("content") or "",
-                                        "widget_id": None,
-                                        "step_id": None,
-                                        "mentions": tp.get("mentions"),
-                                        "mode": tp.get("mode"),
-                                        "model_id": tp.get("model_id"),
-                                    },
-                                    model=model.model_id,
-                                    report_id=report_obj.id,
-                                    parent_id=prev_system.id,
-                                    turn_index=(prev_system.turn_index or 0) + 1,
-                                    message_type="table",
-                                    role="user",
-                                    status="success",
-                                    # Carry user_id from the original head so
-                                    # downstream tools (e.g. create_artifact)
-                                    # see a real user and don't violate
-                                    # NOT NULL constraints.
-                                    user_id=getattr(head, "user_id", None),
-                                )
-                                session.add(next_head)
-                                await session.commit()
-                                await session.refresh(next_head)
-
-                                next_system = Completion(
-                                    prompt=None,
-                                    completion={"content": ""},
-                                    model=model.model_id,
-                                    report_id=report_obj.id,
-                                    parent_id=next_head.id,
-                                    turn_index=next_head.turn_index + 1,
-                                    message_type="table",
-                                    role="system",
-                                    status="in_progress",
-                                )
-                                session.add(next_system)
-                                await session.commit()
-                                await session.refresh(next_system)
-
-                                try:
-                                    start_ev = SSEEvent(
-                                        event="completion.started",
-                                        completion_id=str(next_system.id),
-                                        data={
-                                            "result_id": str(r.id),
-                                            "system_completion_id": str(next_system.id),
-                                            "head_completion_id": str(next_head.id),
-                                            "turn_index": next_head.turn_index,
-                                        },
-                                    )
-                                    await central_queue.put((str(r.id), start_ev))
-                                except Exception:
-                                    pass
-
-                                turn_agent = AgentV2(
-                                    db=session,
-                                    organization=organization,
-                                    organization_settings=org_settings,
-                                    model=model,
-                                    small_model=small_model,
-                                    mode=tp.get("mode"),
-                                    report=report_obj,
-                                    messages=[],
-                                    head_completion=next_head,
-                                    system_completion=next_system,
-                                    widget=None,
-                                    step=None,
-                                    event_queue=eq,
-                                    clients=clients,
-                                    build_id=build_id,
-                                )
-                                await turn_agent.main_execution()
-                                prev_system = next_system
-
-                            # After final turn, evaluate assertions and persist TestResult
-                            try:
-                                # Resolve run/result/case/expectations
-                                _run, result_row, case_row, expectations = await self.evaluator.resolve_by_run_and_report(
-                                    session, str(run.id), str(report_obj.id)
-                                )
-                                # Build snapshot for assertions
-                                snapshot = await self.evaluator.build_final_snapshot(session, str(report_obj.id))
-                                # Prepare judge (optional)
-                                try:
-                                    judge = Judge(model=small_model, organization_settings=org_settings) if judge_model_allowed(small_model) else None
-                                except Exception:
-                                    judge = None
-                                # Determine AgentExecution and duration
-                                agent_execution_id = None
-                                run_duration_ms = None
-                                agent_meta: Dict[str, Any] = {}
-                                try:
-                                    res_exec = await session.execute(
-                                        select(AgentExecution)
-                                        .where(AgentExecution.completion_id == str(system_obj.id))
-                                        .order_by(AgentExecution.created_at.desc())
-                                        .limit(1)
-                                    )
-                                    ae = res_exec.scalar_one_or_none()
-                                    if ae:
-                                        agent_execution_id = str(ae.id)
-                                        run_duration_ms = getattr(ae, "total_duration_ms", None)
-                                        agent_meta = _agent_metadata_from_execution(ae)
-                                        try:
-                                            from app.models.plan_decision import PlanDecision as _PD
-                                            n_iter = (await session.execute(
-                                                select(func.count(_PD.id)).where(_PD.agent_execution_id == str(ae.id))
-                                            )).scalar_one() or 0
-                                            agent_meta["total_iterations"] = int(n_iter)
-                                        except Exception:
-                                            pass
-                                except Exception:
-                                    pass
-                                # Case prompt text
-                                case_prompt_text = ""
-                                try:
-                                    cj = getattr(case_row, "prompt_json", None) or {}
-                                    case_prompt_text = cj.get("content") or ""
-                                except Exception:
-                                    case_prompt_text = ""
-                                # Evaluate
-                                status, result_json = await self.evaluator.evaluate_final(
-                                    db=session,
-                                    expectations=expectations,
-                                    snapshot=snapshot,
-                                    report_id=str(report_obj.id),
-                                    case_prompt_text=case_prompt_text,
-                                    judge=judge,
-                                    organization=organization,
-                                    current_user=current_user,
-                                    run_duration_ms=run_duration_ms,
-                                    agent_metadata=agent_meta,
-                                )
-                                # Persist
-                                await self.evaluator.persist_result_json(
-                                    db=session,
-                                    result=result_row,
-                                    status=status,
-                                    result_json=result_json,
-                                    failure_reason=None,
-                                    agent_execution_id=agent_execution_id,
-                                )
-                                # Emit immediate UI update
-                                try:
-                                    payload = {
-                                        "result_id": str(result_row.id),
-                                        "status": status,
-                                        "result_json": result_json.model_dump(),
-                                    }
-                                    await central_queue.put((str(result_row.id), SSEEvent(event="result.update", completion_id=str(system_completion.id), data=payload)))
-                                except Exception:
-                                    pass
-                            except Exception as e:
-                                # Best-effort: mark result as error
-                                try:
-                                    _run, result_row, _case_row, _expectations = await self.evaluator.resolve_by_run_and_report(
-                                        session, str(run.id), str(report_obj.id)
-                                    )
-                                    # Snapshot real expectations into spec for error path
-                                    try:
-                                        rule_spec = RuleSpec(
-                                            spec_version=getattr(_expectations, "spec_version", 1),
-                                            rules=[(rr.model_dump() if hasattr(rr, "model_dump") else dict(rr)) for rr in (getattr(_expectations, "rules", []) or [])],
-                                            order_mode=getattr(_expectations, "order_mode", None),
-                                        )
-                                    except Exception:
-                                        rule_spec = RuleSpec(spec_version=1, rules=[], order_mode=None)
-                                    await self.evaluator.persist_result_json(
-                                        db=session,
-                                        result=result_row,
-                                        status="error",
-                                        result_json=TestResultJsonSchema(
-                                            spec=rule_spec,
-                                            totals=TestResultTotals(total=0, passed=0, failed=0, duration_ms=None),
-                                            rule_results=[],
-                                        ),
-                                        failure_reason=str(e),
-                                        agent_execution_id=None,
-                                    )
-                                    try:
-                                        payload = {
-                                            "result_id": str(result_row.id),
-                                            "status": "error",
-                                            "failure_reason": str(e),
-                                        }
-                                        await central_queue.put((str(result_row.id), SSEEvent(event="result.update", completion_id=str(system_completion.id), data=payload)))
-                                    except Exception:
-                                        pass
-                                except Exception:
-                                    pass
-                            finished_ev = SSEEvent(
-                                event="completion.finished",
-                                completion_id=str(system_completion.id),
-                                data={"result_id": str(r.id), "status": "success"},
-                            )
-                            # Do not emit completion.finished here; rely on AgentV2 to emit it via event_queue.
-                        except Exception as e:
-                            err = SSEEvent(
-                                event="completion.error",
-                                completion_id=str(system_completion.id),
-                                data={"result_id": str(r.id), "error": str(e)},
-                            )
-                            await central_queue.put((str(r.id), err))
-                            # Persist result status=error so the TestResult
-                            # row leaves `in_progress`. Without this, the
-                            # streamer's aggregate run status is "success"
-                            # (since no result is in {fail,error}) even
-                            # though the agent failed. Use a fresh session
-                            # because ``session`` may be in a tainted
-                            # transactional state after main_execution raised.
-                            try:
-                                _error_async_session = create_async_session_factory()
-                                async with _error_async_session() as _err_session:
-                                    _run, result_row, _case_row, _expectations = await self.evaluator.resolve_by_run_and_report(
-                                        _err_session, str(run.id), str(report_obj.id)
-                                    )
-                                    try:
-                                        rule_spec = RuleSpec(
-                                            spec_version=getattr(_expectations, "spec_version", 1),
-                                            rules=[
-                                                (rr.model_dump() if hasattr(rr, "model_dump") else dict(rr))
-                                                for rr in (getattr(_expectations, "rules", []) or [])
-                                            ],
-                                            order_mode=getattr(_expectations, "order_mode", None),
-                                        )
-                                    except Exception:
-                                        rule_spec = RuleSpec(spec_version=1, rules=[], order_mode=None)
-                                    await self.evaluator.persist_result_json(
-                                        db=_err_session,
-                                        result=result_row,
-                                        status="error",
-                                        result_json=TestResultJsonSchema(
-                                            spec=rule_spec,
-                                            totals=TestResultTotals(total=0, passed=0, failed=0, duration_ms=None),
-                                            rule_results=[],
-                                        ),
-                                        failure_reason=str(e),
-                                        agent_execution_id=None,
-                                    )
-                            except Exception as _persist_err:
-                                logging.warning(
-                                    f"[stream_run] failed to persist error "
-                                    f"status for result={r.id}: {_persist_err!r}"
-                                )
-                            # ALWAYS emit a terminal result.update, even if
-                            # the DB persist above failed, so the streamer
-                            # can mark this result finished and close the
-                            # stream cleanly instead of hanging until the
-                            # client times out.
-                            try:
-                                await central_queue.put((
-                                    str(r.id),
-                                    SSEEvent(
-                                        event="result.update",
-                                        completion_id=str(system_completion.id),
-                                        data={
-                                            "result_id": str(r.id),
-                                            "status": "error",
-                                            "failure_reason": str(e),
-                                        },
-                                    ),
-                                ))
-                            except Exception:
-                                pass
-                        finally:
-                            eq.finish()
-
-                # Start forwarder and runner
+                # Start forwarder and runner. Per-result state is passed to
+                # _execute_result_agent as plain ids — a closure over the loop
+                # variables would late-bind (the task first runs at the loop's
+                # next await, when r/head/system_completion already point at a
+                # different result) and must not share this request's
+                # session-bound ORM instances with concurrent tasks.
                 asyncio.create_task(forward_events(str(r.id), eq))
-                asyncio.create_task(run_agent_task())
+                asyncio.create_task(self._execute_result_agent(
+                    central_queue=central_queue,
+                    eq=eq,
+                    result_id=str(r.id),
+                    run_id=str(run.id),
+                    build_id=str(run.build_id) if run.build_id else None,
+                    report_id=str(head.report_id),
+                    head_id=str(head.id),
+                    system_completion_id=str(system_completion.id),
+                    case_id=str(r.case_id),
+                    organization_id=str(organization.id),
+                    user_id=str(current_user.id),
+                    model_pk=str(model.id) if model else None,
+                    small_model_pk=str(small_model.id) if small_model else None,
+                    prompt_mode=prompt.mode,
+                ))
+                watches.append({
+                    "result_id": str(r.id),
+                    "report_id": str(head.report_id),
+                    "expected_turns": 1 + len(list(getattr(case, "additional_turns_json", None) or [])),
+                })
+
+            # Watchdog: every result this streamer started (or observed still
+            # running) gets the same background finalizer the batch path arms.
+            # A crashed agent or a closed browser tab can no longer leave the
+            # run in_progress forever — _watch_case times out, marks the
+            # result errored, and _finalize_run_if_done stamps the run.
+            if watches:
+                asyncio.create_task(self._watch_and_finalize(
+                    run_id=str(run.id),
+                    organization_id=str(organization.id),
+                    user_id=str(current_user.id),
+                    watches=watches,
+                ))
 
         async def streamer():
             # Emit run.started

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -81,7 +81,7 @@ from app.settings.database import create_async_session_factory
 from app.ai.agent_v2 import AgentV2
 from app.models.agent_execution import AgentExecution
 from app.services.test_evaluation_service import TestEvaluationService
-from app.ai.agents.judge.judge import Judge, judge_model_allowed
+from app.ai.agents.judge.judge import Judge, eval_judge_model_allowed
 from app.schemas.test_results_schema import TestResultTotals, TestResultJsonSchema, RuleSpec
 from app.models.organization import Organization
 
@@ -1216,7 +1216,7 @@ class TestRunService:
             return None
         snapshot = await self.evaluator.build_final_snapshot(session, str(report_id))
         try:
-            judge = Judge(model=small_model, organization_settings=org_settings) if judge_model_allowed(small_model) else None
+            judge = Judge(model=small_model, organization_settings=org_settings) if eval_judge_model_allowed(small_model) else None
         except Exception:
             judge = None
 
@@ -2015,7 +2015,7 @@ class TestRunService:
                             snapshot = await self.evaluator.build_final_snapshot(session, str(head.report_id))
                             judge = None
                             try:
-                                if judge_model_allowed(small_model):
+                                if eval_judge_model_allowed(small_model):
                                     judge = Judge(model=small_model, organization_settings=org_settings)
                             except Exception:
                                 judge = None

--- a/backend/tests/evals/conftest.py
+++ b/backend/tests/evals/conftest.py
@@ -229,11 +229,10 @@ def _install_llm_provider_from_detail(
 
     Installs the selected model plus a DISTINCT judge model, then pins the
     org defaults explicitly: model under test = default, judge model = small
-    default. The judge only runs when the small default differs from the
-    regular default (see ``judge_model_allowed``) — without this, evaluating
-    a provider's own small-default model (e.g. Haiku, Luna) silently disables
-    every ``judge`` rule and those cases fail as "Judge unavailable".
-    Caller is responsible for the env-var check.
+    default. The judge runs on whatever small-default resolution returns
+    (see ``judge_model_allowed``), but benchmarks still want a judge that is
+    NOT the model under test — a model grading its own answers is a biased
+    judge. Caller is responsible for the env-var check.
     """
     env_var = _env_var_for(model_detail)
     api_key = os.getenv(env_var)

--- a/backend/tests/unit/test_judge_gating.py
+++ b/backend/tests/unit/test_judge_gating.py
@@ -1,15 +1,21 @@
-"""Unit tests for LLM-judge gating on the small-default model.
+"""Unit tests for the two LLM-judge gates.
 
-The judge must only run when the org has a small-default model that is
-distinct from the regular default. A small default is almost always set —
-provider creation flags the first enabled model as both default and small
-default — so the gate requires ``is_small_default and not is_default`` on
-the resolved model: a same-as-default small model (both flags on one row)
-and resolution's silent fallback to the regular default are both rejected.
+judge_model_allowed guards agent_v2's background scoring of live chat
+completions: it requires a small-default model DISTINCT from the regular
+default, so per-prompt judge calls are never silently billed to a
+single-model org's only (big) model. A small default is almost always set
+— provider creation flags the first enabled model as both default and
+small default — so the gate requires ``is_small_default and not
+is_default`` on the resolved model.
+
+eval_judge_model_allowed guards judge rules in explicitly-requested eval
+runs: those run on whatever small-default resolution returns (including a
+same-as-default small model or the fallback to the regular default); only
+"no model at all" disables them.
 """
 import types
 
-from app.ai.agents.judge.judge import judge_model_allowed
+from app.ai.agents.judge.judge import judge_model_allowed, eval_judge_model_allowed
 
 
 def _model(*, small=False, default=False):
@@ -19,13 +25,15 @@ def _model(*, small=False, default=False):
     return m
 
 
+# --- background scoring gate (live chat traffic) ---------------------------
+
 def test_no_model_disallows_judge():
     assert judge_model_allowed(None) is False
 
 
 def test_fallback_default_model_disallows_judge():
     # What get_default_model(is_small=True) returns when no small default
-    # exists: the regular default. The judge must not run on it.
+    # exists: the regular default. Background scoring must not run on it.
     assert judge_model_allowed(_model(default=True)) is False
 
 
@@ -35,14 +43,36 @@ def test_distinct_small_default_model_allows_judge():
 
 def test_small_default_same_as_regular_default_disallows_judge():
     # Provider creation flags the first enabled model as BOTH default and
-    # small default. That means the org has no separate small model, so the
-    # judge must not run on it.
+    # small default. That means the org has no separate small model, so
+    # background scoring must not run on it.
     assert judge_model_allowed(_model(small=True, default=True)) is False
 
 
 def test_model_without_flag_attribute_disallows_judge():
     assert judge_model_allowed(object()) is False
 
+
+# --- eval judge gate (explicit eval runs) ----------------------------------
+
+def test_eval_judge_requires_a_model():
+    assert eval_judge_model_allowed(None) is False
+
+
+def test_eval_judge_runs_on_fallback_default_model():
+    assert eval_judge_model_allowed(_model(default=True)) is True
+
+
+def test_eval_judge_runs_on_distinct_small_default():
+    assert eval_judge_model_allowed(_model(small=True)) is True
+
+
+def test_eval_judge_runs_on_same_as_default_small_model():
+    # Single-model orgs: the eval judge runs instead of silently disabling
+    # every judge rule.
+    assert eval_judge_model_allowed(_model(small=True, default=True)) is True
+
+
+# --- agent scoring gate composition ----------------------------------------
 
 def test_agent_scoring_gate_requires_small_default():
     from app.ai.agent_v2 import AgentV2

--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -312,13 +312,16 @@ function localizedStatus(status?: string) {
         error: 'evals.run.statusError',
         in_progress: 'evals.run.statusInProgress',
         pass: 'evals.run.rulePass',
-        stopped: 'evals.run.completionFinished',
+        stopped: 'evals.run.statusStopped',
     }
     const k = map[status]
     return k ? t(k) : status
 }
 
 function derivedRunStatus(r: RunItem) {
+    // A user-initiated stop is not a failure — don't relabel it from the
+    // (partial) per-case tallies.
+    if (r.status === 'stopped') return 'stopped'
     const c = runResults.value[r.id] || { total: 0, passed: 0, failed: 0, error: 0 }
     if (r.status === 'in_progress') return 'in_progress'
     if (c.total > 0 && c.passed === c.total) return 'success'
@@ -376,6 +379,9 @@ function categoryKeysForCase(c: TestCaseRow): string[] {
     for (const r of rules) {
         if (r?.type === 'field' && r?.target?.category) seen.add(String(r.target.category))
         else if (r?.type === 'tool.calls' && r?.tool) seen.add(`tool:${r.tool}`)
+        // Modern flat rule types carry no target.category — without this
+        // they rendered no badge at all in the Rules column.
+        else if (r?.type === 'judge' || r?.type === 'ordering' || r?.type === 'phase') seen.add(String(r.type))
     }
     return Array.from(seen)
 }
@@ -546,19 +552,18 @@ async function loadRuns() {
         const res = await useMyFetch<any[]>('/api/tests/runs?limit=100')
         const runs = (res.data.value as any[]) || []
         allRuns.value = runs
-        const fetches = runs.map((r: any) => useMyFetch<any[]>(`/api/tests/runs/${r.id}/results`))
-        const responses = await Promise.all(fetches)
+        // Per-case statuses come embedded in the listing (case_results) —
+        // fetching /runs/{id}/results per run was 100 extra requests here.
         const map: Record<string, any> = {}
         const caseMap: Record<string, Set<string>> = {}
-        for (let i = 0; i < responses.length; i++) {
-            const r = runs[i]
-            const rows = (responses[i].data.value as any[]) || []
+        for (const r of runs) {
+            const rows = (r as any).case_results || []
             const summary = { total: rows.length, passed: 0, failed: 0, error: 0 }
+            caseMap[r.id] = new Set<string>()
             for (const it of rows) {
                 if (it.status === 'pass') summary.passed++
                 else if (it.status === 'fail') summary.failed++
                 else if (it.status === 'error') summary.error++
-                if (!caseMap[r.id]) caseMap[r.id] = new Set<string>()
                 if (it.case_id) caseMap[r.id].add(String(it.case_id))
             }
             map[r.id] = summary
@@ -691,8 +696,9 @@ async function runAutomationNow() {
     try {
         await useMyFetch(`/data_sources/${id}/automation/run`, { method: 'POST' })
         toast.add({ title: 'Eval run started', color: 'green' })
-        // Give the background loop a moment, then refresh history.
-        setTimeout(() => { loadAutoRuns(); loadAutomation() }, 1500)
+        // Give the background loop a moment, then refresh history — including
+        // the merged Runs table, which previously only updated on reopen.
+        setTimeout(() => { loadAutoRuns(); loadAutomation(); loadRuns() }, 1500)
     } catch (e) {
         toast.add({ title: 'Failed to start reliability check', color: 'red' })
     } finally { triggering.value = false }

--- a/frontend/pages/evals/index.vue
+++ b/frontend/pages/evals/index.vue
@@ -165,7 +165,7 @@
                                   option-attribute="label"
                                   value-attribute="value"
                                   size="xs"
-                                  class="text-xs w-24"
+                                  class="text-xs w-28"
                                 />
                                 <UButton size="xs" variant="soft" :disabled="testsPage <= 1" @click="prevTestsPage">{{ $t('evals.pagination.prev') }}</UButton>
                                 <UButton size="xs" variant="soft" :disabled="!testsHasNext" @click="nextTestsPage">{{ $t('evals.pagination.next') }}</UButton>
@@ -274,7 +274,7 @@
                                   option-attribute="label"
                                   value-attribute="value"
                                   size="xs"
-                                  class="text-xs w-24"
+                                  class="text-xs w-28"
                                 />
                                 <UButton size="xs" variant="soft" :disabled="runsPage <= 1" @click="prevRunsPage">{{ $t('evals.pagination.prev') }}</UButton>
                                 <UButton size="xs" variant="soft" :disabled="!runsHasNext" @click="nextRunsPage">{{ $t('evals.pagination.next') }}</UButton>
@@ -325,7 +325,9 @@ const suiteFilter = ref<string>('all')
 const selectedIds = ref<Set<string>>(new Set())
 const testsPage = ref<number>(1)
 const testsLimit = ref<number>(20)
-const testsHasNext = computed(() => filteredTests.value.length >= testsLimit.value)
+// Set from the over-fetched page in loadCases — length-based heuristics
+// enabled "Next" on an exactly-full last page.
+const testsHasNext = ref<boolean>(false)
 const pageSizeOptions = computed(() => [
     { label: t('evals.pagination.pageSize', { n: 10 }), value: 10 },
     { label: t('evals.pagination.pageSize', { n: 20 }), value: 20 },
@@ -394,16 +396,15 @@ const localizedStatus = (status?: string) => {
         'error': 'evals.run.statusError',
         'in_progress': 'evals.run.statusInProgress',
         'pass': 'evals.run.rulePass',
-        'stopped': 'evals.run.completionFinished',
+        'stopped': 'evals.run.statusStopped',
     }
     const k = keyMap[status]
     return k ? t(k) : status
 }
 
 const statusClass = (status?: string) => {
-    if (status === 'success') return 'bg-green-100 text-green-800'
-    if (status === 'error') return 'bg-red-100 text-red-800'
-    if (status === 'in_progress') return 'bg-gray-100 text-gray-800'
+    if (status === 'success' || status === 'pass') return 'bg-green-100 text-green-800'
+    if (status === 'error' || status === 'fail') return 'bg-red-100 text-red-800'
     return 'bg-gray-100 text-gray-800'
 }
 
@@ -440,7 +441,7 @@ const runCaseFilter = ref<string>('all')
 const runSearchTerm = ref<string>('')
 const runsPage = ref<number>(1)
 const runsLimit = ref<number>(20)
-const runsHasNext = computed(() => runs.value.length >= runsLimit.value)
+const runsHasNext = ref<boolean>(false)
 const runCaseOptions = computed(() => {
     const base = [{ label: t('evals.filter.allCases'), value: 'all' }]
     // If a suite is chosen, list cases for that suite; otherwise list all known tests
@@ -505,6 +506,10 @@ function categoryKeysForCase(c: TestCaseRow): string[] {
             seen.add(String(r.target.category))
         } else if (r?.type === 'tool.calls' && r?.tool) {
             seen.add(`tool:${r.tool}`)
+        } else if (r?.type === 'judge' || r?.type === 'ordering' || r?.type === 'phase') {
+            // Modern flat rule types carry no target.category — without this
+            // they rendered no badge at all in the Rules column.
+            seen.add(String(r.type))
         }
     }
     return Array.from(seen)
@@ -539,10 +544,13 @@ async function loadCases() {
     if (suiteFilter.value !== 'all') params.set('suite_id', suiteFilter.value)
     if ((searchTerm.value || '').trim().length > 0) params.set('search', searchTerm.value.trim())
     params.set('page', String(testsPage.value))
-    params.set('limit', String(testsLimit.value))
+    // Over-fetch by one so "Next" only enables when a next page exists.
+    params.set('limit', String(testsLimit.value + 1))
     const url = `/api/tests/cases?${params.toString()}`
     const casesRes = await useMyFetch<any[]>(url)
-    const items = (casesRes.data.value || []) as any[]
+    const fetched = (casesRes.data.value || []) as any[]
+    testsHasNext.value = fetched.length > testsLimit.value
+    const items = fetched.slice(0, testsLimit.value)
     tests.value = items.map((c: any) => ({
         id: c.id,
         suite_id: c.suite_id,
@@ -602,24 +610,25 @@ async function loadRuns() {
         const params = new URLSearchParams()
         if (runSuiteFilter.value !== 'all') params.set('suite_id', runSuiteFilter.value)
         params.set('page', String(runsPage.value))
-        params.set('limit', String(runsLimit.value))
+        // Over-fetch by one so "Next" only enables when a next page exists.
+        params.set('limit', String(runsLimit.value + 1))
         const res = await useMyFetch<RunItem[]>(`/api/tests/runs?${params.toString()}`)
-        runs.value = (res.data.value as any[]) || []
+        const fetched = (res.data.value as any[]) || []
+        runsHasNext.value = fetched.length > runsLimit.value
+        runs.value = fetched.slice(0, runsLimit.value)
         loadAutomationOutcomes()
-        // fetch results per run to compute summary
-        const fetches = (runs.value || []).map(r => useMyFetch<any[]>(`/api/tests/runs/${r.id}/results`))
-        const responses = await Promise.all(fetches)
+        // Summaries come embedded in the listing (case_results) — no
+        // per-run /results request fan-out.
         const map: Record<string, { total: number; passed: number; failed: number; error: number }> = {}
         const caseMap: Record<string, Set<string>> = {}
-        for (let i = 0; i < responses.length; i++) {
-            const r = runs.value[i]
-            const rows = (responses[i].data.value as any[]) || []
+        for (const r of runs.value) {
+            const rows = (r as any).case_results || []
             const summary = { total: rows.length, passed: 0, failed: 0, error: 0 }
+            caseMap[r.id] = new Set<string>()
             for (const it of rows) {
                 if (it.status === 'pass') summary.passed++
                 else if (it.status === 'fail') summary.failed++
                 else if (it.status === 'error') summary.error++
-                if (!caseMap[r.id]) caseMap[r.id] = new Set<string>()
                 if (it.case_id) caseMap[r.id].add(String(it.case_id))
             }
             map[r.id] = summary
@@ -657,10 +666,6 @@ function editCase(c: TestCaseRow) {
     showAddCase.value = true
 }
 
-function goRuns() {
-    activeTab.value = 'runs'
-}
-
 function resultBadgeClassByStatus(status?: string) {
     if (status === 'success') return 'inline-flex px-2 py-1 rounded-full bg-green-100 text-green-800'
     if (status === 'in_progress') return 'inline-flex px-2 py-1 rounded-full bg-gray-100 text-gray-800'
@@ -675,6 +680,9 @@ function resultSummaryReal(r: RunItem) {
 }
 
 function derivedRunStatus(r: RunItem) {
+    // A user-initiated stop is not a failure — don't relabel it from the
+    // (partial) per-case tallies.
+    if (r.status === 'stopped') return 'stopped'
     const c = runResults.value[r.id] || { total: 0, passed: 0, failed: 0, error: 0 }
     if (r.status === 'in_progress') return 'in_progress'
     if (c.total > 0 && c.passed === c.total) return 'success'
@@ -856,61 +864,6 @@ function onManageSuiteDeleted(suiteId: string) {
     if (suiteFilter.value === suiteId) {
         suiteFilter.value = 'all'
     }
-}
-
-interface TestRunRow {
-    id: string
-    suite_name: string
-    trigger_reason: string
-    status: 'in_progress' | 'success' | 'error'
-    started_at?: string
-    finished_at?: string
-    results: { total: number; passed: number; failed: number; error: number }
-}
-
-// Mock: joined TestRun with aggregated TestResult counts
-const mockRuns = ref<TestRunRow[]>([
-    {
-        id: 'run_1',
-        suite_name: 'Revenue Checks',
-        trigger_reason: 'manual',
-        status: 'success',
-        started_at: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
-        finished_at: new Date(Date.now() - 1000 * 60 * 14).toISOString(),
-        results: { total: 8, passed: 8, failed: 0, error: 0 }
-    },
-    {
-        id: 'run_2',
-        suite_name: 'Churn Risk',
-        trigger_reason: 'schedule',
-        status: 'error',
-        started_at: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
-        finished_at: new Date(Date.now() - 1000 * 60 * 60 * 5 + 1000 * 90).toISOString(),
-        results: { total: 10, passed: 7, failed: 2, error: 1 }
-    },
-    {
-        id: 'run_3',
-        suite_name: 'Cost Guardrails',
-        trigger_reason: 'context_change',
-        status: 'in_progress',
-        started_at: new Date(Date.now() - 1000 * 60 * 2).toISOString(),
-        finished_at: undefined,
-        results: { total: 12, passed: 5, failed: 1, error: 0 }
-    }
-])
-
-const resultSummary = (r: TestRunRow) => {
-    const { total, passed, failed, error } = r.results
-    if (r.status === 'success') return `${passed}/${total} success`
-    if (r.status === 'in_progress') return `${passed}/${total} passing…`
-    const nonPass = failed + error
-    return `${passed}/${total} passing (${nonPass} issues)`
-}
-
-const resultBadgeClass = (r: TestRunRow) => {
-    if (r.status === 'success') return 'inline-flex px-2 py-1 rounded-full bg-green-100 text-green-800'
-    if (r.status === 'in_progress') return 'inline-flex px-2 py-1 rounded-full bg-gray-100 text-gray-800'
-    return 'inline-flex px-2 py-1 rounded-full bg-red-100 text-red-800'
 }
 
 const formatDuration = (start?: string | null, end?: string | null) => {

--- a/frontend/pages/evals/runs/[id].vue
+++ b/frontend/pages/evals/runs/[id].vue
@@ -97,6 +97,13 @@
                 <template v-else-if="row.result.status === 'fail'">
                   <Icon name="heroicons-x-mark" class="w-4 h-4 text-red-600" />
                 </template>
+                <template v-else-if="row.result.status === 'error'">
+                  <Icon name="heroicons-exclamation-triangle" class="w-4 h-4 text-red-600" :title="(row.result as any).failure_reason || ''" />
+                </template>
+                <template v-else>
+                  <!-- init / queued: created but not yet executing -->
+                  <Icon name="heroicons-clock" class="w-4 h-4 text-gray-400" />
+                </template>
                 <!-- X 4/6 Title -->
                 <span class="text-xs font-regular text-gray-500 dark:text-gray-400 truncate">
                   {{ passedAssertions(row) }}/{{ assertionCount(row) }}
@@ -219,6 +226,9 @@
                         <template v-else-if="ruleStatus(row, it.originalIdx) === 'skipped'">
                           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="currentColor"><path d="M10 3a7 7 0 100 14 7 7 0 000-14zM8 9h4v2H8V9z"/></svg>
                           <span class="text-[11px] text-gray-600 dark:text-gray-400">{{ $t('evals.run.ruleSkipped') }}</span>
+                          <!-- Why it was skipped (e.g. "Judge unavailable — enable a small default model…");
+                               judge rules already render it on the Reasoning line -->
+                          <span v-if="ruleMessage(row, it.originalIdx) && !(isJudgeRule(it.rule) && ruleMessage(row, it.originalIdx) === ruleReasoningText(row, it.originalIdx))" class="text-[11px] text-gray-600 dark:text-gray-400">· {{ ruleMessage(row, it.originalIdx) }}</span>
                         </template>
                         <template v-else-if="ruleStatus(row, it.originalIdx) === 'pass'">
                           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 text-green-700" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L7 12.172 4.707 9.879a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l8-8z" clip-rule="evenodd"/></svg>
@@ -227,7 +237,8 @@
                         <template v-else>
                           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 text-red-700" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-10.293a1 1 0 00-1.414-1.414L10 8.586 7.707 6.293a1 1 0 00-1.414 1.414L8.586 10l-2.293 2.293a1 1 0 101.414 1.414L10 11.414l2.293 2.293a1 1 0 001.414-1.414L11.414 10l2.293-2.293z" clip-rule="evenodd"/></svg>
                           <span class="text-[11px] text-red-700">{{ $t('evals.run.ruleFail') }}</span>
-                          <span v-if="ruleMessage(row, it.originalIdx)" class="text-[11px] text-red-700">· {{ ruleMessage(row, it.originalIdx) }}</span>
+                          <!-- Judge failures already render the same text on the Reasoning line above -->
+                          <span v-if="ruleMessage(row, it.originalIdx) && !(isJudgeRule(it.rule) && ruleMessage(row, it.originalIdx) === ruleReasoningText(row, it.originalIdx))" class="text-[11px] text-red-700">· {{ ruleMessage(row, it.originalIdx) }}</span>
                         </template>
                       </div>
                     </div>
@@ -296,7 +307,6 @@ const results = ref<TestResult[]>([])
 const suiteName = ref<string>('')
 type CaseRow = { result: TestResult, case: TestCase }
 const caseRows = ref<CaseRow[]>([])
-const expanded = ref<Record<string, boolean>>({})
 const openRows = ref<Record<string, boolean>>({})
 const models = ref<any[]>([])
 const modelById = computed<Record<string, any>>(() => Object.fromEntries((models.value || []).map((m: any) => [m.model_id || m.id, m])))
@@ -450,6 +460,17 @@ function groupFor(event: string, data: any): string | undefined {
   }
 }
 
+// A line is a duplicate if the same text appeared in the last few entries —
+// the same content arrives via multiple event paths (block.upsert + seed.*),
+// often with another line interleaved, so adjacent-only comparison missed it.
+function isRecentDuplicate(arr: RawLog[], item: RawLog): boolean {
+  const lookback = Math.min(5, arr.length)
+  for (let i = arr.length - lookback; i < arr.length; i++) {
+    if (arr[i].text === item.text && arr[i].label === item.label) return true
+  }
+  return false
+}
+
 function pushLog(resultId: string, event: string, data: any) {
   // Drop extremely noisy token deltas for the mini view
   if (event === 'block.delta.token') return
@@ -476,9 +497,7 @@ function pushLog(resultId: string, event: string, data: any) {
         ? `${name}(${cachedIn}) -> ${outText}`
         : `${name}(${cachedIn})`
       const item: RawLog = { ts: new Date().toISOString(), event, data, label: 'TOOL', text, group: `TOOL:${name}` }
-      // Push duplicate entries instead of replacing, to keep a simple chronological log
-      const last = arr[arr.length - 1]
-      if (!last || !(last.event === item.event && last.text === item.text)) {
+      if (!isRecentDuplicate(arr, item)) {
         arr.push(item)
       }
       if (arr.length > 200) arr.splice(0, arr.length - 200)
@@ -487,10 +506,8 @@ function pushLog(resultId: string, event: string, data: any) {
     }
     const summary = summarizeEvent(event, data)
     if (!summary.text || !String(summary.text).trim()) return
-    // Push event as its own entry; skip if identical to the immediately previous line
     const nextItem: RawLog = { ts: new Date().toISOString(), event, data, label: summary.label, text: summary.text, group: groupFor(event, data) }
-    const prev = arr[arr.length - 1]
-    if (!prev || !(prev.event === nextItem.event && prev.text === nextItem.text)) {
+    if (!isRecentDuplicate(arr, nextItem)) {
       arr.push(nextItem)
     }
     // Keep a bounded buffer per result
@@ -513,14 +530,6 @@ function scrollLogsToBottom(resultId: string) {
   try {
     el.scrollTop = el.scrollHeight
   } catch {}
-}
-
-const isExpanded = (resultId: string, idx: number) => {
-  return !!expanded.value[`${resultId}:${idx}`]
-}
-const toggleExpanded = (resultId: string, idx: number) => {
-  const key = `${resultId}:${idx}`
-  expanded.value[key] = !expanded.value[key]
 }
 
 const isRowExpanded = (resultId: string) => {
@@ -632,18 +641,13 @@ const runStatusClass = (status?: string) => {
   return 'bg-gray-100 text-gray-800'
 }
 
-const ruleIconClass = (status?: string) => {
-  if (status === 'error' || status === 'fail') return 'bg-red-100'
-  if (status === 'in_progress') return 'bg-gray-100'
-  return 'bg-green-100'
-}
-
 const prettyStatus = (status?: string) => {
   if (!status) return '—'
   if (status === 'in_progress') return t('evals.run.statusInProgress')
   if (status === 'success') return t('evals.run.statusSuccess')
   if (status === 'fail') return t('evals.run.statusFailed')
   if (status === 'error') return t('evals.run.statusError')
+  if (status === 'stopped') return t('evals.run.statusStopped')
   return status.replace('_', ' ')
 }
 
@@ -703,8 +707,11 @@ const flipBadgeClass = (flip: string) => {
 }
 
 // Derive run status from individual result statuses to avoid mismatches with backend aggregate
-const derivedRunStatus = computed<'in_progress' | 'success' | 'fail' | 'error'>(() => {
+const derivedRunStatus = computed<'in_progress' | 'success' | 'fail' | 'error' | 'stopped'>(() => {
   try {
+    // A user-initiated stop is not a failure — showing "Error" for a
+    // stopped run misread as the run having crashed.
+    if (run.value?.status === 'stopped') return 'stopped'
     const list = results.value || []
     if (list.some(r => r.status === 'in_progress')) return 'in_progress'
     if (list.some(r => r.status === 'error')) return 'error'
@@ -794,64 +801,44 @@ const assertionCount = (row: CaseRow) => {
   return displayRules(row).length
 }
 
-const modelProviderType = (modelId?: string, caseObj?: TestCase) => {
+// Cases without an explicit model_id run on the org's default model —
+// resolve it from the loaded models list instead of showing the literal
+// word "default".
+const orgDefaultModel = computed<any | null>(() => (models.value || []).find((m: any) => m?.is_default) || null)
+const resolveModel = (modelId?: string, caseObj?: TestCase): any | null => {
   const m = modelById.value[String(modelId || '')]
-  if (m) return m?.provider?.provider_type || 'default'
+  if (m) return m
   const ms: any = (caseObj as any)?.model_summary
-  return ms?.provider_type || 'default'
+  if (ms) return ms
+  if (!modelId) return orgDefaultModel.value
+  return null
+}
+const modelProviderType = (modelId?: string, caseObj?: TestCase) => {
+  const m = resolveModel(modelId, caseObj)
+  return m?.provider?.provider_type || m?.provider_type || 'default'
 }
 const modelDisplayName = (modelId?: string, caseObj?: TestCase) => {
-  const m = modelById.value[String(modelId || '')]
-  if (m) return m?.name || m?.model_id || modelId || t('evals.run.defaultModel')
-  const ms: any = (caseObj as any)?.model_summary
-  return ms?.name || ms?.model_id || modelId || t('evals.run.defaultModel')
+  const m = resolveModel(modelId, caseObj)
+  return m?.name || m?.model_id || modelId || t('evals.run.defaultModel')
 }
 const modelProviderName = (modelId?: string, caseObj?: TestCase) => {
-  const m = modelById.value[String(modelId || '')]
-  if (m) return m?.provider?.name || m?.provider_name || ''
-  const ms: any = (caseObj as any)?.model_summary
-  return ms?.provider_name || ''
-}
-
-const summarizeRule = (rule: any) => {
-  // Very small summary; can be improved
-  try {
-    const target = rule?.target?.field || rule?.target || 'rule'
-    const type = rule?.matcher?.type || 'matcher'
-    return `${target} · ${type}`
-  } catch {
-    return 'rule'
-  }
-}
-
-const mockRuleDuration = (row: CaseRow) => {
-  // Placeholder per-rule duration for UI; replace with real metrics later
-  const base = 2 + (row.case.id.charCodeAt(0) % 5)
-  return `${base}s`
+  const m = resolveModel(modelId, caseObj)
+  return m?.provider?.name || m?.provider_name || ''
 }
 
 const caseDuration = (row: CaseRow) => {
-  // Prefer duration from result_json; otherwise a lightweight placeholder
+  // Real duration from result_json only — a fabricated fallback here used to
+  // show plausible-looking "2s/4s" durations for cases that never ran.
   const ms = row.result.result_json && row.result.result_json.totals && typeof row.result.result_json.totals.duration_ms === 'number'
     ? Number(row.result.result_json.totals.duration_ms)
     : null
-  if (typeof ms === 'number') {
-    if (ms < 1000) return `${ms}ms`
-    const secs = Math.round(ms / 1000)
-    if (secs < 60) return `${secs}s`
-    const mins = Math.floor(secs / 60)
-    const rem = secs % 60
-    return `${mins}m ${rem}s`
-  }
-  // Fallback mock based on rule count to avoid blank UI
-  const rules = assertionCount(row)
-  if (rules <= 0) return '—'
-  const secs = Math.min(300, 2 * rules)
-  return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`
-}
-
-const toPrettyJSON = (v: any) => {
-  try { return JSON.stringify(v, null, 2) } catch { return String(v) }
+  if (typeof ms !== 'number') return '—'
+  if (ms < 1000) return `${ms}ms`
+  const secs = Math.round(ms / 1000)
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const rem = secs % 60
+  return `${mins}m ${rem}s`
 }
 
 // ---- Read-only expectations helpers ----
@@ -1043,20 +1030,6 @@ const ruleReasoningText = (row: { result: TestResult }, idx: number): string => 
   return (rr?.evidence?.reasoning || rr?.message || '') as string
 }
 
-type ConversationMessage = { role: string, content: string }
-const mockLogs = (row: { result: TestResult, case: TestCase }): ConversationMessage[] => {
-  const caseName = row.case.name || 'Test Case'
-  const prompt = typeof row.case.prompt_json?.content === 'string'
-    ? row.case.prompt_json.content
-    : ''
-  const promptSnippet = prompt ? (prompt.length > 160 ? prompt.slice(0, 160) + '…' : prompt) : 'No prompt content provided.'
-  return [
-    { role: 'user', content: `Run "${caseName}" using the latest dataset.` },
-    { role: 'assistant', content: 'Acknowledged. Gathering inputs and evaluating expectations…' },
-    { role: 'assistant', content: `Initial prompt: ${promptSnippet}` }
-  ]
-}
-
 const stopRun = async () => {
   try {
     if (!run.value?.id || run.value.status !== 'in_progress') return
@@ -1148,13 +1121,9 @@ onMounted(async () => {
               const parsed = JSON.parse(data)
               const payload = (parsed && typeof parsed === 'object' && 'data' in parsed) ? (parsed as any).data : parsed
               if (eventName === 'run.started') {
+                // Run-level lifecycle only — fanning "Started" into every
+                // case's log duplicated the per-case completion.started line.
                 if (run.value) run.value.status = 'in_progress'
-                // Fan out a log entry to each result in the run
-                const resList = Array.isArray((payload as any)?.results) ? (payload as any).results : []
-                for (const it of resList) {
-                  const rid = String((it as any)?.result_id || '')
-                  if (rid) pushLog(rid, eventName, payload)
-                }
               } else if (eventName === 'result.update') {
                 const rid = String((payload as any).result_id || '')
                 const idx = results.value.findIndex(r => String(r.id) === rid)
@@ -1190,11 +1159,10 @@ onMounted(async () => {
                   pushLog(rid, eventName, payload)
                 }
               } else if (eventName === 'run.finished') {
+                // Run-level status only. Broadcasting this into every case's
+                // log rendered "Finished · status=error" under PASSING cases
+                // (the run aggregate), reading like the case itself errored.
                 if (run.value && (payload as any)?.status) (run.value as any).status = (payload as any).status
-                // Broadcast finished to all known results
-                for (const r of results.value) {
-                  pushLog(String(r.id), eventName, payload)
-                }
                 // Re-fetch run header and results once the run is finished
                 scheduleResultsRefresh(true)
               } else {
@@ -1226,12 +1194,6 @@ onMounted(async () => {
     }, 100)
   } catch {}
 })
-
-const ruleFailed = (result: TestResult, idx: number) => {
-  const rr = result.result_json?.rule_results || []
-  if (!Array.isArray(rr) || idx < 0 || idx >= rr.length) return false
-  return rr[idx]?.ok === false
-}
 
 // Passed assertions counter per row (only counting visible rules)
 const passedAssertions = (row: CaseRow): number => {

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "نجاح",
       "statusFailed": "فشل",
       "statusError": "خطأ",
+      "statusStopped": "متوقف",
       "rulePending": "بانتظار…",
       "ruleSkipped": "تم التخطي",
       "rulePass": "نجاح",

--- a/locales/de.json
+++ b/locales/de.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Erfolgreich",
       "statusFailed": "Fehlgeschlagen",
       "statusError": "Fehler",
+      "statusStopped": "Gestoppt",
       "rulePending": "Ausstehend …",
       "ruleSkipped": "Übersprungen",
       "rulePass": "Bestanden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -3197,6 +3197,7 @@
       "statusSuccess": "Success",
       "statusFailed": "Failed",
       "statusError": "Error",
+      "statusStopped": "Stopped",
       "rulePending": "Pending…",
       "ruleSkipped": "Skipped",
       "rulePass": "Pass",

--- a/locales/es.json
+++ b/locales/es.json
@@ -2937,6 +2937,7 @@
       "statusSuccess": "Éxito",
       "statusFailed": "Fallida",
       "statusError": "Error",
+      "statusStopped": "Detenido",
       "rulePending": "Pendiente…",
       "ruleSkipped": "Omitida",
       "rulePass": "Éxito",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Succès",
       "statusFailed": "Échec",
       "statusError": "Erreur",
+      "statusStopped": "Arrêté",
       "rulePending": "En attente…",
       "ruleSkipped": "Ignorée",
       "rulePass": "Réussie",

--- a/locales/he.json
+++ b/locales/he.json
@@ -2937,6 +2937,7 @@
       "statusSuccess": "הצלחה",
       "statusFailed": "נכשלה",
       "statusError": "שגיאה",
+      "statusStopped": "הופסק",
       "rulePending": "ממתין…",
       "ruleSkipped": "דולג",
       "rulePass": "עבר",

--- a/locales/it.json
+++ b/locales/it.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Riuscito",
       "statusFailed": "Non riuscito",
       "statusError": "Errore",
+      "statusStopped": "Interrotto",
       "rulePending": "In attesa…",
       "ruleSkipped": "Saltata",
       "rulePass": "Superato",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Sucesso",
       "statusFailed": "Falhou",
       "statusError": "Erro",
+      "statusStopped": "Parado",
       "rulePending": "Pendente…",
       "ruleSkipped": "Ignorada",
       "rulePass": "Passou",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Успех",
       "statusFailed": "Сбой",
       "statusError": "Ошибка",
+      "statusStopped": "Остановлен",
       "rulePending": "Ожидание…",
       "ruleSkipped": "Пропущено",
       "rulePass": "Успех",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -2715,6 +2715,7 @@
       "statusSuccess": "Klart",
       "statusFailed": "Misslyckades",
       "statusError": "Fel",
+      "statusStopped": "Stoppad",
       "rulePending": "Väntar…",
       "ruleSkipped": "Hoppade över",
       "rulePass": "Godkänd",


### PR DESCRIPTION
## Summary

Full pass over the evals system (backend execution + `/evals` pages + Agents-page Evals panel), fixing every issue found in a live sandbox review. All fixes were verified end-to-end through the real UI with Playwright against real agent runs.

### Backend

- **Fix the multi-case run execution race.** `stream_run` spawned per-result agent tasks as closures over its loop variables and shared the request session's ORM objects across concurrently running tasks. Tasks late-bound `r`/`head`/`system_completion` (they first run at the loop's next await), crashing agents with `MissingGreenlet` and attributing the crash to a different case's result. The runner is now `_execute_result_agent`, which takes plain ids and re-loads everything in its own session. Reproduced before the fix (a 3-case "Run Selected" reliably killed one agent and showed the error under the wrong case); the same run now completes cleanly.
- **Runs can no longer hang in `in_progress` forever.** The `_watch_and_finalize` watchdog (previously armed only by the `/runs/batch` path) is now armed at `create_run` time and by `stream_run` for every non-terminal result — a crashed agent, a closed tab, or a never-opened run page now times out, errors the result, and finalizes the run.
- **Org-scope `GET /api/tests/runs`.** The unfiltered branch was a bare `select(TestRun)` — any user with `manage_evals` in any org could list every org's runs. All branches now scope through results → cases → suites. Verified with a seeded foreign org.
- **Judge rules on single-model orgs.** The judge gate is split in two: `judge_model_allowed` (unchanged, strict distinct-small-default) still guards agent_v2's background scoring of live chat completions, while eval runs use the new `eval_judge_model_allowed`, which runs the judge on whatever model small-default resolution returns. Previously every judge rule in a single-model org hard-failed with a bare "Judge unavailable"; if no model resolves at all, the rule is now recorded as `skipped` (not failed) with an explanatory message.
- **`stop_run`** also terminalizes `init` (never-executed) results.
- **`list_runs` embeds per-case statuses** (`case_results`) so list clients no longer issue one `/results` request per listed run.

### Frontend (`/evals`, `/evals/runs/[id]`, `AgentEvalsPanel`)

- Remove fabricated per-case durations (`2s × rule count`) shown for cases that never ran; show the real duration or an em dash.
- Stop fanning `run.started`/`run.finished` into per-case logs (passing cases used to end with `Finished · status=error` from the run aggregate) and dedupe repeated log lines arriving via multiple event paths.
- Add error/queued icons to collapsed case rows; show **Stopped** instead of Error/Failed for user-stopped runs (new `statusStopped` key in all locales).
- Show skip reasons on skipped rules; stop double-printing judge reasoning on failures.
- Resolve the org default model's real name instead of showing the literal word "default".
- Badge `judge`/`ordering`/`phase` rules in the Rules columns (modern flat rule types rendered no badge).
- Consume embedded `case_results` in both run lists (removes the N+1 request fan-out — verified 0 per-run requests) and base pagination's "Next" on an over-fetched row instead of page length.
- Refresh the merged Runs table after "Run evals now"; remove leftover mock data and dead helpers from both evals pages.

## Test plan

- `tests/unit/test_judge_gating.py` rewritten to cover both gates (10 tests), plus `tests/unit/test_eval_wake_dispatch.py`, `tests/unit/test_eval_loop_tools.py`, and `tests/e2e/test_eval_drafts.py` — all passing.
- Live sandbox verification with Playwright + real Anthropic models: multi-case concurrent run completes with correct attribution and zero `MissingGreenlet`; stop flow; build-over-build compare; judge pass/fail reasoning; judge running under a single-model config; skipped-judge rendering when no model is available; cross-org listing exclusion; runs-tab request count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzQNWrPst16picgPA6ysC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzQNWrPst16picgPA6ysC6)_