### PR TITLE
Add Export PDF to the public /r/{id} share page

### DIFF
--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -604,6 +604,52 @@ async def get_public_artifact(
     return await report_service.get_public_artifact(db, report_id, artifact_id, user=user)
 
 
+# One render per report at a time: each export launches a headless Chromium,
+# so concurrent clicks (or several viewers exporting the same dashboard) would
+# stack browser instances and race on the same uploads/pdfs/{artifact_id}.pdf.
+import asyncio as _asyncio
+from collections import defaultdict as _defaultdict
+_pdf_export_locks: dict[str, "_asyncio.Lock"] = _defaultdict(_asyncio.Lock)
+
+
+@router.get("/r/{report_id}/export_pdf")
+async def export_public_report_pdf(
+    report_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: User | None = Depends(current_user_optional),
+):
+    """Download the shared report's dashboard as a PDF.
+
+    Same renderer as the emailed dashboard share (ReportPdfService →
+    headless Chromium over the shared snapshot), same visibility gate as the
+    other /r read endpoints, and the same viewer-data policy: in
+    viewer-identity mode on user-scoped connections the shared snapshot is
+    withheld, so generate_for_report refuses and this returns 409.
+    """
+    # Raises 401/403/404 exactly like the page's other public endpoints.
+    schema = await report_service.get_public_report(db, report_id, user=user)
+
+    from app.services.report_pdf_service import ReportPdfService
+
+    async with _pdf_export_locks[str(report_id)]:
+        pdf_path = await ReportPdfService().generate_for_report(str(report_id))
+
+    import os
+    if not pdf_path or not os.path.isfile(pdf_path):
+        raise HTTPException(
+            status_code=409,
+            detail="PDF export is not available for this report",
+        )
+
+    from fastapi.responses import FileResponse
+    return FileResponse(
+        pdf_path,
+        media_type="application/pdf",
+        filename=f"{schema.title or 'report'}.pdf",
+        content_disposition_type="attachment",
+    )
+
+
 @router.post("/r/{report_id}/rerun", response_model=ReportRerunResultSchema)
 async def refresh_public_report_on_view(
     report_id: str,

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -93,6 +93,21 @@
                     <Icon name="heroicons:arrow-path" :class="['w-3.5 h-3.5', isRunning ? 'animate-spin' : '']" />
                     <span class="hidden sm:inline">{{ isRunning ? 'Running...' : 'Run' }}</span>
                 </button>
+                <!-- Export PDF: server-side render of the shared snapshot,
+                     same ReportPdfService pipeline as the emailed dashboard
+                     share. Hidden for doc artifacts (no server renderer) and
+                     when the snapshot is withheld (backend refuses anyway). -->
+                <button
+                    v-if="canExportPdf"
+                    @click="handleExportPdf"
+                    :disabled="isExportingPdf"
+                    class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-50"
+                    title="Download this dashboard as a PDF"
+                >
+                    <Icon :name="isExportingPdf ? 'heroicons:arrow-path' : 'heroicons:arrow-down-tray'"
+                        :class="['w-3.5 h-3.5', isExportingPdf ? 'animate-spin' : '']" />
+                    <span class="hidden sm:inline">{{ isExportingPdf ? 'Exporting...' : 'Export PDF' }}</span>
+                </button>
                 <!-- Fork button -->
                 <button
                     v-if="forkEligibility?.can_fork"
@@ -338,6 +353,46 @@ async function handleRun() {
         if (!viewerRunFailedReason.value) viewerRunFailedReason.value = runError.value;
     } finally {
         isRunning.value = false;
+    }
+}
+
+// Export PDF state. Docs have no server-side renderer (the backend refuses
+// them) and a withheld snapshot means there is no shared data to render, so
+// the button only shows for page/slides artifacts with a visible snapshot.
+const isExportingPdf = ref(false);
+const exportPdfError = ref<string | null>(null);
+const canExportPdf = computed(() =>
+    reportLoaded.value && hasArtifacts.value && !!artifact.value &&
+    artifact.value.mode !== 'doc' && !snapshotWithheld.value);
+
+async function handleExportPdf() {
+    if (isExportingPdf.value) return;
+    isExportingPdf.value = true;
+    exportPdfError.value = null;
+    try {
+        const { data, error: fetchError } = await useMyFetch(`/api/r/${report_id}/export_pdf`, {
+            responseType: 'blob' as any,
+        });
+        if (fetchError.value || !data.value) throw fetchError.value || new Error('PDF export failed');
+        const blob = data.value as Blob;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        // Strip filesystem-reserved characters only, so non-Latin titles
+        // (e.g. Hebrew) survive as the download name.
+        const base = String(pageTitle.value || 'report').replace(/[\\/:*?"<>|]+/g, ' ').trim();
+        a.download = `${base || 'report'}.pdf`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    } catch (e: any) {
+        console.error('PDF export failed:', e);
+        exportPdfError.value = e?.data?.detail || e?.message || 'PDF export failed';
+        // Surface it in the top bar's existing error slot.
+        runError.value = exportPdfError.value;
+    } finally {
+        isExportingPdf.value = false;
     }
 }
 


### PR DESCRIPTION
New public endpoint GET /api/r/{report_id}/export_pdf renders the shared
report's dashboard through the same ReportPdfService pipeline the emailed
dashboard share uses (headless Chromium over the shared snapshot), behind
the same artifact-visibility gate as the other /r read endpoints. A
per-report lock serializes concurrent exports so simultaneous clicks
don't stack browser instances or race on the output file. Snapshot
withheld (viewer-identity mode) or doc-only reports answer 409.

The share page's top bar gets an Export PDF button that downloads the
rendered file, named after the artifact/report title (non-Latin titles
preserved). Hidden for doc artifacts and withheld snapshots, where the
backend would refuse anyway.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XJLtSp1zJL8H1LSPupPdkn