### PR TITLE
Scope eval automation to chosen suites (multi-select) + encryption-key hardening

### DIFF
--- a/backend/app/routes/agent_reliability.py
+++ b/backend/app/routes/agent_reliability.py
@@ -40,6 +40,11 @@ class AutomationSettingsResponse(BaseModel):
     # Active eval cases resolved for this agent (incl. Auto/global cases). Used
     # by the UI to disable the "Run evals…" modes when there's nothing to run.
     eval_case_count: int = 0
+    # Suites that carry ≥1 active eval case for this agent, each with its case
+    # count. Feeds the "run this suite only" dropdown in the Self Learning modal
+    # and the Run-evals modal. ``id=None`` is never emitted here — "all cases" is
+    # represented client-side.
+    suites: List[Dict[str, Any]] = []
 
 
 class AutomationRunSchema(BaseModel):
@@ -88,10 +93,33 @@ async def _build_settings_response(
             org_defaults = getattr(org_defaults, "value", {}) or {}
     except Exception:
         org_defaults = {}
+    eval_case_count = 0
+    suites: List[Dict[str, Any]] = []
     try:
-        eval_case_count = len(await rel_service.list_agent_eval_case_ids(db, str(organization.id), str(ds.id)))
+        case_ids = await rel_service.list_agent_eval_case_ids(db, str(organization.id), str(ds.id))
+        eval_case_count = len(case_ids)
+        # Group this agent's active cases by suite, resolve suite names, and
+        # return only suites that actually carry cases for this agent.
+        if case_ids:
+            from app.models.eval import TestCase, TestSuite
+            from sqlalchemy import select as _select
+            rows = (await db.execute(
+                _select(TestCase.suite_id).where(TestCase.id.in_([str(c) for c in case_ids]))
+            )).scalars().all()
+            counts: Dict[str, int] = {}
+            for sid in rows:
+                counts[str(sid)] = counts.get(str(sid), 0) + 1
+            name_rows = (await db.execute(
+                _select(TestSuite.id, TestSuite.name).where(TestSuite.id.in_(list(counts.keys())))
+            )).all()
+            names = {str(i): n for i, n in name_rows}
+            suites = [
+                {"id": sid, "name": names.get(sid, sid), "case_count": cnt}
+                for sid, cnt in counts.items()
+            ]
+            suites.sort(key=lambda s: (s["name"] or "").lower())
     except Exception:
-        eval_case_count = 0
+        eval_case_count = eval_case_count or 0
     return AutomationSettingsResponse(
         data_source_id=str(ds.id),
         reliability_status=ds.reliability_status or "training",
@@ -100,6 +128,7 @@ async def _build_settings_response(
         org_defaults=org_defaults if isinstance(org_defaults, dict) else {},
         effective=effective.model_dump(),
         eval_case_count=eval_case_count,
+        suites=suites,
     )
 
 

--- a/backend/app/schemas/agent_automation_schema.py
+++ b/backend/app/schemas/agent_automation_schema.py
@@ -49,6 +49,11 @@ class AgentAutomationPolicy(BaseModel):
     # The single dropdown.
     mode: str = MODE_OFF
 
+    # Optional: restrict the evals this policy runs to a single suite. When
+    # ``None`` the agent's full active eval set is used (every case scoped to
+    # this agent, plus Auto/global cases). Only meaningful for the eval modes.
+    suite_id: Optional[str] = None
+
     # Advanced — only meaningful for ``eval_auto``.
     auto_fix_on_failure: bool = False        # train -> re-eval on failure
     on_repeated_failure: str = ON_FAILURE_TRAINING

--- a/backend/app/schemas/agent_automation_schema.py
+++ b/backend/app/schemas/agent_automation_schema.py
@@ -18,7 +18,7 @@ through :meth:`stage` and the ``mode`` / derived flags.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -49,10 +49,12 @@ class AgentAutomationPolicy(BaseModel):
     # The single dropdown.
     mode: str = MODE_OFF
 
-    # Optional: restrict the evals this policy runs to a single suite. When
-    # ``None`` the agent's full active eval set is used (every case scoped to
-    # this agent, plus Auto/global cases). Only meaningful for the eval modes.
-    suite_id: Optional[str] = None
+    # Optional: restrict the evals this policy runs to a set of suites. When
+    # ``None``/empty the agent's full active eval set is used (every case scoped
+    # to this agent, plus Auto/global cases) — this is also what "all suites
+    # selected" saves as. A non-empty list runs the union of those suites' cases.
+    # Only meaningful for the eval modes.
+    suite_ids: Optional[List[str]] = None
 
     # Advanced — only meaningful for ``eval_auto``.
     auto_fix_on_failure: bool = False        # train -> re-eval on failure

--- a/backend/app/services/agent_reliability_service.py
+++ b/backend/app/services/agent_reliability_service.py
@@ -112,7 +112,7 @@ class AgentReliabilityService:
 
     async def list_agent_eval_case_ids(
         self, db, organization_id: str, data_source_id: str, statuses: Optional[Set[str]] = None,
-        suite_id: Optional[str] = None,
+        suite_ids: Optional[List[str]] = None,
     ) -> List[str]:
         """Active eval cases that belong to this agent.
 
@@ -121,8 +121,9 @@ class AgentReliabilityService:
         — the test-case analogue of a global instruction. Org-scoped via the
         suite chain so Auto cases from other orgs don't leak in.
 
-        When ``suite_id`` is given the result is further narrowed to that one
-        suite — the Self-Learning "run this suite only" setting.
+        When ``suite_ids`` is a non-empty list the result is further narrowed to
+        those suites — the Self-Learning "run these suites only" setting. An
+        empty/None list means "all suites".
         """
         from app.models.eval import TestSuite
         statuses = statuses or {TEST_CASE_STATUS_ACTIVE}
@@ -132,8 +133,8 @@ class AgentReliabilityService:
             .where(TestSuite.organization_id == str(organization_id))
             .where(TestCase.deleted_at.is_(None))
         )
-        if suite_id:
-            stmt = stmt.where(TestCase.suite_id == str(suite_id))
+        if suite_ids:
+            stmt = stmt.where(TestCase.suite_id.in_([str(s) for s in suite_ids]))
         rows = (await db.execute(stmt)).scalars().all()
         out: List[str] = []
         for c in rows:
@@ -222,7 +223,7 @@ class AgentReliabilityService:
                 detail={"reason": "an automation run is already in progress for this agent"},
             )
 
-        case_ids = await self.list_agent_eval_case_ids(db, org_id, ds_id, suite_id=policy.suite_id)
+        case_ids = await self.list_agent_eval_case_ids(db, org_id, ds_id, suite_ids=policy.suite_ids)
         if not case_ids:
             return await self._record(
                 db, org_id, ds_id, trigger, STATUS_NO_EVALS, user=user,
@@ -945,7 +946,7 @@ class AgentReliabilityService:
             case_ids: List[str] = []
             seen: Set[str] = set()
             for ds, _pol in eval_agents:
-                for cid in await self.list_agent_eval_case_ids(db, org_id, str(ds.id), suite_id=_pol.suite_id):
+                for cid in await self.list_agent_eval_case_ids(db, org_id, str(ds.id), suite_ids=_pol.suite_ids):
                     if cid not in seen:
                         seen.add(cid); case_ids.append(cid)
 

--- a/backend/app/services/agent_reliability_service.py
+++ b/backend/app/services/agent_reliability_service.py
@@ -111,7 +111,8 @@ class AgentReliabilityService:
     # ----- eval discovery -----------------------------------------------------
 
     async def list_agent_eval_case_ids(
-        self, db, organization_id: str, data_source_id: str, statuses: Optional[Set[str]] = None
+        self, db, organization_id: str, data_source_id: str, statuses: Optional[Set[str]] = None,
+        suite_id: Optional[str] = None,
     ) -> List[str]:
         """Active eval cases that belong to this agent.
 
@@ -119,6 +120,9 @@ class AgentReliabilityService:
         agent, or is **Auto/empty** (no explicit agents), which means "all agents"
         — the test-case analogue of a global instruction. Org-scoped via the
         suite chain so Auto cases from other orgs don't leak in.
+
+        When ``suite_id`` is given the result is further narrowed to that one
+        suite — the Self-Learning "run this suite only" setting.
         """
         from app.models.eval import TestSuite
         statuses = statuses or {TEST_CASE_STATUS_ACTIVE}
@@ -128,6 +132,8 @@ class AgentReliabilityService:
             .where(TestSuite.organization_id == str(organization_id))
             .where(TestCase.deleted_at.is_(None))
         )
+        if suite_id:
+            stmt = stmt.where(TestCase.suite_id == str(suite_id))
         rows = (await db.execute(stmt)).scalars().all()
         out: List[str] = []
         for c in rows:
@@ -216,7 +222,7 @@ class AgentReliabilityService:
                 detail={"reason": "an automation run is already in progress for this agent"},
             )
 
-        case_ids = await self.list_agent_eval_case_ids(db, org_id, ds_id)
+        case_ids = await self.list_agent_eval_case_ids(db, org_id, ds_id, suite_id=policy.suite_id)
         if not case_ids:
             return await self._record(
                 db, org_id, ds_id, trigger, STATUS_NO_EVALS, user=user,
@@ -939,7 +945,7 @@ class AgentReliabilityService:
             case_ids: List[str] = []
             seen: Set[str] = set()
             for ds, _pol in eval_agents:
-                for cid in await self.list_agent_eval_case_ids(db, org_id, str(ds.id)):
+                for cid in await self.list_agent_eval_case_ids(db, org_id, str(ds.id), suite_id=_pol.suite_id):
                     if cid not in seen:
                         seen.add(cid); case_ids.append(cid)
 

--- a/backend/app/settings/bow_config.py
+++ b/backend/app/settings/bow_config.py
@@ -267,7 +267,20 @@ class BowConfig(BaseModel):
 
     @validator('encryption_key')
     def validate_encryption_key(cls, v):
-        # If the value is empty or still the placeholder, generate a valid key:
+        # If the value is empty or still the placeholder, generate a valid key.
+        # An ephemeral, process-local key is fine for a throwaway run but is a
+        # footgun in any persistent deployment: it changes on every restart, so
+        # everything encrypted with it (LLM provider keys, data-source
+        # credentials) becomes permanently undecryptable after a restart. Warn
+        # loudly so operators pin BOW_ENCRYPTION_KEY instead of silently
+        # bricking their stored secrets.
         if not v or v.strip() in {"", "${BOW_ENCRYPTION_KEY}"}:
+            import logging
+            logging.getLogger(__name__).warning(
+                "BOW_ENCRYPTION_KEY is not set — generating a random, in-memory "
+                "encryption key. It will change on the next restart, making all "
+                "currently-encrypted credentials undecryptable. Set a stable "
+                "BOW_ENCRYPTION_KEY for any non-throwaway deployment."
+            )
             return generate_fernet_key()
         return v

--- a/frontend/components/AgentAutomationSettings.vue
+++ b/frontend/components/AgentAutomationSettings.vue
@@ -24,22 +24,29 @@
       </p>
     </div>
 
-    <!-- Suite selector — which suite's cases the evals run against -->
+    <!-- Suite selector — which suites' cases the evals run against (multi-select) -->
     <div v-if="runsEvals && hasEvals">
       <label class="block text-sm font-medium text-gray-900 dark:text-white mb-1.5">Evaluate against</label>
       <USelectMenu
-        v-model="form.suite_id"
+        v-model="form.suite_ids"
         :options="suiteOptions"
         value-attribute="value"
         option-attribute="label"
+        multiple
         :disabled="!canManage"
         size="md"
         class="w-full"
         :ui="{ width: 'w-full' }"
         @update:model-value="markDirty"
-      />
+      >
+        <template #label>
+          <span v-if="allSuitesSelected">All suites ({{ evalCaseCount }} cases)</span>
+          <span v-else-if="form.suite_ids.length">{{ form.suite_ids.length }} suite{{ form.suite_ids.length === 1 ? '' : 's' }} · {{ selectedCaseCount }} cases</span>
+          <span v-else class="text-gray-400 dark:text-gray-500">No suites selected</span>
+        </template>
+      </USelectMenu>
       <p class="mt-1.5 text-[11px] text-gray-400 dark:text-gray-500">
-        Pick a suite to run only its cases, or all active cases for this agent.
+        All suites run by default — deselect any to narrow the evals.
       </p>
     </div>
 
@@ -95,7 +102,7 @@ const canManage = computed(() => props.agentId ? useCan('manage', { type: 'data_
 
 const defaultForm = () => ({
   mode: 'off',
-  suite_id: 'all',
+  suite_ids: [] as string[],
   auto_fix_on_failure: false,
   on_repeated_failure: 'training',
   max_iterations: 3,
@@ -105,10 +112,10 @@ const evalCaseCount = ref(0)
 const hasEvals = computed(() => evalCaseCount.value > 0)
 const runsEvals = computed(() => form.value.mode === 'eval_review' || form.value.mode === 'eval_auto')
 const suites = ref<Array<{ id: string; name: string; case_count: number }>>([])
-const suiteOptions = computed(() => [
-  { value: 'all', label: `All active cases (${evalCaseCount.value})` },
-  ...suites.value.map(s => ({ value: s.id, label: `${s.name} (${s.case_count})` })),
-])
+const suiteOptions = computed(() => suites.value.map(s => ({ value: s.id, label: `${s.name} (${s.case_count})` })))
+const allSuiteIds = computed(() => suites.value.map(s => s.id))
+const allSuitesSelected = computed(() => suites.value.length > 0 && (form.value.suite_ids?.length || 0) === suites.value.length)
+const selectedCaseCount = computed(() => suites.value.filter(s => (form.value.suite_ids || []).includes(s.id)).reduce((a, s) => a + (s.case_count || 0), 0))
 const modeOptions = computed(() => [
   { value: 'off', label: 'Wait for review' },
   { value: 'auto_approve', label: 'Auto-approve (no evals)' },
@@ -137,15 +144,12 @@ async function loadAutomation() {
     const data: any = res.data.value
     if (!data) return
     form.value = { ...defaultForm(), ...(data.effective || {}) }
-    // Normalize the "all cases" sentinel to 'all' so the select shows its label
-    // (USelectMenu renders an empty/null value as a blank placeholder).
-    if (form.value.suite_id == null) form.value.suite_id = 'all'
     evalCaseCount.value = data.eval_case_count || 0
     suites.value = Array.isArray(data.suites) ? data.suites : []
-    // Drop a stale suite pin (suite deleted / no longer carries agent cases).
-    if (form.value.suite_id && !suites.value.some(s => s.id === form.value.suite_id)) {
-      form.value.suite_id = 'all'
-    }
+    // Empty/null suite_ids means "all suites" — show every suite selected by
+    // default. A stored subset keeps only the ids that still exist.
+    const stored = Array.isArray(form.value.suite_ids) ? form.value.suite_ids.filter((id: string) => allSuiteIds.value.includes(id)) : []
+    form.value.suite_ids = stored.length ? stored : [...allSuiteIds.value]
     dirty.value = false; savedOk.value = false
   } catch (e) { /* noop */ }
 }
@@ -154,7 +158,9 @@ async function saveSettings() {
   if (!id) return
   savingSettings.value = true; savedOk.value = false
   try {
-    await useMyFetch(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value, suite_id: (form.value.suite_id && form.value.suite_id !== 'all') ? form.value.suite_id : null } })
+    // All suites selected → store null ("all", also picks up future suites).
+    const suite_ids = allSuitesSelected.value ? null : (form.value.suite_ids || [])
+    await useMyFetch(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value, suite_ids } })
     savedOk.value = true; dirty.value = false; emit('saved'); await loadAutomation()
   } catch (e) { toast.add({ title: 'Failed to save Self Learning settings', color: 'red' }) }
   finally { savingSettings.value = false }

--- a/frontend/components/AgentAutomationSettings.vue
+++ b/frontend/components/AgentAutomationSettings.vue
@@ -24,6 +24,25 @@
       </p>
     </div>
 
+    <!-- Suite selector — which suite's cases the evals run against -->
+    <div v-if="runsEvals && hasEvals">
+      <label class="block text-sm font-medium text-gray-900 dark:text-white mb-1.5">Evaluate against</label>
+      <USelectMenu
+        v-model="form.suite_id"
+        :options="suiteOptions"
+        value-attribute="value"
+        option-attribute="label"
+        :disabled="!canManage"
+        size="md"
+        class="w-full"
+        :ui="{ width: 'w-full' }"
+        @update:model-value="markDirty"
+      />
+      <p class="mt-1.5 text-[11px] text-gray-400 dark:text-gray-500">
+        Pick a suite to run only its cases, or all active cases for this agent.
+      </p>
+    </div>
+
     <!-- Effective behavior summary -->
     <div class="flex items-start gap-2 rounded-md bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/30 px-3 py-2">
       <UIcon name="i-heroicons-information-circle" class="w-4 h-4 text-blue-500 dark:text-blue-400 shrink-0 mt-0.5" />
@@ -76,6 +95,7 @@ const canManage = computed(() => props.agentId ? useCan('manage', { type: 'data_
 
 const defaultForm = () => ({
   mode: 'off',
+  suite_id: 'all',
   auto_fix_on_failure: false,
   on_repeated_failure: 'training',
   max_iterations: 3,
@@ -83,6 +103,12 @@ const defaultForm = () => ({
 const form = ref<Record<string, any>>(defaultForm())
 const evalCaseCount = ref(0)
 const hasEvals = computed(() => evalCaseCount.value > 0)
+const runsEvals = computed(() => form.value.mode === 'eval_review' || form.value.mode === 'eval_auto')
+const suites = ref<Array<{ id: string; name: string; case_count: number }>>([])
+const suiteOptions = computed(() => [
+  { value: 'all', label: `All active cases (${evalCaseCount.value})` },
+  ...suites.value.map(s => ({ value: s.id, label: `${s.name} (${s.case_count})` })),
+])
 const modeOptions = computed(() => [
   { value: 'off', label: 'Wait for review' },
   { value: 'auto_approve', label: 'Auto-approve (no evals)' },
@@ -111,7 +137,15 @@ async function loadAutomation() {
     const data: any = res.data.value
     if (!data) return
     form.value = { ...defaultForm(), ...(data.effective || {}) }
+    // Normalize the "all cases" sentinel to 'all' so the select shows its label
+    // (USelectMenu renders an empty/null value as a blank placeholder).
+    if (form.value.suite_id == null) form.value.suite_id = 'all'
     evalCaseCount.value = data.eval_case_count || 0
+    suites.value = Array.isArray(data.suites) ? data.suites : []
+    // Drop a stale suite pin (suite deleted / no longer carries agent cases).
+    if (form.value.suite_id && !suites.value.some(s => s.id === form.value.suite_id)) {
+      form.value.suite_id = 'all'
+    }
     dirty.value = false; savedOk.value = false
   } catch (e) { /* noop */ }
 }
@@ -120,7 +154,7 @@ async function saveSettings() {
   if (!id) return
   savingSettings.value = true; savedOk.value = false
   try {
-    await useMyFetch(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value } })
+    await useMyFetch(`/data_sources/${id}/automation`, { method: 'PATCH', body: { ...form.value, suite_id: (form.value.suite_id && form.value.suite_id !== 'all') ? form.value.suite_id : null } })
     savedOk.value = true; dirty.value = false; emit('saved'); await loadAutomation()
   } catch (e) { toast.add({ title: 'Failed to save Self Learning settings', color: 'red' }) }
   finally { savingSettings.value = false }

--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -120,8 +120,8 @@
                 <div class="flex items-center justify-between mb-3">
                     <div class="text-xs text-gray-500 dark:text-gray-400">Every eval run — manual checks and automation.</div>
                     <UButton v-if="canManage && !isGlobal && agentCases.length > 0" color="blue" size="xs" variant="soft" icon="i-heroicons-bolt"
-                        :loading="triggering" @click="runAutomationNow">
-                        Run evals now
+                        @click="openRunEvalsModal">
+                        Run evals
                     </UButton>
                 </div>
                 <div v-if="canManage && !isGlobal && autoEnabled === false" class="mb-4 flex items-center justify-between gap-3 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/40 px-3 py-2">
@@ -186,6 +186,35 @@
             @created="onCaseCreated"
             @updated="onCaseUpdated"
         />
+
+        <!-- Run evals — pick a suite and run its cases -->
+        <UModal v-model="showRunEvals" :ui="{ width: 'sm:max-w-md' }">
+            <div class="p-5">
+                <div class="flex items-center gap-2 mb-3">
+                    <UIcon name="i-heroicons-bolt" class="w-4 h-4 text-blue-500" />
+                    <div class="text-sm font-semibold text-gray-900 dark:text-white">Run evals</div>
+                </div>
+                <label class="block text-sm font-medium text-gray-900 dark:text-white mb-1.5">Suite</label>
+                <USelectMenu
+                    v-model="runEvalsSuiteId"
+                    :options="runEvalsSuiteOptions"
+                    value-attribute="value"
+                    option-attribute="label"
+                    size="md"
+                    class="w-full"
+                    :ui="{ width: 'w-full' }"
+                />
+                <p class="mt-1.5 text-[11px] text-gray-400 dark:text-gray-500">
+                    Runs every active case in the selected suite as one test run.
+                </p>
+                <div class="flex justify-end gap-2 mt-5">
+                    <button class="px-3 py-1.5 text-xs border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50" @click="showRunEvals = false">Cancel</button>
+                    <UButton color="blue" size="sm" :disabled="runEvalsCount === 0" :loading="triggering" @click="runEvalsFromModal">
+                        Run {{ runEvalsCount }} eval{{ runEvalsCount === 1 ? '' : 's' }}
+                    </UButton>
+                </div>
+            </div>
+        </UModal>
 
         <!-- Self Learning (per-agent automation policy) -->
         <UModal v-model="showSelfLearning" :ui="{ width: 'sm:max-w-lg' }">
@@ -634,6 +663,52 @@ const reliabilityStatus = ref('training')
 const publishStatus = ref('published')
 const showSelfLearning = ref(false)
 function onSelfLearningSaved() { toast.add({ title: 'Self Learning settings saved', color: 'green' }) }
+
+// --- Run-evals modal: pick a suite, run its cases as one test run ---
+const showRunEvals = ref(false)
+const runEvalsSuiteId = ref('all')
+// This agent's cases grouped by suite → id list + resolved suite name.
+const suiteGroups = computed(() => {
+    const m = new Map<string, { name: string; ids: string[] }>()
+    for (const c of agentCases.value) {
+        const g = m.get(c.suite_id) || { name: suitesById.value[c.suite_id] || c.suite_name || '—', ids: [] }
+        g.ids.push(c.id); m.set(c.suite_id, g)
+    }
+    return m
+})
+const runEvalsSuiteOptions = computed(() => {
+    const opts: Array<{ value: string; label: string }> = [{ value: 'all', label: `All cases (${agentCases.value.length})` }]
+    for (const [sid, g] of suiteGroups.value) opts.push({ value: sid, label: `${g.name} (${g.ids.length})` })
+    return opts
+})
+const runEvalsCount = computed(() => {
+    if (runEvalsSuiteId.value === 'all') return agentCases.value.length
+    const g = suiteGroups.value.get(runEvalsSuiteId.value)
+    return g ? g.ids.length : 0
+})
+function openRunEvalsModal() {
+    const ids = [...suiteGroups.value.keys()]
+    runEvalsSuiteId.value = ids.length === 1 ? ids[0] : 'all'
+    showRunEvals.value = true
+}
+async function runEvalsFromModal() {
+    const case_ids = runEvalsSuiteId.value !== 'all'
+        ? (suiteGroups.value.get(runEvalsSuiteId.value)?.ids || [])
+        : agentCases.value.map(c => c.id)
+    if (!case_ids.length) return
+    triggering.value = true
+    try {
+        const res: any = await useMyFetch('/api/tests/runs', { method: 'POST', body: { case_ids, trigger_reason: 'manual' } })
+        if (res?.error?.value) throw res.error.value
+        const run = res?.data?.value
+        showRunEvals.value = false
+        activeTab.value = 'runs'
+        if (run?.id) openRunId.value = String(run.id)
+        setTimeout(() => loadRuns(), 1000)
+    } catch (e) {
+        toast.add({ title: 'Failed to run evals', color: 'red' })
+    } finally { triggering.value = false }
+}
 
 const autoRuns = ref<any[]>([])
 const loadingAutoRuns = ref(false)

--- a/frontend/components/AgentEvalsPanel.vue
+++ b/frontend/components/AgentEvalsPanel.vue
@@ -194,18 +194,25 @@
                     <UIcon name="i-heroicons-bolt" class="w-4 h-4 text-blue-500" />
                     <div class="text-sm font-semibold text-gray-900 dark:text-white">Run evals</div>
                 </div>
-                <label class="block text-sm font-medium text-gray-900 dark:text-white mb-1.5">Suite</label>
+                <label class="block text-sm font-medium text-gray-900 dark:text-white mb-1.5">Suites</label>
                 <USelectMenu
-                    v-model="runEvalsSuiteId"
+                    v-model="runEvalsSuiteIds"
                     :options="runEvalsSuiteOptions"
                     value-attribute="value"
                     option-attribute="label"
+                    multiple
                     size="md"
                     class="w-full"
                     :ui="{ width: 'w-full' }"
-                />
+                >
+                    <template #label>
+                        <span v-if="runEvalsAllSelected">All suites ({{ agentCases.length }} cases)</span>
+                        <span v-else-if="runEvalsSuiteIds.length">{{ runEvalsSuiteIds.length }} suite{{ runEvalsSuiteIds.length === 1 ? '' : 's' }} · {{ runEvalsCount }} cases</span>
+                        <span v-else class="text-gray-400 dark:text-gray-500">No suites selected</span>
+                    </template>
+                </USelectMenu>
                 <p class="mt-1.5 text-[11px] text-gray-400 dark:text-gray-500">
-                    Runs every active case in the selected suite as one test run.
+                    Runs every case in the selected suites as one test run.
                 </p>
                 <div class="flex justify-end gap-2 mt-5">
                     <button class="px-3 py-1.5 text-xs border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50" @click="showRunEvals = false">Cancel</button>
@@ -666,7 +673,7 @@ function onSelfLearningSaved() { toast.add({ title: 'Self Learning settings save
 
 // --- Run-evals modal: pick a suite, run its cases as one test run ---
 const showRunEvals = ref(false)
-const runEvalsSuiteId = ref('all')
+const runEvalsSuiteIds = ref<string[]>([])
 // This agent's cases grouped by suite → id list + resolved suite name.
 const suiteGroups = computed(() => {
     const m = new Map<string, { name: string; ids: string[] }>()
@@ -676,25 +683,22 @@ const suiteGroups = computed(() => {
     }
     return m
 })
-const runEvalsSuiteOptions = computed(() => {
-    const opts: Array<{ value: string; label: string }> = [{ value: 'all', label: `All cases (${agentCases.value.length})` }]
-    for (const [sid, g] of suiteGroups.value) opts.push({ value: sid, label: `${g.name} (${g.ids.length})` })
-    return opts
-})
-const runEvalsCount = computed(() => {
-    if (runEvalsSuiteId.value === 'all') return agentCases.value.length
-    const g = suiteGroups.value.get(runEvalsSuiteId.value)
-    return g ? g.ids.length : 0
-})
+const runEvalsSuiteOptions = computed(() =>
+    [...suiteGroups.value.entries()].map(([sid, g]) => ({ value: sid, label: `${g.name} (${g.ids.length})` })))
+const runEvalsAllSelected = computed(() => suiteGroups.value.size > 0 && runEvalsSuiteIds.value.length === suiteGroups.value.size)
+const runEvalsCount = computed(() =>
+    runEvalsSuiteIds.value.reduce((n, sid) => n + (suiteGroups.value.get(sid)?.ids.length || 0), 0))
 function openRunEvalsModal() {
-    const ids = [...suiteGroups.value.keys()]
-    runEvalsSuiteId.value = ids.length === 1 ? ids[0] : 'all'
+    // Default: all suites selected.
+    runEvalsSuiteIds.value = [...suiteGroups.value.keys()]
     showRunEvals.value = true
 }
 async function runEvalsFromModal() {
-    const case_ids = runEvalsSuiteId.value !== 'all'
-        ? (suiteGroups.value.get(runEvalsSuiteId.value)?.ids || [])
-        : agentCases.value.map(c => c.id)
+    const seen = new Set<string>()
+    const case_ids: string[] = []
+    for (const sid of runEvalsSuiteIds.value) {
+        for (const id of (suiteGroups.value.get(sid)?.ids || [])) { if (!seen.has(id)) { seen.add(id); case_ids.push(id) } }
+    }
     if (!case_ids.length) return
     triggering.value = true
     try {


### PR DESCRIPTION
## What

Lets an agent's evals target specific suites, in both the Self Learning policy and a new Run-evals modal, and hardens the encryption-key footgun that silently breaks credentials on restart.

### 1. Suite scoping for evals (multi-select, all suites on by default)
- The per-agent automation policy gains `suite_ids` (a list). When set, the self-learning evals (`eval_review` / `eval_auto`, incl. the auto-fix loop) run only the union of those suites' cases; empty/null = all active cases (unchanged behaviour). `list_agent_eval_case_ids` gained a `suite_ids` filter, and the effective-policy response now returns the agent's suites with case counts to feed the pickers.
- **Self Learning modal**: an "Evaluate against" multi-select. Trigger reads "All suites (N cases)" or "K suites · M cases". All-selected saves as `null` (stays "all" and picks up suites added later); a subset saves the explicit list.
- **Test Runs panel**: "Run evals" now opens a modal with the same multi-select and a dynamic **"Run N evals"** button (sum of the selected suites' cases), running their union as one test run. Defaults to all suites selected.

### 2. Encryption-key hardening
With `BOW_ENCRYPTION_KEY` unset the config silently generates a random, process-local Fernet key. That's fine for a throwaway run but a footgun in a persistent deployment: the key changes on every restart, so everything encrypted with it (LLM provider API keys, data-source credentials) becomes permanently undecryptable — the agent then fails every LLM call and connection with "Failed to decrypt credentials". This PR emits a loud WARNING at config load so operators pin a stable key instead of discovering the loss after a restart.

## Verification (sandbox, PostgreSQL + Claude Haiku, driven through the UI)

- **Suite pickers**: both modals default to all suites checked; deselecting narrows the label/count; Self Learning persists `suite_ids` (subset ↔ null round-trips), and the Run-evals button reflects the selection ("Run 8 evals" → "Run 6 evals" after deselecting a 2-case suite) and creates a run with exactly that many cases.
- **Backend**: `suite_ids` round-trips through the policy schema, PATCH validation, and the effective-policy response, and scopes the automation's case set.
- **Advanced Self Learning, end-to-end with real evals** (after pinning a stable key so the server-side eval path runs green): a breaking instruction → `instruction_change` automation → baseline eval genuinely fails → auto-fix loop runs its iterations, drafting a fix instruction per candidate build and re-evaluating → on give-up, `on_repeated_failure` applies: `training` → agent `reliability_status` becomes **training**, `development` → becomes **development**. Both fallbacks confirmed; passing suites correctly set status back to **ok**.

## Notes
- No new automated tests were added for the `suite_ids` plumbing — a backend test asserting the automation's case set narrows to the pinned suites would be a good follow-up.
- The encryption change is only a warning; it does not alter behaviour when a key is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmyBr1JbrTC3e7PfPUabJ7)_