### PR TITLE
Artifact feedback-loop fixes: render validation, repair, and prompt optimization

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -5024,6 +5024,27 @@ class AgentV2:
                                         },
                                     }
 
+                                # Artifact budget is enforced BEFORE execution: the old
+                                # post-hoc check let an over-budget call run to completion
+                                # (a full artifact LLM generation) before ending the turn.
+                                if tool_name in ("create_artifact", "edit_artifact") and total_artifact_calls >= max_total_artifact_calls:
+                                    return {
+                                        "index": tool_index, "tool_name": tool_name, "tool_input": tool_input,
+                                        "action": action, "skipped": True, "inv": _inv,
+                                        "observation": {
+                                            "summary": (
+                                                f"Artifact call budget reached ({max_total_artifact_calls} per turn); "
+                                                f"'{tool_name}' was not executed. The latest artifact version is preserved."
+                                            ),
+                                            "error": {"code": "artifact_budget_exhausted", "message": "artifact call budget reached"},
+                                            "analysis_complete": True,
+                                            "final_answer": (
+                                                "I've reached the artifact-update limit for this turn. "
+                                                "The latest dashboard version is preserved — ask me to continue if further changes are needed."
+                                            ),
+                                        },
+                                    }
+
                                 async with self._tool_db_lock:
                                     # Start tool execution tracking
                                     tool_execution = await self.project_manager.start_tool_execution_from_models(
@@ -5578,9 +5599,22 @@ class AgentV2:
                                             last_artifact_tool_name = _tn
                                         if consecutive_artifact_tool_count > max_consecutive_artifact_calls or total_artifact_calls > max_total_artifact_calls:
                                             analysis_done = True
+                                            # The forced final answer must reflect what actually
+                                            # happened — claiming success over a version that
+                                            # reported render errors misleads the user.
+                                            _render_errs = (_obs or {}).get("render_errors") or []
+                                            if _render_errs:
+                                                _forced_answer = (
+                                                    f"The dashboard was updated, but the latest version reported "
+                                                    f"{len(_render_errs)} render error(s) that were not fully resolved "
+                                                    f"(first: {str(_render_errs[0])[:200]}). "
+                                                    "Ask me to fix it to continue."
+                                                )
+                                            else:
+                                                _forced_answer = "The dashboard has been created and rendered successfully."
                                             _obs.update({
                                                 "analysis_complete": True,
-                                                "final_answer": f"The dashboard has been created successfully."
+                                                "final_answer": _forced_answer
                                             })
                                     else:
                                         consecutive_artifact_tool_count = 0

--- a/backend/app/ai/runner/tool_runner.py
+++ b/backend/app/ai/runner/tool_runner.py
@@ -7,6 +7,33 @@ from pydantic import ValidationError as PydValidationError
 
 from app.ai.runner.policies import RetryPolicy, TimeoutPolicy
 
+# Error-message fragments that mark a failure as non-recoverable: replaying the
+# identical call cannot succeed (the prompt is still too big, the account is
+# still out of credit), so retrying only doubles cost and latency.
+NON_RECOVERABLE_ERROR_PATTERNS = (
+    # Context window exceeded
+    "context length",
+    "context_length",
+    "maximum context",
+    "context window",
+    "prompt is too long",
+    "too many tokens",
+    "input is too long",
+    "request too large",
+    # Provider credit / quota exhaustion
+    "credit balance",
+    "insufficient credit",
+    "insufficient_quota",
+    "exceeded your current quota",
+    "billing",
+    "payment required",
+)
+
+
+def is_non_recoverable_error(message: Optional[str]) -> bool:
+    m = (message or "").lower()
+    return any(p in m for p in NON_RECOVERABLE_ERROR_PATTERNS)
+
 
 class ToolRunner:
     """Executes a tool with retries, timeouts, and structured observations.
@@ -170,8 +197,14 @@ class ToolRunner:
                     if hard_timer and not hard_timer.cancelled():
                         hard_timer.cancel()
 
-                # Output schema validation (generic)
-                if getattr(tool, "output_model", None) is not None and last_output is not None:
+                # Output schema validation (generic). Failure envelopes
+                # (success=False) deliberately omit success-only fields —
+                # validating them against the success model would replace the
+                # tool's real error observation (e.g. DATA_GAP remediation,
+                # unmatched-diff details) with a generic validation error, so
+                # they pass through untouched.
+                _is_failure_envelope = isinstance(last_output, dict) and last_output.get("success") is False
+                if getattr(tool, "output_model", None) is not None and last_output is not None and not _is_failure_envelope:
                     try:
                         # Validate using the tool-declared output model
                         tool.output_model(**last_output)
@@ -230,8 +263,10 @@ class ToolRunner:
                 last_error = str(e)
                 last_error_type = err_type
 
-            # retry decision
-            if attempt >= self.retry.max_attempts or err_type not in self.retry.retry_on:
+            # retry decision — non-recoverable errors (context window, provider
+            # credit) are never retried: the identical call cannot succeed.
+            _non_recoverable = is_non_recoverable_error(last_error)
+            if attempt >= self.retry.max_attempts or err_type not in self.retry.retry_on or _non_recoverable:
                 # Preserve detailed error information for better debugging
                 error_details = {
                     "type": last_error_type or err_type,
@@ -240,6 +275,13 @@ class ToolRunner:
                     "max_attempts": self.retry.max_attempts,
                     "suggestion": "Tool execution failed repeatedly. Check tool implementation or input arguments."
                 }
+                if _non_recoverable:
+                    error_details["non_recoverable"] = True
+                    error_details["suggestion"] = (
+                        "This error cannot succeed on retry (context window or provider "
+                        "account limit). Reduce the input size or resolve the account issue "
+                        "instead of calling the tool again with the same arguments."
+                    )
                 
                 return {
                     "summary": f"Execution failed for '{tool.name}' after {attempt} attempts",

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import logging
+import time
 from pathlib import Path
 from typing import AsyncIterator, Dict, Any, Type, List, Optional
 
@@ -110,8 +111,29 @@ class CreateArtifactTool(Tool):
                 browser = await p.chromium.launch(headless=True)
                 page = await browser.new_page(viewport={"width": 1280, "height": 720})
 
-                # Capture JS errors during render
-                page.on("pageerror", lambda err: js_errors.append(str(err)))
+                # Capture JS errors during render. Both channels matter:
+                # pageerror catches thrown/uncaught exceptions (incl. Babel
+                # transform errors), console 'error' catches failures that
+                # libraries report without throwing (React render errors).
+                def _on_pageerror(err):
+                    if len(js_errors) < 10:
+                        js_errors.append(str(err))
+
+                def _on_console(msg):
+                    try:
+                        if msg.type == "error" and len(js_errors) < 10:
+                            text = msg.text or ""
+                            # Skip noise that isn't a code defect
+                            if "favicon" in text.lower():
+                                return
+                            entry = f"[console.error] {text}"
+                            if not any(text in e for e in js_errors):
+                                js_errors.append(entry)
+                    except Exception:
+                        pass
+
+                page.on("pageerror", _on_pageerror)
+                page.on("console", _on_console)
 
                 # Write HTML to a temp file and navigate via file:// URL.
                 # This allows vendored scripts (e.g. Tailwind runtime) that use
@@ -315,105 +337,151 @@ class CreateArtifactTool(Tool):
 </html>"""
         return html
 
+    # Maximum in-tool repair LLM calls per artifact operation. Bounded so a
+    # stubborn defect can't consume the whole tool timeout — after this the
+    # tool returns a structured failure and the planner decides.
+    MAX_RENDER_REPAIR_ATTEMPTS = 2
+
+    @staticmethod
+    def fatal_render_errors(errors: List[str]) -> List[str]:
+        """Errors that gate completion: thrown/uncaught exceptions.
+
+        `[console.error]` entries are advisory — React dev builds log
+        non-fatal warnings through console.error, so they inform repair but
+        never fail an otherwise working artifact.
+        """
+        return [e for e in (errors or []) if not e.startswith("[console.error]")]
+
     async def _fix_code(
         self,
         code: str,
         errors: List[str],
         mode: str,
         runtime_ctx: Dict[str, Any],
-        prompt_context: Dict[str, Any],
-        screenshot_base64: Optional[str] = None,
-        completion_images: Optional[List[ImageInput]] = None,
-    ) -> str:
-        """Attempt to fix code errors using the same prompt with error context.
+    ) -> Optional[str]:
+        """Compact in-tool repair: current code + exact errors → corrected code.
 
-        Args:
-            code: The broken code
-            errors: List of error messages
-            mode: 'page' or 'slides'
-            runtime_ctx: Runtime context for LLM access
-            prompt_context: Context needed to rebuild the original prompt
-                (user_prompt, title, viz_profiles, instructions_context,
-                 report_title, allow_llm_see_data, messages_context, image_count)
-            screenshot_base64: Optional screenshot of the broken render for visual context
-            completion_images: Optional list of images from the head completion
-
-        Returns:
-            Fixed code string
+        Deliberately does NOT rebuild the full generation prompt — the model
+        already produced this code; it needs the error, not the whole context.
+        Returns the corrected code, or None if repair was unavailable/failed.
         """
-        error_text = "\n".join(f"- {e}" for e in errors[:5])  # Limit to first 5 errors
+        sigkill_event = runtime_ctx.get("sigkill_event")
+        if sigkill_event and sigkill_event.is_set():
+            return None
 
-        # Rebuild the original prompt with full context
-        base_prompt = self._build_prompt(
-            user_prompt=prompt_context["user_prompt"],
-            title=prompt_context["title"],
-            mode=mode,
-            viz_profiles=prompt_context["viz_profiles"],
-            instructions_context=prompt_context["instructions_context"],
-            report_title=prompt_context["report_title"],
-            allow_llm_see_data=prompt_context["allow_llm_see_data"],
-            messages_context=prompt_context.get("messages_context", ""),
-            image_count=prompt_context.get("image_count", 0),
-            organization_settings=prompt_context.get("organization_settings"),
-        )
+        error_text = "\n".join(f"- {e}" for e in errors[:5])
 
-        # Build screenshot context if available
-        screenshot_context = ""
-        if screenshot_base64:
-            screenshot_context = "\n\nA screenshot of the current broken render is attached. Use it to understand visual issues like layout problems, missing elements, or rendering errors."
+        fix_prompt = f"""You previously wrote the React dashboard code below. It runs in a sandboxed iframe (React 18 + Babel standalone + Tailwind + ECharts via <EChart>, data via useArtifactData()). When rendered, it produced these errors:
 
-        # Append error context and the broken code
-        fix_prompt = f"""{base_prompt}
+{error_text}
 
-═══════════════════════════════════════════════════════════════════════════════
-Fix the following errors
-═══════════════════════════════════════════════════════════════════════════════
-
-The previous code attempt produced these runtime errors:
-
-{error_text}{screenshot_context}
-
-Previous code:
+Current code:
 ```
 {code}
 ```
 
-Fix the errors while keeping the same design and functionality. Output the corrected code:"""
+Fix ONLY what the errors require — do not redesign, restyle, or restructure anything else. Common causes: using a variable/component before its declaration, duplicate declarations, undefined symbols, unguarded nullish values before string methods, malformed JSX.
 
-        # Skip fix if sigkill
-        sigkill_event = runtime_ctx.get("sigkill_event")
-        if sigkill_event and sigkill_event.is_set():
-            return code
+Output the FULL corrected code wrapped in <script type="text/babel"> ... </script>. No explanations, no diff markers, no markdown fences."""
 
-        # Use the same model for fixes
         llm = LLM(runtime_ctx.get("model"), usage_session_maker=async_session_maker)
-
-        # Build image inputs: completion images + screenshot (if available)
-        images: List[ImageInput] = []
-        model = runtime_ctx.get("model")
-        if model and getattr(model, "supports_vision", False):
-            # Add completion images first (user's reference images)
-            if completion_images:
-                images.extend(completion_images)
-            # Add screenshot of broken render last
-            if screenshot_base64:
-                images.append(ImageInput(data=screenshot_base64, media_type="image/png", source_type="base64"))
-
         try:
             chunks: list[str] = []
             async for evt in llm.inference_stream_v2(
                 messages=[Message(role="user", content=fix_prompt)],
-                images=images if images else None,
                 usage_scope="create_artifact_fix",
             ):
+                if sigkill_event and sigkill_event.is_set():
+                    return None
                 if isinstance(evt, TextDeltaEvent):
                     chunks.append(evt.text)
-            response = "".join(chunks)
-            return self._extract_code(response, mode=mode)
-        except Exception as e:
-            logger.exception("Error fixing code")
-            # Return original code if fix fails
-            return code
+            fixed = self._extract_code("".join(chunks), mode=mode)
+            return fixed if fixed and fixed.strip() else None
+        except Exception:
+            logger.exception("In-tool code repair failed")
+            return None
+
+    async def _validate_and_repair_stream(
+        self,
+        code: str,
+        artifact_data: Dict[str, Any],
+        mode: str,
+        runtime_ctx: Dict[str, Any],
+        deadline_monotonic: Optional[float] = None,
+    ) -> AsyncIterator[Any]:
+        """Render-validate page code and repair it in-tool when it fails.
+
+        Async generator: yields ToolProgressEvent items for the UI, then a
+        final dict result:
+          {"code", "clean", "screenshot", "errors", "repair_attempts"}
+
+        - Validation always runs (it needs Playwright, not a vision model or
+          the allow_llm_see_data flag — errors are not data).
+        - Only fatal (thrown) errors gate; console errors ride along as
+          repair context.
+        - If repair can't produce a clean render, the ORIGINAL code and its
+          errors are returned so what's persisted matches what was verified.
+        """
+        import time as _time
+
+        def _time_left() -> bool:
+            return deadline_monotonic is None or _time.monotonic() < deadline_monotonic
+
+        sigkill_event = runtime_ctx.get("sigkill_event")
+
+        yield ToolProgressEvent(type="tool.progress", payload={"stage": "validating_render"})
+        html = self._build_thumbnail_html(artifact_data, code, mode=mode)
+        screenshot, errors = await self._take_preview_screenshot(html)
+        fatal = self.fatal_render_errors(errors)
+
+        original_code = code
+        original_screenshot = screenshot
+        original_errors = errors
+        candidate = code
+        attempts = 0
+
+        while (
+            fatal
+            and attempts < self.MAX_RENDER_REPAIR_ATTEMPTS
+            and _time_left()
+            and not (sigkill_event and sigkill_event.is_set())
+        ):
+            attempts += 1
+            yield ToolProgressEvent(
+                type="tool.progress",
+                payload={"stage": "repairing_code", "attempt": attempts, "error_count": len(fatal)},
+            )
+            fixed = await self._fix_code(candidate, errors, mode, runtime_ctx)
+            if not fixed or fixed == candidate:
+                break
+
+            yield ToolProgressEvent(
+                type="tool.progress",
+                payload={"stage": "validating_render", "attempt": attempts},
+            )
+            html = self._build_thumbnail_html(artifact_data, fixed, mode=mode)
+            screenshot, errors = await self._take_preview_screenshot(html)
+            candidate = fixed
+            fatal = self.fatal_render_errors(errors)
+
+        if not fatal:
+            yield {
+                "code": candidate,
+                "clean": True,
+                "screenshot": screenshot,
+                "errors": errors,
+                "repair_attempts": attempts,
+            }
+        else:
+            # Repair didn't converge — return the original, verified-broken
+            # state rather than an unverified intermediate.
+            yield {
+                "code": original_code,
+                "clean": False,
+                "screenshot": original_screenshot,
+                "errors": original_errors,
+                "repair_attempts": attempts,
+            }
 
     def _build_viz_profile(self, viz: Dict[str, Any], allow_llm_see_data: bool) -> Dict[str, Any]:
         """Build a privacy-aware profile of a visualization's data."""
@@ -438,7 +506,11 @@ Fix the errors while keeping the same design and functionality. Output the corre
             "id": viz.get("id"),
             "title": viz.get("title"),
             "chart_type": viz.get("data_model_type") or "table",
+            # True dataset size; sample_row_count is how many rows are shown
+            # to generation/preview (capped). At runtime the dashboard
+            # receives ALL row_count rows.
             "row_count": viz.get("row_count", 0),
+            "sample_row_count": viz.get("sample_row_count", len(viz.get("rows") or [])),
             "columns": enriched_columns,
         }
 
@@ -515,6 +587,9 @@ Fix the errors while keeping the same design and functionality. Output the corre
 
     async def run_stream(self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]) -> AsyncIterator[ToolEvent]:
         data = CreateArtifactInput(**tool_input)
+        # Repair budget: leave headroom under the runner's 300s hard timeout
+        # for the final persist + observation after the last repair round.
+        _repair_deadline = time.monotonic() + 210
 
         # Early validation: require at least one visualization OR at least one file
         # (an image/PDF-only artifact is allowed when file_ids are provided).
@@ -656,9 +731,14 @@ Fix the errors while keeping the same design and functionality. Output the corre
                 warnings.append(f"Visualization {viz_id} skipped: step status is '{step_status or 'unknown'}' (not success)")
                 continue
 
-            # Get data directly from step (like frontend does)
+            # Get data directly from step (like frontend does). Generation and
+            # headless preview see a bounded sample; the live render receives
+            # the full dataset from the frontend. Keep both counts so the
+            # sample is never mislabeled as the whole dataset.
             step_data = step.data if step else {}
-            rows = (step_data.get("rows") or [])[:100] if step_data else []
+            _all_rows = (step_data.get("rows") or []) if step_data else []
+            rows = _all_rows[:100]
+            total_row_count = len(_all_rows)
             raw_columns = step_data.get("columns") or [] if step_data else []
             data_model = step.data_model if step else {}
             step_info = step_data.get("info") or {} if step_data else {}
@@ -689,7 +769,12 @@ Fix the errors while keeping the same design and functionality. Output the corre
                 "data_model_type": (view_dict.get("view") or {}).get("type") or view_dict.get("type"),
                 "columns": columns,
                 "column_info": column_info,
-                "row_count": len(rows),
+                # row_count is the TRUE dataset size; rows is a sample capped
+                # at 100 for generation/preview. The old code reported the
+                # truncated length as row_count, so the LLM couldn't know the
+                # data was sampled and generated truncation workarounds.
+                "row_count": total_row_count,
+                "sample_row_count": len(rows),
                 "rows": rows,
                 # The profile the planner reads calls this same list
                 # `sample_rows` (see _build_viz_profile), so generated code
@@ -814,32 +899,23 @@ Fix the errors while keeping the same design and functionality. Output the corre
         # Build the prompt for generating React code
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "building_prompt"})
 
-        # Store prompt context for potential fix iterations
-        prompt_context = {
-            "user_prompt": data.prompt,
-            "title": data.title,
-            "viz_profiles": viz_profiles,
-            "instructions_context": instructions_context,
-            "report_title": getattr(report, 'title', None) if report else None,
-            "allow_llm_see_data": allow_llm_see_data,
-            "messages_context": messages_context,
-            "image_count": len(completion_images),
-            "organization_settings": organization_settings,
-        }
-
         prompt = self._build_prompt(
             user_prompt=data.prompt,
             title=data.title,
             mode=data.mode,
             viz_profiles=viz_profiles,
             instructions_context=instructions_context,
-            report_title=prompt_context["report_title"],
+            report_title=getattr(report, 'title', None) if report else None,
             allow_llm_see_data=allow_llm_see_data,
             messages_context=messages_context,
             image_count=len(completion_images),
             organization_settings=organization_settings,
             files=included_files,
         )
+        # Static reference goes in the system prompt so provider-side prompt
+        # caching reuses it across artifact calls (page mode only — slides
+        # keeps its single-prompt path).
+        system_prompt = self._build_page_system_prompt() if data.mode == "page" else None
 
         # Stream from LLM
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "llm_generating"})
@@ -849,6 +925,7 @@ Fix the errors while keeping the same design and functionality. Output the corre
 
         async for evt in llm.inference_stream_v2(
             messages=[Message(role="user", content=prompt)],
+            system=system_prompt,
             images=completion_images if completion_images else None,
             usage_scope="create_artifact",
             usage_scope_ref_id=str(report.id) if report else None,
@@ -968,9 +1045,54 @@ Fix the errors while keeping the same design and functionality. Output the corre
                         f"PPTX preview generation failed; deck is still downloadable: {e}"
                     )
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # Page mode: render-validate (and repair in-tool) BEFORE persisting.
+        # "completed" must mean "renders without fatal errors" — the old flow
+        # committed completed first and only then discovered render errors,
+        # pushing every repair through a full outer planner iteration.
+        # Validation runs regardless of vision support or allow_llm_see_data:
+        # errors are not data. Only the screenshot ATTACHMENT is gated below.
+        # ═══════════════════════════════════════════════════════════════════════
+        screenshot_base64: Optional[str] = None
+        render_errors: list[str] = []
+        render_clean = True
+        repair_attempts = 0
+        thumbnail_html: Optional[str] = None
+        artifact_data: Optional[Dict[str, Any]] = None
+
+        if data.mode == "page":
+            artifact_data = {
+                "report": {
+                    "id": str(report.id) if report else None,
+                    "title": getattr(report, "title", None) if report else None,
+                    "theme": getattr(report, "theme", None) if report else None,
+                },
+                "visualizations": visualizations,
+            }
+            # Inline embedded files as data URIs so the headless render
+            # (which has no auth context) can show images/PDFs via <BowFile>.
+            if included_files:
+                artifact_data["files"] = await self._build_file_datauris(db, included_files)
+
+            _validate_result: Optional[Dict[str, Any]] = None
+            async for _item in self._validate_and_repair_stream(
+                code, artifact_data, data.mode, runtime_ctx, deadline_monotonic=_repair_deadline,
+            ):
+                if isinstance(_item, dict):
+                    _validate_result = _item
+                else:
+                    yield _item
+            if _validate_result is not None:
+                code = _validate_result["code"]
+                render_clean = bool(_validate_result["clean"])
+                screenshot_base64 = _validate_result["screenshot"]
+                render_errors = list(_validate_result["errors"] or [])
+                repair_attempts = int(_validate_result["repair_attempts"] or 0)
+            thumbnail_html = self._build_thumbnail_html(artifact_data, code, mode=data.mode)
+
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "saving_artifact"})
 
-        # Build content object
+        # Build content object (code is final — post-repair when repair ran)
         content: Dict[str, Any] = {
             "code": code,
             "visualization_ids": included_viz_ids,
@@ -986,47 +1108,25 @@ Fix the errors while keeping the same design and functionality. Output the corre
         if data.mode == "slides" and preview_images:
             content["preview_images"] = preview_images
 
-        # Update the pending artifact with content and mark as completed
         artifact.content = content
-        artifact.status = "completed" if (data.mode != "slides" or pptx_success) else "failed"
+        if data.mode == "slides":
+            artifact.status = "completed" if pptx_success else "failed"
+        else:
+            artifact.status = "completed" if render_clean else "failed"
 
         # Set pptx_path for slides mode
         if pptx_path:
             artifact.pptx_path = pptx_path
 
+        # Persist screenshot and render errors for later retrieval (read_artifact)
+        if screenshot_base64 or render_errors:
+            artifact.screenshot_base64 = screenshot_base64
+            artifact.render_errors = render_errors or None
+
         await db.commit()
         await db.refresh(artifact)
 
-        # Page mode: take preview screenshot for planner reflection + generate thumbnail
-        screenshot_base64: Optional[str] = None
-        render_errors: list[str] = []
-        if data.mode == "page":
-            artifact_data = {
-                "report": {
-                    "id": str(report.id) if report else None,
-                    "title": getattr(report, "title", None) if report else None,
-                    "theme": getattr(report, "theme", None) if report else None,
-                },
-                "visualizations": visualizations,
-            }
-            # Inline embedded files as data URIs so the headless thumbnail/screenshot
-            # render (which has no auth context) can show images/PDFs via <BowFile>.
-            if included_files:
-                artifact_data["files"] = await self._build_file_datauris(db, included_files)
-            thumbnail_html = self._build_thumbnail_html(artifact_data, code, mode=data.mode)
-
-            # Take preview screenshot (synchronous, ~3-5s) if model supports vision
-            model = runtime_ctx.get("model")
-            if allow_llm_see_data and model and getattr(model, "supports_vision", False):
-                yield ToolProgressEvent(type="tool.progress", payload={"stage": "capturing_preview"})
-                screenshot_base64, render_errors = await self._take_preview_screenshot(thumbnail_html)
-
-            # Persist screenshot and render errors on artifact for later retrieval (read_artifact)
-            if screenshot_base64 or render_errors:
-                artifact.screenshot_base64 = screenshot_base64
-                artifact.render_errors = render_errors or None
-                await db.commit()
-
+        if data.mode == "page" and thumbnail_html is not None and render_clean:
             # Generate thumbnail in background (for stored thumbnail, non-blocking)
             asyncio.create_task(
                 self._generate_thumbnail_background(
@@ -1041,6 +1141,63 @@ Fix the errors while keeping the same design and functionality. Output the corre
             if first_preview.exists():
                 artifact.thumbnail_path = preview_images[0]
                 await db.commit()
+
+        # Page mode that failed render validation (after bounded in-tool
+        # repair): return a structured failure so the planner sees the real
+        # errors. The artifact row is persisted as status="failed" for
+        # debugging, but it is not presented as a working dashboard.
+        if data.mode == "page" and not render_clean:
+            fatal_errors = self.fatal_render_errors(render_errors)
+            first_error = fatal_errors[0] if fatal_errors else (render_errors[0] if render_errors else "unknown render error")
+            failure_observation: Dict[str, Any] = {
+                "summary": (
+                    f"Artifact '{data.title or 'Untitled'}' failed render validation with "
+                    f"{len(fatal_errors)} fatal error(s) after {repair_attempts} in-tool repair attempt(s). "
+                    f"First error: {first_error}"
+                ),
+                "error": {
+                    "type": "render_validation_failed",
+                    "message": first_error,
+                    "render_errors": render_errors,
+                    "repair_attempts": repair_attempts,
+                    "remediation": (
+                        "The generated code does not render. Call edit_artifact with an edit_prompt "
+                        "that quotes the exact error(s) above, or create_artifact to rebuild with a "
+                        "simpler layout if the errors persist."
+                    ),
+                },
+                "artifact_id": str(artifact.id),
+                "mode": data.mode,
+                "visualization_count": len(visualizations),
+                "visualization_ids": included_viz_ids,
+                "render_errors": render_errors,
+            }
+            if warnings:
+                failure_observation["warnings"] = warnings
+            _model = runtime_ctx.get("model")
+            if screenshot_base64 and allow_llm_see_data and _model and getattr(_model, "supports_vision", False):
+                failure_observation["images"] = [{
+                    "data": screenshot_base64,
+                    "media_type": "image/png",
+                    "source_type": "base64",
+                }]
+            yield ToolEndEvent(
+                type="tool.end",
+                payload={
+                    "output": {
+                        "success": False,
+                        "artifact_id": str(artifact.id),
+                        "error": f"Render validation failed: {first_error}",
+                        "code_preview": {
+                            "language": "jsx",
+                            "code": code,
+                            "collapsed_default": True,
+                        },
+                    },
+                    "observation": failure_observation,
+                },
+            )
+            return
 
         output = CreateArtifactOutput(
             artifact_id=str(artifact.id),
@@ -1075,13 +1232,23 @@ Fix the errors while keeping the same design and functionality. Output the corre
         summary_msg = f"Created artifact '{data.title or 'Untitled'}' with {len(code)} characters of code"
         if data.mode == "slides" and preview_images:
             summary_msg += f". Generated {len(preview_images)} slide preview images."
-        elif render_errors:
-            summary_msg += f". RENDER FAILED with {len(render_errors)} error(s): {render_errors[0]}"
-            if len(render_errors) > 1:
-                summary_msg += f" (and {len(render_errors) - 1} more)"
-            summary_msg += ". The dashboard code has a bug — use edit_artifact to fix the specific error."
-        elif screenshot_base64:
-            summary_msg += ". Screenshot of the rendered dashboard is attached — review it for visual correctness."
+        elif data.mode == "page":
+            if repair_attempts:
+                summary_msg += f". Render validation passed after {repair_attempts} in-tool repair attempt(s)."
+            else:
+                summary_msg += ". Render validation passed."
+            console_warnings = [e for e in render_errors if e.startswith("[console.error]")]
+            if console_warnings:
+                summary_msg += f" {len(console_warnings)} non-fatal console error(s) were logged."
+
+        # Screenshot attachment is gated on privacy + vision (the screenshot
+        # shows the data); validation itself already ran unconditionally.
+        _model = runtime_ctx.get("model")
+        _attach_screenshot = bool(
+            screenshot_base64 and allow_llm_see_data and _model and getattr(_model, "supports_vision", False)
+        )
+        if _attach_screenshot:
+            summary_msg += " Screenshot of the rendered dashboard is attached — review it for visual correctness."
 
         observation: Dict[str, Any] = {
             "summary": summary_msg,
@@ -1092,9 +1259,11 @@ Fix the errors while keeping the same design and functionality. Output the corre
         }
         if render_errors:
             observation["render_errors"] = render_errors
+        if repair_attempts:
+            observation["repair_attempts"] = repair_attempts
 
         # Add preview screenshot for planner reflection (page mode)
-        if screenshot_base64:
+        if _attach_screenshot:
             observation["images"] = [{
                 "data": screenshot_base64,
                 "media_type": "image/png",
@@ -1593,64 +1762,15 @@ prs.save(_pptx_output_path)
 
 Create a beautiful, varied presentation following these design principles. Each slide should look DIFFERENT from the others. Use visual elements, accent shapes, and thoughtful color choices:"""
 
-    def _build_page_prompt(
-        self,
-        user_prompt: str,
-        title: str | None,
-        viz_profiles: List[Dict[str, Any]],
-        instructions_context: str,
-        report_title: str | None,
-        allow_llm_see_data: bool,
-        messages_context: str = "",
-        image_count: int = 0,
-        organization_settings: Any = None,
-        files: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """Build the prompt for generating page/dashboard (React + ECharts)."""
-        viz_json = json.dumps(viz_profiles, indent=2, default=str)
+    def _build_page_system_prompt(self) -> str:
+        """Static system prompt for page/dashboard generation.
 
-        language_directive = build_language_directive(organization_settings)
-
-        # Build attached images context
-        images_context = ""
-        if image_count > 0:
-            images_context = f"\n**Attached Images:** {image_count} image(s) provided for visual reference. Use these to understand the design intent, branding, color schemes, or layout preferences the user wants to incorporate."
-
-        # Build embedded-files context (generated images / uploaded images or PDFs).
-        # These are rendered via the <BowFile> sandbox component by file id.
-        files_context = ""
-        if files:
-            lines = [
-                f'- id="{f["id"]}"  type={f.get("content_type", "")}  name={f.get("filename", "")}'
-                for f in files
-            ]
-            files_context = (
-                "\n**Embedded Files (render with `<BowFile>`):** You MUST place each of these "
-                "files in the layout using `<BowFile id=\"<id>\" />` (see the BowFile entry in the "
-                "sandbox runtime docs). Images render inline; PDFs render in a viewer. Do NOT inline "
-                "base64 and do NOT use a raw <img src>. Available files:\n" + "\n".join(lines)
-            )
-
-        # Note: Previous artifact code is now available via observation context (from create_artifact/read_artifact)
-        # The planner can call read_artifact if needed to load previous code into context
-
-        return f"""Role: frontend developer and data visualization engineer.
-
-═══════════════════════════════════════════════════════════════════════════════
-Design request (primary specification — takes precedence when it conflicts with defaults)
-═══════════════════════════════════════════════════════════════════════════════
-
-**Report Title:** {report_title or title or 'Dashboard'}
-**User Request:** {user_prompt}
-{images_context}
-{files_context}
-{f"**Organization Instructions:**{chr(10)}{instructions_context}" if instructions_context else ""}
-
-{f"**Conversation History:**{chr(10)}{messages_context}" if messages_context else ""}
-{language_directive}
-
-If the user specified a theme, layout, colors, or style above — follow that exactly.
-If the user did not specify styling, use the design guidance at the end of this prompt.
+        Contains only stable reference material (sandbox runtime docs,
+        component contract, filtering rules, design guidance, output format).
+        Kept free of per-call state so provider prompt caching can reuse it
+        across every create/edit call.
+        """
+        return f"""Role: frontend developer and data visualization engineer. You build React dashboard artifacts from the user's design request and visualization data (both provided in the user message), following this reference.
 
 ═══════════════════════════════════════════════════════════════════════════════
 REFERENCE — TOOLS, COMPONENTS & DATA
@@ -1704,6 +1824,7 @@ Each visualization:
   title: "Visualization Title",
   columns: [{{ "headerName": "Album Title", "field": "AlbumTitle", "dtype": "object", "unique_count": 150 }}, ...],
   rows: [{{ "AlbumTitle": "Battlestar Galactica", "total_revenue": 35.82 }}, ...],
+  row_count: 4321,   // TRUE dataset size
   view: {{ /* chart config hints */ }},
   dataModel: {{ /* series/axis config */ }}
 }}
@@ -1713,6 +1834,7 @@ Each visualization:
 - Use `column.headerName` for display labels
 - Column metadata includes `dtype` (pandas type) and `unique_count` — use these for filter/format decisions
 - **Do not hardcode data** — all values should come from `data.visualizations[N].rows`
+- **Sample vs full data:** the `rows`/`sample_rows` shown in the user message are a SAMPLE (capped at 100 rows per visualization) for generation and preview. At runtime the dashboard receives the FULL dataset — `row_count` rows. `row_count` is the true dataset size; `sample_row_count` is the sample size. Write code that works on the full dataset (aggregate with reduce/Map, paginate long tables) and NEVER hardcode workarounds for the sample size.
 - **Defensive coding**: Row values and properties can be `null`/`undefined`. Use optional chaining or fallbacks before calling `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()`, etc. Example: `(row.name || '').includes('x')` or `String(val ?? '').toLowerCase()`. Do not call string methods on a value that could be nullish.
 
 View hints — honor the viz config:
@@ -1739,12 +1861,6 @@ The `view_config` on each visualization describes how the author wants the data 
   }}, []);
   ```
   If the underlying runtime uses richer operators (`equals`, `greater_than`, etc.), either call `setFilter` with the operator-aware object it expects, or compute the filtered rows directly via `filterRows(viz[N].rows)` once the filter is seeded. Render the filtered view when defaults are present so the initial numbers match the author's intent.
-
-YOUR VISUALIZATIONS:
-
-{viz_json}
-
-{"(Full sample data included above)" if allow_llm_see_data else "(Data samples hidden for privacy - use column names and row_count to understand the data structure)"}
 
 FILTERING:
 - Use `useFilters()` hook for cross-visualization filtering — returns `{{ filters, setFilter, resetFilters, filterRows }}`
@@ -1861,7 +1977,74 @@ Structure: all code should be inside `function App() {{ ... }}` with `ReactDOM.c
 
 Rules: `<script type="text/babel">` wrapper. `useArtifactData()` for data. `<EChart option={{...}} />` for charts. Pass `viz={{viz[N]}}` to every KPICard/SectionCard so the built-in info popover shows the data behind it. RESPONSIVE — fluid width, responsive grids (`grid-cols-1 md:grid-cols-2 lg:grid-cols-N`), no fixed-pixel widths, no horizontal page scroll at any width (see RESPONSIVE LAYOUT section above); required unless the user asked for a fixed width. Handle zero rows. No hardcoded data. No UUIDs/branding/emoji. Guard nullish values before string methods (use `(val || '')` or `String(val ?? '')`).
 
-**Code size:** Write compact code — no unnecessary variables, comments, or verbose JSX. Omit default props. Don't repeat theme styling the 'bow' theme already provides. Prefer inline expressions over separate variables when used once. For simple dashboards target under 8K characters. For detailed/specific user requests, use as much space as needed to faithfully implement their design — fidelity to the user's request is more important than brevity.
+**Code size:** Write compact code — no unnecessary variables, comments, or verbose JSX. Omit default props. Don't repeat theme styling the 'bow' theme already provides. Prefer inline expressions over separate variables when used once. For simple dashboards target under 8K characters. For detailed/specific user requests, use as much space as needed to faithfully implement their design — fidelity to the user's request is more important than brevity."""
+
+    def _build_page_prompt(
+        self,
+        user_prompt: str,
+        title: str | None,
+        viz_profiles: List[Dict[str, Any]],
+        instructions_context: str,
+        report_title: str | None,
+        allow_llm_see_data: bool,
+        messages_context: str = "",
+        image_count: int = 0,
+        organization_settings: Any = None,
+        files: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Build the dynamic user prompt for page/dashboard generation.
+
+        Static reference material lives in _build_page_system_prompt (cached
+        as the system prompt); this carries only per-call state.
+        """
+        viz_json = json.dumps(viz_profiles, indent=2, default=str)
+
+        language_directive = build_language_directive(organization_settings)
+
+        # Build attached images context
+        images_context = ""
+        if image_count > 0:
+            images_context = f"\n**Attached Images:** {image_count} image(s) provided for visual reference. Use these to understand the design intent, branding, color schemes, or layout preferences the user wants to incorporate."
+
+        # Build embedded-files context (generated images / uploaded images or PDFs).
+        # These are rendered via the <BowFile> sandbox component by file id.
+        files_context = ""
+        if files:
+            lines = [
+                f'- id="{f["id"]}"  type={f.get("content_type", "")}  name={f.get("filename", "")}'
+                for f in files
+            ]
+            files_context = (
+                "\n**Embedded Files (render with `<BowFile>`):** You MUST place each of these "
+                "files in the layout using `<BowFile id=\"<id>\" />` (see the BowFile entry in the "
+                "sandbox runtime docs). Images render inline; PDFs render in a viewer. Do NOT inline "
+                "base64 and do NOT use a raw <img src>. Available files:\n" + "\n".join(lines)
+            )
+
+        # Note: Previous artifact code is now available via observation context (from create_artifact/read_artifact)
+        # The planner can call read_artifact if needed to load previous code into context
+
+        return f"""═══════════════════════════════════════════════════════════════════════════════
+Design request (primary specification — takes precedence when it conflicts with reference defaults)
+═══════════════════════════════════════════════════════════════════════════════
+
+**Report Title:** {report_title or title or 'Dashboard'}
+**User Request:** {user_prompt}
+{images_context}
+{files_context}
+{f"**Organization Instructions:**{chr(10)}{instructions_context}" if instructions_context else ""}
+
+{f"**Conversation History:**{chr(10)}{messages_context}" if messages_context else ""}
+{language_directive}
+
+If the user specified a theme, layout, colors, or style above — follow that exactly.
+If the user did not specify styling, use the design guidance from the reference instructions.
+
+YOUR VISUALIZATIONS:
+
+{viz_json}
+
+{"(Sample data included above — rows are a sample capped at 100; row_count is the true dataset size)" if allow_llm_see_data else "(Data samples hidden for privacy - use column names and row_count to understand the data structure)"}
 
 Now create the dashboard:"""
 

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -108,7 +108,11 @@ class CreateArtifactTool(Tool):
         try:
             import tempfile, os
             async with async_playwright() as p:
-                browser = await p.chromium.launch(headless=True)
+                # Optional executable override for deployments where the
+                # Playwright-managed browser download is unavailable but a
+                # compatible Chromium exists on disk.
+                _exe = os.environ.get("BOW_CHROMIUM_EXECUTABLE") or None
+                browser = await p.chromium.launch(headless=True, executable_path=_exe)
                 page = await browser.new_page(viewport={"width": 1280, "height": 720})
 
                 # Capture JS errors during render. Both channels matter:
@@ -430,7 +434,22 @@ Output the FULL corrected code wrapped in <script type="text/babel"> ... </scrip
         sigkill_event = runtime_ctx.get("sigkill_event")
 
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "validating_render"})
-        html = self._build_thumbnail_html(artifact_data, code, mode=mode)
+        try:
+            html = self._build_thumbnail_html(artifact_data, code, mode=mode)
+        except Exception as e:
+            # Validation infrastructure unavailable (e.g. vendored libs not
+            # downloaded) must not fail artifact creation — pass through
+            # unvalidated, exactly like the missing-Playwright fallback.
+            logger.warning(f"Render validation unavailable (thumbnail HTML build failed): {e}")
+            yield {
+                "code": code,
+                "clean": True,
+                "screenshot": None,
+                "errors": [],
+                "repair_attempts": 0,
+                "validation_skipped": True,
+            }
+            return
         screenshot, errors = await self._take_preview_screenshot(html)
         fatal = self.fatal_render_errors(errors)
 
@@ -1088,7 +1107,11 @@ Output the FULL corrected code wrapped in <script type="text/babel"> ... </scrip
                 screenshot_base64 = _validate_result["screenshot"]
                 render_errors = list(_validate_result["errors"] or [])
                 repair_attempts = int(_validate_result["repair_attempts"] or 0)
-            thumbnail_html = self._build_thumbnail_html(artifact_data, code, mode=data.mode)
+            try:
+                thumbnail_html = self._build_thumbnail_html(artifact_data, code, mode=data.mode)
+            except Exception as e:
+                logger.warning(f"Thumbnail HTML build failed: {e}")
+                thumbnail_html = None
 
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "saving_artifact"})
 

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -10,6 +10,7 @@ import difflib
 import json
 import logging
 import re
+import time
 from pathlib import Path
 from typing import AsyncIterator, Dict, Any, Type, List, Optional, Tuple
 
@@ -356,8 +357,18 @@ class EditArtifactTool(Tool):
         original_spec: Optional[str] = None,
         organization_settings: Any = None,
         files: Optional[List[Dict[str, Any]]] = None,
+        removed_vizs: Optional[List[Dict[str, str]]] = None,
+        prev_render_errors: Optional[List[str]] = None,
     ) -> str:
-        """Build the prompt for editing existing artifact code."""
+        """Build the dynamic user prompt for editing existing artifact code.
+
+        Page mode deliberately omits the conversation history and the
+        accumulated spec: the planner already distills intent into
+        edit_prompt, and after a diff edit the code IS the current spec.
+        Re-sending both grew edit prompts unboundedly (38K→63K tokens by
+        v11+ in production) and caused context-length failures. Static
+        reference material lives in _build_edit_system_prompt.
+        """
 
         viz_json = json.dumps(viz_profiles, indent=2, default=str)
         language_directive = build_language_directive(organization_settings)
@@ -391,22 +402,25 @@ class EditArtifactTool(Tool):
                 + "\n".join(lines)
             )
 
-        original_spec_section = ""
-        if original_spec:
-            original_spec_section = f"""
-═══════════════════════════════════════════════════════════════════════════════
-ORIGINAL DASHBOARD SPEC (accumulated requirements from previous iterations)
-═══════════════════════════════════════════════════════════════════════════════
-
-{original_spec}
-
-IMPORTANT: The above spec describes what the dashboard should already look like.
-Preserve ALL of these requirements while applying the new edit below.
+        removed_section = ""
+        if removed_vizs:
+            removed_list = "\n".join(f'- "{rv.get("title", "Unknown")}" (id={rv.get("id")})' for rv in removed_vizs)
+            removed_section = f"""
+**REMOVED VISUALIZATIONS — delete their code:** The following visualizations have been REMOVED from this artifact's data payload:
+{removed_list}
+Delete every code section that references them: charts, KPI cards, tables, filters fed by their columns, and any derived computations. CRITICAL: `data.visualizations` is re-indexed after removal — its current order is exactly the VISUALIZATION DATA list below. Update every `viz[N]` index reference in the surviving code to match the new order.
 """
 
-        return f"""You are editing an existing React dashboard. Apply the user's requested change with surgical precision. Do not rewrite code that does not need to change. Preserve all existing functionality, styling, layout, event handlers, and responsive behavior unless the user explicitly asked to change it.{language_directive}
+        render_errors_section = ""
+        if prev_render_errors:
+            errors_list = "\n".join(f"- {e}" for e in prev_render_errors[:5])
+            render_errors_section = f"""
+**KNOWN RENDER ERRORS in the current version:** The existing code produces these errors when rendered:
+{errors_list}
+If the edit request addresses them, these are the exact errors to fix. Either way, your edit must not reproduce them.
+"""
 
-═══════════════════════════════════════════════════════════════════════════════
+        return f"""═══════════════════════════════════════════════════════════════════════════════
 EDIT REQUEST (primary specification — follow exactly)
 ═══════════════════════════════════════════════════════════════════════════════
 
@@ -416,7 +430,29 @@ EDIT REQUEST (primary specification — follow exactly)
 {images_context}
 {files_context}
 {f"**Organization Instructions:**{chr(10)}{instructions_context}" if instructions_context else ""}
-{f"**Conversation History:**{chr(10)}{messages_context}" if messages_context else ""}
+{language_directive}
+{removed_section}{render_errors_section}
+EXISTING DASHBOARD CODE:
+
+```
+{existing_code}
+```
+
+VISUALIZATION DATA (current visualizations in data.visualizations order — for reference if the edit involves data access):
+
+{viz_json}
+
+(Note: `rows`/`sample_rows` above are a sample capped at 100 rows; `row_count` is the true dataset size the live dashboard receives.)
+
+Apply the user's edit now:"""
+
+    def _build_edit_system_prompt(self) -> str:
+        """Static system prompt for dashboard edits.
+
+        Only stable reference material — kept free of per-call state so
+        provider prompt caching reuses it across every edit call.
+        """
+        return f"""You are editing an existing React dashboard. Apply the user's requested change with surgical precision. Do not rewrite code that does not need to change. Preserve all existing functionality, styling, layout, event handlers, and responsive behavior unless the user explicitly asked to change it.
 
 ═══════════════════════════════════════════════════════════════════════════════
 REFERENCE — TOOLS, COMPONENTS & DATA
@@ -424,21 +460,12 @@ REFERENCE — TOOLS, COMPONENTS & DATA
 
 {SANDBOX_RUNTIME_PROMPT}
 
-EXISTING DASHBOARD CODE:
-
-```
-{existing_code}
-```
-{original_spec_section}
-VISUALIZATION DATA (for reference if the edit involves data access):
-
-{viz_json}
-
 DATA ACCESS:
 - `useArtifactData()` returns `{{ report, visualizations }}` or `null` while loading
 - Each viz: `{{ id, title, columns: [{{headerName, field, dtype, unique_count}}], rows: [{{...}}], view, dataModel }}`
 - Access values: `row[column.field]`, display labels: `column.headerName`
 - Column metadata includes `dtype` (pandas type) and `unique_count` — use these for filter/format decisions
+- **Sample vs full data:** `rows` in the user message are a SAMPLE (capped at 100) for editing context; at runtime the dashboard receives the FULL dataset — `row_count` rows. Never write workarounds for the sample size.
 - **NEVER hardcode data** — ALL values from `data.visualizations[N].rows`
 - **DEFENSIVE CODING**: Row values can be `null`/`undefined`. ALWAYS guard before string methods: `(val || '').includes('x')` or `String(val ?? '').toLowerCase()`. Never call `.includes()`, `.toLowerCase()`, `.startsWith()`, `.split()` on a potentially nullish value.
 
@@ -528,9 +555,7 @@ Rules:
 - For NEW charts, use `<EChart option={{...}} height={{N}} />` — supports ALL ECharts types. 'bow' theme handles base styling.
 - Do NOT output full code. Only SEARCH/REPLACE blocks. If the change feels too large for diffs, output nothing — the planner will use create_artifact instead.
 
-⚠️ **Implement the user's full request.** Don't skip requested changes to save tokens. Don't rewrite code the user didn't ask to change.
-
-Apply the user's edit now:"""
+⚠️ **Implement the user's full request.** Don't skip requested changes to save tokens. Don't rewrite code the user didn't ask to change."""
 
     def _build_slides_edit_prompt(
         self,
@@ -616,8 +641,70 @@ Deck rules that still apply to an edit:
 
 Apply the edit now:"""
 
+    async def _retry_failed_diff(
+        self,
+        edit_prompt: str,
+        existing_code: str,
+        failed_diff: str,
+        failure_details: List[str],
+        runtime_ctx: Dict[str, Any],
+    ) -> Optional[str]:
+        """One compact in-tool retry for SEARCH/REPLACE blocks that didn't match.
+
+        Feeds the per-block failure diagnostics (with closest-match hints)
+        back to the model so it can correct the SEARCH text against the real
+        code. Returns the new diff text, or None if unavailable.
+        """
+        sigkill_event = runtime_ctx.get("sigkill_event")
+        if sigkill_event and sigkill_event.is_set():
+            return None
+
+        failures_text = "\n\n".join(failure_details[:5])
+        retry_prompt = f"""You produced SEARCH/REPLACE diff blocks for the edit request below, but some SEARCH blocks did not match the actual code. The artifact was NOT modified.
+
+EDIT REQUEST:
+{edit_prompt}
+
+MATCH FAILURES (with closest-match hints from the real code):
+{failures_text}
+
+ACTUAL CURRENT CODE:
+```
+{existing_code}
+```
+
+YOUR PREVIOUS (failed) DIFF:
+{failed_diff}
+
+Re-emit corrected SEARCH/REPLACE blocks for the SAME edit. Copy SEARCH text exactly from the ACTUAL CURRENT CODE above (2-3 lines of context, byte-exact). Output ONLY the blocks:
+
+<<<<<<< SEARCH
+(exact lines from actual code)
+=======
+(replacement lines)
+>>>>>>> REPLACE"""
+
+        llm = LLM(runtime_ctx.get("model"), usage_session_maker=async_session_maker)
+        try:
+            chunks: list[str] = []
+            async for evt in llm.inference_stream_v2(
+                messages=[Message(role="user", content=retry_prompt)],
+                usage_scope="edit_artifact_diff_retry",
+            ):
+                if sigkill_event and sigkill_event.is_set():
+                    return None
+                if isinstance(evt, TextDeltaEvent):
+                    chunks.append(evt.text)
+            out = "".join(chunks)
+            return out if out.strip() else None
+        except Exception:
+            logger.exception("edit_artifact: diff retry failed")
+            return None
+
     async def run_stream(self, tool_input: Dict[str, Any], runtime_ctx: Dict[str, Any]) -> AsyncIterator[ToolEvent]:
         data = EditArtifactInput(**tool_input)
+        # Repair budget: leave headroom under the runner's 300s hard timeout.
+        _repair_deadline = time.monotonic() + 210
 
         yield ToolStartEvent(type="tool.start", payload={"artifact_id": data.artifact_id, "title": "Editing artifact"})
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "loading_artifact"})
@@ -737,31 +824,59 @@ Apply the edit now:"""
                     })
                     seen_file_ids.add(str(f.id))
 
-        # Merge visualization IDs: existing + any new ones from input + auto-discovered
-        merged_viz_ids = list(existing_viz_ids)
+        # Merge visualization IDs: (existing − removed) + new. Removal is the
+        # only way stale visualizations ever leave an artifact — without it,
+        # replace-flows shipped both the old and the new viz forever.
+        removed_viz_ids = {str(v) for v in (data.remove_visualization_ids or [])}
+        merged_viz_ids = [v for v in existing_viz_ids if str(v) not in removed_viz_ids]
         if data.visualization_ids:
             for vid in data.visualization_ids:
-                if vid not in merged_viz_ids:
+                if vid not in merged_viz_ids and str(vid) not in removed_viz_ids:
                     merged_viz_ids.append(vid)
 
-        # Auto-merge: pick up any report vizs created after the artifact being edited
+        # Auto-merge: pick up report vizs created during THIS turn that the
+        # planner forgot to pass. Scoped to the current head completion —
+        # the old version swept in anything created since the artifact
+        # existed, which grafted unrelated explorations onto the dashboard
+        # and broke replace-flows.
         report_id = str(report.id) if report else None
-        if report_id:
+        head_completion = runtime_ctx.get("head_completion")
+        _turn_started_at = getattr(head_completion, "created_at", None)
+        if report_id and _turn_started_at is not None:
             try:
                 async with async_session_maker() as fresh_db:
                     new_vizs = await fresh_db.execute(
                         select(Visualization.id).where(
                             Visualization.report_id == report_id,
                             Visualization.created_at > artifact.created_at,
+                            Visualization.created_at >= _turn_started_at,
                         )
                     )
                     for (vid,) in new_vizs.all():
                         vid_str = str(vid)
-                        if vid_str not in merged_viz_ids:
+                        if vid_str not in merged_viz_ids and vid_str not in removed_viz_ids:
                             merged_viz_ids.append(vid_str)
-                            logger.info(f"edit_artifact: auto-merged viz {vid_str} (created after artifact)")
+                            logger.info(f"edit_artifact: auto-merged viz {vid_str} (created this turn)")
             except Exception as e:
                 logger.warning(f"edit_artifact: auto-merge viz query failed: {e}")
+
+        # Resolve titles of removed vizs so the prompt can instruct deletion
+        # of their code sections (the model needs names, not UUIDs).
+        removed_viz_info: List[Dict[str, str]] = []
+        if removed_viz_ids:
+            try:
+                async with async_session_maker() as fresh_db:
+                    _removed_rows = await fresh_db.execute(
+                        select(Visualization.id, Visualization.title).where(
+                            Visualization.id.in_(list(removed_viz_ids))
+                        )
+                    )
+                    _found_removed = {str(rid): (rtitle or "Untitled") for rid, rtitle in _removed_rows.all()}
+            except Exception as e:
+                logger.warning(f"edit_artifact: failed to resolve removed viz titles: {e}")
+                _found_removed = {}
+            for rid in removed_viz_ids:
+                removed_viz_info.append({"id": rid, "title": _found_removed.get(rid, "Unknown")})
 
         # Fetch all visualizations (batched query, same as create_artifact)
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "loading_visualizations"})
@@ -811,7 +926,8 @@ Apply the edit now:"""
                 continue
 
             step_data = step.data if step else {}
-            rows = (step_data.get("rows") or [])[:100] if step_data else []
+            _all_rows = (step_data.get("rows") or []) if step_data else []
+            rows = _all_rows[:100]
             raw_columns = step_data.get("columns") or [] if step_data else []
             data_model = step.data_model if step else {}
             step_info = step_data.get("info") or {} if step_data else {}
@@ -828,7 +944,10 @@ Apply the edit now:"""
                 "data_model_type": (view_dict.get("view") or {}).get("type") or view_dict.get("type"),
                 "columns": raw_columns,
                 "column_info": column_info,
-                "row_count": len(rows),
+                # row_count = TRUE dataset size; rows is a 100-row sample
+                # (see create_artifact — same contract).
+                "row_count": len(_all_rows),
+                "sample_row_count": len(rows),
                 "rows": rows,
                 "dataModel": data_model or {},
             }
@@ -888,6 +1007,10 @@ Apply the edit now:"""
         # Build the edit prompt
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "generating_edit"})
 
+        # Feed the edited version's known render errors forward so a repair
+        # edit sees the exact failure instead of a planner paraphrase.
+        prev_render_errors = list(getattr(artifact, "render_errors", None) or [])
+
         prompt = self._build_edit_prompt(
             existing_code=existing_code,
             edit_prompt=data.edit_prompt,
@@ -900,7 +1023,26 @@ Apply the edit now:"""
             original_spec=artifact.generation_prompt,
             organization_settings=organization_settings,
             files=merged_files,
+            removed_vizs=removed_viz_info,
+            prev_render_errors=prev_render_errors,
         )
+        # Static reference goes in the system prompt (cached provider-side);
+        # slides keeps its single-prompt path.
+        system_prompt = self._build_edit_system_prompt() if artifact.mode == "page" else None
+
+        # Attach the broken version's screenshot when this edit is a repair —
+        # gated on privacy + vision like every other screenshot attachment.
+        _edit_images: List[Any] = list(completion_images) if completion_images else []
+        _prev_screenshot = getattr(artifact, "screenshot_base64", None)
+        if (
+            prev_render_errors
+            and _prev_screenshot
+            and allow_llm_see_data
+            and model
+            and getattr(model, "supports_vision", False)
+        ):
+            from app.ai.llm.types import ImageInput as _ImageInput
+            _edit_images.append(_ImageInput(data=_prev_screenshot, media_type="image/png", source_type="base64"))
 
         # Stream LLM response
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "llm_generating"})
@@ -909,7 +1051,8 @@ Apply the edit now:"""
 
         async for evt in llm.inference_stream_v2(
             messages=[Message(role="user", content=prompt)],
-            images=completion_images if completion_images else None,
+            system=system_prompt,
+            images=_edit_images if _edit_images else None,
             usage_scope="edit_artifact",
             usage_scope_ref_id=str(report.id) if report else None,
         ):
@@ -968,6 +1111,29 @@ Apply the edit now:"""
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "applying_edit"})
 
         new_code, diff_applied, num_blocks, failure_details = apply_search_replace_diff(existing_code, buffer)
+
+        # One in-tool retry when blocks were produced but failed to match:
+        # feed the failure diagnostics (with closest-match hints) back to the
+        # model for corrected SEARCH text, instead of bouncing the failure to
+        # a full outer planner iteration.
+        diff_retry_used = False
+        if num_blocks > 0 and not diff_applied and not (sigkill_event and sigkill_event.is_set()):
+            yield ToolProgressEvent(
+                type="tool.progress",
+                payload={"stage": "retrying_diff", "failed_blocks": len(failure_details)},
+            )
+            _retry_buffer = await self._retry_failed_diff(
+                edit_prompt=data.edit_prompt,
+                existing_code=existing_code,
+                failed_diff=buffer,
+                failure_details=failure_details,
+                runtime_ctx=runtime_ctx,
+            )
+            if _retry_buffer:
+                diff_retry_used = True
+                _code2, _applied2, _blocks2, _fail2 = apply_search_replace_diff(existing_code, _retry_buffer)
+                if _blocks2 > 0 and _applied2:
+                    new_code, diff_applied, num_blocks, failure_details = _code2, _applied2, _blocks2, _fail2
 
         edit_failed = False
 
@@ -1039,6 +1205,87 @@ Apply the edit now:"""
             )
             return
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # Page mode: render-validate the edited code (and repair in-tool)
+        # BEFORE persisting a new version. A version that doesn't render is
+        # never persisted — the last good version stays live and the planner
+        # gets a structured failure with the exact errors.
+        # ═══════════════════════════════════════════════════════════════════════
+        screenshot_base64: Optional[str] = None
+        render_errors: list[str] = []
+        render_repair_attempts = 0
+        page_artifact_data: Optional[Dict[str, Any]] = None
+
+        if artifact.mode == "page":
+            page_artifact_data = {
+                "report": {
+                    "id": str(report.id) if report else None,
+                    "title": getattr(report, "title", None) if report else None,
+                    "theme": getattr(report, "theme", None) if report else None,
+                },
+                "visualizations": visualizations,
+            }
+            if merged_files:
+                try:
+                    page_artifact_data["files"] = await self._create_tool._build_file_datauris(db, merged_files)
+                except Exception as e:
+                    logger.warning(f"edit_artifact: failed to build file datauris for validation render: {e}")
+
+            _validate_result: Optional[Dict[str, Any]] = None
+            async for _item in self._create_tool._validate_and_repair_stream(
+                new_code, page_artifact_data, "page", runtime_ctx, deadline_monotonic=_repair_deadline,
+            ):
+                if isinstance(_item, dict):
+                    _validate_result = _item
+                else:
+                    yield _item
+
+            if _validate_result is not None:
+                if _validate_result["clean"]:
+                    new_code = _validate_result["code"]
+                    screenshot_base64 = _validate_result["screenshot"]
+                    render_errors = list(_validate_result["errors"] or [])
+                    render_repair_attempts = int(_validate_result["repair_attempts"] or 0)
+                else:
+                    _fatal = self._create_tool.fatal_render_errors(_validate_result["errors"] or [])
+                    _first_error = _fatal[0] if _fatal else "unknown render error"
+                    _attempts = int(_validate_result["repair_attempts"] or 0)
+                    yield ToolEndEvent(
+                        type="tool.end",
+                        payload={
+                            "output": {
+                                "success": False,
+                                "artifact_id": str(artifact.id),
+                                "error": f"Edited code failed render validation: {_first_error}",
+                            },
+                            "observation": {
+                                "summary": (
+                                    f"Edit rejected for artifact '{artifact.title or 'Untitled'}' (v{artifact.version}): "
+                                    f"the edited code fails to render with {len(_fatal)} fatal error(s) after "
+                                    f"{_attempts} in-tool repair attempt(s). The artifact was NOT modified — "
+                                    f"the previous version remains live. First error: {_first_error}"
+                                ),
+                                "error": {
+                                    "type": "render_validation_failed",
+                                    "message": _first_error,
+                                    "render_errors": _validate_result["errors"] or [],
+                                    "repair_attempts": _attempts,
+                                    "remediation": (
+                                        "Retry edit_artifact with an edit_prompt that quotes the exact error(s) "
+                                        "above and describes a simpler change, or rebuild via create_artifact if "
+                                        "the edit fundamentally conflicts with the existing code."
+                                    ),
+                                },
+                                "artifact_id": str(artifact.id),
+                                "mode": artifact.mode,
+                                "version": artifact.version,
+                                "diff_applied": False,
+                                "warnings": warnings,
+                            },
+                        },
+                    )
+                    return
+
         # Update title if provided
         new_title = data.title or artifact.title
 
@@ -1067,6 +1314,11 @@ Apply the edit now:"""
             version=new_version,
             status="completed",
         )
+        # Page mode reached here only with a validated render — persist the
+        # screenshot and (non-fatal) console errors captured during validation.
+        if screenshot_base64 or render_errors:
+            new_artifact.screenshot_base64 = screenshot_base64
+            new_artifact.render_errors = render_errors or None
         db.add(new_artifact)
         await db.commit()
         await db.refresh(new_artifact)
@@ -1116,33 +1368,10 @@ Apply the edit now:"""
             await db.commit()
             await db.refresh(new_artifact)
 
-        # Page mode: take preview screenshot for planner reflection + generate thumbnail
-        screenshot_base64: Optional[str] = None
-        render_errors: list[str] = []
-        if new_artifact.mode == "page":
-            artifact_data = {
-                "report": {
-                    "id": str(report.id) if report else None,
-                    "title": getattr(report, "title", None) if report else None,
-                    "theme": getattr(report, "theme", None) if report else None,
-                },
-                "visualizations": visualizations,
-            }
-            thumbnail_html = self._create_tool._build_thumbnail_html(artifact_data, new_code, mode=new_artifact.mode)
-
-            # Take preview screenshot (synchronous, ~3-5s) if model supports vision
-            model = runtime_ctx.get("model")
-            if allow_llm_see_data and model and getattr(model, "supports_vision", False):
-                yield ToolProgressEvent(type="tool.progress", payload={"stage": "capturing_preview"})
-                screenshot_base64, render_errors = await self._create_tool._take_preview_screenshot(thumbnail_html)
-
-            # Persist screenshot and render errors on artifact for later retrieval (read_artifact)
-            if screenshot_base64 or render_errors:
-                new_artifact.screenshot_base64 = screenshot_base64
-                new_artifact.render_errors = render_errors or None
-                await db.commit()
-
-            # Generate thumbnail in background (for stored thumbnail, non-blocking)
+        # Page mode: validation (and its screenshot) already ran before the
+        # version was persisted — only the background thumbnail remains.
+        if new_artifact.mode == "page" and page_artifact_data is not None:
+            thumbnail_html = self._create_tool._build_thumbnail_html(page_artifact_data, new_code, mode=new_artifact.mode)
             asyncio.create_task(
                 self._create_tool._generate_thumbnail_background(
                     artifact_id=str(new_artifact.id),
@@ -1186,15 +1415,28 @@ Apply the edit now:"""
         summary_msg = f"Edited artifact '{new_title or 'Untitled'}' (v{new_version})"
         if diff_applied:
             summary_msg += f" — applied {num_blocks} surgical edit(s)"
+            if diff_retry_used:
+                summary_msg += " (after one in-tool diff retry)"
         else:
             summary_msg += " — fell back to full rewrite"
-        if render_errors:
-            summary_msg += f". RENDER FAILED with {len(render_errors)} error(s): {render_errors[0]}"
-            if len(render_errors) > 1:
-                summary_msg += f" (and {len(render_errors) - 1} more)"
-            summary_msg += ". The dashboard code has a bug — use edit_artifact to fix the specific error."
-        elif screenshot_base64:
-            summary_msg += ". Screenshot of the rendered dashboard is attached — review it for visual correctness."
+        if new_artifact.mode == "page":
+            if render_repair_attempts:
+                summary_msg += f". Render validation passed after {render_repair_attempts} in-tool repair attempt(s)."
+            else:
+                summary_msg += ". Render validation passed."
+            _console_warnings = [e for e in render_errors if e.startswith("[console.error]")]
+            if _console_warnings:
+                summary_msg += f" {len(_console_warnings)} non-fatal console error(s) were logged."
+        if removed_viz_info:
+            _removed_titles = ", ".join(rv.get("title", rv.get("id", "?")) for rv in removed_viz_info)
+            summary_msg += f" Removed visualization(s): {_removed_titles}."
+
+        # Screenshot attachment gated on privacy + vision (it shows the data)
+        _attach_screenshot = bool(
+            screenshot_base64 and allow_llm_see_data and model and getattr(model, "supports_vision", False)
+        )
+        if _attach_screenshot:
+            summary_msg += " Screenshot of the rendered dashboard is attached — review it for visual correctness."
 
         observation: Dict[str, Any] = {
             "summary": summary_msg,
@@ -1206,11 +1448,15 @@ Apply the edit now:"""
             "visualization_ids": included_viz_ids,
             "visualization_profiles": viz_profiles,  # columns, sample rows (gated by allow_llm_see_data), data model
         }
+        if removed_viz_info:
+            observation["removed_visualization_ids"] = [rv.get("id") for rv in removed_viz_info]
         if render_errors:
             observation["render_errors"] = render_errors
+        if render_repair_attempts:
+            observation["repair_attempts"] = render_repair_attempts
 
         # Add preview screenshot for planner reflection (page mode)
-        if screenshot_base64:
+        if _attach_screenshot:
             observation["images"] = [{
                 "data": screenshot_base64,
                 "media_type": "image/png",

--- a/backend/app/ai/tools/mcp/create_artifact.py
+++ b/backend/app/ai/tools/mcp/create_artifact.py
@@ -329,6 +329,10 @@ class CreateArtifactMCPTool(MCPTool):
             allow_llm_see_data=allow_llm_see_data,
             messages_context="",
         )
+        # The static reference moved to the system prompt for the agent path;
+        # this sync MCP path sends a single prompt, so prepend it here.
+        if mode == "page":
+            base_prompt = artifact_tool._build_page_system_prompt() + "\n\n" + base_prompt
 
         # Add selection guidance at the beginning of the design request section
         selection_guidance = f"""

--- a/backend/app/ai/tools/mcp/edit_artifact.py
+++ b/backend/app/ai/tools/mcp/edit_artifact.py
@@ -219,12 +219,17 @@ class EditArtifactMCPTool(MCPTool):
         instructions_context = rich_ctx.instructions_text or ""
         prompt = edit_tool._build_edit_prompt(
             existing_code=existing_code,
-            edit_instruction=input_data.edit_instruction,
+            edit_prompt=input_data.edit_instruction,
             mode=artifact.mode,
             viz_profiles=viz_profiles,
             instructions_context=instructions_context,
             report_title=getattr(report, 'title', None),
         )
+        # The static reference (sandbox docs, diff output format) moved to the
+        # system prompt for the agent path; this sync MCP path sends a single
+        # prompt, so prepend it here.
+        if artifact.mode == "page":
+            prompt = edit_tool._build_edit_system_prompt() + "\n\n" + prompt
 
         # LLM inference (non-streaming for MCP). Offloaded to a worker
         # thread because `LLM.inference` is sync and runs the pre-call
@@ -252,7 +257,7 @@ class EditArtifactMCPTool(MCPTool):
             ).model_dump()
 
         # Apply the diff
-        new_code, diff_applied, num_blocks = apply_search_replace_diff(existing_code, response)
+        new_code, diff_applied, num_blocks, _failure_details = apply_search_replace_diff(existing_code, response)
 
         if num_blocks == 0:
             # No diff blocks — try full rewrite fallback

--- a/backend/app/ai/tools/schemas/edit_artifact.py
+++ b/backend/app/ai/tools/schemas/edit_artifact.py
@@ -30,6 +30,12 @@ class EditArtifactInput(BaseModel):
         "Preserve the existing title unless the user asked to rename."
     ))
     visualization_ids: Optional[List[str]] = Field(default=None, description="List of NEW visualization IDs to include in the artifact. IMPORTANT: If you called create_data before this edit, you MUST pass the resulting visualization_id(s) here. Without them, the new visualizations will not appear in the dashboard. Existing visualization IDs from the original artifact are kept automatically — only pass new ones.")
+    remove_visualization_ids: Optional[List[str]] = Field(default=None, description=(
+        "Visualization IDs to REMOVE from the artifact. Use when the user asks to remove a chart/KPI/table, "
+        "or to REPLACE one (pass the old viz id here and the new viz id in visualization_ids). "
+        "Removed visualizations are dropped from the artifact's data payload and their code sections are deleted. "
+        "Without this, edits are additive and stale visualizations stay in the dashboard forever."
+    ))
     title: Optional[str] = Field(default=None, description="Updated title for the artifact. If not provided, the existing title is kept.")
     file_ids: Optional[List[str]] = Field(default=None, description="List of NEW File IDs (generated images from generate_image, or uploaded images/PDFs) to embed. Existing embedded files are kept automatically — only pass new ones. Reference them in the code with <BowFile id=\"<file_id>\" /> (see the sandbox runtime docs).")
 

--- a/backend/app/services/thumbnail_service.py
+++ b/backend/app/services/thumbnail_service.py
@@ -46,8 +46,12 @@ class ThumbnailService:
         thumbnail_path = self.UPLOADS_DIR / f"{artifact_id}.png"
 
         try:
+            import os
             async with async_playwright() as p:
-                browser = await p.chromium.launch(headless=True)
+                # Optional executable override — same contract as the artifact
+                # render validation (BOW_CHROMIUM_EXECUTABLE).
+                _exe = os.environ.get("BOW_CHROMIUM_EXECUTABLE") or None
+                browser = await p.chromium.launch(headless=True, executable_path=_exe)
                 page = await browser.new_page(viewport={"width": 1280, "height": 720})
 
                 await page.set_content(html_content, wait_until="networkidle")

--- a/backend/tests/unit/test_artifact_feedback_loop.py
+++ b/backend/tests/unit/test_artifact_feedback_loop.py
@@ -1,0 +1,271 @@
+"""Artifact feedback-loop fixes.
+
+Covers the production-incident fixes from the 2026-08-05 harness-export
+investigation:
+
+1. ToolRunner no longer validates failure envelopes (success=False) against
+   the SUCCESS output model — doing so replaced meaningful failure
+   observations (DATA_GAP remediation, unmatched-diff details) with a generic
+   "Output validation failed".
+2. ToolRunner never retries non-recoverable errors (context window exceeded,
+   provider credit exhaustion) — production replayed identical oversized
+   prompts and a credit failure twice.
+3. Page-mode edit prompts no longer carry the accumulated spec or the
+   conversation history (they grew edit input from 38K to 63K tokens by
+   v11+), and the static reference moved to a cacheable system prompt.
+4. remove_visualization_ids exists on the edit input, and removed
+   visualizations produce explicit delete + re-index instructions.
+5. fatal_render_errors gates only thrown errors; console errors are advisory.
+6. Visualization profiles carry the true dataset size and the sample size as
+   separate fields.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator, Type
+
+import pytest
+from pydantic import BaseModel, Field
+
+from app.ai.runner.tool_runner import ToolRunner, is_non_recoverable_error
+from app.ai.runner.policies import RetryPolicy
+
+
+# ─── 1. Failure envelopes bypass success-model validation ────────────────────
+
+class _StrictOutput(BaseModel):
+    artifact_id: str = Field(...)
+    code: str = Field(...)
+    version: int = Field(...)
+
+
+class _FailingEnvelopeTool:
+    """Returns a failure envelope that would NOT validate as _StrictOutput."""
+
+    name = "failing_envelope_tool"
+    spec = None
+    metadata = None
+    input_model = None
+    output_model = _StrictOutput
+
+    async def run_stream(self, tool_input, runtime_ctx) -> AsyncIterator[dict]:
+        yield {
+            "type": "tool.end",
+            "payload": {
+                "output": {"success": False, "artifact_id": "a1", "error": "data gap"},
+                "observation": {
+                    "summary": "Edit blocked — data gap: missing customer_id",
+                    "error": {
+                        "type": "data_gap",
+                        "message": "missing customer_id",
+                        "remediation": "Recreate via create_data, do NOT fall back to create_artifact.",
+                    },
+                },
+            },
+        }
+
+
+class _InvalidSuccessTool:
+    """Returns a successful-looking output that fails the output model."""
+
+    name = "invalid_success_tool"
+    spec = None
+    metadata = None
+    input_model = None
+    output_model = _StrictOutput
+
+    async def run_stream(self, tool_input, runtime_ctx) -> AsyncIterator[dict]:
+        yield {
+            "type": "tool.end",
+            "payload": {
+                "output": {"artifact_id": "a1"},  # missing code/version
+                "observation": {"summary": "looks done"},
+            },
+        }
+
+
+async def _noop_emit(event):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_failure_envelope_preserves_real_observation():
+    runner = ToolRunner()
+    result = await runner.run(_FailingEnvelopeTool(), {}, {"mode": "chat"}, _noop_emit)
+
+    observation = result["observation"]
+    assert observation["error"]["type"] == "data_gap"
+    assert "create_data" in observation["error"]["remediation"]
+    assert result["output"]["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_invalid_success_output_still_fails_validation():
+    runner = ToolRunner()
+    result = await runner.run(_InvalidSuccessTool(), {}, {"mode": "chat"}, _noop_emit)
+
+    assert result["error"]["type"] == "output_validation_error"
+
+
+# ─── 2. Non-recoverable errors are never retried ─────────────────────────────
+
+class _ContextLengthTool:
+    name = "context_length_tool"
+    spec = None
+    metadata = None
+    input_model = None
+    output_model = None
+    attempts = 0
+
+    async def run_stream(self, tool_input, runtime_ctx) -> AsyncIterator[dict]:
+        type(self).attempts += 1
+        raise RuntimeError("This model's maximum context length is 200000 tokens; your prompt is too long")
+        yield  # pragma: no cover
+
+
+class _TransientErrorTool:
+    name = "transient_error_tool"
+    spec = None
+    metadata = None
+    input_model = None
+    output_model = None
+    attempts = 0
+
+    async def run_stream(self, tool_input, runtime_ctx) -> AsyncIterator[dict]:
+        type(self).attempts += 1
+        raise RuntimeError("connection reset by peer")
+        yield  # pragma: no cover
+
+
+def test_non_recoverable_error_patterns():
+    assert is_non_recoverable_error("maximum context length exceeded")
+    assert is_non_recoverable_error("Your credit balance is too low")
+    assert is_non_recoverable_error("You exceeded your current quota")
+    assert not is_non_recoverable_error("connection reset by peer")
+    assert not is_non_recoverable_error(None)
+
+
+@pytest.mark.asyncio
+async def test_context_length_error_not_retried():
+    _ContextLengthTool.attempts = 0
+    runner = ToolRunner(retry=RetryPolicy(max_attempts=2, backoff_ms=1, jitter_ms=0))
+    result = await runner.run(_ContextLengthTool(), {}, {"mode": "chat"}, _noop_emit)
+
+    assert _ContextLengthTool.attempts == 1
+    assert result["error"]["non_recoverable"] is True
+
+
+@pytest.mark.asyncio
+async def test_transient_error_still_retried():
+    _TransientErrorTool.attempts = 0
+    runner = ToolRunner(retry=RetryPolicy(max_attempts=2, backoff_ms=1, jitter_ms=0))
+    result = await runner.run(_TransientErrorTool(), {}, {"mode": "chat"}, _noop_emit)
+
+    assert _TransientErrorTool.attempts == 2
+    assert "non_recoverable" not in result["error"]
+
+
+# ─── 3. Edit prompt slimming + system split ──────────────────────────────────
+
+def _build_page_edit_prompt(**overrides):
+    from app.ai.tools.implementations.edit_artifact import EditArtifactTool
+
+    tool = EditArtifactTool()
+    kwargs = dict(
+        existing_code="<script type=\"text/babel\">function App(){return null}</script>",
+        edit_prompt="Make the KPI row blue",
+        mode="page",
+        viz_profiles=[{"id": "v1", "title": "Revenue", "row_count": 5000, "sample_row_count": 100}],
+        instructions_context="",
+        messages_context="user: hello\nassistant: hi",
+        report_title="Q3",
+        original_spec="Build a dashboard\n+ Edit (v2): add filters",
+    )
+    kwargs.update(overrides)
+    return tool, tool._build_edit_prompt(**kwargs)
+
+
+def test_page_edit_prompt_omits_history_and_accumulated_spec():
+    _, prompt = _build_page_edit_prompt()
+    assert "Conversation History" not in prompt
+    assert "ORIGINAL DASHBOARD SPEC" not in prompt
+    assert "Make the KPI row blue" in prompt
+
+
+def test_page_edit_prompt_static_reference_lives_in_system_prompt():
+    tool, prompt = _build_page_edit_prompt()
+    system = tool._build_edit_system_prompt()
+    # Diff output contract + sandbox reference are static → system prompt
+    assert "<<<<<<< SEARCH" in system
+    assert "useArtifactData" in system
+    assert "<<<<<<< SEARCH" not in prompt
+
+
+def test_page_edit_prompt_includes_render_error_feedforward():
+    _, prompt = _build_page_edit_prompt(
+        prev_render_errors=["ReferenceError: fmtX is not defined"],
+    )
+    assert "KNOWN RENDER ERRORS" in prompt
+    assert "fmtX is not defined" in prompt
+
+
+# ─── 4. Visualization removal contract ───────────────────────────────────────
+
+def test_edit_input_accepts_remove_visualization_ids():
+    from app.ai.tools.schemas.edit_artifact import EditArtifactInput
+
+    data = EditArtifactInput(
+        artifact_id="a1",
+        edit_prompt="remove the pie chart",
+        remove_visualization_ids=["v2"],
+    )
+    assert data.remove_visualization_ids == ["v2"]
+
+
+def test_removed_vizs_produce_delete_and_reindex_instructions():
+    _, prompt = _build_page_edit_prompt(
+        removed_vizs=[{"id": "v2", "title": "Sales by Region"}],
+    )
+    assert "REMOVED VISUALIZATIONS" in prompt
+    assert "Sales by Region" in prompt
+    assert "re-indexed" in prompt
+
+
+# ─── 5. Fatal vs advisory render errors ──────────────────────────────────────
+
+def test_fatal_render_errors_ignores_console_entries():
+    from app.ai.tools.implementations.create_artifact import CreateArtifactTool
+
+    errors = [
+        "[console.error] Warning: Each child in a list should have a unique key",
+        "ReferenceError: x is not defined",
+    ]
+    fatal = CreateArtifactTool.fatal_render_errors(errors)
+    assert fatal == ["ReferenceError: x is not defined"]
+    assert CreateArtifactTool.fatal_render_errors([]) == []
+
+
+# ─── 6. Sample vs total row counts ───────────────────────────────────────────
+
+def test_viz_profile_reports_true_and_sample_row_counts():
+    from app.ai.tools.implementations.create_artifact import CreateArtifactTool
+
+    tool = CreateArtifactTool()
+    viz = {
+        "id": "v1",
+        "title": "Revenue",
+        "row_count": 5000,          # true dataset size (from full step rows)
+        "sample_row_count": 100,    # capped sample
+        "rows": [{"a": 1}] * 100,
+        "columns": [{"field": "a"}],
+    }
+    profile = tool._build_viz_profile(viz, allow_llm_see_data=True)
+    assert profile["row_count"] == 5000
+    assert profile["sample_row_count"] == 100
+
+
+def test_create_page_system_prompt_documents_sample_contract():
+    from app.ai.tools.implementations.create_artifact import CreateArtifactTool
+
+    system = CreateArtifactTool()._build_page_system_prompt()
+    assert "Sample vs full data" in system
+    assert "row_count" in system


### PR DESCRIPTION
## Summary

This PR implements production-incident fixes from the 2026-08-05 harness-export investigation, focusing on artifact creation/editing reliability, render validation with in-tool repair, and prompt optimization to prevent context-length failures.

## Key Changes

### 1. Render Validation & In-Tool Repair (Page Mode)
- Added `_validate_and_repair_stream()` to validate generated code before persistence
- Implements bounded in-tool repair loop (`MAX_RENDER_REPAIR_ATTEMPTS = 2`) that attempts to fix fatal render errors without full planner iteration
- Distinguishes fatal errors (thrown/uncaught exceptions) from advisory errors (console.error entries) via `fatal_render_errors()`
- Returns original verified-broken code if repair doesn't converge, ensuring persisted code matches what was validated
- Captures both `pageerror` and `console` error channels during headless preview

### 2. Edit Prompt Optimization
- Removed accumulated spec and conversation history from page-mode edit prompts (reduced 38K→63K token growth in v11+)
- Moved static reference material (sandbox runtime, diff contract, data access patterns) to new `_build_edit_system_prompt()` for provider-side prompt caching
- Added `prev_render_errors` feedforward to edit prompts so model knows which errors to fix
- Added `removed_vizs` section with explicit delete + re-index instructions when visualizations are removed
- Introduced `_retry_failed_diff()` for one compact in-tool retry of unmatched SEARCH/REPLACE blocks

### 3. Visualization Data Handling
- Split row counts into `row_count` (true dataset size) and `sample_row_count` (capped at 100 for generation/preview)
- Prevents LLM from generating truncation workarounds based on sample size
- Updated viz profiles and artifact data structures to carry both counts
- Scoped auto-merge of new visualizations to current turn (via `head_completion.created_at`) instead of all-time

### 4. Tool Runner & Error Handling
- Added `is_non_recoverable_error()` to detect context-length and quota-exhaustion failures
- Non-recoverable errors are never retried (prevents double cost/latency)
- Failure envelopes (success=False) bypass success-model validation, preserving real error observations (DATA_GAP remediation, unmatched-diff details)
- Artifact budget enforcement moved pre-execution to prevent oversized calls from running to completion

### 5. Chromium Executable Override
- Added `BOW_CHROMIUM_EXECUTABLE` environment variable support for deployments where Playwright-managed browser download is unavailable
- Allows fallback to compatible Chromium on disk

### 6. Repair Deadline & Timeout Management
- Added 210-second repair deadline (headroom under 300s runner timeout) for artifact operations
- Ensures final persist + observation completes within hard timeout

## Implementation Details

- Error capture during headless render now uses both `pageerror` (thrown exceptions) and `console` (library-reported failures) channels
- Repair loop respects sigkill events and deadline monotonic time
- System prompts are static and cacheable; dynamic user prompts contain only per-call state
- Removed visualization IDs are resolved to titles for user-facing instructions
- Edit input schema now includes `remove_visualization_ids` field
- Comprehensive test coverage in new `test_artifact_feedback_loop.py`

https://claude.ai/code/session_01GDj3tfMANPmvXbeZUBSiwy