### PR TITLE
Stop the shared conversation page rendering blank bubbles

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -3328,8 +3328,15 @@ class ReportService:
                 "reasoning": b.reasoning,
                 "started_at": b.started_at.isoformat() if b.started_at else None,
                 "completed_at": b.completed_at.isoformat() if b.completed_at else None,
+                # Which phase of the turn produced this block. 'knowledge_harness'
+                # marks the post-analysis reflection sub-loop, which the UI lifts
+                # out of the step stream into its own Knowledge card (the v2
+                # serializer carries the same field). Without it the share page
+                # had no way to tell the two apart and interleaved the harness's
+                # search/create/edit steps into the answer.
+                "phase": getattr(pd, "phase", None) if pd else None,
             }
-            
+
             if pd:
                 block_data["plan_decision"] = {
                     "reasoning": pd.reasoning,

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -3219,10 +3219,36 @@ class ReportService:
         from app.models.completion_block import CompletionBlock
         from app.models.plan_decision import PlanDecision
         from app.models.tool_execution import ToolExecution
-        
-        # Build query with pagination - fetch newest first, then reverse for display
-        completions_query = select(Completion).where(Completion.report_id == report.id)
-        
+        # Read-time tolerance for rows persisted before the write-side sanitizer:
+        # lone surrogates (e.g. pypdf output) crash JSONResponse's utf-8 encode,
+        # which would 500 the whole shared page. Same guard the v2 serializer uses.
+        from app.utils.json_sanitize import sanitize_json_strings
+
+        # Build query with pagination - fetch newest first, then reverse for display.
+        #
+        # Only the two roles the share page can render are transcript content:
+        # 'user' prompts and 'system' replies. Silent session events
+        # (role='event' — the ledger of out-of-band UI actions, see
+        # app.ai.context.session_events) and machine trigger entries
+        # (role='external') carry no prompt and no blocks in the sanitized
+        # payload below, so every one of them used to arrive as a completion the
+        # page rendered as an empty assistant bubble — AND consumed a slot in
+        # the `limit` page, so a report with a busy event ledger paged in almost
+        # no readable messages. Filtering here (not in the UI) keeps the page
+        # size a count of visible messages.
+        #
+        # The second clause hides the internal machine trigger — the synthetic
+        # prompt the agent answers for a webhook/scheduled run — exactly as
+        # get_completions_v2 does for the owner-facing timeline.
+        completions_query = select(Completion).where(
+            Completion.report_id == report.id,
+            Completion.role.in_(("user", "system")),
+            ~(
+                (Completion.webhook_id.isnot(None) | Completion.trigger_source.isnot(None))
+                & (Completion.role == "user")
+            ),
+        )
+
         # If 'before' cursor provided, fetch older completions. The id
         # tiebreaker keeps pagination exact when several completions share a
         # created_at (bulk inserts, webhook bursts): a plain `created_at < ts`
@@ -3313,16 +3339,31 @@ class ReportService:
                 }
             
             if te:
-                # Sanitized tool execution - include results but strip internal IDs
-                block_data["tool_execution"] = {
+                # Sanitized tool execution - include results but strip internal IDs.
+                #
+                # arguments_json is the tool's INPUT and half of what every tool
+                # card renders: the instruction/eval name it wrote, the query it
+                # searched for, and the LLM-authored `title` the collapsed
+                # step-group ticker labels itself with (useBlockGrouping reads
+                # arguments_json.title). Without it the knowledge/eval cards
+                # painted their chrome around blank text — the share view was
+                # already serving the far more revealing result_json, so the
+                # input was withheld to no one's benefit.
+                result_json = te.result_json
+                if isinstance(result_json, dict) and "widget_data" in result_json:
+                    # Whole result sets live here; the card paints from the
+                    # preview and this page ships every block at once.
+                    result_json = {k: v for k, v in result_json.items() if k != "widget_data"}
+                block_data["tool_execution"] = sanitize_json_strings({
                     "id": te.id,
                     "tool_name": te.tool_name,
                     "tool_action": te.tool_action,
                     "status": te.status,
                     "result_summary": te.result_summary,
-                    "result_json": te.result_json,
+                    "arguments_json": te.arguments_json,
+                    "result_json": result_json,
                     "duration_ms": te.duration_ms,
-                }
+                })
             
             completion_id_to_blocks[b.completion_id].append(block_data)
         

--- a/backend/tests/e2e/test_public_conversation_filtering.py
+++ b/backend/tests/e2e/test_public_conversation_filtering.py
@@ -1,0 +1,182 @@
+"""
+Regression guard for what GET /api/c/{token} (public shared conversation) serves.
+
+A report accumulates rows that are NOT transcript content: silent session events
+(role='event' — the ledger of out-of-band UI actions, see
+app.ai.context.session_events), machine trigger entries (role='external') and
+the hidden synthetic prompt the agent answers for a webhook/scheduled run
+(role='user' with webhook_id/trigger_source set).
+
+The share page renders none of them — they carry no prompt and no blocks in the
+sanitized payload — so each one used to arrive as a completion the page drew as
+an empty assistant bubble AND consumed a slot in the `limit` page. A report with
+a busy event ledger (24 events / 28 completions in the report that prompted this
+guard) paged in a wall of blank bubbles and almost nothing readable.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/test_public_conv.db \
+      .venv/bin/python -m pytest tests/e2e/test_public_conversation_filtering.py -v -s
+"""
+import asyncio
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.report import Report
+from app.models.completion import Completion
+from app.services.report_service import ReportService
+
+
+N_TURNS = 6          # 6 user + 6 system = 12 renderable completions
+EVENTS_PER_TURN = 3  # silent noise interleaved between every turn
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed():
+    """One report whose timeline is mostly noise: every turn is followed by a
+    few silent events, an external machine entry and a hidden trigger prompt."""
+    suffix = uuid.uuid4().hex[:8]
+    base = datetime(2026, 1, 1, 10, 0, 0)
+    token = f"tok-{uuid.uuid4().hex}"
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Conv Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        user = User(
+            name="Conv User",
+            email=f"conv-{suffix}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        db.add(user)
+        await db.flush()
+
+        report = Report(
+            title=f"Conv Report {suffix}",
+            slug=f"conv-report-{suffix}",
+            status="draft",
+            user_id=user.id,
+            organization_id=org.id,
+            conversation_visibility="public",
+            conversation_share_token=token,
+        )
+        db.add(report)
+        await db.flush()
+
+        renderable, hidden = [], []
+        t = base
+        for i in range(N_TURNS):
+            t += timedelta(minutes=5)
+            u = Completion(
+                prompt={"content": f"q{i}"}, completion=None, status="success",
+                role="user", report_id=report.id, user_id=user.id, turn_index=i,
+            )
+            u.created_at = u.updated_at = t
+            s = Completion(
+                prompt=None, completion={"content": f"a{i}"}, status="success",
+                role="system", report_id=report.id, turn_index=i,
+            )
+            s.created_at = s.updated_at = t + timedelta(seconds=2)
+            db.add_all([u, s])
+            await db.flush()
+            renderable.extend([str(u.id), str(s.id)])
+
+            for j in range(EVENTS_PER_TURN):
+                ev = Completion(
+                    prompt={"content": f"something happened {i}.{j}"},
+                    completion=None, status="success", role="event",
+                    message_type="llm_changed", report_id=report.id, turn_index=i,
+                )
+                ev.created_at = ev.updated_at = t + timedelta(seconds=10 + j)
+                db.add(ev)
+                await db.flush()
+                hidden.append(str(ev.id))
+
+            ext = Completion(
+                prompt={"content": f"webhook fired {i}"}, completion=None,
+                status="success", role="external", report_id=report.id, turn_index=i,
+            )
+            ext.created_at = ext.updated_at = t + timedelta(seconds=20)
+            trig = Completion(
+                prompt={"content": f"internal trigger {i}"}, completion=None,
+                status="success", role="user", trigger_source="scheduled",
+                report_id=report.id, turn_index=i,
+            )
+            trig.created_at = trig.updated_at = t + timedelta(seconds=21)
+            db.add_all([ext, trig])
+            await db.flush()
+            hidden.extend([str(ext.id), str(trig.id)])
+
+        await db.commit()
+        return {"token": token, "renderable": renderable, "hidden": set(hidden)}
+
+
+async def _walk_pages(svc, token, limit, max_pages=50):
+    served, pages = [], 0
+    before = None
+    async with async_session_maker() as db:
+        while True:
+            resp = await svc.get_public_conversation(db, token, limit=limit, before=before)
+            pages += 1
+            assert len(resp["completions"]) <= limit
+            served.append(resp["completions"])
+            if not resp["has_more"] or pages >= max_pages:
+                return served, pages
+            assert resp["next_before"], "has_more without a next_before cursor"
+            before = str(resp["next_before"])
+
+
+@pytest.mark.e2e
+def test_public_conversation_serves_only_renderable_messages():
+    """Events / external entries / hidden triggers never reach the share page."""
+    async def scenario():
+        svc = ReportService()
+        seeded = await _seed()
+
+        page_list, _ = await _walk_pages(svc, seeded["token"], limit=10)
+        # Pages walk backwards (newest page first, each `before` cursor older),
+        # while each page is itself chronological — reversing the page order
+        # reassembles the transcript as the reader scrolls it.
+        served = [c for page in reversed(page_list) for c in page]
+        served_ids = [str(c["id"]) for c in served]
+
+        leaked = seeded["hidden"] & set(served_ids)
+        assert not leaked, f"{len(leaked)} non-message rows served to the share page"
+        assert {c["role"] for c in served} == {"user", "system"}
+        # Chronological, every real message, exactly once.
+        assert served_ids == seeded["renderable"]
+        # Every user row still carries the prompt the page renders.
+        for c in served:
+            if c["role"] == "user":
+                assert (c["prompt"] or {}).get("content")
+
+    _run(scenario())
+
+
+@pytest.mark.e2e
+def test_page_size_counts_only_renderable_messages():
+    """`limit` is a count of visible messages, not of raw rows — otherwise the
+    first page of a busy report is all noise and the reader sees nothing."""
+    async def scenario():
+        svc = ReportService()
+        seeded = await _seed()
+
+        page_list, page_count = await _walk_pages(svc, seeded["token"], limit=4)
+        # 12 renderable rows / 4 per page. With the noise counted (48 rows) this
+        # took 12 pages and most of them came back visually blank.
+        assert page_count == len(seeded["renderable"]) // 4
+        assert all(len(p) == 4 for p in page_list)
+
+    _run(scenario())

--- a/backend/tests/e2e/test_public_conversation_filtering.py
+++ b/backend/tests/e2e/test_public_conversation_filtering.py
@@ -29,6 +29,10 @@ from app.models.organization import Organization
 from app.models.user import User
 from app.models.report import Report
 from app.models.completion import Completion
+from app.models.agent_execution import AgentExecution
+from app.models.plan_decision import PlanDecision
+from app.models.tool_execution import ToolExecution
+from app.models.completion_block import CompletionBlock
 from app.services.report_service import ReportService
 
 
@@ -178,5 +182,112 @@ def test_page_size_counts_only_renderable_messages():
         # took 12 pages and most of them came back visually blank.
         assert page_count == len(seeded["renderable"]) // 4
         assert all(len(p) == 4 for p in page_list)
+
+    _run(scenario())
+
+
+async def _seed_with_blocks():
+    """One shared report with a single answered turn whose system completion
+    carries a main-loop step and a knowledge-harness step."""
+    suffix = uuid.uuid4().hex[:8]
+    token = f"tok-{uuid.uuid4().hex}"
+    t = datetime(2026, 2, 1, 9, 0, 0)
+
+    async with async_session_maker() as db:
+        org = Organization(name=f"Blocks Org {suffix}")
+        db.add(org)
+        await db.flush()
+        user = User(
+            name="Blocks User", email=f"blocks-{suffix}@example.com",
+            hashed_password="x", is_active=True, is_superuser=False, is_verified=True,
+        )
+        db.add(user)
+        await db.flush()
+        report = Report(
+            title=f"Blocks Report {suffix}", slug=f"blocks-report-{suffix}",
+            status="draft", user_id=user.id, organization_id=org.id,
+            conversation_visibility="public", conversation_share_token=token,
+        )
+        db.add(report)
+        await db.flush()
+
+        u = Completion(
+            prompt={"content": "which tables matter?"}, status="success",
+            role="user", report_id=report.id, user_id=user.id, turn_index=0,
+        )
+        u.created_at = u.updated_at = t
+        s = Completion(
+            prompt=None, completion=None, status="success",
+            role="system", report_id=report.id, turn_index=0,
+        )
+        s.created_at = s.updated_at = t + timedelta(seconds=2)
+        db.add_all([u, s])
+        await db.flush()
+
+        ae = AgentExecution(completion_id=s.id, organization_id=org.id,
+                            report_id=report.id, status="success")
+        db.add(ae)
+        await db.flush()
+
+        def _block(idx, phase, tool, args, result):
+            pd = PlanDecision(agent_execution_id=ae.id, seq=idx, loop_index=idx,
+                              plan_type="action", phase=phase)
+            te = ToolExecution(agent_execution_id=ae.id, tool_name=tool,
+                               arguments_json=args, status="success", success=True,
+                               result_json=result)
+            db.add_all([pd, te])
+            return pd, te
+
+        pd_main, te_main = _block(
+            0, None, "describe_tables", {"title": "Reading orders"},
+            {"success": True, "widget_data": [{"row": i} for i in range(50)]},
+        )
+        pd_harness, te_harness = _block(
+            1, "knowledge_harness", "create_instruction",
+            {"title": "Order status codes", "text": "Status 3 means shipped."},
+            {"success": True, "instruction_id": "i-1", "build_id": "b-1",
+             "title": "Order status codes"},
+        )
+        await db.flush()
+
+        for idx, (pd, te) in enumerate(((pd_main, te_main), (pd_harness, te_harness))):
+            db.add(CompletionBlock(
+                completion_id=s.id, agent_execution_id=ae.id, source_type="tool",
+                plan_decision_id=pd.id, tool_execution_id=te.id,
+                block_index=idx, title=te.tool_name, status="completed",
+            ))
+        await db.commit()
+        return token
+
+
+@pytest.mark.e2e
+def test_blocks_carry_phase_and_tool_arguments():
+    """The tool cards paint from arguments_json, and the Knowledge card is split
+    out of the step stream by `phase` — neither reached the share page before."""
+    async def scenario():
+        svc = ReportService()
+        token = await _seed_with_blocks()
+
+        async with async_session_maker() as db:
+            resp = await svc.get_public_conversation(db, token, limit=10)
+
+        system = [c for c in resp["completions"] if c["role"] == "system"]
+        assert len(system) == 1
+        blocks = system[0]["completion_blocks"]
+        assert len(blocks) == 2
+        by_tool = {b["tool_execution"]["tool_name"]: b for b in blocks}
+
+        main = by_tool["describe_tables"]
+        assert main["phase"] is None
+        # The step-group ticker labels itself from arguments_json.title.
+        assert main["tool_execution"]["arguments_json"]["title"] == "Reading orders"
+        # Whole result sets never ship on a page that renders every block.
+        assert "widget_data" not in main["tool_execution"]["result_json"]
+
+        harness = by_tool["create_instruction"]
+        assert harness["phase"] == "knowledge_harness"
+        # The Knowledge card derives its change list from these two fields.
+        assert harness["tool_execution"]["arguments_json"]["text"]
+        assert harness["tool_execution"]["result_json"]["instruction_id"] == "i-1"
 
     _run(scenario())

--- a/frontend/components/KnowledgeGroup.vue
+++ b/frontend/components/KnowledgeGroup.vue
@@ -50,13 +50,15 @@
           No changes captured from this session.
         </div>
 
+        <!-- The second dim state means "not selected for publish". Nothing is
+             publishable from a transcript, so readonly changes never dim. -->
         <div
           v-for="ch in changes"
           :key="ch.id"
           :class="[
             '-mx-1.5 rounded border border-gray-150 dark:border-gray-800 bg-gray-50 dark:bg-gray-900',
             resolutionFor(ch) === 'rejected' ? 'opacity-50' : '',
-            !isBuildPublished && !resolutionFor(ch) && !selectedIds.has(ch.id) ? 'opacity-50' : ''
+            !readonly && !isBuildPublished && !resolutionFor(ch) && !selectedIds.has(ch.id) ? 'opacity-50' : ''
           ]"
         >
           <div
@@ -114,7 +116,7 @@
                        instruction (see CreateInstructionTool.handleReject), so
                        Open would fetch a 404 and land on an empty form. -->
                   <button
-                    v-if="ch.instructionId && resolutionFor(ch) !== 'rejected'"
+                    v-if="!readonly && ch.instructionId && resolutionFor(ch) !== 'rejected'"
                     class="text-[10px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 flex items-center gap-1"
                     @click.stop="handleEdit(ch)"
                   >
@@ -144,8 +146,8 @@
                 <div
                   v-else
                   class="px-3 py-2 bg-white dark:bg-gray-900"
-                  :class="resolutionFor(ch) === 'rejected' ? '' : 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50'"
-                  @click="handleEdit(ch)"
+                  :class="readonly || resolutionFor(ch) === 'rejected' ? '' : 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50'"
+                  @click="!readonly ? handleEdit(ch) : null"
                 >
                   <TrackedChangesView :diff-ops="diffOpsForChange(ch)" />
                 </div>
@@ -155,7 +157,7 @@
         </div>
 
         <!-- Publish button -->
-        <div v-if="hasUnresolvedChanges && !isBuildPublished && selectedIds.size > 0" class="pt-1">
+        <div v-if="!readonly && hasUnresolvedChanges && !isBuildPublished && selectedIds.size > 0" class="pt-1">
           <button
             class="flex items-center px-2 py-1 text-[10px] font-medium text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800/70 rounded transition-colors disabled:opacity-50"
             :disabled="isPublishingBuild || selectedIds.size === 0"
@@ -171,6 +173,7 @@
 
     <!-- Instruction Modal -->
     <InstructionModalComponent
+      v-if="!readonly"
       v-model="showInstructionModal"
       :instruction="editingInstruction"
       :initial-type="'global'"
@@ -221,6 +224,14 @@ interface Props {
   blocks: HarnessBlock[]
   harnessRunning?: boolean
   knowledgeHarnessBuild?: KnowledgeHarnessBuild | null
+  /** Transcript-only rendering (the public share page). The card is a record
+      of what the harness did, which it derives entirely from the blocks'
+      arguments_json/result_json — steps, changes, titles and diffs all survive.
+      What goes is everything that acts on the workspace or asks it a question:
+      the per-instruction permission fetch, the resolution probe, the review
+      checkboxes, Open, and Publish. Their endpoints are authenticated, and a
+      reader of a shared link has no build to publish. */
+  readonly?: boolean
 }
 
 const props = defineProps<Props>()
@@ -418,6 +429,7 @@ function resolutionFor(ch: Change): 'accepted' | 'rejected' | null {
 }
 
 function canManageChange(ch: Change): boolean {
+  if (props.readonly) return false
   if (!ch.instructionId) return false
   return useCanManageInstruction(instructionDetails.value[ch.instructionId])
 }
@@ -432,6 +444,7 @@ async function loadInstructionDetail(instructionId: string) {
 }
 
 watch(changes, (items) => {
+  if (props.readonly) return
   for (const ch of items) {
     if (ch.instructionId) loadInstructionDetail(ch.instructionId)
   }
@@ -452,6 +465,7 @@ function setResolution(instructionId: string, value: 'accepted' | 'rejected') {
 // Mirrors the tool-card logic: a create that still exists = accepted (deleted =
 // rejected); an edit = accepted only if the live text matches what we proposed.
 async function refreshChangeResolution(ch: Change) {
+  if (props.readonly) return
   const id = ch.instructionId
   if (!id || !ch.buildId) return
   const { data: pendingData } = await useMyFetch(`/instructions/${id}/pending-builds`)
@@ -563,7 +577,7 @@ watch([changes, instructionDetails], ([newCh]) => {
 }, { immediate: true })
 
 const handleEdit = (ch: Change) => {
-  if (!ch.instructionId) return
+  if (props.readonly || !ch.instructionId) return
   // A rejected create no longer exists to open — the reject deleted it.
   if (resolutionFor(ch) === 'rejected') return
   emit('open-instruction', ch.instructionId)

--- a/frontend/components/tools/EditInstructionTool.vue
+++ b/frontend/components/tools/EditInstructionTool.vue
@@ -115,8 +115,9 @@
           <!-- Instruction text - click to edit -->
           <div
             dir="auto"
-            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 cursor-pointer max-h-80 overflow-y-auto"
-            @click="handleEdit()"
+            class="instruction-content text-[12px] text-gray-800 dark:text-gray-200 leading-relaxed mb-2 max-h-80 overflow-y-auto"
+            :class="readonly ? '' : 'cursor-pointer'"
+            @click="!readonly ? handleEdit() : null"
           >
             <InstructionText :text="displayText" :markdown="true" />
           </div>
@@ -165,7 +166,11 @@
 
         <!-- Status row (accepted / rejected / staged). When still resolvable the
              embedded per-hunk review shows the state + inline actions instead. -->
-        <div v-if="isSuccess && instructionId && !canResolve" class="flex items-center gap-1.5 pt-2 border-t border-gray-100 dark:border-gray-800 px-1">
+        <!-- Hidden in a transcript: the verdict is a live workspace fact this
+             card never fetched there, and the fallback branch below would
+             assert "staged in draft build" about an edit long since
+             accepted. -->
+        <div v-if="!readonly && isSuccess && instructionId && !canResolve" class="flex items-center gap-1.5 pt-2 border-t border-gray-100 dark:border-gray-800 px-1">
           <template v-if="resolution === 'accepted'">
             <Icon name="heroicons:check-circle" class="w-3 h-3 text-green-500" />
             <span class="text-[10px] font-medium text-gray-600 dark:text-gray-400">{{ $t('tools.editInstruction.accepted', 'Accepted') }}</span>
@@ -187,7 +192,7 @@
 
         <!-- Resolved evals for this agent, pinned to the draft build this edit
              was staged into (training-mode self-check). -->
-        <div v-if="isSuccess && instructionId && buildId" class="mt-1.5 px-1">
+        <div v-if="!readonly && isSuccess && instructionId && buildId" class="mt-1.5 px-1">
           <ResolvedEvalStrip :instruction-id="instructionId" :build-id="buildId" :agent-ids="reportAgentIds" :report-id="reportId" />
         </div>
 
@@ -261,6 +266,15 @@ interface Props {
   /** The conversation, so a run started from the eval strip reports its
       result back into this thread when it finishes. */
   reportId?: string | null
+  /** Transcript-only rendering (the public share page). The card paints the
+      edit exactly as it happened — header, diff, metadata, reason — all of
+      which come from the tool's own result_json, and drops everything that
+      needs the workspace: the instruction fetch, the verdict probe, the
+      review panel and the eval strip. Their endpoints are authenticated, and
+      an anonymous reader has nothing to review anyway. Without this the card
+      never resolves `awaitingFinal` (the verdict fetch it waits on never
+      fires) and sits on its loading spinner forever. */
+  readonly?: boolean
 }
 
 const props = defineProps<Props>()
@@ -509,7 +523,8 @@ const serverVerdict = ref<'pending' | 'accepted' | 'rejected' | 'unknown' | null
 const panelReady = ref(false)
 
 const canResolve = computed(() =>
-  !!buildId.value && !!instructionId.value && resolution.value === null
+  !props.readonly
+  && !!buildId.value && !!instructionId.value && resolution.value === null
   && serverVerdict.value === 'pending'
 )
 
@@ -519,6 +534,9 @@ const canResolve = computed(() =>
 // content that a later answer would repaint. Verdict-less cards (failed edits,
 // rows with no build) are decidable immediately and skip this entirely.
 const awaitingFinal = computed(() => {
+  // Nothing is pending in a transcript: no verdict fetch is out, so waiting on
+  // one would park the card on its spinner permanently.
+  if (props.readonly) return false
   if (!isSuccess.value || !instructionId.value || !buildId.value) return false
   if (resolution.value !== null) return false
   if (serverVerdict.value === null) return true
@@ -562,6 +580,7 @@ watch([instructionId, () => props.turnActive], ([id, active]) => {
   // No verdict traffic while the turn is streaming: the answer would be
   // stale one call later, and its arrival is what used to mount the panel
   // mid-run. The fetch fires once, when the card settles (turnActive off).
+  if (props.readonly) return
   if (id && !active && resolution.value === null && serverVerdict.value === null) {
     refreshResolutionState()
   }
@@ -706,6 +725,7 @@ const errorMessage = computed(() => {
 
 // Watch instructionId too — it lands after mount with result_json, so a single watch on isExpanded misses it.
 watch([isExpanded, instructionId], async ([expanded, id]) => {
+  if (props.readonly) return
   if (expanded && id && fetchedInstruction.value === null) {
     await fetchInstruction()
   }
@@ -746,7 +766,7 @@ function toggleExpanded() {
 }
 
 async function handleEdit() {
-  if (!instructionId.value) return
+  if (props.readonly || !instructionId.value) return
   // Open the right-pane instruction view with this tool's edited version
   // preselected so the user immediately sees a diff against the current
   // version. The pane resolves the version_number to a version_id from its

--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -83,7 +83,7 @@
                 </div>
 
                 <ul class="max-w-2xl mx-auto space-y-4">
-                    <li v-for="m in conversation.completions" :key="m.id" class="text-gray-700 dark:text-gray-300 text-sm">
+                    <li v-for="m in visibleCompletions" :key="m.id" class="text-gray-700 dark:text-gray-300 text-sm">
                         <!-- Scheduled prompt indicator -->
                         <div v-if="m.scheduled_prompt_id && m.role === 'user'" class="mb-2">
                             <div class="flex items-center gap-1.5 px-3 py-2 text-xs text-gray-400 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-900">
@@ -171,8 +171,13 @@
                                                 />
                                                 <!-- Fallback to generic expandable tool display -->
                                                 <div v-else>
+                                                    <!-- Every unmapped tool names itself. 'clarify' and
+                                                         'suggest_instructions' used to be excluded here, which
+                                                         (they have no component on this page either) left the
+                                                         step rendering nothing at all — a bare avatar with an
+                                                         empty body beside it. -->
                                                     <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">
-                                                        <span class="cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleToolDetails(block.tool_execution.id)" v-if="block.tool_execution.tool_name !== 'clarify' && block.tool_execution.tool_name !== 'suggest_instructions'">
+                                                        <span class="cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleToolDetails(block.tool_execution.id)">
                                                             {{ block.tool_execution.tool_name }}{{ block.tool_execution.tool_action ? ` → ${block.tool_execution.tool_action}` : '' }} ({{ block.tool_execution.status }})
                                                         </span>
                                                         <div v-if="isToolDetailsExpanded(block.tool_execution.id)" class="ms-2 mt-1 text-xs text-gray-400 bg-gray-50 dark:bg-gray-900 p-2 rounded">
@@ -223,7 +228,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { computeBlockGroups } from '~/composables/useBlockGrouping'
 import Spinner from '~/components/Spinner.vue'
 import CreateWidgetTool from '~/components/tools/CreateWidgetTool.vue'
@@ -265,6 +270,30 @@ import CreateNoteTool from '~/components/tools/CreateNoteTool.vue'
 import EditNoteTool from '~/components/tools/EditNoteTool.vue'
 import RouteModelTool from '~/components/tools/RouteModelTool.vue'
 import CreateInstructionTool from '~/components/tools/CreateInstructionTool.vue'
+// Knowledge / training harness: instruction edits, eval suites and their runs.
+// A training conversation is almost entirely these blocks, and every one of
+// them used to fall through to the generic "tool_name (status)" debug line.
+import EditInstructionTool from '~/components/tools/EditInstructionTool.vue'
+import SearchEvalsTool from '~/components/tools/SearchEvalsTool.vue'
+import CreateEvalTool from '~/components/tools/CreateEvalTool.vue'
+import EditEvalTool from '~/components/tools/EditEvalTool.vue'
+import GetEvalRunsTool from '~/components/tools/GetEvalRunsTool.vue'
+import StopEvalRunTool from '~/components/tools/StopEvalRunTool.vue'
+import UpdateUserMemoryTool from '~/components/tools/UpdateUserMemoryTool.vue'
+// Agent actions and bookkeeping — same treatment, same reason.
+import CreateDashboardTool from '~/components/tools/CreateDashboardTool.vue'
+import SendEmailTool from '~/components/tools/SendEmailTool.vue'
+import NotifyTool from '~/components/tools/NotifyTool.vue'
+import CreateScheduledTaskTool from '~/components/tools/CreateScheduledTaskTool.vue'
+import EditScheduledTaskTool from '~/components/tools/EditScheduledTaskTool.vue'
+import CancelScheduledTaskTool from '~/components/tools/CancelScheduledTaskTool.vue'
+import CancelWaitTool from '~/components/tools/CancelWaitTool.vue'
+import ListAgentExecutionsTool from '~/components/tools/ListAgentExecutionsTool.vue'
+import CreatePromptTool from '~/components/tools/CreatePromptTool.vue'
+import EditPromptTool from '~/components/tools/EditPromptTool.vue'
+import SearchPromptsTool from '~/components/tools/SearchPromptsTool.vue'
+import ListConnectionsTool from '~/components/tools/ListConnectionsTool.vue'
+import GetConnectionTool from '~/components/tools/GetConnectionTool.vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 import { useMarkdownAutoDir } from '~/composables/useMarkdownAutoDir'
 
@@ -280,6 +309,24 @@ const conversation = ref<any>({
     completions: [],
     created_at: null,
 })
+
+// ---------------------------------------------------------------------------
+// What this page can actually render: a user prompt, or an assistant turn with
+// blocks (or a stopped/error notice). Anything else — a silent session event
+// (role='event'), a machine trigger entry (role='external'), an assistant row
+// whose blocks were all sanitized away — has no body in the public payload and
+// would otherwise draw a bare avatar with nothing beside it. The backend now
+// filters these out of /api/c/{token} so they don't eat pagination slots
+// either; this guard keeps a stale payload or a future role from putting empty
+// bubbles back on the page.
+// ---------------------------------------------------------------------------
+const visibleCompletions = computed<any[]>(() =>
+    (conversation.value?.completions || []).filter((m: any) => {
+        if (m?.role === 'user') return true
+        if (m?.role !== 'system') return false
+        return (m.completion_blocks?.length || 0) > 0 || m.status === 'stopped' || m.status === 'error'
+    })
+)
 
 // Pagination state
 const hasMore = ref(false)
@@ -512,6 +559,52 @@ function getToolComponent(toolName: string) {
             return RouteModelTool
         case 'create_instruction':
             return CreateInstructionTool
+        case 'edit_instruction':
+            return EditInstructionTool
+        case 'search_evals':
+            return SearchEvalsTool
+        case 'create_eval':
+            return CreateEvalTool
+        case 'edit_eval':
+            return EditEvalTool
+        case 'get_eval_runs':
+            return GetEvalRunsTool
+        case 'stop_eval_run':
+            return StopEvalRunTool
+        case 'update_user_memory':
+            return UpdateUserMemoryTool
+        case 'create_dashboard':
+            return CreateDashboardTool
+        case 'send_email':
+            return SendEmailTool
+        case 'notify':
+            return NotifyTool
+        case 'create_scheduled_task':
+            return CreateScheduledTaskTool
+        case 'edit_scheduled_task':
+            return EditScheduledTaskTool
+        case 'cancel_scheduled_task':
+            return CancelScheduledTaskTool
+        case 'cancel_wait':
+            return CancelWaitTool
+        case 'list_agent_executions':
+            return ListAgentExecutionsTool
+        case 'create_prompt':
+            return CreatePromptTool
+        case 'edit_prompt':
+            return EditPromptTool
+        case 'search_prompts':
+            return SearchPromptsTool
+        case 'list_connections':
+            return ListConnectionsTool
+        case 'get_connection':
+            return GetConnectionTool
+        // Deliberately NOT mapped here (they render in the owner's report view
+        // only): suggest_instructions, clarify, run_eval, get_eval_run,
+        // create_agent, wait. Each drives itself from authenticated endpoints
+        // an anonymous reader cannot call — a review queue, a live run poller,
+        // an answer form — so they need read-only variants before they can be
+        // shown. The fallback below names them instead of drawing nothing.
         default:
             return null
     }

--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -121,7 +121,7 @@
                                 <div class="w-full md:ms-4 max-w-2xl">
                                     <div>
                                         <!-- Render each completion block -->
-                                        <div v-for="block in m.completion_blocks" :key="block.id">
+                                        <div v-for="block in timelineBlocks(m)" :key="block.id">
                                             <!-- Live ticker for a run of low-signal tool steps (policy: useBlockGrouping.ts) -->
                                             <Transition name="fade" appear>
                                                 <BlockGroupTicker
@@ -200,6 +200,17 @@
                                             </div>
                                         </div>
                                     </div>
+
+                                    <!-- Knowledge harness: the post-analysis reflection sub-loop
+                                         is a phase of its own, not part of the answer. Its blocks
+                                         are lifted out of the stream above and rendered as the
+                                         same single collapsible card the report view uses —
+                                         read-only, since a shared link has no build to review. -->
+                                    <KnowledgeGroup
+                                        v-if="harnessBlocks(m).length"
+                                        :blocks="harnessBlocks(m)"
+                                        readonly
+                                    />
 
                                     <!-- Status messages -->
                                     <div v-if="m.status === 'stopped'" class="text-xs text-gray-500 dark:text-gray-400 mt-2 italic">
@@ -328,6 +339,24 @@ const visibleCompletions = computed<any[]>(() =>
     })
 )
 
+// ---------------------------------------------------------------------------
+// The knowledge harness (the post-analysis reflection sub-loop) runs as its own
+// phase and its blocks are tagged `phase === 'knowledge_harness'`. The report
+// view lifts them out of the step stream into one Knowledge card; this page
+// used to have neither the tag nor the split, so a harness run's
+// search/create/edit steps were interleaved into the answer as loose rows.
+// Same split here, from the same field.
+// ---------------------------------------------------------------------------
+const HARNESS_PHASE = 'knowledge_harness'
+
+function timelineBlocks(m: any): any[] {
+    return (m?.completion_blocks || []).filter((b: any) => b?.phase !== HARNESS_PHASE)
+}
+
+function harnessBlocks(m: any): any[] {
+    return (m?.completion_blocks || []).filter((b: any) => b?.phase === HARNESS_PHASE)
+}
+
 // Pagination state
 const hasMore = ref(false)
 const nextBefore = ref<string | null>(null)
@@ -353,7 +382,10 @@ function isGroupExpanded(groupId: string): boolean {
 }
 
 function _groupingFor(m: any) {
-    const blocks = (m?.completion_blocks || [])
+    // Group over the blocks the timeline actually renders: a harness block
+    // sitting between two chip-class steps would otherwise break a run that
+    // reads as continuous on screen.
+    const blocks = timelineBlocks(m)
     const key = `${blocks.length}`
     const hit = _groupingCache.get(String(m.id))
     if (hit && hit.key === key) return hit.grouping


### PR DESCRIPTION
A shared conversation (/c/{token}) served every Completion row on the
report, but the page only renders two of the four roles. Silent session
events (role='event' — the ledger of out-of-band UI actions), machine
trigger entries (role='external') and the hidden synthetic prompt behind a
webhook/scheduled run carry no prompt and no blocks in the sanitized
payload, so each one drew a bare avatar with nothing beside it — and each
one consumed a slot in the `limit` page. The report that surfaced this is
24 events out of 28 completions: its first page was seven empty bubbles,
one question and one answer.

Filter to the renderable roles in the query, so a page size is a count of
visible messages, and guard the list in the UI so a stale payload or a
future role cannot put empty bubbles back.

Also render the knowledge/training harness there, which was the other half
of the empty page:

- Serve arguments_json with each tool execution. It is the tool's INPUT and
  half of what every card renders — the instruction/eval name written, the
  query searched for, and the LLM-authored `title` the collapsed step-group
  ticker labels itself with. The view was already serving the far more
  revealing result_json, so withholding the input only blanked the cards.
  result_json now drops widget_data (whole result sets, on a page that
  ships every block at once) and the payload gets the same lone-surrogate
  scrub the v2 serializer uses.
- Wire the 20 tool components the share view was missing — the eval suite
  and instruction-edit family among them — so a training conversation stops
  falling through to a "tool_name (status)" debug line.
- Give EditInstructionTool a readonly mode: it paints header, diff,
  metadata and reason straight from result_json and drops the instruction
  fetch, verdict probe, review panel and eval strip, whose endpoints an
  anonymous reader cannot call. Without it the card waits on a verdict
  fetch that never fires and sits on its spinner forever.
- Unmapped tools now always name themselves; clarify and suggest_instructions
  were excluded from that fallback and so rendered nothing at all.

suggest_instructions, clarify, run_eval, get_eval_run, create_agent and
wait stay owner-view-only: each drives itself from authenticated endpoints
and needs a read-only variant first.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C5VNKD5gxqNpARBANcmwkX