### PR TITLE
Make the eval strip's chevron open, and show the agent's suites

### DIFF
--- a/backend/app/routes/instruction.py
+++ b/backend/app/routes/instruction.py
@@ -1448,23 +1448,86 @@ from app.models.build_content import BuildContent
 from app.models.instruction_version import InstructionVersion
 
 
+async def _resolved_eval_agent_scope(
+    db: AsyncSession, current_user: User, organization: Organization, agent_ids: Optional[str],
+) -> list:
+    """The caller-supplied agents, narrowed to the ones they may actually see.
+
+    The ids arrive from the client (the conversation's own data sources), so
+    they are a *request*, not authority — an unfiltered pass-through would let
+    any id in the body name another team's agent and read back its suite and
+    case names. Mirrors the access rule used for instruction listing: admins
+    see everything, everyone else sees public agents plus their grants.
+    """
+    from sqlalchemy import or_
+    from app.models.data_source import DataSource as _DS
+    from app.core.permission_resolver import get_accessible_data_source_ids
+
+    requested = [x.strip() for x in (agent_ids or "").split(",") if x.strip()]
+    if not requested:
+        return []
+    is_admin, accessible = await get_accessible_data_source_ids(
+        db, str(current_user.id), str(organization.id)
+    )
+    stmt = select(_DS.id).where(
+        _DS.organization_id == str(organization.id),
+        _DS.deleted_at.is_(None),
+        _DS.id.in_(requested),
+    )
+    if not is_admin:
+        clauses = [_DS.is_public == True]  # noqa: E712
+        if accessible:
+            clauses.append(_DS.id.in_(list(accessible)))
+        stmt = stmt.where(or_(*clauses))
+    allowed = {str(i) for i in (await db.execute(stmt)).scalars().all()}
+    # Preserve the caller's order — the conversation lists its agents in a
+    # meaningful order and the panel groups follow it.
+    return [r for r in requested if r in allowed]
+
+
 @router.get("/instructions/{instruction_id}/resolved-evals")
 async def get_instruction_resolved_evals(
     instruction_id: str,
+    agent_ids: Optional[str] = Query(
+        None,
+        description=(
+            "Comma-separated data source ids of the conversation this instruction "
+            "was edited in. Used ONLY when the instruction is global: such an "
+            "instruction resolves to every agent in the org, which is not a "
+            "runnable set, so the chat's own agents stand in for it."
+        ),
+    ),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
 ):
-    """Evals that 'resolve' for an instruction — the active eval cases scoped to
-    the agent(s) this instruction is attached to. Used by the editor / suggestion
-    review to show, per pending build, what running an eval would actually
-    measure. A run is launched separately via POST /tests/runs with the chosen
-    build_id (the suggestion build) so it tests exactly that change.
+    """Evals that 'resolve' for an instruction, grouped the way the agents tree
+    groups them: one group per agent, each listing that agent's SUITES.
 
-    Global instructions (no data sources) resolve to every agent's cases — we
-    return the aggregate count + agent count rather than inlining them all.
+    Two different questions are being answered at once and conflating them is
+    what makes an eval panel lie. A suite is a *home* (``TestSuite`` docstring):
+    it says where a case was filed. What actually RUNS against an agent is a
+    per-case property (``TestCase.data_source_ids_json``, empty = every agent).
+    So a suite homed to agent A can hold a case targeting B, and the org-wide
+    Drafts bucket can hold cases that run against A. This endpoint returns the
+    union of both — every suite homed to the agent (so an empty Drafts is still
+    visible as the place new evals land) plus every suite holding a case that
+    resolves for it — and puts in each suite row ONLY the case ids that actually
+    resolve. The panel can then show a suite tree whose visible cases are
+    exactly the ones a run will execute.
+
+    Cases are returned as explicit ids rather than the caller running a
+    ``suite_id``: a suite-level run takes the whole suite, which is a different
+    (and for a shared suite, wrong) set than the rows shown here.
+
+    Global instructions have no agents of their own. They resolve to every agent
+    in the org, so they get the org-wide 'global' group (agent-less cases, which
+    run against everything) plus — via ``agent_ids`` — the agents of the
+    conversation the edit was made in, which is the part the author can act on.
     """
-    from app.models.eval import TestCase, TestSuite, TEST_CASE_STATUS_ACTIVE
+    from app.models.eval import (
+        TestCase, TestSuite, TEST_CASE_STATUS_ACTIVE, DEFAULT_DRAFTS_SUITE_NAME,
+    )
     from app.models.data_source import DataSource as _DS
     from app.services.agent_reliability_service import AgentReliabilityService
 
@@ -1475,19 +1538,42 @@ async def get_instruction_resolved_evals(
         raise AppError.not_found(ErrorCode.INSTRUCTION_NOT_FOUND, "Instruction not found")
 
     org_id = str(organization.id)
-    ds_ids = [str(ds.id) for ds in (existing.data_sources or [])]
-    is_global = len(ds_ids) == 0
+    own_ds_ids = [str(ds.id) for ds in (existing.data_sources or [])]
+    is_global = len(own_ds_ids) == 0
     rel = AgentReliabilityService()
 
+    # --- which agents does this panel speak for? -----------------------------
     if is_global:
-        # Aggregate across the whole org — count only, don't inline.
-        agent_count = (await db.execute(
-            select(func.count()).select_from(_DS).where(
-                _DS.organization_id == org_id, _DS.deleted_at.is_(None)
-            )
-        )).scalar() or 0
-        case_rows = (await db.execute(
-            select(TestCase.id)
+        agent_scope = await _resolved_eval_agent_scope(db, current_user, organization, agent_ids)
+        scope_source = "report" if agent_scope else "none"
+    else:
+        agent_scope = own_ds_ids
+        scope_source = "instruction"
+
+    agent_names = {}
+    if agent_scope:
+        rows = (await db.execute(
+            select(_DS.id, _DS.name).where(_DS.id.in_(agent_scope), _DS.deleted_at.is_(None))
+        )).all()
+        agent_names = {str(i): n for i, n in rows}
+        agent_scope = [a for a in agent_scope if a in agent_names]
+
+    # --- suite shelf, read once ----------------------------------------------
+    suite_rows = (await db.execute(
+        select(TestSuite.id, TestSuite.name, TestSuite.data_source_id).where(
+            TestSuite.organization_id == org_id, TestSuite.deleted_at.is_(None)
+        )
+    )).all()
+    suites_by_id = {
+        str(i): {"id": str(i), "name": n, "data_source_id": (str(d) if d else None)}
+        for i, n, d in suite_rows
+    }
+
+    async def _global_case_ids() -> list:
+        """Active cases targeting NO agent — they run against every agent, and
+        are the only ones a global instruction can be said to own."""
+        rows = (await db.execute(
+            select(TestCase.id, TestCase.data_source_ids_json)
             .join(TestSuite, TestSuite.id == TestCase.suite_id)
             .where(
                 TestSuite.organization_id == org_id,
@@ -1495,35 +1581,87 @@ async def get_instruction_resolved_evals(
                 TestCase.deleted_at.is_(None),
             )
         )).all()
-        return {
-            "instruction_id": instruction_id,
-            "is_global": True,
-            "data_source_ids": [],
-            "agent_count": int(agent_count),
-            "case_count": len(case_rows),
-            "cases": [],  # not inlined for global — UI shows count + link
+        return [
+            str(i) for i, ds in rows
+            if not (isinstance(ds, list) and len(ds) > 0)
+        ]
+
+    async def _group(scope: str, label: str, exclude: set) -> dict:
+        if scope == "global":
+            case_ids = await _global_case_ids()
+        else:
+            case_ids = await rel.list_agent_eval_case_ids(db, org_id, scope)
+        case_ids = [c for c in case_ids if c not in exclude]
+
+        cases = []
+        if case_ids:
+            rows = (await db.execute(
+                select(TestCase.id, TestCase.name, TestCase.suite_id)
+                .where(TestCase.id.in_(case_ids))
+                .order_by(TestCase.created_at.asc())
+            )).all()
+            cases = [{"id": str(i), "name": n, "suite_id": str(s)} for i, n, s in rows]
+
+        by_suite = {}
+        for c in cases:
+            by_suite.setdefault(c["suite_id"], []).append(c)
+
+        # Every suite homed here shows up even at zero resolving cases: that is
+        # where the agent's next eval will be filed, and the tree shows it too.
+        homed = {
+            sid for sid, s in suites_by_id.items()
+            if s["data_source_id"] == (None if scope == "global" else scope)
         }
 
-    # Scoped: union of each attached agent's active cases.
-    case_ids: list[str] = []
-    seen: set = set()
-    for ds_id in ds_ids:
-        for cid in await rel.list_agent_eval_case_ids(db, org_id, ds_id):
-            if cid not in seen:
-                seen.add(cid); case_ids.append(cid)
-    cases = []
-    if case_ids:
-        rows = (await db.execute(
-            select(TestCase.id, TestCase.name).where(TestCase.id.in_(case_ids))
-        )).all()
-        cases = [{"id": str(i), "name": n} for i, n in rows]
+        suites = []
+        for sid in set(by_suite) | homed:
+            meta = suites_by_id.get(sid)
+            if meta is None:
+                continue  # case filed in a suite from another org — not ours to show
+            rows_for_suite = by_suite.get(sid, [])
+            suites.append({
+                "id": sid,
+                "name": meta["name"],
+                "is_home": sid in homed,
+                "is_drafts": meta["name"] == DEFAULT_DRAFTS_SUITE_NAME,
+                "case_count": len(rows_for_suite),
+                "cases": [{"id": c["id"], "name": c["name"]} for c in rows_for_suite],
+            })
+        # Runnable suites first, then the empty shelves, each alphabetically —
+        # an empty Drafts should never push what actually runs below the fold.
+        suites.sort(key=lambda s: (s["case_count"] == 0, s["name"].lower()))
+        return {
+            "scope": scope,
+            "label": label,
+            "case_count": len(cases),
+            "suites": suites,
+        }
+
+    groups = []
+    claimed: set = set()
+    if is_global:
+        g = await _group("global", "Org-wide", claimed)
+        claimed.update(c["id"] for s in g["suites"] for c in s["cases"])
+        groups.append(g)
+    for a in agent_scope:
+        # `claimed` also de-duplicates BETWEEN agents: an agent-less case
+        # resolves for every one of them and would otherwise be listed, and run,
+        # once per group.
+        g = await _group(a, agent_names[a], claimed)
+        claimed.update(c["id"] for s in g["suites"] for c in s["cases"])
+        groups.append(g)
+
+    all_cases = [c for g in groups for s in g["suites"] for c in s["cases"]]
     return {
         "instruction_id": instruction_id,
-        "is_global": False,
-        "data_source_ids": ds_ids,
-        "agent_count": len(ds_ids),
-        "case_count": len(cases),
-        "cases": cases,
+        "is_global": is_global,
+        "scope_source": scope_source,
+        "data_source_ids": own_ds_ids,
+        "agent_count": len(agent_scope),
+        "groups": groups,
+        # Flat union, in group order — the run payload and the legacy shape.
+        "case_count": len(all_cases),
+        "cases": all_cases,
     }
 
 

--- a/backend/tests/e2e/test_resolved_evals.py
+++ b/backend/tests/e2e/test_resolved_evals.py
@@ -1,0 +1,160 @@
+"""GET /instructions/{id}/resolved-evals — the eval panel behind a staged
+instruction change.
+
+The contract worth pinning down is that a suite is a HOME and a case's agents
+are its SCOPE (see the ``TestSuite`` model docstring), so the two disagree in
+both directions and the panel has to follow the scope:
+
+  * a case filed in agent A's suite but targeting agent B must not appear
+    under A
+  * an agent-less ("Auto") case filed in an org-wide suite runs against every
+    agent and must appear under each of them
+"""
+import uuid
+
+import pytest
+
+
+def _panel(test_client, instruction_id, token, org_id, agent_ids=None):
+    url = f"/api/instructions/{instruction_id}/resolved-evals"
+    if agent_ids:
+        url += "?agent_ids=" + ",".join(agent_ids)
+    resp = test_client.get(url, headers={
+        "Authorization": f"Bearer {token}",
+        "X-Organization-Id": str(org_id),
+    })
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _group(payload, label):
+    for g in payload["groups"]:
+        if g["label"] == label:
+            return g
+    raise AssertionError(f"no group {label!r} in {[g['label'] for g in payload['groups']]}")
+
+
+def _suite(group, name):
+    for s in group["suites"]:
+        if s["name"] == name:
+            return s
+    raise AssertionError(f"no suite {name!r} in {[s['name'] for s in group['suites']]}")
+
+
+@pytest.fixture
+def scenario(create_user, login_user, whoami, create_data_source, create_test_suite, create_test_case):
+    """Two agents, three suites, four cases — one of each awkward shape."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    auth = dict(user_token=token, org_id=org_id)
+
+    sales = create_data_source(name="Sales DB", type="network_dir", config={"root_path": "/tmp"},
+                               credentials={"auth_type": "none"}, **auth)
+    support = create_data_source(name="Support DB", type="network_dir", config={"root_path": "/tmp"},
+                                 credentials={"auth_type": "none"}, **auth)
+
+    core = create_test_suite(name="Core checks", data_source_id=sales["id"], **auth)
+    drafts = create_test_suite(name="Drafts", data_source_id=sales["id"], **auth)
+    shared = create_test_suite(name="Shared checks", **auth)  # org-wide home
+
+    own = create_test_case(suite_id=core["id"], name="revenue by region",
+                           data_source_ids_json=[sales["id"]], **auth)
+    # Filed in Sales' suite, targets Support.
+    crossed = create_test_case(suite_id=core["id"], name="support backlog",
+                               data_source_ids_json=[support["id"]], **auth)
+    # Targets nobody -> runs against every agent, filed org-wide.
+    auto = create_test_case(suite_id=shared["id"], name="never invents columns",
+                            data_source_ids_json=[], **auth)
+
+    return {
+        "token": token, "org_id": org_id, "auth": auth,
+        "sales": sales, "support": support,
+        "core": core, "drafts": drafts, "shared": shared,
+        "own": own, "crossed": crossed, "auto": auto,
+    }
+
+
+@pytest.mark.e2e
+def test_scoped_instruction_lists_suites_for_its_own_agent(test_client, create_instruction, scenario):
+    s = scenario
+    instruction = create_instruction(text="Group revenue by fiscal quarter.",
+                                     data_source_ids=[s["sales"]["id"]], **s["auth"])
+
+    payload = _panel(test_client, instruction["id"], s["token"], s["org_id"])
+
+    assert payload["is_global"] is False
+    assert payload["scope_source"] == "instruction"
+    assert [g["label"] for g in payload["groups"]] == ["Sales DB"]
+
+    sales = _group(payload, "Sales DB")
+    names = {c["name"] for suite in sales["suites"] for c in suite["cases"]}
+    # The Auto case runs for this agent even though it is filed org-wide...
+    assert "never invents columns" in names
+    assert _suite(sales, "Shared checks")["is_home"] is False
+    # ...and the case filed here but aimed at another agent does not.
+    assert "support backlog" not in names
+    assert {c["name"] for c in _suite(sales, "Core checks")["cases"]} == {"revenue by region"}
+
+    # The agent's empty Drafts still shows: it is where the next eval lands.
+    drafts = _suite(sales, "Drafts")
+    assert drafts["case_count"] == 0
+    assert drafts["is_home"] is True and drafts["is_drafts"] is True
+
+    # Suites holding runnable cases sort above the empty shelves.
+    assert sales["suites"][-1]["name"] == "Drafts"
+
+    # The flat list is exactly what a run would execute.
+    assert payload["case_count"] == 2
+    assert {c["name"] for c in payload["cases"]} == {"revenue by region", "never invents columns"}
+
+
+@pytest.mark.e2e
+def test_global_instruction_uses_org_wide_plus_the_chats_agents(test_client, create_instruction, scenario):
+    s = scenario
+    instruction = create_instruction(text="Never fabricate a column.", data_source_ids=[], **s["auth"])
+
+    # No chat agents: a global instruction owns only the agent-less cases.
+    bare = _panel(test_client, instruction["id"], s["token"], s["org_id"])
+    assert bare["is_global"] is True and bare["scope_source"] == "none"
+    assert [g["label"] for g in bare["groups"]] == ["Org-wide"]
+    assert bare["case_count"] == 1
+
+    # With the conversation's agents, they are appended as their own groups.
+    scoped = _panel(test_client, instruction["id"], s["token"], s["org_id"],
+                    agent_ids=[s["sales"]["id"], s["support"]["id"]])
+    assert scoped["scope_source"] == "report"
+    assert [g["label"] for g in scoped["groups"]] == ["Org-wide", "Sales DB", "Support DB"]
+
+    # The Auto case is claimed once by Org-wide, not repeated (and re-run) under
+    # every agent it also resolves for.
+    assert [c["name"] for c in scoped["cases"]].count("never invents columns") == 1
+    assert {c["name"] for suite in _group(scoped, "Sales DB")["suites"] for c in suite["cases"]} == {"revenue by region"}
+    assert {c["name"] for suite in _group(scoped, "Support DB")["suites"] for c in suite["cases"]} == {"support backlog"}
+
+
+@pytest.mark.e2e
+def test_agent_ids_cannot_widen_what_the_caller_may_see(
+    test_client, create_user, login_user, whoami, create_instruction, scenario,
+):
+    """``agent_ids`` is a request from the client, not authority: a member who
+    cannot see an agent must not learn its suite and case names by naming it."""
+    s = scenario
+    instruction = create_instruction(text="Never fabricate a column.", data_source_ids=[], **s["auth"])
+
+    # A plain member of the SAME org: they can read the global instruction, but
+    # the agents are private (is_public defaults to False) and ungranted.
+    email = f"member_{uuid.uuid4().hex[:6]}@test.com"
+    invite = test_client.post(
+        f"/api/organizations/{s['org_id']}/members",
+        json={"organization_id": s["org_id"], "email": email, "role": "member"},
+        headers={"Authorization": f"Bearer {s['token']}", "X-Organization-Id": str(s["org_id"])},
+    )
+    assert invite.status_code == 200, invite.json()
+    create_user(email=email, password="test123")
+    member_token = login_user(email=email, password="test123")
+
+    payload = _panel(test_client, instruction["id"], member_token, s["org_id"],
+                     agent_ids=[s["sales"]["id"], s["support"]["id"]])
+    assert payload["agent_count"] == 0
+    assert [g["label"] for g in payload["groups"]] == ["Org-wide"]

--- a/backend/tests/fixtures/eval.py
+++ b/backend/tests/fixtures/eval.py
@@ -102,7 +102,7 @@ def get_test_suite(test_client):
 
 @pytest.fixture
 def create_test_suite(test_client):
-    def _create_test_suite(*, name="Sample Suite", description=None, user_token=None, org_id=None):
+    def _create_test_suite(*, name="Sample Suite", description=None, data_source_id=None, user_token=None, org_id=None):
         if user_token is None:
             pytest.fail("User token is required for create_test_suite")
         if org_id is None:
@@ -111,6 +111,7 @@ def create_test_suite(test_client):
         payload = {
             "name": name,
             "description": description,
+            "data_source_id": data_source_id,
         }
 
         headers = {

--- a/frontend/components/instructions/ResolvedEvalStrip.vue
+++ b/frontend/components/instructions/ResolvedEvalStrip.vue
@@ -1,132 +1,286 @@
 <template>
   <span v-if="loaded && data" class="inline-flex items-center text-[11px]" @click.stop>
-    <!-- Global instruction: count + link, nothing to run inline -->
-    <template v-if="data.is_global">
-      <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400">
-        <UIcon name="i-heroicons-beaker" class="w-3.5 h-3.5 text-violet-400" />
-        {{ data.case_count }} eval{{ data.case_count === 1 ? '' : 's' }} · {{ data.agent_count }} agent{{ data.agent_count === 1 ? '' : 's' }}
+    <!-- Nothing resolves and no shelf to show: grayed, disabled -->
+    <template v-if="!data.case_count && !hasShelf">
+      <span class="inline-flex items-center gap-1 px-2 h-6 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/40 text-gray-300 dark:text-gray-600 cursor-not-allowed"
+        :title="$t('evals.strip.noneResolved')">
+        <UIcon name="i-heroicons-beaker" class="w-3.5 h-3.5" />
+        {{ $t('agentsPage.runEval') }}
       </span>
-      <NuxtLink to="/agents" class="ms-1.5 text-blue-600 dark:text-blue-400 hover:underline">View all</NuxtLink>
     </template>
 
-    <!-- Scoped with cases: compact Run-eval button + chevron popover -->
-    <template v-else-if="data.case_count > 0">
-      <div class="inline-flex items-center rounded-md border border-gray-200 dark:border-gray-800 overflow-hidden bg-white dark:bg-gray-900">
-        <button type="button" class="inline-flex items-center gap-1 px-2 h-6 hover:bg-gray-50 dark:hover:bg-gray-800/50 disabled:opacity-50"
-          :disabled="runState === 'running'" @click.stop="runEval">
-          <Spinner v-if="runState === 'running'" class="w-3 h-3 text-violet-600" />
+    <!-- Split control: run-everything on the left, the suite tree behind the
+         chevron. NOTE the wrapper deliberately has no `overflow-hidden` — the
+         popover panel renders inside it, so clipping the corners would clip the
+         panel to a 24px pill. The children round their own outer edges. -->
+    <template v-else>
+      <div class="inline-flex items-center rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+        <button type="button"
+          class="inline-flex items-center gap-1 px-2 h-6 rounded-s-md hover:bg-gray-50 dark:hover:bg-gray-800/50 disabled:opacity-50"
+          :disabled="isRunning || !data.case_count" @click.stop="runCases(allCaseIds)">
+          <Spinner v-if="isRunning" class="w-3 h-3 text-violet-600" />
           <UIcon v-else name="i-heroicons-beaker" class="w-3.5 h-3.5 text-violet-500" />
-          <span v-if="runState === 'running'" class="text-gray-600 dark:text-gray-400">Running {{ doneCount }}/{{ data.case_count }}</span>
-          <span v-else-if="runState === 'done'" class="inline-flex items-center gap-1">
-            <span class="text-green-600 dark:text-green-400 font-medium">✓ {{ passed }}</span>
-            <span v-if="failed" class="text-red-600 dark:text-red-400 font-medium">✗ {{ failed }}</span>
+          <span v-if="isRunning" class="text-gray-600 dark:text-gray-400">
+            {{ $t('evals.strip.runningCount', { done: summary.done, total: summary.total }) }}
           </span>
-          <span v-else class="text-gray-700 dark:text-gray-300">Run eval</span>
+          <span v-else-if="activeRun" class="inline-flex items-center gap-1">
+            <span class="text-green-600 dark:text-green-400 font-medium">✓ {{ summary.passed }}</span>
+            <span v-if="summary.failed" class="text-red-600 dark:text-red-400 font-medium">✗ {{ summary.failed }}</span>
+          </span>
+          <span v-else class="text-gray-700 dark:text-gray-300">{{ $t('agentsPage.runEval') }}</span>
         </button>
-        <UPopover :popper="{ placement: 'bottom-end' }">
-          <button type="button" class="px-1 h-6 border-s border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50" :title="`${data.case_count} resolved eval${data.case_count === 1 ? '' : 's'}`" @click.stop>
+
+        <!-- No @click.stop on this button: the click has to reach UPopover's
+             own trigger wrapper, which is what toggles the panel. -->
+        <UPopover :popper="{ placement: 'bottom-end', strategy: 'fixed' }" :ui="{ ring: '', shadow: 'shadow-lg' }">
+          <button type="button"
+            class="px-1 h-6 rounded-e-md border-s border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+            :title="$t('evals.strip.title')">
             <UIcon name="i-heroicons-chevron-down" class="w-3 h-3 text-gray-400 dark:text-gray-500" />
           </button>
+
           <template #panel>
-            <div class="p-2 w-72 max-h-72 overflow-auto" @click.stop>
-              <div class="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5 px-0.5">
-                {{ data.case_count }} eval{{ data.case_count === 1 ? '' : 's' }} for this agent
-                <span v-if="buildId" class="normal-case text-gray-400 dark:text-gray-500">· pinned to this change</span>
+            <div class="w-80 max-h-96 overflow-auto p-2" @click.stop>
+              <div class="flex items-center gap-1 px-0.5 mb-1 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                <span>{{ $t('evals.strip.title') }}</span>
+                <span v-if="buildId" class="normal-case ms-auto">{{ $t('evals.strip.pinned') }}</span>
               </div>
-              <div v-for="c in data.cases" :key="c.id" class="flex items-center gap-1.5 py-1 px-0.5 text-[11px]">
-                <span class="w-3 text-center shrink-0" :class="statusColor(c.id)">{{ statusSymbol(c.id) }}</span>
-                <span class="truncate text-gray-700 dark:text-gray-300">{{ c.name }}</span>
+
+              <button v-if="data.case_count" type="button"
+                class="w-full flex items-center gap-1.5 px-1.5 h-7 rounded hover:bg-gray-50 dark:hover:bg-gray-800/50 disabled:opacity-50"
+                :disabled="isRunning" @click.stop="runCases(allCaseIds)">
+                <UIcon name="i-heroicons-play" class="w-3 h-3 text-blue-500 shrink-0" />
+                <span class="text-[11px] font-medium text-gray-700 dark:text-gray-300">{{ $t('evals.strip.runAll') }}</span>
+                <span class="ms-auto text-[10px] text-gray-400 dark:text-gray-500">{{ data.case_count }}</span>
+              </button>
+
+              <div v-for="g in data.groups" :key="g.scope" class="mt-1.5">
+                <div class="flex items-center gap-1 px-0.5 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  <UIcon :name="g.scope === 'global' ? 'i-heroicons-globe-alt' : 'i-heroicons-cpu-chip'" class="w-3 h-3 shrink-0" />
+                  <span class="truncate">{{ g.scope === 'global' ? $t('evals.strip.orgWide') : g.label }}</span>
+                  <!-- A global instruction has no agents of its own; say so
+                       rather than let the chat's agents read as the truth. -->
+                  <span v-if="data.scope_source === 'report' && g.scope !== 'global'" class="normal-case shrink-0">· {{ $t('evals.strip.fromChat') }}</span>
+                </div>
+
+                <div v-if="!g.suites.length" class="px-2 py-1 text-[11px] text-gray-400 dark:text-gray-500">
+                  {{ $t('agentsPage.noSuites') }}
+                </div>
+
+                <div v-for="s in g.suites" :key="s.id">
+                  <button type="button"
+                    class="w-full flex items-center gap-1.5 px-1.5 h-7 rounded hover:bg-gray-50 dark:hover:bg-gray-800/50 disabled:opacity-50 disabled:hover:bg-transparent"
+                    :disabled="isRunning || !s.case_count"
+                    :title="s.case_count ? $t('evals.strip.runSuite', { name: s.name }) : $t('evals.strip.emptyShelf')"
+                    @click.stop="runCases(s.cases.map((c) => c.id))">
+                    <UIcon name="i-heroicons-folder" class="w-3.5 h-3.5 shrink-0" :class="s.case_count ? 'text-violet-400' : 'text-gray-300 dark:text-gray-600'" />
+                    <span class="truncate text-[11px]" :class="s.case_count ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'">{{ s.name }}</span>
+                    <span v-if="s.is_drafts" class="shrink-0 px-1 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-[9px]">{{ $t('evals.strip.default') }}</span>
+                    <span class="ms-auto shrink-0 inline-flex items-center gap-1 text-[10px]">
+                      <template v-if="suiteRollup(s).done">
+                        <span v-if="suiteRollup(s).passed" class="text-green-600 dark:text-green-400">✓ {{ suiteRollup(s).passed }}</span>
+                        <span v-if="suiteRollup(s).failed" class="text-red-600 dark:text-red-400">✗ {{ suiteRollup(s).failed }}</span>
+                        <!-- "/3" rather than a bare 3: next to a ✓/✗ tally an
+                             unmarked number reads as a third outcome. -->
+                        <span class="text-gray-400 dark:text-gray-500">/ {{ s.case_count }}</span>
+                      </template>
+                      <span v-else class="text-gray-400 dark:text-gray-500">{{ s.case_count }}</span>
+                    </span>
+                  </button>
+
+                  <div v-for="c in s.cases" :key="c.id" class="flex items-center gap-1.5 py-0.5 ps-7 pe-1.5 text-[11px]">
+                    <span class="w-3 text-center shrink-0" :class="statusColor(c.id)">{{ statusSymbol(c.id) }}</span>
+                    <span class="truncate text-gray-600 dark:text-gray-400">{{ c.name }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Live run status, same shape the suggestion-review panel uses
+                   so the two controls report a run identically. -->
+              <div v-if="activeRun" class="mt-2 pt-2 border-t border-gray-100 dark:border-gray-800 space-y-1.5">
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-1.5">
+                    <UIcon :name="isRunning ? 'i-heroicons-arrow-path' : (activeRun.status === 'success' ? 'i-heroicons-check-circle' : 'i-heroicons-x-circle')"
+                      :class="['w-3.5 h-3.5', isRunning ? 'text-blue-500 animate-spin' : (activeRun.status === 'success' ? 'text-green-500' : 'text-red-500')]" />
+                    <span class="text-[11px] font-medium text-gray-700 dark:text-gray-300">{{ prettyStatus }}</span>
+                  </div>
+                  <NuxtLink :to="`/evals/runs/${activeRun.id}`" class="text-[10px] text-blue-500 dark:text-blue-400 hover:underline inline-flex items-center gap-0.5">
+                    {{ $t('agentsPage.viewDetails') }}<UIcon name="i-heroicons-arrow-top-right-on-square" class="w-2.5 h-2.5" />
+                  </NuxtLink>
+                </div>
+                <div class="flex flex-wrap items-center gap-1.5 text-[10px]">
+                  <span class="px-1.5 py-0.5 rounded border bg-slate-50 dark:bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-500/30">{{ $t('agentsPage.casesLabel') }}: {{ summary.total }}</span>
+                  <span class="px-1.5 py-0.5 rounded border bg-green-50 dark:bg-green-500/10 text-green-700 dark:text-green-400 border-green-200 dark:border-green-500/30">{{ $t('agentsPage.passLabel') }}: {{ summary.passed }}</span>
+                  <span class="px-1.5 py-0.5 rounded border bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 border-red-200 dark:border-red-500/30">{{ $t('agentsPage.failLabel') }}: {{ summary.failed }}</span>
+                  <span v-if="summary.inProgress" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-500/30">
+                    <UIcon name="i-heroicons-arrow-path" class="w-2.5 h-2.5 animate-spin" />{{ $t('agentsPage.runningLabel') }}: {{ summary.inProgress }}
+                  </span>
+                </div>
+                <div v-if="isRunning" class="w-full bg-gray-100 dark:bg-gray-800 rounded-full h-1.5">
+                  <div class="bg-blue-500 h-1.5 rounded-full transition-all duration-300" :style="{ width: `${summary.progressPercent}%` }" />
+                </div>
               </div>
             </div>
           </template>
         </UPopover>
       </div>
     </template>
-
-    <!-- No evals resolved: grayed, disabled -->
-    <template v-else>
-      <span class="inline-flex items-center gap-1 px-2 h-6 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/40 text-gray-300 dark:text-gray-600 cursor-not-allowed"
-        title="No evals resolved for this agent yet">
-        <UIcon name="i-heroicons-beaker" class="w-3.5 h-3.5" />
-        Run eval
-      </span>
-    </template>
   </span>
 </template>
 
 <script setup lang="ts">
-// Compact resolved-eval control: a "Run eval" button + chevron popover listing
-// the eval cases that resolve for the instruction's agent. When `buildId` is
-// given the run is pinned to that suggestion/draft build, so it measures exactly
-// that change in isolation.
+// Compact resolved-eval control: a "Run eval" button + a chevron popover that
+// mirrors the agents tree's EVALS node — one group per agent, listing that
+// agent's SUITES with the cases underneath. Clicking a suite runs just that
+// suite; the button at the top runs everything.
+//
+// Two details that are easy to get wrong and were wrong here before:
+//
+//   * The run goes to POST /tests/runs/batch, NOT /tests/runs. The latter only
+//     creates `init` placeholder results and leaves execution to whoever opens
+//     the run page's SSE stream (see TestRunService.create_run) — from here
+//     nobody ever does, so the strip sat at "Running 0/1" until the 15-minute
+//     watchdog errored it out. /runs/batch executes in the background itself.
+//   * It runs explicit case_ids rather than a suite_id. A suite is a home, not
+//     a scope: a suite-level run takes every case filed there, including ones
+//     targeting a different agent. The ids shown in a row are the ids that run.
+//
+// When `buildId` is given the run is pinned to that suggestion/draft build, so
+// it measures exactly that change in isolation.
+import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import Spinner from '~/components/Spinner.vue'
-const props = defineProps<{ instructionId: string; buildId?: string | null }>()
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  instructionId: string
+  buildId?: string | null
+  /** Agents of the conversation this edit was made in. Only consulted for a
+      GLOBAL instruction, which has no agents of its own — see the endpoint. */
+  agentIds?: string[]
+}>()
+
+const { t } = useI18n()
+
+const TERMINAL = ['pass', 'fail', 'error', 'stopped']
 
 const data = ref<any>(null)
 const loaded = ref(false)
-const runState = ref<'idle' | 'running' | 'done'>('idle')
-const passed = ref(0)
-const failed = ref(0)
-const doneCount = ref(0)
-const caseStatus = ref<Record<string, string>>({})
+const activeRun = ref<any>(null)
+const results = ref<any[]>([])
+const launchedCaseIds = ref<string[]>([])
+let poll: any = null
+
+const isRunning = computed(() => activeRun.value?.status === 'in_progress')
+const allCaseIds = computed<string[]>(() => (data.value?.cases || []).map((c: any) => String(c.id)))
+const hasShelf = computed(() => (data.value?.groups || []).some((g: any) => (g.suites || []).length))
+
+const statusByCase = computed<Record<string, string>>(() => {
+  const m: Record<string, string> = {}
+  for (const r of results.value) m[String(r.case_id)] = r.status
+  return m
+})
+
+const summary = computed(() => {
+  const rs = results.value
+  const passed = rs.filter((r: any) => r.status === 'pass').length
+  const failed = rs.filter((r: any) => r.status === 'fail' || r.status === 'error').length
+  const done = rs.filter((r: any) => TERMINAL.includes(r.status)).length
+  // Total comes from what was launched, not from how many results exist yet —
+  // results appear as the run creates them, so the denominator would otherwise
+  // climb while the numerator does.
+  const total = launchedCaseIds.value.length || rs.length
+  return {
+    total, passed, failed, done,
+    inProgress: Math.max(0, total - done),
+    progressPercent: total > 0 ? Math.round((done / total) * 100) : 0,
+  }
+})
+
+const prettyStatus = computed(() => {
+  const s = activeRun.value?.status
+  if (s === 'in_progress') return t('agentsPage.evalStatusRunning')
+  if (s === 'success') return t('agentsPage.evalStatusPassed')
+  if (s === 'fail' || s === 'error') return t('agentsPage.evalStatusFailed')
+  return s || '—'
+})
+
+function suiteRollup(s: any) {
+  let passed = 0, failed = 0, done = 0
+  for (const c of (s.cases || [])) {
+    const st = statusByCase.value[String(c.id)]
+    if (st === 'pass') { passed++; done++ }
+    else if (st === 'fail' || st === 'error') { failed++; done++ }
+    else if (st === 'stopped') done++
+  }
+  return { passed, failed, done }
+}
 
 function statusSymbol(id: string) {
-  const s = caseStatus.value[id]
+  const s = statusByCase.value[String(id)]
   if (s === 'pass') return '✓'
   if (s === 'fail' || s === 'error') return '✗'
-  if (runState.value === 'running') return '·'
   return '·'
 }
 function statusColor(id: string) {
-  const s = caseStatus.value[id]
-  if (s === 'pass') return 'text-green-600'
-  if (s === 'fail' || s === 'error') return 'text-red-600'
-  return 'text-gray-300'
+  const s = statusByCase.value[String(id)]
+  if (s === 'pass') return 'text-green-600 dark:text-green-400'
+  if (s === 'fail' || s === 'error') return 'text-red-600 dark:text-red-400'
+  return 'text-gray-300 dark:text-gray-600'
 }
 
 async function load() {
   loaded.value = false
   try {
-    const res = await useMyFetch<any>(`/instructions/${props.instructionId}/resolved-evals`, { method: 'GET' })
+    const ids = (props.agentIds || []).filter(Boolean)
+    const q = ids.length ? `?agent_ids=${encodeURIComponent(ids.join(','))}` : ''
+    const res = await useMyFetch<any>(`/instructions/${props.instructionId}/resolved-evals${q}`, { method: 'GET' })
     data.value = res.data.value
   } catch (e) { data.value = null }
   loaded.value = true
 }
 
-async function runEval() {
-  if (!data.value?.cases?.length) return
-  runState.value = 'running'; passed.value = 0; failed.value = 0; doneCount.value = 0; caseStatus.value = {}
+async function runCases(caseIds: string[]) {
+  const ids = (caseIds || []).filter(Boolean)
+  if (!ids.length || isRunning.value) return
+  results.value = []
+  launchedCaseIds.value = ids
   try {
-    const body: any = { case_ids: data.value.cases.map((c: any) => c.id), trigger_reason: 'resolved_eval' }
+    const body: any = { case_ids: ids, trigger_reason: 'resolved_eval' }
     if (props.buildId) body.build_id = props.buildId
-    const res: any = await useMyFetch('/api/tests/runs', { method: 'POST', body })
+    const res: any = await useMyFetch('/api/tests/runs/batch', { method: 'POST', body })
     const run = res?.data?.value
-    if (!run?.id) { runState.value = 'idle'; return }
-    await poll(run.id)
+    if (!run?.id) { launchedCaseIds.value = []; return }
+    activeRun.value = run
+    await refreshRun()
+    startPoll()
   } catch (e) {
-    runState.value = 'idle'
+    launchedCaseIds.value = []
   }
 }
 
-async function poll(runId: string) {
-  const deadline = Date.now() + 8 * 60 * 1000
-  while (Date.now() < deadline) {
-    await new Promise(r => setTimeout(r, 2000))
-    try {
-      const res: any = await useMyFetch(`/api/tests/runs/${runId}/results`)
-      const results: any[] = res?.data?.value || []
-      const next: Record<string, string> = {}
-      for (const r of results) next[r.case_id] = r.status
-      caseStatus.value = next
-      passed.value = results.filter(r => r.status === 'pass').length
-      failed.value = results.filter(r => r.status === 'fail' || r.status === 'error').length
-      doneCount.value = results.filter(r => ['pass', 'fail', 'error', 'stopped'].includes(r.status)).length
-      if (doneCount.value >= (data.value?.case_count || 0) && doneCount.value > 0) break
-    } catch (e) { /* keep polling */ }
-  }
-  runState.value = 'done'
+async function refreshRun() {
+  const id = activeRun.value?.id
+  if (!id) return
+  try {
+    const [runRes, resRes]: any[] = await Promise.all([
+      useMyFetch<any>(`/api/tests/runs/${id}`),
+      useMyFetch<any[]>(`/api/tests/runs/${id}/results`),
+    ])
+    if (runRes?.data?.value) activeRun.value = runRes.data.value
+    results.value = resRes?.data?.value || []
+  } catch (e) { /* keep the last good view; the poll will retry */ }
 }
 
-watch(() => [props.instructionId, props.buildId], load)
+function stopPoll() { if (poll) { clearInterval(poll); poll = null } }
+function startPoll() {
+  if (poll) return
+  poll = setInterval(async () => {
+    await refreshRun()
+    if (activeRun.value && activeRun.value.status !== 'in_progress') stopPoll()
+  }, 2000)
+}
+
+watch(() => [props.instructionId, props.buildId, (props.agentIds || []).join(',')], load)
 onMounted(load)
+onBeforeUnmount(stopPoll)
 </script>

--- a/frontend/components/tools/CreateInstructionTool.vue
+++ b/frontend/components/tools/CreateInstructionTool.vue
@@ -135,7 +135,7 @@
               </span>
             </template>
             <!-- Resolved evals for this agent, pinned to the draft build -->
-            <ResolvedEvalStrip v-if="buildId" :instruction-id="instructionId" :build-id="buildId" class="ms-auto" />
+            <ResolvedEvalStrip v-if="buildId" :instruction-id="instructionId" :build-id="buildId" :agent-ids="reportAgentIds" class="ms-auto" />
           </div>
 
           <!-- Error message -->
@@ -183,12 +183,19 @@ interface Props {
   toolExecution: ToolExecution
   // Shared/public view: no click-to-edit, no accept/reject, no authed fetches.
   readonly?: boolean
+  /** The conversation's agents. Only used to scope the eval strip when the
+      created instruction is global (it then has no agents of its own). */
+  dataSources?: any[]
 }
 
 const props = defineProps<Props>()
 const emit = defineEmits<{
   (e: 'instruction-updated'): void
 }>()
+
+const reportAgentIds = computed<string[]>(() =>
+  (props.dataSources || []).map((d: any) => String(d?.id || '')).filter(Boolean)
+)
 
 const toast = useToast()
 const isExpanded = ref(true)

--- a/frontend/components/tools/EditInstructionTool.vue
+++ b/frontend/components/tools/EditInstructionTool.vue
@@ -180,7 +180,7 @@
         <!-- Resolved evals for this agent, pinned to the draft build this edit
              was staged into (training-mode self-check). -->
         <div v-if="isSuccess && instructionId && buildId" class="mt-1.5 px-1">
-          <ResolvedEvalStrip :instruction-id="instructionId" :build-id="buildId" />
+          <ResolvedEvalStrip :instruction-id="instructionId" :build-id="buildId" :agent-ids="reportAgentIds" />
         </div>
 
         <!-- Reason. Amber for a rejection — the edit was refused, nothing
@@ -247,6 +247,9 @@ interface Props {
       panel — so nothing on screen can change shape mid-run. The final state
       renders exactly once, from the refetched blocks. */
   turnActive?: boolean
+  /** The conversation's agents. Only used to scope the eval strip when the
+      edited instruction is global (it then has no agents of its own). */
+  dataSources?: any[]
 }
 
 const props = defineProps<Props>()
@@ -254,6 +257,11 @@ const emit = defineEmits<{
   (e: 'instruction-updated'): void
   (e: 'openInstruction', id: string, opts?: { initialVersionNumber?: number | null }): void
 }>()
+
+// Agents of the conversation, for the eval strip's global-instruction fallback.
+const reportAgentIds = computed<string[]>(() =>
+  (props.dataSources || []).map((d: any) => String(d?.id || '')).filter(Boolean)
+)
 
 const isExpanded = ref(true)
 // Set once the reader clicks this card's header: from then on its open/closed

--- a/locales/en.json
+++ b/locales/en.json
@@ -3500,6 +3500,18 @@
       "listContains": "list contains value",
       "listContainsAny": "list contains any",
       "listContainsAll": "list contains all"
+    },
+    "strip": {
+      "title": "Evals for this change",
+      "pinned": "pinned to this change",
+      "runAll": "Run all",
+      "runningCount": "Running {done}/{total}",
+      "runSuite": "Run {name}",
+      "orgWide": "Org-wide",
+      "fromChat": "in this chat",
+      "default": "default",
+      "emptyShelf": "No evals filed here yet",
+      "noneResolved": "No evals resolved for this agent yet"
     }
   },
   "monitoring": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -3219,6 +3219,18 @@
       "listContains": "lista contiene valor",
       "listContainsAny": "lista contiene alguno",
       "listContainsAll": "lista contiene todos"
+    },
+    "strip": {
+      "title": "Evaluaciones de este cambio",
+      "pinned": "fijado a este cambio",
+      "runAll": "Ejecutar todo",
+      "runningCount": "Ejecutando {done}/{total}",
+      "runSuite": "Ejecutar {name}",
+      "orgWide": "Toda la organización",
+      "fromChat": "en este chat",
+      "default": "predeterminado",
+      "emptyShelf": "Aún no hay evaluaciones aquí",
+      "noneResolved": "Aún no hay evaluaciones para este agente"
     }
   },
   "monitoring": {

--- a/locales/he.json
+++ b/locales/he.json
@@ -3219,6 +3219,18 @@
       "listContains": "הרשימה מכילה ערך",
       "listContainsAny": "הרשימה מכילה לפחות אחד",
       "listContainsAll": "הרשימה מכילה את כולם"
+    },
+    "strip": {
+      "title": "בדיקות איכות לשינוי הזה",
+      "pinned": "מקובע לשינוי הזה",
+      "runAll": "הרצת הכול",
+      "runningCount": "רץ {done}/{total}",
+      "runSuite": "הרצת {name}",
+      "orgWide": "כלל־ארגוני",
+      "fromChat": "בשיחה הזו",
+      "default": "ברירת מחדל",
+      "emptyShelf": "עדיין אין כאן בדיקות",
+      "noneResolved": "עדיין אין בדיקות איכות לסוכן הזה"
     }
   },
   "monitoring": {


### PR DESCRIPTION
The chevron next to "Run eval" on a staged instruction change did nothing when clicked, and the "Run eval" button next to it hung at `Running 0/1` forever. Both are fixed, and the panel behind the chevron now shows what the agents tree shows: the agent's **suites**, with the cases that will actually run underneath.

## Why the chevron did nothing

Its trigger button carried `@click.stop`, which cancelled the click before it reached the `UPopover` wrapper that toggles the panel. This is the same mechanism `MultiSelectFilter.vue` uses *deliberately* on its clear-✕ so that clearing does **not** open the panel — accidental here. It was the only `@click.stop` on a popover trigger in the codebase.

Independently, the trigger sat inside an `overflow-hidden` wrapper (there to round the split button's inner border), so even once it opened, a 288px panel would have been clipped to a 24px pill. The wrapper now rounds its children's outer edges instead of clipping, and the popper uses `strategy: 'fixed'`.

## What the panel shows

One group per agent, each listing its suites with the resolving cases underneath — mirroring the `EVALS` node in the agents tree.

Getting this right means honoring the distinction the `TestSuite` model documents: a suite is a **home**, a case's `data_source_ids_json` is its **scope**. The two disagree in both directions, so listing homed suites alone would be wrong twice over:

- a case filed in agent A's suite but **targeting B** must not appear under A;
- an agent-less "Auto" case filed in an org-wide suite **runs against every agent** and must appear under each.

So `resolved-evals` returns the union — every suite homed to the agent, plus every suite holding a case that resolves for it — and puts only the resolving case ids in each row. Homed suites appear even at zero cases, so an empty `Drafts` stays visible as the place the next eval lands.

## Global instructions

A global instruction has no agents of its own, and "every agent in the org" is not a runnable set — previously it rendered no run button at all. It now gets the org-wide agent-less cases **plus**, via a new `agent_ids` query param, the agents of the conversation the edit was made in, labelled `· in this chat` rather than passed off as the instruction's own scope. Those ids come from the client, so they are narrowed to what the caller may actually see before anything is returned.

## Why `Running 0/1` hung

The strip posted to `/tests/runs`, which only creates `init` placeholder results and leaves execution to whoever opens the run page's SSE stream (`TestRunService.create_run`). From a chat transcript nobody ever does, so the run sat untouched until the 15-minute watchdog errored it out — while the strip's own 8-minute poll gave up first and reported 0 passed / 0 failed.

Runs now go to `POST /tests/runs/batch`, which executes in the background itself (the same endpoint the suggestion-review panel and the agent's `run_eval` tool already use). Clicking a suite runs just that suite, by explicit case ids rather than `suite_id`: a suite-level run takes every case filed there, which for a shared suite is not what the rows say.

Under the tree sits the run block the suggestion-review panel already uses — status, `Cases/Pass/Fail/Running` chips, progress bar, and a link to `/evals/runs/{id}` — so the two controls report a run identically.

## Verification

Driven end to end against a local sandbox (backend + frontend + real LLM), through the UI:

- A real training-mode chat produced the `Edit instruction` cards; the chevron opens, and evals execute for real — judge verdicts, not setup errors (`status=fail`, no `failure_reason`).
- Confirmed in the DB that a suite-row click produced a 3-case run and "Run all" a 4-case run, both `trigger_reason=resolved_eval` with the draft `build_id` set.
- Both traps verified live: a case filed in Sales DB's suite but targeting Support DB appears only under Support DB; the org-wide Auto case appears once under Org-wide, not repeated (and re-run) per agent.
- Dark mode checked.

New: `backend/tests/e2e/test_resolved_evals.py` — 3 tests pinning both traps, the cross-group dedupe, and that `agent_ids` cannot widen what a caller may see. The endpoint had no coverage before.

Regression: 73 tests green across `test_eval`, `test_eval_drafts`, `test_rbac_evals`, `test_build`, `test_rbac_eval_suite_authority`.

## Note

Run state does not survive a page reload — the strip forgets a finished run on remount. That was true before this change too; re-attaching would need a "latest run for this build + cases" lookup. The run itself remains at `/evals/runs/{id}` and in the agent's Evals panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKY3aQAZPrQYoWz7u28epZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKY3aQAZPrQYoWz7u28epZ)_