### PR TITLE
Make write_csv and tool-call parsing resilient: salvage malformed args, detect truncation, handle Hebrew content

### DIFF
--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -1,4 +1,6 @@
 import json
+
+from app.ai.llm.toolcall_args import parse_tool_call_arguments
 from typing import Any, AsyncGenerator, AsyncIterator, Optional
 
 from anthropic import Anthropic as AnthropicAPI, AsyncAnthropic
@@ -443,10 +445,7 @@ class Anthropic(LLMClient):
                 if idx in open_tool_blocks:
                     pending = open_tool_blocks.pop(idx)
                     raw = pending["input_buffer"]
-                    try:
-                        parsed = json.loads(raw) if raw.strip() else {}
-                    except Exception:
-                        parsed = {"_unparsable": True, "_raw": raw}
+                    parsed = parse_tool_call_arguments(raw, pending["name"])
                     yield ToolUseCompleteEvent(
                         id=pending["id"],
                         name=pending["name"],

--- a/backend/app/ai/llm/clients/azure_client.py
+++ b/backend/app/ai/llm/clients/azure_client.py
@@ -1,4 +1,6 @@
 import json
+
+from app.ai.llm.toolcall_args import parse_tool_call_arguments
 import os
 from openai import AzureOpenAI, AsyncAzureOpenAI
 from typing import AsyncGenerator, AsyncIterator, Any, Optional
@@ -317,10 +319,7 @@ class AzureClient(LLMClient):
 
         for pending in open_calls.values():
             raw = pending["args_buffer"]
-            try:
-                parsed = json.loads(raw) if raw.strip() else {}
-            except Exception:
-                parsed = {"_unparsable": True, "_raw": raw}
+            parsed = parse_tool_call_arguments(raw, pending["name"])
             yield ToolUseCompleteEvent(
                 id=pending["id"],
                 name=pending["name"],

--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import base64
 import json
+
+from app.ai.llm.toolcall_args import parse_tool_call_arguments
 import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncGenerator, AsyncIterator, Optional
@@ -72,6 +74,18 @@ _MIME_TO_FORMAT = {
     "image/gif": "gif",
     "image/webp": "webp",
 }
+
+
+_DEFAULT_BEDROCK_MAX_TOKENS = 8192
+
+
+def _bedrock_max_tokens() -> int:
+    """Output-token budget for Bedrock requests (BOW_BEDROCK_MAX_TOKENS)."""
+    try:
+        value = int(os.environ.get("BOW_BEDROCK_MAX_TOKENS", "") or _DEFAULT_BEDROCK_MAX_TOKENS)
+    except ValueError:
+        return _DEFAULT_BEDROCK_MAX_TOKENS
+    return value if value > 0 else _DEFAULT_BEDROCK_MAX_TOKENS
 
 
 class BedrockClient(LLMClient):
@@ -178,6 +192,7 @@ class BedrockClient(LLMClient):
         response = self.client.converse(
             modelId=model_id,
             messages=[{"role": "user", "content": self._build_content(prompt, images)}],
+            inferenceConfig={"maxTokens": _bedrock_max_tokens()},
         )
 
         # Extract text from response
@@ -332,7 +347,17 @@ class BedrockClient(LLMClient):
                     bedrock_messages[-1]["content"] = image_blocks + bedrock_messages[-1]["content"]
                 else:
                     bedrock_messages.append({"role": "user", "content": image_blocks})
-        request_kwargs: dict = {"modelId": model_id, "messages": bedrock_messages}
+        request_kwargs: dict = {
+            "modelId": model_id,
+            "messages": bedrock_messages,
+            # Bedrock's default maxTokens when unspecified is the model
+            # provider's default — typically far below what codegen and
+            # data-generation calls need, which surfaced as generated code
+            # truncated mid-string. Pin an explicit budget instead. 8192 is
+            # accepted across the current Bedrock model families; override
+            # per-deployment when a model supports more.
+            "inferenceConfig": {"maxTokens": _bedrock_max_tokens()},
+        }
         if system:
             request_kwargs["system"] = [{"text": system}]
         if thinking:
@@ -340,6 +365,9 @@ class BedrockClient(LLMClient):
             request_kwargs["additionalModelRequestFields"] = {
                 "thinking": {"type": "enabled", "budget_tokens": budget}
             }
+            # maxTokens must exceed the thinking budget or the request fails.
+            if request_kwargs["inferenceConfig"]["maxTokens"] <= budget:
+                request_kwargs["inferenceConfig"]["maxTokens"] = budget + 4096
         if tools:
             tc = self._translate_tools(tools)
             # disableParallelToolUse in toolChoice.auto requires botocore ≥ 1.37;
@@ -424,10 +452,7 @@ class BedrockClient(LLMClient):
                 if idx in open_calls:
                     pending = open_calls[idx]
                     raw = pending["args_buffer"]
-                    try:
-                        parsed = json.loads(raw) if raw.strip() else {}
-                    except Exception:
-                        parsed = {"_unparsable": True, "_raw": raw}
+                    parsed = parse_tool_call_arguments(raw, pending["name"])
                     yield ToolUseCompleteEvent(
                         id=pending["id"],
                         name=pending["name"],

--- a/backend/app/ai/llm/clients/openai_client.py
+++ b/backend/app/ai/llm/clients/openai_client.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+
+from app.ai.llm.toolcall_args import parse_tool_call_arguments
 import os
 import uuid
 from typing import AsyncGenerator, AsyncIterator, Any, Optional
@@ -449,10 +451,7 @@ class OpenAi(LLMClient):
         # Emit complete events for all accumulated tool calls
         for pending in open_calls.values():
             raw = pending["args_buffer"]
-            try:
-                parsed = json.loads(raw) if raw.strip() else {}
-            except Exception:
-                parsed = {"_unparsable": True, "_raw": raw}
+            parsed = parse_tool_call_arguments(raw, pending["name"])
             yield ToolUseCompleteEvent(
                 id=pending["id"],
                 name=pending["name"],

--- a/backend/app/ai/llm/clients/openai_responses_client.py
+++ b/backend/app/ai/llm/clients/openai_responses_client.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+
+from app.ai.llm.toolcall_args import parse_tool_call_arguments
 import os
 from typing import AsyncGenerator, AsyncIterator, Any, Optional
 
@@ -426,10 +428,7 @@ class OpenAIResponsesClient(LLMClient):
                 if item_id in open_calls:
                     pending = open_calls.pop(item_id)
                     raw = getattr(event, "arguments", "") or pending["args_buffer"]
-                    try:
-                        parsed = json.loads(raw) if raw.strip() else {}
-                    except Exception:
-                        parsed = {"_unparsable": True, "_raw": raw}
+                    parsed = parse_tool_call_arguments(raw, pending["name"])
                     stop_reason = "tool_use"
                     yield ToolUseCompleteEvent(id=pending["call_id"], name=pending["name"], input=parsed)
 

--- a/backend/app/ai/llm/toolcall_args.py
+++ b/backend/app/ai/llm/toolcall_args.py
@@ -1,0 +1,242 @@
+"""Tolerant parsing for streamed tool-call argument JSON.
+
+Providers stream tool-call arguments as raw text fragments that the model is
+trusted to emit as valid JSON. Models slip in predictable ways:
+
+- prose wrapped around the object (``functions.write_csv: {...}``, trailing
+  backticks);
+- Python-style literals (single-quoted strings) instead of JSON;
+- unescaped double quotes inside string values — endemic for Hebrew/Arabic
+  content, where the ASCII ``"`` appears INSIDE words as an abbreviation mark
+  (e.g. ארה"ב, מנכ"ל), so any text-heavy argument is full of them;
+- raw control characters (newlines/tabs) inside string values.
+
+Dropping the whole call over one of these wastes an agent round-trip on a
+misleading "field required" error. This module runs a conservative salvage
+ladder instead; every rung must produce a dict that round-trips ``json.loads``
+semantics, and anything ambiguous falls through to the explicit
+``_unparsable`` marker so the runner can hand the model accurate feedback.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Keys of the failure marker returned when every rung fails. The runner keys
+# off UNPARSABLE_KEY to produce a JSON-syntax error message instead of a
+# missing-field one.
+UNPARSABLE_KEY = "_unparsable"
+RAW_KEY = "_raw"
+ERROR_KEY = "_error"
+
+# A leading wrapper is only stripped when it is short and looks like tool-call
+# prose (tool name, colon, markdown fence) — not when it looks like lost data.
+_MAX_LEADING_CHARS = 96
+_LEADING_ALLOWED_RE = re.compile(r"^[\w\s\"'`.:/\\-]+$")
+_MAX_TRAILING_CHARS = 3
+
+_STRUCTURAL_AFTER_CLOSE = {",", "}", "]", ":"}
+
+_CONTROL_ESCAPES = {"\n": "\\n", "\r": "\\r", "\t": "\\t"}
+
+
+def _as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(value, dict) and all(isinstance(k, str) for k in value.keys()):
+        return value
+    return None
+
+
+def _try_json(text: str) -> Optional[Dict[str, Any]]:
+    try:
+        return _as_dict(json.loads(text))
+    except Exception:
+        return None
+
+
+def _try_python_literal(text: str) -> Optional[Dict[str, Any]]:
+    """Parse Python-literal syntax (accepts single-quoted strings).
+
+    ``ast.literal_eval`` evaluates literals only — no names, calls, or
+    operators — so this is safe on model output.
+    """
+    try:
+        return _as_dict(ast.literal_eval(text))
+    except Exception:
+        return None
+
+
+def _extract_balanced_object(raw: str) -> Optional[str]:
+    """Return the first balanced ``{...}`` span, honoring strings and escapes.
+
+    Only accepts the span when whatever surrounds it is small, plausible
+    wrapper junk — a large stripped prefix would mean discarding real data.
+    """
+    start = raw.find("{")
+    if start < 0:
+        return None
+
+    prefix = raw[:start].strip()
+    if prefix and (
+        len(prefix) > _MAX_LEADING_CHARS or not _LEADING_ALLOWED_RE.match(prefix)
+    ):
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(raw)):
+        ch = raw[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                suffix = raw[i + 1 :].strip()
+                if len(suffix) > _MAX_TRAILING_CHARS:
+                    return None
+                return raw[start : i + 1]
+    return None
+
+
+def _looks_like_key_start(text: str, index: int) -> bool:
+    """True when ``text[index:]`` begins a ``"key":`` member (short key)."""
+    if index >= len(text) or text[index] not in "\"'":
+        return False
+    quote = text[index]
+    end = text.find(quote, index + 1)
+    if end < 0 or end - index > 100:
+        return False
+    rest = text[end + 1 :].lstrip()
+    return rest.startswith(":")
+
+
+def _skip_ws(text: str, index: int) -> int:
+    while index < len(text) and text[index].isspace():
+        index += 1
+    return index
+
+
+def _repair_string_damage(raw: str) -> Optional[str]:
+    """Re-serialize ``raw`` fixing in-string damage: bare ``"`` and control chars.
+
+    Walks the text with JSON structure awareness. Inside a string, an
+    unescaped ``"`` only closes the string when what follows reads as JSON
+    structure (``:`` for a key; ``}``/``]``/end for a value; ``,`` only when
+    followed by another ``"key":``). Any other ``"`` is treated as an embedded
+    literal quote and escaped — the Hebrew abbreviation case. Raw control
+    characters inside strings are escaped as well.
+
+    Returns the repaired text, or None when the input has no string damage
+    this pass can address.
+    """
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    changed = False
+
+    for i, ch in enumerate(raw):
+        if not in_string:
+            if ch == '"':
+                in_string = True
+            out.append(ch)
+            continue
+
+        if escaped:
+            out.append(ch)
+            escaped = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            escaped = True
+            continue
+        if ch in _CONTROL_ESCAPES:
+            out.append(_CONTROL_ESCAPES[ch])
+            changed = True
+            continue
+        if ch != '"':
+            out.append(ch)
+            continue
+
+        # Candidate closing quote: close only when what follows is structure.
+        nxt = _skip_ws(raw, i + 1)
+        follower = raw[nxt] if nxt < len(raw) else ""
+        if follower in (":", "}", "]") or nxt >= len(raw):
+            in_string = False
+            out.append(ch)
+        elif follower == "," and _looks_like_key_start(raw, _skip_ws(raw, nxt + 1)):
+            in_string = False
+            out.append(ch)
+        else:
+            out.append('\\"')
+            changed = True
+
+    return "".join(out) if changed else None
+
+
+def parse_tool_call_arguments(raw: str, tool_name: str = "") -> Dict[str, Any]:
+    """Parse a streamed tool-call argument buffer into a dict.
+
+    Runs the salvage ladder; on total failure returns the ``_unparsable``
+    marker dict carrying the raw buffer and the original JSON error, which the
+    tool runner turns into accurate model feedback.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return {}
+
+    try:
+        loaded = json.loads(text)
+        as_dict = _as_dict(loaded)
+        if as_dict is not None:
+            return as_dict
+        json_error = f"arguments are valid JSON but not an object (got {type(loaded).__name__})"
+    except Exception as e:
+        json_error = str(e)
+
+    salvaged, rung = _salvage(text)
+    if salvaged is not None:
+        logger.warning(
+            "tool-call arguments for %r salvaged via %s (raw length %d)",
+            tool_name or "<unknown>", rung, len(text),
+        )
+        return salvaged
+
+    return {UNPARSABLE_KEY: True, RAW_KEY: raw, ERROR_KEY: json_error}
+
+
+def _salvage(text: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    extracted = _extract_balanced_object(text)
+    if extracted is not None and extracted != text:
+        parsed = _try_json(extracted)
+        if parsed is not None:
+            return parsed, "wrapper_strip"
+
+    parsed = _try_python_literal(text)
+    if parsed is not None:
+        return parsed, "python_literal"
+
+    for candidate, rung in ((text, "string_repair"), (extracted, "wrapper_strip+string_repair")):
+        if candidate is None:
+            continue
+        repaired = _repair_string_damage(candidate)
+        if repaired is not None:
+            parsed = _try_json(repaired)
+            if parsed is not None:
+                return parsed, rung
+
+    return None, ""

--- a/backend/app/ai/runner/tool_runner.py
+++ b/backend/app/ai/runner/tool_runner.py
@@ -47,6 +47,44 @@ class ToolRunner:
                 },
             }
 
+        # Arguments that failed JSON parsing arrive as the client layer's
+        # _unparsable marker. Running those through schema validation reports
+        # "field required" for every field — pointing the model at a problem
+        # it doesn't have. Short-circuit with the real one: broken JSON.
+        from app.ai.llm.toolcall_args import ERROR_KEY, RAW_KEY, UNPARSABLE_KEY
+        if isinstance(arguments, dict) and arguments.get(UNPARSABLE_KEY):
+            failures = self.validation_failure_counts.get(tool.name, 0) + 1
+            self.validation_failure_counts[tool.name] = failures
+            json_error = arguments.get(ERROR_KEY) or "invalid JSON"
+            raw_tail = str(arguments.get(RAW_KEY) or "")[-200:]
+            error_message = (
+                f"The tool-call arguments were not valid JSON and could not be "
+                f"recovered ({json_error}). Re-emit the call as ONE valid JSON "
+                f'object. Escape any double quote inside a string value as \\" '
+                f'— including in-word quotes in Hebrew/Arabic text (ארה"ב → '
+                f'ארה\\"ב) — and do not wrap the object in prose or code fences.'
+            )
+            observation = {
+                "summary": f"Malformed tool-call arguments for '{tool.name}' (attempt {failures}/{self.max_validation_failures})",
+                "success": False,
+                "error": {
+                    "type": "malformed_tool_arguments",
+                    "message": error_message,
+                    "json_error": json_error,
+                    "raw_tail": raw_tail,
+                },
+            }
+            if failures >= self.max_validation_failures:
+                observation["analysis_complete"] = True
+                observation["final_answer"] = (
+                    "Unable to complete task: the model repeatedly produced "
+                    f"malformed tool-call arguments for '{tool.name}' ({json_error})."
+                )
+            return {
+                "observation": observation,
+                "output": {"success": False, "error_message": error_message},
+            }
+
         # Validate input if tool declares schema
         try:
             if getattr(tool, "input_model", None) is not None:

--- a/backend/tests/unit/test_bedrock_max_tokens.py
+++ b/backend/tests/unit/test_bedrock_max_tokens.py
@@ -1,0 +1,29 @@
+"""Bedrock requests must carry an explicit output-token budget.
+
+Without inferenceConfig.maxTokens, Bedrock falls back to the model provider's
+default cap — far below what codegen needs, which surfaced as generated code
+truncated mid-string ("unterminated string literal").
+"""
+from __future__ import annotations
+
+from app.ai.llm.clients.bedrock_client import (
+    _DEFAULT_BEDROCK_MAX_TOKENS,
+    _bedrock_max_tokens,
+)
+
+
+def test_default_budget(monkeypatch):
+    monkeypatch.delenv("BOW_BEDROCK_MAX_TOKENS", raising=False)
+    assert _bedrock_max_tokens() == _DEFAULT_BEDROCK_MAX_TOKENS
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("BOW_BEDROCK_MAX_TOKENS", "32768")
+    assert _bedrock_max_tokens() == 32768
+
+
+def test_garbage_env_falls_back(monkeypatch):
+    monkeypatch.setenv("BOW_BEDROCK_MAX_TOKENS", "not-a-number")
+    assert _bedrock_max_tokens() == _DEFAULT_BEDROCK_MAX_TOKENS
+    monkeypatch.setenv("BOW_BEDROCK_MAX_TOKENS", "-5")
+    assert _bedrock_max_tokens() == _DEFAULT_BEDROCK_MAX_TOKENS

--- a/backend/tests/unit/test_toolcall_args_salvage.py
+++ b/backend/tests/unit/test_toolcall_args_salvage.py
@@ -1,0 +1,150 @@
+"""Salvage ladder for streamed tool-call argument JSON.
+
+Models mangle tool-call argument JSON in predictable ways — prose wrappers,
+Python-style single quotes, unescaped in-word quotes in Hebrew/Arabic values
+(ארה"ב), raw newlines inside strings. Each used to collapse the whole call
+into an ``_unparsable`` marker whose downstream symptom was the misleading
+"user_prompt: Field required". The ladder recovers every predictable case and
+falls back to an accurate marker for the rest.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.ai.llm.toolcall_args import (
+    ERROR_KEY,
+    RAW_KEY,
+    UNPARSABLE_KEY,
+    parse_tool_call_arguments,
+)
+
+
+def test_valid_json_passes_through():
+    args = parse_tool_call_arguments('{"user_prompt": "צור טבלה", "title": "מס 2025"}')
+    assert args == {"user_prompt": "צור טבלה", "title": "מס 2025"}
+
+
+def test_empty_buffer_is_empty_object():
+    assert parse_tool_call_arguments("") == {}
+    assert parse_tool_call_arguments("   ") == {}
+
+
+# --- unescaped in-word quotes (the Hebrew abbreviation case) ---------------
+
+def test_unescaped_hebrew_abbreviation_quote_in_value():
+    raw = '{"user_prompt": "ניתוח חברות ארה"ב לפי שנה", "title": "Analysis"}'
+    args = parse_tool_call_arguments(raw, "write_csv")
+    assert args["user_prompt"] == 'ניתוח חברות ארה"ב לפי שנה'
+    assert args["title"] == "Analysis"
+
+
+def test_multiple_embedded_quotes():
+    raw = '{"user_prompt": "השווה בין צה"ל, מנכ"ל וארה"ב", "title": "T"}'
+    args = parse_tool_call_arguments(raw)
+    assert args["user_prompt"] == 'השווה בין צה"ל, מנכ"ל וארה"ב'
+
+
+def test_embedded_quote_followed_by_comma_inside_text():
+    # The "," after the embedded quote must not close the string: what follows
+    # the comma is prose, not a "key": pattern.
+    raw = '{"user_prompt": "אמר "שלום", ואז הלך", "title": "T"}'
+    args = parse_tool_call_arguments(raw)
+    assert args["user_prompt"] == 'אמר "שלום", ואז הלך'
+    assert args["title"] == "T"
+
+
+def test_raw_newline_inside_string_value():
+    raw = '{"user_prompt": "line one\nline two"}'
+    args = parse_tool_call_arguments(raw)
+    assert args["user_prompt"] == "line one\nline two"
+
+
+# --- prose wrappers --------------------------------------------------------
+
+def test_markdown_fence_wrapper():
+    raw = '```json\n{"user_prompt": "build table"}\n```'
+    args = parse_tool_call_arguments(raw)
+    assert args == {"user_prompt": "build table"}
+
+
+def test_tool_name_prefix_wrapper():
+    raw = 'tools.write_csv: {"user_prompt": "build table"}'
+    args = parse_tool_call_arguments(raw)
+    assert args == {"user_prompt": "build table"}
+
+
+def test_long_leading_junk_is_not_stripped():
+    # Stripping a large prefix would mean silently discarding data.
+    raw = ("x" * 200) + '{"a": 1}'
+    args = parse_tool_call_arguments(raw)
+    assert args.get(UNPARSABLE_KEY) is True
+
+
+# --- python-literal syntax -------------------------------------------------
+
+def test_single_quoted_python_style_dict():
+    raw = "{'user_prompt': 'ניתוח ארה\"ב', 'title': 'T'}"
+    args = parse_tool_call_arguments(raw)
+    assert args["user_prompt"] == 'ניתוח ארה"ב'
+    assert args["title"] == "T"
+
+
+# --- honest failure --------------------------------------------------------
+
+def test_truncated_buffer_fails_with_marker():
+    raw = '{"user_prompt": "cut off mid-str'
+    args = parse_tool_call_arguments(raw, "write_csv")
+    assert args[UNPARSABLE_KEY] is True
+    assert args[RAW_KEY] == raw
+    assert args[ERROR_KEY]
+
+
+def test_non_object_json_fails_with_marker():
+    args = parse_tool_call_arguments('["a", "b"]')
+    assert args[UNPARSABLE_KEY] is True
+    assert "not an object" in args[ERROR_KEY]
+
+
+def test_salvaged_output_is_round_trippable():
+    raw = '{"user_prompt": "דו"ח שנתי", "title": "R"}'
+    args = parse_tool_call_arguments(raw)
+    assert json.loads(json.dumps(args, ensure_ascii=False)) == args
+
+
+# --- runner integration ----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_runner_reports_json_error_not_missing_field():
+    from app.ai.runner.tool_runner import ToolRunner
+    from pydantic import BaseModel, Field
+    from typing import Type
+
+    class _In(BaseModel):
+        user_prompt: str = Field(...)
+
+    class _Tool:
+        name = "write_csv"
+        spec = None
+        metadata = None
+        output_model = None
+
+        @property
+        def input_model(self) -> Type[BaseModel]:
+            return _In
+
+    async def _emit(evt):
+        return None
+
+    runner = ToolRunner()
+    marker = parse_tool_call_arguments('{"user_prompt": "totally broken')
+    result = await runner.run(_Tool(), marker, {"mode": "chat"}, _emit)
+
+    observation = result["observation"]
+    assert observation["success"] is False
+    assert observation["error"]["type"] == "malformed_tool_arguments"
+    # The feedback must describe broken JSON, not a missing field.
+    assert "Field required" not in observation["error"]["message"]
+    assert "JSON" in observation["error"]["message"]
+    assert result["output"]["success"] is False


### PR DESCRIPTION
## Problem

`write_csv` was failing repeatedly in production (Hebrew-content org on Bedrock), in three distinct ways that all killed runs or wasted rounds:

1. **`user_prompt: Field required` run kills.** Streamed tool-call argument JSON that failed to parse collapsed into an `{_unparsable, _raw}` marker; pydantic then reported every field as missing — pointing the model at a problem it didn't have. Two strikes (counted across the whole run, never reset) force-terminated the run, and the UI rendered the failed calls as green "CSV written ✓" cards.
2. **Codegen quote/truncation failures.** Generated Python broke on quote escaping in Hebrew text, and code cut off at the output-token cap was executed anyway, producing misleading "unterminated string literal" feedback. `write_csv` hard-coded `retries=1`, so it was the only codegen tool with no self-repair loop.
3. **Hebrew content made everything systematically worse.** The ASCII `"` is part of Hebrew orthography (in-word abbreviation mark: ארה"ב, מנכ"ל), so Hebrew values are saturated with embedded quotes; Hebrew also tokenizes ~2-4× less efficiently, hitting output caps sooner. Bedrock requests carried no `maxTokens` at all, so output was capped at the provider's low default.

## Changes

**Tool-call argument salvage ladder** (`app/ai/llm/toolcall_args.py`, wired into all five provider clients — applies to every tool, not just write_csv):
- strict `json.loads`
- balanced-object extraction (strips short prose/markdown wrappers; refuses to discard large prefixes)
- Python-literal parsing (single-quoted dicts)
- in-string damage repair: escapes bare `"` inside string values via structural lookahead, plus raw control characters

**Runner** (`app/ai/runner/tool_runner.py`):
- unrecoverable `_unparsable` args short-circuit with an accurate "invalid JSON" message (with parse error and escaping guidance) instead of a missing-field list
- validation-failure strikes reset on the next valid call; only consecutive failures can terminate
- validation failures return `observation` + `output` with `success: false` so the UI shows a real error card

**write_csv** (`app/ai/tools/...`):
- `WriteCsvInput` recovers `user_prompt` from common aliases (`prompt`, `instruction`, `description`, `task`) and falls back to `title`; JSON schema still advertises it as required
- tool description names its arguments explicitly
- uses the org `limit_code_retries` budget instead of hard-coded `retries=1`
- CSV display filename keeps word characters in any script (Hebrew titles no longer degrade to `2025.csv` or the generic default)

**Coder** (`app/ai/agents/coder/coder.py`):
- all three codegen streams detect `stop_reason=max_tokens` and raise with actionable "regenerate compactly" feedback instead of executing truncated code
- transform prompt: wrap text literals in single quotes (no escaping needed for in-word `"`), never backslash-escaped double-quoted literals

**Bedrock client**:
- explicit `inferenceConfig.maxTokens` (default 8192, `BOW_BEDROCK_MAX_TOKENS` override, auto-raised above a thinking budget)

## Verification

- 90+ unit tests across the touched areas, including Hebrew fixtures mirroring the production failures (new: `test_toolcall_args_salvage.py`, `test_bedrock_max_tokens.py`, `test_coder_truncation.py`, `test_write_csv_prompt_fallback.py`, `test_tool_runner_validation.py`)
- Live sandbox e2e (OpenAI GPT-5.6 Luna as the single enabled model): raw Hebrew file → `write_csv` → table rendered with in-word quotes intact, Hebrew display filename, `tool_executions` success in DB
- Before/after harness over the production failure fixtures: every previously run-killing case now either executes (salvaged) or returns accurate retry feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MPUEz4mBf1sTMwtfPDCU8

---
_Generated by [Claude Code](https://claude.ai/code/session_018MPUEz4mBf1sTMwtfPDCU8)_