### PR TITLE
Fix Step embedding to prioritize creator tools over readers

### DIFF
--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -100,26 +100,49 @@ from app.services.report_payload_projection import (
 )
 
 
+# Tools whose card is the primary renderer of the Step they created (code +
+# result table). Reader tools (read_query, create_artifact, ...) also stamp
+# created_step_id via the orchestrator's current-step fallback, but their
+# cards never render the Step inline — they carry their own bounded preview
+# and hydrate on expansion.
+STEP_CREATOR_TOOL_NAMES = frozenset(
+    {
+        "create_data",
+        "create_widget",
+        "write_csv",
+        "create_and_execute_code",
+        "execute_code",
+        "execute_sql",
+    }
+)
+
+
 def _latest_block_per_step(
     blocks: list["CompletionBlock"],
     te_map: dict[str, "ToolExecution"],
     all_completions: list["Completion"],
 ) -> dict[str, str]:
-    """Map created_step_id -> id of the chronologically latest block referencing it.
+    """Map created_step_id -> id of the block that should embed it inline.
 
-    Blocks are fetched ordered by completion_id (a UUID), so iteration order says
-    nothing about time; rank by the completion's position in the chronological
-    completion list, then by block_index within the completion.
+    The Step-creating tool's card is the one that renders code and rows, so it
+    wins over reader blocks that merely reference the same Step. Among equals,
+    chronology decides — blocks are fetched ordered by completion_id (a UUID),
+    so iteration order says nothing about time; rank by the completion's
+    position in the chronological completion list, then block_index.
     """
     completion_rank = {str(c.id): idx for idx, c in enumerate(all_completions)}
     latest: dict[str, str] = {}
-    best_key: dict[str, tuple[int, int]] = {}
+    best_key: dict[str, tuple[int, int, int]] = {}
     for b in blocks:
         te = te_map.get(b.tool_execution_id) if b.tool_execution_id else None
         if not te or not te.created_step_id:
             continue
         sid = str(te.created_step_id)
-        key = (completion_rank.get(str(b.completion_id), -1), b.block_index or 0)
+        key = (
+            1 if te.tool_name in STEP_CREATOR_TOOL_NAMES else 0,
+            completion_rank.get(str(b.completion_id), -1),
+            b.block_index or 0,
+        )
         if sid not in best_key or key >= best_key[sid]:
             best_key[sid] = key
             latest[sid] = str(b.id)

--- a/backend/tests/e2e/test_report_read_regressions.py
+++ b/backend/tests/e2e/test_report_read_regressions.py
@@ -43,7 +43,7 @@ def _rows(n):
 _COLUMNS = [{"field": "order_id"}, {"field": "amount"}]
 
 
-async def _seed_shared_step(completion_ids):
+async def _seed_shared_step(completion_ids, tool_names=None):
     """Two chronological completions whose tool executions share one Step.
 
     ``completion_ids`` fixes the UUIDs so the test controls whether UUID order
@@ -118,7 +118,7 @@ async def _seed_shared_step(completion_ids):
             await db.flush()
             te = ToolExecution(
                 agent_execution_id=ae.id,
-                tool_name="create_and_execute_code",
+                tool_name=(tool_names[turn] if tool_names else "create_and_execute_code"),
                 status="success",
                 success=True,
                 arguments_json={},
@@ -191,6 +191,42 @@ def test_shared_step_embeds_on_the_chronologically_latest_card(uuid_order_matche
     assert oldest.tool_execution.created_step is None, (
         "older cards keep only the id and hydrate on expansion"
     )
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("reader_tool", ["read_query", "create_artifact"])
+def test_creator_card_keeps_the_embed_over_later_reader_blocks(reader_tool):
+    """The orchestrator stamps reader tools with the creator's step id; the
+    inline Step copy must stay on the create_data card, which is the only
+    card that renders the step's code and rows."""
+    first, second = sorted(str(uuid.uuid4()) for _ in range(2))
+
+    async def scenario():
+        seeded = await _seed_shared_step(
+            [first, second],
+            tool_names=["create_data", reader_tool],
+        )
+        async with async_session_maker() as db:
+            service = CompletionService()
+            return await service.get_completions_v2(
+                db,
+                seeded["report_id"],
+                organization=seeded["org"],
+                current_user=seeded["user"],
+                limit=50,
+            )
+
+    response = _run(scenario())
+    blocks = _tool_blocks_by_turn(response)
+    creator = blocks[0]
+    reader = blocks[1]
+    assert creator.tool_execution.tool_name == "create_data"
+    assert creator.tool_execution.created_step is not None, (
+        "the create_data card must keep the inline Step even when a later "
+        f"{reader_tool} block references the same step"
+    )
+    assert (creator.tool_execution.created_step.data or {}).get("rows")
+    assert reader.tool_execution.created_step is None
 
 
 def _v1_step_summary(rows, row_count):

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -244,7 +244,9 @@ const currentAttempt = computed(() => {
 })
 const hasPreview = computed(() => {
   const te: any = props.toolExecution
-  const hasObject = !!(te?.created_widget || te?.created_step)
+  // A bare created_step_id is enough: ToolWidgetPreview hydrates the full
+  // Step on mount when the inline copy was deduplicated to another block.
+  const hasObject = !!(te?.created_widget || te?.created_step || te?.created_step_id)
   const hasViz = Array.isArray(te?.created_visualizations) && te.created_visualizations.length > 0
   const hasQuery = !!(te?.result_json?.query_id)
   const hasRows = Array.isArray(te?.result_json?.data?.rows) || Array.isArray(te?.result_json?.widget_data?.rows)


### PR DESCRIPTION
## Summary
This PR fixes an issue where reader tools (like `read_query` and `create_artifact`) could incorrectly claim the inline Step embedding that should belong to the tool that created the Step. The fix ensures that Step-creating tools always keep their inline code and result table display, even when later reader blocks reference the same Step.

## Key Changes

- **Added `STEP_CREATOR_TOOL_NAMES` constant** in `completion_service.py` to identify tools whose cards are the primary renderers of Steps they create (`create_data`, `create_widget`, `write_csv`, `create_and_execute_code`, `execute_code`, `execute_sql`)

- **Updated `_latest_block_per_step()` logic** to prioritize Step-creator tools over reader tools when multiple blocks reference the same Step. The ranking now uses a 3-tuple: `(is_creator_tool, completion_rank, block_index)` instead of just `(completion_rank, block_index)`

- **Enhanced test coverage** with new `test_creator_card_keeps_the_embed_over_later_reader_blocks()` test that validates the creator tool retains the inline Step while reader tools do not

- **Updated `_seed_shared_step()` helper** to accept optional `tool_names` parameter for flexible test scenario creation

- **Fixed frontend preview logic** in `CreateDataTool.vue` to handle cases where only `created_step_id` is present (without the full `created_step` object), allowing the preview to hydrate the Step on mount when the inline copy was deduplicated to another block

## Implementation Details

The core issue was that the orchestrator stamps `created_step_id` on both creator and reader tool executions (via the current-step fallback), but only the creator tool's card should render the Step inline with code and result table. Reader tools carry their own bounded preview and hydrate on expansion. The fix ensures the creator tool always wins the embedding through explicit tool name classification and ranking priority.

https://claude.ai/code/session_01UNcKAzvAANgog1qizKZY8A