### PR TITLE
Fix agent loop to properly handle empty planner decisions and step exhaustion

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1771,12 +1771,30 @@ class AgentV2:
                         final_decision = evt.data
                         break
 
-                if not final_decision:
+                # A decision object that exists but carries no content (no
+                # action, no text, no reasoning) — or carries a planner error —
+                # is treated exactly like no decision at all. It used to pass
+                # the truthiness check below and get persisted, leaving a blank
+                # "Planning (unknown)" block on otherwise-finished turns.
+                _h_actions = list(getattr(final_decision, "actions", None) or []) if final_decision else []
+                if final_decision is not None and not _h_actions and getattr(final_decision, "action", None):
+                    _h_actions = [final_decision.action]
+                _h_usable = bool(
+                    final_decision is not None
+                    and getattr(final_decision, "error", None) is None
+                    and (
+                        _h_actions
+                        or (getattr(final_decision, "assistant_message", None) or "").strip()
+                        or (getattr(final_decision, "final_answer", None) or "").strip()
+                        or (getattr(final_decision, "reasoning_message", None) or "").strip()
+                    )
+                )
+                if not _h_usable:
                     # One retry: a single malformed/empty reply must not end
                     # the phase empty-handed (the v2 envelope failure mode).
                     empty_decision_retries += 1
                     if empty_decision_retries > 1:
-                        logger.warning("Knowledge harness: no decision twice in a row; stopping")
+                        logger.warning("Knowledge harness: no usable decision twice in a row; stopping")
                         break
                     observation = {"summary": "The planner returned no decision; retrying."}
                     continue
@@ -3984,6 +4002,10 @@ class AgentV2:
             # on this path too, so we use this to suppress follow-up suggestions
             # for a turn that ended on an error.
             completion_errored = False
+            # Set when the outer loop burns through every allotted step without
+            # a terminal break. That is a failed turn — the run produced no
+            # final answer — and must never inherit the default 'success'.
+            planner_steps_exhausted = False
             
             # Lazy draft build: don't pre-seed. The first create_instruction
             # or edit_instruction tool call lazy-creates the draft and writes
@@ -4637,9 +4659,17 @@ class AgentV2:
                                             # first preserves it.
                                             try:
                                                 if isinstance(self.system_completion.completion, dict):
+                                                    # No classified LLM payload → fall back to the
+                                                    # planner's own typed error (e.g. empty_response
+                                                    # with its stop reason + stream event mix) so the
+                                                    # stored row stays diagnosable.
+                                                    _planner_err_payload = llm_err_payload or {
+                                                        "code": err_code,
+                                                        "details": getattr(decision.error, "details", None),
+                                                    }
                                                     self.system_completion.completion = {
                                                         **self.system_completion.completion,
-                                                        "error": {**(llm_err_payload or {"code": "unknown"}),
+                                                        "error": {**_planner_err_payload,
                                                                   "message": _final_msg},
                                                     }
                                             except Exception:
@@ -4912,14 +4942,60 @@ class AgentV2:
                                     )
 
                                 break
-                            # Retry flow: action plan with missing action
-                            if (getattr(decision, "plan_type", None) == "action") and not action:
+                            # Retry flow: non-terminal decision with no executable
+                            # action. plan_type is deliberately NOT consulted here:
+                            # a decision that reaches this point made no progress
+                            # this iteration (nothing to run, nothing terminal), and
+                            # decisions whose plan_type is None used to fall through
+                            # a plan_type=="action" gate into a bare `continue` —
+                            # replaying the identical prompt every step until the
+                            # loop limit. Whatever the model or provider, a
+                            # no-action non-terminal decision gets an explicit
+                            # error observation and counts against the
+                            # invalid-output budget; exhausting that budget ends
+                            # the turn as an ERROR, never as an implicit success.
+                            if not action:
                                 if invalid_retry_count >= max_invalid_retries:
-                                    # Too many retries, exit
+                                    analysis_done = True
+                                    completion_errored = True
+                                    completion_finished_emitted = True
+                                    _np_err = {
+                                        "code": "no_progress",
+                                        "summary": "The model made no progress",
+                                    }
+                                    _np_msg = (
+                                        "The model repeatedly returned neither a tool action nor an answer; "
+                                        f"giving up after {invalid_retry_count + 1} attempts."
+                                    )
+                                    if self.system_completion:
+                                        try:
+                                            await self.project_manager.update_completion_status(
+                                                self.db, self.system_completion, 'error'
+                                            )
+                                            try:
+                                                if isinstance(self.system_completion.completion, dict):
+                                                    self.system_completion.completion = {
+                                                        **self.system_completion.completion,
+                                                        "error": {**_np_err, "message": _np_msg},
+                                                    }
+                                            except Exception:
+                                                pass
+                                            await self.project_manager.update_message(
+                                                self.db, self.system_completion, message=_np_msg
+                                            )
+                                            if self.event_queue:
+                                                await self.event_queue.put(SSEEvent(
+                                                    event="completion.finished",
+                                                    completion_id=str(self.system_completion.id),
+                                                    data={"status": "error",
+                                                          "error": {**_np_err, "message": _np_msg}},
+                                                ))
+                                        except Exception as _np_exc:
+                                            logger.warning(f"[agent] no-progress terminal update failed: {_np_exc!r}")
                                     break
                                 observation = {
-                                    "summary": "Planner chose action plan but returned no tool/action; retrying",
-                                    "error": {"code": "missing_action", "message": "Choose a tool and arguments"},
+                                    "summary": "Planner returned neither a tool action nor a final answer; retrying",
+                                    "error": {"code": "missing_action", "message": "Choose a tool and arguments, or finish with a clear final answer"},
                                 }
                                 invalid_retry_count += 1
                                 # Emit retry event
@@ -4939,8 +5015,6 @@ class AgentV2:
                                     pass
                                 # End streaming loop so outer loop can retry
                                 break
-                            if not action:
-                                continue
 
                             # === Multi-tool dispatch loop ===
                             # parallel_tool_calls=False / disable_parallel_tool_use=True keep
@@ -5829,6 +5903,18 @@ class AgentV2:
                         }
                         continue
                     raise
+            else:
+                # range(step_limit) ran dry with no terminal break: no final
+                # answer, no terminal error. Historically this fell through to
+                # the default-'success' finalizer — production runs with 100
+                # blank planner decisions and zero tools were recorded as
+                # successful turns. Mark it so the finalizer reports an error.
+                planner_steps_exhausted = True
+                completion_errored = True
+                logger.warning(
+                    "[agent] planner step limit (%s) exhausted without a terminal decision",
+                    step_limit,
+                )
 
             # === Post-analysis tasks ===
             # Runs once after the outer loop exits, regardless of whether the
@@ -5840,8 +5926,14 @@ class AgentV2:
             else:
                 # Normal mode: Run knowledge harness sub-loop if triggers fired.
                 # Harness creates/edits instructions and submits them as a draft AI build for review.
+                # Skipped when the turn ended in an error — a failed completion
+                # must not spawn further LLM work or extra blocks.
                 try:
-                    res = await self._should_suggest_instructions(prev_tool_name_before_last_user)
+                    res = (
+                        {"decision": False}
+                        if completion_errored
+                        else await self._should_suggest_instructions(prev_tool_name_before_last_user)
+                    )
                     if res.get("decision", False):
                         await self._run_knowledge_harness(
                             res.get("conditions", []),
@@ -5897,7 +5989,7 @@ class AgentV2:
             # self-healing — a later turn retries until a real title sticks.
             try:
                 current_title = (getattr(self.report, "title", "") or "").strip() if self.report else ""
-                if self.head_completion and self.report and current_title.lower() in ("", "untitled report"):
+                if self.head_completion and self.report and not completion_errored and current_title.lower() in ("", "untitled report"):
                     # Generate title (small model)
                     messages_section = await self.context_hub.message_builder.build(max_messages=5)
                     messages_context = messages_section.render()
@@ -5942,10 +6034,22 @@ class AgentV2:
             except Exception:
                 final_messages_context = ""
             observation_snapshot = self.context_hub.observation_builder.to_dict()
-            asyncio.create_task(self._run_late_scoring_background(final_messages_context, observation_snapshot))
+            # Scoring judges the quality of an ANSWER; an errored turn has none,
+            # and every skipped auxiliary call keeps a failing provider from
+            # burning further quota.
+            if not completion_errored:
+                asyncio.create_task(self._run_late_scoring_background(final_messages_context, observation_snapshot))
 
-            # Finish agent execution
-            status = 'sigkill' if self.sigkill_event.is_set() else 'success'
+            # Finish agent execution. A turn whose completion errored (planner
+            # retries exhausted, step limit hit) must not record a successful
+            # execution — production traces used to show 100 blank decisions,
+            # zero tools, and an agent_execution marked 'success'.
+            if self.sigkill_event.is_set():
+                status = 'sigkill'
+            elif completion_errored:
+                status = 'error'
+            else:
+                status = 'success'
             await self.project_manager.finish_agent_execution(
                 self.db,
                 agent_execution=self.current_execution,
@@ -5984,7 +6088,30 @@ class AgentV2:
             # Drain runs in the background (post-finished) — see comment in
             # the analysis_complete branch above for rationale.
             if self.system_completion and not completion_finished_emitted:
-                completion_status = 'stopped' if self.sigkill_event.is_set() else 'success'
+                if self.sigkill_event.is_set():
+                    completion_status = 'stopped'
+                elif planner_steps_exhausted:
+                    completion_status = 'error'
+                else:
+                    completion_status = 'success'
+                _finished_error = None
+                if planner_steps_exhausted and completion_status == 'error':
+                    _exh_msg = (
+                        f"Stopped after reaching the maximum number of planning steps ({step_limit}) "
+                        "without completing the request."
+                    )
+                    _finished_error = {"code": "planner_step_limit", "message": _exh_msg}
+                    try:
+                        if isinstance(self.system_completion.completion, dict):
+                            self.system_completion.completion = {
+                                **self.system_completion.completion,
+                                "error": _finished_error,
+                            }
+                        await self.project_manager.update_message(
+                            self.db, self.system_completion, message=_exh_msg
+                        )
+                    except Exception as _exh_exc:
+                        logger.warning(f"[agent] step-limit completion update failed: {_exh_exc!r}")
                 await self.project_manager.update_completion_status(
                     self.db,
                     self.system_completion,
@@ -5996,7 +6123,10 @@ class AgentV2:
                     finished_event = SSEEvent(
                         event="completion.finished",
                         completion_id=str(self.system_completion.id),
-                        data={"status": completion_status}
+                        data=(
+                            {"status": completion_status, "error": _finished_error}
+                            if _finished_error else {"status": completion_status}
+                        )
                     )
                     await self.event_queue.put(finished_event)
                 completion_finished_emitted = True

--- a/backend/app/ai/agents/planner/planner_v3.py
+++ b/backend/app/ai/agents/planner/planner_v3.py
@@ -188,6 +188,14 @@ class PlannerV3:
         action_id_index: dict[str, int] = {}  # tool_use_id -> index in completed_actions
         input_buffers: dict[str, str] = {}  # tool_use_id -> accumulated partial input JSON
         stop_reason: Optional[str] = None
+        raw_stop_reason: Optional[str] = None
+        # Stream forensics: how many events of each type the adapter surfaced.
+        # A stream can legally end with nothing but a stop + usage (provider
+        # refusals, stop reasons or content-block types the adapter doesn't
+        # know) — when that happens, this mix plus the raw stop reason is the
+        # only evidence of what actually came back, so it rides along on the
+        # empty_response error below instead of being dropped.
+        event_type_counts: dict[str, int] = {}
         final_prompt_tokens = prompt_tokens_est
         final_completion_tokens = 0
         final_cache_read_tokens = 0
@@ -208,7 +216,10 @@ class PlannerV3:
                 usage_scope_ref_id=None,
                 prompt_tokens_estimate=prompt_tokens_est,
             ):
-                if sigkill_event.is_set():
+                _etype = getattr(evt, "type", None) or evt.__class__.__name__
+                event_type_counts[_etype] = event_type_counts.get(_etype, 0) + 1
+
+                if sigkill_event is not None and sigkill_event.is_set():
                     break
 
                 if isinstance(evt, TextDeltaEvent):
@@ -365,6 +376,7 @@ class PlannerV3:
 
                 if isinstance(evt, MessageStopEvent):
                     stop_reason = evt.stop_reason
+                    raw_stop_reason = getattr(evt, "raw_stop_reason", None) or evt.stop_reason
                     continue
 
                 if isinstance(evt, UsageEvent):
@@ -428,6 +440,40 @@ class PlannerV3:
             cache_read_tokens=final_cache_read_tokens,
             cache_creation_tokens=final_cache_creation_tokens,
         )
+
+        # A stream that produced NO semantic output — no text, no reasoning,
+        # no tool call, no web search — is never a valid planner turn, whatever
+        # the stop reason. Without this check it folds into a schema-valid,
+        # error-free, completely empty decision, and the agent loop has nothing
+        # to retry on: it replays the identical prompt and gets the identical
+        # empty stream until the step limit (observed in production as 100
+        # blank decisions / ~450k prompt tokens finalized as "success").
+        # Typical trigger: a stop reason the adapter doesn't recognize (OpenAI
+        # "content_filter", Anthropic "refusal") normalized to "other", with
+        # the response body empty or made of dropped block types. Surfacing it
+        # as a typed error routes it into the agent's existing bounded
+        # retry-then-fail flow, with the evidence preserved.
+        if (
+            final_decision.error is None
+            and not completed_actions
+            and not (final_decision.assistant_message or "").strip()
+            and not (final_decision.reasoning_message or "").strip()
+            and state.web_search_count == 0
+            and not (sigkill_event is not None and sigkill_event.is_set())
+        ):
+            final_decision.analysis_complete = False  # an empty turn is never terminal
+            final_decision.error = PlannerError(
+                code="empty_response",
+                message=(
+                    "The model returned no output (no text, no tool call, no answer); "
+                    f"stop_reason={raw_stop_reason or stop_reason or 'none'}"
+                ),
+                details={
+                    "stop_reason": stop_reason,
+                    "raw_stop_reason": raw_stop_reason,
+                    "stream_event_counts": event_type_counts,
+                },
+            )
         yield PlannerDecisionEvent(type="planner.decision.final", data=final_decision)
 
     # ------------------------------------------------------------------

--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -506,7 +506,8 @@ class Anthropic(LLMClient):
                     cache_creation_tokens = usage.cache_creation_tokens
                 if stop_reason:
                     yield MessageStopEvent(
-                        stop_reason=_STOP_REASON_MAP.get(stop_reason, "other")
+                        stop_reason=_STOP_REASON_MAP.get(stop_reason, "other"),
+                        raw_stop_reason=stop_reason,
                     )
                 continue
 

--- a/backend/app/ai/llm/clients/azure_client.py
+++ b/backend/app/ai/llm/clients/azure_client.py
@@ -357,7 +357,10 @@ class AzureClient(LLMClient):
             )
 
         _stop_map = {"stop": "end_turn", "tool_calls": "tool_use", "length": "max_tokens"}
-        yield MessageStopEvent(stop_reason=_stop_map.get(stop_reason or "", "other"))
+        yield MessageStopEvent(
+            stop_reason=_stop_map.get(stop_reason or "", "other"),
+            raw_stop_reason=stop_reason,
+        )
 
         yield UsageEvent(
             input_tokens=prompt_tokens,

--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -377,6 +377,7 @@ class BedrockClient(LLMClient):
         prompt_tokens = 0
         completion_tokens = 0
         stop_reason = "end_turn"
+        raw_stop_reason = None
 
         while True:
             event = await event_queue.get()
@@ -455,6 +456,7 @@ class BedrockClient(LLMClient):
                 bedrock_stop = event["messageStop"].get("stopReason", "end_turn")
                 _stop_map = {"end_turn": "end_turn", "tool_use": "tool_use", "max_tokens": "max_tokens"}
                 stop_reason = _stop_map.get(bedrock_stop, "other")
+                raw_stop_reason = bedrock_stop
 
             elif "metadata" in event:
                 usage = event["metadata"].get("usage", {})
@@ -463,6 +465,6 @@ class BedrockClient(LLMClient):
 
         await future
 
-        yield MessageStopEvent(stop_reason=stop_reason)
+        yield MessageStopEvent(stop_reason=stop_reason, raw_stop_reason=raw_stop_reason)
         yield UsageEvent(input_tokens=prompt_tokens, output_tokens=completion_tokens)
         self._set_last_usage(LLMUsage(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens))

--- a/backend/app/ai/llm/clients/openai_client.py
+++ b/backend/app/ai/llm/clients/openai_client.py
@@ -490,7 +490,10 @@ class OpenAi(LLMClient):
 
         # Map OpenAI finish_reason to our vocabulary
         _stop_map = {"stop": "end_turn", "tool_calls": "tool_use", "length": "max_tokens"}
-        yield MessageStopEvent(stop_reason=_stop_map.get(stop_reason or "", "other"))
+        yield MessageStopEvent(
+            stop_reason=_stop_map.get(stop_reason or "", "other"),
+            raw_stop_reason=stop_reason,
+        )
 
         yield UsageEvent(
             input_tokens=prompt_tokens,

--- a/backend/app/ai/llm/types.py
+++ b/backend/app/ai/llm/types.py
@@ -172,8 +172,16 @@ class WebSearchResultEvent:
 
 @dataclass
 class MessageStopEvent:
-    """End of the message. stop_reason normalized across providers."""
+    """End of the message. stop_reason normalized across providers.
+
+    raw_stop_reason carries the provider's own value untranslated. The
+    normalized vocabulary is intentionally small, so any stop reason a client
+    doesn't know collapses to "other" — keeping the original alongside is what
+    makes an "other" stop diagnosable downstream (planner_v3 persists it when
+    a stream ends with no usable output).
+    """
     stop_reason: Literal["end_turn", "tool_use", "max_tokens", "stop_sequence", "other"] = "other"
+    raw_stop_reason: Optional[str] = None
     type: Literal["message_stop"] = "message_stop"
 
 

--- a/backend/tests/unit/test_agent_loop_rescue.py
+++ b/backend/tests/unit/test_agent_loop_rescue.py
@@ -150,3 +150,133 @@ async def test_planner_stream_error_carries_preclassified_payload():
     pre = (err.details or {}).get("llm_error")
     assert isinstance(pre, dict)
     assert pre.get("code") == "context_length"
+
+
+# ── planner_v3 empty-stream rejection ──────────────────────────────────────
+#
+# A stream that ends with nothing but a stop + usage (a provider refusal, a
+# stop reason or content-block type the adapter doesn't recognize) used to
+# fold into a schema-valid, error-free, completely EMPTY decision. The agent
+# loop then had nothing to retry on and replayed the identical prompt until
+# the step limit — observed in production as 100 blank plan decisions and
+# ~450k prompt tokens finalized as "success". These tests pin the planner
+# boundary: no semantic output ⇒ typed error, with the raw stop reason and
+# stream event mix preserved; real tool-only and text-only streams stay valid.
+
+def _bare_planner():
+    import types
+    from app.ai.agents.planner.planner_v3 import PlannerV3
+    from app.ai.agents.planner.prompt_builder_v3 import PromptBuilderV3
+
+    planner = PlannerV3.__new__(PlannerV3)  # skip __init__ (constructs a real LLM)
+    planner.tool_catalog = []
+    planner.prompt_builder = PromptBuilderV3()
+    planner._tool_category = {}
+    planner.llm = types.SimpleNamespace(
+        model=types.SimpleNamespace(
+            model_id="any-model",
+            provider=types.SimpleNamespace(provider_type="custom"),
+        ),
+    )
+    return planner
+
+
+async def _final_decision(planner):
+    import asyncio
+    from app.schemas.ai.planner import PlannerInput
+
+    final = None
+    async for evt in planner.execute(PlannerInput(user_message="hi"), sigkill_event=asyncio.Event()):
+        if getattr(evt, "type", "") == "planner.decision.final":
+            final = evt.data
+    assert final is not None, "expected a final decision event"
+    return final
+
+
+@pytest.mark.asyncio
+async def test_planner_rejects_stream_without_semantic_output():
+    """Stop + usage only — the exact production runaway shape (a few
+    completion tokens, zero text/tool events, unmapped stop reason)."""
+    from app.ai.llm.types import MessageStopEvent, UsageEvent
+
+    planner = _bare_planner()
+
+    async def _empty_stream(**kwargs):
+        yield MessageStopEvent(stop_reason="other", raw_stop_reason="content_filter")
+        yield UsageEvent(input_tokens=4478, output_tokens=4, cache_creation_tokens=8000)
+
+    planner.llm.inference_stream_v2 = _empty_stream
+
+    final = await _final_decision(planner)
+    assert final.error is not None, "an empty stream must not produce a valid decision"
+    assert final.error.code == "empty_response"
+    assert final.analysis_complete is False  # an empty turn is never terminal
+    assert not final.actions and final.action is None
+    # Diagnostics survive: raw stop reason, event mix, token usage.
+    details = final.error.details or {}
+    assert details.get("raw_stop_reason") == "content_filter"
+    assert details.get("stream_event_counts", {}).get("message_stop") == 1
+    assert final.metrics is not None and final.metrics.token_usage is not None
+    assert final.metrics.token_usage.prompt_tokens == 4478
+
+
+@pytest.mark.asyncio
+async def test_planner_rejects_empty_end_turn():
+    """end_turn with no content is equally useless — it used to finalize the
+    turn as a successful answer with empty text."""
+    from app.ai.llm.types import MessageStopEvent, UsageEvent
+
+    planner = _bare_planner()
+
+    async def _empty_stream(**kwargs):
+        yield MessageStopEvent(stop_reason="end_turn", raw_stop_reason="end_turn")
+        yield UsageEvent(input_tokens=100, output_tokens=1)
+
+    planner.llm.inference_stream_v2 = _empty_stream
+
+    final = await _final_decision(planner)
+    assert final.error is not None and final.error.code == "empty_response"
+    assert final.analysis_complete is False
+
+
+@pytest.mark.asyncio
+async def test_planner_accepts_tool_only_stream():
+    """A native tool call without narration is the normal v3 shape — the
+    rejection must not touch it."""
+    from app.ai.llm.types import (
+        MessageStopEvent, ToolUseCompleteEvent, ToolUseStartEvent, UsageEvent,
+    )
+
+    planner = _bare_planner()
+
+    async def _tool_stream(**kwargs):
+        yield ToolUseStartEvent(id="tu_1", name="create_data")
+        yield ToolUseCompleteEvent(id="tu_1", name="create_data", input={"title": "x"})
+        yield MessageStopEvent(stop_reason="tool_use", raw_stop_reason="tool_calls")
+        yield UsageEvent(input_tokens=100, output_tokens=20)
+
+    planner.llm.inference_stream_v2 = _tool_stream
+
+    final = await _final_decision(planner)
+    assert final.error is None
+    assert final.actions and final.actions[0].name == "create_data"
+
+
+@pytest.mark.asyncio
+async def test_planner_accepts_text_only_stream():
+    """A plain final answer (text + end_turn) stays a terminal decision."""
+    from app.ai.llm.types import MessageStopEvent, TextDeltaEvent, UsageEvent
+
+    planner = _bare_planner()
+
+    async def _text_stream(**kwargs):
+        yield TextDeltaEvent(text="All done: revenue grew 8%.")
+        yield MessageStopEvent(stop_reason="end_turn", raw_stop_reason="stop")
+        yield UsageEvent(input_tokens=100, output_tokens=10)
+
+    planner.llm.inference_stream_v2 = _text_stream
+
+    final = await _final_decision(planner)
+    assert final.error is None
+    assert final.analysis_complete is True
+    assert (final.assistant_message or "").startswith("All done")


### PR DESCRIPTION
## Summary

This PR fixes critical issues in the agent execution loop where empty or invalid planner decisions were not properly rejected, and where reaching the step limit without a terminal decision was incorrectly recorded as success. These bugs caused production runs with 100+ blank planner decisions and zero tool calls to be finalized as successful completions.

## Key Changes

- **Empty response detection in planner_v3**: Added validation to reject streams that produce no semantic output (no text, no tool calls, no reasoning, no web searches). These now return a typed `empty_response` error instead of an empty valid decision, enabling the agent loop's retry mechanism.

- **Raw stop reason preservation**: Added `raw_stop_reason` field to `MessageStopEvent` across all LLM clients (OpenAI, Azure, Anthropic, Bedrock) to preserve provider-specific stop reasons for diagnostics when normalized stop reasons collapse to "other".

- **Stream event forensics**: Planner now tracks event type counts during streaming to preserve evidence of what actually came back when a stream ends with no usable output.

- **Improved decision usability check**: Replaced simple truthiness check with comprehensive validation that examines actions, text content, reasoning, and error state to determine if a decision is actually usable.

- **No-progress retry budget**: Added explicit handling for decisions with no executable action. When the invalid retry count is exhausted, the turn now terminates with an `error` status and `no_progress` error code instead of silently continuing.

- **Step limit exhaustion handling**: Added `planner_steps_exhausted` flag to detect when the outer loop completes without a terminal break. These turns now:
  - Record `completion_errored = True` to prevent auxiliary LLM calls (knowledge harness, scoring, title generation)
  - Set agent execution status to `error` instead of `success`
  - Set completion status to `error` with `planner_step_limit` error code
  - Include diagnostic message about reaching the maximum planning steps

- **Knowledge harness skip on error**: Knowledge harness sub-loop is now skipped when a turn ends in error to prevent spawning additional LLM work on failed completions.

## Implementation Details

- The decision usability check now validates: presence of actions, non-empty assistant message, non-empty final answer, non-empty reasoning message, and absence of errors.
- No-progress errors are properly persisted to the completion record with status updates and SSE events before breaking the loop.
- Step limit exhaustion is detected via the `else` clause of the `range(step_limit)` loop, ensuring it only triggers when the loop completes naturally without a `break`.
- Error status propagation ensures failed turns don't trigger downstream operations like scoring or title generation that assume a valid answer exists.

https://claude.ai/code/session_01RsTEGoDJWZ2hteZvrG5z2D