### PR TITLE
Match filters against what the grid shows, in one shared evaluator

### DIFF
--- a/frontend/components/DashboardComponent.vue
+++ b/frontend/components/DashboardComponent.vue
@@ -217,6 +217,7 @@ import CardBlock from '@/components/dashboard/blocks/CardBlock.vue';
 import ColumnLayoutBlock from '@/components/dashboard/blocks/ColumnLayoutBlock.vue';
 import FilterBuilder from '@/components/dashboard/FilterBuilder.vue';
 import { resolveEntryByType } from '@/components/dashboard/registry'
+import { evaluateFilters as sharedEvaluateFilters } from '~/composables/useSharedFilters'
 import { themes } from '@/components/dashboard/themes'
     import { useDashboardTheme } from '@/components/dashboard/composables/useDashboardTheme'
 
@@ -550,40 +551,7 @@ import { themes } from '@/components/dashboard/themes'
 
     // Static filter evaluation function (used when FilterBuilder ref is not available)
     function evaluateFiltersStatic(row: any, groups: any[], targetVizId: string): boolean {
-        if (!groups.length) return true;
-        
-        // OR across groups
-        return groups.some(group => {
-            // AND within group
-            return group.conditions.every((cond: any) => {
-                const [vizId, ...rest] = (cond.column || '').split(':');
-                const columnName = rest.join(':');
-                // Only apply condition if it targets the current visualization
-                if (vizId !== targetVizId) return true;
-                
-                const value = row[columnName];
-                const target = cond.value;
-                
-                const stringValue = String(value).toLowerCase();
-                const stringTarget = String(target).toLowerCase();
-
-                switch (cond.operator) {
-                    case 'equals': return stringValue === stringTarget;
-                    case 'not_equals': return stringValue !== stringTarget;
-                    case 'contains': return stringValue.includes(stringTarget);
-                    case 'not_contains': return !stringValue.includes(stringTarget);
-                    case 'starts_with': return stringValue.startsWith(stringTarget);
-                    case 'ends_with': return stringValue.endsWith(stringTarget);
-                    case 'greater_than': return Number(value) > Number(target);
-                    case 'less_than': return Number(value) < Number(target);
-                    case 'gte': return Number(value) >= Number(target);
-                    case 'lte': return Number(value) <= Number(target);
-                    case 'is_empty': return value == null || value === '';
-                    case 'is_not_empty': return value != null && value !== '';
-                    default: return true;
-                }
-            });
-        });
+        return sharedEvaluateFilters(row, groups as any, targetVizId);
     }
 
     // --- Lifecycle Hooks ---

--- a/frontend/components/dashboard/FilterBuilder.vue
+++ b/frontend/components/dashboard/FilterBuilder.vue
@@ -227,6 +227,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { evaluateOperator, isIncompleteCondition } from '~/composables/useSharedFilters'
 
 // Types
 interface FilterCondition {
@@ -740,59 +741,17 @@ function evaluateCondition(row: any, condition: FilterCondition, widgetId?: stri
     return true // Don't filter out rows for non-matching widget conditions
   }
 
+  // Half-written condition: no-op rather than matching nothing
+  if (isIncompleteCondition(condition as any)) {
+    return true
+  }
+
   // Case-insensitive column lookup
   const columnKey = Object.keys(row).find(
     k => k.toLowerCase() === columnName.toLowerCase()
   )
   const value = columnKey ? row[columnKey] : undefined
-  const target = condition.value
-
-  switch (condition.operator) {
-    case 'equals':
-      return String(value).toLowerCase() === String(target).toLowerCase()
-    case 'not_equals':
-      return String(value).toLowerCase() !== String(target).toLowerCase()
-    case 'contains':
-      return String(value).toLowerCase().includes(String(target).toLowerCase())
-    case 'not_contains':
-      return !String(value).toLowerCase().includes(String(target).toLowerCase())
-    case 'starts_with':
-      return String(value).toLowerCase().startsWith(String(target).toLowerCase())
-    case 'ends_with':
-      return String(value).toLowerCase().endsWith(String(target).toLowerCase())
-    case 'greater_than':
-      return Number(value) > Number(target)
-    case 'less_than':
-      return Number(value) < Number(target)
-    case 'gte':
-      return Number(value) >= Number(target)
-    case 'lte':
-      return Number(value) <= Number(target)
-    case 'between':
-      return Number(value) >= Number(target) && Number(value) <= Number(condition.value2)
-    case 'before':
-      return new Date(value) < new Date(target)
-    case 'after':
-      return new Date(value) > new Date(target)
-    case 'in':
-      return Array.isArray(target) && target.some(t =>
-        String(value).toLowerCase() === String(t).toLowerCase()
-      )
-    case 'not_in':
-      return !Array.isArray(target) || !target.some(t =>
-        String(value).toLowerCase() === String(t).toLowerCase()
-      )
-    case 'is_empty':
-      return value == null || value === ''
-    case 'is_not_empty':
-      return value != null && value !== ''
-    case 'is_true':
-      return value === true || value === 'true' || value === 1
-    case 'is_false':
-      return value === false || value === 'false' || value === 0
-    default:
-      return true
-  }
+  return evaluateOperator(value, condition.operator, condition.value, condition.value2)
 }
 
 // Expose filter evaluation function for parent component

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -374,6 +374,7 @@ import VisualizationFilter from '@/components/dashboard/VisualizationFilter.vue'
 import {
   parseColumnKey,
   evaluateFilters as sharedEvaluateFilters,
+  evaluateOperator,
   type FilterGroup
 } from '~/composables/useSharedFilters'
 
@@ -552,29 +553,13 @@ const filteredRows = computed(() => {
 })
 
 // Lightweight evaluator for a view's plain-column defaultFilters (no vizId
-// prefix). Mirrors the operators in DefaultFilterCondition.
+// prefix). Delegates to the shared operator semantics so default filters and
+// user filters agree on whitespace/number/case normalization.
 function matchDefaultFilter(row: any, f: any): boolean {
   if (!row || !f || !f.column) return true
   const key = Object.keys(row).find(k => k.toLowerCase() === String(f.column).toLowerCase())
   if (key === undefined) return true
-  const cell = row[key]
-  const s = (x: any) => (x === null || x === undefined) ? '' : String(x)
-  const op = String(f.operator || 'equals')
-  switch (op) {
-    case 'equals': return s(cell) === s(f.value)
-    case 'not_equals': return s(cell) !== s(f.value)
-    case 'contains': return s(cell).includes(s(f.value))
-    case 'not_contains': return !s(cell).includes(s(f.value))
-    case 'starts_with': return s(cell).startsWith(s(f.value))
-    case 'ends_with': return s(cell).endsWith(s(f.value))
-    case 'greater_than': return Number(cell) > Number(f.value)
-    case 'less_than': return Number(cell) < Number(f.value)
-    case 'gte': return Number(cell) >= Number(f.value)
-    case 'lte': return Number(cell) <= Number(f.value)
-    case 'is_empty': return s(cell) === ''
-    case 'is_not_empty': return s(cell) !== ''
-    default: return true
-  }
+  return evaluateOperator(row[key], String(f.operator || 'equals'), f.value, f.value2)
 }
 
 // Normalize the view to ensure it's in the v2 format { view: {...}, version: 'v2' }

--- a/frontend/composables/useSharedFilters.ts
+++ b/frontend/composables/useSharedFilters.ts
@@ -133,6 +133,78 @@ export function isIncompleteCondition(condition: FilterCondition): boolean {
   return isBlank(condition.value)
 }
 
+// The user types what the grid shows, and the grid hides the raw value's rough
+// edges: SQL Server CHAR columns pad with trailing spaces ("X707 " renders as
+// "X707"), numbers arrive as 7837 or "7837.0" depending on the producing tool,
+// and Python serializes booleans as "True"/"False". So every comparison
+// normalizes both sides: trim, compare numerically when both sides are numbers,
+// fold case.
+function normStr(x: any): string {
+  return x == null ? '' : String(x).trim()
+}
+
+function normFold(x: any): string {
+  return normStr(x).toLowerCase()
+}
+
+function toNum(x: any): number {
+  if (typeof x === 'number') return x
+  const s = normStr(x)
+  return s === '' ? NaN : Number(s)
+}
+
+function looseEquals(value: any, target: any): boolean {
+  const a = toNum(value)
+  const b = toNum(target)
+  if (Number.isFinite(a) && Number.isFinite(b)) return a === b
+  return normFold(value) === normFold(target)
+}
+
+export function evaluateOperator(value: any, operator: string, target: any, target2?: any): boolean {
+  switch (operator) {
+    case 'equals':
+      return looseEquals(value, target)
+    case 'not_equals':
+      return !looseEquals(value, target)
+    case 'contains':
+      return normFold(value).includes(normFold(target))
+    case 'not_contains':
+      return !normFold(value).includes(normFold(target))
+    case 'starts_with':
+      return normFold(value).startsWith(normFold(target))
+    case 'ends_with':
+      return normFold(value).endsWith(normFold(target))
+    case 'greater_than':
+      return toNum(value) > toNum(target)
+    case 'less_than':
+      return toNum(value) < toNum(target)
+    case 'gte':
+      return toNum(value) >= toNum(target)
+    case 'lte':
+      return toNum(value) <= toNum(target)
+    case 'between':
+      return toNum(value) >= toNum(target) && toNum(value) <= toNum(target2)
+    case 'before':
+      return new Date(value) < new Date(target)
+    case 'after':
+      return new Date(value) > new Date(target)
+    case 'in':
+      return Array.isArray(target) && target.some(t => looseEquals(value, t))
+    case 'not_in':
+      return !Array.isArray(target) || !target.some(t => looseEquals(value, t))
+    case 'is_empty':
+      return normStr(value) === ''
+    case 'is_not_empty':
+      return normStr(value) !== ''
+    case 'is_true':
+      return value === true || value === 1 || normFold(value) === 'true'
+    case 'is_false':
+      return value === false || value === 0 || normFold(value) === 'false'
+    default:
+      return true
+  }
+}
+
 export function evaluateCondition(row: any, condition: FilterCondition, targetVizId?: string): boolean {
   const { vizId: condVizId, columnName } = parseColumnKey(condition.column)
 
@@ -149,46 +221,7 @@ export function evaluateCondition(row: any, condition: FilterCondition, targetVi
   // Case-insensitive column lookup
   const columnKey = Object.keys(row).find(k => k.toLowerCase() === columnName.toLowerCase())
   const value = columnKey ? row[columnKey] : undefined
-  const target = condition.value
-  
-  switch (condition.operator) {
-    case 'equals':
-      return String(value).toLowerCase() === String(target).toLowerCase()
-    case 'not_equals':
-      return String(value).toLowerCase() !== String(target).toLowerCase()
-    case 'contains':
-      return String(value).toLowerCase().includes(String(target).toLowerCase())
-    case 'not_contains':
-      return !String(value).toLowerCase().includes(String(target).toLowerCase())
-    case 'starts_with':
-      return String(value).toLowerCase().startsWith(String(target).toLowerCase())
-    case 'ends_with':
-      return String(value).toLowerCase().endsWith(String(target).toLowerCase())
-    case 'greater_than':
-      return Number(value) > Number(target)
-    case 'less_than':
-      return Number(value) < Number(target)
-    case 'gte':
-      return Number(value) >= Number(target)
-    case 'lte':
-      return Number(value) <= Number(target)
-    case 'between':
-      return Number(value) >= Number(target) && Number(value) <= Number(condition.value2)
-    case 'before':
-      return new Date(value) < new Date(target)
-    case 'after':
-      return new Date(value) > new Date(target)
-    case 'is_empty':
-      return value == null || value === ''
-    case 'is_not_empty':
-      return value != null && value !== ''
-    case 'is_true':
-      return value === true || value === 'true' || value === 1
-    case 'is_false':
-      return value === false || value === 'false' || value === 0
-    default:
-      return true
-  }
+  return evaluateOperator(value, condition.operator, condition.value, condition.value2)
 }
 
 export function evaluateFilters(row: any, groups: FilterGroup[], targetVizId?: string): boolean {

--- a/frontend/tests/unit/useSharedFilters.mjs
+++ b/frontend/tests/unit/useSharedFilters.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+
+import {
+  evaluateOperator,
+  evaluateCondition,
+  evaluateFilters,
+} from '../../composables/useSharedFilters.ts'
+
+// --- whitespace normalization ------------------------------------------------
+
+// SQL Server CHAR columns pad values with trailing spaces; the grid renders
+// "X707 " and "X707" identically, and the user types what they see.
+assert.equal(evaluateOperator('X707 ', 'equals', 'X707'), true, 'trailing-padded cell must equal the typed value')
+assert.equal(evaluateOperator('X707', 'equals', ' X707 '), true, 'padded typed value must equal the clean cell')
+assert.equal(evaluateOperator('X707 ', 'not_equals', 'X707'), false)
+assert.equal(evaluateOperator(' X707', 'starts_with', 'X7'), true)
+assert.equal(evaluateOperator('X707 ', 'ends_with', '07'), true)
+assert.equal(evaluateOperator('X707 ', 'contains', ' 707 '), true)
+
+// A padded-empty CHAR cell renders as blank, so it must count as empty.
+assert.equal(evaluateOperator('   ', 'is_empty', undefined), true)
+assert.equal(evaluateOperator('   ', 'is_not_empty', undefined), false)
+assert.equal(evaluateOperator(null, 'is_empty', undefined), true)
+assert.equal(evaluateOperator('x', 'is_not_empty', undefined), true)
+
+console.log('padded values match what the grid displays')
+
+// --- numeric equality --------------------------------------------------------
+
+// Producing tools disagree on number formatting: pandas emits "7837.0" where
+// the user types 7837. Both sides numeric -> compare numerically.
+assert.equal(evaluateOperator('7837.0', 'equals', '7837'), true)
+assert.equal(evaluateOperator(7837, 'equals', '7837'), true)
+assert.equal(evaluateOperator('0100', 'equals', 100), true)
+assert.equal(evaluateOperator('7837.5', 'equals', '7837'), false)
+// Mixed numeric/text falls back to string comparison, not NaN weirdness.
+assert.equal(evaluateOperator('X707', 'equals', 707), false)
+
+// Comparisons trim too, and null is no longer coerced to 0.
+assert.equal(evaluateOperator(' 42 ', 'greater_than', '41'), true)
+assert.equal(evaluateOperator(null, 'less_than', 5), false, 'null must not compare as 0')
+assert.equal(evaluateOperator('', 'gte', 0), false, 'blank must not compare as 0')
+assert.equal(evaluateOperator(' 10 ', 'between', 5, 15), true)
+
+console.log('numbers compare numerically regardless of formatting')
+
+// --- booleans ----------------------------------------------------------------
+
+// Python serializes booleans as "True"/"False".
+assert.equal(evaluateOperator('True', 'is_true', undefined), true)
+assert.equal(evaluateOperator('False', 'is_false', undefined), true)
+assert.equal(evaluateOperator(true, 'is_true', undefined), true)
+assert.equal(evaluateOperator(0, 'is_false', undefined), true)
+assert.equal(evaluateOperator('False', 'is_true', undefined), false)
+
+console.log('python-style booleans are recognized')
+
+// --- in / not_in -------------------------------------------------------------
+
+assert.equal(evaluateOperator('X707 ', 'in', ['X707', 'Y701']), true)
+assert.equal(evaluateOperator('Z999', 'not_in', ['X707', 'Y701']), true)
+
+console.log('membership operators normalize like equals')
+
+// --- condition plumbing ------------------------------------------------------
+
+const row = { proj: 'X707 ', amount: '7837.0' }
+
+// Full condition path: viz targeting + case-insensitive column lookup.
+assert.equal(
+  evaluateCondition(row, { id: '1', column: 'viz1:Proj', operator: 'equals', value: 'X707' }, 'viz1'),
+  true,
+)
+// Conditions for another visualization never filter this one.
+assert.equal(
+  evaluateCondition(row, { id: '1', column: 'viz2:proj', operator: 'equals', value: 'nope' }, 'viz1'),
+  true,
+)
+// A half-written condition (blank value) is a no-op, not a match-nothing.
+assert.equal(
+  evaluateCondition(row, { id: '1', column: 'viz1:proj', operator: 'equals', value: '' }, 'viz1'),
+  true,
+)
+
+// Groups: OR across groups, AND within a group.
+const groups = [
+  { id: 'g1', conditions: [
+    { id: 'c1', column: 'viz1:proj', operator: 'equals', value: 'X707' },
+    { id: 'c2', column: 'viz1:amount', operator: 'equals', value: '7837' },
+  ] },
+]
+assert.equal(evaluateFilters(row, groups, 'viz1'), true)
+assert.equal(evaluateFilters({ proj: 'Y701', amount: 1 }, groups, 'viz1'), false)
+
+console.log('condition targeting and grouping still hold')


### PR DESCRIPTION
## Problem

Filtering `Proj equals X707` in a ToolWidgetPreview card returned **0 of 431 rows** while X707 rows sat visibly in the table. Root cause: SQL Server CHAR columns return values padded with trailing spaces (`"X707 "`), the grid renders the padding invisibly, and the filter's `equals` comparison was whitespace-sensitive — the user types what they see, and it never matches.

Reproduced end-to-end in a live sandbox (Playwright driving the real chat UI): a table whose `proj` values are stored padded gives `equals X707 → 0 of 60`, while typing the invisible trailing space (`X707␣`) gives 5 of 60.

## The same family of bugs, audited

The evaluator existed as **four divergent copies**, each with variations of the mismatch:

- `useSharedFilters.ts` `evaluateCondition` — whitespace-sensitive string operators (the reported bug)
- Numeric equals compared as strings in all copies: `"7837.0"` (pandas) vs typed `7837` → no match
- Boolean operators missed Python-serialized `"True"`/`"False"`
- `ToolWidgetPreview.matchDefaultFilter` was additionally case-sensitive, so `view.defaultFilters` disagreed with the identical user filter
- `DashboardComponent`'s static fallback: case-sensitive column lookup, no half-written-condition guard
- `is_empty` missed whitespace-only cells (padded-blank CHAR renders empty but didn't match)
- `null`/blank coerced to `0` in numeric comparisons (`null < 5` was true)

## Fix

One exported `evaluateOperator()` in `useSharedFilters.ts` now holds all operator semantics: trim both sides, compare numerically when both sides parse as numbers, fold case, accept capitalized booleans, treat whitespace-only as empty, and never coerce null to 0. The three duplicated evaluators (`FilterBuilder`, `DashboardComponent` static fallback, `ToolWidgetPreview.matchDefaultFilter`) delegate to it, so user filters, dashboard filters, and view default-filters can no longer drift. `FilterBuilder` also gains the incomplete-condition guard the shared evaluator already had.

## Verification

- New unit tests: `frontend/tests/unit/useSharedFilters.mjs` (`node --experimental-strip-types`, all green) — padding, numeric formatting, booleans, membership ops, targeting/grouping semantics
- E2E (Playwright against the real app): padded report `equals X707` → **5 of 60** pre-apply, applied table shows exactly the 5 X707 rows, header 5/60
- Regression E2E on a clean-data report: counts unchanged (6 of 60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLyarEkwXfky85B51T74aP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLyarEkwXfky85B51T74aP)_