### PR TITLE
Fix eval run listings 500ing on Postgres (DISTINCT id … ORDER BY created_at)

### DIFF
--- a/backend/app/ai/tools/implementations/get_eval_runs.py
+++ b/backend/app/ai/tools/implementations/get_eval_runs.py
@@ -154,15 +154,19 @@ class GetEvalRunsTool(Tool):
             )
             if data.status != "all":
                 stmt = stmt.where(TestRun.status == data.status)
-            # Distinct over the ID only — TestRun has a ``json`` column and
-            # Postgres cannot compare those for an entity-level DISTINCT.
+            # Distinct over id + created_at, never the entity — TestRun has a
+            # ``json`` column and Postgres cannot compare those for an
+            # entity-level DISTINCT. created_at is selected because Postgres
+            # also demands that every ORDER BY expression appear in a DISTINCT
+            # select list; it is functionally determined by the id, so the pair
+            # is still one row per run.
             id_stmt = (
-                stmt.with_only_columns(TestRun.id, maintain_column_froms=True)
+                stmt.with_only_columns(TestRun.id, TestRun.created_at, maintain_column_froms=True)
                 .order_by(TestRun.created_at.desc())
                 .distinct()
                 .limit(data.limit)
             )
-            run_ids = list((await db.execute(id_stmt)).scalars().all())
+            run_ids = [row.id for row in (await db.execute(id_stmt)).all()]
             runs = list((await db.execute(
                 select(TestRun)
                 .where(TestRun.id.in_(run_ids))

--- a/backend/app/services/test_run_service.py
+++ b/backend/app/services/test_run_service.py
@@ -478,18 +478,21 @@ class TestRunService:
         agent_clause = agent_scope_clause(TestCase.data_source_ids_json, data_source_id, scope)
         if agent_clause is not None:
             stmt = stmt.where(agent_clause)
-        # Distinct over the ID only: TestRun carries a ``json`` summary column,
-        # and Postgres SELECT DISTINCT needs an equality operator for every
-        # selected column — which the json type has none of. Paginate the id
-        # list, then load the rows.
+        # Distinct over id + created_at, not the entity: TestRun carries a
+        # ``json`` summary column, and Postgres SELECT DISTINCT needs an
+        # equality operator for every selected column — which the json type has
+        # none of. created_at has to be selected too, because Postgres also
+        # requires every ORDER BY expression to appear in a DISTINCT select
+        # list; it is functionally determined by the id, so the pair is still
+        # one row per run. Paginate the id list, then load the rows.
         id_stmt = (
-            stmt.with_only_columns(TestRun.id, maintain_column_froms=True)
+            stmt.with_only_columns(TestRun.id, TestRun.created_at, maintain_column_froms=True)
             .order_by(TestRun.created_at.desc())
             .distinct()
             .offset((page - 1) * limit)
             .limit(limit)
         )
-        ids = [r for r in (await db.execute(id_stmt)).scalars().all()]
+        ids = [row.id for row in (await db.execute(id_stmt)).all()]
         if not ids:
             return []
         res = await db.execute(


### PR DESCRIPTION
## What & why

`get_eval_runs` (and the evals runs list page) were failing on Postgres. The user-visible symptom was an agent turn dying with:

> This Session's transaction has been rolled back … `InFailedSQLTransactionError: current transaction is aborted` … `UPDATE agent_executions SET latest_seq=…`

That `agent_executions` UPDATE is a **decoy** — it's just the next statement after the transaction was already poisoned. The real failure is upstream.

### Root cause

Commit `b60a981` moved the eval run listings from an entity-level `DISTINCT` to a `DISTINCT` over the `id` column (to dodge Postgres refusing to compare the `json` summary column). Both id-only variants kept ordering by `created_at`:

```sql
SELECT DISTINCT test_runs.id FROM ... ORDER BY test_runs.created_at DESC
```

Postgres rejects this with **42P10** — *"for SELECT DISTINCT, ORDER BY expressions must appear in the select list."* SQLite accepts it, so the sqlite CI leg and all local runs stayed green while Postgres 500'd.

Two sites were affected, both untested on the read path:
- `backend/app/ai/tools/implementations/get_eval_runs.py` — the agent tool (this is what the screenshot hit).
- `backend/app/services/test_run_service.py::list_runs` — backs `GET /api/tests/runs`, i.e. the evals runs list page.

The tool shares the agent's DB session and catches the DB error without rolling back, which is why it surfaced later as the unrelated "current transaction is aborted" on the next `agent_executions` write.

### Fix

Select `created_at` alongside `id` in the DISTINCT list. It's functionally determined by the id, so the pair is still one row per run and the pagination window is unchanged:

```sql
SELECT DISTINCT test_runs.id, test_runs.created_at FROM ... ORDER BY test_runs.created_at DESC
```

## Validation

Booted a full sandbox on **PostgreSQL 16** (backend + Nuxt frontend + live Anthropic **Claude Haiku 4.5**) and drove the eval stack end-to-end through the real UI and agent, verifying at the DB / backend-log / HTTP layers.

**The reported failure is reproduced green:** `GET /api/tests/runs` and every `?status=` filter return **200** against a mixed success/error run set, and the **`get_eval_runs` agent tool** — the exact tool in the bug screenshot — runs to `success` inside a real training completion and returns output **byte-identical** to what KnowledgeExplorer (`GET /tests/runs`) shows: `[…/success 1/1, …/success 1/1, …/error 0/1, …/error 0/1]`.

Full end-to-end steps exercised (all passed):

| # | Step | Result |
|---|------|--------|
| 1 | Boot on Postgres, migrate, backend+frontend up | ✅ migrations clean |
| 2 | Admin + org + Haiku LLM | ✅ |
| 3 | Admin creates `music store` connection (SQLite/Chinook) | ✅ 11 tables, queryable |
| 4 | Invite 5 users, custom **Agent Creator** role via **group** on the connection | ✅ all Active, role via group |
| 5 | Each user creates an agent; share manage vs query | ✅ grants resolve; query-only user 403'd from re-sharing |
| 6 | Eval e2e: suite → case → run → response | ✅ agent ran real SQL (`COUNT(DISTINCT ArtistId)=275`), judge passed |
| 7 | Training: instruction + `run_eval` before accepting + finish event | ✅ instruction stayed `draft`; run pinned to Build #1; wake event fired |
| 8 | Eval runs visible in KnowledgeExplorer | ✅ 4 runs listed |
| 9 | Move cases between suites; delete suites | ✅ case moved, suite deleted, runs intact |
| 10 | `get_eval_runs`/`get_eval_run` tools in completions match KnowledgeExplorer | ✅ **byte-identical** output |

## Notes & issue log from validation

These came out of the sandbox run. **None are regressions from this PR** and none block the eval flows — captured here for visibility.

- **Untested read path (the class of bug):** neither affected query had execution coverage on the Postgres leg — `get_eval_runs` has only input-defaults/digest unit tests, and no e2e test does a `GET /api/tests/runs`. That's why a Postgres-only DISTINCT error shipped twice from the same file. Worth a follow-up test that executes both against Postgres.
- **Tool error handling swallows DB errors without rollback:** tools run on the agent's own session (`runtime_ctx["db"]` is `self.db`). `get_eval_runs`' blanket `except Exception` logs + yields `tool.error` but does **not** roll back, so any DB-level error inside a tool poisons the whole conversation and resurfaces as an unrelated aborted-transaction on the next write. Not fixed here (out of scope), but the failure mode is worth a central rollback in tool dispatch.
- **Model id 404 (environment, not product):** `claude-3-5-haiku-20241022` returns 404 from the Anthropic endpoint used here; only `claude-haiku-4-5-20251001` is in `/llm/available_models`. Product behaved correctly — the eval run went to `error` rather than hanging.
- **`/reports/{id}` chat page renders blank / hangs in headless Chromium** (SSE-heavy); `/agents`, `/evals/runs/{id}`, `/settings/*` render fine. Only relevant if chat screenshots are wanted in CI.
- **Minor admin ergonomics:** `PATCH /llm/models/{id}` with `{model_id}` → 500; `DELETE /llm/providers/{id}` → 400 while in use; `POST /llm/models/{id}/toggle` → 422 while referenced. All worked around; tangential to evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmyBr1JbrTC3e7PfPUabJ7)_