### PR TITLE
Stop rendering python-pptx slides source as raw text when previews are missing

### DIFF
--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -203,6 +203,28 @@
         class="absolute inset-0"
       />
 
+      <!-- Slides without previews: content.code is python-pptx source, which
+           the browser cannot render — never inject it into the iframe. -->
+      <div v-else-if="slidesPreviewsMissing" class="absolute inset-0 flex flex-col items-center justify-center bg-white dark:bg-gray-900">
+        <Icon name="heroicons:presentation-chart-bar" class="w-8 h-8 text-gray-400 mb-3" />
+        <template v-if="selectedArtifact?.status === 'failed'">
+          <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slides generation failed</h3>
+          <p class="text-xs text-gray-400 mb-4 max-w-sm text-center">
+            The presentation could not be built. Ask the agent to regenerate the slides.
+          </p>
+        </template>
+        <template v-else>
+          <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slide previews unavailable</h3>
+          <p class="text-xs text-gray-400 mb-4 max-w-sm text-center">
+            The deck was built, but preview images could not be generated on the server. You can still download the PowerPoint file.
+          </p>
+          <UButton @click="exportPptx" :disabled="isExporting" size="xs" color="purple" variant="soft">
+            <Icon name="heroicons:arrow-down-tray" class="w-4 h-4" />
+            Export PPTX
+          </UButton>
+        </template>
+      </div>
+
       <!-- Doc Mode - owner editing (TipTap) -->
       <DocEditor
         v-else-if="isDocMode && selectedArtifact && isEditingDoc"
@@ -256,7 +278,7 @@
            slides render as page images through SlideViewer, so there is no
            iframe for the element picker to talk to) -->
       <div
-        v-if="hasArtifact && !isLoading && !isPendingArtifact && !snapshotWithheld && !iframeError && !isDocMode && !hasSlidesWithPreviews"
+        v-if="hasArtifact && !isLoading && !isPendingArtifact && !snapshotWithheld && !iframeError && !isDocMode && !hasSlidesWithPreviews && !slidesPreviewsMissing"
         class="absolute bottom-4 left-4 z-20"
       >
         <button
@@ -337,6 +359,11 @@
               :visualizations="visualizationsData"
               class="absolute inset-0"
             />
+            <!-- Slides without previews have no renderable content -->
+            <div v-else-if="isFullscreenOpen && slidesPreviewsMissing" class="absolute inset-0 flex flex-col items-center justify-center text-gray-400">
+              <Icon name="heroicons:presentation-chart-bar" class="w-8 h-8 mb-2" />
+              <span class="text-sm">Slide previews unavailable</span>
+            </div>
             <!-- Other artifacts use iframe -->
             <iframe
               v-else-if="isFullscreenOpen && iframeSrcdoc"
@@ -361,7 +388,7 @@ import SlideViewer from './SlideViewer.vue';
 import DocViewer from './DocViewer.vue';
 import DocEditor from './DocEditor.vue';
 import ViewerRunGate from './ViewerRunGate.vue';
-import { buildArtifactIframeHtml } from '~/utils/artifactIframe';
+import { buildArtifactIframeHtml, isHtmlSlidesCode } from '~/utils/artifactIframe';
 
 const { t } = useI18n();
 const toast = useToast();
@@ -675,6 +702,16 @@ const hasSlidesWithPreviews = computed(() => {
   if (selectedArtifact.value.mode !== 'slides') return false;
   const previewImages = selectedArtifact.value.content?.preview_images;
   return Array.isArray(previewImages) && previewImages.length > 0;
+});
+
+// Slides artifact whose previews are missing (preview generation failed, or
+// the pptx build itself failed) and whose code is python-pptx source, not
+// legacy HTML slides. Such an artifact has nothing browser-renderable — show
+// the dedicated fallback instead of the iframe.
+const slidesPreviewsMissing = computed(() => {
+  if (selectedArtifact.value?.mode !== 'slides') return false;
+  if (hasSlidesWithPreviews.value) return false;
+  return !isHtmlSlidesCode(selectedArtifact.value?.content?.code || '');
 });
 
 // Doc mode: markdown document rendered by DocViewer (no iframe, no JSX)
@@ -1462,6 +1499,10 @@ const iframeSrcdoc = computed(() => {
   // code routinely assumes rows exist — don't execute it at all. The
   // ViewerRunGate covers this state until the viewer's own run resolves it.
   if (snapshotWithheld.value) return undefined;
+
+  // Slides without previews carry python-pptx source; it must never be
+  // injected into the iframe (the browser would render it as raw text).
+  if (slidesPreviewsMissing.value) return undefined;
 
   // If artifacts exist, wait for the selected artifact to be fully loaded
   if (artifactsList.value.length > 0 && !selectedArtifact.value?.content?.code) return undefined;

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -172,6 +172,15 @@
                     class="absolute inset-0"
                 />
 
+                <!-- Slides without previews: python-pptx source is not
+                     browser-renderable — show a fallback, never the iframe -->
+                <div v-else-if="slidesPreviewsMissing && artifact" class="absolute inset-0 flex items-center justify-center text-gray-400">
+                    <div class="text-center">
+                        <Icon name="heroicons:presentation-chart-bar" class="w-12 h-12 mx-auto mb-3 opacity-50" />
+                        <p>Slide previews are not available for this presentation</p>
+                    </div>
+                </div>
+
                 <!-- Shared Document - read-only DocViewer -->
                 <DocViewer
                     v-else-if="isDocMode && artifact"
@@ -245,7 +254,7 @@ import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue';
 import SlideViewer from '~/components/dashboard/SlideViewer.vue';
 import DocViewer from '~/components/dashboard/DocViewer.vue';
 import ViewerRunGate from '~/components/dashboard/ViewerRunGate.vue';
-import { buildArtifactIframeHtml } from '~/utils/artifactIframe';
+import { buildArtifactIframeHtml, isHtmlSlidesCode } from '~/utils/artifactIframe';
 
 const route = useRoute();
 const report_id = route.params.id;
@@ -465,6 +474,15 @@ const hasSlidesWithPreviews = computed(() => {
     return Array.isArray(previewImages) && previewImages.length > 0;
 });
 
+// Slides artifact with no previews and python-pptx code — nothing the browser
+// can render, so the page shows a fallback instead of injecting the source
+// into the iframe (where it would appear as raw text).
+const slidesPreviewsMissing = computed(() => {
+    if (artifact.value?.mode !== 'slides') return false;
+    if (hasSlidesWithPreviews.value) return false;
+    return !isHtmlSlidesCode(artifact.value?.content?.code || '');
+});
+
 // Shared document (mode='doc') — rendered read-only in DocViewer, never an iframe
 const isDocMode = computed(() => artifact.value?.mode === 'doc');
 
@@ -651,6 +669,9 @@ const iframeSrcdoc = computed(() => {
 
     const artifactCode = artifact.value?.content?.code;
     if (!artifactCode) return null;
+
+    // python-pptx slides source must never be injected into the iframe
+    if (slidesPreviewsMissing.value) return null;
 
     return buildArtifactIframeHtml({
         data: {

--- a/frontend/public/mcp-artifact-app.html
+++ b/frontend/public/mcp-artifact-app.html
@@ -192,6 +192,12 @@
 
       function injectArtifactCode(code, mode) {
         if (mode === 'slides') {
+          // Legacy slides stored HTML; the current pipeline stores python-pptx
+          // source, which must never be dumped into the DOM as markup.
+          if (!/<\s*(!doctype|html|head|body|script|style|div|section)\b/i.test(code || '')) {
+            showError('Slide previews are not available for this presentation.');
+            return;
+          }
           var root = document.getElementById('root');
           if (root) root.innerHTML = code;
           return;

--- a/frontend/utils/artifactIframe.ts
+++ b/frontend/utils/artifactIframe.ts
@@ -41,6 +41,16 @@ export interface ArtifactIframeOptions {
 
 const SC = '</' + 'script>';
 
+/**
+ * Legacy slides artifacts stored browser-renderable HTML in content.code;
+ * the current pipeline stores python-pptx source that only the backend can
+ * execute. Only markup may be injected into the slides iframe — Python
+ * dumped into a <body> renders as a wall of source text.
+ */
+export function isHtmlSlidesCode(code: string): boolean {
+  return /<\s*(!doctype|html|head|body|script|style|div|section)\b/i.test(code || '');
+}
+
 function buildSlidesHtml(data: ArtifactIframeData, code: string): string {
   return `<!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Bug

A slides artifact whose preview images are missing rendered as a wall of raw python-pptx source code on a dark background instead of slides.

**Chain of failure:**
1. For `mode: "slides"`, `content.code` holds python-pptx source that is executed server-side; the UI is supposed to show PNG previews (LibreOffice → PDF → pdf2image).
2. If preview generation fails (LibreOffice missing/misconfigured, `soffice` timeout, poppler missing), the artifact is still saved as `completed` with no `preview_images` — the failure is only a log warning. If the pptx build itself fails, the artifact is saved as `failed`, which the frontend had no branch for at all.
3. With no previews, all three render surfaces fell through to the legacy slides iframe template, which injects `content.code` directly into the document `<body>` — that template predates the pptx pipeline and assumes slides code is HTML. Python isn't markup, so the browser dumps it as text.

## Fix

New `isHtmlSlidesCode()` helper in `frontend/utils/artifactIframe.ts` gates the iframe path: only legacy HTML slides artifacts may be injected as markup; python-pptx source never reaches the DOM. Each surface gets a proper state instead:

- **`ArtifactFrame.vue`** (in-app): "Slide previews unavailable" with a working **Export PPTX** button (the deck still exists and is downloadable), or "Slides generation failed" for `status: "failed"` artifacts. Also guards the iframe srcdoc, the Polish Dashboard button, and the fullscreen modal against this state.
- **`pages/r/[id]/index.vue`** (public share page): plain fallback message instead of the iframe.
- **`public/mcp-artifact-app.html`** (MCP hosts): same guard, error message instead of `innerHTML` injection.

## Verification

Verified end-to-end in a full local sandbox (FastAPI + Nuxt + Playwright/Chromium), driving the real UI against seeded slides artifacts:

| Scenario | Result |
|---|---|
| Slides artifact, `completed`, no previews (pre-fix) | Bug reproduced: raw Python rendered as text |
| Same artifact, post-fix | Fallback panel with Export PPTX; DOM contains no source code |
| Slides artifact, `status: "failed"` | "Slides generation failed" state |
| Published report on public `/r/{id}` | Fallback message; asserted no `prs.slides.add_slide` in page text |
| Slides artifact **with** preview PNGs (regression) | SlideViewer unchanged: slide 1/3, thumbnails, navigation all work |

Heuristic sanity-checked both ways: Python code (including `a < b` comparisons) is not misdetected as HTML; legacy `<div class="slide">` markup still routes to the old iframe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQHGAhSdzVBLHawAqKVH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKQHGAhSdzVBLHawAqKVH6)_