### PR TITLE
Enforce conversation ownership and fix share notification links

### DIFF
--- a/backend/app/routes/completion.py
+++ b/backend/app/routes/completion.py
@@ -26,8 +26,16 @@ router = APIRouter(tags=["completions"])
 
 completion_service = CompletionService()
 
+# A report's conversation is owner-only. Every report-scoped route here passes
+# `model=Report, owner_only=True` so the decorator resolves the report inside the
+# caller's org and enforces ownership: reads (`view_*`) additionally admit full
+# admins and project collaborators via the decorator's read-only bypasses, while
+# writes stay strictly with the owner. Without `owner_only` the decorator skips
+# its whole object gate and any org member holding the role could read or post
+# into another user's conversation. Sharing a dashboard grants the artifact
+# surface (/r/{id}) only — never the transcript.
 @router.post("/api/reports/{report_id}/completions/estimate", response_model=CompletionContextEstimateSchema)
-@requires_permission('create_reports')
+@requires_permission('create_reports', model=Report, owner_only=True)
 async def estimate_completion_tokens(
     report_id: str,
     completion: CompletionCreate,
@@ -44,7 +52,7 @@ async def estimate_completion_tokens(
     )
 
 @router.post("/api/reports/{report_id}/context/compact")
-@requires_permission('create_reports')
+@requires_permission('create_reports', model=Report, owner_only=True)
 async def compact_report_context(
     report_id: str,
     current_user: User = Depends(current_user),
@@ -90,7 +98,7 @@ async def compact_report_context(
 
 
 @router.post("/api/reports/{report_id}/completions")
-@requires_permission('create_reports')
+@requires_permission('create_reports', model=Report, owner_only=True)
 async def create_completion(
     report_id: str,
     completion: CompletionCreate,
@@ -141,7 +149,7 @@ async def create_completion(
     )
 
 @router.get("/api/reports/{report_id}/completions/{completion_id}/stream")
-@requires_permission('view_reports', model=Report)
+@requires_permission('view_reports', model=Report, owner_only=True)
 async def watch_completion_stream(
     report_id: str,
     completion_id: str,
@@ -161,7 +169,7 @@ async def watch_completion_stream(
 
 
 @router.get("/api/reports/{report_id}/completions.legacy")
-@requires_permission('view_reports', model=Report)
+@requires_permission('view_reports', model=Report, owner_only=True)
 async def get_completions(report_id: str, current_user: User = Depends(current_user), organization: Organization = Depends(get_current_organization), db: AsyncSession = Depends(get_async_db)):
     return await completion_service.get_completions(db, report_id, organization, current_user)
 
@@ -177,7 +185,7 @@ async def get_completion_plans(completion_id: str, current_user: User = Depends(
 
 
 @router.get("/api/reports/{report_id}/completions")
-@requires_permission('view_reports', model=Report)
+@requires_permission('view_reports', model=Report, owner_only=True)
 async def get_completions_v2(
     report_id: str,
     limit: int = 10,

--- a/backend/app/services/inbox_service.py
+++ b/backend/app/services/inbox_service.py
@@ -230,6 +230,20 @@ class InboxService:
         else:
             title = f"{sender} shared a dashboard with you"
             body = f'{sender} shared the dashboard "{rtitle}" with you.'
+        # Land the recipient on the surface that was actually shared — the same
+        # URLs the share modals copy and the share emails carry:
+        #   artifact     -> /r/{id}      read-only dashboard viewer
+        #   conversation -> /c/{token}   read-only transcript
+        # Never /reports/{id}: that is the authoring workspace, which no share
+        # grants. set_visibility mints conversation_share_token whenever
+        # conversation visibility leaves 'none', so the token is present for
+        # every conversation share; the workspace stays a last-resort fallback
+        # for a caller that somehow notifies without one (still permission-gated).
+        if is_conv:
+            token = getattr(report, "conversation_share_token", None)
+            link = f"/c/{token}" if token else f"/reports/{report.id}"
+        else:
+            link = f"/r/{report.id}"
         return await self.notify_users(
             db,
             organization_id=str(report.organization_id),
@@ -239,7 +253,7 @@ class InboxService:
             title=title,
             body=body,
             actor_user_id=str(actor_user.id),
-            link=f"/reports/{report.id}",
+            link=link,
             # `i18n` lets the inbox re-render the copy in the viewer's locale;
             # the English title/body above stay as the fallback.
             subject={"kind": "report", "report_id": str(report.id), "share_type": share_type,

--- a/backend/tests/e2e/test_conversation_access.py
+++ b/backend/tests/e2e/test_conversation_access.py
@@ -1,0 +1,186 @@
+"""E2E tests for conversation (transcript) access control and share links.
+
+A report's conversation is owner-only. Sharing the *dashboard* grants the
+artifact surface (/r/{id}) and nothing else — in particular it must not open
+the authoring workspace's transcript, which is what the share notification
+used to link to.
+
+Covers:
+- GET /api/reports/{id}/completions: owner yes, full admin yes (read-only
+  bypass), plain org member no, dashboard-share recipient no.
+- POST /api/reports/{id}/completions: owner-only, admins included.
+- Share notification links: /r/{id} for a dashboard share, /c/{token} for a
+  conversation share — never /reports/{id}.
+"""
+import pytest
+import uuid
+
+
+def _headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _setup_admin_and_member(create_user, login_user, whoami, test_client):
+    """Org creator (full admin) + an invited plain member."""
+    email1 = f"conv_admin_{uuid.uuid4().hex[:6]}@test.com"
+    create_user(email=email1, password="test123")
+    admin_token = login_user(email=email1, password="test123")
+    org_id = whoami(admin_token)["organizations"][0]["id"]
+
+    email2 = f"conv_member_{uuid.uuid4().hex[:6]}@test.com"
+    test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": email2, "role": "member"},
+        headers=_headers(admin_token, org_id),
+    )
+    create_user(email=email2, password="test123")
+    member_token = login_user(email=email2, password="test123")
+    member_id = whoami(member_token)["id"]
+    return admin_token, member_token, org_id, member_id
+
+
+@pytest.mark.e2e
+def test_plain_member_cannot_read_another_users_conversation(
+    test_client, create_report, create_user, login_user, whoami,
+):
+    """A member with view_reports may not read a conversation they don't own."""
+    admin_token, member_token, org_id, _ = _setup_admin_and_member(
+        create_user, login_user, whoami, test_client)
+
+    report = create_report(title="Admin's Private Analysis", user_token=admin_token,
+                           org_id=org_id, data_sources=[])
+
+    resp = test_client.get(f"/api/reports/{report['id']}/completions",
+                           headers=_headers(member_token, org_id))
+    assert resp.status_code == 403, resp.json()
+
+    # Same gate on the legacy list and the re-attachable SSE watch stream.
+    resp = test_client.get(f"/api/reports/{report['id']}/completions.legacy",
+                           headers=_headers(member_token, org_id))
+    assert resp.status_code == 403
+
+    resp = test_client.get(
+        f"/api/reports/{report['id']}/completions/{uuid.uuid4().hex}/stream",
+        headers=_headers(member_token, org_id))
+    assert resp.status_code == 403
+
+    # The owner still reads their own conversation.
+    resp = test_client.get(f"/api/reports/{report['id']}/completions",
+                           headers=_headers(admin_token, org_id))
+    assert resp.status_code == 200, resp.json()
+
+
+@pytest.mark.e2e
+def test_full_admin_can_read_any_conversation(
+    test_client, create_report, create_user, login_user, whoami,
+):
+    """Full admins keep the read-only ownership bypass (view_* permissions)."""
+    admin_token, member_token, org_id, _ = _setup_admin_and_member(
+        create_user, login_user, whoami, test_client)
+
+    report = create_report(title="Member's Analysis", user_token=member_token,
+                           org_id=org_id, data_sources=[])
+
+    resp = test_client.get(f"/api/reports/{report['id']}/completions",
+                           headers=_headers(admin_token, org_id))
+    assert resp.status_code == 200, resp.json()
+
+
+@pytest.mark.e2e
+def test_plain_member_cannot_post_into_another_users_conversation(
+    test_client, create_report, create_user, login_user, whoami,
+):
+    """Writing a turn is owner-only — admins included (create_reports is not a
+    view_* permission, so the admin bypass does not apply)."""
+    admin_token, member_token, org_id, _ = _setup_admin_and_member(
+        create_user, login_user, whoami, test_client)
+
+    report = create_report(title="Admin's Private Analysis", user_token=admin_token,
+                           org_id=org_id, data_sources=[])
+
+    resp = test_client.post(
+        f"/api/reports/{report['id']}/completions",
+        json={"prompt": {"content": "inject a turn"}},
+        headers=_headers(member_token, org_id),
+    )
+    assert resp.status_code == 403, resp.json()
+
+    resp = test_client.post(
+        f"/api/reports/{report['id']}/completions/estimate",
+        json={"prompt": {"content": "how big is this context"}},
+        headers=_headers(member_token, org_id),
+    )
+    assert resp.status_code == 403
+
+    resp = test_client.post(f"/api/reports/{report['id']}/context/compact",
+                            headers=_headers(member_token, org_id))
+    assert resp.status_code == 403
+
+    # The owner's own composer is untouched (no LLM configured in this env, so
+    # anything but an ownership rejection is fine).
+    resp = test_client.post(
+        f"/api/reports/{report['id']}/completions",
+        json={"prompt": {"content": "owner turn"}},
+        headers=_headers(admin_token, org_id),
+    )
+    assert resp.status_code != 403
+
+
+@pytest.mark.e2e
+def test_dashboard_share_does_not_grant_the_conversation(
+    test_client, create_report, set_visibility, create_user, login_user, whoami,
+):
+    """A shared dashboard grants /r/{id} only: the recipient reaches the report
+    record but never its transcript."""
+    admin_token, member_token, org_id, member_id = _setup_admin_and_member(
+        create_user, login_user, whoami, test_client)
+
+    report = create_report(title="Service Events by Depot", user_token=admin_token,
+                           org_id=org_id, data_sources=[])
+    set_visibility(report["id"], "artifact", "shared", user_token=admin_token,
+                   org_id=org_id, shared_user_ids=[member_id])
+
+    # The share grants the dashboard surface.
+    resp = test_client.get(f"/api/r/{report['id']}", headers=_headers(member_token, org_id))
+    assert resp.status_code == 200, resp.json()
+
+    # ...and not the conversation.
+    resp = test_client.get(f"/api/reports/{report['id']}/completions",
+                           headers=_headers(member_token, org_id))
+    assert resp.status_code == 403, resp.json()
+
+
+@pytest.mark.e2e
+def test_share_notification_links_to_the_shared_surface(
+    test_client, create_report, set_visibility, create_user, login_user, whoami,
+):
+    """The in-app share notification points at the surface that was shared:
+    /r/{id} for a dashboard, /c/{token} for a conversation."""
+    admin_token, member_token, org_id, member_id = _setup_admin_and_member(
+        create_user, login_user, whoami, test_client)
+
+    report = create_report(title="Service Events by Depot", user_token=admin_token,
+                           org_id=org_id, data_sources=[])
+    set_visibility(report["id"], "artifact", "shared", user_token=admin_token,
+                   org_id=org_id, shared_user_ids=[member_id])
+
+    resp = test_client.get("/api/notifications?source=share",
+                           headers=_headers(member_token, org_id))
+    assert resp.status_code == 200, resp.json()
+    items = resp.json()["items"]
+    artifact_notes = [n for n in items if n["type"] == "share_artifact"]
+    assert len(artifact_notes) == 1, items
+    assert artifact_notes[0]["link"] == f"/r/{report['id']}"
+
+    # Conversation share: the read-only transcript link, keyed by the token
+    # set_visibility mints when conversation visibility leaves 'none'.
+    vis = set_visibility(report["id"], "conversation", "shared", user_token=admin_token,
+                         org_id=org_id, shared_user_ids=[member_id]).json()
+    token = vis["conversation_share_token"]
+    assert token
+
+    resp = test_client.get("/api/notifications?source=share",
+                           headers=_headers(member_token, org_id))
+    conv_notes = [n for n in resp.json()["items"] if n["type"] == "share_conversation"]
+    assert len(conv_notes) == 1, resp.json()["items"]
+    assert conv_notes[0]["link"] == f"/c/{token}"

--- a/docs/design/user-inbox-notifications.md
+++ b/docs/design/user-inbox-notifications.md
@@ -252,8 +252,8 @@ call-to-action** (the row is the link). Counts render as a badge from
 
 | type | severity | title | body | link |
 |---|---|---|---|---|
-| `share_conversation` | info | `{actor} shared a conversation with you` | `{actor} shared "{report}" with you.` | `/reports/{id}` |
-| `share_artifact` | info | `{actor} shared a dashboard with you` | `{actor} shared the dashboard "{report}" with you.` | `/reports/{id}` |
+| `share_conversation` | info | `{actor} shared a conversation with you` | `{actor} shared "{report}" with you.` | `/c/{conversation_share_token}` |
+| `share_artifact` | info | `{actor} shared a dashboard with you` | `{actor} shared the dashboard "{report}" with you.` | `/r/{id}` |
 | `agent_access` | info | `You were added to {agent}` | `{actor} added you to {agent}. You can now chat with this agent and explore its data.` | `/agents/{agent}` |
 
 **Scheduled runs** — `source="schedule"`, link `/reports/{id}`:

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1,7 +1,9 @@
 <template>
 
-	<!-- Loading until report and completions are fetched -->
-	<div v-if="(!reportLoaded || !completionsLoaded) && messages.length === 0 && !reportNotFound" class="h-dvh w-full flex items-center justify-center text-gray-500">
+	<!-- Loading until report and completions are fetched. `redirectingToViewer`
+	     holds this state through the hand-off to /r/{id} for a viewer who only
+	     has the dashboard, so the workspace never paints behind the redirect. -->
+	<div v-if="(!reportLoaded || !completionsLoaded || redirectingToViewer) && messages.length === 0 && !reportNotFound" class="h-dvh w-full flex items-center justify-center text-gray-500">
 		<Spinner class="w-5 h-5 me-2" />
 		<span class="text-sm">{{ $t('reportView.loadingReport') }}</span>
 	</div>
@@ -1529,6 +1531,9 @@ const reportLoaded = ref(false)
 const reportNotFound = ref(false)
 const completionsLoaded = ref(false)
 const report = ref<any | null>(null)
+// True once the conversation came back 403 and we are handing off to /r/{id}
+// (a viewer who was shared the dashboard, not the transcript).
+const redirectingToViewer = ref(false)
 
 // Read-only mode: project collaborators can open member reports but only the
 // owner gets the composer; everyone else sees the fork bar.
@@ -3691,6 +3696,10 @@ async function loadCompletions({ skipEstimate = false } = {}) {
 			// link pointed at /r/{id}, and bookmarks.
 			const status = (error?.value as any)?.statusCode || (error?.value as any)?.status
 			if (status === 403) {
+				// The backend stays the authority on who may read a transcript
+				// (owner, full admin, project collaborator) — the page doesn't
+				// re-derive that rule, it just honours the refusal.
+				redirectingToViewer.value = true
 				navigateTo(`/r/${report_id}`, { replace: true })
 				return
 			}

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -3684,6 +3684,16 @@ async function loadCompletions({ skipEstimate = false } = {}) {
 			// A transient failure must not fall through as an empty response — that
 			// would wipe the rendered transcript (and reset the pagination cursor).
 			console.error('Error loading completions:', error?.value)
+			// The conversation is owner-only. A viewer who only has the dashboard
+			// (a shared artifact) can open this page but not its transcript — send
+			// them to the surface they do have instead of retrying into an empty
+			// workspace. Covers stale links: share notifications sent before the
+			// link pointed at /r/{id}, and bookmarks.
+			const status = (error?.value as any)?.statusCode || (error?.value as any)?.status
+			if (status === 403) {
+				navigateTo(`/r/${report_id}`, { replace: true })
+				return
+			}
 			if (messages.value.length === 0 && initialLoadRetries < 3) {
 				initialLoadRetries++
 				window.setTimeout(() => loadCompletions({ skipEstimate: true }), 1000 * initialLoadRetries)


### PR DESCRIPTION
## Summary
This PR enforces strict ownership controls on report conversations and corrects share notification links to point to the appropriate surfaces rather than the authoring workspace.

## Key Changes

**Conversation Access Control:**
- Added `owner_only=True` parameter to all conversation-related endpoints in `completion.py`:
  - POST `/api/reports/{id}/completions` (create turn)
  - POST `/api/reports/{id}/completions/estimate` (token estimation)
  - POST `/api/reports/{id}/context/compact` (context compaction)
  - GET `/api/reports/{id}/completions` (list turns)
  - GET `/api/reports/{id}/completions.legacy` (legacy list)
  - GET `/api/reports/{id}/completions/{id}/stream` (SSE watch stream)
- This ensures conversations remain strictly owner-only, with full admins able to read (via `view_*` bypass) but not write
- Plain org members and dashboard-share recipients are now blocked from accessing conversations

**Share Notification Links:**
- Updated `inbox_service.py` to generate correct links based on share type:
  - Dashboard shares (`artifact`) → `/r/{id}` (read-only dashboard viewer)
  - Conversation shares (`conversation`) → `/c/{token}` (read-only transcript via share token)
  - Never `/reports/{id}` (the authoring workspace)
- Share tokens are minted by `set_visibility` when conversation visibility leaves 'none'

**Frontend Graceful Degradation:**
- Updated `reports/[id]/index.vue` to detect 403 responses when loading conversations
- Redirects users without conversation access to `/r/{id}` (the dashboard surface they may have)
- Handles stale bookmarks and pre-fix share notification links

**Documentation:**
- Updated `user-inbox-notifications.md` to reflect correct notification link destinations

## Implementation Details

The `owner_only=True` parameter leverages the existing `requires_permission` decorator's object-gating mechanism to:
1. Resolve the report within the caller's organization
2. Enforce ownership for write operations (POST endpoints)
3. Admit full admins and project collaborators for read operations via the decorator's read-only bypasses
4. Block all other org members and external users

This maintains the principle that sharing a dashboard grants only the artifact surface (`/r/{id}`), never the transcript, while preserving admin oversight capabilities.

https://claude.ai/code/session_018RUxucevwkkaCreiiQ4cDX