### PR TITLE
Move organization switcher to workspace header

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -76,7 +76,27 @@
 
       <ul class="font-normal text-[13px] !ps-0 shrink-0">
         <li class="flex items-center mb-3" :class="isCollapsed ? 'flex-col gap-1' : 'justify-between'">
-            <button @click="router.push('/')" :class="['flex items-center text-gray-700 group min-w-0 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800/70 transition-colors', isCollapsed ? 'justify-center p-1' : 'gap-2 px-2.5 py-1']">
+            <!-- Workspace header. With a single org this is just a link home
+                 (the only desktop path to '/'). With several, it doubles as the
+                 org switcher and carries 'Home' as its first item so that path
+                 isn't lost. Users with one org see no switcher affordance. -->
+            <UDropdown v-if="hasMultipleOrgs" :items="organizationDropdownItems"
+              :popper="{ placement: isCollapsed ? 'right-start' : 'bottom-start' }" class="min-w-0"
+              :ui="{ width: 'w-56', item: { size: 'text-[13px]', padding: 'px-2 py-1.5' } }">
+              <template #item="{ item }">
+                <img v-if="item.iconUrl" :src="item.iconUrl" alt="" class="w-4 h-4 shrink-0 rounded object-contain" />
+                <UIcon v-else-if="item.icon" :name="item.icon" class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                <span v-else class="w-4 h-4 shrink-0"></span>
+                <span class="truncate text-gray-700 dark:text-gray-200">{{ item.label }}</span>
+                <UIcon v-if="item.isCurrent" name="i-heroicons-check" class="w-4 h-4 shrink-0 ms-auto text-gray-400 dark:text-gray-500" />
+              </template>
+              <button :class="workspaceButtonClass" :aria-label="$t('nav.switchOrganization')">
+                <img :src="workspaceIconUrl || '/assets/logo-128.png'" alt="Bag of words" :class="isCollapsed ? 'w-8 object-contain' : 'max-h-6 max-w-[84px] object-contain shrink-0'" />
+                <span v-if="showText && organization?.name" class="text-[13px] font-semibold text-gray-700 dark:text-gray-200 truncate">{{ organization.name }}</span>
+                <UIcon v-if="showText" name="i-heroicons-chevron-up-down" class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+              </button>
+            </UDropdown>
+            <button v-else @click="router.push('/')" :class="workspaceButtonClass">
               <img :src="workspaceIconUrl || '/assets/logo-128.png'" alt="Bag of words" :class="isCollapsed ? 'w-8 object-contain' : 'max-h-6 max-w-[84px] object-contain shrink-0'" />
               <span v-if="showText && organization?.name" class="text-[13px] font-semibold text-gray-700 dark:text-gray-200 truncate">{{ organization.name }}</span>
             </button>
@@ -743,6 +763,13 @@
     const org = orgs.find((o: any) => o.id === orgId) || orgs[0]
     return org?.icon_url || null
   })
+
+  // Shared by both workspace-header variants (plain home link vs. org-switcher
+  // trigger) so their styling can't drift apart.
+  const workspaceButtonClass = computed(() => [
+    'flex items-center text-gray-700 group min-w-0 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800/70 transition-colors',
+    isCollapsed.value ? 'justify-center p-1' : 'gap-2 px-2.5 py-1',
+  ])
   const { signIn, signOut, token, data: currentUser, status, lastRefreshedAt, getSession } = useAuth()
   const { organization, setOrganization } = useOrganization()
   const { onboarding, fetchOnboarding } = useOnboarding()
@@ -1210,6 +1237,38 @@
     return ((currentUser.value as any)?.organizations || []) as any[]
   })
 
+  // Only multi-org users get a switcher; with one org the header stays a plain
+  // link home and nothing hints that switching exists.
+  const hasMultipleOrgs = computed<boolean>(() => userOrganizations.value.length > 1)
+
+  const organizationDropdownItems = computed(() => {
+    // whoami returns the orgs unordered (no ORDER BY on the membership join), so
+    // sort here — otherwise the rows of a primary header control can reshuffle
+    // between page loads.
+    const orgs = [...userOrganizations.value].sort((a: any, b: any) =>
+      String(a?.name || '').localeCompare(String(b?.name || ''))
+    )
+    return [
+      [{
+        label: t('nav.home'),
+        icon: 'i-heroicons-home',
+        click: () => router.push('/'),
+      }],
+      orgs.map((org: any) => ({
+        label: org.name,
+        // Falls back to the generic glyph so rows without a custom org icon
+        // still line up with the ones that have one.
+        iconUrl: org.icon_url || null,
+        icon: 'i-heroicons-building-office-2',
+        // Not `active`: the dropdown's item slot scope already exposes an
+        // `active` of its own (HeadlessUI's hover state).
+        isCurrent: org.id === organization.value?.id,
+        disabled: org.id === organization.value?.id,
+        click: () => setOrganization(org.id),
+      })),
+    ]
+  })
+
   const userDropdownItems = computed(() => {
     const groups: any[] = []
     groups.push([{
@@ -1242,17 +1301,8 @@
     })
     groups.push(resources)
 
-    const orgs = userOrganizations.value
-    if (orgs.length > 1) {
-      groups.push(
-        orgs.map((org: any) => ({
-          label: org.name,
-          icon: org.id === organization.value?.id ? 'heroicons-check' : undefined,
-          disabled: org.id === organization.value?.id,
-          click: () => setOrganization(org.id),
-        }))
-      )
-    }
+    // The org switcher lives in the workspace header now — keeping a copy here
+    // would give multi-org users two of them.
     groups.push([{
       label: t('auth.logout'),
       icon: 'heroicons-arrow-left',

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -335,6 +335,7 @@
     "newReport": "تقرير جديد",
     "expandSidebar": "توسيع الشريط الجانبي",
     "collapseSidebar": "طيّ الشريط الجانبي",
+    "switchOrganization": "تبديل المؤسسة",
     "version": "الإصدار",
     "loggedInAs": "تم تسجيل الدخول باسم {name}",
     "prompts": "المطالبات",

--- a/locales/de.json
+++ b/locales/de.json
@@ -337,6 +337,7 @@
     "newReport": "Neuer Bericht",
     "expandSidebar": "Seitenleiste erweitern",
     "collapseSidebar": "Seitenleiste einklappen",
+    "switchOrganization": "Organisation wechseln",
     "version": "Version",
     "loggedInAs": "Angemeldet als {name}",
     "prompts": "Prompts",

--- a/locales/en.json
+++ b/locales/en.json
@@ -370,6 +370,7 @@
     "newReport": "New report",
     "expandSidebar": "Expand sidebar",
     "collapseSidebar": "Collapse sidebar",
+    "switchOrganization": "Switch organization",
     "version": "Version",
     "loggedInAs": "Logged in as {name}",
     "prompts": "Prompts",

--- a/locales/es.json
+++ b/locales/es.json
@@ -353,6 +353,7 @@
     "newReport": "Nuevo informe",
     "expandSidebar": "Expandir barra lateral",
     "collapseSidebar": "Contraer barra lateral",
+    "switchOrganization": "Cambiar de organización",
     "version": "Versión",
     "loggedInAs": "Sesión iniciada como {name}",
     "prompts": "Prompts",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -337,6 +337,7 @@
     "newReport": "Nouveau rapport",
     "expandSidebar": "Développer la barre latérale",
     "collapseSidebar": "Réduire la barre latérale",
+    "switchOrganization": "Changer d'organisation",
     "version": "Version",
     "loggedInAs": "Connecté en tant que {name}",
     "prompts": "Prompts",

--- a/locales/he.json
+++ b/locales/he.json
@@ -353,6 +353,7 @@
     "newReport": "דוח חדש",
     "expandSidebar": "הרחבת סרגל הצד",
     "collapseSidebar": "כיווץ סרגל הצד",
+    "switchOrganization": "החלפת ארגון",
     "version": "גרסה",
     "loggedInAs": "מחובר/ת בתור {name}",
     "prompts": "פרומפטים",

--- a/locales/it.json
+++ b/locales/it.json
@@ -337,6 +337,7 @@
     "newReport": "Nuovo report",
     "expandSidebar": "Espandi barra laterale",
     "collapseSidebar": "Comprimi barra laterale",
+    "switchOrganization": "Cambia organizzazione",
     "version": "Versione",
     "loggedInAs": "Connesso come {name}",
     "prompts": "Prompt",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -337,6 +337,7 @@
     "newReport": "Novo relatório",
     "expandSidebar": "Expandir barra lateral",
     "collapseSidebar": "Recolher barra lateral",
+    "switchOrganization": "Alternar organização",
     "version": "Versão",
     "loggedInAs": "Conectado como {name}",
     "prompts": "Prompts",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -337,6 +337,7 @@
     "newReport": "Новый отчёт",
     "expandSidebar": "Развернуть боковую панель",
     "collapseSidebar": "Свернуть боковую панель",
+    "switchOrganization": "Сменить организацию",
     "version": "Версия",
     "loggedInAs": "Вошли как {name}",
     "prompts": "Промпты",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -337,6 +337,7 @@
     "newReport": "Ny rapport",
     "expandSidebar": "Expandera sidopanel",
     "collapseSidebar": "Fäll ihop sidopanel",
+    "switchOrganization": "Byt organisation",
     "version": "Version",
     "loggedInAs": "Inloggad som {name}",
     "prompts": "Prompter",


### PR DESCRIPTION
## Summary
Relocates the organization switcher from the user dropdown menu to the workspace header for multi-organization users, improving discoverability and accessibility of the org-switching feature.

## Key Changes
- **Workspace header redesign**: For users with multiple organizations, the workspace header now displays a dropdown menu that includes:
  - A "Home" link (preserving the desktop path to `/`)
  - Sorted list of organizations with icons
  - Current organization highlighted with a checkmark
  - Single-org users continue to see a plain home link with no switcher affordance

- **Shared styling**: Extracted `workspaceButtonClass` computed property to ensure consistent styling between the dropdown trigger and plain home link variants

- **Removed duplicate switcher**: Eliminated the organization switcher from the user dropdown menu to avoid duplication for multi-org users

- **Internationalization**: Added `switchOrganization` translation key across all supported locales (en, ar, de, es, fr, he, it, pt, ru, sv)

## Implementation Details
- Organization list is sorted alphabetically by name to ensure consistent ordering across page loads
- Dropdown respects the collapsed/expanded sidebar state with appropriate positioning (`right-start` when collapsed, `bottom-start` when expanded)
- Organization icons fall back to a building icon if no custom icon is provided
- Current organization is disabled in the dropdown to prevent redundant clicks

https://claude.ai/code/session_011AQF48Ek6Abj7YuiQkeCdd