### PR TITLE
Make Snowflake schema field optional to support database-wide indexing

### DIFF
--- a/backend/app/data_sources/clients/snowflake_client.py
+++ b/backend/app/data_sources/clients/snowflake_client.py
@@ -28,7 +28,11 @@ class SnowflakeClient(DataSourceClient):
         account,
         warehouse,
         database,
-        schema,
+        # Optional: blank means "discover across the whole database". The
+        # service layer strips empty config values before constructing the
+        # client, so a required `schema` blew up as a missing positional arg
+        # whenever the (optional) Schema field was left empty in the UI.
+        schema: Optional[str] = None,
         user: Optional[str] = None,
         password: Optional[str] = None,
         private_key_pem: Optional[str] = None,

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -391,7 +391,12 @@ class SnowflakeConfig(BaseModel):
     account: str = Field(..., title="Account", description="The unique account identifier. For example: ABCDEF-GHIJKL", json_schema_extra={"ui:type": "string"})
     warehouse: str = Field(..., title="Warehouse", description="", json_schema_extra={"ui:type": "string"})
     database: str = Field(..., title="Database", description="", json_schema_extra={"ui:type": "string"})
-    schema: str = Field(..., title="Schema", description="Can be a comma-separated list of schemas", json_schema_extra={"ui:type": "string"})
+    schema: Optional[str] = Field(
+        None,
+        title="Schema",
+        description="Optional schema or comma-separated list of schemas (leave empty to index the whole database)",
+        json_schema_extra={"ui:type": "string"},
+    )
     role: Optional[str] = Field(
         None,
         title="Role",


### PR DESCRIPTION
## Summary
Updated the Snowflake data source configuration to make the schema field optional, allowing users to index an entire database without specifying individual schemas.

## Key Changes
- **Schema field is now optional** in `SnowflakeConfig`: Changed from required `str` to `Optional[str]` with a default value of `None`
- **Updated field description** to clarify that leaving the schema empty will index the whole database
- **Fixed client initialization** in `SnowflakeClient`: Made the `schema` parameter optional with a default value of `None` to prevent errors when the schema field is left empty in the UI

## Implementation Details
The schema field previously required a value, which caused issues when users wanted to discover and index all schemas across an entire database. By making it optional, users can now:
- Leave the schema field empty to index the entire database
- Provide a single schema name or comma-separated list of schemas for targeted indexing

The service layer strips empty config values before constructing the client, so making the schema parameter optional in the client constructor prevents missing positional argument errors when the UI field is left blank.

https://claude.ai/code/session_01WR9oVn432K2eKsLFGaHMXt