### PR TITLE
Persist report agent changes to the user's default scope

### DIFF
--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -593,8 +593,11 @@ async function persistSelectionIfReport() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ data_sources: ids })
         })
-        // Surface the resulting agent_scope_changed session-event strip.
-        window.dispatchEvent(new CustomEvent('report:mutated', { detail: { reportId: props.reportId, kind: 'data_sources' } }))
+        // Surface the resulting agent_scope_changed session-event strip. Carry
+        // the new ids so listeners can react without re-reading state that a
+        // downstream async watch may not have flushed yet (e.g. the report page
+        // mirroring this scope into the user's default).
+        window.dispatchEvent(new CustomEvent('report:mutated', { detail: { reportId: props.reportId, kind: 'data_sources', ids } }))
     } catch (e) {
         console.error('Failed to update report data sources:', e)
     }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -4154,9 +4154,26 @@ onMounted(() => {
     markdownAutoDir.value = useMarkdownAutoDir()
 })
 
+// Mirror a report's agent scope into the user's default (memberships
+// default_data_source_ids), the same store the home-page prompt box persists
+// to — so changing agents inside a report also seeds the next new report.
+// selectedAgents is read-only here; selectAgents writes it, tripping the
+// debounced PUT /users/me/default_agents watcher in useAgent.
+const { selectAgents, selectedAgents } = useAgent()
+
 function onReportMutated(ev: CustomEvent) {
     const rid = ev?.detail?.reportId
     if (rid && String(rid) !== String(report_id)) return
+    // Only genuine user toggles dispatch this with `ids` (persistSelectionIfReport);
+    // report hydration never does, so opening a report can't silently overwrite the
+    // default. Guard against a no-op re-save when the scope already matches.
+    if (ev?.detail?.kind === 'data_sources' && Array.isArray(ev.detail.ids)) {
+        const ids = ev.detail.ids.map((id: any) => String(id))
+        const current = [...selectedAgents.value]
+        if (!(ids.length === current.length && ids.every((id: string, i: number) => id === current[i]))) {
+            selectAgents(ids)
+        }
+    }
     onReportFilesChanged()
 }
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary

Changing agents inside an open report (`/reports/[id]`) now also updates the user's **default agent scope** (`memberships.default_data_source_ids`) — so the next new report inherits it, mirroring the home-page prompt box.

Previously, per-report persistence (`PUT /reports/{id}`) already worked, but it was deliberately decoupled from the user default. This wires that propagation while keeping the trap-avoidance intact.

## Changes

- **`frontend/components/prompt/DataSourceSelector.vue`** — the `report:mutated` event already emitted on a genuine agent toggle now carries the new `ids` in its detail, so listeners don't have to re-read state that a downstream async `watch` hasn't flushed yet.
- **`frontend/pages/reports/[id]/index.vue`** — `onReportMutated` handles `kind: 'data_sources'` by calling `selectAgents(ids)` from `useAgent`, which trips the existing debounced `PUT /users/me/default_agents` watcher and localStorage cache.

## Why it's safe

- The hook fires **only** from `persistSelectionIfReport()` — i.e. real user toggles — and **never** on report hydration, so opening a report can't silently overwrite the user's default.
- A no-op guard skips re-saving when the scope already matches the current default.
- Ids are carried in the event rather than read from `currentAgents`, because the parent re-emit (`PromptBoxV2.vue` `watch`) flushes *after* the event dispatches and would otherwise be a tick stale.

## Behavioral note

This intentionally reverses the earlier decoupling: narrowing one report's agents now moves the global default too. That is the requested behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaBc1wUbx3PzkWqcvAhwt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaBc1wUbx3PzkWqcvAhwt6)_