### PR TITLE
Restrict Admin sidebar entry to users with actual admin permissions

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -682,6 +682,24 @@
     settingsTabPermissions.find(tab => useCan(tab.permission)) || null
   )
 
+  // Admin-level permissions that justify surfacing the Admin entry at all.
+  // `view_members` is deliberately absent: it is baseline for every org member
+  // (see BASELINE_PERMISSIONS in app/core/permissions_registry.py), so keying
+  // visibility off the reachable-tab list alone put an Admin button in every
+  // ordinary member's sidebar, linking to a read-only user list. A non-admin
+  // gets no Admin entry.
+  const adminAreaPermissions = [
+    'manage_members',
+    'manage_service_accounts',
+    'manage_settings',
+    'manage_llm',
+    'view_audit_logs',
+    'manage_identity_providers',
+  ]
+  const canAccessAdminArea = computed(() =>
+    adminAreaPermissions.some(permission => useCan(permission))
+  )
+
   const mainNavItems: NavItem[] = [
     { href: '/automations', icon: 'heroicons-bolt', label: 'nav.automations' },
     { href: '/dashboards', icon: 'heroicons-chart-bar-square', label: 'nav.dashboards' },
@@ -700,10 +718,11 @@
     // The Settings entry was always shown but hard-linked to /settings/members,
     // which requires `view_members`. A user on a custom role without that perm
     // would click it and get silently bounced to '/' by permissions.global.ts —
-    // i.e. "the Settings button does nothing". Only surface it when the user can
-    // actually reach a settings tab, and point it at the first one they can open.
+    // i.e. "the Settings button does nothing". Only surface it when the user
+    // holds an actual admin permission AND can reach a settings tab, and point
+    // it at the first one they can open.
     const tab = firstAccessibleSettingsTab.value
-    if (tab) {
+    if (tab && canAccessAdminArea.value) {
       items.push({ href: `/settings/${tab.name}`, activePath: '/settings', icon: 'heroicons-cog-6-tooth', label: 'nav.admin' })
     }
     return items


### PR DESCRIPTION
## Summary
This change prevents the Admin/Settings sidebar entry from appearing for users who only have the baseline `view_members` permission. Previously, any organization member could see the Admin button even if they lacked permissions to access any admin features, resulting in a non-functional UI element.

## Key Changes
- Added `adminAreaPermissions` array defining permissions that justify showing the Admin entry (manage_members, manage_service_accounts, manage_settings, manage_llm, view_audit_logs, manage_identity_providers)
- Introduced `canAccessAdminArea` computed property that checks if the user has at least one admin-level permission
- Updated the Settings/Admin navbar item visibility logic to require both:
  - Access to at least one settings tab (existing check)
  - Possession of an actual admin permission (new check)
- Updated code comments to clarify the rationale for the permission check

## Implementation Details
The `view_members` permission is intentionally excluded from the admin permissions list because it's a baseline permission granted to every organization member (as defined in `BASELINE_PERMISSIONS`). This prevents the Admin button from appearing in the sidebar for ordinary members who would only see a read-only user list with no actionable admin features.

https://claude.ai/code/session_01PXmCUb4ZcscHzUnRnuXobt