### PR TITLE
Prevent duplicate member invitations with loading state

### DIFF
--- a/frontend/components/MembersComponent.vue
+++ b/frontend/components/MembersComponent.vue
@@ -421,9 +421,9 @@
     </div>
 
     <!-- Invite Modal -->
-    <UModal v-model="inviteModalOpen">
+    <UModal v-model="inviteModalOpen" :prevent-close="inviteLoading">
         <div class="p-4 relative">
-            <button @click="inviteModalOpen = false" class="absolute top-2 end-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 outline-none">
+            <button :disabled="inviteLoading" @click="inviteModalOpen = false" class="absolute top-2 end-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 outline-none disabled:opacity-50 disabled:cursor-not-allowed">
                 <Icon name="heroicons:x-mark" class="w-5 h-5" />
             </button>
             <h1 class="text-lg font-semibold">{{ $t('settings.members.inviteTitle') }}</h1>
@@ -489,6 +489,7 @@
                     <UButton
                         type="button"
                         variant="ghost"
+                        :disabled="inviteLoading"
                         @click="inviteModalOpen = false"
                     >
                         {{ $t('settings.members.cancel') }}
@@ -496,7 +497,9 @@
                     <UButton
                         type="submit"
                         color="blue"
+                        :disabled="inviteLoading"
                     >
+                        <Spinner v-if="inviteLoading" class="w-4 h-4" />
                         {{ $t('settings.members.sendInvitation') }}
                     </UButton>
                 </div>
@@ -1131,6 +1134,7 @@ watch(showQuotaColumn, (enabled) => {
 const canManageGroups = computed(() => hasFeature('custom_roles') && useCan('manage_groups'))
 
 const inviteModalOpen = ref(false)
+const inviteLoading = ref(false)
 const inviteForm = ref({
     email: '',
     role: 'member',
@@ -1349,6 +1353,8 @@ const removeMember = async (member: Member) => {
 }
 
 const inviteMember = async () => {
+    if (inviteLoading.value) return
+    inviteLoading.value = true
     try {
         const response = await useMyFetch(`/organizations/${organizationId}/members`, {
             method: 'POST',
@@ -1417,6 +1423,8 @@ const inviteMember = async () => {
         inviteModalOpen.value = false
     } catch (error) {
         console.error('Failed to invite member:', error)
+    } finally {
+        inviteLoading.value = false
     }
 }
 </script>


### PR DESCRIPTION
## Summary
Added loading state management to the invite member modal to prevent duplicate submissions and improve UX during the invitation process.

## Key Changes
- Added `inviteLoading` ref to track the invitation submission state
- Prevented modal from closing while an invitation is being sent via `:prevent-close="inviteLoading"`
- Disabled the close button (X) in the modal header during loading with visual feedback (opacity and cursor changes)
- Disabled both Cancel and Send Invitation buttons while loading is in progress
- Added a loading spinner to the Send Invitation button when the request is pending
- Implemented early return guard in `inviteMember()` to prevent multiple simultaneous requests
- Added `finally` block to ensure `inviteLoading` is reset to `false` after the request completes (success or error)

## Implementation Details
The loading state is properly managed throughout the invitation lifecycle:
- Set to `true` at the start of `inviteMember()`
- Reset to `false` in the `finally` block to handle both success and error cases
- Guards against duplicate submissions with an early return check
- Provides visual feedback to users that their request is being processed

https://claude.ai/code/session_01U1Zs6K3ssCi2DaC3VrCeab