### PR TITLE
Stop write_csv runs dying on recoverable errors

### DIFF
--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -1186,11 +1186,14 @@ class Coder:
            in a column — they serialize as unreadable Python reprs.
         6. Cross-connection joins do not work in SQL; query each connection separately and merge in pandas.
         7. Use read-only operations on data sources (no insert/update/delete/drop).
-        8. **Embedding literal text values** (product names, RTL/Hebrew/Arabic text, anything
-           that may contain quotes): use triple-quoted strings (\"\"\"...\"\"\") or build the rows from a
-           triple-quoted CSV block via `io.StringIO` — never backslash-escape quotes inside
-           single-line string literals; mixed-direction text makes those escapes easy to get
-           wrong and the whole function fails to parse.
+        8. **Embedding literal text values**: Hebrew/Arabic text embeds the ASCII double-quote
+           INSIDE words as an abbreviation mark (e.g. ארה"ב, צה"ל, מנכ"ל), so quote-bearing
+           values are the norm there, not the exception. Wrap every text literal in SINGLE
+           quotes ('ארה"ב' — no escaping needed) or triple quotes; NEVER write double-quoted
+           literals with backslash-escaped quotes (\"...\") — mixed-direction text makes those
+           escapes easy to misplace and the whole function fails to parse. Avoid inline CSV
+           blocks for such text (embedded quotes break CSV parsing too); a list of
+           single-quoted tuples is the safe shape.
 
         **Print for verification**: `print(df.head())` and `print(f'Shape: {{df.shape}}')` so the shape
         is visible in the log. Printing is for verification only — the DataFrame is the deliverable.

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -1158,6 +1158,11 @@ class Coder:
            in a column — they serialize as unreadable Python reprs.
         6. Cross-connection joins do not work in SQL; query each connection separately and merge in pandas.
         7. Use read-only operations on data sources (no insert/update/delete/drop).
+        8. **Embedding literal text values** (product names, RTL/Hebrew/Arabic text, anything
+           that may contain quotes): use triple-quoted strings (\"\"\"...\"\"\") or build the rows from a
+           triple-quoted CSV block via `io.StringIO` — never backslash-escape quotes inside
+           single-line string literals; mixed-direction text makes those escapes easy to get
+           wrong and the whole function fails to parse.
 
         **Print for verification**: `print(df.head())` and `print(f'Shape: {{df.shape}}')` so the shape
         is visible in the log. Printing is for verification only — the DataFrame is the deliverable.

--- a/backend/app/ai/agents/coder/coder.py
+++ b/backend/app/ai/agents/coder/coder.py
@@ -5,7 +5,24 @@ from partialjson.json_parser import JSONParser
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.llm import LLM
-from app.ai.llm.types import Message, TextDeltaEvent
+from app.ai.llm.types import Message, MessageStopEvent, TextDeltaEvent
+
+
+# Raised message when a codegen stream stops at the model's output-token cap.
+# Truncated code is a guaranteed SyntaxError downstream ("unterminated string
+# literal") with feedback that misleads the retry — surfacing the cutoff here
+# routes an actionable message into the executor's retry loop instead.
+_TRUNCATION_ERROR = (
+    "the generated code hit the model's output-token limit and was cut off "
+    "mid-code. Regenerate a COMPACT version: build repetitive data "
+    "programmatically (loops, ranges, io.StringIO over a CSV block) instead of "
+    "inlining every row as a separate literal, and keep the row count to what "
+    "the request actually needs."
+)
+
+
+def _is_truncation(evt) -> bool:
+    return isinstance(evt, MessageStopEvent) and evt.stop_reason == "max_tokens"
 from app.models.llm_model import LLMModel
 import re
 import json
@@ -881,6 +898,7 @@ class Coder:
             """
 
             chunks: list[str] = []
+            truncated = False
             with tracer.start_as_current_span("coder.generate_code_stream") as span:
                 span.set_attribute("coder.retry", retries)
                 span.set_attribute("coder.prompt_chars", len(text))
@@ -892,8 +910,13 @@ class Coder:
                 ):
                     if isinstance(evt, TextDeltaEvent):
                         chunks.append(evt.text)
+                    elif _is_truncation(evt):
+                        truncated = True
                 span.set_attribute("coder.chunks", len(chunks))
                 span.set_attribute("coder.output_chars", sum(len(chunk) for chunk in chunks))
+                span.set_attribute("coder.truncated", truncated)
+            if truncated:
+                raise RuntimeError(_TRUNCATION_ERROR)
             result = "".join(chunks)
             result = re.sub(r'^\s*```(?:[A-Za-z0-9_\-]+)?\s*\r?\n', '', result.strip(), flags=re.IGNORECASE)
             result = re.sub(r'(?m)^\s*```\s*$', '', result)
@@ -1032,12 +1055,17 @@ class Coder:
         """
 
         chunks: list[str] = []
+        truncated = False
         async for evt in self.llm.inference_stream_v2(
             messages=[Message(role="user", content=text)],
             usage_scope="create_data.inspection",
         ):
             if isinstance(evt, TextDeltaEvent):
                 chunks.append(evt.text)
+            elif _is_truncation(evt):
+                truncated = True
+        if truncated:
+            raise RuntimeError(_TRUNCATION_ERROR)
         result = "".join(chunks)
 
         # Clean up code fences
@@ -1173,12 +1201,17 @@ class Coder:
         """
 
         chunks: list[str] = []
+        truncated = False
         async for evt in self.llm.inference_stream_v2(
             messages=[Message(role="user", content=text)],
             usage_scope="write_csv.transform",
         ):
             if isinstance(evt, TextDeltaEvent):
                 chunks.append(evt.text)
+            elif _is_truncation(evt):
+                truncated = True
+        if truncated:
+            raise RuntimeError(_TRUNCATION_ERROR)
         result = "".join(chunks)
 
         result = re.sub(r'^\s*```(?:[A-Za-z0-9_\-]+)?\s*\r?\n', '', result.strip(), flags=re.IGNORECASE)

--- a/backend/app/ai/runner/tool_runner.py
+++ b/backend/app/ai/runner/tool_runner.py
@@ -51,6 +51,10 @@ class ToolRunner:
         try:
             if getattr(tool, "input_model", None) is not None:
                 arguments = tool.input_model(**arguments).model_dump()
+            # A valid call ends the failure streak: the cap below is meant to
+            # stop a model stuck repeating the same malformed call, not to
+            # kill a long run over two isolated mistakes far apart.
+            self.validation_failure_counts.pop(tool.name, None)
         except PydValidationError as ve:
             failures = self.validation_failure_counts.get(tool.name, 0) + 1
             self.validation_failure_counts[tool.name] = failures
@@ -58,28 +62,42 @@ class ToolRunner:
             # Build detailed error message
             error_details = ve.errors()
             field_errors = [f"{'.'.join(map(str, err['loc']))}: {err['msg']}" for err in error_details]
+            error_message = f"Validation failed: {'; '.join(field_errors)}"
+
+            # The "output" half lands in the tool_execution's result_json —
+            # without success=False there, the UI renders the failed call as
+            # a completed tool ("CSV written ✓" on a call that never ran).
+            failed_output = {"success": False, "error_message": error_message}
 
             if failures >= self.max_validation_failures:
                 return {
-                    "summary": f"Tool '{tool.name}' failed validation {self.max_validation_failures} times and cannot be executed",
-                    "error": {
-                        "type": "repeated_validation_error", 
-                        "message": f"Repeated validation failures: {'; '.join(field_errors)}",
-                        "details": error_details,
-                        "suggestion": "Check tool schema requirements and fix input format"
+                    "observation": {
+                        "summary": f"Tool '{tool.name}' failed validation {self.max_validation_failures} times and cannot be executed",
+                        "success": False,
+                        "error": {
+                            "type": "repeated_validation_error",
+                            "message": f"Repeated validation failures: {'; '.join(field_errors)}",
+                            "details": error_details,
+                            "suggestion": "Check tool schema requirements and fix input format"
+                        },
+                        "analysis_complete": True,
+                        "final_answer": f"Unable to complete task due to repeated tool validation errors: {'; '.join(field_errors)}"
                     },
-                    "analysis_complete": True,
-                    "final_answer": f"Unable to complete task due to repeated tool validation errors: {'; '.join(field_errors)}"
+                    "output": failed_output,
                 }
-            
+
             return {
-                "summary": f"Invalid input for '{tool.name}' (attempt {failures}/{self.max_validation_failures})",
-                "error": {
-                    "type": "validation_error", 
-                    "details": error_details,
-                    "field_errors": field_errors,
-                    "message": f"Validation failed: {'; '.join(field_errors)}"
+                "observation": {
+                    "summary": f"Invalid input for '{tool.name}' (attempt {failures}/{self.max_validation_failures})",
+                    "success": False,
+                    "error": {
+                        "type": "validation_error",
+                        "details": error_details,
+                        "field_errors": field_errors,
+                        "message": error_message
+                    },
                 },
+                "output": failed_output,
             }
 
         attempt = 0
@@ -152,8 +170,6 @@ class ToolRunner:
                     if hard_timer and not hard_timer.cancelled():
                         hard_timer.cancel()
 
-                # Reset this tool's validation failure streak on successful execution
-                self.validation_failure_counts.pop(tool.name, None)
                 # Output schema validation (generic)
                 if getattr(tool, "output_model", None) is not None and last_output is not None:
                     try:

--- a/backend/app/ai/tools/implementations/write_csv.py
+++ b/backend/app/ai/tools/implementations/write_csv.py
@@ -35,8 +35,10 @@ def _derive_csv_filename(title: str | None) -> str:
     if not title:
         return _DEFAULT_CSV_FILENAME
 
-    # Keep alphanumerics, dashes and underscores; collapse everything else.
-    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", title.strip())
+    # Keep word characters in ANY script (Hebrew/Arabic/CJK titles must
+    # survive — an ASCII-only allowlist reduced them to the generic default),
+    # plus dashes and dots; collapse everything else.
+    slug = re.sub(r"[^\w.-]+", "_", title.strip(), flags=re.UNICODE)
     slug = re.sub(r"_+", "_", slug).strip("._-")
     # Drop any extension the slug may carry so we control the suffix.
     slug = re.sub(r"\.csv$", "", slug, flags=re.IGNORECASE)

--- a/backend/app/ai/tools/implementations/write_csv.py
+++ b/backend/app/ai/tools/implementations/write_csv.py
@@ -75,6 +75,13 @@ Do not use when:
       create_data(source_file_ids=[file_id]) instead — it loads the file directly.
     - You need to query a SQL database (use create_data instead)
     - The input is a large or irregular UNSTRUCTURED file (raw log, free-text doc, transcript) and the ask is narrative ("why", "what happened", "summarize") — read it in windows (read_file offset/length) and accumulate findings in a note instead of loading it here. Only use write_csv on unstructured input when it has a regular, parseable pattern AND the ask needs aggregation.
+
+Arguments:
+    - user_prompt (REQUIRED): what data to generate or how to transform the input,
+      e.g. "Parse the log lines, extract timestamp/level/message, keep ERROR rows only".
+    - title: short title for the result; also names the saved CSV file.
+    - source_file_ids: file IDs the code should read (e.g. the file_id from execute_mcp).
+    - tables_by_source: optional tables to resolve for context.
             """,
             category="action",
             version="1.0.0",
@@ -218,7 +225,12 @@ Do not use when:
         execution_start = time.monotonic()
 
         async for e in streamer.generate_and_execute_stream_v2(
-            request=CodeGenRequest(context=codegen_context, retries=1),
+            # No explicit retries: fall back to the org's `limit_code_retries`
+            # like create_data/inspect_data do. The hard-coded retries=1 gave
+            # write_csv a single attempt — any codegen syntax slip (e.g. bad
+            # quote escaping in RTL text) failed the tool instead of being
+            # fed back to the coder for a fix.
+            request=CodeGenRequest(context=codegen_context),
             ds_clients=runtime_ctx.get("ds_clients", {}),
             excel_files=(
                 scoped_files if scoped_files else runtime_ctx.get("excel_files", [])

--- a/backend/app/ai/tools/schemas/write_csv.py
+++ b/backend/app/ai/tools/schemas/write_csv.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, Dict, Any
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, model_validator
 
 
 class WriteCsvInput(BaseModel):
@@ -7,6 +7,21 @@ class WriteCsvInput(BaseModel):
         ...,
         description="Description of what data to generate or how to transform raw data. E.g. 'Create a table with columns A, B, C' or 'Parse logs, extract timestamp, level, message. Filter ERROR only.'"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_user_prompt(cls, values: Any) -> Any:
+        # Models routinely rename or drop this field ("prompt", or title-only
+        # calls), and a missing required field burns a validation strike that
+        # can kill the whole run. Recover the intent instead of failing.
+        if isinstance(values, dict) and not values.get("user_prompt"):
+            fallbacks = ("prompt", "instruction", "description", "task", "title")
+            for key in fallbacks:
+                v = values.get(key)
+                if isinstance(v, str) and v.strip():
+                    values["user_prompt"] = v.strip()
+                    break
+        return values
     title: Optional[str] = Field(
         default=None,
         description="Title for the generated data visualization. Also used to name the saved CSV file, so prefer a short, descriptive title (e.g. 'Software Houses Income Tax 2025'). If not provided, a default title and filename will be used."

--- a/backend/tests/unit/test_coder_truncation.py
+++ b/backend/tests/unit/test_coder_truncation.py
@@ -1,0 +1,75 @@
+"""Codegen truncation detection.
+
+When the coder's LLM stream stops at the model's output-token cap (e.g. a
+write_csv call that inlines hundreds of literal rows), the collected text is
+cut off mid-string. Executing it is a guaranteed "unterminated string literal"
+SyntaxError whose feedback misleads the retry. The coder must instead raise
+with an actionable message, which the executor's retry loop feeds back to the
+next generation attempt.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.ai.agents.coder.coder import Coder, _TRUNCATION_ERROR, _is_truncation
+from app.ai.llm.types import MessageStopEvent, TextDeltaEvent
+
+
+class _FakeLLM:
+    def __init__(self, events):
+        self._events = events
+
+    async def inference_stream_v2(self, **kwargs):
+        for evt in self._events:
+            yield evt
+
+
+def _bare_coder(events, monkeypatch) -> Coder:
+    coder = object.__new__(Coder)
+    coder.llm = _FakeLLM(events)
+    monkeypatch.setattr(Coder, "_time_context", lambda self: "now")
+    return coder
+
+
+def _transform_kwargs():
+    return dict(
+        prompt="build a table",
+        schemas="",
+        ds_clients={},
+        excel_files=[],
+        code_and_error_messages=[],
+        memories="",
+        previous_messages="",
+        retries=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncated_transform_stream_raises(monkeypatch):
+    events = [
+        TextDeltaEvent(text="def generate_df(ds_clients, excel_files):\n"),
+        TextDeltaEvent(text='    rows = [("a", "unterminated'),
+        MessageStopEvent(stop_reason="max_tokens"),
+    ]
+    coder = _bare_coder(events, monkeypatch)
+    with pytest.raises(RuntimeError, match="output-token limit"):
+        await coder.generate_transform_code(**_transform_kwargs())
+
+
+@pytest.mark.asyncio
+async def test_complete_transform_stream_returns_code(monkeypatch):
+    code = "def generate_df(ds_clients, excel_files):\n    return None"
+    events = [
+        TextDeltaEvent(text=code),
+        MessageStopEvent(stop_reason="end_turn"),
+    ]
+    coder = _bare_coder(events, monkeypatch)
+    result = await coder.generate_transform_code(**_transform_kwargs())
+    assert "def generate_df" in result
+
+
+def test_is_truncation_only_matches_max_tokens():
+    assert _is_truncation(MessageStopEvent(stop_reason="max_tokens"))
+    assert not _is_truncation(MessageStopEvent(stop_reason="end_turn"))
+    assert not _is_truncation(TextDeltaEvent(text="max_tokens"))
+    assert _TRUNCATION_ERROR  # message exists and is non-empty

--- a/backend/tests/unit/test_concurrent_tool_dispatch.py
+++ b/backend/tests/unit/test_concurrent_tool_dispatch.py
@@ -560,19 +560,19 @@ async def test_validation_failures_tracked_per_tool_not_globally():
     a, b = _ValidatingTool(), _OtherTool()
 
     r1 = await runner.run(a, {}, {}, _noop_emit)  # invalid input for a
-    assert r1["error"]["type"] == "validation_error"
+    assert r1["observation"]["error"]["type"] == "validation_error"
 
     # A SUCCESS on tool b must not reset tool a's streak
     rb = await runner.run(b, {"required_field": "x"}, {}, _noop_emit)
     assert "error" not in rb.get("observation", {})
 
     r2 = await runner.run(a, {}, {}, _noop_emit)  # second invalid input for a
-    assert r2["error"]["type"] == "repeated_validation_error"
-    assert r2.get("analysis_complete") is True
+    assert r2["observation"]["error"]["type"] == "repeated_validation_error"
+    assert r2["observation"].get("analysis_complete") is True
 
     # And tool b's own streak is independent
     rb1 = await runner.run(b, {}, {}, _noop_emit)
-    assert rb1["error"]["type"] == "validation_error"
+    assert rb1["observation"]["error"]["type"] == "validation_error"
 
 
 @pytest.mark.asyncio
@@ -582,7 +582,7 @@ async def test_success_resets_only_that_tools_streak():
     await runner.run(a, {}, {}, _noop_emit)               # streak 1
     await runner.run(a, {"required_field": "x"}, {}, _noop_emit)  # success -> reset
     r = await runner.run(a, {}, {}, _noop_emit)
-    assert r["error"]["type"] == "validation_error"       # streak restarted, not terminal
+    assert r["observation"]["error"]["type"] == "validation_error"  # streak restarted, not terminal
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_tool_runner_validation.py
+++ b/backend/tests/unit/test_tool_runner_validation.py
@@ -1,0 +1,91 @@
+"""ToolRunner input-validation failure handling.
+
+Two regressions from the write_csv "user_prompt: Field required" incident:
+
+1. The failure counter was never reset on a valid call, so two isolated
+   malformed calls anywhere in a long run — even with successes in between —
+   tripped the cap and killed the whole run with a forced final_answer.
+2. Validation failures returned a bare observation with no ``output`` half,
+   so the tool_execution's result_json carried no ``success: False`` and the
+   UI rendered the failed call as a completed tool ("CSV written ✓").
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator, Type
+
+import pytest
+from pydantic import BaseModel, Field
+
+from app.ai.runner.tool_runner import ToolRunner
+
+
+class _EchoInput(BaseModel):
+    user_prompt: str = Field(...)
+
+
+class _FakeTool:
+    name = "fake_tool"
+    spec = None
+    metadata = None
+
+    @property
+    def input_model(self) -> Type[BaseModel]:
+        return _EchoInput
+
+    output_model = None
+
+    async def run_stream(self, tool_input, runtime_ctx) -> AsyncIterator[dict]:
+        yield {
+            "type": "tool.end",
+            "payload": {
+                "output": {"echo": tool_input},
+                "observation": {"summary": "ok", "success": True},
+            },
+        }
+
+
+async def _noop_emit(event):
+    return None
+
+
+async def _run(runner, arguments):
+    return await runner.run(_FakeTool(), arguments, {"mode": "chat"}, _noop_emit)
+
+
+@pytest.mark.asyncio
+async def test_validation_failure_reports_failed_output():
+    runner = ToolRunner()
+    result = await _run(runner, {})
+
+    observation = result["observation"]
+    assert observation["success"] is False
+    assert observation["error"]["type"] == "validation_error"
+    assert "analysis_complete" not in observation
+
+    output = result["output"]
+    assert output["success"] is False
+    assert "user_prompt" in output["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_consecutive_failures_terminate():
+    runner = ToolRunner()
+    await _run(runner, {})
+    result = await _run(runner, {})
+
+    observation = result["observation"]
+    assert observation["error"]["type"] == "repeated_validation_error"
+    assert observation["analysis_complete"] is True
+    assert "user_prompt" in observation["final_answer"]
+    assert result["output"]["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_valid_call_resets_failure_streak():
+    runner = ToolRunner()
+    await _run(runner, {})  # strike 1
+    await _run(runner, {"user_prompt": "ok"})  # valid call clears the streak
+    result = await _run(runner, {})  # counts as strike 1 again, not strike 2
+
+    assert result["observation"]["error"]["type"] == "validation_error"
+    assert "analysis_complete" not in result["observation"]

--- a/backend/tests/unit/test_write_csv_filename.py
+++ b/backend/tests/unit/test_write_csv_filename.py
@@ -22,6 +22,10 @@ from app.ai.tools.implementations.write_csv import (
         ("Software Houses Income Tax 2025", "Software_Houses_Income_Tax_2025.csv"),
         ("Sales — Q1/Q2 (2025)!!!", "Sales_Q1_Q2_2025.csv"),
         ("report.csv", "report.csv"),  # existing extension is normalized, not doubled
+        # Non-ASCII scripts survive — an ASCII-only allowlist stripped Hebrew
+        # titles down to digits ("2025.csv") or the generic default.
+        ("מס הכנסה בתי תוכנה 2025", "מס_הכנסה_בתי_תוכנה_2025.csv"),
+        ('Sales ארה"ב Q1', "Sales_ארה_ב_Q1.csv"),  # the abbreviation quote is not filename-safe
     ],
 )
 def test_derives_readable_name(title, expected):

--- a/backend/tests/unit/test_write_csv_prompt_fallback.py
+++ b/backend/tests/unit/test_write_csv_prompt_fallback.py
@@ -1,0 +1,51 @@
+"""write_csv input tolerance for the ``user_prompt`` field.
+
+Planners that only see the tool's prose description (no JSON schema) routinely
+rename the field ("prompt") or omit it in favor of ``title`` +
+``source_file_ids``. Each such call used to burn a validation strike — two of
+them killed the whole run with "user_prompt: Field required". The input model
+now recovers the intent from common aliases and falls back to the title.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.tools.schemas.write_csv import WriteCsvInput
+
+
+def test_user_prompt_passes_through():
+    data = WriteCsvInput(user_prompt="Parse the logs", title="Errors")
+    assert data.user_prompt == "Parse the logs"
+
+
+@pytest.mark.parametrize("alias", ["prompt", "instruction", "description", "task"])
+def test_common_aliases_accepted(alias):
+    data = WriteCsvInput(**{alias: "Parse the logs"})
+    assert data.user_prompt == "Parse the logs"
+
+
+def test_title_only_call_falls_back_to_title():
+    data = WriteCsvInput(title="Software Houses Income Tax 2025")
+    assert data.user_prompt == "Software Houses Income Tax 2025"
+    assert data.title == "Software Houses Income Tax 2025"
+
+
+def test_explicit_user_prompt_wins_over_alias_and_title():
+    data = WriteCsvInput(user_prompt="real", prompt="alias", title="title")
+    assert data.user_prompt == "real"
+
+
+def test_blank_alias_is_skipped():
+    data = WriteCsvInput(prompt="   ", title="Fallback Title")
+    assert data.user_prompt == "Fallback Title"
+
+
+def test_still_required_when_nothing_usable():
+    with pytest.raises(ValidationError):
+        WriteCsvInput(source_file_ids=["abc"])
+
+
+def test_json_schema_still_advertises_user_prompt_required():
+    schema = WriteCsvInput.model_json_schema()
+    assert "user_prompt" in schema.get("required", [])


### PR DESCRIPTION
Two failure modes kept killing write_csv in production:

1. "user_prompt: Field required" — planners slip into the dominant
   `prompt` arg name (create_artifact/create_dashboard/generate_image all
   use it) or send title-only calls. Each malformed call burned a
   validation strike that never reset, and two strikes anywhere in a run
   hard-killed it with a forced final_answer — while the UI rendered the
   failed calls as "CSV written ✓" because the validation return carried
   no success flag.

2. Codegen syntax slips (e.g. backslash-escaped quotes inside Hebrew
   text) failed the tool outright: write_csv hard-coded retries=1, so it
   was the only codegen tool without the error-feedback retry loop.

Fixes:
- WriteCsvInput recovers user_prompt from common aliases (prompt,
  instruction, description, task) and falls back to title; the JSON
  schema still advertises it as required.
- ToolRunner resets a tool's validation-failure streak on the next valid
  call, and returns validation failures as observation+output so
  result_json carries success=false and the UI shows a real error.
- write_csv name its arguments in the tool description, and uses the
  org's limit_code_retries budget like create_data/inspect_data.
- Transform codegen prompt: embed quote-bearing literals via
  triple-quoted strings/StringIO instead of escaped quotes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018MPUEz4mBf1sTMwtfPDCU8