### PR TITLE
Emit a session event when a report artifact is reverted to an earlier version

### DIFF
--- a/backend/app/ai/context/session_events.py
+++ b/backend/app/ai/context/session_events.py
@@ -61,6 +61,7 @@ ARTIFACT_SCHEDULE_SET = "artifact_schedule_set"
 ARTIFACT_SCHEDULE_CHANGED = "artifact_schedule_changed"
 ARTIFACT_SCHEDULE_REMOVED = "artifact_schedule_removed"
 ARTIFACT_DATA_REFRESHED = "artifact_data_refreshed"
+ARTIFACT_VERSION_REVERTED = "artifact_version_reverted"
 # knowledge / instructions
 INSTRUCTION_ACCEPTED = "instruction_accepted"
 INSTRUCTION_REJECTED = "instruction_rejected"
@@ -91,6 +92,7 @@ EVENT_UI_VISIBLE = {
     ARTIFACT_SCHEDULE_SET,
     ARTIFACT_SCHEDULE_CHANGED,
     ARTIFACT_SCHEDULE_REMOVED,
+    ARTIFACT_VERSION_REVERTED,
     # A review verdict is reached OUTSIDE the conversation (Knowledge Explorer),
     # so the timeline strip is the only place a reader of the report can see
     # that a suggestion this session produced was accepted or turned down.
@@ -220,6 +222,11 @@ def default_event_content(kind: str, meta: dict | None = None) -> str:
         return f'The refresh schedule for "{m.get("title") or "Artifact"}" was removed'
     if kind == ARTIFACT_DATA_REFRESHED:
         return f'Data for "{m.get("title") or "Artifact"}" was refreshed'
+    if kind == ARTIFACT_VERSION_REVERTED:
+        title = m.get("title") or "Artifact"
+        v = m.get("from_version")
+        return (f'"{title}" was reverted to version {v}' if v
+                else f'"{title}" was reverted to an earlier version')
 
     # An instruction routinely carries SEVERAL pending suggestions at once, so a
     # verdict that names only the instruction is ambiguous — "which one did they

--- a/backend/app/routes/artifact.py
+++ b/backend/app/routes/artifact.py
@@ -377,9 +377,24 @@ async def duplicate_artifact(
     db: AsyncSession = Depends(get_async_db),
 ):
     """Duplicate an artifact to make it the latest (default) version."""
+    original = await service.get(db, artifact_id)
     artifact = await service.duplicate(db, artifact_id, user_id=current_user.id)
     if not artifact:
         raise AppError.not_found(ErrorCode.ARTIFACT_NOT_FOUND, "Artifact not found")
+    # Silent session event: the user reverted the report to an earlier artifact
+    # version (same ledger as model changes / file uploads).
+    from types import SimpleNamespace
+    from app.services.session_event_service import SessionEventService
+    from app.ai.context.session_events import ARTIFACT_VERSION_REVERTED
+    await SessionEventService.emit_safe(
+        db, report=SimpleNamespace(id=str(artifact.report_id)),
+        kind=ARTIFACT_VERSION_REVERTED, user=current_user,
+        meta={"title": artifact.title,
+              "from_version": getattr(original, "version", None),
+              "new_version": artifact.version,
+              "source_artifact_id": str(artifact_id)},
+        target_type="artifact", target_id=str(artifact.id),
+    )
     return ArtifactSchema.model_validate(artifact)
 
 

--- a/backend/tests/unit/test_session_events.py
+++ b/backend/tests/unit/test_session_events.py
@@ -138,6 +138,13 @@ def test_policy_maps():
     from app.ai.context.session_events import INSTRUCTION_ACCEPTED, INSTRUCTION_REJECTED
     assert is_event_kind_ui_visible(INSTRUCTION_ACCEPTED) is True
     assert is_event_kind_ui_visible(INSTRUCTION_REJECTED) is True
+    # Reverting to an earlier artifact version is a user action the timeline
+    # (and the agent) should see, like a model change.
+    from app.ai.context.session_events import ARTIFACT_VERSION_REVERTED, default_event_content
+    assert is_event_kind_ui_visible(ARTIFACT_VERSION_REVERTED) is True
+    assert default_event_content(
+        ARTIFACT_VERSION_REVERTED, {"title": "Sales dashboard", "from_version": 3}
+    ) == '"Sales dashboard" was reverted to version 3'
     # LLM: everything except pure audit.
     assert is_event_kind_llm_visible(FEEDBACK_GIVEN) is True
     assert is_event_kind_llm_visible(EXPORT_DOWNLOADED) is False

--- a/frontend/components/SessionEvent.vue
+++ b/frontend/components/SessionEvent.vue
@@ -36,6 +36,7 @@ const ICONS: Record<string, string> = {
   artifact_schedule_set: 'heroicons-clock',
   artifact_schedule_changed: 'heroicons-clock',
   artifact_schedule_removed: 'heroicons-clock',
+  artifact_version_reverted: 'heroicons-arrow-uturn-left',
   instruction_accepted: 'heroicons-cube',
   instruction_rejected: 'heroicons-cube',
 }
@@ -99,6 +100,13 @@ function resolveKey(): { key: string | null; params: Record<string, any> } {
     case 'artifact_schedule_set': return { key: 'artifact_schedule_set', params: { title: meta.title || '' } }
     case 'artifact_schedule_changed': return { key: 'artifact_schedule_changed', params: { title: meta.title || '' } }
     case 'artifact_schedule_removed': return { key: 'artifact_schedule_removed', params: { title: meta.title || '' } }
+    case 'artifact_version_reverted': {
+      const title = meta.title || ''
+      const v = meta.from_version
+      return v
+        ? { key: 'artifact_version_reverted', params: { title, v } }
+        : { key: 'artifact_version_reverted_generic', params: { title } }
+    }
     default: return { key: null, params: {} }
   }
 }

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -857,6 +857,12 @@ async function useThisVersion() {
     }
 
     toast.add({ title: 'Version set as default', color: 'green' });
+
+    // The revert emits a silent artifact_version_reverted session event
+    // server-side — reload the timeline so its strip appears (no websocket).
+    window.dispatchEvent(new CustomEvent('report:mutated', {
+      detail: { reportId: props.reportId, kind: 'artifact_version' }
+    }));
   } catch (error: any) {
     console.error('Failed to set version as default:', error);
     toast.add({ title: 'Error', description: 'Failed to set version as default.', color: 'red' });

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1950,6 +1950,7 @@ const EVENT_UI_VISIBLE = new Set<string>([
 	'artifact_schedule_set',
 	'artifact_schedule_changed',
 	'artifact_schedule_removed',
+	'artifact_version_reverted',
 	'instruction_accepted',
 	'instruction_rejected',
 ])

--- a/locales/en.json
+++ b/locales/en.json
@@ -4237,6 +4237,8 @@
     "artifact_schedule_set": "A refresh was scheduled for \"{title}\"",
     "artifact_schedule_changed": "The refresh schedule for \"{title}\" was changed",
     "artifact_schedule_removed": "The refresh schedule for \"{title}\" was removed",
+    "artifact_version_reverted": "\"{title}\" was reverted to version {v}",
+    "artifact_version_reverted_generic": "\"{title}\" was reverted to an earlier version",
     "instruction_accepted_versioned": "Suggested edit to “{title}” (v{v}) was accepted",
     "instruction_accepted": "Suggested edit to “{title}” was accepted",
     "instruction_accepted_generic": "A suggested instruction edit was accepted",

--- a/locales/es.json
+++ b/locales/es.json
@@ -3992,6 +3992,8 @@
     "artifact_schedule_set": "Se programó una actualización para \"{title}\"",
     "artifact_schedule_changed": "Se cambió la programación de actualización de \"{title}\"",
     "artifact_schedule_removed": "Se eliminó la programación de actualización de \"{title}\"",
+    "artifact_version_reverted": "Se revirtió \"{title}\" a la versión {v}",
+    "artifact_version_reverted_generic": "Se revirtió \"{title}\" a una versión anterior",
     "instruction_accepted_versioned": "Se aceptó la edición sugerida de “{title}” (v{v})",
     "instruction_accepted": "Se aceptó la edición sugerida de “{title}”",
     "instruction_accepted_generic": "Se aceptó una edición sugerida de instrucción",

--- a/locales/he.json
+++ b/locales/he.json
@@ -3992,6 +3992,8 @@
     "artifact_schedule_set": "תוזמן רענון עבור \"{title}\"",
     "artifact_schedule_changed": "תזמון הרענון עבור \"{title}\" שונה",
     "artifact_schedule_removed": "תזמון הרענון עבור \"{title}\" הוסר",
+    "artifact_version_reverted": "\"{title}\" שוחזר לגרסה {v}",
+    "artifact_version_reverted_generic": "\"{title}\" שוחזר לגרסה קודמת",
     "instruction_accepted_versioned": "העריכה המוצעת ל-“{title}” (v{v}) אושרה",
     "instruction_accepted": "העריכה המוצעת ל-“{title}” אושרה",
     "instruction_accepted_generic": "עריכה מוצעת של הנחיה אושרה",


### PR DESCRIPTION
Clicking "Use this version" on a non-latest artifact now records an
artifact_version_reverted session event in the report timeline, matching
how model changes and file uploads are surfaced. The strip is UI-visible,
LLM-visible, and localized (en/es/he); the frontend reloads the timeline
via report:mutated after a successful revert.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LEvHNQRMkfRzUGdqcL75FJ