### PR TITLE
Add Salesforce Client Credentials auth (Connected App without a username)

### DIFF
--- a/backend/app/data_sources/clients/salesforce_client.py
+++ b/backend/app/data_sources/clients/salesforce_client.py
@@ -459,8 +459,9 @@ class SalesforceClient(DataSourceClient):
             "Flow is enabled on the app, and that a Run As user is set under its "
             "OAuth Policies."
         )
-        # The single most common misconfiguration, and one Salesforce reports
-        # only as a generic invalid_client — worth naming explicitly.
+        # Confirmed against a live org: posting this grant to login.salesforce.com
+        # returns `invalid_grant: request not supported on this domain`, which
+        # does not say what to do about it.
         if (urlparse(self._login_url()).hostname or "") in GENERIC_LOGIN_HOSTS:
             hint += (
                 " Salesforce serves this grant from your org's My Domain — set the "
@@ -540,10 +541,26 @@ class SalesforceClient(DataSourceClient):
         yield session
 
     def test_connection(self):
-        """Test the Salesforce connection with a lightweight authenticated call."""
+        """Test the connection by exercising what indexing actually needs.
+
+        Not `sf.limits()`: that REST resource additionally requires the "View
+        Setup and Configuration" system permission, which the Minimum Access —
+        API Only Integrations profile (Salesforce's own recommendation for a
+        client-credentials Run As user) does not grant. A correctly configured
+        integration user failed the test with `API_DISABLED_FOR_ORG: limits
+        resource is not enabled` while being perfectly able to query.
+
+        Describe is the honest probe — it is the first call schema discovery
+        makes, so passing here means the connector can actually index.
+        """
         try:
             with self.connect() as sf:
-                sf.limits()
+                if self.objects:
+                    # An explicit allowlist skips global describe, so probe the
+                    # same way discovery will.
+                    getattr(sf, self.objects[0]).describe()
+                else:
+                    sf.describe()
                 return {"success": True, "message": "Connected to Salesforce"}
         except SalesforceConnectionError as e:
             return {"success": False, "message": str(e)}

--- a/backend/tests/unit/test_salesforce_client.py
+++ b/backend/tests/unit/test_salesforce_client.py
@@ -637,10 +637,26 @@ class TestConnectionAndPrompts:
     def test_test_connection_failure(self, monkeypatch):
         def boom(self):
             raise RuntimeError("INVALID_SESSION_ID")
-        monkeypatch.setattr(_FakeSalesforce, "limits", boom)
+        monkeypatch.setattr(_FakeSalesforce, "describe", boom)
         c = SalesforceClient(access_token="t", instance_url="https://x")
         res = c.test_connection()
         assert res["success"] is False and "INVALID_SESSION_ID" in res["message"]
+
+    def test_test_connection_does_not_touch_the_limits_resource(self, monkeypatch):
+        # /limits additionally requires "View Setup and Configuration", which
+        # the Minimum Access — API Only Integrations profile does not grant, so
+        # a working integration user failed the test with API_DISABLED_FOR_ORG.
+        def boom(self):
+            raise RuntimeError("API_DISABLED_FOR_ORG: limits resource is not enabled")
+        monkeypatch.setattr(_FakeSalesforce, "limits", boom)
+        c = SalesforceClient(access_token="t", instance_url="https://x")
+        assert c.test_connection()["success"] is True
+
+    def test_test_connection_probes_the_configured_object(self):
+        # With an explicit allowlist, discovery never calls global describe —
+        # so neither should the probe.
+        c = SalesforceClient(access_token="t", instance_url="https://x", objects="Widget__c")
+        assert c.test_connection()["success"] is True
 
     def test_prompt_schema_renders(self):
         c = SalesforceClient(access_token="t", instance_url="https://x")

--- a/docs/feedback-loops/salesforce-connector.md
+++ b/docs/feedback-loops/salesforce-connector.md
@@ -222,3 +222,20 @@ longer reports a blank required field as a credential failure. The `ruff`
 findings on `salesforce_client.py` are pre-existing style rules (`UP045` and
 friends, 211 before / 217 after, all of the same codes) — the added
 `Optional[str]` ctor parameter matches the surrounding signature.
+
+## Follow-up from the customer's live org
+
+Two things the sandbox (fake keys) could not show, both confirmed against
+`rooms.my.salesforce.com` with the real Connected App:
+
+1. `login.salesforce.com` rejects this grant with `invalid_grant: request not
+   supported on this domain` — so the My Domain requirement is real, not just
+   a recommendation, and the hint fires on exactly the right error.
+2. With the My Domain set, **the token exchange succeeded** and the failure
+   moved to the probe: `API_DISABLED_FOR_ORG: limits resource is not enabled`.
+   `/limits` requires the "View Setup and Configuration" system permission on
+   top of API access, and the Minimum Access — API Only Integrations profile
+   (Salesforce's own recommendation for a Run As user) does not grant it. So
+   the connection test rejected a correctly configured integration user that
+   could query fine. `test_connection` now probes with describe — the first
+   call schema discovery makes — so a pass means indexing will work.


### PR DESCRIPTION
## Why

The Salesforce connector only offered the JWT Bearer flow, whose assertion names a user in its `sub` claim — so the form demands a Username. An org whose Connected App is set up for the OAuth 2.0 **Client Credentials** grant has no username to give (the identity comes from the app's **Run As** user, configured in Salesforce Setup) and no field to put its consumer secret in. Those orgs could not connect at all, and the form's generic "Connection failed" made it look like a credential problem.

Both halves of the original report were true: JWT Bearer genuinely requires a username, and Client Credentials genuinely has none.

## What changed

- **New `client_credentials` auth variant** — Consumer Key + Consumer Secret, no username. JWT stays the default, since Client Credentials requires a Run As user to be configured in Salesforce first.
- **`_token_exchange()`** extracted and shared by both grants; `_client_credentials_access()` posts the grant to the org's token endpoint. The selected auth name never reaches the client (`construct_client` strips it), so `_auth_mode` discriminates the two Connected App flows on secret-vs-private-key.
- **`_login_url()` accepts a full host.** Sandbox My Domains (`acme--dev.sandbox.my.salesforce.com`) cannot be written as a bare subdomain, and Salesforce serves this grant only from the org's own host — which the failure hint points at when the request went to `login`/`test`.
- **Better errors.** A half-filled Connected App names the empty field, and `ConnectForm` surfaces 422 field errors instead of a bare "Connection failed" — blank inputs are stripped before the request, so a required-but-empty box arrived as a *missing* key and the API's precise answer was being discarded.
- **`test_connection` no longer probes `/limits`.** That resource additionally requires the "View Setup and Configuration" system permission, which the *Minimum Access – API Only Integrations* profile — Salesforce's own recommendation for a Run As user — does not grant. It probes with describe instead, the first call schema discovery makes, so passing means the connector can actually index.

## Verification

- **Unit** — 60 pass. New coverage for the grant body (asserting no `username`/`assertion` is smuggled in), the JWT-vs-secret discrimination, the My-Domain hint firing only on generic hosts, full-host domains, and the probe change.
- **Sandbox, live Salesforce token endpoint** — booted backend + frontend and drove the connect modal with Playwright. The dropdown lists three variants; Client Credentials renders exactly Consumer Key + Consumer Secret. Test connection with `domain=login` posted for real to `https://login.salesforce.com/services/oauth2/token`; blank-username JWT now reads "Username: Field required".
- **Stored round-trip (in-process)** — a saved connection reloaded in a fresh session logs `Final param keys=['sandbox','domain','consumer_key','consumer_secret']` (`auth_type` stripped, as expected) and still posts the right grant with the decrypted secret.
- **Customer's live org** — confirmed `login.salesforce.com` rejects this grant with `invalid_grant: request not supported on this domain`, so the My Domain requirement is hard rather than advisory; with the My Domain set the token exchange succeeded, which is what surfaced the `/limits` probe bug fixed here.

Loops written up in `docs/feedback-loops/salesforce-connector.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vPiS6UBzzHkqjHMPFiuDn)_