### PR TITLE
Fix modal width reactivity issue in ScheduledPromptModal

### DIFF
--- a/frontend/components/ScheduledPromptModal.vue
+++ b/frontend/components/ScheduledPromptModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <UModal v-model="isOpen" :ui="{ width: viewMode ? 'sm:max-w-4xl' : 'sm:max-w-2xl' }">
+    <UModal v-model="isOpen" :ui="{ width: modalWidth }">
         <UCard :ui="{ body: { padding: 'px-5 py-4 sm:p-5' }, header: { padding: 'px-5 py-3 sm:px-5 sm:py-3' }, footer: { padding: 'px-5 py-3 sm:px-5 sm:py-3' } }">
             <template #header>
                 <div class="flex items-center justify-between">
@@ -423,6 +423,14 @@ const isActive = ref(props.scheduledPrompt?.is_active ?? true)
 // An existing task opens read-only — you usually come here to check on it, not
 // to change it. A new one goes straight to the form.
 const viewMode = ref(!!props.scheduledPrompt)
+
+// UModal (Nuxt UI v2) re-applies the transition's hidden `enterFrom` classes
+// to the dialog panel whenever a class in the `ui` prop changes while the
+// modal is open, leaving the panel stuck at opacity-0. So the width cannot
+// follow viewMode reactively: freeze it per open — wide when opening on an
+// existing task (two-column summary), narrow when opening straight into the
+// form — and keep it until the modal closes.
+const modalWidth = ref(viewMode.value ? 'sm:max-w-4xl' : 'sm:max-w-2xl')
 const { getCronLabel } = useCronLabel()
 // Handles naive-UTC strings and renders in the org's timezone.
 const { formatDateTime } = useFormatDate()
@@ -612,6 +620,7 @@ if (props.scheduledPrompt?.cron_schedule) {
 watch(isOpen, (open) => {
     if (open) {
         viewMode.value = !!props.scheduledPrompt
+        modalWidth.value = viewMode.value ? 'sm:max-w-4xl' : 'sm:max-w-2xl'
         if (props.scheduledPrompt) { fetchRuns(); fetchViewDetails() }
     }
 }, { immediate: true })


### PR DESCRIPTION
## Summary
Fixed a visual bug where the ScheduledPromptModal would become invisible when switching between view modes while the modal was open. The issue was caused by Nuxt UI v2's modal re-applying transition classes whenever the `ui` prop changed, leaving the panel stuck at opacity-0.

## Changes
- Extracted the modal width calculation into a separate reactive `modalWidth` ref that is frozen per modal open/close cycle, rather than reactively following `viewMode`
- Updated the modal's `:ui` binding to use the static `modalWidth` ref instead of a computed expression
- Added logic in the `isOpen` watcher to set `modalWidth` when the modal opens, ensuring it's wide (sm:max-w-4xl) for existing tasks and narrow (sm:max-w-2xl) for new ones
- Added detailed comment explaining the workaround and the underlying Nuxt UI v2 limitation

## Implementation Details
The modal width is now determined at open time and remains constant until the modal closes. This prevents the `ui` prop from changing while the modal is visible, which was triggering Nuxt UI's transition re-application and causing the opacity issue.

https://claude.ai/code/session_01U3KcXBtC4po9wFQeFfXugr