### PR TITLE
Add table_ref_ids to light instruction projection for tree grouping

### DIFF
--- a/backend/app/schemas/instruction_schema.py
+++ b/backend/app/schemas/instruction_schema.py
@@ -264,6 +264,12 @@ class InstructionListItemSchema(BaseModel):
     pending_created_by: Optional[str] = None
     pending_created_at: Optional[UTCDatetime] = None
 
+    #: Ids of the `datasource_table` objects this instruction references — the
+    #: one piece of reference data a list surface needs, because the tree files
+    #: each instruction under the tables it references. The reference rows
+    #: themselves stay off the light row; open the instruction for those.
+    table_ref_ids: List[str] = []
+
     data_sources: List[DataSourceMinimalSchema] = []
     labels: List[InstructionLabelSchema] = []
     created_at: UTCDatetime

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -4139,6 +4139,34 @@ class InstructionService:
         from app.schemas.data_source_schema import DataSourceMinimalSchema
         from app.schemas.instruction_label_schema import InstructionLabelSchema
 
+        # Table references for the light projection. The tree groups an agent's
+        # instructions under the tables they reference, so a row that carries no
+        # reference at all cannot be filed — every table node read as empty once
+        # the tree moved to this projection. Only the referenced table ids are
+        # needed for that (a handful of uuids), not the reference rows, so this
+        # stays a single flat SELECT rather than a relationship hydration.
+        table_ref_ids: Dict[str, List[str]] = {}
+        if light and instructions:
+            from app.models.instruction_reference import InstructionReference
+            ref_rows = await db.execute(
+                select(
+                    InstructionReference.instruction_id,
+                    InstructionReference.object_id,
+                )
+                .where(
+                    and_(
+                        InstructionReference.instruction_id.in_(
+                            [str(i.id) for i in instructions]
+                        ),
+                        InstructionReference.object_type == "datasource_table",
+                    )
+                )
+            )
+            for ref_instruction_id, object_id in ref_rows.all():
+                bucket = table_ref_ids.setdefault(str(ref_instruction_id), [])
+                if str(object_id) not in bucket:
+                    bucket.append(str(object_id))
+
         list_items: List = []
         for inst in instructions:
             ds_min = [DataSourceMinimalSchema.from_orm(ds) for ds in (inst.data_sources or [])]
@@ -4168,6 +4196,7 @@ class InstructionService:
                         applicable_modes=getattr(inst, "applicable_modes", None),
                         applicable_channels=getattr(inst, "applicable_channels", None),
                         current_version_id=getattr(inst, "current_version_id", None),
+                        table_ref_ids=table_ref_ids.get(str(inst.id), []),
                         data_sources=ds_min,
                         labels=[InstructionLabelSchema.from_orm(l) for l in (inst.labels or [])],
                         created_at=inst.created_at,

--- a/backend/tests/e2e/test_instruction_light_view.py
+++ b/backend/tests/e2e/test_instruction_light_view.py
@@ -118,3 +118,96 @@ def test_light_view_may_page_past_the_full_view_ceiling(test_client,
 def test_unknown_view_is_rejected(test_client, agent_with_instructions):
     ctx = agent_with_instructions(1)
     assert _get(test_client, ctx, view="tiny").status_code >= 400
+
+
+@pytest.mark.e2e
+def test_light_view_carries_the_referenced_table_ids(test_client, create_user,
+                                                     login_user, whoami):
+    """The tree files each instruction under the tables it references.
+
+    That grouping reads the list rows, so dropping references from the light
+    projection didn't just hide a badge — every table node rendered "No rules
+    attached" however many instructions were pinned to it. The light row carries
+    the referenced table ids (and only the ids) so the grouping works without
+    hydrating the reference rows.
+    """
+    import datetime
+    import os
+
+    from sqlalchemy import create_engine, text
+
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    me = whoami(token)
+    org_id = str(me["organizations"][0]["id"])
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": org_id}
+
+    ds_id = str(uuid.uuid4())
+    table_id = str(uuid.uuid4())
+    url = os.environ["TEST_DATABASE_URL"]
+    sync_url = url.replace("sqlite+aiosqlite:", "sqlite:").replace(
+        "postgresql+asyncpg:", "postgresql:")
+    engine = create_engine(sync_url)
+    now = datetime.datetime.utcnow()
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO data_sources (id,created_at,updated_at,name,is_active,"
+                    "organization_id,is_public,use_llm_sync,publish_status,reliability_status)"
+                    " VALUES (:id,:ca,:ua,:name,:active,:org,:pub,:llm,:pubst,:rel)"
+                ),
+                {"id": ds_id, "ca": now, "ua": now, "name": "Ref Agent", "active": True,
+                 "org": org_id, "pub": False, "llm": False, "pubst": "published",
+                 "rel": "unknown"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO data_source_memberships (id,created_at,updated_at,"
+                    "data_source_id,principal_type,principal_id,config)"
+                    " VALUES (:id,:ca,:ua,:ds,:pt,:pid,:cfg)"
+                ),
+                {"id": str(uuid.uuid4()), "ca": now, "ua": now, "ds": ds_id,
+                 "pt": "user", "pid": str(me["id"]), "cfg": '{"role": "owner"}'},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO datasource_tables (id,created_at,updated_at,name,"
+                    "datasource_id,is_active,columns,no_rows,pks,fks)"
+                    " VALUES (:id,:ca,:ua,:name,:ds,:active,:cols,:nr,:pks,:fks)"
+                ),
+                {"id": table_id, "ca": now, "ua": now, "name": "orders", "ds": ds_id,
+                 "active": True, "cols": "[]", "nr": 0, "pks": "[]", "fks": "[]"},
+            )
+    finally:
+        engine.dispose()
+
+    pinned = test_client.post(
+        "/api/instructions",
+        json={"text": "Pinned to orders", "status": "published", "category": "general",
+              "data_source_ids": [ds_id],
+              "references": [{"object_type": "datasource_table",
+                              "object_id": table_id, "display_text": "orders"}]},
+        headers=headers,
+    )
+    assert pinned.status_code == 200, pinned.text[:400]
+    unpinned = test_client.post(
+        "/api/instructions",
+        json={"text": "Not pinned", "status": "published", "category": "general",
+              "data_source_ids": [ds_id]},
+        headers=headers,
+    )
+    assert unpinned.status_code == 200, unpinned.text[:400]
+
+    r = test_client.get(
+        "/api/instructions",
+        params={"data_source_ids": ds_id, "include_global": "false",
+                "include_own": "true", "include_drafts": "true",
+                "view": "light", "limit": 200},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text[:400]
+    by_id = {i["id"]: i for i in r.json()["items"]}
+    assert by_id[pinned.json()["id"]]["table_ref_ids"] == [table_id]
+    # An instruction with no references reports none — not a missing key.
+    assert by_id[unpinned.json()["id"]]["table_ref_ids"] == []

--- a/frontend/components/InstructionPrivateCreateComponent.vue
+++ b/frontend/components/InstructionPrivateCreateComponent.vue
@@ -600,12 +600,24 @@ const filteredMentionableOptions = computed(() => {
     })
 })
 
-// Load mode options for dropdown
-const loadModeOptions = [
-    { value: 'always' as const, label: 'Always', description: 'Always included in AI context' },
-    { value: 'intelligent' as const, label: 'Smart', description: 'Included only when relevant to the query' },
-    { value: 'disabled' as const, label: 'Disabled', description: 'Never included in AI context' }
-]
+// Load mode options for dropdown.
+//
+// 'Disabled' is no longer offered: it looked like the harder off-switch while
+// being the weaker one (the instruction still reads as Active and is still
+// returned by the agent's search_instructions, which filters on status alone).
+// Setting the status to Inactive is the switch that takes it out of play. The
+// option stays listed while an instruction is already on it, so legacy rows
+// show their real value — and loses it once moved to Always/Smart.
+const loadModeOptions = computed(() => {
+    const options: { value: SharedForm['load_mode']; label: string; description: string }[] = [
+        { value: 'always', label: 'Always', description: 'Always included in AI context' },
+        { value: 'intelligent', label: 'Smart', description: 'Included only when relevant to the query' },
+    ]
+    if (props.sharedForm.load_mode === 'disabled') {
+        options.push({ value: 'disabled', label: 'Disabled', description: 'Never included in AI context' })
+    }
+    return options
+})
 
 const getLoadModeIcon = (mode: string) => {
     const icons: Record<string, string> = {

--- a/frontend/components/KSelect.vue
+++ b/frontend/components/KSelect.vue
@@ -1,8 +1,11 @@
 <template>
   <UPopover :popper="{ placement: 'bottom-start' }" :ui="{ ring: '', shadow: 'shadow-md' }">
     <button type="button" class="inline-flex items-center gap-1.5 h-7 px-2 rounded-md text-[11px] text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800/70 transition-colors max-w-[180px]">
-      <template v-if="selectedTypes.length">
-        <DataSourceIcon v-for="(t, i) in selectedTypes.slice(0, 3)" :key="i" :type="t" class="w-3.5 h-3.5 shrink-0" />
+      <template v-if="selectedIcons.length">
+        <template v-for="(o, i) in selectedIcons.slice(0, 3)" :key="i">
+          <DataSourceIcon v-if="o.type" :type="o.type" :connector-key="o.connectorKey" :icon="o.iconToken" class="w-3.5 h-3.5 shrink-0" />
+          <UIcon v-else-if="o.heroicon" :name="o.heroicon" class="w-3 h-3 text-gray-400 dark:text-gray-500 shrink-0" />
+        </template>
       </template>
       <UIcon v-else-if="icon" :name="icon" class="w-3 h-3 text-gray-400 dark:text-gray-500 shrink-0" />
       <span class="truncate">{{ displayLabel }}</span>
@@ -20,7 +23,8 @@
             <UIcon v-if="isSel(opt.value)" name="i-heroicons-check" class="w-2.5 h-2.5 text-white dark:text-gray-900" />
           </span>
           <UIcon v-else name="i-heroicons-check" class="w-3 h-3 shrink-0" :class="isSel(opt.value) ? 'text-gray-900 dark:text-gray-100' : 'text-transparent'" />
-          <DataSourceIcon v-if="opt.type" :type="opt.type" class="w-3.5 h-3.5 shrink-0" />
+          <DataSourceIcon v-if="opt.type" :type="opt.type" :connector-key="opt.connectorKey" :icon="opt.iconToken" class="w-3.5 h-3.5 shrink-0" />
+          <UIcon v-else-if="opt.heroicon" :name="opt.heroicon" class="w-3 h-3 shrink-0 text-gray-400 dark:text-gray-500" />
           <span class="text-gray-700 dark:text-gray-300 truncate">{{ opt.label }}</span>
         </button>
         <button
@@ -36,20 +40,37 @@
 
 <script setup lang="ts">
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
+// An option renders its leading glyph one of two ways: `type` (+ the optional
+// `connectorKey` / `iconToken` overrides, forwarded so a connector-backed agent
+// shows its brand logo and a custom agent emoji still wins) goes to
+// DataSourceIcon; `heroicon` covers options that aren't a data source at all —
+// a connection tool, say — which would otherwise render with no icon.
+interface KSelectOption {
+  value: string
+  label: string
+  type?: string
+  connectorKey?: string | null
+  iconToken?: string | null
+  heroicon?: string
+}
 const props = defineProps<{
   modelValue: any
-  options: { value: string; label: string; type?: string }[]
+  options: KSelectOption[]
   multiple?: boolean
   icon?: string
   placeholder?: string
+  // Render a multi-selection as "first +N" instead of joining every label.
+  // The button is width-capped, so a joined list of long values (table paths,
+  // say) truncates to noise past the first entry.
+  summarize?: boolean
 }>()
 const emit = defineEmits(['update:modelValue'])
 
 const selectedOptions = computed(() => {
   const vals = props.multiple ? (props.modelValue || []) : (props.modelValue != null && props.modelValue !== '' ? [props.modelValue] : [])
-  return vals.map((v: string) => props.options.find(o => o.value === v)).filter(Boolean) as { value: string; label: string; type?: string }[]
+  return vals.map((v: string) => props.options.find(o => o.value === v)).filter(Boolean) as KSelectOption[]
 })
-const selectedTypes = computed(() => selectedOptions.value.map(o => o.type).filter(Boolean) as string[])
+const selectedIcons = computed(() => selectedOptions.value.filter(o => o.type || o.heroicon))
 const isSel = (v: string) => props.multiple ? (props.modelValue || []).includes(v) : props.modelValue === v
 const pick = (v: string, close?: () => void) => {
   if (props.multiple) {
@@ -66,7 +87,9 @@ const displayLabel = computed(() => {
   if (props.multiple) {
     const a = props.modelValue || []
     if (!a.length) return props.placeholder || 'Any'
-    return a.map((v: string) => props.options.find(o => o.value === v)?.label || v).join(', ')
+    const labels = a.map((v: string) => props.options.find(o => o.value === v)?.label || v)
+    if (props.summarize && labels.length > 1) return `${labels[0]} +${labels.length - 1}`
+    return labels.join(', ')
   }
   return props.options.find(o => o.value === props.modelValue)?.label || props.placeholder || '—'
 })

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -876,11 +876,14 @@
                 <KSelect v-if="metaEditable && singleAgentId && !creating" v-model="primarySelectValue" :options="primaryOpts" icon="i-heroicons-star" />
                 <span v-else-if="!metaEditable && (detail?.primary_for || []).length" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 text-[11px] font-medium"><UIcon name="i-heroicons-star" class="w-3 h-3" />{{ $t('agentsPage.primary') }}</span>
                 <!-- References -->
-                <span v-for="(r, i) in draft.references" :key="'ref'+i" class="inline-flex items-center gap-1 ps-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px] font-mono" :class="metaEditable ? 'pe-1' : 'pe-2'">
+                <!-- Editors get the picker alone: it already renders what is
+                     attached, so the chips beside it were the same references a
+                     second time. Read-only viewers, who have no picker, keep
+                     the chips. (Same shape as Labels, just below.) -->
+                <span v-for="(r, i) in (!metaEditable ? (detail?.references || []) : [])" :key="'ref'+i" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px] font-mono">
                   <UIcon :name="h.getRefIcon(r.object_type)" class="w-3 h-3 text-gray-400 dark:text-gray-500" />{{ r.display_text || r.object_id }}
-                  <button v-if="metaEditable" type="button" class="w-3.5 h-3.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 flex items-center justify-center" @click="removeRef(i); onMetaChange()"><UIcon name="i-heroicons-x-mark" class="w-2.5 h-2.5" /></button>
                 </span>
-                <KSelect v-if="metaEditable && refOptions.length" v-model="refIds" :options="refOptions" multiple :placeholder="$t('agentsPage.addReference')" icon="i-heroicons-table-cells" @update:modelValue="onMetaChange" />
+                <KSelect v-if="metaEditable && refOptions.length" v-model="refIds" :options="refOptions" multiple summarize :placeholder="$t('agentsPage.addReference')" icon="i-heroicons-table-cells" @update:modelValue="onMetaChange" />
                 <!-- Labels -->
                 <KSelect v-if="metaEditable && labelOpts.length" v-model="draft.label_ids" :options="labelOpts" multiple :placeholder="$t('agentsPage.addLabel')" icon="i-heroicons-tag" @update:modelValue="onMetaChange" />
                 <span v-for="l in (!metaEditable ? (detail.labels || []) : [])" :key="l.id" class="inline-flex items-center px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]">{{ l.name }}</span>
@@ -1750,14 +1753,28 @@ const channelLabel = (v: string) => channelOpts.value.find(o => o.value === v)?.
 // Reference options come from the selected agents' tables and their enabled
 // connection tools (overlay-resolved by /data_sources/{id}/tools).
 const refOptions = computed(() => {
-  const opts: { value: string; label: string; type?: string; objectType: string }[] = []
+  const opts: { value: string; label: string; type?: string; connectorKey?: string | null; iconToken?: string | null; heroicon?: string; objectType: string }[] = []
   for (const aid of draft.data_source_ids) {
     const a = agents.value.find(x => x.id === aid)
-    for (const t of (agentTables.value[aid] || [])) opts.push({ value: t.id, label: t.name, type: a?.type, objectType: 'datasource_table' })
+    // connector_key + icon ride along so a connector-backed agent shows its
+    // brand logo and a custom agent emoji still wins — passing only `type` left
+    // both rendering the generic type asset.
+    for (const t of (agentTables.value[aid] || [])) opts.push({ value: t.id, label: t.name, type: a?.type, connectorKey: a?.connector_key, iconToken: a?.icon, objectType: 'datasource_table' })
     for (const tool of (agentTools.value[aid] || [])) {
       if (tool.is_enabled === false) continue
-      opts.push({ value: String(tool.id), label: tool.name, objectType: 'connection_tool' })
+      // A tool is not a data source, so it gets a heroicon rather than none.
+      opts.push({ value: String(tool.id), label: tool.name, heroicon: h.getRefIcon('connection_tool'), objectType: 'connection_tool' })
     }
+  }
+  // The picker is the only place an editor sees the attached references, so
+  // every reference must resolve to an option — otherwise one attached to an
+  // agent whose tables haven't loaded (or that has since left the instruction's
+  // scope) would render as a bare uuid, and the refIds setter would write that
+  // uuid back as its display_text.
+  for (const r of draft.references) {
+    const id = String(r.object_id)
+    if (opts.some(o => o.value === id)) continue
+    opts.push({ value: id, label: r.display_text || id, heroicon: h.getRefIcon(r.object_type), objectType: r.object_type })
   }
   return opts
 })
@@ -1781,7 +1798,6 @@ const onEditorMention = (item: any) => {
 }
 // Newly scoped agents need their tables/tools loaded for refOptions.
 watch(() => [...draft.data_source_ids], (ids) => { ids.forEach(id => loadAgentMeta(id)) })
-const removeRef = (i: number) => { draft.references.splice(i, 1) }
 
 const showHistory = ref(false)
 const versions = ref<any[]>([])
@@ -3297,7 +3313,18 @@ const listFor = (kind: string) => {
 // still showing in the report agent panel. Appearing under both its table and
 // its agent is the lesser problem: nothing an agent carries goes unlisted.
 const listForAgent = (id: string) => applyFilters(allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === id)))
-const listForTable = (agentId: string, tableId: string) => applyFilters(allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === agentId) && (i.references || []).some((r: any) => r.object_type === 'datasource_table' && String(r.object_id) === tableId)))
+// Which tables an instruction is filed under. List rows come from the light
+// projection, which carries `table_ref_ids` and no reference rows; a hydrated
+// row (the open instruction) carries the full `references` instead. Reading
+// only the latter is what left every table node in the tree empty.
+const tableRefIds = (ins: any): string[] => {
+  const light = (ins?.table_ref_ids || []) as string[]
+  if (light.length) return light.map(String)
+  return (ins?.references || [])
+    .filter((r: any) => r.object_type === 'datasource_table')
+    .map((r: any) => String(r.object_id))
+}
+const listForTable = (agentId: string, tableId: string) => applyFilters(allInstructions.value.filter(i => (i.data_sources || []).some(d => d.id === agentId) && tableRefIds(i).includes(tableId)))
 // The tree only surfaces ACTIVE (in-scope) tables — the lean working set the
 // agent actually reasons with. The full catalog (active + inactive) lives on the
 // agent's Tables page; the tree is not a schema browser.
@@ -3459,10 +3486,18 @@ const saveMeta = async () => {
     const { data, error } = await useMyFetch<Instruction>(`/api/instructions/${detail.value.id}`, { method: 'PUT', body })
     // useMyFetch doesn't throw on HTTP errors — surface them so the change isn't silently dropped.
     if (error.value) throw new Error((error.value as any)?.data?.detail || (error.value as any)?.message || 'Save failed')
-    if (data.value) detail.value = { ...detail.value, ...(data.value as any) }
+    // The PUT response is the full row — the only post-save shape that carries
+    // `text` and `references`. Re-seeding the pane from the refreshed LIST row
+    // instead (what this used to do) silently emptied both: those rows are the
+    // light projection, which drops the body and the references by design. The
+    // draft is what the next autosave sends back, so the clobber didn't just
+    // hide the reference you had just added — the following metadata change
+    // PUT it away again as `references: []` and the body as `text: ""`.
+    if (data.value) {
+      detail.value = { ...detail.value, ...(data.value as any) }
+      if (!editing.value) syncDraft(detail.value)
+    }
     await refreshLists()
-    const fresh = allInstructions.value.find(i => i.id === detail.value?.id)
-    if (fresh && !editing.value) { detail.value = fresh; syncDraft(fresh) }
     toast.add({ title: t('agentsPage.toastSaved'), color: 'green' })
   } catch (e: any) { toast.add({ title: t('agentsPage.toastSaveFailed'), description: e?.message, color: 'red' }) } finally { savingMeta.value = false }
 }

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -850,7 +850,7 @@
                 <span v-else class="inline-flex items-center px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px] font-medium">{{ h.getStatusLabel(detail) }}</span>
                 <!-- Loading (skills are always 'Smart' — locked) -->
                 <template v-if="metaEditable">
-                  <KSelect v-if="draft.kind !== 'skill'" v-model="draft.load_mode" :options="loadOpts" icon="i-heroicons-bolt" @update:modelValue="onMetaChange" />
+                  <KSelect v-if="draft.kind !== 'skill'" v-model="draft.load_mode" :options="loadEditOpts" icon="i-heroicons-bolt" @update:modelValue="onMetaChange" />
                   <span v-else class="inline-flex items-center px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-[11px] font-medium" :title="$t('agentsPage.smartTip')"><UIcon name="i-heroicons-bolt" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.smart') }}</span>
                 </template>
                 <span v-else class="inline-flex items-center px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px] font-medium"><UIcon name="i-heroicons-bolt" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500" />{{ h.getLoadModeLabel(detail.load_mode) }}</span>
@@ -1851,7 +1851,19 @@ onMounted(() => {
 
 const statusOpts = computed(() => [{ value: 'published', label: t('agentsPage.optStatusActive') }, { value: 'draft', label: t('agentsPage.optStatusInactive') }, { value: 'pending_review', label: t('agentsPage.optStatusPending') }])
 const statusEditOpts = computed(() => [{ value: 'published', label: t('agentsPage.optStatusActive') }, { value: 'draft', label: t('agentsPage.optStatusInactive') }])
+// Filter list keeps "Off" so existing disabled rows remain findable.
 const loadOpts = computed(() => [{ value: 'always', label: t('agentsPage.optLoadAlways') }, { value: 'intelligent', label: t('agentsPage.optLoadSmart') }, { value: 'disabled', label: t('agentsPage.optLoadOff') }])
+// The editor no longer OFFERS "Off": it read as the harder off-switch while
+// being the weaker one (the row still shows Active, stays in the build, and is
+// still returned by the agent's search_instructions, which filters on status
+// only). Inactive is the switch that actually takes an instruction out of play.
+// "Off" stays listed while a row is already on it, so legacy rows render their
+// real value instead of an empty select — and drop the option once moved off.
+const loadEditOpts = computed(() => {
+  const opts = [{ value: 'always', label: t('agentsPage.optLoadAlways') }, { value: 'intelligent', label: t('agentsPage.optLoadSmart') }]
+  if (draft.load_mode === 'disabled') opts.push({ value: 'disabled', label: t('agentsPage.optLoadOff') })
+  return opts
+})
 const sourceOpts = computed(() => [{ value: 'user', label: t('agentsPage.optSourceUser') }, { value: 'ai', label: t('agentsPage.optSourceAi') }, { value: 'git', label: t('agentsPage.optSourceGit') }])
 const categoryOpts = computed(() => categories.value.filter(c => c !== 'dashboard').map(c => ({ value: c, label: h.formatCategory(c) })))
 const agentOpts = computed(() => agents.value.map(a => ({ value: a.id, label: a.name, type: a.type })))

--- a/frontend/components/tools/EditInstructionTool.vue
+++ b/frontend/components/tools/EditInstructionTool.vue
@@ -35,9 +35,9 @@
             :name="isExpanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'"
             class="w-3 h-3 me-1 text-gray-400 flex-shrink-0 rtl-flip"
           />
-          <Icon name="heroicons-x-circle" class="w-3 h-3 me-1 text-orange-500 flex-shrink-0" />
+          <Icon name="heroicons-exclamation-triangle" class="w-3 h-3 me-1 text-amber-500 flex-shrink-0" />
           <span>{{ $t('tools.editInstruction.rejected') }}</span>
-          <span v-if="rejectedReason" class="ms-1.5 text-orange-600 text-[10px]">({{ rejectedReason }})</span>
+          <span v-if="rejectedReason" class="ms-1.5 text-amber-600 dark:text-amber-500 text-[10px]">({{ prettyRejectedReason }})</span>
         </span>
         <span v-else class="text-gray-600 dark:text-gray-400 flex items-center">
           <Icon
@@ -98,11 +98,14 @@
           </div>
         </div>
 
-        <!-- Instruction card for non-text changes or when no diff -->
-        <div v-else-if="!turnActive && !awaitingFinal" class="hover:bg-gray-50 dark:hover:bg-gray-800/50 border border-gray-150 dark:border-gray-800 rounded-md p-3 transition-colors">
+        <!-- Instruction card for non-text changes or when no diff. Requires the
+             text: the wrapper used to render whenever there was no diff, so a
+             card whose only child is `v-if="displayText"` drew an empty bordered
+             box whenever that text wasn't there — a rejected edit (no
+             new_text), or any card whose instruction fetch hadn't landed. -->
+        <div v-else-if="!turnActive && !awaitingFinal && displayText && !isUnsuccessful" class="hover:bg-gray-50 dark:hover:bg-gray-800/50 border border-gray-150 dark:border-gray-800 rounded-md p-3 transition-colors">
           <!-- Instruction text - click to edit -->
           <div
-            v-if="displayText"
             dir="auto"
             class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer"
             @click="handleEdit()"
@@ -180,8 +183,15 @@
           <ResolvedEvalStrip :instruction-id="instructionId" :build-id="buildId" />
         </div>
 
-        <!-- Error message -->
-        <div v-if="errorMessage" class="text-[10px] text-red-500 bg-red-50/50 rounded px-2 py-1">
+        <!-- Reason. Amber for a rejection — the edit was refused, nothing
+             broke and nothing changed; red stays for an actual tool error. -->
+        <div
+          v-if="errorMessage"
+          class="text-[11px] rounded px-2 py-1.5 leading-relaxed"
+          :class="isRejected
+            ? 'text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20'
+            : 'text-red-600 dark:text-red-300 bg-red-50/50 dark:bg-red-500/10 border border-red-100 dark:border-red-500/20'"
+        >
           {{ errorMessage }}
         </div>
       </div>
@@ -246,6 +256,9 @@ const emit = defineEmits<{
 }>()
 
 const isExpanded = ref(true)
+// Set once the reader clicks this card's header: from then on its open/closed
+// state is theirs, and nothing auto-collapses it out from under them.
+const userToggled = ref(false)
 const localGlobalStatus = ref<string | null>(null)
 const isLoadingVersions = ref(false)
 const fetchedInstruction = ref<any>(null)
@@ -407,6 +420,15 @@ const isRejected = computed(() => {
   return status.value === 'success' && rj.success === false && rj.rejected_reason
 })
 
+// A rejected or failed edit changed nothing, so its body is noise: there is no
+// diff to read and no action to take, only the reason — which the header
+// already carries. It opens collapsed, and a card that fails mid-stream
+// collapses when the verdict lands rather than leaving a spent block open.
+const isUnsuccessful = computed(() => !!isRejected.value || status.value === 'error')
+watch(isUnsuccessful, (bad) => {
+  if (bad && !userToggled.value) isExpanded.value = false
+}, { immediate: true })
+
 // Extract from arguments_json (input) - these are the updates applied.
 // NOTE: there is deliberately no `updatedText` here. `arguments_json.text` is
 // the edit's INPUT — with an anchored edit a snippet, not a document — so it
@@ -536,6 +558,9 @@ const rejectedReason = computed(() => {
   return rj.rejected_reason || ''
 })
 
+// `ambiguous_anchor` is a code for the model; the header is read by a person.
+const prettyRejectedReason = computed(() => rejectedReason.value.replace(/_/g, ' '))
+
 const currentGlobalStatus = computed(() => {
   if (localGlobalStatus.value !== null) return localGlobalStatus.value
   return fetchedInstruction.value?.global_status || null
@@ -633,14 +658,25 @@ const headerTitle = computed(() => {
   return (typeof title === 'string' && title.trim()) ? title.trim() : truncatedText.value
 })
 
+// The rejection message is written for the MODEL: it restates how to retry and
+// then quotes the entire current instruction text so the next call can anchor on
+// it. Printing that verbatim turned a one-line "your anchor wasn't unique" into
+// a wall of red containing the whole instruction — which the card renders above
+// anyway. Keep the actionable sentence, drop the quoted document and the
+// "Edit rejected:" prefix the header already says.
+const stripEchoedText = (message: string) => {
+  const cut = message.split(/\s*Current instruction text:/)[0]
+  return cut.replace(/^\s*Edit rejected:\s*/, '').trim()
+}
+
 const errorMessage = computed(() => {
   if (status.value === 'error') {
     const rj = props.toolExecution?.result_json || {}
-    return rj.error || rj.message || t('tools.editInstruction.errorOccurred')
+    return stripEchoedText(rj.error || rj.message || t('tools.editInstruction.errorOccurred'))
   }
   if (isRejected.value) {
     const rj = props.toolExecution?.result_json || {}
-    return rj.message || ''
+    return stripEchoedText(rj.message || '')
   }
   return ''
 })
@@ -675,8 +711,14 @@ async function fetchInstruction() {
 }
 
 function toggleExpanded() {
-  if (status.value !== 'running') {
-    isExpanded.value = !isExpanded.value
+  if (status.value === 'running') return
+  userToggled.value = true
+  isExpanded.value = !isExpanded.value
+  // A first fetch that failed (or ran before the id landed) left this null and
+  // the guard below never retried it — the body then rendered empty for the
+  // rest of the session. Reopening the card is the natural retry.
+  if (isExpanded.value && instructionId.value && fetchedInstruction.value === null) {
+    fetchInstruction()
   }
 }
 

--- a/frontend/composables/useInstructionHelpers.ts
+++ b/frontend/composables/useInstructionHelpers.ts
@@ -71,6 +71,9 @@ export interface Instruction {
   structured_data?: Record<string, any> | null
   formatted_content?: string | null
   references?: any[]
+  //: Referenced datasource_table ids. Present on light list rows, which carry
+  //: no `references` — the tree files instructions under tables with this.
+  table_ref_ids?: string[]
 }
 
 export function useInstructionHelpers() {


### PR DESCRIPTION
## Summary
This PR adds support for grouping instructions by their referenced tables in the knowledge explorer tree view by including table reference IDs in the light instruction projection. Previously, the tree would show empty when using the light projection because it couldn't determine which tables each instruction referenced.

## Key Changes

**Backend:**
- Added `table_ref_ids` field to `InstructionListItemSchema` containing only the IDs of referenced `datasource_table` objects
- Implemented efficient query in `_execute_instructions_query` to fetch table references separately for light projections, avoiding full reference row hydration
- Added e2e test verifying that light rows carry referenced table IDs correctly

**Frontend - Knowledge Explorer:**
- Updated `listForTable` to use a new `tableRefIds` helper that reads from `table_ref_ids` (light projection) or falls back to full `references` (hydrated rows)
- Fixed reference picker to include unresolved references as options, preventing orphaned UUIDs when referenced agents haven't loaded
- Improved reference display: editors see only the picker (which renders selections), read-only viewers see chips
- Added `summarize` prop to KSelect for multi-selections to display as "first +N" instead of full comma-separated list
- Enhanced reference options to include `connectorKey` and `iconToken` for proper agent branding, plus `heroicon` for non-datasource references

**Frontend - Edit Instruction Tool:**
- Changed rejection icon from x-circle (orange) to exclamation-triangle (amber) to better distinguish from errors
- Improved error message display: strips echoed instruction text and "Edit rejected:" prefix for cleaner presentation
- Added `userToggled` state to prevent auto-collapse of cards after user interaction
- Fixed card rendering to require `displayText` to avoid empty bordered boxes for rejected edits or pending fetches
- Added retry logic: reopening a card that failed on first fetch now retries the instruction fetch

**Frontend - Instruction Creation:**
- Removed "Disabled" load mode from new instruction creation options (still available for legacy instructions)
- Updated load mode options to be computed, conditionally including "Disabled" only for existing instructions already set to that mode

## Implementation Details
- The light projection optimization avoids hydrating full reference objects, keeping the query efficient while providing the minimal data needed for tree grouping
- Reference picker now handles both resolved and unresolved references gracefully, ensuring all attached references remain selectable
- Error/rejection messaging improved to be more user-friendly by removing model-facing technical details and redundant instruction text

https://claude.ai/code/session_013RArBMd3EXzLUL18fAoKQR