### PR TITLE
Make Auto an empty agent scope, and persist the user's choice

### DIFF
--- a/backend/alembic/versions/usrdsdef01_add_membership_default_data_sources.py
+++ b/backend/alembic/versions/usrdsdef01_add_membership_default_data_sources.py
@@ -1,0 +1,40 @@
+"""add default_data_source_ids to memberships
+
+Revision ID: usrdsdef01
+Revises: oidcgrp01
+Create Date: 2026-08-08 00:00:00.000000
+
+Per-user default agent scope, scoped per organization (memberships is the
+per-user-per-org record, same as the custom-instructions note and the default
+LLM model). JSON list of data_source ids — soft references with no DB-level
+FK on purpose: a stale id (agent deleted, or access revoked later) is pruned
+at read time, so deletes never need to cascade here.
+
+NULL is the default and means Auto (no pin), which is also how a report
+encodes it. Nothing is backfilled: every existing member starts on Auto.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'usrdsdef01'
+down_revision: Union[str, None] = 'oidcgrp01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Idempotent add: dev databases may already carry the column from an
+    # earlier run of this migration while alembic_version points before it.
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("memberships")}
+    if "default_data_source_ids" not in cols:
+        op.add_column("memberships", sa.Column("default_data_source_ids", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("memberships")}
+    if "default_data_source_ids" in cols:
+        op.drop_column("memberships", "default_data_source_ids")

--- a/backend/app/models/membership.py
+++ b/backend/app/models/membership.py
@@ -26,6 +26,17 @@ class Membership(BaseSchema):
     # Per-user default LLM model for this org. Soft reference (no FK): a stale
     # value falls back to the org default at resolve time.
     default_llm_model_id = Column(String(36), nullable=True)
+    # Per-user default agent scope for this org: the data_source ids the user
+    # pinned in the prompt box, carried across sessions so a new report opens
+    # with the scope they last chose. JSON list of ids; soft references, same
+    # convention as default_llm_model_id — stale ids are pruned at read time
+    # rather than cascaded on delete.
+    #
+    # NULL and [] both mean Auto (no pin), matching how a report encodes it
+    # (see agent_focus_common.report_selection_is_auto): the scope is resolved
+    # per run against the user's access instead of frozen into a list. Storing
+    # every agent here would NOT be Auto — it would pin today's roster.
+    default_data_source_ids = Column(JSON, nullable=True)
     # Per-user, per-org profile attributes synced from the org's identity
     # provider (Entra ID Graph /me — job title, department, etc.). Populated on
     # login when the org enables Entra profile sync; rendered into the agent's

--- a/backend/app/routes/user_profile.py
+++ b/backend/app/routes/user_profile.py
@@ -23,10 +23,12 @@ from app.schemas.organization_schema import (
 )
 from app.services.organization_service import OrganizationService
 from app.services.llm_service import LLMService
+from app.services.data_source_service import DataSourceService
 
 router = APIRouter(tags=["users"])
 organization_service = OrganizationService()
 llm_service = LLMService()
+data_source_service = DataSourceService()
 
 
 class UserInstructionsSchema(BaseModel):
@@ -140,6 +142,60 @@ async def update_my_default_model(
     Self-service, but the model must be one the user is allowed to use."""
     model_id = await llm_service.set_user_default_model(db, organization, current_user, payload.model_id)
     return UserDefaultModelSchema(model_id=model_id)
+
+
+class UserDefaultAgentsSchema(BaseModel):
+    # data_source ids the user pinned in the prompt box. An EMPTY list is not
+    # "no agents" — it is Auto, the absence of a pin, which the backend
+    # resolves per run against the user's access (see
+    # agent_focus_common.report_selection_is_auto). Listing every agent here
+    # would instead freeze today's roster.
+    data_source_ids: list[str] = Field(default_factory=list)
+
+
+@router.get("/users/me/default_agents", response_model=UserDefaultAgentsSchema)
+async def get_my_default_agents(
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Return the current user's default agent scope for the active
+    organization, pruned to the agents they can still pin. A scope whose
+    agents have all gone away comes back empty — that is Auto, and it is the
+    right answer: it never leaves the picker naming an agent that isn't
+    there."""
+    membership = await _get_current_membership(db, current_user, organization)
+    stored = (membership.default_data_source_ids if membership else None) or []
+    ids = await data_source_service.filter_pinnable_data_source_ids(
+        db, stored, current_user, organization
+    )
+    return UserDefaultAgentsSchema(data_source_ids=ids)
+
+
+@router.put("/users/me/default_agents", response_model=UserDefaultAgentsSchema)
+async def update_my_default_agents(
+    payload: UserDefaultAgentsSchema,
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Set or clear (empty list = Auto) the current user's default agent
+    scope. Self-service: any member may pin their own scope, but only to
+    agents they can actually see — ids they can't are dropped rather than
+    rejected, so a stale tab racing an agent deletion still saves the rest.
+    The response is what was stored, so the client can reconcile."""
+    membership = await _get_current_membership(db, current_user, organization)
+    if not membership:
+        raise HTTPException(status_code=404, detail="Membership not found")
+
+    ids = await data_source_service.filter_pinnable_data_source_ids(
+        db, payload.data_source_ids, current_user, organization
+    )
+    # Store [] rather than NULL for a deliberate Auto: both read as Auto, and
+    # keeping the row distinguishable helps when debugging a user's scope.
+    membership.default_data_source_ids = ids
+    await db.commit()
+    return UserDefaultAgentsSchema(data_source_ids=ids)
 
 
 _AVATAR_MAX_BYTES = 5 * 1024 * 1024  # 5 MB upload cap

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2306,6 +2306,53 @@ class DataSourceService:
             out.append(ds)
         return out
 
+    async def filter_pinnable_data_source_ids(
+        self,
+        db: AsyncSession,
+        data_source_ids: list,
+        current_user: User | None,
+        organization: Organization,
+    ) -> list[str]:
+        """Keep only the ids that still name an agent this user may pin.
+
+        For stored agent *scopes* (the per-user default in
+        ``memberships.default_data_source_ids``) rather than live objects: an
+        id survives when the agent still exists in this organization, is
+        active and not soft-deleted, and the user can see it. Input order is
+        preserved and duplicates collapse, so a saved scope keeps the order
+        the user chose.
+
+        Pruning is silent by design — the same contract as the per-user
+        default model: an agent deleted, deactivated, or un-shared after being
+        picked must degrade the preference to Auto, never break the prompt box
+        with a scope naming an agent that isn't there.
+        """
+        wanted = [str(x) for x in (data_source_ids or []) if x]
+        if not wanted:
+            return []
+
+        result = await db.execute(
+            select(DataSource)
+            .options(lazyload("*"))
+            .where(
+                DataSource.id.in_(wanted),
+                DataSource.organization_id == str(organization.id),
+                DataSource.is_active == True,
+                DataSource.deleted_at.is_(None),
+            )
+        )
+        found = list(result.scalars().all())
+        visible = await self.filter_user_visible_data_sources(
+            db, found, current_user, organization
+        )
+        visible_ids = {str(ds.id) for ds in visible}
+
+        out: list[str] = []
+        for ds_id in wanted:
+            if ds_id in visible_ids and ds_id not in out:
+                out.append(ds_id)
+        return out
+
     async def filter_user_visible_data_sources(
         self,
         db: AsyncSession,

--- a/backend/tests/e2e/rbac/test_user_default_agents.py
+++ b/backend/tests/e2e/rbac/test_user_default_agents.py
@@ -1,0 +1,192 @@
+"""
+E2E tests for the per-user default agent scope
+(memberships.default_data_source_ids).
+
+Behavior under test:
+- an empty list is Auto, not "no agents": it is the default for a fresh
+  membership and what the prompt box renders as Auto, so the backend must never
+  substitute the whole roster for it;
+- any member can pin/clear their own scope (`PUT /users/me/default_agents`) and
+  read it back (`GET`), with order preserved and duplicates collapsed;
+- the preference is per user and per organization — one user's scope never
+  leaks into another's, and pinning in one org does not touch the other;
+- setting is scoped to what the caller can see: ids for agents they can't see
+  (or that don't exist) are dropped rather than 4xx, so a stale tab racing an
+  agent deletion still saves the rest;
+- resolution is lenient the same way the default-model preference is: an agent
+  deleted after being pinned silently disappears from the stored scope, and a
+  scope that loses every agent degrades to Auto instead of erroring.
+
+Uses the RBAC cast fixtures.
+"""
+import uuid
+
+import pytest
+
+
+def _headers(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _get_agents(test_client, token, org_id):
+    resp = test_client.get("/api/users/me/default_agents", headers=_headers(token, org_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data_source_ids"]
+
+
+def _put_agents(test_client, token, org_id, ids):
+    return test_client.put(
+        "/api/users/me/default_agents",
+        json={"data_source_ids": ids},
+        headers=_headers(token, org_id),
+    )
+
+
+@pytest.fixture
+def cast(test_client, bootstrap_admin, invite_user_to_org, sqlite_data_source):
+    """Admin + member in one org, with a public agent both can see and a
+    private one only the admin is a member of."""
+    admin = bootstrap_admin("agentdef")
+    member = invite_user_to_org(org_id=admin["org_id"], admin_token=admin["token"])
+    shared = sqlite_data_source(
+        name=f"shared_{uuid.uuid4().hex[:6]}",
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+        is_public=True,
+    )
+    private = sqlite_data_source(
+        name=f"private_{uuid.uuid4().hex[:6]}",
+        user_token=admin["token"],
+        org_id=admin["org_id"],
+        is_public=False,
+    )
+    return {
+        "admin": admin,
+        "member": member,
+        "org_id": admin["org_id"],
+        "shared_id": shared["id"],
+        "private_id": private["id"],
+    }
+
+
+# ── Auto is the default, and it is an empty list ─────────────────────────
+
+
+@pytest.mark.e2e
+def test_fresh_membership_defaults_to_auto(test_client, cast):
+    """A member who never picked anything is on Auto — and Auto is empty, NOT
+    every agent they can reach. Returning the roster here is what makes the
+    prompt box open with everything checked."""
+    assert _get_agents(test_client, cast["member"]["token"], cast["org_id"]) == []
+    assert _get_agents(test_client, cast["admin"]["token"], cast["org_id"]) == []
+
+
+@pytest.mark.e2e
+def test_member_pins_and_clears_own_scope(test_client, cast):
+    member_t, org = cast["member"]["token"], cast["org_id"]
+
+    resp = _put_agents(test_client, member_t, org, [cast["shared_id"]])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data_source_ids"] == [cast["shared_id"]]
+    assert _get_agents(test_client, member_t, org) == [cast["shared_id"]]
+
+    # Clearing is a first-class choice, and it lands back on Auto.
+    resp = _put_agents(test_client, member_t, org, [])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data_source_ids"] == []
+    assert _get_agents(test_client, member_t, org) == []
+
+
+@pytest.mark.e2e
+def test_scope_keeps_order_and_collapses_duplicates(test_client, cast):
+    admin_t, org = cast["admin"]["token"], cast["org_id"]
+    ordered = [cast["private_id"], cast["shared_id"]]
+
+    resp = _put_agents(test_client, admin_t, org, ordered + [cast["private_id"]])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data_source_ids"] == ordered
+    assert _get_agents(test_client, admin_t, org) == ordered
+
+
+# ── per user, per org ────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_scope_is_per_user(test_client, cast):
+    org = cast["org_id"]
+    assert _put_agents(test_client, cast["admin"]["token"], org, [cast["shared_id"]]).status_code == 200
+
+    # The other member is untouched by the admin's choice.
+    assert _get_agents(test_client, cast["member"]["token"], org) == []
+
+
+@pytest.mark.e2e
+def test_scope_is_per_organization(test_client, bootstrap_admin, sqlite_data_source):
+    """The scope lives on the membership, so each workspace carries its own —
+    ids from one org would not even resolve in the other."""
+    first = bootstrap_admin("agentdef_org1")
+    second = bootstrap_admin("agentdef_org2")
+    ds = sqlite_data_source(
+        name=f"a_{uuid.uuid4().hex[:6]}",
+        user_token=first["token"],
+        org_id=first["org_id"],
+        is_public=True,
+    )
+
+    assert _put_agents(test_client, first["token"], first["org_id"], [ds["id"]]).status_code == 200
+    assert _get_agents(test_client, first["token"], first["org_id"]) == [ds["id"]]
+    # A different org's membership starts on Auto and stays there.
+    assert _get_agents(test_client, second["token"], second["org_id"]) == []
+
+
+# ── access: writes are filtered, not rejected ────────────────────────────
+
+
+@pytest.mark.e2e
+def test_unknown_id_is_dropped_not_rejected(test_client, cast):
+    """A stale tab racing an agent deletion should still save the rest of the
+    scope rather than failing the whole write."""
+    member_t, org = cast["member"]["token"], cast["org_id"]
+    resp = _put_agents(test_client, member_t, org, [str(uuid.uuid4()), cast["shared_id"]])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data_source_ids"] == [cast["shared_id"]]
+
+
+@pytest.mark.e2e
+def test_member_cannot_pin_an_agent_they_cannot_see(test_client, cast):
+    """The private agent belongs to the admin only. A member naming it gets it
+    dropped — the preference must not become a way to reference (or discover)
+    an agent they have no access to."""
+    member_t, org = cast["member"]["token"], cast["org_id"]
+    resp = _put_agents(test_client, member_t, org, [cast["private_id"], cast["shared_id"]])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data_source_ids"] == [cast["shared_id"]]
+
+    # ...while the admin, who is a member of it, can.
+    admin_resp = _put_agents(test_client, cast["admin"]["token"], org, [cast["private_id"]])
+    assert admin_resp.status_code == 200, admin_resp.text
+    assert admin_resp.json()["data_source_ids"] == [cast["private_id"]]
+
+
+# ── stale scopes degrade to Auto rather than breaking ────────────────────
+
+
+@pytest.mark.e2e
+def test_deleted_agent_drops_out_and_empty_scope_reads_as_auto(test_client, cast):
+    """Resolution is lenient: a pinned agent that goes away is pruned on read,
+    and a scope that loses everything reads as Auto. A user preference must
+    never leave the picker naming an agent that isn't there."""
+    admin_t, org = cast["admin"]["token"], cast["org_id"]
+    assert _put_agents(test_client, admin_t, org, [cast["private_id"], cast["shared_id"]]).status_code == 200
+
+    del_resp = test_client.delete(
+        f"/api/data_sources/{cast['private_id']}", headers=_headers(admin_t, org)
+    )
+    assert del_resp.status_code in (200, 204), del_resp.text
+    assert _get_agents(test_client, admin_t, org) == [cast["shared_id"]]
+
+    del_resp = test_client.delete(
+        f"/api/data_sources/{cast['shared_id']}", headers=_headers(admin_t, org)
+    )
+    assert del_resp.status_code in (200, 204), del_resp.text
+    assert _get_agents(test_client, admin_t, org) == []

--- a/frontend/components/AgentSelector.vue
+++ b/frontend/components/AgentSelector.vue
@@ -255,6 +255,7 @@ const {
   isAllAgents,
   currentAgentName,
   selectedAgentObjects,
+  effectiveAgentObjects,
   consoleAgents,
   consoleSelectedAgents,
   consoleAgentName,
@@ -312,11 +313,14 @@ async function onCredentialsSaved() {
   await initAgent()
 }
 
-// Returns the connection type when exactly one agent is selected (for icon display)
+// Returns the connection type when exactly one agent is selected (for icon
+// display). Reads the RESOLVED list, not the pin, so a one-agent workspace on
+// Auto keeps showing that agent's icon next to its name — the trigger label
+// (`describeSelection`) names it in that case too.
 const singleSelectedConnection = computed(() => {
   const selected = props.consoleScope
     ? listAgents.value.filter(a => activeSelection.value.includes(a.id))
-    : selectedAgentObjects.value
+    : effectiveAgentObjects.value
   if (selected.length === 1) {
     return selected[0].connections?.[0]?.type || null
   }

--- a/frontend/components/automations/ScheduledTab.vue
+++ b/frontend/components/automations/ScheduledTab.vue
@@ -226,6 +226,8 @@ const openNewTask = async () => {
   if (creatingTask.value) return
   creatingTask.value = true
   try {
+    // Empty under Auto: a scheduled task inherits the same scope semantics as
+    // any other new report, and the modal lets the user pin agents explicitly.
     const dataSourceIds = selectedAgentObjects.value.map((a: any) => a.id)
     const response = await useMyFetch('/reports', {
       method: 'POST',

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -5,6 +5,8 @@
                 <button
                     class="inline-flex items-center text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md p-2 text-xs"
                     :disabled="isLoading"
+                    data-testid="agent-scope-trigger"
+                    :data-auto="isAutoMode ? 'true' : 'false'"
                 >
                     <span v-if="isLoading" class="flex items-center">
                         <Spinner class="w-4 h-4 text-gray-400 animate-spin" />
@@ -63,6 +65,8 @@
                                 <div
                                     class="px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer flex items-center justify-between"
                                     @click="toggleAutoMode"
+                                    data-testid="agent-scope-auto"
+                                    :data-selected="isAutoMode ? 'true' : 'false'"
                                 >
                                     <div class="flex items-center">
                                         <Icon name="heroicons-bolt" class="h-4 w-4 text-gray-500 dark:text-gray-400 me-2" />
@@ -88,6 +92,9 @@
                                     @click="() => { toggleDataSource(ds); }"
                                     @mouseenter="onDataSourceHover(ds.id, $event)"
                                     @mouseleave="onDataSourceHoverLeave()"
+                                    data-testid="agent-scope-option"
+                                    :data-agent-name="ds.name"
+                                    :data-selected="(!isAutoMode && isSelected(ds)) ? 'true' : 'false'"
                                 >
                                     <div class="flex items-center min-w-0">
                                         <DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon="ds.icon" class="h-4 flex-shrink-0" />

--- a/frontend/composables/useAgent.ts
+++ b/frontend/composables/useAgent.ts
@@ -1,7 +1,16 @@
 /**
  * Agent selection composable.
  * Manages which agents (data sources) are currently selected/filtered.
- * Selection is persisted to localStorage so it survives page refreshes.
+ *
+ * The selection IS the user's agent scope, and an empty selection is Auto —
+ * "whatever I can access, resolved per run" — not "every agent, pinned". See
+ * utils/agentSelection.ts; the distinction is the whole reason
+ * `selectedAgentObjects` and `effectiveAgentObjects` are separate below.
+ *
+ * It persists per user per organization in `memberships.default_data_source_ids`
+ * (GET/PUT /users/me/default_agents), with localStorage as a same-origin cache
+ * so the prompt box renders the right scope on first paint instead of flashing
+ * Auto until the request lands. The server value always wins on reconcile.
  */
 import { useCan, useHasOrgWideConsole } from '~/composables/usePermissions'
 
@@ -31,42 +40,48 @@ interface Agent {
   connections: AgentConnection[]  // Now an array of connections
 }
 
-// Storage key for persisting agent selection
+// Cache key for the agent selection. Org-scoped: the scope lives on the
+// membership, so one workspace's pinned agents must not surface as another's —
+// the ids wouldn't even resolve there.
 const STORAGE_KEY = 'bow_selected_agents'
 const LEGACY_STORAGE_KEY = 'bow_selected_domains'
+const storageKeyFor = (orgId: string | null) => (orgId ? `${STORAGE_KEY}:${orgId}` : STORAGE_KEY)
 
-// Load saved selection from localStorage
-function loadFromStorage(): string[] {
-  if (typeof window === 'undefined') return []
+function readJsonArray(key: string): string[] | null {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) return JSON.parse(stored)
-    // One-time migration from legacy key so users don't lose their selection.
-    const legacy = localStorage.getItem(LEGACY_STORAGE_KEY)
-    if (legacy) {
-      localStorage.setItem(STORAGE_KEY, legacy)
-      localStorage.removeItem(LEGACY_STORAGE_KEY)
-      return JSON.parse(legacy)
-    }
-    return []
+    const raw = localStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.map((x: any) => String(x)) : null
   } catch {
-    return []
+    return null
   }
 }
 
+// Load the cached selection for an org. Falls back to the pre-org-scoped keys
+// once, so an existing user's pinned agents survive the move to per-org keys
+// (and the older `bow_selected_domains` rename before it).
+function loadFromStorage(orgId: string | null): string[] {
+  if (typeof window === 'undefined') return []
+  const scoped = readJsonArray(storageKeyFor(orgId))
+  if (scoped) return scoped
+  return readJsonArray(STORAGE_KEY) || readJsonArray(LEGACY_STORAGE_KEY) || []
+}
+
 // Save selection to localStorage
-function saveToStorage(agentIds: string[]) {
+function saveToStorage(agentIds: string[], orgId: string | null) {
   if (typeof window === 'undefined') return
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(agentIds))
+    localStorage.setItem(storageKeyFor(orgId), JSON.stringify(agentIds))
   } catch (e) {
     console.warn('Failed to save agent selection:', e)
   }
 }
 
-// Global state (shared across components)
-// Initialize from localStorage if available
-const selectedAgents = ref<string[]>(loadFromStorage())
+// Global state (shared across components). Starts on Auto and is filled by
+// initAgentPreference() — the org isn't known at module-evaluation time, and
+// the cache is keyed by it.
+const selectedAgents = ref<string[]>([])
 const agents = ref<Agent[]>([])
 const loading = ref(false)
 let watcherInitialized = false
@@ -88,13 +103,121 @@ const consoleAgentPool = ref<Agent[]>([])
 let inflightConsolePool: Promise<void> | null = null
 let consolePoolLoadedAt = 0
 
+// Persistence state for the per-user agent scope. `preferenceOrgId` is the org
+// the current selection belongs to, so a workspace switch reloads rather than
+// saving one org's ids onto another's membership.
+let preferenceOrgId: string | null = null
+let preferenceLoaded = false
+let inflightPreference: Promise<void> | null = null
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+// What the membership is known to hold. Applying the loaded scope trips the
+// watcher — Vue flushes it a tick later, by which point the load has finished —
+// so without this every page load would PUT the value it just read back,
+// overwriting anything another tab or device changed in between.
+let serverIds: string[] | null = null
+// Selections come in bursts (a click on one row can clear a pin and set
+// another), and each one is a PUT. Coalesce them.
+const PREFERENCE_SAVE_DEBOUNCE_MS = 400
+
+const sameIds = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((id, i) => id === b[i])
+
 export function useAgent() {
-  // Set up watcher to persist selection changes (only once)
+  // Set up watcher to persist selection changes (only once). The cache write is
+  // synchronous so a reload paints the right scope immediately; the server
+  // write is debounced and only runs once the preference has been loaded — a
+  // watcher firing during the initial load would otherwise PUT the cached value
+  // straight back and undo a change made from another device.
   if (!watcherInitialized && typeof window !== 'undefined') {
     watch(selectedAgents, (newSelection) => {
-      saveToStorage(newSelection)
+      const ids = [...newSelection]
+      saveToStorage(ids, preferenceOrgId)
+      if (!preferenceLoaded) return
+      // Already what the membership holds — either this IS the loaded value
+      // arriving, or the user landed back on it mid-debounce. Drop any pending
+      // write too: the intermediate value it carries is no longer the scope.
+      if (serverIds && sameIds(ids, serverIds)) {
+        if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+        return
+      }
+      if (saveTimer) clearTimeout(saveTimer)
+      saveTimer = setTimeout(() => { saveTimer = null; void persistPreference(ids) }, PREFERENCE_SAVE_DEBOUNCE_MS)
     }, { deep: true })
     watcherInitialized = true
+  }
+
+  // Write the scope to the caller's membership. Failures are non-fatal: the
+  // selection still applies to this session and stays in the local cache, so a
+  // blip in this request never blocks the user from picking an agent.
+  async function persistPreference(ids: string[]) {
+    try {
+      const { data } = await useMyFetch<{ data_source_ids: string[] }>('/users/me/default_agents', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data_source_ids: ids }),
+      })
+      // The server prunes ids the user may no longer pin, so reconcile — but
+      // only if the user hasn't moved on to a different selection since.
+      const stored = (data.value as any)?.data_source_ids
+      if (!Array.isArray(stored)) return
+      serverIds = [...stored]
+      if (sameIds([...selectedAgents.value], ids) && !sameIds(stored, ids)) {
+        selectedAgents.value = stored
+      }
+    } catch (error) {
+      console.warn('Failed to persist agent selection:', error)
+    }
+  }
+
+  // Load the stored scope for the active org: cache first (so first paint is
+  // right), then the membership value, which wins. Safe to call from several
+  // components — concurrent callers share one request, and it only reloads when
+  // the org changes or `force` is passed.
+  async function initAgentPreference(opts: { force?: boolean } = {}) {
+    if (typeof window === 'undefined') return
+    const { organization, ensureOrganization } = useOrganization()
+    await ensureOrganization()
+    const orgId = organization.value?.id || null
+
+    if (!opts.force && preferenceLoaded && preferenceOrgId === orgId) return
+    if (!opts.force && inflightPreference && preferenceOrgId === orgId) return inflightPreference
+
+    if (preferenceOrgId !== orgId) {
+      // New workspace: drop the old org's scope before anything can save it
+      // back, and stop treating it as loaded.
+      preferenceLoaded = false
+      preferenceOrgId = orgId
+      serverIds = null
+      if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+      selectedAgents.value = loadFromStorage(orgId)
+    }
+
+    inflightPreference = (async () => {
+      try {
+        const { data } = await useMyFetch<{ data_source_ids: string[] }>('/users/me/default_agents')
+        const ids = (data.value as any)?.data_source_ids
+        // No usable answer (useMyFetch reports HTTP failures through `error`,
+        // not by throwing) — leave `preferenceLoaded` false so we keep the
+        // cached scope and never write a guess back over the stored one.
+        if (!Array.isArray(ids)) return
+        const loaded = ids.map((x: any) => String(x))
+        serverIds = [...loaded]
+        if (!sameIds(loaded, [...selectedAgents.value])) {
+          selectedAgents.value = loaded
+        }
+        preferenceLoaded = true
+      } catch (error) {
+        // Offline or a 5xx: keep the cached scope for this session rather than
+        // silently resetting the user to Auto. Leaving `preferenceLoaded` false
+        // also keeps us from writing that guess back to the membership.
+        console.warn('Failed to load agent selection:', error)
+      }
+    })()
+    try {
+      await inflightPreference
+    } finally {
+      inflightPreference = null
+    }
   }
 
   // Watch for agents list changes and clean up stale selections
@@ -233,13 +356,32 @@ export function useAgent() {
   // a refetch happens only when the selection actually changes.
   const consoleSelectionKey = computed(() => consoleSelectedAgents.value.join(','))
 
-  // Computed: get the selected agent objects
-  const selectedAgentObjects = computed(() => {
-    if (selectedAgents.value.length === 0) {
-      return agents.value // All agents when none selected
-    }
-    return agents.value.filter(a => selectedAgents.value.includes(a.id))
-  })
+  // The agents the user actually pinned. Empty under Auto — and it must STAY
+  // empty: Auto is the absence of a pin, not a pin covering everything (see
+  // utils/agentSelection.ts). Fanning it out here is what used to make the
+  // prompt box open with every agent checked, so picking one meant unchecking
+  // the rest, and what made every new report freeze today's roster instead of
+  // resolving its scope per run.
+  //
+  // A pinned id the loaded list doesn't cover yet keeps its place as a bare
+  // {id} rather than dropping out — same reasoning as `alignSelection` in
+  // DataSourceSelector. Dropping it would WIDEN the scope (an empty selection
+  // is Auto), and since the saved scope arrives before `agents` does, dropping
+  // would briefly render Auto and let that echo back as a real change,
+  // overwriting the user's pin with Auto. Stale ids are cleaned by the watcher
+  // below, once the list is actually loaded.
+  const agentsById = computed(() => new Map(agents.value.map(a => [a.id, a])))
+  const selectedAgentObjects = computed(() =>
+    selectedAgents.value.map(id => agentsById.value.get(id) || ({ id, connections: [] } as unknown as Agent))
+  )
+
+  // The agents the current selection RESOLVES to right now — the pinned ones,
+  // or the whole roster under Auto. For callers that need something concrete to
+  // render or fetch against (starter prompts, the instructions panel). Never
+  // use this to build a report's `data_sources`: it turns Auto into a pin.
+  const effectiveAgentObjects = computed(() =>
+    selectedAgents.value.length === 0 ? agents.value : selectedAgentObjects.value
+  )
 
   // Toggle agent selection
   function toggleAgent(agentId: string | null) {
@@ -329,6 +471,7 @@ export function useAgent() {
     isAllAgents,
     currentAgentName,
     selectedAgentObjects,
+    effectiveAgentObjects,
     consoleAgents,
     hasConsoleAgents,
     consoleSelectedAgents,
@@ -339,6 +482,7 @@ export function useAgent() {
     toggleAgent,
     isAgentSelected,
     initAgent,
+    initAgentPreference,
     initConsoleAgents,
     setAgents,
     clearSelection,

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -729,7 +729,7 @@
   })
   
   // Agent management - use selectedAgentObjects for new report creation
-  const { initAgent, selectedAgentObjects, agents, hasAgents } = useAgent()
+  const { initAgent, initAgentPreference, selectedAgentObjects, agents, hasAgents } = useAgent()
 
   // Projects (shared folders) shown above the recent reports list.
   const { projects, fetchProjects, createProject, updateProject, deleteProject, moveReport } = useProjects()
@@ -785,6 +785,10 @@
         await Promise.all([
           fetchOnboarding({ in_onboarding: false }),
           initAgent(),
+          // The user's saved agent scope (membership-backed). Loaded here, not
+          // on the home page, because "New report" in this sidebar creates a
+          // report from it too.
+          initAgentPreference(),
           fetchRecentReports(),
           fetchProjects()
         ])
@@ -1297,8 +1301,10 @@ const createNewReport = async () => {
   
   try {
     // Inside a project, hand the choice of agents to the project's defaults
-    // (see useNewReportProjectContext). Outside one, use the selected agents
-    // from AgentSelector, or all agents if none selected.
+    // (see useNewReportProjectContext). Outside one, use the agents pinned in
+    // AgentSelector — empty when the selection is Auto, which is exactly how
+    // the backend encodes Auto (it resolves the scope per run instead of
+    // freezing today's roster onto the report).
     const dataSourceIds = activeProjectId.value
       ? []
       : selectedAgentObjects.value.map((a: any) => a.id)

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -34,6 +34,7 @@
           :initialSelectedDataSources="selectedDataSources"
           :compact="true"
           @update:modelValue="handlePromptUpdate"
+          @update:selectedDataSources="onAgentScopeChanged"
           @openInstructions="showInstructionsModal = true"
         />
       </div>
@@ -79,12 +80,13 @@
               :textareaContent="textareaContent"
               :initialSelectedDataSources="selectedDataSources"
               @update:modelValue="handlePromptUpdate"
+              @update:selectedDataSources="onAgentScopeChanged"
               @openInstructions="showInstructionsModal = true"
           />
       </div>
-      <div class="w-full mx-auto mt-0 space-x-3 space-y-3" v-if="selectedDataSources">
+      <div class="w-full mx-auto mt-0 space-x-3 space-y-3" v-if="resolvedDataSources">
         <DataSourceQuestionsHome
-            :data_sources="selectedDataSources"
+            :data_sources="resolvedDataSources"
             @update-content="updateTextarea"
         />
       </div>
@@ -180,21 +182,37 @@ import McpIcon from '~/components/icons/McpIcon.vue';
 import { useCan } from '~/composables/usePermissions'
 const router = useRouter()
 const { onboarding, fetchOnboarding } = useOnboarding()
-const { selectedAgentObjects } = useAgent()
+const { selectedAgentObjects, effectiveAgentObjects, selectedAgents, selectAgents } = useAgent()
 const previous_reports = ref<any[]>([])
 const models = ref<any[]>([])
 const isLoading = ref(true)
 const hasLoadedModels = ref(false)
 
-// Use selected agents from AgentSelector as the data sources
+// What the prompt box opens with: the agents the user pinned, which under Auto
+// is nothing at all. Handing it the resolved roster instead would render Auto
+// as "all agents selected" and pin them onto the report this page creates.
 const selectedDataSources = computed(() => selectedAgentObjects.value)
+// What the selection resolves to today — for panels that need concrete agents
+// to fetch/render against rather than a scope to send to the backend.
+const resolvedDataSources = computed(() => effectiveAgentObjects.value)
 
-// Instructions modal: the agents the panel shows = the prompt box's current
-// selection (in auto-mode that's every agent) followed by an always-present
+// Picking agents in the prompt box IS the user's scope choice, so it feeds the
+// shared selection and persists to their membership. Guarded against the round
+// trip: the box mirrors `selectedDataSources` back on every prop sync, and
+// re-setting the same ids would re-save on each keystroke-driven re-render.
+const onAgentScopeChanged = (list: any[]) => {
+  const ids = (list || []).map((ds: any) => String(ds.id))
+  const current = [...selectedAgents.value]
+  if (ids.length === current.length && ids.every((id, i) => id === current[i])) return
+  selectAgents(ids)
+}
+
+// Instructions modal: the agents the panel shows = what the prompt box's scope
+// resolves to (under Auto that's every agent) followed by an always-present
 // "Global" entry for instructions attached to no agent.
 const showInstructionsModal = ref(false)
 const instructionPanelAgents = computed(() => [
-  ...(selectedDataSources.value || []),
+  ...(resolvedDataSources.value || []),
   { id: '__global__', name: 'Global', isGlobal: true },
 ])
 const onInstructionStarter = (starter: string) => {

--- a/frontend/pages/reports/index.vue
+++ b/frontend/pages/reports/index.vue
@@ -873,6 +873,8 @@ const createNewReport = async () => {
     if (creatingReport.value) return
     creatingReport.value = true
     try {
+        // Empty under Auto — the backend reads that as "resolve my scope per
+        // run", so don't substitute the whole roster here.
         const dataSourceIds = selectedAgentObjects.value.map((a: any) => a.id)
 
         const response: any = await useMyFetch('/reports', {

--- a/frontend/tests/home/agent-scope.spec.ts
+++ b/frontend/tests/home/agent-scope.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '../fixtures/feature-test';
+
+/**
+ * The prompt box's agent scope is a MODE, not a set (see
+ * frontend/utils/agentSelection.ts): Auto means "no agent pinned", and the
+ * backend resolves it per run. Rendering Auto as "every agent selected" both
+ * forces the user to deselect their way down to one agent and pins today's
+ * whole roster onto every report the home page creates.
+ */
+
+const trigger = (page) => page.getByTestId('agent-scope-trigger').first();
+
+async function openScopePanel(page) {
+  // The panel stays open after picking a row, so close anything already open
+  // before toggling — otherwise the click just dismisses it.
+  await page.mouse.click(20, 20);
+  await page.waitForTimeout(400);
+  await trigger(page).click();
+  await expect(page.getByTestId('agent-scope-auto')).toBeVisible({ timeout: 15000 });
+}
+
+test('the prompt box opens on Auto, with no agent pinned', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'commit' });
+  await page.waitForLoadState('domcontentloaded');
+  await expect(trigger(page)).toBeVisible({ timeout: 20000 });
+
+  await openScopePanel(page);
+  const options = page.getByTestId('agent-scope-option');
+  if ((await options.count()) === 0) test.skip(true, 'workspace has no agents to scope');
+
+  await expect(page.getByTestId('agent-scope-auto')).toHaveAttribute('data-selected', 'true');
+  // The point of the test: Auto is empty. Not one row is checked.
+  await expect(options.filter({ has: page.locator('[data-selected="true"]') })).toHaveCount(0);
+  for (const option of await options.all()) {
+    await expect(option).toHaveAttribute('data-selected', 'false');
+  }
+});
+
+test('picking one agent from Auto pins exactly that agent', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'commit' });
+  await page.waitForLoadState('domcontentloaded');
+  await expect(trigger(page)).toBeVisible({ timeout: 20000 });
+
+  await openScopePanel(page);
+  const options = page.getByTestId('agent-scope-option');
+  if ((await options.count()) === 0) test.skip(true, 'workspace has no agents to scope');
+
+  const target = options.first();
+  const name = await target.getAttribute('data-agent-name');
+  await target.click();
+  await page.waitForTimeout(1000);
+
+  await openScopePanel(page);
+  await expect(page.getByTestId('agent-scope-auto')).toHaveAttribute('data-selected', 'false');
+  await expect(page.locator('[data-testid="agent-scope-option"][data-selected="true"]')).toHaveCount(1);
+  await expect(page.locator(`[data-testid="agent-scope-option"][data-agent-name="${name}"]`))
+    .toHaveAttribute('data-selected', 'true');
+
+  // ...and Auto is one click back, not N.
+  await page.getByTestId('agent-scope-auto').click();
+  await page.waitForTimeout(1000);
+  await openScopePanel(page);
+  await expect(page.getByTestId('agent-scope-auto')).toHaveAttribute('data-selected', 'true');
+  await expect(page.locator('[data-testid="agent-scope-option"][data-selected="true"]')).toHaveCount(0);
+});


### PR DESCRIPTION
The prompt box rendered Auto as "every agent checked", so picking one
agent meant unchecking the rest, and every report the home page created
was hard-pinned to the whole roster.

Auto is a mode, not a set (utils/agentSelection.ts): no agent pinned,
resolved per run against the user's access. The picker already modelled
it that way, but `useAgent().selectedAgentObjects` fanned an empty
selection out into every agent, and pages/index.vue handed that to
PromptBoxV2 as the current selection. So Auto never reached the picker,
and `POST /reports` carried every agent id — leaving
`report_selection_is_auto` false, freezing today's roster onto the
report, and never picking up agents added later.

Keep the empty selection empty all the way to the wire, and split off
`effectiveAgentObjects` for the callers that genuinely need the resolved
list (starter prompts, the instructions panel) rather than a scope to
send to the backend.

Also persist the scope per user per org, alongside the existing default
LLM model preference:

- `memberships.default_data_source_ids` (JSON, NULL/[] = Auto)
- `GET/PUT /users/me/default_agents`, self-service, filtered to agents
  the caller can see; stale ids are pruned on read the same way a stale
  default model silently falls back, so a preference can never leave the
  picker naming an agent that isn't there
- picking agents in the home prompt box now feeds that preference;
  localStorage stays as an org-keyed cache so first paint is right

Existing reports are untouched: a report's own `data_sources` still wins,
manual pins still render as pins, and changing a report's agents does not
touch the user's default.

Verified against a live sandbox (backend + frontend + real LLM): the
default scope now posts `data_sources: []` where it previously posted all
three agent ids, an Auto report resolves at run time to the same three
agents and completes normally, and pre-existing pinned reports keep their
scope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014F5fr2Mvta4HP3xCV8rebV