### PR TITLE
security: harden public PDF export against path traversal

### DIFF
--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -641,9 +641,22 @@ async def export_public_report_pdf(
             detail="PDF export is not available for this report",
         )
 
+    # Defense-in-depth: generate_for_report builds this path from the DB
+    # artifact id under UPLOADS_DIR — never from raw request input. Still, rebuild
+    # the served path from that fixed root plus only the bare filename, so no
+    # directory component of the computed path can point outside the export tree,
+    # and confirm the result resolves back inside UPLOADS_DIR before streaming it.
+    uploads_root = ReportPdfService.UPLOADS_DIR.resolve()
+    safe_pdf = (uploads_root / os.path.basename(pdf_path)).resolve()
+    if not safe_pdf.is_relative_to(uploads_root) or not safe_pdf.is_file():
+        raise HTTPException(
+            status_code=409,
+            detail="PDF export is not available for this report",
+        )
+
     from fastapi.responses import FileResponse
     return FileResponse(
-        pdf_path,
+        str(safe_pdf),
         media_type="application/pdf",
         filename=f"{schema.title or 'report'}.pdf",
         content_disposition_type="attachment",


### PR DESCRIPTION
Snyk Code flagged a High-severity path-traversal in the public report PDF export endpoint (GET /r/{report_id}/export_pdf): an HTTP-derived value flows into fastapi.responses.FileResponse used as a filesystem path.

In practice the served path is built internally from the DB artifact id under ReportPdfService.UPLOADS_DIR and the request's report_id only reaches a parameterized SQL query, so traversal is not actually reachable. This adds defense-in-depth regardless: rebuild the served path from the fixed UPLOADS_DIR root plus only os.path.basename(pdf_path), then confirm it still resolves inside UPLOADS_DIR before streaming. Any path component that could ever point outside the export tree is stripped, and the endpoint returns the existing 409 otherwise.

Behavior is unchanged for legitimate exports. Snyk Code now reports 0 high/critical issues.


Claude-Session: https://claude.ai/code/session_01JVsVALjUxpHuXBMuXADwnk