### PR TITLE
Add monday.com as a queryable data source with GraphQL API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Use your own API keys, endpoints, and model deployments. Multiple providers and 
 | NetSuite | Business app |
 | Salesforce | Business app |
 | ServiceNow | Business app |
-| monday.com | Business app |
+| Monday data | Business app |
 | AWS Cost Explorer | Business app |
 | PostHog | Business app |
 | Outlook Mail | Business app |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Use your own API keys, endpoints, and model deployments. Multiple providers and 
 | NetSuite | Business app |
 | Salesforce | Business app |
 | ServiceNow | Business app |
+| monday.com | Business app |
 | AWS Cost Explorer | Business app |
 | PostHog | Business app |
 | Outlook Mail | Business app |

--- a/backend/app/data_sources/clients/monday_client.py
+++ b/backend/app/data_sources/clients/monday_client.py
@@ -161,16 +161,29 @@ class MondayClient(DataSourceClient):
 
     def test_connection(self):
         try:
-            data = self._gql("query { me { name email } account { name } boards (limit: 1) { id } }")
-            me = data.get("me") or {}
-            account = data.get("account") or {}
-            return {
-                "success": True,
-                "message": (
-                    f"Connected to monday.com as {me.get('name')} ({me.get('email')}) "
-                    f"on account '{account.get('name')}'"
-                ),
-            }
+            try:
+                data = self._gql("query { me { name email } account { name } boards (limit: 1) { id } }")
+                me = data.get("me") or {}
+                account = data.get("account") or {}
+                return {
+                    "success": True,
+                    "message": (
+                        f"Connected to monday.com as {me.get('name')} ({me.get('email')}) "
+                        f"on account '{account.get('name')}'"
+                    ),
+                }
+            except RuntimeError as e:
+                # OAuth tokens minted before me:read was requested (or apps that
+                # never enabled it) fail ONLY the Query.me identity probe —
+                # boards remain fully queryable, so degrade instead of failing.
+                if "Query.me" not in str(e) and "missing required scopes" not in str(e):
+                    raise
+                data = self._gql("query { account { name } boards (limit: 1) { id } }")
+                account = data.get("account") or {}
+                return {
+                    "success": True,
+                    "message": f"Connected to monday.com on account '{account.get('name')}'",
+                }
         except Exception as e:
             return {"success": False, "message": str(e)}
 

--- a/backend/app/data_sources/clients/monday_client.py
+++ b/backend/app/data_sources/clients/monday_client.py
@@ -1,0 +1,634 @@
+"""monday.com data source client.
+
+Talks to the monday.com GraphQL API (https://api.monday.com/v2). Boards are
+exposed as tables: each board column becomes a schema column, and
+`execute_query` returns board items as DataFrame rows via `items_page` with
+cursor pagination. There is no SQL endpoint; queries are JSON specs (see
+`system_prompt`) that map 1:1 to an `items_page` call with `query_params`.
+
+Auth is a single token in the Authorization header — either the connection's
+service API token (`api_token`) or a per-user delegated OAuth token
+(`access_token`); the API treats them identically, so no auth-mode branching.
+
+Filter quirk verified live: status/dropdown rules match on label INDICES, not
+label text ("Done" matches nothing; its index does). The client translates
+label text in `compare_value` to indices using the board's column settings so
+generated queries can filter by the human-readable label.
+"""
+import json
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import requests
+
+from app.data_sources.clients.base import DataSourceClient
+from app.ai.prompt_formatters import ForeignKey, Table, TableColumn, ServiceFormatter
+
+API_URL = "https://api.monday.com/v2"
+API_VERSION = "2024-10"
+
+MAX_ROWS = 10_000        # hard cap per execute_query
+PAGE_SIZE = 500          # items_page maximum page size
+DEFAULT_LIMIT = 100      # when the query spec omits `limit`
+BOARDS_PAGE = 50         # boards per page during schema discovery
+MAX_BOARDS = 1_000       # discovery cap — beyond this, scope with the config
+RETRIES = 6              # per-request retries on 429/complexity/5xx
+
+# monday column type → pandas-ish dtype for prompt schemas.
+_TYPE_MAP = {
+    "numbers": "float",
+    "rating": "int",
+    "checkbox": "bool",
+    "date": "date",
+    "creation_log": "datetime",
+    "last_updated": "datetime",
+    "timeline": "str",
+    "status": "str",
+    "dropdown": "str",
+    "people": "str",
+    "text": "str",
+    "long_text": "str",
+    "email": "str",
+    "phone": "str",
+    "link": "str",
+    "board_relation": "str",
+    "mirror": "str",
+    "formula": "str",
+    "item_id": "int",
+    "hour": "str",
+    "week": "str",
+    "world_clock": "str",
+    "country": "str",
+    "location": "str",
+    "tags": "str",
+    "color_picker": "str",
+    "file": "str",
+    "vote": "int",
+    "name": "str",
+}
+
+# Column types whose settings carry an index→label map that rules filter by.
+_LABELED_TYPES = {"status", "dropdown"}
+
+
+class MondayClient(DataSourceClient):
+
+    def __init__(
+        self,
+        api_token: Optional[str] = None,
+        access_token: Optional[str] = None,
+        workspaces: Optional[str] = None,
+        boards: Optional[str] = None,
+    ):
+        self.api_token = api_token
+        # Per-user delegated OAuth token (from user_connection_credentials);
+        # construct_client passes whichever token fields the signature accepts.
+        self.access_token = access_token
+        self.workspaces = [w.strip() for w in workspaces.split(",") if w.strip()] if workspaces else None
+        self.boards = [b.strip() for b in boards.split(",") if b.strip()] if boards else None
+        # board catalog cache: list of raw board dicts from the API
+        self._boards_cache: Optional[List[dict]] = None
+
+    # ── transport ───────────────────────────────────────────────────────────
+
+    def _token(self) -> str:
+        token = self.api_token or self.access_token
+        if not token:
+            raise RuntimeError(
+                "monday.com client has no credentials: provide an API token or sign in with OAuth."
+            )
+        return token
+
+    def _gql(self, query: str, variables: Optional[dict] = None) -> dict:
+        """POST one GraphQL request, absorbing 429s and complexity throttles.
+
+        monday's 429 responses are HTML (not JSON) with a Retry-After header;
+        complexity exhaustion arrives as a JSON error containing "reset in N
+        seconds". Both are transient — wait and retry rather than fail the
+        whole indexing run or query.
+        """
+        payload: Dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        last_error = "unknown error"
+        for attempt in range(RETRIES):
+            response = requests.post(
+                API_URL,
+                json=payload,
+                headers={
+                    "Authorization": self._token(),
+                    "Content-Type": "application/json",
+                    "API-Version": API_VERSION,
+                },
+                timeout=120,
+            )
+            if response.status_code == 429:
+                wait = int(response.headers.get("Retry-After", "30"))
+                time.sleep(min(wait, 60))
+                continue
+            if response.status_code == 401:
+                if self.access_token and not self.api_token:
+                    raise RuntimeError(
+                        "monday.com authentication failed (401): the OAuth token was "
+                        "rejected (revoked or the app was uninstalled) — sign in again."
+                    )
+                raise RuntimeError("monday.com authentication failed (401): check the API token.")
+            if response.status_code >= 500:
+                last_error = f"HTTP {response.status_code}"
+                time.sleep(2 ** attempt)
+                continue
+            try:
+                body = response.json()
+            except ValueError:
+                raise RuntimeError(
+                    f"monday.com API returned a non-JSON response (HTTP {response.status_code})."
+                )
+            errors = body.get("errors") or []
+            if errors:
+                text = json.dumps(errors)
+                match = re.search(r"reset in (\d+) seconds", text)
+                if match or "ComplexityException" in text or "COMPLEXITY" in text:
+                    time.sleep(int(match.group(1)) + 1 if match else 30)
+                    continue
+                messages = "; ".join(str(e.get("message", e)) for e in errors)
+                raise RuntimeError(f"monday.com API error: {messages}")
+            return body.get("data") or {}
+        raise RuntimeError(f"monday.com API kept throttling/failing ({last_error}); try again later.")
+
+    # ── connection ──────────────────────────────────────────────────────────
+
+    def test_connection(self):
+        try:
+            data = self._gql("query { me { name email } account { name } boards (limit: 1) { id } }")
+            me = data.get("me") or {}
+            account = data.get("account") or {}
+            return {
+                "success": True,
+                "message": (
+                    f"Connected to monday.com as {me.get('name')} ({me.get('email')}) "
+                    f"on account '{account.get('name')}'"
+                ),
+            }
+        except Exception as e:
+            return {"success": False, "message": str(e)}
+
+    # ── board catalog ───────────────────────────────────────────────────────
+
+    def _fetch_boards(self) -> List[dict]:
+        """All active boards visible to the token, with columns, paginated."""
+        if self._boards_cache is not None:
+            return self._boards_cache
+        boards: List[dict] = []
+        page = 1
+        while len(boards) < MAX_BOARDS:
+            data = self._gql(
+                """
+                query ($limit: Int!, $page: Int!) {
+                  boards (limit: $limit, page: $page, state: active, order_by: created_at) {
+                    id name description board_kind items_count
+                    workspace { id name }
+                    columns { id title type settings_str }
+                  }
+                }
+                """,
+                {"limit": BOARDS_PAGE, "page": page},
+            )
+            batch = data.get("boards") or []
+            boards.extend(batch)
+            if len(batch) < BOARDS_PAGE:
+                break
+            page += 1
+
+        # Subitem boards are auto-managed shadows of their parent board.
+        boards = [b for b in boards if not (b.get("name") or "").startswith("Subitems of ")]
+
+        if self.workspaces:
+            wanted = {w.lower() for w in self.workspaces}
+            boards = [
+                b for b in boards
+                if str((b.get("workspace") or {}).get("id")) in wanted
+                or ((b.get("workspace") or {}).get("name") or "").lower() in wanted
+            ]
+        if self.boards:
+            wanted = {x.lower() for x in self.boards}
+            boards = [
+                b for b in boards
+                if str(b.get("id")) in wanted or (b.get("name") or "").lower() in wanted
+            ]
+        self._boards_cache = boards
+        return boards
+
+    def _table_names(self, boards: List[dict]) -> Dict[str, dict]:
+        """Stable table name per board: the board name, disambiguated with the
+        board id when several boards share one name."""
+        by_name: Dict[str, List[dict]] = {}
+        for board in boards:
+            by_name.setdefault(board.get("name") or f"board {board['id']}", []).append(board)
+        names: Dict[str, dict] = {}
+        for name, group in by_name.items():
+            if len(group) == 1:
+                names[name] = group[0]
+            else:
+                for board in group:
+                    names[f"{name} [{board['id']}]"] = board
+        return names
+
+    def _resolve_board(self, ref) -> dict:
+        """Accept a board id (int/str), exact board name, or disambiguated
+        'name [id]' and return the raw board dict."""
+        boards = self._fetch_boards()
+        text = str(ref).strip()
+        for board in boards:
+            if str(board["id"]) == text:
+                return board
+        match = re.match(r"^(.*) \[(\d+)\]$", text)
+        if match:
+            for board in boards:
+                if str(board["id"]) == match.group(2):
+                    return board
+        lowered = text.lower()
+        named = [b for b in boards if (b.get("name") or "").lower() == lowered]
+        if len(named) == 1:
+            return named[0]
+        if len(named) > 1:
+            options = ", ".join(f"{b['name']} [{b['id']}]" for b in named)
+            raise ValueError(
+                f"Board name {text!r} is ambiguous — use the board id or one of: {options}"
+            )
+        raise ValueError(f"Board {text!r} not found (by id or name) among {len(boards)} visible boards.")
+
+    # ── schema discovery ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _column_labels(column: dict) -> Optional[Dict[str, str]]:
+        """index → label for status/dropdown columns, from settings_str."""
+        if column.get("type") not in _LABELED_TYPES:
+            return None
+        try:
+            settings = json.loads(column.get("settings_str") or "{}")
+        except ValueError:
+            return None
+        if column["type"] == "status":
+            labels = settings.get("labels") or {}
+            return {str(k): str(v) for k, v in labels.items()} or None
+        labels = (settings.get("settings") or settings).get("labels") or []
+        if isinstance(labels, list):
+            return {str(l.get("id")): str(l.get("name")) for l in labels if l.get("name")} or None
+        return None
+
+    def _build_table(self, name: str, board: dict, board_names_by_id: Dict[str, str]) -> Table:
+        columns = [
+            TableColumn(name="item_id", dtype="int", description="monday item id"),
+            TableColumn(name="name", dtype="str", description="item name"),
+            TableColumn(name="group", dtype="str", description="board group the item belongs to"),
+        ]
+        fks: List[ForeignKey] = []
+        seen = {"item_id", "name", "group"}
+        for column in board.get("columns") or []:
+            if column.get("type") == "name":
+                continue  # the built-in first column IS the item name above
+            title = column.get("title") or column.get("id")
+            col_name = title if title not in seen else f"{title} ({column['id']})"
+            seen.add(col_name)
+            dtype = _TYPE_MAP.get(column.get("type"), "str")
+            parts = [f"type: {column.get('type')}", f"id: {column.get('id')}"]
+            labels = self._column_labels(column)
+            if labels:
+                parts.append("labels: " + ", ".join(sorted(labels.values())))
+            table_column = TableColumn(name=col_name, dtype=dtype, description="; ".join(parts))
+            columns.append(table_column)
+
+            if column.get("type") == "board_relation":
+                try:
+                    settings = json.loads(column.get("settings_str") or "{}")
+                    for linked_id in settings.get("boardIds") or []:
+                        linked_name = board_names_by_id.get(str(linked_id))
+                        if linked_name:
+                            fks.append(ForeignKey(
+                                column=table_column,
+                                references_name=linked_name,
+                                references_column=TableColumn(name="item_id", dtype="int"),
+                            ))
+                except ValueError:
+                    pass
+
+        workspace = (board.get("workspace") or {}).get("name")
+        description_bits = [bit for bit in [
+            board.get("description"),
+            f"workspace: {workspace}" if workspace else None,
+            f"{board.get('items_count')} items" if board.get("items_count") is not None else None,
+        ] if bit]
+        return Table(
+            name=name,
+            columns=columns,
+            pks=[TableColumn(name="item_id", dtype="int")],
+            fks=fks,
+            description="; ".join(description_bits) or None,
+            metadata_json={"board_id": str(board["id"]), "workspace": workspace},
+        )
+
+    def get_schemas(self, progress_callback=None) -> List[Table]:
+        boards = self._fetch_boards()
+        names = self._table_names(boards)
+        board_names_by_id = {str(b["id"]): n for n, b in names.items()}
+        tables: List[Table] = []
+        total = len(names)
+        for i, (name, board) in enumerate(names.items()):
+            tables.append(self._build_table(name, board, board_names_by_id))
+            if progress_callback and (i % 25 == 0 or i == total - 1):
+                try:
+                    progress_callback(current=i + 1, total=total, message=f"Indexed {i + 1}/{total} boards")
+                except TypeError:
+                    pass
+        return tables
+
+    def get_schema(self, table_name: str) -> Table:
+        board = self._resolve_board(table_name)
+        boards = self._fetch_boards()
+        names = self._table_names(boards)
+        board_names_by_id = {str(b["id"]): n for n, b in names.items()}
+        name = board_names_by_id.get(str(board["id"]), board.get("name") or str(board["id"]))
+        return self._build_table(name, board, board_names_by_id)
+
+    # ── querying ────────────────────────────────────────────────────────────
+
+    def execute_query(self, query: str) -> pd.DataFrame:
+        """Execute a monday.com query spec and return a DataFrame.
+
+        `query` is a JSON string:
+            {"board": "Sales Pipeline Q3",          (required: board name or id)
+             "columns": ["Status", "Amount"],       (optional: titles or ids)
+             "rules": [{"column_id": "Status",
+                        "compare_value": ["Done"],
+                        "operator": "any_of"}],     (optional items_page rules)
+             "operator": "and",                     (optional: and | or)
+             "order_by": {"column_id": "Due Date",
+                          "direction": "desc"},     (optional)
+             "limit": 500}                          (optional, default 100)
+        """
+        spec = self._parse_spec(query)
+        board = self._resolve_board(spec["board"])
+        board_columns = [c for c in (board.get("columns") or []) if c.get("type") != "name"]
+        by_key = self._columns_by_key(board_columns)
+
+        selected = self._selected_columns(spec.get("columns"), board_columns, by_key)
+        query_params = self._build_query_params(spec, by_key)
+        limit = min(int(spec.get("limit") or DEFAULT_LIMIT), MAX_ROWS)
+
+        column_ids = [c["id"] for c in selected]
+        items = self._fetch_items(board["id"], column_ids, query_params, limit)
+        return self._items_to_df(items, selected)
+
+    def _parse_spec(self, query) -> dict:
+        if isinstance(query, dict):
+            spec = query
+        else:
+            try:
+                spec = json.loads(query)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "monday.com query must be a JSON object like "
+                    '{"board": "Sales Pipeline", "limit": 100} — got: ' + str(query)[:200]
+                )
+        if not isinstance(spec, dict) or not spec.get("board"):
+            raise ValueError('monday.com query spec must include a "board" key (board name or id).')
+        return spec
+
+    @staticmethod
+    def _columns_by_key(board_columns: List[dict]) -> Dict[str, dict]:
+        """id and lowercase-title lookup for a board's columns."""
+        by_key: Dict[str, dict] = {}
+        for column in board_columns:
+            by_key[column["id"]] = column
+            title = (column.get("title") or "").lower()
+            # first column wins on duplicate titles; ids stay unambiguous
+            by_key.setdefault(title, column)
+        return by_key
+
+    def _selected_columns(self, requested, board_columns: List[dict], by_key: Dict[str, dict]) -> List[dict]:
+        if not requested:
+            return board_columns
+        selected, missing = [], []
+        for ref in requested:
+            column = by_key.get(str(ref)) or by_key.get(str(ref).lower())
+            if column is None:
+                missing.append(str(ref))
+            elif column not in selected:
+                selected.append(column)
+        if missing:
+            available = ", ".join(f"{c['title']} ({c['id']})" for c in board_columns)
+            raise ValueError(
+                f"Unknown column(s) {missing} — available columns: {available}"
+            )
+        return selected
+
+    def _build_query_params(self, spec: dict, by_key: Dict[str, dict]) -> Optional[dict]:
+        rules = spec.get("rules")
+        order_by = spec.get("order_by")
+        if not rules and not order_by:
+            return None
+        query_params: Dict[str, Any] = {}
+        if rules:
+            resolved_rules = []
+            for rule in rules:
+                rule = dict(rule)
+                ref = str(rule.get("column_id", ""))
+                column = by_key.get(ref) or by_key.get(ref.lower())
+                if column is not None:
+                    rule["column_id"] = column["id"]
+                    rule["compare_value"] = self._translate_labels(column, rule.get("compare_value"))
+                resolved_rules.append(rule)
+            query_params["rules"] = resolved_rules
+            query_params["operator"] = spec.get("operator") or "and"
+        if order_by:
+            entries = order_by if isinstance(order_by, list) else [order_by]
+            resolved_order = []
+            for entry in entries:
+                entry = dict(entry)
+                ref = str(entry.get("column_id", ""))
+                column = by_key.get(ref) or by_key.get(ref.lower())
+                if column is not None:
+                    entry["column_id"] = column["id"]
+                resolved_order.append(entry)
+            query_params["order_by"] = resolved_order
+        return query_params
+
+    def _translate_labels(self, column: dict, compare_value):
+        """Rules on status/dropdown columns match label INDICES (verified live:
+        text values match nothing) — translate label text to index."""
+        labels = self._column_labels(column)
+        if not labels or not isinstance(compare_value, list):
+            return compare_value
+        by_text = {v.lower(): k for k, v in labels.items()}
+        translated = []
+        for value in compare_value:
+            if isinstance(value, str) and value.lower() in by_text:
+                index = by_text[value.lower()]
+                translated.append(int(index) if index.lstrip("-").isdigit() else index)
+            else:
+                translated.append(value)
+        return translated
+
+    def _fetch_items(self, board_id, column_ids: List[str], query_params: Optional[dict], limit: int) -> List[dict]:
+        items: List[dict] = []
+        item_fields = (
+            "id name group { title } column_values (ids: $cols) { id text value type }"
+            if column_ids else "id name group { title }"
+        )
+        first_page = min(PAGE_SIZE, limit)
+        variables: Dict[str, Any] = {"bid": [str(board_id)], "limit": first_page}
+        if column_ids:
+            variables["cols"] = column_ids
+        params_arg = ""
+        if query_params:
+            variables["qp"] = query_params
+            params_arg = ", query_params: $qp"
+        cols_var = ", $cols: [String!]" if column_ids else ""
+        qp_var = ", $qp: ItemsQuery" if query_params else ""
+        data = self._gql(
+            f"query ($bid: [ID!], $limit: Int!{cols_var}{qp_var}) {{"
+            f" boards (ids: $bid) {{ items_page (limit: $limit{params_arg}) {{"
+            f" cursor items {{ {item_fields} }} }} }} }}",
+            variables,
+        )
+        boards = data.get("boards") or []
+        if not boards:
+            raise RuntimeError(f"Board {board_id} not accessible with these credentials.")
+        page = boards[0]["items_page"]
+        items.extend(page["items"])
+        cursor = page.get("cursor")
+
+        while cursor and len(items) < limit:
+            page_size = min(PAGE_SIZE, limit - len(items))
+            next_vars: Dict[str, Any] = {"cursor": cursor, "limit": page_size}
+            if column_ids:
+                next_vars["cols"] = column_ids
+            data = self._gql(
+                f"query ($cursor: String!, $limit: Int!{cols_var}) {{"
+                f" next_items_page (cursor: $cursor, limit: $limit) {{"
+                f" cursor items {{ {item_fields} }} }} }}",
+                next_vars,
+            )
+            page = data.get("next_items_page") or {}
+            items.extend(page.get("items") or [])
+            cursor = page.get("cursor")
+        return items[:limit]
+
+    def _items_to_df(self, items: List[dict], selected: List[dict]) -> pd.DataFrame:
+        # DataFrame column name per board column: title, disambiguated like the schema.
+        names: Dict[str, str] = {}
+        seen = {"item_id", "name", "group"}
+        for column in selected:
+            title = column.get("title") or column["id"]
+            name = title if title not in seen else f"{title} ({column['id']})"
+            seen.add(name)
+            names[column["id"]] = name
+
+        rows = []
+        for item in items:
+            row: Dict[str, Any] = {
+                "item_id": int(item["id"]),
+                "name": item.get("name"),
+                "group": (item.get("group") or {}).get("title"),
+            }
+            for value in item.get("column_values") or []:
+                target = names.get(value.get("id"))
+                if target is None:
+                    continue
+                row[target] = self._cell_value(value)
+            rows.append(row)
+
+        # Deterministic shape regardless of returned values: base columns +
+        # every selected column, in board order (a column that is empty on all
+        # returned items would otherwise vanish from the frame).
+        expected = ["item_id", "name", "group"] + list(names.values())
+        frame = pd.DataFrame(rows)
+        if frame.empty:
+            return pd.DataFrame(columns=expected)
+        return frame.reindex(columns=expected)
+
+    @staticmethod
+    def _cell_value(value: dict):
+        """One typed scalar per cell. `text` is monday's display string; typed
+        columns parse it (or the raw JSON `value`) into a real dtype."""
+        kind = value.get("type")
+        text = value.get("text")
+        if kind == "numbers":
+            if text in (None, ""):
+                return None
+            try:
+                return float(text)
+            except ValueError:
+                return text
+        if kind == "rating":
+            if text in (None, ""):
+                return None
+            try:
+                return int(float(text))
+            except ValueError:
+                return text
+        if kind == "checkbox":
+            try:
+                raw = json.loads(value.get("value") or "null") or {}
+                return str(raw.get("checked")).lower() == "true"
+            except ValueError:
+                return False
+        return text if text != "" else None
+
+    # ── prompts ─────────────────────────────────────────────────────────────
+
+    def prompt_schema(self):
+        return ServiceFormatter(self.get_schemas()).table_str
+
+    def system_prompt(self):
+        text = """
+        ## monday.com Integration
+        Query monday.com boards via `execute_query(query)` where `query` is a JSON string:
+
+        ```json
+        {"board": "Sales Pipeline Q3",
+         "columns": ["Status", "Amount", "Due Date"],
+         "rules": [{"column_id": "Status", "compare_value": ["Done", "In Progress"], "operator": "any_of"}],
+         "operator": "and",
+         "order_by": {"column_id": "Due Date", "direction": "desc"},
+         "limit": 500}
+        ```
+
+        - `board` (required): board name (as shown in the schema) or numeric board id.
+        - `columns` (optional): column titles or ids to return; omit for all columns.
+        - `rules` (optional): items_page filter rules, combined with `operator`
+          ("and"/"or"). Useful operators: `any_of` / `not_any_of` (status,
+          dropdown, people), `contains_text` / `not_contains_text` (text and
+          item names via column_id "name"), `is_empty` / `is_not_empty`.
+          For status/dropdown you can pass label text ("Done") — it is
+          translated to the label index automatically.
+        - `order_by` (optional): {"column_id": ..., "direction": "asc"|"desc"}.
+        - `limit` (optional): max rows, default 100, cap 10000.
+
+        The DataFrame has `item_id`, `name` (item name), `group`, then one column
+        per board column, named by column TITLE. Types: numbers → float,
+        rating → int, checkbox → bool, everything else (status, people, date,
+        timeline, dropdown, …) → display TEXT strings; empty cells → None.
+        Status columns hold label text ("Done"), date columns "YYYY-MM-DD"
+        strings (parse with pd.to_datetime), timeline "YYYY-MM-DD - YYYY-MM-DD".
+
+        Date/number comparisons in `rules` are unreliable in the monday API —
+        fetch the rows (set `limit` high enough) and filter/aggregate in pandas
+        instead. Do NOT try to join boards in the API; fetch each board and
+        merge in pandas on item name or a connect-boards column.
+
+        Examples:
+        ```python
+        df = client.execute_query('{"board": "Engineering Bug Tracker", "columns": ["Status", "Priority", "Due Date"], "rules": [{"column_id": "Status", "compare_value": ["Done"], "operator": "not_any_of"}], "limit": 1000}')
+        df = client.execute_query('{"board": "Sales Pipeline Q3", "limit": 2000}')
+        df["Amount"] = pd.to_numeric(df["Amount"], errors="coerce")  # numbers columns are already float; only needed for text columns
+        ```
+        """
+        return text
+
+    @property
+    def description(self):
+        text = "monday.com client — query boards as tables (items, statuses, dates, people, numbers) via the GraphQL API."
+        return text + "\n\n" + self.system_prompt()

--- a/backend/app/data_sources/clients/monday_client.py
+++ b/backend/app/data_sources/clients/monday_client.py
@@ -420,11 +420,18 @@ class MondayClient(DataSourceClient):
             by_key.setdefault(title, column)
         return by_key
 
+    # Always-present DataFrame columns. The published schema lists them on every
+    # board table, so generated specs legitimately request them — accept and
+    # skip them instead of failing (they are returned regardless).
+    _BASE_COLUMNS = {"item_id", "name", "group"}
+
     def _selected_columns(self, requested, board_columns: List[dict], by_key: Dict[str, dict]) -> List[dict]:
         if not requested:
             return board_columns
         selected, missing = [], []
         for ref in requested:
+            if str(ref).lower() in self._BASE_COLUMNS:
+                continue
             column = by_key.get(str(ref)) or by_key.get(str(ref).lower())
             if column is None:
                 missing.append(str(ref))
@@ -433,7 +440,8 @@ class MondayClient(DataSourceClient):
         if missing:
             available = ", ".join(f"{c['title']} ({c['id']})" for c in board_columns)
             raise ValueError(
-                f"Unknown column(s) {missing} — available columns: {available}"
+                f"Unknown column(s) {missing} — available columns: {available} "
+                "(item_id, name and group are always included and need not be requested)"
             )
         return selected
 

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -626,7 +626,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
     "monday": DataSourceRegistryEntry(
         type="monday",
         category="services",
-        title="monday.com",
+        title="Monday data",
         description="Query monday.com boards as data — items, statuses, dates, people and numbers become tables the agent can filter and aggregate.",
         config_schema=MondayConfig,
         credentials_auth=AuthOptions(default="api_token", by_auth={

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -32,6 +32,7 @@ from app.schemas.data_sources.configs import (
     AwsRedshiftConfig,
     TableauConfig,
     SalesforceConfig,
+    MondayConfig,
     ServiceNowConfig,
     ZabbixConfig,
     ZabbixTokenCredentials,
@@ -177,6 +178,7 @@ from app.schemas.data_sources.configs import (
     SalesforceCredentials,
     SalesforceJWTCredentials,
     SalesforceClientCredentials,
+    MondayApiTokenCredentials,
     ServiceNowCredentials,
     MongoDBCredentials,
     PostHogCredentials,
@@ -619,6 +621,27 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
         }),
         # Explicit path: dynamic resolution would derive "ServicenowClient" (lowercase n).
         client_path="app.data_sources.clients.servicenow_client.ServiceNowClient",
+        version="beta",
+    ),
+    "monday": DataSourceRegistryEntry(
+        type="monday",
+        category="services",
+        title="monday.com",
+        description="Query monday.com boards as data — items, statuses, dates, people and numbers become tables the agent can filter and aggregate.",
+        config_schema=MondayConfig,
+        credentials_auth=AuthOptions(default="api_token", by_auth={
+            # The api_token schema also carries optional oauth_client_id/secret
+            # (ServiceNow pattern): the service token drives catalog indexing,
+            # the OAuth app fields power the per-user "oauth" sign-in below.
+            # `user` scope on api_token = bring-your-own-token.
+            "api_token": AuthVariant(title="API Token", schema=MondayApiTokenCredentials, scopes=["system", "user"]),
+            # Per-user delegated OAuth: authorization-code flow against
+            # auth.monday.com; queries run as the signed-in user so board
+            # permissions apply natively. monday access tokens do not expire
+            # and no refresh token is issued.
+            "oauth": AuthVariant(title="Sign in with monday.com", schema=OAuthDelegatedCredentials, scopes=["user"]),
+        }),
+        client_path="app.data_sources.clients.monday_client.MondayClient",
         version="beta",
     ),
     "priority_erp": DataSourceRegistryEntry(

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -523,6 +523,50 @@ class SalesforceConfig(BaseModel):
     objects: Optional[str] = Field(None, title="Objects", description="Optional comma-separated objects to index (e.g. Account,Contact,MyObj__c). Leave blank to auto-discover.", json_schema_extra={"ui:type": "string"})
 
 
+# monday.com
+class MondayApiTokenCredentials(BaseModel):
+    """Service API token, plus an optional OAuth app for per-user sign-in
+    (mirrors ServiceNowCredentials). The API token drives catalog indexing and
+    system-scope queries; the `oauth_*` fields — from an app created in
+    monday.com's Developer Center — enable the "Sign in with monday.com"
+    per-user flow and are consumed only by the OAuth authorize/token endpoints
+    (construct_client strips `oauth_`-prefixed keys before they reach the
+    client)."""
+    api_token: str = Field(
+        ...,
+        title="API Token",
+        description="A monday.com API token (avatar → Developers → My access tokens). Use a dedicated service user's token so shared queries don't depend on one person's account.",
+        json_schema_extra={"ui:type": "password"},
+    )
+    oauth_client_id: Optional[str] = Field(
+        None,
+        title="OAuth Client ID",
+        description="Client ID of an app created in monday.com's Developer Center — enables per-user sign-in",
+        json_schema_extra={"ui:type": "string"},
+    )
+    oauth_client_secret: Optional[str] = Field(
+        None,
+        title="OAuth Client Secret",
+        description="Client Secret of the monday.com app",
+        json_schema_extra={"ui:type": "password"},
+    )
+
+
+class MondayConfig(BaseModel):
+    workspaces: Optional[str] = Field(
+        None,
+        title="Workspaces",
+        description="Optional comma-separated workspace names or ids to index. Leave blank for all workspaces the token can see.",
+        json_schema_extra={"ui:type": "string"},
+    )
+    boards: Optional[str] = Field(
+        None,
+        title="Boards",
+        description="Optional comma-separated board names or ids to index. Leave blank to index every visible board.",
+        json_schema_extra={"ui:type": "textarea"},
+    )
+
+
 # ServiceNow
 class ServiceNowCredentials(BaseModel):
     """Service-account basic auth, plus an optional OAuth client for per-user

--- a/backend/app/services/connection_oauth_service.py
+++ b/backend/app/services/connection_oauth_service.py
@@ -255,6 +255,33 @@ def get_oauth_params(connection: Connection) -> dict:
             "provider_name": "servicenow",
         }
 
+    if conn_type == "monday":
+        # monday.com OAuth endpoints are global (auth.monday.com) for all
+        # regions — an EU account still authorizes against the global host.
+        # The admin registers an app in the Developer Center and saves its
+        # client id/secret on the connection (api_token credentials schema).
+        # monday access tokens DO NOT expire and no refresh token is issued,
+        # so there is no refresh path — a 401 later means re-connect.
+        client_id = creds.get("oauth_client_id")
+        client_secret = creds.get("oauth_client_secret")
+        if not client_id or not client_secret:
+            raise ValueError(
+                f"Connection {connection.id} missing oauth_client_id/oauth_client_secret for monday.com OAuth. "
+                "Create an app in monday.com's Developer Center (with this server's redirect URL) and save its "
+                "client ID and secret on the connection."
+            )
+
+        return {
+            "authorize_url": "https://auth.monday.com/oauth2/authorize",
+            "token_url": "https://auth.monday.com/oauth2/token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            # Read-only scopes: enough to index boards and run queries as the
+            # signed-in user. Write scopes are deliberately excluded.
+            "scopes": "boards:read workspaces:read users:read account:read",
+            "provider_name": "monday",
+        }
+
     if conn_type == "priority_erp":
         # Priority's OAuth2 is ON-PREMISE ONLY — its own guide states it is
         # "relevant only for on-prem (non-SaaS) installations" — and needs the

--- a/backend/app/services/connection_oauth_service.py
+++ b/backend/app/services/connection_oauth_service.py
@@ -277,8 +277,10 @@ def get_oauth_params(connection: Connection) -> dict:
             "client_id": client_id,
             "client_secret": client_secret,
             # Read-only scopes: enough to index boards and run queries as the
-            # signed-in user. Write scopes are deliberately excluded.
-            "scopes": "boards:read workspaces:read users:read account:read",
+            # signed-in user. Write scopes are deliberately excluded. `me:read`
+            # covers the Query.me identity probe in test_connection — personal
+            # API tokens carry it implicitly, delegated tokens must request it.
+            "scopes": "me:read boards:read workspaces:read users:read account:read",
             "provider_name": "monday",
         }
 

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -235,7 +235,7 @@ def default_user_auth_modes(conn_type: str, config: dict, credentials: dict) -> 
     from app.services.connection_oauth_service import ENTRA_OBO_CONNECTION_TYPES
     if conn_type in ENTRA_OBO_CONNECTION_TYPES:
         return ["oauth"]
-    if conn_type in ("servicenow", "snowflake", "bigquery") and (credentials or {}).get("oauth_client_id"):
+    if conn_type in ("servicenow", "snowflake", "bigquery", "monday") and (credentials or {}).get("oauth_client_id"):
         # Admin supplied an OAuth app/security integration → per-user auth
         # means OAuth sign-in (Fabric-style). Without one, modes stay unset so
         # users may still bring their own credentials (password, keypair, or

--- a/backend/tests/integrations/ds_clients.py
+++ b/backend/tests/integrations/ds_clients.py
@@ -65,6 +65,10 @@ DATA_SOURCES = [
     #               "username": "BWUSER", "password": "...", "catalog": "0D_NW_C01"}}
     "businessobjects",
     "sap_bw",
+    # Remote mode: monday.com has no self-hostable server, so this runs only
+    # against a live account configured in integrations.json (skips otherwise):
+    #   {"monday": {"enabled": true, "api_token": "..."}}
+    "monday",
 ]
 
 

--- a/backend/tests/unit/test_connection_oauth.py
+++ b/backend/tests/unit/test_connection_oauth.py
@@ -200,7 +200,7 @@ class TestGetOAuthParams:
         assert params["token_url"] == "https://auth.monday.com/oauth2/token"
         assert params["client_id"] == "mc1"
         assert params["client_secret"] == "ms1"
-        assert params["scopes"] == "boards:read workspaces:read users:read account:read"
+        assert params["scopes"] == "me:read boards:read workspaces:read users:read account:read"
 
     def test_monday_missing_oauth_creds_raises(self):
         conn = _make_connection(type="monday", credentials={"api_token": "svc-token"})

--- a/backend/tests/unit/test_connection_oauth.py
+++ b/backend/tests/unit/test_connection_oauth.py
@@ -186,6 +186,27 @@ class TestGetOAuthParams:
         with pytest.raises(ValueError, match="account"):
             get_oauth_params(conn)
 
+    def test_monday(self):
+        conn = _make_connection(
+            type="monday",
+            credentials={
+                "api_token": "svc-token",
+                "oauth_client_id": "mc1", "oauth_client_secret": "ms1",
+            },
+        )
+        params = get_oauth_params(conn)
+        assert params["provider_name"] == "monday"
+        assert params["authorize_url"] == "https://auth.monday.com/oauth2/authorize"
+        assert params["token_url"] == "https://auth.monday.com/oauth2/token"
+        assert params["client_id"] == "mc1"
+        assert params["client_secret"] == "ms1"
+        assert params["scopes"] == "boards:read workspaces:read users:read account:read"
+
+    def test_monday_missing_oauth_creds_raises(self):
+        conn = _make_connection(type="monday", credentials={"api_token": "svc-token"})
+        with pytest.raises(ValueError, match="oauth_client_id"):
+            get_oauth_params(conn)
+
     def test_servicenow(self):
         conn = _make_connection(
             type="servicenow",

--- a/backend/tests/unit/test_monday_client.py
+++ b/backend/tests/unit/test_monday_client.py
@@ -1,0 +1,314 @@
+"""Unit tests for MondayClient.
+
+Covers the client contract:
+- test_connection: success and auth failure
+- get_schemas: boards -> tables, subitem-board filtering, duplicate-name
+  disambiguation, status labels in column descriptions, board_relation ->
+  foreign keys, workspace/board config scoping
+- execute_query: JSON spec parsing, column selection by title or id,
+  status-label -> index translation in rules, cursor pagination, row cap,
+  typed cell values (numbers -> float, checkbox -> bool, rating -> int,
+  empty -> None), deterministic empty-result columns
+
+HTTP is faked at the `requests.post` boundary with payloads shaped like real
+monday.com GraphQL responses (verified live against api.monday.com)."""
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from app.data_sources.clients.monday_client import MondayClient
+
+
+STATUS_SETTINGS = json.dumps({
+    "labels": {"0": "Backlog", "1": "In Progress", "2": "Done"},
+})
+
+BOARD_MAIN = {
+    "id": "111",
+    "name": "Sales Pipeline",
+    "description": "Q3 deals",
+    "board_kind": "public",
+    "items_count": 3,
+    "workspace": {"id": "9", "name": "Sales"},
+    "columns": [
+        {"id": "name", "title": "Name", "type": "name", "settings_str": "{}"},
+        {"id": "color_1", "title": "Status", "type": "status", "settings_str": STATUS_SETTINGS},
+        {"id": "numbers_1", "title": "Amount", "type": "numbers", "settings_str": "{}"},
+        {"id": "date_1", "title": "Due Date", "type": "date", "settings_str": "{}"},
+        {"id": "check_1", "title": "Approved", "type": "checkbox", "settings_str": "{}"},
+        {"id": "rating_1", "title": "Priority", "type": "rating", "settings_str": "{}"},
+        {"id": "relation_1", "title": "Account", "type": "board_relation",
+         "settings_str": json.dumps({"boardIds": [222]})},
+    ],
+}
+
+BOARD_LINKED = {
+    "id": "222",
+    "name": "Accounts",
+    "description": None,
+    "board_kind": "public",
+    "items_count": 1,
+    "workspace": {"id": "9", "name": "Sales"},
+    "columns": [
+        {"id": "name", "title": "Name", "type": "name", "settings_str": "{}"},
+        {"id": "text_1", "title": "Industry", "type": "text", "settings_str": "{}"},
+    ],
+}
+
+BOARD_SUBITEMS = {
+    "id": "333",
+    "name": "Subitems of Sales Pipeline",
+    "description": None,
+    "board_kind": "public",
+    "items_count": 0,
+    "workspace": {"id": "9", "name": "Sales"},
+    "columns": [{"id": "name", "title": "Name", "type": "name", "settings_str": "{}"}],
+}
+
+BOARD_DUPE_A = {**BOARD_LINKED, "id": "444", "name": "Tasks", "workspace": {"id": "9", "name": "Sales"}}
+BOARD_DUPE_B = {**BOARD_LINKED, "id": "555", "name": "Tasks", "workspace": {"id": "10", "name": "Ops"}}
+
+
+def item(item_id, name, values):
+    return {"id": str(item_id), "name": name, "group": {"title": "Main"}, "column_values": values}
+
+
+ITEMS_PAGE_1 = {
+    "cursor": "CURSOR-2",
+    "items": [
+        item(1, "Deal A", [
+            {"id": "color_1", "text": "Done", "value": None, "type": "status"},
+            {"id": "numbers_1", "text": "1200.5", "value": '"1200.5"', "type": "numbers"},
+            {"id": "date_1", "text": "2026-01-15", "value": None, "type": "date"},
+            {"id": "check_1", "text": "v", "value": '{"checked":"true"}', "type": "checkbox"},
+            {"id": "rating_1", "text": "4", "value": '{"rating":4}', "type": "rating"},
+        ]),
+        item(2, "Deal B", [
+            {"id": "color_1", "text": "Backlog", "value": None, "type": "status"},
+            {"id": "numbers_1", "text": "", "value": None, "type": "numbers"},
+            {"id": "date_1", "text": "", "value": None, "type": "date"},
+            {"id": "check_1", "text": "", "value": None, "type": "checkbox"},
+            {"id": "rating_1", "text": "", "value": None, "type": "rating"},
+        ]),
+    ],
+}
+
+ITEMS_PAGE_2 = {
+    "cursor": None,
+    "items": [
+        item(3, "Deal C", [
+            {"id": "color_1", "text": "In Progress", "value": None, "type": "status"},
+            {"id": "numbers_1", "text": "99", "value": '"99"', "type": "numbers"},
+            {"id": "date_1", "text": "2026-02-01", "value": None, "type": "date"},
+            {"id": "check_1", "text": "", "value": None, "type": "checkbox"},
+            {"id": "rating_1", "text": "2", "value": '{"rating":2}', "type": "rating"},
+        ]),
+    ],
+}
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, headers=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = json.dumps(payload) if not isinstance(payload, str) else payload
+
+    def json(self):
+        if isinstance(self._payload, str):
+            raise ValueError("not json")
+        return self._payload
+
+
+def fake_post(monkeypatch, responder):
+    calls = []
+
+    def post(url, json=None, headers=None, timeout=None):
+        calls.append(json)
+        return responder(json["query"], json.get("variables") or {})
+
+    monkeypatch.setattr("app.data_sources.clients.monday_client.requests.post", post)
+    return calls
+
+
+def boards_responder(boards):
+    def responder(query, variables):
+        if "boards (limit: $limit, page: $page" in query:
+            page = variables.get("page", 1)
+            return FakeResponse({"data": {"boards": boards if page == 1 else []}})
+        if "next_items_page" in query:
+            return FakeResponse({"data": {"next_items_page": ITEMS_PAGE_2}})
+        if "items_page" in query:
+            return FakeResponse({"data": {"boards": [{"items_page": ITEMS_PAGE_1}]}})
+        if "me {" in query or "me {" in query.replace("  ", " "):
+            return FakeResponse({"data": {
+                "me": {"name": "Test User", "email": "t@example.com"},
+                "account": {"name": "Acme"}, "boards": [{"id": "111"}],
+            }})
+        raise AssertionError(f"unexpected query: {query}")
+    return responder
+
+
+ALL_BOARDS = [BOARD_MAIN, BOARD_LINKED, BOARD_SUBITEMS, BOARD_DUPE_A, BOARD_DUPE_B]
+
+
+# ── test_connection ─────────────────────────────────────────────────────────
+
+def test_connection_success(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    result = MondayClient(api_token="t").test_connection()
+    assert result["success"] is True
+    assert "Test User" in result["message"] and "Acme" in result["message"]
+
+
+def test_connection_auth_failure(monkeypatch):
+    fake_post(monkeypatch, lambda q, v: FakeResponse("<html>denied</html>", status_code=401))
+    result = MondayClient(api_token="bad").test_connection()
+    assert result["success"] is False
+    assert "401" in result["message"]
+
+
+def test_no_credentials():
+    result = MondayClient().test_connection()
+    assert result["success"] is False
+    assert "no credentials" in result["message"]
+
+
+# ── get_schemas ─────────────────────────────────────────────────────────────
+
+def test_get_schemas_shape(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    tables = MondayClient(api_token="t").get_schemas()
+    names = {t.name for t in tables}
+    # subitem board dropped; duplicate names disambiguated with the board id
+    assert names == {"Sales Pipeline", "Accounts", "Tasks [444]", "Tasks [555]"}
+
+    main = next(t for t in tables if t.name == "Sales Pipeline")
+    columns = {c.name: c for c in main.columns}
+    # base columns + board columns named by title; "name"-type column not duplicated
+    assert list(columns)[:3] == ["item_id", "name", "group"]
+    assert columns["Amount"].dtype == "float"
+    assert columns["Approved"].dtype == "bool"
+    assert columns["Priority"].dtype == "int"
+    assert columns["Due Date"].dtype == "date"
+    # status labels surface in the column description for the planner
+    assert "Done" in columns["Status"].description
+    assert main.pks[0].name == "item_id"
+    assert main.metadata_json["board_id"] == "111"
+
+    # board_relation -> FK to the linked board's table name
+    assert len(main.fks) == 1
+    assert main.fks[0].references_name == "Accounts"
+    assert main.fks[0].column.name == "Account"
+
+
+def test_get_schemas_scoping(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    tables = MondayClient(api_token="t", workspaces="Ops").get_schemas()
+    assert [t.name for t in tables] == ["Tasks"]
+
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    tables = MondayClient(api_token="t", boards="111").get_schemas()
+    assert [t.name for t in tables] == ["Sales Pipeline"]
+
+
+# ── execute_query ───────────────────────────────────────────────────────────
+
+def test_execute_query_flattening_and_pagination(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    df = MondayClient(api_token="t").execute_query(json.dumps({"board": "Sales Pipeline", "limit": 10}))
+    assert list(df.columns) == [
+        "item_id", "name", "group", "Status", "Amount", "Due Date", "Approved", "Priority", "Account",
+    ]
+    # both pages fetched through the cursor
+    assert len(df) == 3
+    row = df.iloc[0]
+    assert row["item_id"] == 1
+    assert row["Amount"] == 1200.5
+    assert row["Approved"] is True or row["Approved"] == True  # noqa: E712
+    assert row["Priority"] == 4
+    assert row["Status"] == "Done"
+    # empty cells -> None/NaN, not ""
+    assert pd.isna(df.iloc[1]["Amount"])
+    assert df.iloc[1]["Approved"] == False  # noqa: E712
+
+
+def test_execute_query_row_cap(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    df = MondayClient(api_token="t").execute_query(json.dumps({"board": "111", "limit": 2}))
+    assert len(df) == 2  # stopped at the cap, no second page beyond it
+
+
+def test_execute_query_column_selection_and_label_translation(monkeypatch):
+    calls = fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    client = MondayClient(api_token="t")
+    df = client.execute_query(json.dumps({
+        "board": "Sales Pipeline",
+        "columns": ["Status", "numbers_1"],          # title AND raw id both resolve
+        "rules": [{"column_id": "Status", "compare_value": ["Done", "In Progress"], "operator": "any_of"}],
+        "order_by": {"column_id": "Due Date", "direction": "desc"},
+        "limit": 3,
+    }))
+    assert "Status" in df.columns and "Amount" in df.columns
+    items_call = next(c for c in calls if c.get("variables", {}).get("qp"))
+    qp = items_call["variables"]["qp"]
+    # label text translated to label indices; column titles resolved to ids
+    assert qp["rules"][0]["column_id"] == "color_1"
+    assert qp["rules"][0]["compare_value"] == [2, 1]
+    assert qp["order_by"][0]["column_id"] == "date_1"
+    assert items_call["variables"]["cols"] == ["color_1", "numbers_1"]
+
+
+def test_execute_query_bad_specs(monkeypatch):
+    fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    client = MondayClient(api_token="t")
+    with pytest.raises(ValueError, match="JSON object"):
+        client.execute_query("SELECT * FROM boards")
+    with pytest.raises(ValueError, match='"board" key'):
+        client.execute_query(json.dumps({"limit": 5}))
+    with pytest.raises(ValueError, match="not found"):
+        client.execute_query(json.dumps({"board": "No Such Board"}))
+    with pytest.raises(ValueError, match="ambiguous"):
+        client.execute_query(json.dumps({"board": "Tasks"}))
+    with pytest.raises(ValueError, match="Unknown column"):
+        client.execute_query(json.dumps({"board": "Sales Pipeline", "columns": ["Nope"]}))
+
+
+def test_execute_query_empty_result_columns(monkeypatch):
+    def responder(query, variables):
+        if "boards (limit: $limit, page: $page" in query:
+            page = variables.get("page", 1)
+            return FakeResponse({"data": {"boards": [BOARD_MAIN] if page == 1 else []}})
+        if "items_page" in query:
+            return FakeResponse({"data": {"boards": [{"items_page": {"cursor": None, "items": []}}]}})
+        raise AssertionError(query)
+
+    fake_post(monkeypatch, responder)
+    df = MondayClient(api_token="t").execute_query(
+        json.dumps({"board": "Sales Pipeline", "columns": ["Amount"], "limit": 5})
+    )
+    assert df.empty
+    assert list(df.columns) == ["item_id", "name", "group", "Amount"]
+
+
+# ── throttling ──────────────────────────────────────────────────────────────
+
+def test_retry_on_429(monkeypatch):
+    attempts = {"n": 0}
+
+    def responder(query, variables):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return FakeResponse("<html>rate limited</html>", status_code=429, headers={"Retry-After": "0"})
+        return FakeResponse({"data": {
+            "me": {"name": "U", "email": "u@e.com"}, "account": {"name": "A"}, "boards": [],
+        }})
+
+    fake_post(monkeypatch, responder)
+    monkeypatch.setattr("app.data_sources.clients.monday_client.time.sleep", lambda s: None)
+    result = MondayClient(api_token="t").test_connection()
+    assert result["success"] is True
+    assert attempts["n"] == 2

--- a/backend/tests/unit/test_monday_client.py
+++ b/backend/tests/unit/test_monday_client.py
@@ -164,6 +164,21 @@ def test_connection_success(monkeypatch):
     assert "Test User" in result["message"] and "Acme" in result["message"]
 
 
+def test_connection_degrades_without_me_scope(monkeypatch):
+    """A delegated OAuth token without me:read fails only the Query.me probe —
+    test_connection must fall back to account-level fields, not fail."""
+    def responder(query, variables):
+        if "me {" in query:
+            return FakeResponse({"errors": [{"message":
+                "Unauthorized to load field 'Query.me', Reason: missing required scopes"}]})
+        return FakeResponse({"data": {"account": {"name": "Acme"}, "boards": [{"id": "111"}]}})
+
+    fake_post(monkeypatch, responder)
+    result = MondayClient(access_token="delegated").test_connection()
+    assert result["success"] is True
+    assert "Acme" in result["message"]
+
+
 def test_connection_auth_failure(monkeypatch):
     fake_post(monkeypatch, lambda q, v: FakeResponse("<html>denied</html>", status_code=401))
     result = MondayClient(api_token="bad").test_connection()

--- a/backend/tests/unit/test_monday_client.py
+++ b/backend/tests/unit/test_monday_client.py
@@ -277,6 +277,21 @@ def test_execute_query_column_selection_and_label_translation(monkeypatch):
     assert items_call["variables"]["cols"] == ["color_1", "numbers_1"]
 
 
+def test_execute_query_accepts_base_columns_in_selection(monkeypatch):
+    """The published schema lists item_id/name/group on every table, so specs
+    legitimately request them — they must be accepted (and skipped), not fail
+    as unknown columns."""
+    calls = fake_post(monkeypatch, boards_responder(ALL_BOARDS))
+    df = MondayClient(api_token="t").execute_query(json.dumps({
+        "board": "Sales Pipeline",
+        "columns": ["item_id", "name", "group", "Status"],
+        "limit": 3,
+    }))
+    assert list(df.columns) == ["item_id", "name", "group", "Status"]
+    items_call = next(c for c in calls if "items_page" in c["query"])
+    assert items_call["variables"]["cols"] == ["color_1"]  # only the board column is fetched
+
+
 def test_execute_query_bad_specs(monkeypatch):
     fake_post(monkeypatch, boards_responder(ALL_BOARDS))
     client = MondayClient(api_token="t")

--- a/docs/feedback-loops/monday-connector.md
+++ b/docs/feedback-loops/monday-connector.md
@@ -1,0 +1,74 @@
+# monday.com connector — sandbox feedback loop
+
+Adds `monday` as a first-class queryable data source type (boards → tables →
+`execute_query` → DataFrame), alongside the existing `monday` MCP preset
+(which stays, for tool-style access). Verified end-to-end against a live
+monday.com trial account (EU region) with Claude 4.5 Haiku as the only model.
+
+## What was built
+
+- `backend/app/data_sources/clients/monday_client.py` — `MondayClient(DataSourceClient)`
+  over the GraphQL API (`api.monday.com/v2`, API-Version 2024-10). Boards →
+  `Table` (name-disambiguated with `[board_id]` on duplicates), columns →
+  `TableColumn` named by column TITLE (id in the description), status/dropdown
+  labels surfaced in column descriptions, `board_relation` columns → FKs.
+  `execute_query` takes a JSON spec (`board`, `columns`, `rules`, `operator`,
+  `order_by`, `limit`) → `items_page` + `next_items_page` cursor pagination
+  (page 500, cap 10k). 429s (HTML body + Retry-After) and complexity
+  throttles are absorbed with bounded retries.
+- `configs.py`: `MondayConfig` (workspaces/boards scoping), `MondayApiTokenCredentials`
+  (api_token + optional oauth_client_id/secret, ServiceNow pattern).
+- Registry: `monday` entry — `api_token` (system+user) + `oauth` (user,
+  `OAuthDelegatedCredentials`), explicit `client_path`, category `services`.
+- `connection_oauth_service.get_oauth_params`: `monday` branch —
+  `https://auth.monday.com/oauth2/{authorize,token}`, read-only scopes
+  (`boards:read workspaces:read users:read account:read`). monday tokens do
+  not expire; no refresh token exists, so there is no refresh path.
+- `connection_service.default_user_auth_modes`: monday added to the
+  oauth_client_id → `["oauth"]` list.
+- Tests: `tests/unit/test_monday_client.py` (11), two monday cases in
+  `tests/unit/test_connection_oauth.py`, `monday` in
+  `tests/integrations/ds_clients.py` (remote mode, needs
+  `{"monday": {"enabled": true, "api_token": "..."}}`).
+
+## Live findings (worth keeping)
+
+- **Filter rules match label INDICES, not text.** `{"compare_value": ["Done"],
+  "operator": "any_of"}` on a status column returns 0 rows; the index (e.g. 2)
+  matches. The client translates label text → index from `settings_str`, so
+  generated queries can use human labels. Verified live both ways.
+- **`greater_than` on timeline columns** → `no_operator_config` error; date
+  comparisons in rules are unreliable. The system prompt steers the coder to
+  fetch + filter in pandas.
+- **429s come back as HTML** (a font-embedded page), not JSON — parse nothing,
+  read `Retry-After`.
+- **Trial accounts have a small daily API budget.** Bulk-seeding ~300 boards
+  exhausted it (~800 mutations in): after that even `query { me { id } }`
+  429s for hours. Plan seeding/indexing accordingly; the client's bounded
+  retries surface a clean error instead of hanging forever.
+- Community license: switching a monday connection to `user_required`
+  (per-user OAuth) is enterprise-gated like every tables-shaped connector.
+
+## Sandbox loop (reproduced)
+
+1. Boot backend + frontend per `sandbox-feedback-loop`; Anthropic provider with
+   ONLY Claude 4.5 Haiku enabled (becomes default).
+2. `/agents/new` → Services → monday.com tile → schema-generated form
+   (Workspaces/Boards config, API Token credential) → Test connection
+   ("Connected to monday.com as … on account …") → Save and Continue →
+   "Discovered 4 tables · 1s".
+3. Tables step defaults to INACTIVE — "Select all" + Save (agent page →
+   "N tables" → Select all → Save; verify `datasource_tables.is_active=1`).
+4. Chat: "How many items does each board have? And show the status breakdown of
+   the Product Roadmap Q4 [000] board" → Haiku generated
+   `ds_clients["Monday:monday.com"].execute_query('{"board": …, "limit": 10000}')`
+   and a second step with `"columns": ["Status"]` — both steps `success`,
+   38 requests to api.monday.com in the backend log, 751-item board proved
+   cursor pagination past the 500-row page.
+5. OAuth: token endpoint validated the app's client id/secret live
+   (`invalid_grant` for a fake code vs `Invalid client_secret param` /
+   `Invalid client_id param` for wrong credentials); authorize 302s into
+   monday login carrying the request payload. Browser consent not automatable
+   here (Chromium egress blocked in the remote sandbox + account is Google
+   SSO) — the last mile needs a human click on the authorize URL produced by
+   `GET /connections/{id}/oauth/authorize`.

--- a/frontend/components/DataSourceIcon.vue
+++ b/frontend/components/DataSourceIcon.vue
@@ -101,6 +101,8 @@ const iconPath = computed(() => {
         outlook_mail: 'outlook_mail.svg',
         elasticsearch: 'elasticsearch.svg',
         s3: 's3.svg',
+        // Same brand asset as the monday MCP preset (CONNECTOR_ICON_FILE above).
+        monday: 'monday.svg',
     };
     if (TYPE_ICON_FILE[t]) {
         return `/data_sources_icons/${TYPE_ICON_FILE[t]}`;


### PR DESCRIPTION
## Summary
Adds monday.com as a first-class queryable data source type alongside the existing MCP preset. Users can now query monday.com boards as tables with filtering, sorting, and pagination support through a JSON spec interface.

## Key Changes

### Core Client Implementation
- **`MondayClient`** (`backend/app/data_sources/clients/monday_client.py`): Full GraphQL API client for monday.com (api.monday.com/v2, API-Version 2024-10)
  - Schema discovery: boards → tables with name disambiguation on duplicates, columns → `TableColumn` with types mapped to pandas dtypes
  - Status/dropdown labels surfaced in column descriptions; `board_relation` columns mapped to foreign keys
  - `execute_query` accepts JSON specs (`board`, `columns`, `rules`, `operator`, `order_by`, `limit`) and returns DataFrames via cursor pagination (page size 500, cap 10k rows)
  - Handles 429 throttling (HTML responses with Retry-After header) and complexity exhaustion with bounded retries
  - **Label translation quirk**: Filter rules match label indices, not text; client automatically translates human-readable labels to indices from column settings
  - Typed cell value parsing: numbers → float, rating → int, checkbox → bool, empty cells → None

### Configuration & Credentials
- **`MondayConfig`** and **`MondayApiTokenCredentials`** in `configs.py`: Service API token (for indexing/system queries) plus optional OAuth app credentials (client_id/secret) for per-user sign-in
- Registry entry in `data_source_registry.py`: `monday` type with category `services`, both token and OAuth credential modes

### OAuth Integration
- **`connection_oauth_service.py`**: monday.com OAuth endpoints (`https://auth.monday.com/oauth2/{authorize,token}`) with read-only scopes (`boards:read workspaces:read users:read account:read`)
- Note: monday tokens do not expire; no refresh token mechanism exists
- **`connection_service.py`**: monday added to `default_user_auth_modes` for oauth_client_id support

### Testing & Documentation
- **Unit tests** (`test_monday_client.py`): 11 tests covering connection, schema discovery (subitem filtering, duplicate name disambiguation, label surfacing, foreign keys), query execution (spec parsing, column selection, label translation, pagination, row capping, typed values, empty results), and throttling retry logic
- **OAuth tests** (`test_connection_oauth.py`): monday OAuth parameter validation
- **Integration tests** (`ds_clients.py`): monday added to remote-mode test suite
- **Documentation** (`monday-connector.md`): Live findings (label index matching, timeline operator limitations, HTML 429 responses, trial account budget constraints) and sandbox feedback loop reproduction steps
- **UI**: Icon mapping in `DataSourceIcon.vue`, README updated with monday.com entry

## Notable Implementation Details

- **Workspace/board scoping**: Optional `workspaces` and `boards` config fields filter discovery by name or id
- **Deterministic schema**: Empty result DataFrames include all expected columns (base + selected) even if no items returned
- **Retry strategy**: 6 attempts per request with exponential backoff for 5xx errors; 429s and complexity throttles detected via status code and error message patterns
- **Column naming**: Board columns named by TITLE (id in description); duplicates disambiguated with `(id)` suffix; built-in columns (item_id, name, group) always present

https://claude.ai/code/session_01LFvL7iMxemsu2ZBFrw8qWk