### PR TITLE
Fix Zabbix silent-empty-results failure mode and severity filter param

### DIFF
--- a/backend/app/data_sources/clients/zabbix_client.py
+++ b/backend/app/data_sources/clients/zabbix_client.py
@@ -261,9 +261,25 @@ class ZabbixClient(DataSourceClient):
         try:
             with self.connect() as session:
                 version = self._rpc(session, "apiinfo.version", [], auth=False)
-                # One authed call proves the credentials + read access.
-                self._rpc(session, "host.get", {"countOutput": True, "limit": 1})
-                return {"success": True, "message": f"Connected to Zabbix API v{version}"}
+                # The host count doubles as a visibility check: Zabbix silently
+                # filters every *.get to the API user's permitted host groups, so
+                # a credential with no host-group read access "connects" fine but
+                # sees an empty world — surface that here instead of at query time.
+                count = int(self._rpc(session, "host.get", {"countOutput": True}) or 0)
+                if count == 0:
+                    return {
+                        "success": True,
+                        "message": (
+                            f"Connected to Zabbix API v{version}, but 0 hosts are visible "
+                            "to this credential — all queries will return empty results. "
+                            "Grant the API user's user group read permission on the "
+                            "relevant host groups (or use a Super admin token)."
+                        ),
+                    }
+                return {
+                    "success": True,
+                    "message": f"Connected to Zabbix API v{version} ({count} hosts visible)",
+                }
         except Exception as e:
             return {"success": False, "message": str(e)}
 
@@ -384,7 +400,7 @@ class ZabbixClient(DataSourceClient):
 
         ```json
         {"table": "problems",
-         "params": {"severity": [4, 5], "recent": true, "sortfield": "eventid", "sortorder": "DESC"},
+         "params": {"severities": [4, 5], "recent": true, "sortfield": "eventid", "sortorder": "DESC"},
          "output": ["eventid", "objectid", "name", "severity", "clock"],
          "limit": 100}
         ```
@@ -407,6 +423,9 @@ class ZabbixClient(DataSourceClient):
           `pd.to_datetime(df["clock"], unit="s")`.
         - Severity / priority is an integer 0-5:
           0 not_classified, 1 information, 2 warning, 3 average, 4 high, 5 disaster.
+          To FILTER problems/events by severity the param is `severities`
+          (plural, an array) — `severity` is only the column name and is
+          rejected by the API as an unexpected parameter.
         - `history` REQUIRES `itemids` AND the matching `history` value-type
           (0 float [default], 3 unsigned int, 1 char, 2 log, 4 text) — a bare
           history.get returns nothing. Bound it with time_from (epoch).
@@ -419,7 +438,7 @@ class ZabbixClient(DataSourceClient):
         Examples:
         ```python
         # Open high/disaster problems, newest first
-        df = client.execute_query('{"table": "problems", "params": {"severity": [4,5], "sortfield": "eventid", "sortorder": "DESC"}, "limit": 200}')
+        df = client.execute_query('{"table": "problems", "params": {"severities": [4,5], "sortfield": "eventid", "sortorder": "DESC"}, "limit": 200}')
         # All items for a host
         df = client.execute_query('{"table": "items", "params": {"hostids": ["10084"], "search": {"key_": "cpu"}}, "limit": 100}')
         # Last 24h of a metric as trends

--- a/backend/tests/unit/test_zabbix_client.py
+++ b/backend/tests/unit/test_zabbix_client.py
@@ -237,3 +237,34 @@ class TestConnection:
         res = c.test_connection()
         assert res["success"] is False
         assert "Invalid params" in res["message"]
+
+    def test_visible_host_count_in_message(self, patch_session):
+        # Zabbix returns countOutput as a string.
+        patch_session({"apiinfo.version": "7.0.29", "host.get": "20"})
+        c = ZabbixClient(url="http://z", api_token="t")
+        res = c.test_connection()
+        assert res["success"] is True
+        assert "20 hosts visible" in res["message"]
+
+    def test_zero_visible_hosts_warns(self, patch_session):
+        # A credential with no host-group read permission authenticates fine
+        # but Zabbix silently filters everything to an empty world — the
+        # connection test must call that out instead of reporting plain success.
+        patch_session({"apiinfo.version": "7.0.29", "host.get": "0"})
+        c = ZabbixClient(url="http://z", api_token="t")
+        res = c.test_connection()
+        assert res["success"] is True
+        assert "0 hosts" in res["message"]
+        assert "permission" in res["message"].lower()
+
+
+# ---------- prompt guidance ---------- #
+
+class TestPrompts:
+    def test_severity_filter_documented_as_plural(self):
+        # The API filter param is `severities`; `severity` (singular) is
+        # rejected by Zabbix as an unexpected parameter, so the prompt must
+        # never teach it as a filter.
+        text = ZabbixClient(url="http://z", api_token="t").system_prompt()
+        assert '"severities"' in text
+        assert '"severity":' not in text

--- a/docs/feedback-loops/zabbix-connector.md
+++ b/docs/feedback-loops/zabbix-connector.md
@@ -97,6 +97,43 @@ value-type (0 float default, 3 unsigned) — a bare `history.get` returns
 nothing. This is documented in `system_prompt()` and surfaced in the schema
 description.
 
+## Loop C — customer-reported "every query is empty" (live Zabbix 7.0.29)
+
+Field report: a customer connected successfully but every query (events, etc.)
+returned empty. Reproduced and root-caused against the `tools/zabbix` stack:
+
+```bash
+# after the Loop B seed: create the misconfiguration customers hit —
+# a dedicated API user whose user group has NO host-group read permission
+# (usergroup.create with no rights → user.create roleid=1 → token.create)
+```
+
+Driving the real `ZabbixClient` with that token:
+
+```
+test_connection (limited)  -> success: True, 'Connected to Zabbix API v7.0.29'  (before fix)
+hosts/items/events/problems/triggers -> 0 rows each   # Zabbix ACLs filter silently
+```
+
+Two defects confirmed, both fixed:
+
+1. **Invisible permission failure.** Zabbix silently scopes every `*.get` to
+   the API user's permitted host groups; `test_connection()` passed on a
+   `countOutput` of 0. It now reports visibility:
+   `'Connected to Zabbix API v7.0.29 (21 hosts visible)'`, and on 0 visible
+   hosts warns that all queries will be empty and to grant the user group
+   read permission on host groups.
+2. **`severity` vs `severities`.** `system_prompt()` taught the agent to
+   filter with `"severity": [4,5]`; live 7.0 rejects it
+   (`Invalid parameter "/": unexpected parameter "severity"`). The filter
+   param is `severities` (plural) — confirmed live: `problems.severities=[4,5]
+   → 18 rows`, `events.severities=[4,5] → 122 rows`. Prompt + examples fixed
+   and the guidance now calls out singular-vs-plural explicitly.
+
+Regression coverage: `test_visible_host_count_in_message`,
+`test_zero_visible_hosts_warns`, `test_severity_filter_documented_as_plural`
+in `tests/unit/test_zabbix_client.py` (25 tests total).
+
 ## What this proves / regression notes
 
 - The connector resolves via the registry, is enterprise-gated, discovers its


### PR DESCRIPTION
## Problem

A customer connected the Zabbix data source successfully but every query (events, problems, etc.) returned empty.

Reproduced against a live Zabbix 7.0.29 (`tools/zabbix` stack + seeders) by recreating the classic misconfiguration: a dedicated API user whose user group has **no host-group read permission**. Zabbix ACLs filter silently rather than erroring, so:

- `test_connection()` returned a clean `Connected to Zabbix API v7.0.29` (it accepted a `countOutput` of 0)
- every table — hosts, items, events, problems, triggers — returned 0 rows

While verifying, a second live-confirmed defect surfaced: `system_prompt()` taught the agent to filter with `"severity": [4,5]`, which Zabbix 7.0 rejects outright (`Invalid parameter "/": unexpected parameter "severity"`). The API filter param is `severities` (plural).

## Changes

- **`test_connection()` reports visibility, not just auth** — includes the visible host count (`Connected to Zabbix API v7.0.29 (21 hosts visible)`) and, when 0 hosts are visible, warns that all queries will return empty and points at the API user's host-group read permissions. The customer's silent failure becomes a self-explanatory message at connect time.
- **`severity` → `severities`** in `system_prompt()` and its examples, with an explicit note that `severity` is only a column name and is rejected as a filter param.

## Verification

- Live loop against seeded Zabbix 7.0.29: limited token now gets the warning message; admin token reports `(21 hosts visible)`; `problems.severities=[4,5]` → 18 rows, `events.severities=[4,5]` → 122 rows.
- Unit suite extended 22 → 25 tests (`test_visible_host_count_in_message`, `test_zero_visible_hosts_warns`, `test_severity_filter_documented_as_plural`), all passing.
- Recorded as Loop C in `docs/feedback-loops/zabbix-connector.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g4ZZcz1Q4wtkhdMN15hd3

---
_Generated by [Claude Code](https://claude.ai/code/session_018g4ZZcz1Q4wtkhdMN15hd3)_