### PR TITLE
Add timeout protection to PDF export to prevent hanging

### DIFF
--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -611,6 +611,13 @@ import asyncio as _asyncio
 from collections import defaultdict as _defaultdict
 _pdf_export_locks: dict[str, "_asyncio.Lock"] = _defaultdict(_asyncio.Lock)
 
+# Upper bound on one export request: waiting for the lock (at most one render
+# already in flight) plus our own render. The render itself is capped at
+# ReportPdfService.RENDER_TIMEOUT_SECONDS; without this outer bound a request
+# queued behind a wedged render would wait forever and the client would sit at
+# "Exporting..." with no way to learn it failed.
+_PDF_EXPORT_TIMEOUT_SECONDS = 330
+
 
 @router.get("/r/{report_id}/export_pdf")
 async def export_public_report_pdf(
@@ -631,8 +638,19 @@ async def export_public_report_pdf(
 
     from app.services.report_pdf_service import ReportPdfService
 
-    async with _pdf_export_locks[str(report_id)]:
-        pdf_path = await ReportPdfService().generate_for_report(str(report_id))
+    async def _generate_locked() -> str | None:
+        async with _pdf_export_locks[str(report_id)]:
+            return await ReportPdfService().generate_for_report(str(report_id))
+
+    try:
+        pdf_path = await _asyncio.wait_for(
+            _generate_locked(), timeout=_PDF_EXPORT_TIMEOUT_SECONDS
+        )
+    except _asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail="PDF export timed out. Please try again.",
+        )
 
     import os
     if not pdf_path or not os.path.isfile(pdf_path):

--- a/backend/app/services/report_pdf_service.py
+++ b/backend/app/services/report_pdf_service.py
@@ -211,6 +211,12 @@ class ReportPdfService:
     OVERFLOW_GUTTER_PX = 32
     # Seconds to let ECharts re-render after each layout change.
     SETTLE_SECONDS = 1.2
+    # Hard wall-clock cap on one Chromium render. The individual Playwright
+    # calls each have their own timeout, but page.pdf() does not — a wedged
+    # renderer (huge canvas at device_scale_factor=2, OOMing tab) would
+    # otherwise hang the awaiting request forever, and with it every caller
+    # queued on the per-report export lock.
+    RENDER_TIMEOUT_SECONDS = 150
 
     def __init__(self):
         self.UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
@@ -227,10 +233,30 @@ class ReportPdfService:
             Relative path to the PDF file (e.g. "pdfs/{id}.pdf"), or None on failure.
         """
         try:
-            from playwright.async_api import async_playwright
+            from playwright.async_api import async_playwright  # noqa: F401
         except ImportError:
             logger.warning("Playwright not installed, skipping PDF generation")
             return None
+
+        try:
+            return await asyncio.wait_for(
+                self._generate_pdf_inner(artifact_id, html_content),
+                timeout=self.RENDER_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "PDF render for artifact %s exceeded %ss; aborting",
+                artifact_id, self.RENDER_TIMEOUT_SECONDS,
+            )
+            return None
+        except Exception as e:
+            logger.exception(f"Failed to generate PDF for artifact {artifact_id}: {e}")
+            return None
+
+    async def _generate_pdf_inner(self, artifact_id: str, html_content: str) -> Optional[str]:
+        """The actual render. Callers go through generate_pdf, which bounds this
+        with RENDER_TIMEOUT_SECONDS and turns any failure into None."""
+        from playwright.async_api import async_playwright
 
         pdf_path = self.UPLOADS_DIR / f"{artifact_id}.pdf"
 

--- a/backend/app/services/report_pdf_service.py
+++ b/backend/app/services/report_pdf_service.py
@@ -26,6 +26,9 @@ import asyncio
 import json
 import logging
 import math
+import os
+import signal
+import uuid
 from pathlib import Path
 from typing import Any, Optional
 
@@ -193,6 +196,57 @@ _PRINT_CSS = """
 """
 
 
+def _kill_chromium_tree(marker: str) -> int:
+    """SIGKILL the Chromium launched with `marker` in its argv, descendants first.
+
+    When a render times out, the task cancellation can interrupt Playwright's
+    own teardown, and even a clean teardown cannot stop a renderer whose main
+    thread is spinning in JS: it never services the shutdown IPC, survives its
+    parent's death, reparents to init and burns a core forever. So the process
+    tree has to be walked and killed leaf-first while the parent links are
+    still intact. /proc-based and best-effort: on hosts without /proc (deploys
+    run on Linux) this is a silent no-op.
+    """
+    killed = 0
+    try:
+        children_by_parent: dict[int, list[int]] = {}
+        marked: list[int] = []
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            try:
+                cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().decode("utf-8", "replace")
+                stat = Path(f"/proc/{pid}/stat").read_text()
+            except OSError:
+                continue
+            try:
+                # Field 4 of /proc/pid/stat, after the parenthesised comm
+                # (which may itself contain spaces).
+                ppid = int(stat.rsplit(")", 1)[1].split()[1])
+            except (IndexError, ValueError):
+                continue
+            children_by_parent.setdefault(ppid, []).append(pid)
+            if marker in cmdline:
+                marked.append(pid)
+
+        def _descendants(pid: int):
+            for child in children_by_parent.get(pid, []):
+                yield from _descendants(child)
+                yield child
+
+        for root in marked:
+            for pid in [*_descendants(root), root]:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    killed += 1
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return killed
+
+
 class ReportPdfService:
     """Generates PDF snapshots of artifacts using headless Chromium."""
 
@@ -238,9 +292,14 @@ class ReportPdfService:
             logger.warning("Playwright not installed, skipping PDF generation")
             return None
 
+        # Unique argv marker so a timed-out render's Chromium tree can be
+        # found and killed — cancellation interrupts Playwright's teardown,
+        # and a wedged renderer survives even a clean one (see
+        # _kill_chromium_tree). Chromium ignores unknown switches.
+        marker = f"--bow-pdf-export={uuid.uuid4().hex}"
         try:
             return await asyncio.wait_for(
-                self._generate_pdf_inner(artifact_id, html_content),
+                self._generate_pdf_inner(artifact_id, html_content, marker),
                 timeout=self.RENDER_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
@@ -248,12 +307,21 @@ class ReportPdfService:
                 "PDF render for artifact %s exceeded %ss; aborting",
                 artifact_id, self.RENDER_TIMEOUT_SECONDS,
             )
+            killed = await asyncio.to_thread(_kill_chromium_tree, marker)
+            if killed:
+                logger.info(
+                    "Killed %s leftover Chromium processes for artifact %s",
+                    killed, artifact_id,
+                )
             return None
         except Exception as e:
             logger.exception(f"Failed to generate PDF for artifact {artifact_id}: {e}")
+            await asyncio.to_thread(_kill_chromium_tree, marker)
             return None
 
-    async def _generate_pdf_inner(self, artifact_id: str, html_content: str) -> Optional[str]:
+    async def _generate_pdf_inner(
+        self, artifact_id: str, html_content: str, marker: str
+    ) -> Optional[str]:
         """The actual render. Callers go through generate_pdf, which bounds this
         with RENDER_TIMEOUT_SECONDS and turns any failure into None."""
         from playwright.async_api import async_playwright
@@ -267,7 +335,7 @@ class ReportPdfService:
 
         try:
             async with async_playwright() as p:
-                browser = await p.chromium.launch(headless=True)
+                browser = await p.chromium.launch(headless=True, args=[marker])
                 # Lay out at the printable width from the start: responsive
                 # breakpoints and every JS-measured chart size are then computed
                 # for the paper, not for a desktop window that does not exist.

--- a/backend/tests/unit/test_report_pdf_timeout.py
+++ b/backend/tests/unit/test_report_pdf_timeout.py
@@ -1,0 +1,43 @@
+"""The PDF export must never hang forever.
+
+A wedged Chromium (page.pdf() has no per-call timeout) used to hang the
+awaiting request indefinitely — and with it every request queued on the
+per-report export lock, leaving the share page stuck at "Exporting...".
+generate_pdf now bounds the whole render with RENDER_TIMEOUT_SECONDS and
+reports failure as None, which the route turns into an HTTP error.
+"""
+
+import asyncio
+
+import pytest
+
+from app.services.report_pdf_service import ReportPdfService
+
+
+@pytest.mark.asyncio
+async def test_generate_pdf_times_out_instead_of_hanging(monkeypatch):
+    service = ReportPdfService()
+
+    async def hang_forever(artifact_id, html_content):
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(service, "_generate_pdf_inner", hang_forever)
+    monkeypatch.setattr(ReportPdfService, "RENDER_TIMEOUT_SECONDS", 0.05)
+
+    result = await asyncio.wait_for(
+        service.generate_pdf("artifact-under-test", "<html></html>"),
+        timeout=5,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_pdf_returns_none_on_render_failure(monkeypatch):
+    service = ReportPdfService()
+
+    async def explode(artifact_id, html_content):
+        raise RuntimeError("chromium crashed")
+
+    monkeypatch.setattr(service, "_generate_pdf_inner", explode)
+
+    assert await service.generate_pdf("artifact-under-test", "<html></html>") is None

--- a/backend/tests/unit/test_report_pdf_timeout.py
+++ b/backend/tests/unit/test_report_pdf_timeout.py
@@ -18,7 +18,7 @@ from app.services.report_pdf_service import ReportPdfService
 async def test_generate_pdf_times_out_instead_of_hanging(monkeypatch):
     service = ReportPdfService()
 
-    async def hang_forever(artifact_id, html_content):
+    async def hang_forever(artifact_id, html_content, marker):
         await asyncio.sleep(3600)
 
     monkeypatch.setattr(service, "_generate_pdf_inner", hang_forever)
@@ -35,7 +35,7 @@ async def test_generate_pdf_times_out_instead_of_hanging(monkeypatch):
 async def test_generate_pdf_returns_none_on_render_failure(monkeypatch):
     service = ReportPdfService()
 
-    async def explode(artifact_id, html_content):
+    async def explode(artifact_id, html_content, marker):
         raise RuntimeError("chromium crashed")
 
     monkeypatch.setattr(service, "_generate_pdf_inner", explode)

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -372,6 +372,11 @@ async function handleExportPdf() {
     try {
         const { data, error: fetchError } = await useMyFetch(`/api/r/${report_id}/export_pdf`, {
             responseType: 'blob' as any,
+            // ofetch's default retry list includes 409/504 — exactly what a
+            // failed/timed-out export returns — and a silent retry re-runs a
+            // multi-minute server-side render, doubling how long the button
+            // spins before the user sees the error. Fail once, fail visibly.
+            retry: 0,
             // The server bounds an export at ~5.5 min (render cap + lock wait);
             // this backstop keeps the button from spinning forever if the
             // request itself goes into a black hole (dropped connection, proxy
@@ -394,7 +399,14 @@ async function handleExportPdf() {
         URL.revokeObjectURL(url);
     } catch (e: any) {
         console.error('PDF export failed:', e);
-        exportPdfError.value = e?.data?.detail || e?.message || 'PDF export failed';
+        // With responseType 'blob' the error body arrives as a Blob, so the
+        // server's JSON {detail} has to be read out of it — otherwise the user
+        // sees the raw ofetch message instead of e.g. "PDF export timed out".
+        let detail = e?.data?.detail;
+        if (!detail && e?.data instanceof Blob) {
+            try { detail = JSON.parse(await e.data.text())?.detail; } catch { /* not JSON */ }
+        }
+        exportPdfError.value = detail || e?.message || 'PDF export failed';
         // Surface it in the top bar's existing error slot.
         runError.value = exportPdfError.value;
     } finally {

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -372,7 +372,13 @@ async function handleExportPdf() {
     try {
         const { data, error: fetchError } = await useMyFetch(`/api/r/${report_id}/export_pdf`, {
             responseType: 'blob' as any,
-        });
+            // The server bounds an export at ~5.5 min (render cap + lock wait);
+            // this backstop keeps the button from spinning forever if the
+            // request itself goes into a black hole (dropped connection, proxy
+            // buffering with no response). Without it the finally below never
+            // runs and the UI is stuck at "Exporting...".
+            timeout: 360_000,
+        } as any);
         if (fetchError.value || !data.value) throw fetchError.value || new Error('PDF export failed');
         const blob = data.value as Blob;
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
This PR adds comprehensive timeout protection to the PDF export feature to prevent requests from hanging indefinitely when the Chromium renderer becomes wedged or unresponsive.

## Key Changes

- **Backend timeout enforcement**: Added `RENDER_TIMEOUT_SECONDS = 150` to `ReportPdfService` to cap individual render operations. The `generate_pdf` method now wraps the actual render in `asyncio.wait_for()` with this timeout.

- **Process cleanup on timeout**: Implemented `_kill_chromium_tree()` function that forcefully terminates Chromium processes and their descendants when a render times out. This prevents zombie processes from consuming resources when task cancellation interrupts Playwright's teardown.

- **Unique process markers**: Each render is launched with a unique `--bow-pdf-export={uuid}` argument, allowing the cleanup function to identify and kill only the specific Chromium tree associated with a timed-out render.

- **Route-level timeout**: Added `_PDF_EXPORT_TIMEOUT_SECONDS = 330` in the report route to bound the entire export operation (lock wait + render), returning a 504 status code on timeout instead of hanging indefinitely.

- **Frontend resilience**: Updated the PDF export button handler to:
  - Disable automatic retries (which would re-run expensive renders)
  - Add a 6-minute request timeout to prevent UI from spinning forever
  - Properly extract error details from blob responses to show user-friendly timeout messages

- **Test coverage**: Added unit tests verifying that `generate_pdf` returns `None` on timeout and on render failures, ensuring the timeout mechanism works as expected.

## Implementation Details

The solution addresses a critical issue where a wedged Chromium renderer (e.g., spinning in JavaScript or OOMing) would never service shutdown IPC and survive even clean teardown, causing the export request to hang forever and blocking all subsequent exports queued on the per-report lock.

The `/proc`-based process tree walking in `_kill_chromium_tree()` is Linux-specific but gracefully degrades to a no-op on systems without `/proc`, making it safe for all deployment environments.

https://claude.ai/code/session_017SqDkfeYciTFLdSRGjJTTY