### PR TITLE
Let the query-capturing wrapper pass through keyword-only execute_query calls

### DIFF
--- a/backend/app/ai/code_execution/code_execution.py
+++ b/backend/app/ai/code_execution/code_execution.py
@@ -610,6 +610,26 @@ def augment_db_error_hint(error_text: str) -> str:
 # Query Capturing Wrapper (captures queries passed to execute_query)
 # =============================================================================
 
+# Sentinel for "no positional query was passed". Distinct from None so a client
+# that legitimately receives None as its first argument is not misread.
+_NO_QUERY = object()
+
+
+def _describe_keyword_call(kwargs: dict) -> str:
+    """A capture string for a keyword-only execute_query call.
+
+    Clients whose query surface is not a statement string (Qlik's
+    app/dimensions/measures hypercubes) still need something meaningful in
+    captured_queries, the timing rows, and rate-limit/quota messages — this is
+    what the UI shows as "the query" for that step.
+    """
+    try:
+        body = json.dumps(kwargs, default=str, ensure_ascii=False)
+    except Exception:
+        body = repr(kwargs)
+    return f"execute_query({body})"
+
+
 class QueryCapturingClientWrapper:
     """Wrapper around a database client that captures all queries passed to execute_query.
 
@@ -651,18 +671,32 @@ class QueryCapturingClientWrapper:
             else query_concurrency.DEFAULT_MAX_CONCURRENT_QUERIES
         )
 
-    def execute_query(self, query: str, *args, **kwargs):
-        """Intercept execute_query calls to capture the query string and wall-clock duration."""
-        if isinstance(query, str):
-            self._captured_queries.append(query)
+    def execute_query(self, query=_NO_QUERY, *args, **kwargs):
+        """Intercept execute_query calls to capture the query string and wall-clock duration.
+
+        `query` is optional because not every client's query surface is a
+        statement string: the Qlik connectors take keyword arguments only
+        (app=..., dimensions=..., measures=...), and their system prompts teach
+        the agent that calling convention. Requiring a positional here made
+        every such call die in the wrapper — before the client was reached —
+        with "missing 1 required positional argument". For keyword-only calls
+        the bookkeeping (capture, timings, rate limit, quotas) uses a
+        synthesized description of the call instead.
+        """
+        if query is _NO_QUERY:
+            capture = _describe_keyword_call(kwargs)
+        else:
+            capture = query
+        if isinstance(capture, str):
+            self._captured_queries.append(capture)
         idx = len(self._captured_timings)
         _q_start = _time.monotonic()
         with _tracer.start_as_current_span("datasource.execute_query") as span:
             span.set_attribute("datasource.type", type(self._original).__name__)
             span.set_attribute("datasource.query_timeout_seconds", self._query_timeout_seconds)
             try:
-                self._enforce_rate_limit(query)
-                self._consume_query_quota(query)
+                self._enforce_rate_limit(capture)
+                self._consume_query_quota(capture)
                 # Hold a per-connection concurrency slot for the duration of
                 # the query. A burst queues here instead of arriving at the
                 # source all at once; the wait budget is the same wall clock
@@ -679,7 +713,7 @@ class QueryCapturingClientWrapper:
                 _q_ms = (_time.monotonic() - _q_start) * 1000.0
                 rows = len(result) if hasattr(result, '__len__') else None
                 result_bytes = estimate_result_size_bytes(result)
-                self._consume_data_bytes_quota(query, result_bytes, rows)
+                self._consume_data_bytes_quota(capture, result_bytes, rows)
                 if rows is not None:
                     span.set_attribute("datasource.result_rows", rows)
                 span.set_attribute("datasource.result_bytes", result_bytes)
@@ -688,7 +722,7 @@ class QueryCapturingClientWrapper:
                     "query_ms": round(_q_ms, 1),
                     "rows": rows,
                     "result_bytes": result_bytes,
-                    "sql": query[:500] if isinstance(query, str) else None,
+                    "sql": capture[:500] if isinstance(capture, str) else None,
                 })
                 return result
             except QueryTimeoutError as e:
@@ -697,7 +731,7 @@ class QueryCapturingClientWrapper:
                     "index": idx,
                     "query_ms": round(_q_ms, 1),
                     "rows": None,
-                    "sql": query[:500] if isinstance(query, str) else None,
+                    "sql": capture[:500] if isinstance(capture, str) else None,
                     "error": str(e)[:200],
                     "error_type": "timeout",
                     "timeout_seconds": self._query_timeout_seconds,
@@ -714,7 +748,7 @@ class QueryCapturingClientWrapper:
                     "index": idx,
                     "query_ms": round(_q_ms, 1),
                     "rows": None,
-                    "sql": query[:500] if isinstance(query, str) else None,
+                    "sql": capture[:500] if isinstance(capture, str) else None,
                     "error": str(e)[:200],
                 })
                 span.set_status(StatusCode.ERROR, str(e))
@@ -739,7 +773,12 @@ class QueryCapturingClientWrapper:
 
         def runner():
             try:
-                holder["value"] = self._original.execute_query(query, *args, **kwargs)
+                if query is _NO_QUERY:
+                    # Keyword-only client call — there was no positional to
+                    # forward (args is necessarily empty in this case).
+                    holder["value"] = self._original.execute_query(**kwargs)
+                else:
+                    holder["value"] = self._original.execute_query(query, *args, **kwargs)
             except BaseException as exc:
                 holder["exc"] = exc
 
@@ -878,13 +917,15 @@ class QueryCapturingClientWrapper:
             "sql": query[:500] if isinstance(query, str) else None,
         }
 
-    def query(self, query: str, *args, **kwargs):
+    def query(self, query=_NO_QUERY, *args, **kwargs):
         """Alias for execute_query.
 
         Model-generated code often calls `.query(...)` instead of
         `.execute_query(...)`. Route it through our own `execute_query` so the
         call is still captured, timed, and metered — delegating via __getattr__
         would hit the raw client and bypass all of that instrumentation.
+        Passing the _NO_QUERY sentinel through positionally is deliberate:
+        execute_query recognizes it as "keyword-only call".
         """
         return self.execute_query(query, *args, **kwargs)
 

--- a/backend/tests/unit/test_query_timeout.py
+++ b/backend/tests/unit/test_query_timeout.py
@@ -422,3 +422,91 @@ def test_timeout_failure_payload_carries_db_message_and_failed_sql():
     failed_sql = last_failed.get("sql")
     assert db_message and "exceeded" in db_message.lower()
     assert failed_sql == "select pg_sleep(2)"
+
+
+# ---------------------------------------------------------------------------
+# Keyword-only clients (Qlik-shaped execute_query)
+# ---------------------------------------------------------------------------
+#
+# Not every client's query surface is a statement string: the Qlik connectors
+# take keyword arguments only (app=..., dimensions=..., measures=...) and their
+# system prompts teach the agent that calling convention. The wrapper used to
+# require a positional `query`, so every such call died in the wrapper itself —
+# before the client was reached — with "missing 1 required positional
+# argument: 'query'".
+
+
+class _KeywordOnlyClient:
+    """A Qlik-shaped client: no positional statement, keyword query surface."""
+
+    def __init__(self):
+        self.calls = []
+        self._bow_connection_id = None
+
+    def execute_query(self, app=None, dimensions=None, measures=None, filters=None,
+                      max_rows=10000, table_name=None, **_kwargs):
+        self.calls.append({"app": app, "dimensions": dimensions, "measures": measures})
+        return pd.DataFrame({"Region": ["EMEA"], "Rev": [10]})
+
+
+def test_keyword_only_call_reaches_the_client():
+    client = _KeywordOnlyClient()
+    wrapper = _make_wrapper(client)
+
+    df = wrapper.execute_query(
+        app="Sales/Consumer Sales",
+        dimensions=["Region"],
+        measures=[{"expr": "Sum([Sales])", "alias": "Rev"}],
+    )
+
+    assert len(df) == 1
+    assert client.calls == [{
+        "app": "Sales/Consumer Sales",
+        "dimensions": ["Region"],
+        "measures": [{"expr": "Sum([Sales])", "alias": "Rev"}],
+    }]
+
+
+def test_keyword_only_call_is_captured_with_its_arguments():
+    """The synthesized capture is what the UI shows as "the query" for the
+    step — it must carry the dimensions/measures, not just an app name."""
+    client = _KeywordOnlyClient()
+    wrapper = _make_wrapper(client)
+    wrapper.execute_query(app="Sales/Consumer Sales", dimensions=["Region"])
+
+    assert len(wrapper._captured_queries) == 1
+    captured = wrapper._captured_queries[0]
+    assert "Sales/Consumer Sales" in captured
+    assert "Region" in captured
+
+    timing = wrapper._captured_timings[0]
+    assert timing["sql"] and "Sales/Consumer Sales" in timing["sql"]
+    assert timing["rows"] == 1
+
+
+def test_keyword_only_call_works_through_the_query_alias():
+    client = _KeywordOnlyClient()
+    wrapper = _make_wrapper(client)
+    df = wrapper.query(app="Sales/Consumer Sales", dimensions=["Region"])
+    assert len(df) == 1
+    assert client.calls[0]["app"] == "Sales/Consumer Sales"
+
+
+def test_keyword_only_call_still_honours_the_timeout():
+    class _SlowKeywordClient(_KeywordOnlyClient):
+        def execute_query(self, **kwargs):
+            time.sleep(2)
+            return pd.DataFrame()
+
+    wrapper = _make_wrapper(_SlowKeywordClient(), timeout=1)
+    with pytest.raises(QueryTimeoutError):
+        wrapper.execute_query(app="Sales/Consumer Sales", dimensions=["Region"])
+
+
+def test_positional_calls_are_unchanged():
+    """The sentinel default must not disturb the SQL-shaped path."""
+    client = _StubClient()
+    wrapper = _make_wrapper(client)
+    wrapper.execute_query("select 1")
+    assert wrapper._captured_queries == ["select 1"]
+    assert wrapper._captured_timings[0]["sql"] == "select 1"


### PR DESCRIPTION
## Summary

Every data-source client runs inside `QueryCapturingClientWrapper` during agent code execution — it's the chokepoint for query capture, timeouts, cancellation, rate limits and quotas. Its `execute_query` required a **positional** `query` string, shaped for SQL clients.

The Qlik connectors' query surface is keyword-only (`app=..., dimensions=..., measures=...`), and their system prompts teach the agent exactly that convention. So every generated Qlik query died **in the wrapper**, before the client was ever reached, with:

```
QueryCapturingClientWrapper.execute_query() missing 1 required positional argument: 'query'
```

Indexing worked (it doesn't pass through the wrapper), which made the connector look healthy until the first Create Data step. Reproduced live against a Qlik Sense Enterprise 31.62 site.

## Change

- `query` now defaults to a `_NO_QUERY` sentinel (distinct from `None`, so a client legitimately receiving `None` isn't misread).
- Keyword-only calls forward as `original.execute_query(**kwargs)`.
- Bookkeeping — `captured_queries`, timing rows, rate-limit and quota messages — records a synthesized `execute_query({...json of kwargs...})` string, so the planner and UI still see the dimensions/measures that made up the query. This capture is *richer* than what a positional-only convention could record.
- Positional callers take the exact same path as before, byte for byte; the `.query` alias inherits the behavior by passing the sentinel through.

Alternatives considered and rejected: teaching the agent to pass the app positionally (prompt-enforced, one model-drift from the same crash, and captures only the app name), and a dict-shaped `query` argument (still needs a wrapper capture change, plus an unpack shim and API churn in both Qlik clients).

## Tests

5 new tests in `tests/unit/test_query_timeout.py`: keyword-only call reaches the client, capture carries the full arguments, `.query` alias works, timeout still enforced on keyword calls, and the positional path is unchanged. 24/24 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5nLejNyxGBAhAEFGnhp98

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5nLejNyxGBAhAEFGnhp98)_