### PR TITLE
Make a manual agent selection a hard scope for report runs

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -949,41 +949,6 @@ class AgentV2:
         except Exception:
             return ()
 
-    async def _manual_awareness_roster(self, user):
-        """Names-only <available_agents> line for MANUAL selections below the
-        roster threshold. None when the selection already covers everything the
-        user can access (or outside chat/deep). Cached for the run."""
-        if getattr(self, "_manual_roster_cached", False):
-            return self._manual_roster
-        self._manual_roster_cached = True
-        self._manual_roster = None
-        try:
-            if self.mode not in ("chat", "deep") or not self.report or user is None:
-                return None
-            attached = list(getattr(self.report, "data_sources", None) or [])
-            if not attached:
-                return None
-            from app.ai.tools.implementations.agent_focus_common import (
-                accessible_agents,
-                signin_required_ids,
-            )
-            from app.ai.context.agent_roster import render_manual_awareness_xml
-            attached_ids = {str(d.id) for d in attached}
-            extras = [
-                d for d in await accessible_agents(self.db, self.organization, user)
-                if str(d.id) not in attached_ids
-            ]
-            if not extras:
-                return None
-            needs = await signin_required_ids(self.db, extras, user)
-            self._manual_roster = render_manual_awareness_xml(
-                [getattr(d, "name", "") or "" for d in attached],
-                [((getattr(d, "name", "") or ""), str(d.id) in needs) for d in extras],
-            )
-        except Exception:
-            logger.exception("manual awareness roster failed")
-        return self._manual_roster
-
     async def _ensure_clients_for_attached(self) -> None:
         """Build query clients for agents attached AFTER run start (approved
         set_report_agents expansion) — without this create_data against the new
@@ -1175,11 +1140,10 @@ class AgentV2:
                 loaded_ids=list(_loaded),
             )
             if _mode == "all":
-                # Manual selection below the threshold: full schema as always,
-                # plus a names-only awareness line so the model knows OTHER
-                # accessible agents exist and can PROPOSE one (approval-gated)
-                # instead of answering "I don't have that data".
-                return _plain(), await self._manual_awareness_roster(user)
+                # Few agents attached (manual selection or small Auto scope):
+                # full schema as always. A manual selection is a hard scope —
+                # other accessible agents are deliberately NOT surfaced.
+                return _plain(), None
             if _mode == "pick" and not _loaded:
                 # Many agents, nothing picked or loaded yet: roster only — the
                 # model must search/set before data work.

--- a/backend/app/ai/context/agent_roster.py
+++ b/backend/app/ai/context/agent_roster.py
@@ -364,39 +364,3 @@ async def build_focus_and_roster(
             )
         )
     return focus_ids, render_agent_roster_xml(agents, focus_ids, usage=usage, top_k=top_k, loaded_ids=loaded_ids), mode
-
-
-def render_manual_awareness_xml(
-    selected_names: List[str],
-    extras: List[Tuple[str, bool]],
-    name_cap: int = MORE_AGENTS_NAME_CAP,
-) -> Optional[str]:
-    """Awareness block for MANUAL selections below the roster threshold.
-
-    The user picked specific agent(s); their full schemas render as usual. This
-    one-liner tells the model the org has OTHER accessible agents (names only,
-    "(sign-in required)" when the user must Connect first), so a question the
-    selection can't answer becomes a proposal instead of "I don't have that
-    data". Expanding still goes through set_report_agents' user approval.
-    """
-    if not extras:
-        return None
-    total = len(selected_names) + len(extras)
-    named = extras[:name_cap]
-    names = ", ".join(
-        _xml_escape(n) + (" (sign-in required)" if needs else "")
-        for n, needs in named
-    )
-    overflow = len(extras) - len(named)
-    suffix = f" (+{overflow} more)" if overflow > 0 else ""
-    return (
-        f'<available_agents count="{total}" selected="{len(selected_names)}">\n'
-        "  The user selected specific agents for this report — their full <agent> "
-        "schemas are below; work with those by default. The organization has other "
-        "agents you may PROPOSE when the ask clearly needs data the selection lacks: "
-        "use search_agents to find one (set_report_agents will ask the user before "
-        "adding it; agents marked sign-in required need the user to Connect them "
-        "from the agent selector first).\n"
-        f'  <more_agents count="{len(extras)}">{names}{suffix}</more_agents>\n'
-        "</available_agents>"
-    )

--- a/backend/app/ai/tools/implementations/agent_focus_common.py
+++ b/backend/app/ai/tools/implementations/agent_focus_common.py
@@ -4,9 +4,10 @@
 
   - ``report.data_sources`` EMPTY = **Auto**: the user delegated scoping, so the
     working set is every agent they can access and the tools act freely.
-  - Non-empty = **manual**: the user picked agents. Search may still look across
-    accessible agents (to propose one), but expanding the report beyond the
-    user's selection requires their approval (see set_report_agents).
+  - Non-empty = **manual**: the user picked agents, and that selection is a HARD
+    scope — search and focus operate on the selected agents only; other
+    accessible agents are never searched, loaded, or proposed. The user changes
+    the scope themselves from the agent selector.
   - **training**: the actor curates agents they MANAGE (org-level
     ``manage_instructions`` → all agents, or a per-agent ``manage`` grant).
 """
@@ -80,8 +81,9 @@ async def resolve_candidate_agents(
 ) -> Tuple[List[Any], str, set]:
     """Return ``(agents, scope_label, attached_ids)`` for search/focus.
 
-    ``attached_ids`` is the raw manual selection (empty under Auto) — an agent
-    outside it needs user approval to be attached in manual mode.
+    ``attached_ids`` is the raw manual selection (empty under Auto). In manual
+    mode the selection is the whole candidate pool — agents outside it are out
+    of scope entirely.
     """
     if mode == "training":
         from app.core.permission_resolver import get_ds_ids_with_permission
@@ -110,13 +112,9 @@ async def resolve_candidate_agents(
         agents = await accessible_agents(db, organization, user)
         return agents, "accessible", {str(a.id) for a in agents}
 
-    # Manual: the user's selection first, plus other accessible agents the
-    # model may PROPOSE (attaching one requires the user's approval).
-    extras = [
-        ds for ds in await accessible_agents(db, organization, user)
-        if str(ds.id) not in attached_ids
-    ]
-    return attached + extras, "attached+accessible", attached_ids
+    # Manual: the user's selection is a hard scope — no other agents are
+    # searched or proposed. The user widens it from the agent selector.
+    return attached, "attached", attached_ids
 
 
 async def render_agents_full(db, organization: Any, report: Any, user: Any, data_sources: List[Any]) -> str:

--- a/backend/app/ai/tools/implementations/search_agents.py
+++ b/backend/app/ai/tools/implementations/search_agents.py
@@ -309,7 +309,7 @@ class SearchAgentsTool(Tool):
                 + (", EMAIL agent — use search_email/read_email/list_emails, not file tools" if surface_by_id.get(it.id) == "email" else "")
                 + (", matched on table names only" if strength.get(it.id) == "weak" else "")
                 + (", focused" if it.focused else "")
-                + ("" if it.attached else ", not in the user's selection — focusing it will ask for their approval")
+                + ("" if it.attached else ", not attached to this report yet")
                 + (", SIGN-IN REQUIRED — the user must Connect this agent from the agent selector before it can be used; do not set_report_agents it, tell the user instead" if it.needs_signin else "")
                 + (f") — {it.description}" if it.description else ")")
                 for it in items

--- a/backend/app/ai/tools/implementations/set_report_agents.py
+++ b/backend/app/ai/tools/implementations/set_report_agents.py
@@ -5,11 +5,9 @@ schema is rendered into context). Selection semantics:
 
   - **Auto** (no manual agent selection on the report): every accessible agent
     is already in scope — the tool only writes the focus, freely.
-  - **Manual** (the user picked agents): focusing within the selection is free;
-    focusing an agent OUTSIDE it means expanding the user's scope, so the run
-    pauses for their approval (Allow/Deny card showing the agents + the
-    model's ``reason``). Denied/timed out → the tool soft-fails and the run
-    continues within the current scope.
+  - **Manual** (the user picked agents): the selection is a HARD scope.
+    Focusing within it is free; an agent outside it is rejected outright — the
+    user widens the scope themselves from the agent selector.
   - **training**: the actor curates agents they manage — attach without
     confirmation (mirrors create_agent).
 
@@ -48,9 +46,10 @@ class SetReportAgentsTool(Tool):
                 "search_agents to pin the agent you'll work with. Pass the agent ids to "
                 "focus, or an empty list to clear the focus (revert to automatic "
                 "selection). When the user has manually selected agents on this report, "
-                "focusing an agent OUTSIDE their selection asks them for approval — "
-                "always set `reason` with one short sentence they will see. In training "
-                "mode this attaches agents you manage without asking."
+                "that selection is a hard scope: agents outside it are rejected — if "
+                "the task needs another agent, tell the user to add it from the agent "
+                "selector. In training mode this attaches agents you manage without "
+                "asking."
             ),
             category="action",
             version="1.1.0",
@@ -127,33 +126,48 @@ class SetReportAgentsTool(Tool):
 
             valid: List[Any] = []          # (ds, needs_attach)
             rejected: List[str] = []
+            out_of_scope: List[str] = []
             for did in requested:
                 ds = attached_by_id.get(did)
-                if ds is None:
-                    from sqlalchemy.orm import selectinload
-                    ds = (await db.execute(
-                        select(DataSource)
-                        .options(selectinload(DataSource.connections))
-                        .where(
-                            DataSource.id == did,
-                            DataSource.organization_id == str(organization.id),
-                        )
-                    )).scalar_one_or_none()
-                    if ds is None or not await user_can_focus_agent(db, organization, user, did, mode):
-                        rejected.append(did)
-                        continue
-                    # Under Auto the agent is already in scope (resolution covers
-                    # it) — attaching would silently convert Auto into a manual
-                    # pin. Only manual/training reports actually attach.
-                    valid.append((ds, not is_auto))
-                else:
+                if ds is not None:
                     valid.append((ds, False))
+                    continue
+                # Not in the report's selection. A MANUAL selection is a hard
+                # scope in chat/deep — never attach beyond it.
+                if not is_auto and mode != "training":
+                    rejected.append(did)
+                    out_of_scope.append(did)
+                    continue
+                from sqlalchemy.orm import selectinload
+                ds = (await db.execute(
+                    select(DataSource)
+                    .options(selectinload(DataSource.connections))
+                    .where(
+                        DataSource.id == did,
+                        DataSource.organization_id == str(organization.id),
+                    )
+                )).scalar_one_or_none()
+                if ds is None or not await user_can_focus_agent(db, organization, user, did, mode):
+                    rejected.append(did)
+                    continue
+                # Under Auto the agent is already in scope (resolution covers
+                # it) — attaching would silently convert Auto into a manual
+                # pin. Only training reports actually attach.
+                valid.append((ds, mode == "training"))
 
+            _scope_note = (
+                "outside the user's selected agents — a manual selection is a hard "
+                "scope; work with the selected agents, or tell the user to add the "
+                "agent from the agent selector"
+            )
             if not valid:
-                msg = (
-                    "None of the requested agents could be focused "
-                    f"({'not found / not permitted' if rejected else 'no ids given'})."
-                )
+                if out_of_scope:
+                    reason = _scope_note
+                elif rejected:
+                    reason = "not found / not permitted"
+                else:
+                    reason = "no ids given"
+                msg = f"None of the requested agents could be focused ({reason})."
                 out = SetReportAgentsOutput(success=False, rejected_ids=rejected, message=msg)
                 yield ToolEndEvent(type="tool.end", payload={"output": out.model_dump(),
                                     "observation": {"summary": msg, "success": False, "artifacts": []}})
@@ -177,26 +191,7 @@ class SetReportAgentsTool(Tool):
                                         "observation": {"summary": msg, "success": False, "artifacts": []}})
                     return
 
-            # Manual-selection guard: expanding beyond the user's own pick needs
-            # their approval (chat/deep only — training curates freely).
-            expansion = [ds for ds, needs_attach in valid if needs_attach]
-            if expansion and mode != "training":
-                async for ev in self._confirm_expansion(runtime_ctx, expansion, data.reason):
-                    if isinstance(ev, dict):
-                        # sentinel: denial/timeout end-event payload
-                        out = SetReportAgentsOutput(
-                            success=False,
-                            rejected_ids=[str(d.id) for d in expansion],
-                            message=ev["summary"],
-                        )
-                        yield ToolEndEvent(type="tool.end", payload={
-                            "output": {**out.model_dump(), "approval": ev.get("approval")},
-                            "observation": {"summary": ev["summary"], "success": False, "artifacts": []},
-                        })
-                        return
-                    yield ev
-
-            # Apply: attach what needs attaching, then set the focus.
+            # Apply: attach what needs attaching (training only), then set the focus.
             valid_ids: List[str] = []
             valid_names: List[str] = []
             added_names: List[str] = []
@@ -221,7 +216,9 @@ class SetReportAgentsTool(Tool):
                 f"Focused this report on {len(valid_ids)} agent(s): {names}. "
                 "Their full schema is in context from the next step."
             )
-            if rejected:
+            if out_of_scope:
+                msg += f" Rejected {len(out_of_scope)} id(s) {_scope_note}."
+            elif rejected:
                 msg += f" Skipped {len(rejected)} id(s) that weren't found or permitted."
             out = SetReportAgentsOutput(
                 success=True, focused_agent_ids=valid_ids, focused_agent_names=valid_names,
@@ -249,62 +246,3 @@ class SetReportAgentsTool(Tool):
             except Exception:
                 pass
             yield ToolErrorEvent(type="tool.error", payload={"error": f"Failed to set focus: {e}", "code": "SET_FOCUS_FAILED"})
-
-    async def _confirm_expansion(self, runtime_ctx: Dict[str, Any], expansion: List[Any], reason: str | None):
-        """Pause for the user's Allow/Deny on adding agents beyond their manual
-        selection. Yields tool events; yields a final dict sentinel when the
-        expansion is NOT approved (denied / timed out / non-interactive run)."""
-        from app.ai.tools.confirmation import KIND_BUILTIN_TOOL, stream_user_confirmation
-        from app.services.tool_policy_service import ToolPolicyService
-
-        names = [getattr(d, "name", "") or str(d.id) for d in expansion]
-        label = ", ".join(names)
-
-        if not ToolPolicyService.is_interactive_run(runtime_ctx):
-            yield {
-                "summary": (
-                    f"Agent(s) {label} are outside this report's user-selected agents and this "
-                    "run cannot ask for approval (non-interactive). Continue with the current "
-                    "agents, or the user can add them from the agent selector."
-                ),
-                "approval": None,
-            }
-            return
-
-        result: Dict[str, Any] = {}
-        async for ev in stream_user_confirmation(
-            runtime_ctx,
-            kind=KIND_BUILTIN_TOOL,
-            tool_name="set_report_agents",
-            payload={
-                "agent_ids": [str(d.id) for d in expansion],
-                "agent_names": names,
-                "agents": [
-                    {
-                        "id": str(d.id), "name": getattr(d, "name", "") or "",
-                        "icon": getattr(d, "icon", None),
-                        "type": getattr((list(getattr(d, "connections", None) or []) or [None])[0], "type", None),
-                        "connector_key": ((getattr((list(getattr(d, "connections", None) or []) or [None])[0], "config", None) or {}).get("catalog_key") if isinstance(getattr((list(getattr(d, "connections", None) or []) or [None])[0], "config", None), dict) else None),
-                    }
-                    for d in expansion
-                ],
-                "reason": reason or "",
-            },
-            result=result,
-        ):
-            yield ev
-
-        approval = {
-            "approved": result.get("approved", False),
-            "timed_out": result.get("timed_out", True),
-            "resolved_by_name": result.get("resolved_by_name"),
-        }
-        if not result.get("approved"):
-            cause = "the approval request timed out" if result.get("timed_out") else "the user declined"
-            yield {
-                "summary": (
-                    f"Did not add agent(s) {label} — {cause}. Continue the task with the "
-                    "currently selected agents; only retry if the user explicitly asks."
-                ),
-                "approval": approval,
-            }

--- a/backend/app/ai/tools/schemas/set_report_agents.py
+++ b/backend/app/ai/tools/schemas/set_report_agents.py
@@ -19,9 +19,7 @@ class SetReportAgentsInput(BaseModel):
         None,
         description=(
             "One short sentence for the USER explaining why these agents are needed "
-            "(e.g. 'Need the Sales agent for order-level revenue'). Required in spirit "
-            "when the report has a manual agent selection and you're adding an agent "
-            "outside it — the user sees this on the approval card."
+            "(e.g. 'Need the Sales agent for order-level revenue')."
         ),
     )
     title: Optional[str] = Field(
@@ -34,8 +32,8 @@ class SetReportAgentsOutput(BaseModel):
     success: bool = Field(..., description="Whether the focus was updated")
     focused_agent_ids: List[str] = Field(default_factory=list)
     focused_agent_names: List[str] = Field(default_factory=list)
-    # Names actually ATTACHED to the report by this call (approved expansion) —
-    # UI says "Added X to the report" for these vs "Focused on X".
+    # Names actually ATTACHED to the report by this call (training-mode
+    # curation) — UI says "Added X to the report" for these vs "Focused on X".
     added_agent_names: List[str] = Field(default_factory=list)
     rejected_ids: List[str] = Field(default_factory=list)
     message: Optional[str] = None

--- a/backend/tests/unit/test_agent_focus_scope.py
+++ b/backend/tests/unit/test_agent_focus_scope.py
@@ -2,9 +2,9 @@
 
 Requirements pinned here:
   - TRAINING: search/set operate only on agents the user can MANAGE.
-  - Chat/deep MANUAL selection: the user's agents come first; other accessible
-    agents are proposable but flagged as not attached (attached_ids excludes
-    them — expanding to one requires user approval).
+  - Chat/deep MANUAL selection: hard scope — the candidate pool is EXACTLY the
+    user's selected agents; other accessible agents are never searched, loaded,
+    or proposed.
   - Chat/deep AUTO (empty selection): the working set is every accessible
     agent, and everything counts as in-scope (nothing needs attach/approval).
 """
@@ -45,18 +45,18 @@ def _agent(i):
 
 
 @pytest.mark.asyncio
-async def test_manual_scope_is_selection_plus_proposable(monkeypatch):
+async def test_manual_scope_is_selection_only(monkeypatch):
     async def fake_accessible(db, org, user):
-        return [_agent(1), _agent(2), _agent(3)]  # org-wide accessible
+        raise AssertionError("manual scope must not enumerate accessible agents")
     monkeypatch.setattr(afc, "accessible_agents", fake_accessible)
 
     report = SimpleNamespace(data_sources=[_agent(1), _agent(2)])  # manual pick
     agents, scope, attached_ids = await resolve_candidate_agents(
         _FakeDB([]), SimpleNamespace(id="org"), SimpleNamespace(id="u"), report, "chat"
     )
-    assert scope == "attached+accessible"
-    assert [a.id for a in agents] == ["id1", "id2", "id3"]  # selection first, extras after
-    assert attached_ids == {"id1", "id2"}                    # id3 would need approval
+    assert scope == "attached"
+    assert [a.id for a in agents] == ["id1", "id2"]  # the selection, nothing else
+    assert attached_ids == {"id1", "id2"}
     assert not report_selection_is_auto(report)
 
 

--- a/backend/tests/unit/test_agent_roster.py
+++ b/backend/tests/unit/test_agent_roster.py
@@ -106,15 +106,3 @@ def test_render_roster_top_k_tail():
     assert "search_agents" in xml
     # true total always visible
     assert 'count="15"' in xml
-
-
-def test_manual_awareness_xml():
-    from app.ai.context.agent_roster import render_manual_awareness_xml
-    xml = render_manual_awareness_xml(["Gmail"], [("Music Store", False), ("PowerBI", True)])
-    assert 'count="3"' in xml and 'selected="1"' in xml
-    assert '<more_agents count="2">' in xml
-    assert "Music Store" in xml
-    assert "PowerBI (sign-in required)" in xml
-    assert "search_agents" in xml and "ask the user" in xml
-    # nothing beyond the selection -> no block at all
-    assert render_manual_awareness_xml(["Gmail"], []) is None


### PR DESCRIPTION
## Problem

When a user manually selects agent(s) for a report, the run could still see the rest of the org's accessible agents:

- `search_agents` searched across all accessible agents — matching on table names would surface unrelated sources and load their **full schemas** into the LLM context without approval.
- `set_report_agents` could attach an agent outside the selection after an Allow/Deny approval card.
- The planner context carried a names-only `<available_agents>` awareness block inviting it to propose other agents.

In practice (see the reported session) the planner searched for table names it already had in scope, matched 2–3 unrelated sources, and the UI showed their icons on a single-agent report — reading as "looking in other places."

## Change

A manual selection is now a **hard scope** — the run only searches/uses the selected agents:

- `resolve_candidate_agents` returns just the attached agents in chat/deep (scope `"attached"`); other accessible agents are never candidates for search or focus.
- `set_report_agents` rejects ids outside the selection outright, with a message telling the model to work with the selected agents or ask the user to widen the scope from the agent selector. The expansion approval flow (`_confirm_expansion`) is removed; the frontend approval card component remains so historic runs still render.
- The manual-awareness `<available_agents>` block is no longer injected into the planner context, and `render_manual_awareness_xml` is removed.

**Unchanged:** Auto (empty selection) still works across all accessible agents, and training mode still curates managed agents.

## Tests

- `test_agent_focus_scope.py`: manual-scope test now pins "selection only" and asserts `accessible_agents` is never enumerated in manual mode.
- `test_agent_roster.py`: removed the awareness-XML test alongside the removed helper.
- Targeted unit tests pass (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiFFLbuxrYzqZPPXJqS4qQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiFFLbuxrYzqZPPXJqS4qQ)_