### PR TITLE
Keep Power BI column metadata through an incremental reload

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -1630,13 +1630,40 @@ UNION(
             full_name = f"{ds_name}/{_clean_table_display_name(tbl_name)}"
 
             def _cols(items):
+                """Rebuild columns from the persisted definition.
+
+                `description` and `metadata` are carried through, not just
+                name/dtype. The metadata is what marks a column as a measure
+                (with its return type) or as a hidden join key, and the schema
+                renderer reads exactly those keys — so reducing a column to
+                {name, dtype} here silently downgrades every model on an
+                incremental reload: measures reach the agent as untyped columns
+                it can no longer tell to invoke by name, and hidden keys look
+                like ordinary report fields. `normalize_indexed_columns` stores
+                both for precisely this reason; dropping them on the way back
+                out undoes that.
+                """
                 cols = []
                 for c in items or []:
-                    name = c.get("name") if isinstance(c, dict) else getattr(c, "name", None)
+                    is_dict = isinstance(c, dict)
+                    name = c.get("name") if is_dict else getattr(c, "name", None)
                     if not name:
                         continue
-                    dtype = c.get("dtype") if isinstance(c, dict) else getattr(c, "dtype", None)
-                    cols.append(TableColumn(name=name, dtype=dtype or "unknown"))
+                    dtype = c.get("dtype") if is_dict else getattr(c, "dtype", None)
+                    description = (c.get("description") if is_dict
+                                   else getattr(c, "description", None))
+                    meta = c.get("metadata") if is_dict else getattr(c, "metadata", None)
+                    # Only a real dict: on a SQLAlchemy ORM instance `.metadata`
+                    # is the declarative MetaData registry, which would fail
+                    # TableColumn validation and abort the whole rebuild.
+                    if not isinstance(meta, dict) or not meta:
+                        meta = None
+                    cols.append(TableColumn(
+                        name=name,
+                        dtype=dtype or "unknown",
+                        description=description or None,
+                        metadata=meta,
+                    ))
                 return cols
 
             fks: List[ForeignKey] = []

--- a/backend/tests/unit/test_powerbi_relationships.py
+++ b/backend/tests/unit/test_powerbi_relationships.py
@@ -391,3 +391,123 @@ class TestNonAdminPathEndToEnd:
         # it must not disable the feature for other models either.
         assert c._execute_dax_internal.call_count == 1
         assert c._info_functions_supported is None
+
+
+class TestIncrementalReloadPreservesColumnMetadata:
+    """An incremental reload must not downgrade what a full index captured.
+
+    `refresh_data_source_schema` runs the interactive Reload with
+    introspection="incremental", which rebuilds every already-known dataset from
+    the stored catalog via `_tables_from_prior` instead of re-introspecting it.
+    That rebuild used to reduce each column to {name, dtype}, discarding the
+    `metadata` that `normalize_indexed_columns` had deliberately persisted — so
+    one click of Reload stripped `role=measure`/`returns` off every measure and
+    `hidden` off every join key, and the stripped form was written straight back
+    to the catalog. Verified live against a tenant: 118 column-metadata entries
+    (9 measures, 20 hidden keys) went to 0, while `fks` survived intact.
+
+    That matters because the connector's own system prompt tells the agent to
+    invoke a measure by name rather than re-deriving it with SUM — a hand-rolled
+    equivalent does not reproduce the measure's filter context and disagrees
+    with the customer's own reports. An untyped column carries no such signal.
+    """
+
+    # One measure and one hidden join key — exactly what the reload dropped.
+    PRIOR = {
+        "FleetOps/fact_service_event": {
+            "columns": [
+                {"name": "svc_vehicle_key", "dtype": "Integer",
+                 "metadata": {"role": "column", "hidden": True}},
+                {"name": "parts_cost", "dtype": "Number",
+                 "metadata": {"role": "column"}},
+                {"name": "Total Parts Cost", "dtype": "measure",
+                 "description": "SUM(fact_service_event[parts_cost])",
+                 "metadata": {"role": "measure", "returns": "Number",
+                              "expression": "SUM(fact_service_event[parts_cost])"}},
+            ],
+            "pks": [],
+            "fks": [{
+                "column": {"name": "svc_vehicle_key", "dtype": "unknown"},
+                "references_name": "FleetOps/dim_vehicle",
+                "references_column": {"name": "vehicle_key", "dtype": "unknown"},
+            }],
+            "metadata_json": {"powerbi": {
+                "datasetId": "ds1", "tableName": "fact_service_event",
+            }},
+        },
+    }
+
+    def _rebuild(self):
+        c = _mk_client()
+        prior_entries = list(self.PRIOR.items())
+        tables = c._tables_from_prior(
+            prior_entries, {"id": "ds1", "name": "FleetOps"}, "ws1", "BOW", [],
+        )
+        assert len(tables) == 1
+        return {col.name: col for col in tables[0].columns}
+
+    def test_measure_keeps_role_and_return_type(self):
+        cols = self._rebuild()
+        measure = cols["Total Parts Cost"]
+        assert measure.dtype == "measure"
+        assert measure.metadata == {
+            "role": "measure", "returns": "Number",
+            "expression": "SUM(fact_service_event[parts_cost])",
+        }
+        assert measure.description == "SUM(fact_service_event[parts_cost])"
+
+    def test_hidden_join_key_stays_flagged_hidden(self):
+        cols = self._rebuild()
+        assert cols["svc_vehicle_key"].metadata == {"role": "column", "hidden": True}
+
+    def test_plain_column_keeps_its_role(self):
+        cols = self._rebuild()
+        assert cols["parts_cost"].metadata == {"role": "column"}
+
+    def test_relationships_still_survive_the_rebuild(self):
+        """FKs were never the casualty here — pin that the fix did not disturb
+        the one thing the reload already got right."""
+        c = _mk_client()
+        tables = c._tables_from_prior(
+            list(self.PRIOR.items()), {"id": "ds1", "name": "FleetOps"}, "ws1", "BOW", [],
+        )
+        fks = tables[0].fks
+        assert len(fks) == 1
+        assert fks[0].column.name == "svc_vehicle_key"
+        assert fks[0].references_name == "FleetOps/dim_vehicle"
+
+    def test_column_without_metadata_stays_clean(self):
+        """A source supplying no metadata must not gain an empty dict — the
+        renderer branches on presence, and {} would read as 'has metadata'."""
+        c = _mk_client()
+        prior = {"FleetOps/t": {
+            "columns": [{"name": "plain", "dtype": "Text"}],
+            "pks": [], "fks": [],
+            "metadata_json": {"powerbi": {"datasetId": "ds1", "tableName": "t"}},
+        }}
+        tables = c._tables_from_prior(
+            list(prior.items()), {"id": "ds1", "name": "FleetOps"}, "ws1", "BOW", [],
+        )
+        col = tables[0].columns[0]
+        assert col.metadata is None
+        assert col.description is None
+
+    def test_orm_style_metadata_attribute_is_ignored(self):
+        """On a SQLAlchemy instance `.metadata` is the declarative MetaData
+        registry, not column metadata. Passing it through would fail
+        TableColumn validation and abort the entire rebuild."""
+        class _Ormish:
+            name = "c1"
+            dtype = "Text"
+            description = None
+            metadata = object()  # not a dict — the MetaData registry stand-in
+
+        c = _mk_client()
+        prior = {"FleetOps/t": {
+            "columns": [_Ormish()], "pks": [], "fks": [],
+            "metadata_json": {"powerbi": {"datasetId": "ds1", "tableName": "t"}},
+        }}
+        tables = c._tables_from_prior(
+            list(prior.items()), {"id": "ds1", "name": "FleetOps"}, "ws1", "BOW", [],
+        )
+        assert tables[0].columns[0].metadata is None

--- a/docs/feedback-loops/powerbi-missing-relationships.md
+++ b/docs/feedback-loops/powerbi-missing-relationships.md
@@ -114,3 +114,13 @@ dataset `RelHiddenProbe` was created by this loop and can be deleted.
 - Incremental discovery reuses `fks` from the prior catalog, so models indexed
   before this change keep their empty relationships until a reindex that does
   not pass `prior_tables`.
+- That same reuse path (`_tables_from_prior`) rebuilt columns as `{name, dtype}`
+  only, discarding the `metadata` that `normalize_indexed_columns` persists — so
+  the interactive Reload (`introspection="incremental"`) stripped `role=measure`
+  and `returns` off every measure, and `hidden` off every join key, then wrote
+  the stripped form back to the catalog. `fks` were never affected. Measured
+  live against the fixture models: 118 column-metadata entries (9 measures, 20
+  hidden keys) → 0 after one Reload; 118 → 118 after the fix. Pinned by
+  `TestIncrementalReloadPreservesColumnMetadata`. The relationship work above is
+  what made this visible — hidden keys only matter once relationships reference
+  them.


### PR DESCRIPTION
## What

`_tables_from_prior` rebuilds an already-known dataset from the stored catalog instead of re-introspecting it — which is what the interactive **Reload** does (`refresh_data_source_schema` passes `introspection="incremental"`). That rebuild reduced every column to `{name, dtype}`, discarding the `description` and `metadata` that `normalize_indexed_columns` deliberately persists.

So one click of Reload stripped `role=measure` and `returns` off every measure and `hidden` off every join key, then wrote the stripped form straight back to the catalog.

Relationships were never affected — `fks` are reconstructed properly a few lines below and survive intact. This turned up while answering a separate question about whether Power BI relationships are loaded by default (they are).

## Why it matters

The connector's own system prompt tells the agent to invoke a measure by name rather than re-derive it with `SUM`, precisely because a hand-rolled equivalent does not reproduce the measure's filter context and will disagree with the customer's own Power BI reports. After a Reload the agent can no longer tell which columns are measures, so it loses that signal. Hidden join keys likewise reach it looking like ordinary report fields — the exact condition the earlier relationship work fixed.

A scheduled full reindex restores everything, so the damage window is "until the next full reindex" — but Reload is user-triggerable and the degraded form is persisted.

## Verification

Measured live against a tenant, running the real round trip (full index → persist → incremental reload → persist) against fixture models built by `tools/agent/pbi_build_fixture_models.py`:

| | full index | after Reload (before fix) | after Reload (with fix) |
|---|---|---|---|
| columns with metadata | 118 | **0** | 118 |
| `role=measure` | 9 | **0** | 9 |
| `hidden=true` | 20 | **0** | 20 |
| foreign keys | 14 | 14 | 14 |

Rendered through the real schema renderer, `FleetOps/fact_service_event` degraded from

```xml
<column name="svc_vehicle_key" dtype="Integer" role="column" hidden="true"/>
<column name="Total Parts Cost" dtype="measure" role="measure" returns="Number"/>
```

to

```xml
<column name="svc_vehicle_key" dtype="Integer"/>
<column name="Total Parts Cost" dtype="measure"/>
```

With the fix the rendered prompt XML is byte-identical across a reload.

## Changes

- `backend/app/data_sources/clients/powerbi_client.py` — `_cols()` carries `description` and `metadata` through. Guarded against the SQLAlchemy `.metadata` trap: on an ORM instance that attribute is the declarative `MetaData` registry, which would fail `TableColumn` validation and abort the entire rebuild. A column with no metadata stays `None` rather than gaining an empty dict, since the renderer branches on presence.
- `backend/tests/unit/test_powerbi_relationships.py` — `TestIncrementalReloadPreservesColumnMetadata`, 6 tests. Checked they are not vacuous: 3 fail without the fix, 3 are regression guards that pass both ways (fks survive, no-metadata stays clean, ORM `.metadata` ignored).
- `docs/feedback-loops/powerbi-missing-relationships.md` — note in the regression section, which already documented this reuse path.

## Testing

- `TestIncrementalReloadPreservesColumnMetadata` — 6 new, all pass; 3 confirmed failing without the fix
- Full run across `powerbi` / `schema_context` / `schema_prompt` / `refresh_overlay` — **181 passed**
- Live re-verification against the tenant, before and after

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTmgLNf3HJpwXf7sUQDM2u)_