### PR TITLE
Offer an agent's own suites when filing its test cases

### DIFF
--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -243,6 +243,9 @@ const allCases = ref<TestCaseRow[]>([])
 const allRuns = ref<RunItem[]>([])
 const runResults = ref<Record<string, { total: number; passed: number; failed: number; error: number }>>({})
 const suitesById = ref<Record<string, string>>({})
+// The subset of suitesById homed on this scope — the only valid default
+// destination when authoring a new case here.
+const ownSuiteIds = ref<Set<string>>(new Set())
 const searchTerm = ref('')
 const selectedIds = ref<Set<string>>(new Set())
 const casesPage = ref(1)
@@ -424,8 +427,12 @@ function editCase(c: TestCaseRow) {
 }
 
 function addNewTest() {
-    const suiteId = Object.keys(suitesById.value)[0] || ''
-    selectedSuiteId.value = suiteId
+    // The default destination must be one of THIS scope's shelves. This used to
+    // take the first key of the org-wide name map, so "Add new test" on an agent
+    // silently preselected whichever suite happened to sort first in the org —
+    // usually another agent's. Empty is the honest answer when it has none; the
+    // editor's picker then requires a choice (or "Create New Suite…").
+    selectedSuiteId.value = [...ownSuiteIds.value][0] || ''
     selectedCaseId.value = ''
     showAddCase.value = true
 }
@@ -529,11 +536,17 @@ function onCaseUpdated(c: any) {
     selectedCaseId.value = ''
 }
 
+// Deliberately org-wide: this is the id→name map for the Suite column, and a
+// case shown here can legitimately live on an org-wide shelf. It is NOT a list
+// of places to file into — see addNewTest.
 async function loadSuites() {
     try {
         const res = await useMyFetch<any[]>('/api/tests/suites?limit=100')
         const list = (res.data.value || []) as any[]
         suitesById.value = Object.fromEntries(list.map((s: any) => [s.id, s.name]))
+        ownSuiteIds.value = new Set(list
+            .filter((s: any) => isGlobal.value ? !s.data_source_id : String(s.data_source_id || '') === agentId.value)
+            .map((s: any) => String(s.id)))
     } catch {}
 }
 

--- a/frontend/components/monitoring/TestCaseEditor.vue
+++ b/frontend/components/monitoring/TestCaseEditor.vue
@@ -25,7 +25,10 @@
                             @change="onSuiteMenuChanged"
                         >
                             <template #option="{ option }">
-                                <div class="text-xs truncate">{{ option.label }}</div>
+                                <div class="flex items-center gap-1.5 min-w-0 w-full">
+                                    <span class="text-xs truncate">{{ option.label }}</span>
+                                    <span v-if="option.hint" class="ms-auto shrink-0 text-[10px] px-1 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400">{{ option.hint }}</span>
+                                </div>
                             </template>
                         </USelectMenu>
                     </div>
@@ -355,11 +358,20 @@ const buildsLoading = ref(false)
 const router = useRouter()
 // Suites
 const suitesLoading = ref(false)
-const suites = ref<Array<{ id: string, name: string }>>([])
+const suites = ref<Array<{ id: string, name: string, scope?: 'agent' | 'global' | 'other' }>>([])
 const selectedSuiteIdLocal = ref<string>(props.suiteId || '')
 const suiteOptions = computed(() => {
-  const base = (suites.value || []).map(s => ({ label: s.name, value: s.id }))
-  return [...base, { label: 'Create New Suite…', value: '__create__' }]
+  const base = (suites.value || []).map(s => ({
+    label: s.name,
+    value: s.id,
+    // Only meaningful next to an agent's own shelves; with no agent every
+    // suite here is org-wide and the tag would be on every row. 'other' is the
+    // one case worth flagging regardless — a shelf belonging to a different
+    // agent, which only appears when an existing case is already filed there.
+    hint: s.scope === 'other' ? 'Another agent'
+      : (props.agentId && s.scope === 'global') ? 'Org-wide' : '',
+  }))
+  return [...base, { label: 'Create New Suite…', value: '__create__', hint: '' }]
 })
 const showCreateSuiteModal = ref(false)
 // Build selection for test runs
@@ -577,11 +589,30 @@ watch([() => props.caseId, isOpen], async ([cid, open]) => {
   }
 })
 
+// This asked for every suite in the ORGANIZATION, so authoring a case for one
+// agent offered the shelves of all the others — while the tree beside it, asking
+// the same endpoint with a scope, said "No suites yet" for the same agent. Two
+// answers to one question on one screen, and picking a foreign entry silently
+// filed the case onto another agent's shelf (create_case gates on the case's
+// agents, never on the destination suite).
+//
+// Org-wide suites stay offered: their cases run against every agent, so they are
+// a real destination, not clutter. They are just labelled as such — which also
+// disambiguates two suites that happen to share a name.
 async function loadSuites() {
   suitesLoading.value = true
   try {
-    const res: any = await useMyFetch('/api/tests/suites?limit=100')
-    suites.value = (res?.data?.value || []) as Array<{ id: string, name: string }>
+    const scoped = props.agentId
+      ? `data_source_id=${encodeURIComponent(props.agentId)}`
+      : 'scope=global'
+    const reqs = [useMyFetch(`/api/tests/suites?limit=100&${scoped}`)]
+    // An agent's own shelves come first, then the org-wide ones. With no agent
+    // the first request already IS the org-wide list — don't ask twice.
+    if (props.agentId) reqs.push(useMyFetch('/api/tests/suites?limit=100&scope=global'))
+    const [own, global] = await Promise.all(reqs)
+    const rows = (r: any) => ((r?.data?.value || []) as Array<{ id: string, name: string }>)
+    suites.value = rows(own).map(s => ({ ...s, scope: 'agent' as const }))
+      .concat(rows(global).map(s => ({ ...s, scope: 'global' as const })))
   } catch (e) {
     suites.value = []
   } finally {
@@ -599,6 +630,23 @@ async function loadBuilds() {
   } finally {
     buildsLoading.value = false
   }
+}
+
+// Editing a case whose suite is outside this editor's scope — one filed onto
+// another agent's shelf back when the picker offered every suite in the org.
+// Narrowing the list would otherwise blank the Suite box for it and hide where
+// the case actually lives, so the row is added back, named and tagged.
+async function ensureSuiteListed(suiteId: string) {
+  if (!suiteId || (suites.value || []).some(s => s.id === suiteId)) return
+  try {
+    const res: any = await useMyFetch(`/api/tests/suites/${suiteId}`)
+    const s = res?.data?.value
+    if (!s?.id) return
+    const scope = s.data_source_id
+      ? (String(s.data_source_id) === String(props.agentId) ? 'agent' : 'other')
+      : 'global'
+    suites.value = [...suites.value, { id: s.id, name: s.name, scope: scope as any }]
+  } catch { /* leave it unlisted rather than block the edit */ }
 }
 
 async function ensureSuiteId(): Promise<string> {
@@ -619,7 +667,11 @@ function onSuiteMenuChanged() {
 function onSuiteCreatedFromModal(suite: { id: string; name: string }) {
   // Update list and select the newly created suite
   const exists = (suites.value || []).some(s => s.id === suite.id)
-  if (!exists) suites.value = [...suites.value, { id: suite.id, name: suite.name }]
+  // CreateSuiteModal is handed this editor's agent, so a suite made here is
+  // homed on it (org-wide only when there is no agent) — tag it to match, or the
+  // row it inserts would read "Org-wide" against an agent's own new shelf.
+  const scope = props.agentId ? 'agent' as const : 'global' as const
+  if (!exists) suites.value = [...suites.value, { id: suite.id, name: suite.name, scope }]
   selectedSuiteIdLocal.value = suite.id
 }
 
@@ -1012,6 +1064,7 @@ async function loadCaseForEdit(caseId: string) {
     if (!c) return
     // Suite
     selectedSuiteIdLocal.value = c.suite_id || selectedSuiteIdLocal.value
+    await ensureSuiteListed(selectedSuiteIdLocal.value)
     // Prompt
     promptText.value = (c.prompt_json?.content || '').trim()
     testSelectedModelId.value = c.prompt_json?.model_id || ''


### PR DESCRIPTION
Authoring a test case for one agent listed **the shelves of every agent in the organization**.

`TestCaseEditor.loadSuites()` fetched `/tests/suites` with no scope, while the tree beside it asked the same endpoint with `data_source_id` and answered "No suites yet" for that same agent. Two answers to one question, on one screen — the agent had no suites, and the picker offered five.

## Why it was more than clutter

Picking a foreign entry **filed the case onto another agent's shelf**, and nothing stopped it:

- `create_case` gates on the agents the *case* targets, never on the destination suite.
- `_require_suite_authority` guards only rename/delete.

That produces the exact state the explorer tree already has to tolerate — a case sitting in one agent's suite while targeting another — and it cuts both ways: the case lands somewhere its owner can't run it, and the *suite's* owner then can't run their own suite either, since `run_suite` requires authority over every case in it.

## What changed

**The picker asks with the editor's own scope** — `data_source_id=<agent>` when it has one, `scope=global` when it doesn't — plus a second request for the org-wide shelves.

Org-wide suites stay in the list. Their cases run against every agent, so they're a real destination rather than clutter; they just carry an `Org-wide` tag. That tag also disambiguates two suites that share a name, as two called `test` did in the report. For an agent with no suites of its own the dropdown now matches the tree: the org-wide ones and *Create New Suite…*, which already passes the agent through, so a suite made there is homed correctly.

**A regression narrowing would have caused, handled.** Editing a case already filed outside the scope (from before this fix) would have blanked the Suite box and hidden where the case actually lives. `ensureSuiteListed()` fetches that suite back and tags it `Another agent`.

**`AgentEvalsPanel.addNewTest()` had the same bug one step earlier.** Its default destination was `Object.keys(suitesById)[0]` — the first key of the org-wide name map, i.e. whichever suite sorted first in the organization, usually another agent's. It now defaults to one of the current scope's own shelves, or to nothing, which makes the picker require a choice. The panel's org-wide fetch stays: it's the id→name map for the Suite column, and a listed case may legitimately live on an org-wide shelf.

## Deliberately not included

Whether the API should **refuse** to file a case into a suite the author doesn't manage. It's tempting and the consequence above is real, but auto-drafted per-agent cases land in the org-wide `Drafts` bucket by design, so a naive "must manage the destination suite" gate would break that flow. It needs its own decision rather than a rider on a UI fix.

## Verification

`nuxt build` clean. Frontend-only change; no API or schema changes (`data_source_id` was already on `TestSuiteSchema`, and `list_suites` has taken `data_source_id`/`scope` since suites got a home agent — this is the caller that never passed them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4ortFPcBn6jpgp86yqQs5