### PR TITLE
Add identity overlay auth for Qlik Sense on-prem

### DIFF
--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -106,6 +106,7 @@ from app.schemas.data_sources.configs import (
     # Qlik Sense Enterprise on Windows (on-prem)
     QlikSenseOnPremConfig,
     QlikSenseOnPremCertCredentials,
+    QlikSenseOnPremUserIdentityCredentials,
     # Microsoft Fabric
     MSFabricConfig,
     MSFabricCredentials,
@@ -205,6 +206,13 @@ class AuthVariant(BaseModel):
     title: str
     schema: Type[BaseModel]
     scopes: list[str] = ["system", "user"]  # which contexts this auth is allowed in
+    # An overlay variant does not stand alone: at resolve time its (user)
+    # credentials are merged OVER the connection's system credentials instead of
+    # replacing them. This is how per-user auth works for sources whose shared
+    # secret is heavy or admin-equivalent (a Qlik client certificate): the admin
+    # keeps the secret on the connection, the user contributes only their
+    # identity fields. Only meaningful on user-scoped variants.
+    overlay: bool = False
 
     class Config:
         arbitrary_types_allowed = True
@@ -1191,13 +1199,23 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         credentials_auth=AuthOptions(
             default="certificate",
             by_auth={
+                # The certificate is admin-equivalent on the Qlik site, so it is
+                # system-scope only — per-user auth must never mean handing the
+                # site certificate to every user.
                 "certificate": AuthVariant(
                     title="Client Certificate (mutual TLS)",
                     schema=QlikSenseOnPremCertCredentials,
-                    # A user-scoped credential reuses the same certificate but
-                    # names that user in User ID, so Qlik applies their own app
-                    # permissions and Section Access rules.
-                    scopes=["system", "user"],
+                    scopes=["system"],
+                ),
+                # Per-user auth: the user contributes only their Qlik identity;
+                # the admin's certificate is merged underneath at query time
+                # (overlay). Qlik then evaluates their queries with their own
+                # stream access and Section Access rules.
+                "identity": AuthVariant(
+                    title="Qlik Identity (uses the connection's certificate)",
+                    schema=QlikSenseOnPremUserIdentityCredentials,
+                    scopes=["user"],
+                    overlay=True,
                 ),
             },
         ),
@@ -1795,6 +1813,35 @@ def get_entry(ds_type: str) -> DataSourceRegistryEntry:
     if entry.dev_only and not _is_dev_environment():
         raise ValueError(f"Unknown data source type: {ds_type}")
     return entry
+
+
+def is_overlay_auth(ds_type: str, auth_mode: str) -> bool:
+    """True when this auth variant's credentials extend the connection's system
+    credentials rather than replace them (see AuthVariant.overlay)."""
+    entry = REGISTRY.get(ds_type)
+    if not entry or not auth_mode:
+        return False
+    variant = (entry.credentials_auth.by_auth or {}).get(auth_mode)
+    return bool(variant and variant.overlay)
+
+
+def overlay_system_credentials(connection, user_creds: dict, auth_mode: str) -> dict:
+    """Resolve an overlay variant: the user's credentials merged over the
+    connection's system credentials.
+
+    Empty user values are dropped before the merge so a blank optional field
+    cannot clobber a value the system credential provides. Non-overlay modes
+    pass through unchanged, so every resolver can call this unconditionally.
+    """
+    user_creds = user_creds or {}
+    if not is_overlay_auth(getattr(connection, "type", None), auth_mode):
+        return user_creds
+    try:
+        base = connection.decrypt_credentials() or {}
+    except Exception:
+        base = {}
+    layered = {k: v for k, v in user_creds.items() if v is not None and v != ""}
+    return {**base, **layered}
 
 
 def list_available_data_sources(include_tool_providers: bool = True) -> list[dict]:

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -2436,19 +2436,24 @@ class QlikSenseOnPremCertCredentials(BaseModel):
 
     A Qlik client certificate is admin-equivalent — it can act as any user on
     the site — so treat it like an admin password and re-export if it leaks.
+
+    The PEM fields are textareas, not password inputs, on purpose: a PEM file is
+    multi-line and OpenSSL needs its line structure, while a single-line
+    password input strips newlines on paste and silently corrupts the material.
+    Same trade BigQuery makes for its service-account JSON.
     """
 
     client_cert: str = Field(
         ...,
         title="Client Certificate (client.pem)",
-        description="Full PEM contents of client.pem, including the BEGIN/END CERTIFICATE lines.",
-        json_schema_extra={"ui:type": "password"},
+        description="Paste the full contents of client.pem, including the BEGIN/END CERTIFICATE lines.",
+        json_schema_extra={"ui:type": "textarea"},
     )
     client_key: str = Field(
         ...,
         title="Client Key (client_key.pem)",
-        description="Full PEM contents of client_key.pem, including the BEGIN/END PRIVATE KEY lines.",
-        json_schema_extra={"ui:type": "password"},
+        description="Paste the full contents of client_key.pem, including the BEGIN/END PRIVATE KEY lines.",
+        json_schema_extra={"ui:type": "textarea"},
     )
     client_key_password: Optional[str] = Field(
         None,
@@ -2460,10 +2465,10 @@ class QlikSenseOnPremCertCredentials(BaseModel):
         None,
         title="Root CA Certificate (root.pem)",
         description=(
-            "Full PEM contents of root.pem. Qlik signs its service certificates with its own "
-            "root, so this is what makes 'Verify SSL' work on a default install."
+            "Paste the full contents of root.pem. Qlik signs its service certificates with its "
+            "own root, so this is what makes 'Verify SSL' work on a default install."
         ),
-        json_schema_extra={"ui:type": "password"},
+        json_schema_extra={"ui:type": "textarea"},
     )
     user_directory: Optional[str] = Field(
         None,
@@ -2486,14 +2491,46 @@ class QlikSenseOnPremCertCredentials(BaseModel):
     )
 
 
+class QlikSenseOnPremUserIdentityCredentials(BaseModel):
+    """Per-user identity for a connection that requires user authentication.
+
+    Deliberately holds NO certificate material: the admin's client certificate
+    stays on the connection's system credentials, and this identity is merged
+    over it at query time (the variant is marked ``overlay`` in the registry).
+    The user only states who Qlik should evaluate their queries as — Qlik then
+    applies that account's stream access and Section Access rules.
+    """
+
+    user_directory: str = Field(
+        ...,
+        title="User Directory",
+        description=(
+            "Your Qlik user directory, e.g. your AD domain name — the part before the "
+            "backslash in DOMAIN\\user in the Qlik hub."
+        ),
+        json_schema_extra={"ui:type": "string"},
+    )
+    user_id: str = Field(
+        ...,
+        title="User ID",
+        description="Your Qlik user id — queries run with your stream access and Section Access rules.",
+        json_schema_extra={"ui:type": "string"},
+    )
+
+
 class QlikSenseOnPremConfig(BaseModel):
+    """Connection form for QSEoW — deliberately small, like the Power BI and
+    BigQuery forms. Crawl-behavior knobs (impersonate_app_owner,
+    include_master_items, include_lineage, max_apps, max_concurrency,
+    timeout_sec) stay client constructor defaults rather than form fields:
+    they tune discovery internals, not connection identity."""
+
     server_url: str = Field(
         ...,
         title="Server URL",
         description=(
-            "Qlik Sense central node hostname, e.g. https://qlik.corp.example.com. "
-            "Must match the name the certificate was exported for. Any port here is ignored — "
-            "QRS and the Engine have their own ports below."
+            "Qlik Sense central node hostname, e.g. https://qlik.corp.example.com — the name "
+            "the certificate was exported for. Any port here is ignored."
         ),
         json_schema_extra={"ui:type": "string"},
     )
@@ -2501,73 +2538,33 @@ class QlikSenseOnPremConfig(BaseModel):
         True,
         title="Verify SSL",
         description=(
-            "Verify the server's TLS certificate. Requires the Root CA Certificate above on a "
-            "default install, which uses self-signed service certificates."
+            "Verify the server's TLS certificate. A default install uses self-signed service "
+            "certificates, so this needs root.pem pasted in the credentials section."
         ),
         json_schema_extra={"ui:type": "boolean"},
     )
     stream_filter: Optional[str] = Field(
         None,
         title="Stream Filter",
-        description="Optional comma-separated list of stream names or IDs. If empty, all visible streams are crawled.",
+        description="Optional comma-separated stream names or IDs. Empty crawls all visible streams.",
         json_schema_extra={"ui:type": "string"},
     )
     published_only: bool = Field(
         True,
         title="Published Apps Only",
-        description="Skip apps still in a user's personal work area. Only published apps belong to a stream.",
+        description="Skip apps still in a user's personal work area.",
         json_schema_extra={"ui:type": "boolean"},
-    )
-    impersonate_app_owner: bool = Field(
-        True,
-        title="Impersonate App Owner",
-        description=(
-            "When no User ID is configured, open each app as its owner. The owner always has "
-            "access to their own app, which avoids Section Access refusals during discovery. "
-            "Ignored when User ID is set."
-        ),
-        json_schema_extra={"ui:type": "boolean"},
-    )
-    include_master_items: bool = Field(
-        True,
-        title="Include Master Items",
-        description="Extract each app's master measures (with expressions), master dimensions and variables.",
-        json_schema_extra={"ui:type": "boolean"},
-    )
-    include_lineage: bool = Field(
-        True,
-        title="Include Lineage",
-        description="Extract each app's data lineage — the QVD files, databases and connections its script loads from.",
-        json_schema_extra={"ui:type": "boolean"},
-    )
-    max_apps: Optional[int] = Field(
-        None,
-        title="Max Apps",
-        description="Optional cap on how many apps to crawl, most recently reloaded first. Empty means all.",
-        json_schema_extra={"ui:type": "number"},
-    )
-    max_concurrency: int = Field(
-        4,
-        title="Max Concurrency",
-        description="Apps opened in parallel. Each open loads the app into Engine memory, so keep this low.",
-        json_schema_extra={"ui:type": "number"},
     )
     qrs_port: int = Field(
         4242,
         title="QRS Port",
-        description="Qlik Repository Service port. 4242 unless it was changed at install time.",
+        description="Qlik Repository Service port. 4242 unless changed at install time.",
         json_schema_extra={"ui:type": "number"},
     )
     engine_port: int = Field(
         4747,
         title="Engine Port",
-        description="Qlik Engine Service port. 4747 unless it was changed at install time.",
-        json_schema_extra={"ui:type": "number"},
-    )
-    timeout_sec: int = Field(
-        60,
-        title="Timeout (seconds)",
-        description="Per-request timeout for QRS calls and Engine sessions.",
+        description="Qlik Engine Service port. 4747 unless changed at install time.",
         json_schema_extra={"ui:type": "number"},
     )
 

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -246,6 +246,12 @@ def default_user_auth_modes(conn_type: str, config: dict, credentials: dict) -> 
         # constrained delegation (no per-user secret; UPN derived at query
         # time from the login identity).
         return ["kerberos_delegated"]
+    if conn_type == "qlik_sense_onprem":
+        # Per-user auth is the identity overlay: the user names their Qlik
+        # account, the connection's certificate is merged underneath. The
+        # certificate variant itself is system-scope only — it is
+        # admin-equivalent on the Qlik site and must not be requested per user.
+        return ["identity"]
     return None
 
 
@@ -1880,7 +1886,10 @@ class ConnectionService:
                 logger.warning(f"OAuth token refresh check failed: {e}")
                 return row.decrypt_credentials()
 
-        return row.decrypt_credentials()
+        # Overlay variants (e.g. Qlik on-prem "identity") carry only the user's
+        # identity fields — merge them over the connection's system credentials.
+        from app.schemas.data_source_registry import overlay_system_credentials
+        return overlay_system_credentials(connection, row.decrypt_credentials() or {}, row.auth_mode)
 
     @staticmethod
     def _kerberos_delegated_credentials(connection: Connection, user: User, row) -> Optional[dict]:

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2209,7 +2209,10 @@ class DataSourceService:
             # fallback, and the "connect required" 403.
             from app.services.connection_service import ConnectionService
             return await ConnectionService().resolve_credentials(db, conn, current_user)
-        return row.decrypt_credentials() or {}
+        # Overlay variants (e.g. Qlik on-prem "identity") carry only the user's
+        # identity fields — the connection's system credentials supply the rest.
+        from app.schemas.data_source_registry import overlay_system_credentials
+        return overlay_system_credentials(conn, row.decrypt_credentials() or {}, row.auth_mode)
 
     async def construct_client(self, db: AsyncSession, data_source: DataSource, current_user: User | None):
         """
@@ -2703,7 +2706,12 @@ class DataSourceService:
             try:
                 row = await u_svc.get_primary_active_row(db, data_source, current_user)
                 if row:
-                    return row.decrypt_credentials() or {}
+                    # Overlay variants merge over the connection's system
+                    # credentials instead of replacing them.
+                    from app.schemas.data_source_registry import overlay_system_credentials
+                    return overlay_system_credentials(
+                        connection, row.decrypt_credentials() or {}, row.auth_mode
+                    )
             except Exception:
                 pass
 

--- a/backend/app/services/user_data_source_credentials_service.py
+++ b/backend/app/services/user_data_source_credentials_service.py
@@ -377,9 +377,14 @@ class UserDataSourceCredentialsService:
         except Exception as e:
             raise HTTPException(status_code=422, detail=f"Invalid credentials: {e}")
 
-        # Build client with provided creds without persisting
+        # Build client with provided creds without persisting. For an overlay
+        # variant the user's payload is only their identity fields, so the
+        # connection's system credentials (e.g. the Qlik client certificate)
+        # go underneath — exactly as the runtime resolver will merge them.
+        from app.schemas.data_source_registry import overlay_system_credentials
+        creds = overlay_system_credentials(connection, payload.credentials or {}, payload.auth_mode)
         ClientClass = resolve_client_class(ds_type)
-        params = {**(config or {}), **(payload.credentials or {})}
+        params = {**(config or {}), **creds}
         # Strip meta keys
         meta_keys = {"auth_type", "auth_policy", "allowed_user_auth_modes"}
         params = {k: v for k, v in params.items() if v is not None and k not in meta_keys}

--- a/backend/tests/unit/test_qlik_sense_onprem_client.py
+++ b/backend/tests/unit/test_qlik_sense_onprem_client.py
@@ -1276,17 +1276,55 @@ class TestRegistry:
         assert entry.category == "bi"
         assert resolve_client_class("qlik_sense_onprem") is QlikSenseOnPremClient
 
-    def test_the_certificate_variant_is_offered_to_both_scopes(self):
+    def test_the_certificate_variant_is_system_scope_only(self):
+        """The certificate is admin-equivalent on the Qlik site — offering it at
+        user scope would mean handing the site certificate to every user."""
         from app.schemas.data_source_registry import REGISTRY
 
         variant = REGISTRY["qlik_sense_onprem"].credentials_auth.by_auth["certificate"]
-        assert set(variant.scopes) == {"system", "user"}
+        assert set(variant.scopes) == {"system"}
+        assert variant.overlay is False
         fields = variant.schema.model_fields
         assert fields["client_cert"].is_required()
         assert fields["client_key"].is_required()
-        # The acting identity is per-credential, which is what lets a user-scoped
-        # connection be evaluated as that user.
         assert "user_id" in fields
+
+    def test_pem_fields_are_textareas_not_password_inputs(self):
+        """A password input is single-line and strips newlines on paste, which
+        silently corrupts a PEM. BigQuery's service-account JSON sets the
+        precedent: multi-line secrets are textareas."""
+        from app.schemas.data_source_registry import REGISTRY
+
+        fields = REGISTRY["qlik_sense_onprem"].credentials_auth.by_auth["certificate"].schema.model_fields
+        for pem_field in ("client_cert", "client_key", "root_ca"):
+            extra = fields[pem_field].json_schema_extra
+            assert extra["ui:type"] == "textarea", pem_field
+        # The key passphrase is single-line and genuinely a password.
+        assert fields["client_key_password"].json_schema_extra["ui:type"] == "password"
+
+    def test_the_user_variant_is_an_identity_overlay(self):
+        """Per-user auth asks for User Directory + User ID and nothing else —
+        the certificate stays on the connection's system credentials."""
+        from app.schemas.data_source_registry import REGISTRY
+
+        variant = REGISTRY["qlik_sense_onprem"].credentials_auth.by_auth["identity"]
+        assert set(variant.scopes) == {"user"}
+        assert variant.overlay is True
+        fields = variant.schema.model_fields
+        assert set(fields) == {"user_directory", "user_id"}
+        assert fields["user_directory"].is_required()
+        assert fields["user_id"].is_required()
+
+    def test_config_form_is_slim_like_the_peer_connectors(self):
+        """Crawl-behavior knobs are constructor defaults, not form fields —
+        the Power BI config is one field, BigQuery's is four."""
+        from app.schemas.data_source_registry import REGISTRY
+
+        fields = set(REGISTRY["qlik_sense_onprem"].config_schema.model_fields)
+        assert fields == {
+            "server_url", "verify_ssl", "stream_filter", "published_only",
+            "qrs_port", "engine_port",
+        }
 
     def test_config_and_credential_fields_match_the_constructor(self):
         """The registry schemas ARE the connection form, and connection_service
@@ -1298,7 +1336,86 @@ class TestRegistry:
 
         entry = REGISTRY["qlik_sense_onprem"]
         params = set(inspect.signature(QlikSenseOnPremClient.__init__).parameters) - {"self"}
-        declared = set(entry.config_schema.model_fields) | set(
-            entry.credentials_auth.by_auth["certificate"].schema.model_fields
-        )
+        declared = set(entry.config_schema.model_fields)
+        for variant in entry.credentials_auth.by_auth.values():
+            declared |= set(variant.schema.model_fields)
         assert declared <= params, f"not accepted by the client: {sorted(declared - params)}"
+
+
+class TestIdentityOverlayResolution:
+    """The overlay merge that makes per-user auth work: the user's identity
+    fields layered over the connection's system credentials."""
+
+    class _FakeConnection:
+        type = "qlik_sense_onprem"
+
+        def __init__(self, creds):
+            self._creds = creds
+
+        def decrypt_credentials(self):
+            return self._creds
+
+    SYSTEM_CREDS = {
+        "client_cert": CERT_PEM,
+        "client_key": KEY_PEM,
+        "root_ca": None,
+        "user_directory": None,
+        "user_id": None,
+    }
+
+    def test_identity_creds_merge_over_the_system_certificate(self):
+        from app.schemas.data_source_registry import overlay_system_credentials
+
+        conn = self._FakeConnection(self.SYSTEM_CREDS)
+        merged = overlay_system_credentials(
+            conn, {"user_directory": "EXAMPLECORP", "user_id": "dana"}, "identity"
+        )
+        assert merged["client_cert"] == CERT_PEM
+        assert merged["client_key"] == KEY_PEM
+        assert merged["user_directory"] == "EXAMPLECORP"
+        assert merged["user_id"] == "dana"
+
+    def test_the_merged_credentials_construct_a_working_client(self):
+        """End to end through the constructor: identity + system certs must
+        yield a client that acts as the user on every request."""
+        from app.schemas.data_source_registry import overlay_system_credentials
+
+        conn = self._FakeConnection(self.SYSTEM_CREDS)
+        merged = overlay_system_credentials(
+            conn, {"user_directory": "EXAMPLECORP", "user_id": "dana"}, "identity"
+        )
+        client = QlikSenseOnPremClient(server_url="https://qlik.corp.example.com", **merged)
+        assert client._acting_user() == "UserDirectory=EXAMPLECORP; UserId=dana"
+        # The explicit identity also wins over app-owner impersonation.
+        assert client._acting_user({"owner": {"userDirectory": "X", "userId": "y"}}) == (
+            "UserDirectory=EXAMPLECORP; UserId=dana"
+        )
+
+    def test_blank_user_values_do_not_clobber_system_values(self):
+        from app.schemas.data_source_registry import overlay_system_credentials
+
+        conn = self._FakeConnection({**self.SYSTEM_CREDS, "user_directory": "SVCDIR"})
+        merged = overlay_system_credentials(conn, {"user_directory": "", "user_id": "dana"}, "identity")
+        assert merged["user_directory"] == "SVCDIR"
+
+    def test_non_overlay_modes_pass_through_untouched(self):
+        """A certificate credential replaces system creds wholesale, exactly as
+        every non-overlay variant always has."""
+        from app.schemas.data_source_registry import overlay_system_credentials
+
+        conn = self._FakeConnection(self.SYSTEM_CREDS)
+        user_creds = {"client_cert": "other", "client_key": "other-key"}
+        assert overlay_system_credentials(conn, user_creds, "certificate") == user_creds
+
+    def test_other_connector_types_are_unaffected(self):
+        from app.schemas.data_source_registry import is_overlay_auth
+
+        assert is_overlay_auth("qlik_sense_onprem", "identity") is True
+        assert is_overlay_auth("qlik_sense_onprem", "certificate") is False
+        assert is_overlay_auth("postgresql", "userpass") is False
+        assert is_overlay_auth("nonexistent_type", "identity") is False
+
+    def test_user_required_connections_default_to_the_identity_mode(self):
+        from app.services.connection_service import default_user_auth_modes
+
+        assert default_user_auth_modes("qlik_sense_onprem", {}, {}) == ["identity"]

--- a/docs/qlik-sense-onprem-connector.md
+++ b/docs/qlik-sense-onprem-connector.md
@@ -37,9 +37,19 @@ the repo because it contained live credentials (see *Security* below).
    name the account Qlik should evaluate it as via
    `X-Qlik-User: UserDirectory=…; UserId=…`. That header is what decides which
    apps are visible and which Section Access rules apply — it is the row-level
-   security story, and it is why the acting identity lives in the
-   **credentials** schema (a user-scoped credential reuses the same certificate
-   with that user's `UserId`).
+   security story.
+
+   Per-user auth builds on this with an **identity overlay**: the certificate
+   variant is system-scope only (it is admin-equivalent on the site, so it must
+   never be requested from end users), and the user-scope variant asks for just
+   `User Directory` + `User ID`. The variant is marked `overlay=True` in the
+   registry, and every credential resolver merges the user's identity fields
+   over the connection's system credentials
+   (`overlay_system_credentials` in `data_source_registry.py`) before the
+   client is constructed — so the user's queries carry the admin's certificate
+   but *their* `X-Qlik-User`, and Qlik applies their stream access and Section
+   Access. The same mechanism is generic: any connector whose shared secret is
+   heavy or admin-equivalent can add an overlay variant.
 
 3. **Ports are fixed and separate.** QRS is `:4242`, the Engine is `:4747`, and
    neither is the QMC/hub port. Any port in the configured Server URL is
@@ -159,6 +169,19 @@ BOW_DATABASE_URL="sqlite:///db/app.db" uv run pytest \
 
 All QRS and Engine I/O is mocked; the certificate tests generate a throwaway
 self-signed EC pair so `load_cert_chain` has something real to load.
+
+## Form notes
+
+- The three PEM fields (`client_cert`, `client_key`, `root_ca`) are
+  `ui:type: textarea`, not `password`: a password input is single-line and
+  strips newlines on paste, which silently corrupts a PEM (OpenSSL needs the
+  line structure). BigQuery's service-account JSON is the precedent.
+- The config form is deliberately slim (server URL, Verify SSL, stream filter,
+  published-only, and the two ports). Crawl-behavior knobs
+  (`impersonate_app_owner`, `include_master_items`, `include_lineage`,
+  `max_apps`, `max_concurrency`, `timeout_sec`) remain client constructor
+  parameters with defaults — they tune discovery internals, not connection
+  identity, and the peer connectors (Power BI: one config field) set the bar.
 
 ## Not yet covered
 


### PR DESCRIPTION
## Summary

Implements per-user authentication for Qlik Sense on-premises by introducing an "identity overlay" pattern. This allows users to authenticate with their own Qlik identity while the connection's admin certificate remains system-scoped, avoiding the security risk of distributing admin-equivalent credentials to end users.

## Key Changes

- **New credential variant**: Added `QlikSenseOnPremUserIdentityCredentials` schema that captures only `user_directory` and `user_id` fields
- **Overlay mechanism**: Introduced `overlay_system_credentials()` and `is_overlay_auth()` functions in `data_source_registry.py` to merge user credentials over system credentials at resolution time
- **Certificate security**: Changed certificate variant from `["system", "user"]` scopes to `["system"]` only, preventing accidental distribution of admin credentials
- **UI improvements**: Changed PEM fields (`client_cert`, `client_key`, `root_ca`) from password inputs to textareas to preserve line structure (following BigQuery's precedent)
- **Streamlined config form**: Removed crawl-behavior knobs (`impersonate_app_owner`, `include_master_items`, `include_lineage`, `max_apps`, `max_concurrency`, `timeout_sec`) from the config schema—these remain constructor defaults
- **Credential resolution**: Updated all credential resolvers (`data_source_service.py`, `connection_service.py`, `user_data_source_credentials_service.py`) to apply overlay merging
- **Default auth mode**: Set `identity` as the default user auth mode for Qlik on-prem connections

## Implementation Details

- The overlay pattern is generic and extensible: any connector with a heavy or admin-equivalent shared secret can adopt it by marking a variant with `overlay=True`
- Empty user credential values are dropped before merge to prevent clobbering system values
- Non-overlay variants pass through unchanged, allowing all resolvers to call `overlay_system_credentials()` unconditionally
- The merged credentials are applied consistently across test credential validation, runtime resolution, and data source construction

https://claude.ai/code/session_01Q5nLejNyxGBAhAEFGnhp98