### PR TITLE
Fix Splunk connector on deployments that reject wildcard index searches

### DIFF
--- a/backend/app/data_sources/clients/splunk_client.py
+++ b/backend/app/data_sources/clients/splunk_client.py
@@ -28,6 +28,8 @@ Auth is Splunk-native:
   - `userpass` → HTTP basic against the management port (older on-prem installs).
 """
 import json
+import logging
+import re
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -36,6 +38,7 @@ import requests
 from app.data_sources.clients.base import DataSourceClient
 from app.ai.prompt_formatters import Table, TableColumn, ServiceFormatter
 
+logger = logging.getLogger(__name__)
 
 MAX_ROWS = 50_000              # hard cap per execute_query
 DEFAULT_LIMIT = 1_000         # when the query spec omits `limit`
@@ -43,6 +46,11 @@ HTTP_TIMEOUT = 180            # seconds per REST request (searches can be slow)
 SAMPLE_EVENTS = 500          # events sampled per sourcetype for field discovery
 DEFAULT_MAX_SAMPLED = 50     # top-K sourcetypes that get field sampling
 CATALOG_SEARCH = "| tstats count where index=* by index, sourcetype"
+INDEX_CHUNK = 20             # indexes per OR-list tstats when wildcards are blocked
+
+# An SPL wildcard-index reference (`index=*`). Hardened deployments (Splunk
+# Cloud guardrails, ES-restricted roles) reject searches containing it.
+_WILDCARD_INDEX = re.compile(r'index\s*=\s*"?\*', re.IGNORECASE)
 
 
 class SplunkClient(DataSourceClient):
@@ -57,6 +65,7 @@ class SplunkClient(DataSourceClient):
         verify_ssl: bool = True,
         discovery_window_days: int = 7,
         max_sampled_sourcetypes: int = DEFAULT_MAX_SAMPLED,
+        indexes: Optional[str] = None,
     ):
         # Accept a bare host, host:port, or a full URL. Normalize to the
         # management-port base URL (https by default).
@@ -73,6 +82,17 @@ class SplunkClient(DataSourceClient):
         self.verify_ssl = verify_ssl
         self.discovery_window_days = int(discovery_window_days or 7)
         self.max_sampled_sourcetypes = int(max_sampled_sourcetypes or DEFAULT_MAX_SAMPLED)
+        # Optional comma-separated index scope (also the escape hatch when the
+        # deployment denies both wildcard searches and index enumeration).
+        self._config_indexes: List[str] = []
+        if isinstance(indexes, str) and indexes.strip():
+            seen = set()
+            for part in indexes.split(","):
+                p = part.strip()
+                if p and p not in seen:
+                    seen.add(p)
+                    self._config_indexes.append(p)
+        self._indexes_cache: Optional[List[str]] = None
 
     @property
     def description(self):
@@ -165,7 +185,17 @@ class SplunkClient(DataSourceClient):
         # Surface search-time messages (e.g. bad SPL) as errors.
         for msg in (body.get("messages") or []):
             if msg.get("type", "").upper() in ("ERROR", "FATAL"):
-                raise RuntimeError(f"Splunk search error: {msg.get('text')}")
+                text = f"Splunk search error: {msg.get('text')}"
+                # A wildcard-index search rejected by a hardened deployment is
+                # recoverable — tell the caller (usually the agent) which
+                # indexes exist so it can rewrite with an explicit index.
+                if _WILDCARD_INDEX.search(spl or ""):
+                    known = self._known_indexes()
+                    if known:
+                        text += (" Hint: this deployment may forbid wildcard index "
+                                 "searches — rewrite the search with an explicit index. "
+                                 f"Known indexes: {', '.join(known)}.")
+                raise RuntimeError(text)
         return body.get("results") or []
 
     # ── connection ──────────────────────────────────────────────────────────
@@ -186,41 +216,128 @@ class SplunkClient(DataSourceClient):
     def _window(self) -> str:
         return f"-{self.discovery_window_days}d"
 
-    def _catalog_pairs(self) -> List[Dict[str, Any]]:
-        """Cheap `index::sourcetype` enumeration via tstats (tsidx metadata).
+    def _list_indexes(self) -> List[str]:
+        """Index names visible to the connection, via the REST index catalog
+        (`GET /services/data/indexes`) — NO search runs, so it works even on
+        deployments that reject wildcard index searches.
 
-        Falls back to a metadata search if tstats is unavailable (rare).
+        Best-effort: an error (endpoint denied to the role) returns [].
+        Internal indexes (leading `_`) are excluded. Cached per client.
         """
+        if self._indexes_cache is not None:
+            return self._indexes_cache
+        names: List[str] = []
         try:
-            rows = self._run_search(CATALOG_SEARCH, earliest=self._window(),
-                                    latest="now", count=MAX_ROWS)
+            body = self._get("/services/data/indexes", params={"count": 0})
+            for entry in (body.get("entry") or []):
+                name = entry.get("name")
+                if name and not name.startswith("_"):
+                    names.append(name)
+        except Exception as e:
+            logger.warning(f"Splunk index enumeration failed: {e}")
+        self._indexes_cache = names
+        return names
+
+    def _known_indexes(self) -> List[str]:
+        """Indexes to scope searches to: the admin-configured list wins,
+        otherwise the REST-enumerated list."""
+        return self._config_indexes or self._list_indexes()
+
+    @staticmethod
+    def _scoped_catalog_search(indexes: List[str]) -> str:
+        clause = " OR ".join(f"index={i}" for i in indexes)
+        return f"| tstats count where ({clause}) by index, sourcetype"
+
+    def _catalog_pairs(self) -> List[Dict[str, Any]]:
+        """`index::sourcetype` enumeration via tstats (tsidx metadata).
+
+        Three tiers, all cheap:
+          1. One global `index=*` tstats — the fast path on deployments that
+             allow wildcard searches (skipped when the admin scoped `indexes`).
+          2. Explicit OR-list tstats over the known indexes (configured or
+             REST-enumerated) — no wildcard, so it survives hardened
+             deployments that reject `index=*`. Chunked to bound SPL length.
+          3. `| metadata` — sourcetypes only, no index pairing. The index is
+             recorded as UNKNOWN (None), never `*`: storing a wildcard here
+             poisons every later query on restricted deployments.
+        """
+        if not self._config_indexes:
+            try:
+                rows = self._run_search(CATALOG_SEARCH, earliest=self._window(),
+                                        latest="now", count=MAX_ROWS)
+                if rows:
+                    return rows
+            except Exception as e:
+                logger.warning(
+                    f"Splunk wildcard tstats catalog failed (deployment may forbid "
+                    f"index=*); falling back to explicit index enumeration: {e}")
+        # Tier 2: explicit OR-list tstats over known indexes.
+        known = self._known_indexes()
+        if known:
+            rows: List[Dict[str, Any]] = []
+            for i in range(0, len(known), INDEX_CHUNK):
+                chunk = known[i:i + INDEX_CHUNK]
+                try:
+                    rows.extend(self._run_search(
+                        self._scoped_catalog_search(chunk),
+                        earliest=self._window(), latest="now", count=MAX_ROWS))
+                except Exception as e:
+                    logger.warning(f"Splunk scoped tstats catalog failed for {chunk}: {e}")
             if rows:
                 return rows
-        except Exception as e:
-            print(f"Splunk tstats catalog failed, falling back to metadata: {e}")
-        # Fallback: metadata gives sourcetypes but not the index pairing.
+        # Tier 3: metadata — no index pairing; record the index as unknown.
         try:
             rows = self._run_search("| metadata type=sourcetypes index=*",
                                     earliest=self._window(), latest="now", count=MAX_ROWS)
-            return [{"index": "*", "sourcetype": r.get("sourcetype"),
+            return [{"index": None, "sourcetype": r.get("sourcetype"),
                      "count": r.get("totalCount")} for r in rows if r.get("sourcetype")]
         except Exception as e:
-            print(f"Splunk metadata catalog failed: {e}")
+            logger.warning(f"Splunk metadata catalog failed: {e}")
             return []
 
-    def _sample_fields(self, index: str, sourcetype: str) -> List[TableColumn]:
+    def _resolve_index(self, sourcetype: str) -> Optional[str]:
+        """Find which known index holds a sourcetype — one OR-list tstats per
+        chunk, no wildcard. Returns None when it can't be determined."""
+        known = self._known_indexes()
+        for i in range(0, len(known), INDEX_CHUNK):
+            chunk = known[i:i + INDEX_CHUNK]
+            clause = " OR ".join(f"index={x}" for x in chunk)
+            spl = (f'| tstats count where ({clause}) sourcetype="{sourcetype}" '
+                   f'by index | sort - count')
+            try:
+                rows = self._run_search(spl, earliest=self._window(), latest="now", count=10)
+            except Exception as e:
+                logger.warning(f"Splunk index resolution failed for {sourcetype}: {e}")
+                continue
+            for r in rows:
+                if r.get("index"):
+                    return r["index"]
+        return None
+
+    def _sample_fields(self, index: Optional[str], sourcetype: str) -> List[TableColumn]:
         """Sample fields for one sourcetype via a bounded fieldsummary search.
 
         Best-effort: any failure returns [] (the table stays thin). Bounded by
         the discovery window + a head cap so it can't scan all-time.
+
+        NEVER emits `index=*` — hardened deployments reject wildcard index
+        searches outright. An unknown index is resolved via the index catalog
+        first; if it still can't be determined, the table stays thin.
         """
-        idx = "*" if index in (None, "", "*") else index
+        idx = None if index in (None, "", "*") else index
+        if idx is None:
+            idx = self._resolve_index(sourcetype)
+        if idx is None:
+            logger.warning(
+                f"Splunk field sample skipped for sourcetype='{sourcetype}': "
+                f"index unknown and could not be resolved (wildcard searches not used).")
+            return []
         spl = (f'search index={idx} sourcetype="{sourcetype}" '
                f'| head {SAMPLE_EVENTS} | fieldsummary maxvals=0')
         try:
             rows = self._run_search(spl, earliest=self._window(), latest="now", count=1000)
         except Exception as e:
-            print(f"Splunk field sample failed for {index}::{sourcetype}: {e}")
+            logger.warning(f"Splunk field sample failed for {idx}::{sourcetype}: {e}")
             return []
         columns: List[TableColumn] = []
         for r in rows:
@@ -260,11 +377,13 @@ class SplunkClient(DataSourceClient):
 
         tables: List[Table] = []
         for i, p in enumerate(pairs):
-            index = p.get("index") or "*"
+            index = p.get("index") or None
+            if index == "*":
+                index = None
             sourcetype = p.get("sourcetype")
             if not sourcetype:
                 continue
-            name = f"{index}::{sourcetype}"
+            name = f"{index}::{sourcetype}" if index else sourcetype
             count = _cnt(p)
             columns: List[TableColumn] = []
             sampled = i < self.max_sampled_sourcetypes
@@ -274,13 +393,23 @@ class SplunkClient(DataSourceClient):
                 desc = (f"Splunk events: index='{index}', sourcetype='{sourcetype}' "
                         f"(~{count:,} events, fields sampled from last "
                         f"{self.discovery_window_days}d).")
-            else:
+            elif index:
                 desc = (f"Splunk events: index='{index}', sourcetype='{sourcetype}' "
                         f"(~{count:,} events). Schema-on-read: fields NOT pre-sampled "
                         f"(cost cap) — the data IS present. You MUST discover fields "
                         f"yourself, do NOT ask the user: run `search index={index} "
                         f"sourcetype=\"{sourcetype}\" | head 1000 | fieldsummary`, read the "
                         f"field names, then query.")
+            else:
+                # Index unknown (metadata-only catalog on a deployment that
+                # denied both wildcard searches and index enumeration).
+                desc = (f"Splunk events: sourcetype='{sourcetype}' (~{count:,} events). "
+                        f"The index could NOT be determined (this deployment restricts "
+                        f"index discovery) — do NOT use `index=*`, it is rejected here. "
+                        f"Query with `sourcetype=\"{sourcetype}\"` alone (searches the "
+                        f"role's default indexes), or ask the user/admin which index "
+                        f"holds this sourcetype and query `index=<that> "
+                        f"sourcetype=\"{sourcetype}\"`.")
             tables.append(Table(
                 name=name, description=desc, columns=columns, pks=[], fks=[],
                 metadata_json={"index": index, "sourcetype": sourcetype,
@@ -295,13 +424,18 @@ class SplunkClient(DataSourceClient):
 
     def get_schema(self, table_name: str) -> Table:
         """Fields for a single `index::sourcetype` table (samples on demand —
-        this is how the thin-tail tables fill in their columns)."""
+        this is how the thin-tail tables fill in their columns).
+
+        A bare-sourcetype name (or a legacy `*::sourcetype` one) has its index
+        resolved via the index catalog — no wildcard search is ever emitted."""
         if "::" in table_name:
             index, sourcetype = table_name.split("::", 1)
         else:
-            index, sourcetype = "*", table_name
+            index, sourcetype = None, table_name
+        if index == "*":
+            index = None
         columns = self._sample_fields(index, sourcetype)
-        desc = f"Splunk events: index='{index}', sourcetype='{sourcetype}'."
+        desc = f"Splunk events: index='{index or 'unknown'}', sourcetype='{sourcetype}'."
         return Table(name=table_name, description=desc, columns=columns, pks=[], fks=[],
                      metadata_json={"index": index, "sourcetype": sourcetype})
 
@@ -395,15 +529,19 @@ class SplunkClient(DataSourceClient):
         - `_time` is the event time; `_raw` is the raw event text.
         - Use transforming commands to aggregate: `| stats count by host`,
           `| timechart span=1h count`, `| top limit=10 status`.
-        - Search across multiple indexes/sourcetypes with `index=*` or
-          `(index=web OR index=app)`.
+        - ALWAYS name the index(es) you search — take them from the table
+          names (`index::sourcetype`). Span multiple indexes with an explicit
+          OR list: `(index=web OR index=app)`. Do NOT use `index=*`: many
+          deployments (Splunk Cloud guardrails, restricted roles) REJECT
+          wildcard index searches with "you must specify a specific index" —
+          and even where allowed, an explicit index is faster.
 
         Examples:
         ```python
         # Discover fields for a thin (un-sampled) sourcetype first
         df = client.execute_query('search index=app sourcetype="log4j" | head 5')
-        # Error events per host, last 24h
-        df = client.execute_query('{"spl": "search index=* (level=ERROR OR log_level=error) | stats count by host", "earliest": "-24h"}')
+        # Error events per host across two indexes, last 24h
+        df = client.execute_query('{"spl": "search (index=web OR index=app) (level=ERROR OR log_level=error) | stats count by host", "earliest": "-24h"}')
         # HTTP 5xx over time
         df = client.execute_query('{"spl": "search index=web sourcetype=access_combined status>=500 | timechart span=1h count", "earliest": "-7d"}')
         ```

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -1264,6 +1264,12 @@ class SplunkConfig(BaseModel):
         description="Cap on how many sourcetypes (ranked by event volume) get their fields sampled during indexing. The rest stay thin and are discovered on demand. Keeps reindexing cheap.",
         json_schema_extra={"ui:type": "number"},
     )
+    indexes: Optional[str] = Field(
+        None,
+        title="Indexes",
+        description="Optional comma-separated list of indexes to discover and query (e.g. 'web,app,security'). Leave empty to auto-discover. Set this when the deployment restricts index enumeration or you want to scope the connection to specific indexes.",
+        json_schema_extra={"ui:type": "string"},
+    )
 
 
 # Elasticsearch

--- a/backend/tests/unit/test_splunk_client.py
+++ b/backend/tests/unit/test_splunk_client.py
@@ -10,6 +10,11 @@ Covers:
   never fails discovery
 - execute_query(): SPL string vs JSON envelope, limit cap, DataFrame shape
 - test_connection() success / failure
+- hardened deployments that REJECT wildcard index searches (`index=*`):
+  discovery falls back to REST index enumeration + explicit OR-list tstats,
+  never emits another wildcard, never stores `*` as an index, resolves legacy
+  `*::sourcetype` names, and enriches wildcard-rejection errors with the
+  known index list so the agent can self-correct
 
 The search boundary (`_run_search`) is mocked, so these run with no live Splunk.
 """
@@ -18,7 +23,9 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from app.data_sources.clients.splunk_client import SplunkClient, MAX_ROWS, CATALOG_SEARCH
+from app.data_sources.clients.splunk_client import (
+    SplunkClient, MAX_ROWS, CATALOG_SEARCH, _WILDCARD_INDEX,
+)
 
 
 # ---------- url + auth ---------- #
@@ -181,6 +188,143 @@ def test_execute_query_empty_results_empty_df(monkeypatch):
     monkeypatch.setattr(c, "_run_search", lambda *a, **k: [])
     df = c.execute_query("search index=web")
     assert isinstance(df, pd.DataFrame) and df.empty
+
+
+# ---------- hardened deployments (wildcard index searches rejected) ---------- #
+
+_REST_INDEXES = {"entry": [{"name": "web"}, {"name": "app"},
+                           {"name": "security"}, {"name": "_internal"}]}
+
+
+def _wildcard_rejecting_run(ran, pairs, allow_metadata=False):
+    """A fake `_run_search` mimicking a hardened Splunk: any SPL containing
+    `index=*` is rejected (optionally excepting `| metadata`)."""
+    def fake_run(spl, earliest=None, latest=None, count=1000):
+        ran.append(spl)
+        if spl.lstrip("|").strip().lower().startswith("metadata"):
+            if allow_metadata:
+                return [{"sourcetype": p["sourcetype"], "totalCount": p["count"]}
+                        for p in pairs]
+            raise RuntimeError("wildcard index searches are not permitted")
+        if _WILDCARD_INDEX.search(spl):
+            raise RuntimeError("You must specify a specific index; "
+                               "wildcard index searches are not permitted")
+        if spl.startswith("| tstats") and "sourcetype=" not in spl:
+            return pairs  # scoped OR-list catalog
+        if "fieldsummary" in spl:
+            return [{"field": "status", "count": "10", "numeric_count": "10"}]
+        return []
+    return fake_run
+
+
+def test_wildcard_blocked_discovery_falls_back_to_rest_enumeration(monkeypatch):
+    """When `index=*` is rejected, discovery enumerates indexes over REST and
+    still produces real `index::sourcetype` tables with sampled fields —
+    emitting no wildcard search beyond the initial fast-path attempt."""
+    c = SplunkClient(host="h", api_token="t", max_sampled_sourcetypes=10)
+    ran: list = []
+    pairs = [{"index": "web", "sourcetype": "access_combined", "count": "6000"},
+             {"index": "app", "sourcetype": "log4j", "count": "3000"}]
+    monkeypatch.setattr(c, "_run_search", _wildcard_rejecting_run(ran, pairs))
+    monkeypatch.setattr(c, "_get", lambda path, params=None: _REST_INDEXES)
+
+    tables = {t.name: t for t in c.get_schemas()}
+
+    assert set(tables) == {"web::access_combined", "app::log4j"}
+    assert tables["web::access_combined"].columns          # sampled, not thin
+    assert tables["app::log4j"].metadata_json["index"] == "app"
+    # The scoped catalog used an explicit OR list of the REST-enumerated
+    # indexes (internal `_internal` excluded).
+    scoped = [s for s in ran if s.startswith("| tstats") and "(" in s]
+    assert scoped and "(index=web OR index=app OR index=security)" in scoped[0]
+    # Only the initial fast-path tstats used a wildcard; nothing after it did.
+    wildcards = [s for s in ran if _WILDCARD_INDEX.search(s)]
+    assert wildcards == [CATALOG_SEARCH]
+
+
+def test_metadata_last_resort_never_stores_wildcard_index(monkeypatch):
+    """When index enumeration is ALSO denied, the metadata catalog still
+    surfaces sourcetypes — with the index recorded as unknown (None), never
+    `*`, and no wildcard field sampling attempted."""
+    c = SplunkClient(host="h", api_token="t", max_sampled_sourcetypes=10)
+    ran: list = []
+    pairs = [{"index": None, "sourcetype": "log4j", "count": "3000"}]
+    monkeypatch.setattr(c, "_run_search",
+                        _wildcard_rejecting_run(ran, pairs, allow_metadata=True))
+    monkeypatch.setattr(c, "_get",
+                        lambda path, params=None: (_ for _ in ()).throw(RuntimeError("403")))
+
+    tables = c.get_schemas()
+
+    assert [t.name for t in tables] == ["log4j"]           # bare sourcetype, no '*::'
+    assert tables[0].metadata_json["index"] is None
+    # The description must not INSTRUCT a wildcard search (the old behavior
+    # was `run search index=* sourcetype=...`); warning against it is fine.
+    assert "search index=*" not in tables[0].description
+    assert "do NOT use `index=*`" in tables[0].description
+    # No wildcard search after the initial fast-path attempt (sampling was
+    # skipped entirely rather than emitted with `index=*`).
+    wildcards = [s for s in ran if _WILDCARD_INDEX.search(s)
+                 and not s.lstrip("|").strip().lower().startswith("metadata")]
+    assert wildcards == [CATALOG_SEARCH]
+
+
+def test_config_indexes_scope_skips_wildcard_entirely(monkeypatch):
+    """An admin-scoped `indexes` config never tries the wildcard fast path."""
+    c = SplunkClient(host="h", api_token="t", indexes="web, app", max_sampled_sourcetypes=0)
+    ran: list = []
+    pairs = [{"index": "web", "sourcetype": "access_combined", "count": "1"}]
+    monkeypatch.setattr(c, "_run_search", _wildcard_rejecting_run(ran, pairs))
+
+    tables = c.get_schemas()
+
+    assert [t.name for t in tables] == ["web::access_combined"]
+    assert all(not _WILDCARD_INDEX.search(s) for s in ran)
+    assert "(index=web OR index=app)" in ran[0]
+
+
+def test_get_schema_resolves_legacy_wildcard_table_name(monkeypatch):
+    """A legacy `*::sourcetype` table (stored by the old fallback) has its
+    index resolved through the index catalog instead of emitting `index=*`."""
+    c = SplunkClient(host="h", api_token="t")
+    ran: list = []
+
+    def fake_run(spl, earliest=None, latest=None, count=1000):
+        ran.append(spl)
+        assert not _WILDCARD_INDEX.search(spl), f"wildcard emitted: {spl}"
+        if spl.startswith("| tstats") and 'sourcetype="log4j"' in spl:
+            return [{"index": "app", "count": "3000"}]
+        assert "index=app" in spl and "fieldsummary" in spl
+        return [{"field": "level", "count": "5", "numeric_count": "0"}]
+
+    monkeypatch.setattr(c, "_run_search", fake_run)
+    monkeypatch.setattr(c, "_get", lambda path, params=None: _REST_INDEXES)
+
+    t = c.get_schema("*::log4j")
+    assert [col.name for col in t.columns] == ["level"]
+    assert t.metadata_json["sourcetype"] == "log4j"
+
+
+def test_wildcard_rejection_error_includes_known_indexes(monkeypatch):
+    """A rejected `index=*` search raises an error enriched with the known
+    index list, so the agent can rewrite with an explicit index."""
+    c = SplunkClient(host="h", api_token="t")
+
+    class FakeResp:
+        status_code = 200
+        def json(self):
+            return {"messages": [{"type": "ERROR",
+                                  "text": "You must specify a specific index."}]}
+
+    monkeypatch.setattr("app.data_sources.clients.splunk_client.requests.post",
+                        lambda *a, **k: FakeResp())
+    monkeypatch.setattr(c, "_known_indexes", lambda: ["web", "app"])
+
+    with pytest.raises(RuntimeError) as e:
+        c._run_search("search index=* | stats count")
+    msg = str(e.value)
+    assert "specific index" in msg
+    assert "Known indexes: web, app" in msg
 
 
 # ---------- connection ---------- #

--- a/docs/feedback-loops/splunk-wildcard-index-restriction.md
+++ b/docs/feedback-loops/splunk-wildcard-index-restriction.md
@@ -1,0 +1,102 @@
+# Feedback Loop — Splunk wildcard-index restriction (bug reproduction)
+
+Reproduces a customer-reported failure of the Splunk connector against a
+hardened deployment where **wildcard index searches (`index=*`) are
+administratively rejected** (common on Splunk Cloud / ES-hardened roles).
+Customer symptoms: schema indexing "finds 4-6 objects", but every
+`create_data` / `inspect_data` errors with *"you have to specify a specific
+index, no global wildcards"*, and the user has no way to know the index —
+"I'd expect it to learn it in the schema indexing".
+
+No product code is changed by this loop — it is a **reproduction harness**
+for `backend/app/data_sources/clients/splunk_client.py`, whose discovery and
+prompts are built on `index=*` everywhere.
+
+## Root cause chain (all in `splunk_client.py`)
+
+1. The ONLY place real index names are learned is the wildcard catalog
+   search `| tstats count where index=* by index, sourcetype`. When the
+   deployment rejects wildcards, it fails.
+2. `_catalog_pairs()` then falls back to `| metadata type=sourcetypes
+   index=*` and **hardcodes `index: "*"`** for every sourcetype. The failure
+   is only `print()`ed — discovery silently degrades. Tables come out named
+   `*::<sourcetype>`.
+3. `_sample_fields()` maps index `*` → `search index=* …` → also rejected →
+   every table is thin (0 columns), and each thin table's description tells
+   the agent to run `search index=* sourcetype=… | fieldsummary` itself.
+4. The `system_prompt()` teaches `index=*` and uses it in examples, and
+   there is no other way to learn index names (no `GET
+   /services/data/indexes`, no config field to scope indexes) — so the agent
+   either emits the forbidden wildcard (error) or guesses index names
+   (empty results), and finally asks the user for the index.
+
+## Reproduction environment
+
+```bash
+cd tools/splunk
+docker compose up -d          # real Splunk 9.3 (if :8000 clashes with the
+                              # backend, override ports to expose only 8088/8089)
+python3 seed_splunk.py        # 13k events across 5 index::sourcetype pairs
+
+# The "hardened customer deployment": a guard proxy on :8091 in front of the
+# management port that rejects any search containing a wildcard index with a
+# Splunk-style ERROR ("Search not executed: You must specify a specific
+# index… Global wildcard index searches (e.g. index=*) are not permitted"),
+# passes `| metadata` and index-scoped searches through.
+python3 wildcard_guard_proxy.py
+```
+
+Then boot the app (enterprise license required — Splunk is an enterprise
+data source), configure an Anthropic **Claude 4.5 Haiku** model, and connect
+a `splunk` data source with `host=http://127.0.0.1:8091`.
+
+## Observed (2026-08-04, Splunk 9.3.14, Claude 4.5 Haiku)
+
+Schema indexing — "found objects, learned no index":
+
+```
+test_connection -> "Connected successfully. Found 5 tables."
+discovered tables (5):        # metadata fallback: index collapsed to '*'
+  *::access_combined  cols=0
+  *::log4j            cols=0
+  *::json_app         cols=0
+  *::auth_audit       cols=0
+  *::collectd         cols=0
+backend log: "Splunk field sample failed for *::<st>: … You must specify a
+specific index …" x5   (tstats catalog + all field sampling blocked)
+```
+
+Chat turn ("Show me a count of error events by host from the logs for the
+last 24 hours"), from `tool_executions`:
+
+| tool | outcome |
+|---|---|
+| `describe_tables` | success — 5 thin `*::` tables, descriptions say `search index=*` |
+| `create_data` | error — index-less searches hit non-default indexes → empty DataFrame |
+| `inspect_data` | error — **"Splunk search error: Search not executed: You must specify a specific index for this search. Global wildcard index searches (e.g. index=*) are not permitted…"** (verbatim customer error) |
+| `create_data` (retry) | error — the model *guessed* `index=main` / `index=default` (data is in `app`) → empty |
+
+Final agent message asks the user: *"Can you confirm which Splunk index
+contains the log4j events?"* — the customer-reported dead end.
+
+Guard-proxy log of the agent's actual SPL during the turn:
+
+```
+BLOCKED search index=* sourcetype="log4j" | head 1000 | fieldsummary   (x2)
+allowed search index=main    sourcetype="log4j" … | stats count by host   -> empty
+allowed search index=default sourcetype="log4j" … | stats count by host   -> empty
+```
+
+## Fix directions this repro validates
+
+- Enumerate indexes via REST (`GET /services/data/indexes`) — works with no
+  search at all — and run the tstats catalog per-index instead of `index=*`.
+- Never store `*` as an index in the metadata fallback; surface catalog
+  degradation as a visible warning instead of a `print`.
+- Optional `indexes` config field on `SplunkConfig` to scope discovery.
+- Drop/conditionalize the `index=*` guidance in `system_prompt()` and thin-
+  table descriptions.
+
+A fix is correct when, against the guard proxy, discovery yields
+`<real_index>::<sourcetype>` tables with sampled fields and the same chat
+prompt completes without any BLOCKED line in the guard log.

--- a/docs/feedback-loops/splunk-wildcard-index-restriction.md
+++ b/docs/feedback-loops/splunk-wildcard-index-restriction.md
@@ -100,3 +100,28 @@ allowed search index=default sourcetype="log4j" … | stats count by host   -> e
 A fix is correct when, against the guard proxy, discovery yields
 `<real_index>::<sourcetype>` tables with sampled fields and the same chat
 prompt completes without any BLOCKED line in the guard log.
+
+## Fix verified (2026-08-04, same environment)
+
+The fix (`splunk_client.py`: REST index enumeration via `GET
+/services/data/indexes`, explicit OR-list tstats catalog, no `index=*` in
+field sampling or prompts, wildcard-error hint listing known indexes, plus an
+optional `indexes` scope on `SplunkConfig`) was validated against the same
+guard proxy and Claude 4.5 Haiku:
+
+```
+discovery:
+  BLOCKED | tstats count where index=* ...            # fast-path attempt only
+  allowed | tstats count where (index=app OR ... OR index=web) by index, sourcetype
+  allowed search index=web sourcetype="access_combined" | head 500 | fieldsummary
+  ... (per-index sampling for all 5 sourcetypes)
+tables: web::access_combined (16 cols), app::log4j (14), app::json_app (15),
+        security::auth_audit (14), metrics::collectd (12)   # real indexes, no '*::'
+
+chat ("count of error events by host, last 24h"):
+  allowed search index=app sourcetype="log4j" level=ERROR | stats count by host | sort - count
+  tool_executions: create_data success (12 rows x 2 cols, bar_chart) — one shot,
+  no inspect_data error, no clarifying question, zero blocked agent searches
+unit tests: 20 passed (15 pre-existing + 5 restricted-deployment cases)
+e2e: tests/e2e/test_data_source.py + test_connection.py — 11 passed
+```

--- a/tools/splunk/wildcard_guard_proxy.py
+++ b/tools/splunk/wildcard_guard_proxy.py
@@ -1,0 +1,101 @@
+"""Reverse proxy in front of Splunk's management port that emulates a hardened
+deployment where wildcard index searches are administratively blocked.
+
+Policy (mirrors the customer-reported behavior):
+  - `| metadata ...` searches pass through (metadata commands bypass the guard).
+  - Any other search whose SPL references a wildcard index (`index=*`) is
+    rejected with a Splunk-style ERROR message: "You must specify a specific
+    index...".
+  - Everything else (server info, index-scoped searches, etc.) passes through.
+
+Listens on http://0.0.0.0:8091 → forwards to https://127.0.0.1:8089.
+Every search decision is logged to stdout.
+"""
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+
+UPSTREAM = "https://127.0.0.1:8089"
+WILDCARD_INDEX = re.compile(r'index\s*(?:=|::|\bIN\b)\s*"?\*', re.IGNORECASE)
+
+BLOCK_BODY = json.dumps({
+    "messages": [{
+        "type": "ERROR",
+        "text": ("Search not executed: You must specify a specific index for this "
+                 "search. Global wildcard index searches (e.g. index=*) are not "
+                 "permitted on this deployment. Contact your Splunk administrator."),
+    }],
+    "results": [],
+    "preview": False,
+}).encode()
+
+HOP_HEADERS = {"connection", "keep-alive", "transfer-encoding", "host",
+               "content-length", "content-encoding"}
+
+
+def blocked(spl: str) -> bool:
+    s = (spl or "").strip()
+    if s.startswith("|") and s.lstrip("|").strip().lower().startswith("metadata"):
+        return False  # metadata commands bypass the guard
+    return bool(WILDCARD_INDEX.search(s))
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        sys.stdout.write("[proxy] " + fmt % args + "\n")
+        sys.stdout.flush()
+
+    def _forward(self, body: bytes | None):
+        url = f"{UPSTREAM}{self.path}"
+        headers = {k: v for k, v in self.headers.items()
+                   if k.lower() not in HOP_HEADERS}
+        resp = requests.request(self.command, url, data=body, headers=headers,
+                                verify=False, timeout=300, proxies={"http": None, "https": None})
+        payload = resp.content
+        self.send_response(resp.status_code)
+        for k, v in resp.headers.items():
+            if k.lower() not in HOP_HEADERS:
+                self.send_header(k, v)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _reject(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=UTF-8")
+        self.send_header("Content-Length", str(len(BLOCK_BODY)))
+        self.end_headers()
+        self.wfile.write(BLOCK_BODY)
+
+    def do_GET(self):
+        self._forward(None)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        if self.path.startswith("/services/search/jobs"):
+            form = parse_qs(body.decode("utf-8", "replace"))
+            spl = (form.get("search") or [""])[0]
+            if blocked(spl):
+                print(f"[guard] BLOCKED wildcard search: {spl[:200]}", flush=True)
+                return self._reject()
+            print(f"[guard] allowed search: {spl[:200]}", flush=True)
+        self._forward(body)
+
+    do_DELETE = do_GET
+    do_PUT = do_POST
+
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("0.0.0.0", 8091), Handler)
+    print("guard proxy on :8091 ->", UPSTREAM, flush=True)
+    srv.serve_forever()


### PR DESCRIPTION
## Problem

On hardened Splunk deployments (Splunk Cloud guardrails, ES-restricted roles) that reject wildcard index searches, the connector broke down end to end — as reported by a customer:

- Schema indexing "found 4–6 objects" but every table came out named `*::<sourcetype>` with **0 columns**: the wildcard `| tstats count where index=*` catalog was rejected, and the `| metadata` fallback silently hardcoded the index as `*`.
- Every `create_data` / `inspect_data` then failed with *"you must specify a specific index, no global wildcards"*, because field sampling, thin-table descriptions, and the system prompt all emitted `index=*` — and the schema never contained a real index name to fall back on.
- The agent's only remaining move was to ask the user which index holds the data.

## Fix (`splunk_client.py` + one config field)

- **Index enumeration without searching**: `_list_indexes()` uses `GET /services/data/indexes` (pure REST — immune to the wildcard ban). When the fast-path wildcard tstats is rejected, the catalog is rebuilt with an explicit OR-list tstats over the enumerated indexes (chunked by 20): `| tstats count where (index=web OR index=app …) by index, sourcetype`.
- **Never store `*` as an index**: the `| metadata` last resort records the index as unknown (`None`) instead of `*`, and unknown-index tables get honest guidance instead of a `search index=*` instruction.
- **Field sampling never emits `index=*`**: unknown indexes are resolved via a scoped tstats lookup (`_resolve_index`); legacy `*::sourcetype` table names resolve the same way in `get_schema`.
- **Self-correcting errors**: a rejected wildcard search now raises with the known index list appended ("Known indexes: web, app, … — rewrite with an explicit index"), so the agent recovers instead of guessing `main`/`default`.
- **Prompt rewrite**: the system prompt teaches explicit indexes and `(index=a OR index=b)` spans; the `index=*` examples are gone.
- **`indexes` config field** on `SplunkConfig`: optional comma-separated scope, and the escape hatch when even index enumeration is denied.
- Catalog degradation now logs warnings instead of `print`.

## Verification

Reproduced and verified in a live sandbox (real Splunk 9.3 + a guard proxy emulating the customer's wildcard-rejecting deployment + Claude 4.5 Haiku driving the real chat UI) — full evidence in `docs/feedback-loops/splunk-wildcard-index-restriction.md`:

- **Before**: 5 tables named `*::sourcetype`, 0 columns; chat turn = 2 failed `create_data` + 1 failed `inspect_data` (verbatim customer error), ending with the agent asking the user for the index.
- **After** (same guard, same prompt): discovery yields `web::access_combined` (16 cols), `app::log4j` (14), `app::json_app` (15), `security::auth_audit` (14), `metrics::collectd` (12); the chat completes in **one** `create_data` — Haiku wrote `search index=app sourcetype="log4j" level=ERROR | stats count by host` — 12 rows, bar chart, zero blocked searches.
- Unit suite: 20 passed (15 pre-existing + 5 new restricted-deployment cases). `tests/e2e/test_data_source.py` + `test_connection.py`: 11 passed.

## Rollout note

Existing installs hit by this bug have `*::sourcetype` tables stored; re-running schema indexing replaces them with real `index::sourcetype` tables (different names — saved instructions referencing `*::` names should be checked). If a deployment also denies the index-catalog endpoint, the new "Indexes" connection field is the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zwCqsddhysJPJaD1TdNY7

---
_Generated by [Claude Code](https://claude.ai/code/session_017zwCqsddhysJPJaD1TdNY7)_