### PR TITLE
fix(instructions): clamp the edit card's resolved body to the pending panel's height

### DIFF
--- a/frontend/components/tools/EditInstructionTool.vue
+++ b/frontend/components/tools/EditInstructionTool.vue
@@ -93,7 +93,15 @@
                  this edit was based on. -->
             <span v-if="versionNumber" class="text-[10px] text-gray-500 dark:text-gray-400">v{{ versionNumber }}</span>
           </div>
-          <div class="px-3 py-2 bg-white dark:bg-gray-900">
+          <!-- Same clamp as the pending review panel above (its compact mode is
+               `px-3 py-2 max-h-80`), on purpose: resolving a suggestion swaps
+               this body in for that one, and any other number would make the
+               card jump height at that moment. Until this, the resolved branches
+               were the only ones with no bound — a long instruction rendered in
+               full, so a transcript of edits was a transcript of whole
+               documents. Clamped, never truncated: the diff is only meaningful
+               whole, so the rest scrolls. -->
+          <div class="px-3 py-2 bg-white dark:bg-gray-900 max-h-80 overflow-y-auto">
             <TrackedChangesView :diff-ops="diffOps" />
           </div>
         </div>
@@ -107,7 +115,7 @@
           <!-- Instruction text - click to edit -->
           <div
             dir="auto"
-            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer"
+            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer max-h-80 overflow-y-auto"
             @click="handleEdit()"
           >
             <InstructionText :text="displayText" :markdown="true" />


### PR DESCRIPTION
The edit-instruction card had three body branches and only one was bounded.
The pending review panel clamps at max-h-80 (InstructionTrackedChanges compact
mode); the resolved read-only diff and the instruction-card fallback had no
bound at all, so a long instruction rendered in full and one edit filled the
viewport several times over. A report replaying many historical edits — each
card opens expanded — was a stack of whole documents.

Both resolved branches now carry the same max-h-80 as the pending panel. Same
number on purpose: resolving a suggestion swaps one body in for the other, so
any other value would make the card change height at that moment.

Clamped, not truncated — the content still scrolls in full. Verified in a local
sandbox against seeded cards for all three branches: the resolved diff's body
goes 1018px -> 320px with all 2342 chars still reachable, the instruction-card
fallback clamps to the same 320px, and the pending panel measures 320px
unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pwow5jCLukVketNS5FXJat