### PR TITLE
Fix image attachment order with tool_result blocks

### DIFF
--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -226,6 +226,26 @@ class Anthropic(LLMClient):
         return out
 
     @staticmethod
+    def _attach_images(msgs: list[dict], image_blocks: list[dict]) -> None:
+        """Fold standalone image inputs into the last user turn, in place.
+
+        tool_result blocks must stay first in the user message that answers a
+        tool_use — the API rejects the request ("tool_use ids were found
+        without tool_result blocks immediately after") when any other block
+        precedes them. Images therefore land after the tool results, but ahead
+        of plain text (Anthropic recommends images before text).
+        """
+        if msgs and msgs[-1]["role"] == "user":
+            last = msgs[-1]
+            if isinstance(last["content"], str):
+                last["content"] = [{"type": "text", "text": last["content"]}]
+            results = [b for b in last["content"] if b.get("type") == "tool_result"]
+            rest = [b for b in last["content"] if b.get("type") != "tool_result"]
+            last["content"] = results + image_blocks + rest
+        else:
+            msgs.append({"role": "user", "content": image_blocks})
+
+    @staticmethod
     def _translate_tools(tools: list[ToolSpec]) -> list[dict]:
         return [
             {
@@ -260,13 +280,7 @@ class Anthropic(LLMClient):
                         "type": "image",
                         "source": {"type": "base64", "media_type": img.media_type, "data": img.data},
                     })
-            if msgs and msgs[-1]["role"] == "user":
-                last = msgs[-1]
-                if isinstance(last["content"], str):
-                    last["content"] = [{"type": "text", "text": last["content"]}]
-                last["content"] = image_blocks + last["content"]
-            else:
-                msgs.append({"role": "user", "content": image_blocks})
+            self._attach_images(msgs, image_blocks)
 
         request_kwargs: dict[str, Any] = {
             "model": model_id,

--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -327,9 +327,16 @@ class BedrockClient(LLMClient):
             image_blocks = [b for b in (self._image_block(img) for img in images) if b is not None]
             if image_blocks:
                 if bedrock_messages and bedrock_messages[-1]["role"] == "user":
-                    # Converse requires image blocks to precede any tool_result
-                    # block in a message; prepend so ordering stays valid.
-                    bedrock_messages[-1]["content"] = image_blocks + bedrock_messages[-1]["content"]
+                    # toolResult blocks must stay first in the user turn that
+                    # answers a tool_use — Anthropic models reject the request
+                    # ("tool_use ids were found without tool_result blocks
+                    # immediately after") when any other block precedes them.
+                    # Images land after the tool results but ahead of plain
+                    # text (Anthropic recommends images before text).
+                    last = bedrock_messages[-1]
+                    results = [b for b in last["content"] if "toolResult" in b]
+                    rest = [b for b in last["content"] if "toolResult" not in b]
+                    last["content"] = results + image_blocks + rest
                 else:
                     bedrock_messages.append({"role": "user", "content": image_blocks})
         request_kwargs: dict = {"modelId": model_id, "messages": bedrock_messages}

--- a/backend/tests/unit/test_anthropic_image_attach.py
+++ b/backend/tests/unit/test_anthropic_image_attach.py
@@ -1,0 +1,55 @@
+"""Standalone vision images must not displace tool_result blocks.
+
+The agent passes tool-produced images (rendered pages, screenshots) to the LLM
+call via the separate `images=` argument, at which point the last user message
+is the tool_result turn. Anthropic requires tool_result blocks to be the first
+content of that message — anything before them fails validation with
+"tool_use ids were found without tool_result blocks immediately after".
+"""
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.ai.llm.clients.anthropic_client import Anthropic  # noqa: E402
+from app.ai.llm.types import Message  # noqa: E402
+
+_IMG = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "x"}}
+
+
+def test_images_attach_after_tool_results():
+    msgs = Anthropic._translate_messages([
+        Message(role="user", content="read page 1"),
+        Message(role="assistant", content=[
+            {"type": "tool_use", "id": "call_0", "name": "read_file", "input": {"pages": "1"}},
+        ]),
+        Message(role="user", content=[
+            {"type": "tool_result", "tool_use_id": "call_0", "content": "rendered 1 page"},
+        ]),
+    ])
+    Anthropic._attach_images(msgs, [_IMG])
+
+    last = msgs[-1]["content"]
+    assert last[0]["type"] == "tool_result", "tool_result must stay the first block"
+    assert any(b["type"] == "image" for b in last[1:]), "image must still be attached"
+
+
+def test_images_precede_text_when_no_tool_results():
+    msgs = Anthropic._translate_messages([Message(role="user", content="what does this show?")])
+    Anthropic._attach_images(msgs, [_IMG])
+
+    last = msgs[-1]["content"]
+    assert last[0]["type"] == "image"
+    assert last[-1]["type"] == "text"
+
+
+def test_images_open_new_user_turn_after_assistant():
+    msgs = Anthropic._translate_messages([
+        Message(role="user", content="hi"),
+        Message(role="assistant", content="hello"),
+    ])
+    Anthropic._attach_images(msgs, [_IMG])
+
+    assert msgs[-1] == {"role": "user", "content": [_IMG]}

--- a/backend/tests/unit/test_bedrock_client_auth.py
+++ b/backend/tests/unit/test_bedrock_client_auth.py
@@ -132,6 +132,35 @@ async def test_inference_stream_v2_attaches_images_to_last_user_message():
 
 
 @pytest.mark.asyncio
+async def test_inference_stream_v2_images_go_after_tool_results():
+    """A tool that returns rendered images (e.g. a PDF page read as vision)
+    hands them to the LLM call via `images=` while the last user message is the
+    tool_result turn. The toolResult block must stay FIRST: Anthropic models
+    reject the request ("tool_use ids were found without tool_result blocks
+    immediately after") when an image precedes it."""
+    client = BedrockClient(region=_REGION, auth_mode="iam")
+    captured = _capture_converse_stream(client)
+
+    images = [ImageInput(data=_PNG_B64, media_type="image/png", source_type="base64")]
+    messages = [
+        Message(role="user", content="read page 1"),
+        Message(role="assistant", content=[
+            {"type": "tool_use", "id": "call_0", "name": "read_file", "input": {"pages": "1"}},
+        ]),
+        Message(role="user", content=[
+            {"type": "tool_result", "tool_use_id": "call_0", "content": "rendered 1 page"},
+        ]),
+    ]
+
+    await _drain(client.inference_stream_v2(model_id="anthropic.claude", messages=messages, images=images))
+
+    last = captured["messages"][-1]
+    assert last["role"] == "user"
+    assert "toolResult" in last["content"][0], "toolResult must stay the first block"
+    assert any("image" in b for b in last["content"][1:]), "image must still be attached"
+
+
+@pytest.mark.asyncio
 async def test_inference_stream_v2_skips_url_images():
     client = BedrockClient(region=_REGION, auth_mode="iam")
     captured = _capture_converse_stream(client)


### PR DESCRIPTION
## Summary
Fixed a critical issue where standalone vision images were being prepended to user messages containing tool_result blocks, causing Anthropic API validation errors. The API requires tool_result blocks to be the first content in a message, and rejects requests with the error "tool_use ids were found without tool_result blocks immediately after" when other blocks precede them.

## Key Changes
- **anthropic_client.py**: Extracted image attachment logic into a new `_attach_images()` static method that intelligently orders message content blocks:
  - Keeps tool_result blocks first (required by Anthropic API)
  - Places images after tool_results but before plain text (Anthropic's recommended order)
  - Opens a new user turn with images when the last message is from the assistant
  - Updated `inference_stream_v2()` to use the new method

- **bedrock_client.py**: Updated image attachment logic to match the same ordering rules:
  - Reordered blocks so toolResult blocks stay first
  - Images now come after toolResult blocks but before other content
  - Updated comments to clarify the Anthropic API requirement

- **test_anthropic_image_attach.py**: Added comprehensive unit tests covering:
  - Images correctly attach after tool_result blocks while keeping them first
  - Images precede text when no tool_results are present
  - Images open a new user turn when the last message is from the assistant

## Implementation Details
The fix ensures proper message structure for vision-enabled tool calls where tools return rendered content (e.g., PDF pages, screenshots) that need to be passed to the LLM via the `images=` parameter while the last user message contains the tool_result block.

https://claude.ai/code/session_012rtPs8LVKiL44WXBQ8Wmcx