### PR TITLE
Prevent folding of blocks carrying user-facing messages

### DIFF
--- a/frontend/composables/useBlockGrouping.ts
+++ b/frontend/composables/useBlockGrouping.ts
@@ -12,6 +12,9 @@
  * - Deliverables (create_data, artifacts, docs), clarify, approvals, the plan
  *   note, errors, and in-flight blocks NEVER fold: content and failures must
  *   stay visible, and the live block is the user's status line.
+ * - A block that carries a user-facing message (content / assistant /
+ *   final_answer) NEVER folds and breaks the run — folding would hide the
+ *   message. Only pure consecutive tool blocks group.
  * - ANY run of two or more consecutive chip-class blocks folds into one
  *   "live ticker" line (single morphing label while running, compact summary
  *   when settled) — one visual grammar for every run, no threshold split.
@@ -118,10 +121,19 @@ export function isGroupableBlock(block: any): boolean {
   if (!te || !GROUPABLE_TOOLS.has(te.tool_name)) return false
   if (FAILED_STATUSES.has(String(te.status || ''))) return false
   if (FAILED_STATUSES.has(String(block?.status || ''))) return false
-  // A block that carries the final answer (or any user-directed prose beyond
-  // the pre-tool sentence rendered inside the thinking box) is content.
-  if (block?.plan_decision?.final_answer) return false
+  // A block that carries a user-facing message is content, never a chip.
+  if (blockHasMessage(block)) return false
   return true
+}
+
+/** Whether a block carries user-facing message prose — block.content, the
+    planner's assistant_message, or the final answer. Both the report view and
+    the public share view render this text as the assistant message under the
+    thinking box, so folding such a block would hide it. */
+export function blockHasMessage(block: any): boolean {
+  const pd = block?.plan_decision
+  const hasText = (v: any) => typeof v === 'string' && v.trim() !== ''
+  return hasText(block?.content) || hasText(pd?.final_answer) || hasText(pd?.assistant)
 }
 
 /** Human label for a running tool, used when the block carries no LLM
@@ -353,7 +365,7 @@ export function computeBlockGroups(
     const b = list[i]
     if (opts?.breakBefore?.(b)) flush()
     const te = b?.tool_execution
-    const groupableTool = !!te && GROUPABLE_TOOLS.has(te.tool_name) && !b?.plan_decision?.final_answer
+    const groupableTool = !!te && GROUPABLE_TOOLS.has(te.tool_name) && !blockHasMessage(b)
     const errCls = classifyBlockError(b, i === list.length - 1)
     if (errCls === 'handled' && groupableTool) {
       // Absorbed: the run continues around a handled probe failure — it is

--- a/frontend/tests/unit/useBlockGrouping.mjs
+++ b/frontend/tests/unit/useBlockGrouping.mjs
@@ -50,6 +50,17 @@ assert.equal(
   isGroupableBlock(chip('read_file', { block: { plan_decision: { final_answer: 'done' } } })),
   false,
 )
+// blocks carrying a user-facing message are content, never chips
+assert.equal(
+  isGroupableBlock(chip('read_file', { block: { content: 'Let me check the tables first.' } })),
+  false,
+)
+assert.equal(
+  isGroupableBlock(chip('read_file', { block: { plan_decision: { assistant: 'Looking into it.' } } })),
+  false,
+)
+// whitespace-only text is not a message
+assert.equal(isGroupableBlock(chip('read_file', { block: { content: '  \n' } })), true)
 
 // --- computeBlockGroups -----------------------------------------------------
 
@@ -96,6 +107,34 @@ assert.equal(
   assert.equal(g.groupOf[a[0].id].count, 3)
   assert.equal(g.groupOf[mid.id], undefined)
   assert.equal(g.groupOf[b[0].id].count, 2)
+}
+
+// a chip that ALSO carries a message splits runs exactly like a deliverable:
+// 2 chips, chip-with-message, 2 chips -> two groups of 2, the message block
+// stays visible on its own
+{
+  const a = [chip('read_file'), chip('read_file')]
+  const mid = chip('describe_tables', { block: { content: 'The schema looks off — checking further.' } })
+  const b = [chip('read_file'), chip('read_file')]
+  const g = computeBlockGroups([...a, mid, ...b])
+  assert.equal(Object.keys(g.headerAt).length, 2)
+  assert.equal(g.groupOf[a[0].id].count, 2)
+  assert.equal(g.groupOf[mid.id], undefined)
+  assert.equal(g.groupOf[b[0].id].count, 2)
+}
+
+// a HANDLED error on a block that carries a message is NOT absorbed either
+{
+  const blocks = [
+    chip('read_file'),
+    chip('read_file'),
+    chip('read_file', { te: { status: 'error', result_summary: 'probe failed' }, block: { content: 'That did not work, trying another way.' } }),
+    chip('read_file'),
+    chip('read_file'),
+  ]
+  const g = computeBlockGroups(blocks)
+  assert.equal(Object.keys(g.headerAt).length, 2)
+  assert.equal(g.groupOf[blocks[2].id], undefined)
 }
 
 // a HANDLED error (run continued past it) is ABSORBED, counted as an issue


### PR DESCRIPTION
## Summary
Blocks that carry user-facing messages (content, assistant notes, or final answers) should never be folded into groupings, as this would hide important information from the user. This change extracts message detection logic into a reusable function and applies it consistently across block grouping logic.

## Key Changes
- **New `blockHasMessage()` function**: Centralizes detection of user-facing message prose across three fields:
  - `block.content` — direct block content
  - `block.plan_decision.final_answer` — final answer text
  - `block.plan_decision.assistant` — planner's assistant message
  
  Only non-empty, non-whitespace text counts as a message.

- **Updated `isGroupableBlock()`**: Now uses `blockHasMessage()` instead of only checking `final_answer`, catching all message-carrying blocks.

- **Updated `computeBlockGroups()`**: Applies the same message check when determining if a tool block can be absorbed into a grouping.

- **Documentation**: Added clarifying comments explaining that blocks with user-facing messages must stay visible and break runs, preventing folding that would hide content.

## Notable Details
- Whitespace-only text (e.g., `'  \n'`) is explicitly not treated as a message, allowing such blocks to still be grouped.
- The change ensures consistent behavior across both the grouping decision logic and the run computation logic.
- Test cases added verify that message-carrying blocks split groupings correctly, including edge cases like handled errors with messages.

https://claude.ai/code/session_01MXsJHxQoA8cJBpkDXjn9Lf