### PR TITLE
Stop the agent-scope e2e test clicking the onboarding banner

### DIFF
--- a/frontend/pages/onboarding/data/index.vue
+++ b/frontend/pages/onboarding/data/index.vue
@@ -49,6 +49,7 @@
                     :key="`demo-${demo.id}`"
                     @click="installDemo(demo.id)"
                     :disabled="installingDemo === demo.id"
+                    :data-testid="`onboarding-demo-${demo.id}`"
                     class="inline-flex items-center gap-2 px-3 py-1.5 text-xs text-gray-600 dark:text-gray-400 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <Spinner v-if="installingDemo === demo.id" class="h-3" />

--- a/frontend/tests/home/agent-scope.spec.ts
+++ b/frontend/tests/home/agent-scope.spec.ts
@@ -13,10 +13,20 @@ const trigger = (page) => page.getByTestId('agent-scope-trigger').first();
 async function openScopePanel(page) {
   // The panel stays open after picking a row, so close anything already open
   // before toggling — otherwise the click just dismisses it.
-  await page.mouse.click(20, 20);
+  //
+  // Escape, not a click at a fixed coordinate: the top of the viewport can be
+  // covered by the fixed onboarding banner (layouts/default.vue), which is a
+  // full-width link to the onboarding wizard. Clicking blind at (20, 20) hit
+  // it on CI and navigated away from the prompt box entirely.
+  await page.keyboard.press('Escape');
   await page.waitForTimeout(400);
-  await trigger(page).click();
-  await expect(page.getByTestId('agent-scope-auto')).toBeVisible({ timeout: 15000 });
+  // If Escape didn't take, the panel is still open — toggling now would close
+  // it, so only click when it's actually shut.
+  const auto = page.getByTestId('agent-scope-auto');
+  if (!(await auto.isVisible().catch(() => false))) {
+    await trigger(page).click();
+  }
+  await expect(auto).toBeVisible({ timeout: 15000 });
 }
 
 test('the prompt box opens on Auto, with no agent pinned', async ({ page }) => {

--- a/frontend/tests/onboarding/onboarding-wizard.spec.ts
+++ b/frontend/tests/onboarding/onboarding-wizard.spec.ts
@@ -109,18 +109,24 @@ test.describe('Onboarding Wizard', () => {
     // Wait for data source options to load
     await page.waitForTimeout(2000);
     
-    // Look for and click a sample database (Chinook)
-    const sampleButton = page.getByRole('button', { name: /chinook/i });
-    
-    if (await sampleButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+    // Install the Chinook sample database. Matched by test id, not by label:
+    // this used to look for a button named /chinook/i, but the demo is
+    // presented under its display name ("Music Store"), so the match silently
+    // failed and the run fell through to the assert-only branch below. The org
+    // then had no data source for the whole suite, which left the fixed
+    // onboarding banner up on every page for every later test.
+    const sampleButton = page.getByTestId('onboarding-demo-chinook');
+    const alreadyInstalled = !(await sampleButton.isVisible({ timeout: 10000 }).catch(() => false));
+
+    if (!alreadyInstalled) {
       await sampleButton.click();
-      
+
       // Wait for installation and navigation to schema page
       await page.waitForURL('**/schema', { timeout: 30000 });
-      
+
       // On schema page, wait for it to load
       await page.waitForLoadState('domcontentloaded');
-      
+
       // Look for continue/save button
       const continueButton = page.getByRole('button', { name: /continue|save|next/i }).first();
       if (await continueButton.isVisible({ timeout: 10000 }).catch(() => false)) {
@@ -128,7 +134,8 @@ test.describe('Onboarding Wizard', () => {
         await page.waitForLoadState('domcontentloaded');
       }
     } else {
-      // If no sample DB, look for any data source type to verify page works
+      // Only reachable on a retry, where the demo is installed already and so
+      // no longer listed. Verify the page still renders its connector picker.
       const dsTypes = page.locator('button').filter({ hasText: /sqlite|postgres|duckdb|mysql/i }).first();
       await expect(dsTypes).toBeVisible({ timeout: 10000 });
     }


### PR DESCRIPTION
The two `tests/home/agent-scope.spec.ts` tests have timed out on **every** e2e run since they landed in `29b5a82` — they are the only reason the workflow is red ([latest run](https://github.com/bagofwords1/bagofwords/actions/runs/31276007058/job/93149504792)). Not flaky: all three attempts fail identically.

## What was happening

`openScopePanel()` closed any stray popover with `page.mouse.click(20, 20)`. On CI that coordinate sits inside the fixed onboarding banner (`layouts/default.vue:6` — `fixed top-0 start-0 end-0 z-[1000]`, full width), whose handler is `router.push(showGlobalOnboardingBannerLink)`. So the click navigated to `/onboarding/data` instead of dismissing the popover; the prompt box unmounted and the next `agent-scope-trigger` click waited out the 60s timeout.

From the trace artifact: `agent-scope-trigger` is visible at 96.5s, `mouse.click(20,20)` fires at 97.604s, and a `GET /api/organization/onboarding?in_onboarding=true` (the `/onboarding` route middleware) starts in the same millisecond. The failure snapshot is the wizard's "Connect data" page.

The banner was up because the CI workspace had **no data source**. `useTopBanner` shows the banner whenever the LLM and data-source steps aren't both done, and the onboarding API returned `"data_source_created": {"status": "pending"}` for the whole run. That traces back to the wizard's step 3, which looked for a sample-database button named `/chinook/i` — but the demo renders under its display name, `"Music Store"` (`backend/app/schemas/demo_data_source_schema.py:49`). The locator missed, the test silently took its assert-only fallback, and the sample database was never installed. Every other test papers over the fallout with an "if redirected to /onboarding, click Skip" workaround; agent-scope had none.

Locally, where a data source exists, no banner renders and the blind click is harmless — which is why this shipped green.

## Changes

- `tests/home/agent-scope.spec.ts` — press Escape instead of clicking a fixed coordinate, and only toggle the trigger when the panel is actually closed (so the helper is correct whether or not Escape lands).
- `tests/onboarding/onboarding-wizard.spec.ts` — match the sample database by test id rather than by display label, so it is actually installed.
- `pages/onboarding/data/index.vue` — add `data-testid="onboarding-demo-<id>"` to the demo buttons, so renaming a demo can't silently break the test again.

The second fix matters beyond the banner: with zero agents in the workspace, both agent-scope tests would hit `test.skip('workspace has no agents to scope')` and assert nothing. With the sample database installed they run for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wMSG1JHPpJxNh65MA8REB

---
_Generated by [Claude Code](https://claude.ai/code/session_016wMSG1JHPpJxNh65MA8REB)_