### PR TITLE
Scope eval listings to one agent in SQL, not in the browser

### DIFF
--- a/backend/app/core/eval_scope.py
+++ b/backend/app/core/eval_scope.py
@@ -24,7 +24,9 @@ owner in training mode being offered an eval tool that always failed.
 """
 from __future__ import annotations
 
-from typing import Any, Iterable, Sequence, Tuple
+from typing import Any, Iterable, Optional, Sequence, Tuple
+
+from sqlalchemy import String, cast, or_
 
 
 async def eval_agent_scope(db, user_id: str, org_id: str) -> Tuple[bool, set]:
@@ -94,6 +96,56 @@ def filter_cases(cases: Iterable[Any], unscoped: bool, agent_ids: set) -> list:
     if unscoped:
         return list(cases)
     return [c for c in cases if can_view_case(c, unscoped, agent_ids)]
+
+
+# --- Agent narrowing, in SQL -------------------------------------------------
+#
+# The predicates above answer "may this caller see it?". These answer "does it
+# belong to the agent being looked at?" — presentation, not authority, and they
+# must be applied on top of an authority filter, never instead of one.
+#
+# They exist in SQL because the per-agent eval views were narrowing a page of
+# ORG-WIDE rows in the browser: the client asked for the newest 100 runs in the
+# organization and kept the ones touching its agent. With enough traffic from
+# other agents, an agent's own runs fell off the end of that page and the panel
+# said "no runs" for an agent that had plenty. Filtering before LIMIT makes the
+# window per-agent, so the cap bounds one agent's history instead of the org's.
+#
+# Matching is textual because ``data_source_ids_json`` is a portable ``JSON``
+# column, and JSON containment operators differ between Postgres and SQLite.
+# Casting to text and substring-matching a quoted id behaves identically on
+# both; the same cast is already how case search works.
+
+_EMPTY_JSON_TEXT = ("[]", "null", "")
+
+
+def _targets_no_agent(column):
+    """The row names no agent — i.e. it applies to every agent in the org."""
+    return or_(column.is_(None), cast(column, String).in_(_EMPTY_JSON_TEXT))
+
+
+def _targets_agent(column, agent_id: str):
+    # autoescape so an id carrying % or _ cannot widen the match.
+    return cast(column, String).contains(f'"{agent_id}"', autoescape=True)
+
+
+def agent_scope_clause(column, data_source_id: Optional[str] = None, scope: Optional[str] = None):
+    """Narrow eval rows to one agent's world. ``None`` means "no narrowing".
+
+    ``data_source_id`` matches that agent's rows PLUS the agent-less ones, which
+    run against every agent and so are genuinely part of what that agent is
+    tested by. ``scope="global"`` matches only the agent-less rows.
+
+    Note this is deliberately wider than ``TestSuite.data_source_id`` filtering
+    in ``list_suites``: a suite's home agent is a filing location and belongs to
+    exactly one shelf, whereas an agent-less CASE really does execute against
+    the agent you are looking at.
+    """
+    if data_source_id:
+        return or_(_targets_no_agent(column), _targets_agent(column, str(data_source_id)))
+    if scope == "global":
+        return _targets_no_agent(column)
+    return None
 
 
 def holds_any_eval_authority(unscoped: bool, agent_ids: Sequence | set) -> bool:

--- a/backend/app/routes/test.py
+++ b/backend/app/routes/test.py
@@ -71,6 +71,19 @@ def _filter_cases(cases, unscoped: bool, agent_ids: set):
     return filter_cases(cases, unscoped, agent_ids)
 
 
+def _narrow_to_agent(cases, data_source_id: Optional[str], scope: Optional[str]):
+    """In-Python twin of ``agent_scope_clause``, for the already-materialized
+    single-suite branch. Presentation only — authority is applied separately."""
+    if not data_source_id and scope != "global":
+        return cases
+    out = []
+    for c in cases:
+        ds = {str(x) for x in (getattr(c, "data_source_ids_json", None) or [])}
+        if not ds or (data_source_id and str(data_source_id) in ds):
+            out.append(c)
+    return out
+
+
 async def _require_case_authority(
     db: AsyncSession, user: User, organization: Organization, case,
 ) -> None:
@@ -365,20 +378,37 @@ async def list_cases(suite_id: str, db: AsyncSession = Depends(get_async_db), or
 @requires_permission('manage_evals', resource_scoped=True)
 async def list_cases_across_suites(
     suite_id: Optional[str] = None,
+    suite_ids: Optional[List[str]] = Query(None),
     search: Optional[str] = None,
     page: int = Query(1, ge=1),
     limit: int = Query(100, ge=1, le=1000),
+    data_source_id: Optional[str] = None,
+    scope: Optional[str] = None,
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
     current_user: User = Depends(current_user),
 ):
-    """List test cases across suites with optional suite and text search filters."""
-    scope = await _eval_agent_scope(db, current_user, organization)
+    """List test cases across suites, optionally narrowed to one agent.
+
+    ``data_source_id`` returns the cases that agent is tested by (its own, plus
+    the agent-less ones that run against every agent); ``scope=global`` returns
+    only the agent-less ones. Narrowing happens in SQL so ``limit`` bounds the
+    agent's cases and not the organization's.
+
+    ``suite_ids`` narrows by filing location instead of by target — what the
+    agent tree needs for the cases sitting in this agent's suites, which may
+    include one dragged in that targets someone else.
+    """
+    authority = await _eval_agent_scope(db, current_user, organization)
     if suite_id:
         cases = await case_service.list_cases(db, str(organization.id), current_user, suite_id)
+        cases = _narrow_to_agent(cases, data_source_id, scope)
     else:
-        cases = await case_service.list_cases_multi(db, str(organization.id), current_user, suite_ids=None, search=search, page=page, limit=limit)
-    return _filter_cases(cases, *scope)
+        cases = await case_service.list_cases_multi(
+            db, str(organization.id), current_user, suite_ids=suite_ids or None, search=search,
+            page=page, limit=limit, data_source_id=data_source_id, scope=scope,
+        )
+    return _filter_cases(cases, *authority)
 
 
 @router.get("/cases/{case_id}", response_model=TestCaseSchema)
@@ -474,11 +504,24 @@ async def list_runs(
     status: Optional[str] = None,
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
+    data_source_id: Optional[str] = None,
+    scope: Optional[str] = None,
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
     current_user: User = Depends(current_user)
 ):
-    runs = await run_service.list_runs(db, str(organization.id), current_user, suite_id=suite_id, status=status, page=page, limit=limit)
+    """List runs, optionally narrowed to the ones that touched one agent.
+
+    ``data_source_id`` keeps a run when any case it executed concerns that agent;
+    ``scope=global`` keeps a run that executed at least one agent-less case. A
+    run spanning both worlds appears under both, which is right — it happened in
+    both. As with cases, the narrowing is in SQL so ``limit`` bounds one agent's
+    history rather than the organization's.
+    """
+    runs = await run_service.list_runs(
+        db, str(organization.id), current_user, suite_id=suite_id, status=status,
+        page=page, limit=limit, data_source_id=data_source_id, scope=scope,
+    )
     unscoped, agent_ids = await _eval_agent_scope(db, current_user, organization)
     if unscoped:
         return runs

--- a/backend/app/services/test_case_service.py
+++ b/backend/app/services/test_case_service.py
@@ -12,6 +12,7 @@ from app.models.eval import (
 )
 from app.models.llm_model import LLMModel
 from app.models.llm_provider import LLMProvider
+from app.core.eval_scope import agent_scope_clause
 
 
 class TestCaseService:
@@ -228,12 +229,17 @@ class TestCaseService:
         search: Optional[str] = None,
         page: int = 1,
         limit: int = 50,
+        data_source_id: Optional[str] = None,
+        scope: Optional[str] = None,
     ) -> List[TestCase]:
         """List cases across suites with optional filters. Joins through TestSuite to enforce org scope.
 
-        Note: This method is provided for future endpoints and UI filters; current UI composes
-        per-suite requests client-side. Searching matches against TestCase.name and a coarse
-        string match on prompt_json (DB-dependent JSON LIKE behavior).
+        Searching matches against TestCase.name and a coarse string match on
+        prompt_json (DB-dependent JSON LIKE behavior).
+
+        ``data_source_id`` / ``scope`` narrow to one agent BEFORE the limit is
+        applied, so the page is that agent's newest cases rather than the org's
+        newest cases that happen to include it.
         """
         # Ensure suites belong to org when filtering
         if suite_ids:
@@ -252,6 +258,9 @@ class TestCaseService:
             like = f"%{search}%"
             # Coarse match on prompt_json string representation; portable enough for SQLite/postgres
             stmt = stmt.where(or_(TestCase.name.ilike(like), cast(TestCase.prompt_json, String).ilike(like)))
+        agent_clause = agent_scope_clause(TestCase.data_source_ids_json, data_source_id, scope)
+        if agent_clause is not None:
+            stmt = stmt.where(agent_clause)
         stmt = stmt.order_by(TestCase.created_at.desc()).offset((page - 1) * limit).limit(limit)
         res = await db.execute(stmt)
         return res.scalars().all()

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -70,6 +70,7 @@ def _agent_metadata_from_execution(ae) -> Dict[str, Any]:
     }
 
 from app.models.eval import TestSuite, TestCase, TestRun, TestResult
+from app.core.eval_scope import agent_scope_clause
 from app.models.report import Report
 from app.services.report_service import ReportService
 from app.models.completion import Completion
@@ -448,7 +449,7 @@ class TestRunService:
             _ = await self._get_suite(db, organization_id, str(sid))
         return run
 
-    async def list_runs(self, db: AsyncSession, organization_id: str, current_user, suite_id: Optional[str] = None, status: Optional[str] = None, page: int = 1, limit: int = 20) -> List[TestRun]:
+    async def list_runs(self, db: AsyncSession, organization_id: str, current_user, suite_id: Optional[str] = None, status: Optional[str] = None, page: int = 1, limit: int = 20, data_source_id: Optional[str] = None, scope: Optional[str] = None) -> List[TestRun]:
         # TestRun has no organization_id column — scope through the
         # results → cases → suites chain on EVERY branch. The unfiltered
         # branch used to be a bare select(TestRun), leaking other orgs' run
@@ -465,6 +466,18 @@ class TestRunService:
         if suite_id:
             await self._get_suite(db, organization_id, suite_id)
             stmt = stmt.where(TestCase.suite_id == str(suite_id))
+        # Narrow to one agent's runs. The join already fans a run out over the
+        # cases it executed, so a WHERE here keeps a run when ANY of its cases
+        # concerns the agent — the union that run relevance calls for, since a
+        # routing eval spanning A and B is genuinely part of A's history.
+        #
+        # Deliberately NOT filtered on TestCase.deleted_at: the case list is,
+        # so a client that resolved this by intersecting with the case list lost
+        # every past run of a case that was later deleted. The run happened; it
+        # stays in the agent's history.
+        agent_clause = agent_scope_clause(TestCase.data_source_ids_json, data_source_id, scope)
+        if agent_clause is not None:
+            stmt = stmt.where(agent_clause)
         # Distinct over the ID only: TestRun carries a ``json`` summary column,
         # and Postgres SELECT DISTINCT needs an equality operator for every
         # selected column — which the json type has none of. Paginate the id

--- a/backend/tests/e2e/rbac/test_rbac_evals.py
+++ b/backend/tests/e2e/rbac/test_rbac_evals.py
@@ -14,7 +14,38 @@ referenced ``"create_evals"`` which is not a registered resource
 permission, so per-DS evals authors were locked out entirely. See the
 PR description for context.)
 """
+import asyncio
+import uuid
+
 import pytest
+
+from app.dependencies import async_session_maker
+from app.models.eval import TestResult, TestRun
+
+
+
+def _seed_run(case_id):
+    """Insert a TestRun with one TestResult for ``case_id`` and return its id."""
+    async def _go():
+        async with async_session_maker() as db:
+            run = TestRun(
+                title=f"seeded-{case_id[:8]}",
+                suite_ids="",
+                status="success",
+                trigger_reason="manual",
+            )
+            db.add(run)
+            await db.flush()
+            db.add(TestResult(
+                run_id=str(run.id),
+                case_id=str(case_id),
+                head_completion_id=str(uuid.uuid4()),
+                status="pass",
+            ))
+            await db.commit()
+            return str(run.id)
+
+    return asyncio.run(_go())
 
 
 def _hdr(token, org_id):
@@ -203,3 +234,97 @@ def test_eval_case_create_resource_scoped(test_client, evals_world):
             )
 
     assert not failures, "\n".join(failures)
+
+
+# ────────────────────────────────────────────────────────────────────
+# Agent narrowing — presentation, on top of authority
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_case_and_run_listings_narrow_to_one_agent(test_client, evals_world):
+    """``data_source_id`` / ``scope=global`` narrow the case and run listings.
+
+    Both listings used to be org-wide only, and the per-agent Evals panel
+    narrowed a PAGE of them in the browser: the newest N runs in the
+    organization, kept if they touched one of the newest M cases. An agent whose
+    runs sat past the org's newest N therefore showed "no runs" while having
+    plenty, and deleting a test case erased every past run of it from the
+    agent's history — the runs were only reachable *via* the case list.
+
+    Narrowing server-side is what makes the page per-agent. This asserts the
+    semantics that narrowing has to have:
+
+      - an agent's listing includes the agent-less cases, which run against
+        every agent and so are part of what it is tested by;
+      - ``scope=global`` shows only those agent-less ones;
+      - another agent's cases never appear;
+      - and a run survives its case being deleted.
+    """
+    org_id = evals_world["org_id"]
+    admin = evals_world["principals"]["admin"]
+    hdr = _hdr(admin["token"], org_id)
+    ds_a_id = evals_world["ds_a"]["id"]
+    ds_b_id = evals_world["ds_b"]["id"]
+
+    suite_id = test_client.post(
+        "/api/tests/suites",
+        json={"name": "Narrowing Suite", "description": None},
+        headers=hdr,
+    ).json()["id"]
+
+    def _case(name, ds_ids):
+        resp = test_client.post(
+            f"/api/tests/suites/{suite_id}/cases",
+            json={
+                "name": name,
+                "prompt_json": {"content": name},
+                "expectations_json": {"spec_version": 1, "rules": [], "order_mode": "flexible"},
+                "data_source_ids_json": ds_ids,
+            },
+            headers=hdr,
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["id"]
+
+    case_a = _case("targets-a", [ds_a_id])
+    case_b = _case("targets-b", [ds_b_id])
+    case_global = _case("targets-nobody", [])
+
+    def _case_ids(query):
+        resp = test_client.get(f"/api/tests/cases?limit=1000&{query}", headers=hdr)
+        assert resp.status_code == 200, resp.text
+        return {c["id"] for c in resp.json()}
+
+    for_a = _case_ids(f"data_source_id={ds_a_id}")
+    assert case_a in for_a and case_global in for_a
+    assert case_b not in for_a
+
+    for_global = _case_ids("scope=global")
+    assert case_global in for_global
+    assert case_a not in for_global and case_b not in for_global
+
+    # No narrowing params → unchanged behaviour, everything the caller may read.
+    unnarrowed = _case_ids("")
+    assert {case_a, case_b, case_global} <= unnarrowed
+
+    # Runs follow the cases they executed. Seeded directly rather than through
+    # POST /tests/runs: that route needs a configured default model and starts
+    # real agent work, none of which this assertion is about.
+    run_a = _seed_run(case_a)
+    run_b = _seed_run(case_b)
+
+    def _run_ids(query):
+        resp = test_client.get(f"/api/tests/runs?limit=100&{query}", headers=hdr)
+        assert resp.status_code == 200, resp.text
+        return {r["id"] for r in resp.json()}
+
+    runs_for_a = _run_ids(f"data_source_id={ds_a_id}")
+    assert run_a in runs_for_a
+    assert run_b not in runs_for_a
+
+    # The regression the narrowing exists to prevent: deleting the case must not
+    # take its run history with it.
+    assert test_client.delete(f"/api/tests/cases/{case_a}", headers=hdr).status_code == 200
+    assert case_a not in _case_ids(f"data_source_id={ds_a_id}")
+    assert run_a in _run_ids(f"data_source_id={ds_a_id}")

--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -211,7 +211,7 @@ import EvalRunDetail from '~/components/EvalRunDetail.vue'
 const { t } = useI18n()
 const toast = useToast()
 
-const props = defineProps<{ agentId?: string; global?: boolean }>()
+const props = defineProps<{ agentId?: string; global?: boolean; initialRunId?: string }>()
 const agentId = computed(() => props.agentId || '')
 // Global mode shows org-wide evals (cases not scoped to any data source/agent),
 // which apply to ALL agents. Admin-gated via the `manage_evals` org permission.
@@ -242,7 +242,6 @@ const loadingRuns = ref(false)
 const allCases = ref<TestCaseRow[]>([])
 const allRuns = ref<RunItem[]>([])
 const runResults = ref<Record<string, { total: number; passed: number; failed: number; error: number }>>({})
-const runResultsCaseIds = ref<Record<string, Set<string>>>({})
 const suitesById = ref<Record<string, string>>({})
 const searchTerm = ref('')
 const selectedIds = ref<Set<string>>(new Set())
@@ -252,32 +251,26 @@ const showAddCase = ref(false)
 const selectedSuiteId = ref('')
 const selectedCaseId = ref('')
 
-// Filter cases to this agent
+// The agent narrowing now happens in SQL (see agent_scope_clause) — both lists
+// arrive already scoped, so all that is left here is the free-text search.
+//
+// It used to be done here, over a page of ORG-WIDE rows: the newest 100 runs in
+// the organization, kept if they touched one of the newest 500 cases. Three
+// things fell out of that and all three go away with the fetch being scoped:
+// an agent whose runs sat past the org's 100 newest showed "no runs"; deleting
+// a test case erased every past run of it from the agent's history, because
+// runs were found only *via* the case list; and typing in the Tests search box
+// emptied the Runs tab, since the search fed the same case set.
 const agentCases = computed(() => {
-    const id = agentId.value
-    if (!isGlobal.value && !id) return []
+    if (!isGlobal.value && !agentId.value) return []
     const term = searchTerm.value.trim().toLowerCase()
-    return allCases.value.filter(c => {
-        // Auto / empty data sources => "all agents" (like a global instruction).
-        const dsids = c.data_source_ids_json || []
-        // Global view: only org-wide cases (no data-source scope). Agent view:
-        // org-wide cases + cases scoped to this agent.
-        const matches = isGlobal.value ? dsids.length === 0 : (dsids.length === 0 || dsids.includes(id))
-        if (!matches) return false
-        if (term) return (c.prompt_json?.content || '').toLowerCase().includes(term)
-        return true
-    })
+    if (!term) return allCases.value
+    return allCases.value.filter(c => (c.prompt_json?.content || '').toLowerCase().includes(term))
 })
 
-// Filter runs that contain any of this agent's cases
-const agentCaseIds = computed(() => new Set(agentCases.value.map(c => c.id)))
 const agentRuns = computed(() => {
     if (!isGlobal.value && !agentId.value) return []
-    return allRuns.value.filter(r => {
-        const caseIds = runResultsCaseIds.value[r.id]
-        if (!caseIds) return false
-        return [...caseIds].some(id => agentCaseIds.value.has(id))
-    })
+    return allRuns.value
 })
 
 const pagedCases = computed(() => {
@@ -440,6 +433,11 @@ function addNewTest() {
 // Nested run detail — runs open in place inside the explorer instead of
 // navigating away to /evals/runs/{id}.
 const openRunId = ref<string>('')
+// A run launched from outside the panel (the tree's "run suite") opens straight
+// into its detail. Immediate, since the panel is mounted by the same click.
+watch(() => props.initialRunId, (id) => {
+    if (id && id !== openRunId.value) { activeTab.value = 'runs'; openRunId.value = String(id) }
+}, { immediate: true })
 function closeRunDetail() {
     openRunId.value = ''
     // Statuses moved while the detail was open — refresh the table.
@@ -539,10 +537,15 @@ async function loadSuites() {
     } catch {}
 }
 
+// Both listings take the agent narrowing as a query param, so `limit` bounds
+// this agent's history instead of the organization's.
+const scopeQuery = computed(() =>
+    isGlobal.value ? 'scope=global' : `data_source_id=${encodeURIComponent(agentId.value)}`)
+
 async function loadCases() {
     loadingCases.value = true
     try {
-        const res = await useMyFetch<any[]>('/api/tests/cases?limit=500')
+        const res = await useMyFetch<any[]>(`/api/tests/cases?limit=500&${scopeQuery.value}`)
         const items = (res.data.value || []) as any[]
         allCases.value = items.map((c: any) => ({
             id: c.id,
@@ -564,27 +567,23 @@ async function loadCases() {
 async function loadRuns() {
     loadingRuns.value = true
     try {
-        const res = await useMyFetch<any[]>('/api/tests/runs?limit=100')
+        const res = await useMyFetch<any[]>(`/api/tests/runs?limit=100&${scopeQuery.value}`)
         const runs = (res.data.value as any[]) || []
         allRuns.value = runs
         // Per-case statuses come embedded in the listing (case_results) —
         // fetching /runs/{id}/results per run was 100 extra requests here.
         const map: Record<string, any> = {}
-        const caseMap: Record<string, Set<string>> = {}
         for (const r of runs) {
             const rows = (r as any).case_results || []
             const summary = { total: rows.length, passed: 0, failed: 0, error: 0 }
-            caseMap[r.id] = new Set<string>()
             for (const it of rows) {
                 if (it.status === 'pass') summary.passed++
                 else if (it.status === 'fail') summary.failed++
                 else if (it.status === 'error') summary.error++
-                if (it.case_id) caseMap[r.id].add(String(it.case_id))
             }
             map[r.id] = summary
         }
         runResults.value = map
-        runResultsCaseIds.value = caseMap
     } catch {
         allRuns.value = []
     } finally {

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -576,8 +576,8 @@
             <button class="h-7 w-7 rounded-md flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800/70 shrink-0" @click="closePanel"><UIcon name="i-heroicons-x-mark" class="w-4 h-4" /></button>
           </div>
           <div class="flex-1 overflow-auto">
-            <AgentEvalsPanel v-if="panelView.kind === 'evals'" :key="'evals-' + panelView.agentId" :agent-id="panelView.agentId" />
-            <AgentEvalsPanel v-else-if="panelView.kind === 'global-evals'" key="global-evals" global />
+            <AgentEvalsPanel v-if="panelView.kind === 'evals'" :key="'evals-' + panelView.agentId" :agent-id="panelView.agentId" :initial-run-id="pendingRunId" />
+            <AgentEvalsPanel v-else-if="panelView.kind === 'global-evals'" key="global-evals" global :initial-run-id="pendingRunId" />
             <AgentSettingsPanel v-else-if="panelView.kind === 'settings'" :key="'settings-' + panelView.agentId" :agent-id="panelView.agentId" @updated="onAgentSettingsUpdated" @deleted="onAgentDeleted" />
             <div v-else class="px-6 py-4">
               <TablesSelector
@@ -1540,18 +1540,24 @@ async function loadEvalTree(scope: string, opts: { force?: boolean } = {}) {
   if (cur?.loaded && !opts.force) return
   evalTree.value = { ...evalTree.value, [scope]: { suites: cur?.suites || [], cases: cur?.cases || [], unfiled: cur?.unfiled || [], loaded: !!cur?.loaded, loading: true } }
   try {
-    // Suites are asked for by scope; cases come back already filtered to what
-    // this user may read, and are bucketed by their suite here.
+    // Suites are asked for by scope. Cases are asked for twice because the two
+    // buckets below are answers to different questions, and asking one org-wide
+    // question instead used to lose both once an org had more cases than the
+    // page: by FILING (what sits in this agent's suites, which may include one
+    // dragged in that targets someone else) and by TARGET (what this agent is
+    // tested by, wherever it is filed). Both come back already filtered to what
+    // this user may read.
     const scopeQ = scope === 'global' ? 'scope=global' : `data_source_id=${encodeURIComponent(scope)}`
-    const [sRes, cRes] = await Promise.all([
-      useMyFetch(`/api/tests/suites?limit=100&${scopeQ}`),
-      useMyFetch('/api/tests/cases?limit=1000'),
-    ])
+    const sRes: any = await useMyFetch(`/api/tests/suites?limit=100&${scopeQ}`)
     const suites = ((sRes as any)?.data?.value || []) as EvalSuite[]
     const suiteIds = new Set(suites.map(x => String(x.id)))
-    const all = ((cRes as any)?.data?.value || []) as EvalCase[]
-    const cases = all.filter(c => suiteIds.has(String(c.suite_id)))
-    // Cases that belong here by TARGET but sit in a suite that lives elsewhere
+    const suiteQ = suites.map(s => `suite_ids=${encodeURIComponent(String(s.id))}`).join('&')
+    const [filedRes, targetedRes] = await Promise.all([
+      suiteQ ? useMyFetch(`/api/tests/cases?limit=1000&${suiteQ}`) : Promise.resolve(null),
+      useMyFetch(`/api/tests/cases?limit=1000&${scopeQ}`),
+    ])
+    const cases = (((filedRes as any)?.data?.value || []) as EvalCase[])
+    // Cases that belong here by target but sit in a suite that lives elsewhere
     // — chiefly the org-wide Drafts bucket, where everything auto-drafted used
     // to land before suites had a home. Without this they would be invisible in
     // the tree even though their agent's manager owns them, and there would be
@@ -1560,7 +1566,8 @@ async function loadEvalTree(scope: string, opts: { force?: boolean } = {}) {
       const ds = (c.data_source_ids_json || []).map(String)
       return scope === 'global' ? ds.length === 0 : (ds.length === 1 && ds[0] === scope)
     }
-    const unfiled = all.filter(c => !suiteIds.has(String(c.suite_id)) && belongsHere(c))
+    const unfiled = (((targetedRes as any)?.data?.value || []) as EvalCase[])
+      .filter(c => !suiteIds.has(String(c.suite_id)) && belongsHere(c))
     evalTree.value = { ...evalTree.value, [scope]: { suites, cases, unfiled, loaded: true, loading: false } }
   } catch (e) {
     console.error('Failed to load eval suites', e)
@@ -1608,6 +1615,31 @@ const canManageEvalScope = (scope: string) =>
 const createSuiteIn = (scope: string) => openDirModal('create', scope, { kind: 'suite' })
 const renameSuite = (scope: string, suite: any) => openDirModal('rename', scope, { kind: 'suite', suite })
 const deleteSuite = (scope: string, suite: any) => openDirModal('delete', scope, { kind: 'suite', suite })
+
+// Run a whole suite from the tree. POST /tests/suites/{id}/runs has existed and
+// been permission-gated all along with no caller — running a suite meant
+// opening it, ticking every case and using "run selected". The new run opens in
+// the Evals panel for this scope, the same place a single-case run lands.
+const runningSuiteId = ref('')
+const pendingRunId = ref('')
+async function runSuite(scope: string, suite: any) {
+  if (runningSuiteId.value) return
+  runningSuiteId.value = String(suite.id)
+  try {
+    const res: any = await useMyFetch(`/api/tests/suites/${suite.id}/runs`, { method: 'POST' })
+    if (res?.error?.value) throw res.error.value
+    const run = res?.data?.value
+    if (!run?.id) throw new Error('No run returned')
+    pendingRunId.value = String(run.id)
+    if (scope === 'global') openGlobalEvals()
+    else openPanel('evals', scope)
+  } catch (e: any) {
+    const detail = e?.data?.detail || e?.response?._data?.detail
+    toast.add({ title: t('agentsPage.runSuiteFailed'), description: typeof detail === 'string' ? detail : undefined, color: 'red' })
+  } finally {
+    runningSuiteId.value = ''
+  }
+}
 
 async function submitSuiteModal(m: any, name: string) {
   const fail = (e: any) => {
@@ -3504,8 +3536,8 @@ const fmtDate = (s?: string) => { if (!s) return ''; try { return _df.format(s, 
 
 // ── Inline tree sub-components ──────────────────────────
 const TreeGroup = defineComponent({
-  props: { label: String, icon: String, count: { type: Number, default: undefined }, countAccent: Boolean, pending: Boolean, open: Boolean, mono: Boolean, indent: { type: Number, default: 0 }, addable: Boolean, folderable: Boolean, gearable: Boolean, reloadable: Boolean, renamable: Boolean, deletable: Boolean, badge: String, badgeInteractive: { type: Boolean, default: true }, disabled: Boolean, labelClickable: Boolean, active: Boolean, statusDot: String, lock: Boolean, dropActive: Boolean, onDropzone: Function, onDragover: Function, onDragleave: Function },
-  emits: ['toggle', 'add', 'folder', 'gear', 'reload', 'rename', 'delete', 'badge', 'label'],
+  props: { label: String, icon: String, count: { type: Number, default: undefined }, countAccent: Boolean, pending: Boolean, open: Boolean, mono: Boolean, indent: { type: Number, default: 0 }, addable: Boolean, folderable: Boolean, gearable: Boolean, reloadable: Boolean, renamable: Boolean, deletable: Boolean, runnable: Boolean, running: Boolean, badge: String, badgeInteractive: { type: Boolean, default: true }, disabled: Boolean, labelClickable: Boolean, active: Boolean, statusDot: String, lock: Boolean, dropActive: Boolean, onDropzone: Function, onDragover: Function, onDragleave: Function },
+  emits: ['toggle', 'add', 'folder', 'gear', 'reload', 'rename', 'delete', 'run', 'badge', 'label'],
   setup(props, { slots, emit }) {
     // When `labelClickable` is set, the chevron/icon area toggles the tree and the
     // label text opens the panel (`@label`); otherwise the whole row toggles.
@@ -3532,6 +3564,9 @@ const TreeGroup = defineComponent({
           : createElement('span', { class: 'shrink-0 inline-flex items-center px-1.5 h-5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-[10px] font-medium' }, props.badge)) : null,
         (props.reloadable && !props.disabled) ? createElement('button', { class: 'shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 flex items-center justify-center', title: t('agentsPage.tipReload'), onClick: (e: Event) => { e.stopPropagation(); emit('reload') } }, [createElement(resolveComponent('UIcon'), { name: 'i-heroicons-arrow-path', class: 'w-3 h-3' })]) : null,
         (props.gearable && !props.disabled) ? createElement('button', { class: 'shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 flex items-center justify-center', title: t('agentsPage.tipManage'), onClick: (e: Event) => { e.stopPropagation(); emit('gear') } }, [createElement(resolveComponent('UIcon'), { name: 'i-heroicons-cog-6-tooth', class: 'w-3 h-3' })]) : null,
+        // Kept visible while running (no opacity-0) — the row is the only
+        // feedback that the run started before its detail pane opens.
+        (props.runnable && !props.disabled) ? createElement('button', { class: ['shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 flex items-center justify-center', props.running ? 'text-blue-500 opacity-100' : 'text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100'], disabled: props.running, title: t('agentsPage.tipRunSuite'), onClick: (e: Event) => { e.stopPropagation(); if (!props.running) emit('run') } }, [createElement(resolveComponent('UIcon'), { name: props.running ? 'i-heroicons-arrow-path' : 'i-heroicons-play', class: ['w-3 h-3', props.running ? 'animate-spin' : ''] })]) : null,
         (props.renamable && !props.disabled) ? createElement('button', { class: 'shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 flex items-center justify-center', title: t('agentsPage.tipRename'), onClick: (e: Event) => { e.stopPropagation(); emit('rename') } }, [createElement(resolveComponent('UIcon'), { name: 'i-heroicons-pencil', class: 'w-3 h-3' })]) : null,
         (props.deletable && !props.disabled) ? createElement('button', { class: 'shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 flex items-center justify-center', title: t('agentsPage.tipDeleteSuite'), onClick: (e: Event) => { e.stopPropagation(); emit('delete') } }, [createElement(resolveComponent('UIcon'), { name: 'i-heroicons-trash', class: 'w-3 h-3' })]) : null,
         (props.folderable && !props.disabled) ? createElement('button', { class: 'shrink-0 w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 flex items-center justify-center', title: t('agentsPage.tipNewFolder'), onClick: (e: Event) => { e.stopPropagation(); emit('folder') } }, [createElement(resolveComponent('UIcon'), { name: 'i-heroicons-folder-plus', class: 'w-3 h-3' })]) : null,
@@ -3718,12 +3753,17 @@ const SuiteNode = defineComponent({
           addable: props.canManage,
           renamable: props.canManage,
           deletable: props.canManage,
+          // Only offered when there is something to run — a play button on an
+          // empty folder can only produce a 400.
+          runnable: props.canManage && cases.length > 0,
+          running: runningSuiteId.value === String(props.suite.id),
           dropActive: active(),
           open: isOpen(key()),
           onToggle: () => expand(key()),
           onAdd: () => openNewEvalCase(props.scope, String(props.suite.id)),
           onRename: () => renameSuite(props.scope, props.suite),
           onDelete: () => deleteSuite(props.scope, props.suite),
+          onRun: () => runSuite(props.scope, props.suite),
         }, {
           default: () => [
             ...cases.map((c: any) => createElement(CaseLeaf, {

--- a/locales/de.json
+++ b/locales/de.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Diese Suite ausführen",
+    "runSuiteFailed": "Suite konnte nicht ausgeführt werden"
   },
   "smoke": {
     "hello": "Hallo",

--- a/locales/en.json
+++ b/locales/en.json
@@ -284,7 +284,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Run this suite",
+    "runSuiteFailed": "Failed to run suite"
   },
   "commandPalette": {
     "placeholder": "Search reports, agents, instructions…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -284,7 +284,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Ejecutar esta suite",
+    "runSuiteFailed": "No se pudo ejecutar la suite"
   },
   "smoke": {
     "hello": "Hola",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Exécuter cette suite",
+    "runSuiteFailed": "Échec de l'exécution de la suite"
   },
   "smoke": {
     "hello": "Bonjour",

--- a/locales/he.json
+++ b/locales/he.json
@@ -284,7 +284,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "הרצת חבילה זו",
+    "runSuiteFailed": "הרצת החבילה נכשלה"
   },
   "smoke": {
     "hello": "שלום",

--- a/locales/it.json
+++ b/locales/it.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Esegui questa suite",
+    "runSuiteFailed": "Impossibile eseguire la suite"
   },
   "smoke": {
     "hello": "Ciao",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Executar esta suíte",
+    "runSuiteFailed": "Falha ao executar a suíte"
   },
   "smoke": {
     "hello": "Olá",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Запустить этот набор",
+    "runSuiteFailed": "Не удалось запустить набор"
   },
   "smoke": {
     "hello": "Привет",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -271,7 +271,9 @@
     "suiteDeleteConfirm": "Delete “{name}” and the test cases in it you manage? Tests belonging to agents you don’t manage are moved to Drafts, not deleted.",
     "suiteDeleteReparented": "{count} test case(s) moved to Drafts instead of being deleted.",
     "toastSuiteDeleted": "Suite deleted",
-    "tipDeleteSuite": "Delete suite"
+    "tipDeleteSuite": "Delete suite",
+    "tipRunSuite": "Kör den här sviten",
+    "runSuiteFailed": "Det gick inte att köra sviten"
   },
   "smoke": {
     "hello": "Hej",


### PR DESCRIPTION
An agent's Evals panel could report **"no runs" for an agent that had plenty**.

Both eval listings were org-wide only, so the per-agent panel narrowed a *page* of org-wide rows client-side: the newest 100 runs in the organization, kept if they touched one of the newest 500 cases. Three failures fall out of that shape.

| | what happens |
|---|---|
| **Cap** | Once other agents produce more than 100 runs newer than yours, your runs are simply not in the page that gets filtered. Same one level down at 500 cases — lose the cases and every run goes with them. No paging, no "load more", and the empty state is identical to "never ran". |
| **Deleted case** | The case list excludes soft-deleted rows, and runs were reachable only *via* that list — so deleting a test erased its entire run history from the panel while the runs sat untouched in the database. |
| **Search bleed** | The intersection was computed from the same case set the Tests search box filters, so typing a query emptied the Runs tab. With the input hidden on that tab, nothing on screen explained it. |

The client-side intersection has been there since the panel was written; this is not a regression from recent work.

## What changed

**`/tests/cases` and `/tests/runs` take `data_source_id` / `scope=global`**, applied before `LIMIT` so the page is one agent's history rather than the org's newest rows that happen to include it. `agent_scope_clause` joins the existing predicates in `app.core.eval_scope`, matching the JSON column as text because containment operators differ between Postgres and SQLite — the same cast case search already uses.

An agent's listing includes the agent-less cases, which run against every agent and so are genuinely part of what it is tested by; `scope=global` returns only those. This is deliberately wider than `TestSuite.data_source_id` filtering in `list_suites`: a suite's home is a filing location and sits on exactly one shelf, whereas an agent-less *case* really does execute against the agent you're looking at.

The run filter deliberately does **not** exclude deleted cases. The run happened; it stays in the agent's history.

**`AgentEvalsPanel`** drops the client-side intersection entirely — both lists arrive scoped, leaving only the free-text search, which no longer reaches the Runs tab.

**The explorer tree** was asking one org-wide question for two different things; it now asks both. Cases by *filing* (`suite_ids`, new param) for what sits in this agent's suites — which may include one dragged in that targets someone else — and by *target* for what the agent is tested by wherever it's filed. The second is what surfaces auto-drafted cases stranded in the org-wide `Drafts` bucket.

## Also: running a suite

`POST /tests/suites/{id}/runs` has been implemented and permission-gated all along **with no caller** — running a suite meant opening it, ticking every case and using "run selected". It's a play button on the suite row now (only when the suite has cases; a play button on an empty folder can only produce a 400), and the run opens in the Evals panel where a single-case run already lands.

## Verification

- `tests/e2e/test_eval.py` + `test_eval_drafts.py` — 16 passed
- `tests/e2e/rbac/test_rbac_evals.py` — 3 passed, including a new `test_case_and_run_listings_narrow_to_one_agent` asserting the narrowing semantics and the deleted-case regression. It seeds run rows directly rather than going through `POST /tests/runs`, which needs a configured default model and starts real agent work — neither of which the assertion is about.
- Predicate SQL rendered and checked against both the Postgres and SQLite dialects.
- `nuxt build` clean.

## Not included

Investigated during this work, left alone: the **"Run eval" button** on instruction review cards (`ResolvedEvalStrip.vue`) keeps its entire run state in component-local refs and reloads nothing, so a refresh resets it to "Run eval" while the run itself completes normally and shows up under Evals. Same file sets `runState = 'done'` unconditionally after its poll loop, so a hung run renders as a green check with zero passes. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4ortFPcBn6jpgp86yqQs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4ortFPcBn6jpgp86yqQs5)_