### PR TITLE
Add comprehensive telemetry tracking across platform features

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -5,6 +5,7 @@ import os
 import re as _re_mod
 import time as _time
 import uuid as _uuid_mod
+from collections import Counter
 from datetime import datetime
 from contextlib import asynccontextmanager
 from typing import Dict, List, Optional
@@ -621,6 +622,11 @@ class AgentV2:
         # Agent execution tracking
         self.project_manager = ProjectManager()
         self.current_execution = None
+
+        # In-memory telemetry rollups for this run, flushed once at
+        # agent_execution_completed — cheap counters, no DB/IO in the hot path.
+        self._tool_call_counts: Counter = Counter()
+        self._iteration_count: int = 0
 
         # Background DB writes scheduled during the loop. Drained before the
         # final `completion.finished` SSE so the API doesn't return a "done"
@@ -4074,6 +4080,7 @@ class AgentV2:
             _mlog(f"loop_starting step_limit={step_limit}")
 
             for loop_index in range(step_limit):
+                self._iteration_count += 1
                 try:
                     # Test-only fault injection (inert unless BOW_AGENT_LOOP_FAULTS is set):
                     # raises here so the rescue path below is exercisable end-to-end.
@@ -5435,16 +5442,26 @@ class AgentV2:
                                     else:
                                         asyncio.create_task(_bg_post_snap())
 
-                                    # Telemetry: tool finished
+                                    # Telemetry: tool finished (in-memory counter — no IO)
+                                    self._tool_call_counts[tool_name] += 1
                                     try:
+                                        _tool_props = {
+                                            "agent_execution_id": str(self.current_execution.id),
+                                            "tool_name": tool_name,
+                                            "status": "error" if _observation_failed(observation) else "success",
+                                            "duration_ms": getattr(tool_execution, "duration_ms", None),
+                                        }
+                                        # Model-routing detail: route_model's own observation already
+                                        # carries from/to model + reason, so surface it on this same
+                                        # event instead of adding a dedicated routing event.
+                                        if tool_name == "route_model" and isinstance(observation, dict):
+                                            _tool_props["routed"] = observation.get("routed")
+                                            _tool_props["from_model"] = observation.get("from_model")
+                                            _tool_props["to_model"] = observation.get("model")
+                                            _tool_props["routing_reason"] = observation.get("reason")
                                         await telemetry.capture(
                                             "agent_tool_finished",
-                                            {
-                                                "agent_execution_id": str(self.current_execution.id),
-                                                "tool_name": tool_name,
-                                                "status": "error" if _observation_failed(observation) else "success",
-                                                "duration_ms": getattr(tool_execution, "duration_ms", None),
-                                            },
+                                            _tool_props,
                                             user_id=str(getattr(self.head_completion, 'user_id', None)) if hasattr(self.head_completion, 'user_id') and self.head_completion.user_id else None,
                                             org_id=str(self.organization.id) if self.organization else None,
                                         )
@@ -6144,14 +6161,26 @@ class AgentV2:
                     await self.db.commit()
             except Exception as e:
                 logger.warning(f"Failed to bump report last_activity_at: {e}")
-            # Telemetry: agent execution completed
+            # Telemetry: agent execution completed. Token totals come from
+            # token_usage_json, already computed by finish_agent_execution()
+            # just above — no extra query/IO here, just reading the field.
             try:
+                _exec_props = {
+                    "agent_execution_id": str(self.current_execution.id),
+                    "status": status,
+                    "model_id": getattr(self.model, "model_id", None),
+                    "iterations": self._iteration_count,
+                    "tool_call_counts": dict(self._tool_call_counts),
+                    "total_tool_calls": sum(self._tool_call_counts.values()),
+                }
+                _token_usage = getattr(self.current_execution, "token_usage_json", None) or {}
+                if _token_usage:
+                    _exec_props["prompt_tokens"] = _token_usage.get("prompt_tokens")
+                    _exec_props["completion_tokens"] = _token_usage.get("completion_tokens")
+                    _exec_props["total_tokens"] = _token_usage.get("total_tokens")
                 await telemetry.capture(
                     "agent_execution_completed",
-                    {
-                        "agent_execution_id": str(self.current_execution.id),
-                        "status": status,
-                    },
+                    _exec_props,
                     user_id=str(getattr(self.head_completion, 'user_id', None)) if hasattr(self.head_completion, 'user_id') and self.head_completion.user_id else None,
                     org_id=str(self.organization.id) if self.organization else None,
                 )

--- a/backend/app/core/telemetry.py
+++ b/backend/app/core/telemetry.py
@@ -72,6 +72,33 @@ def _do_identify(distinct_id: str, properties: dict) -> None:
         logger.exception("telemetry._do_identify failed")
 
 
+def _do_group_identify(group_type: str, group_key: str, properties: dict) -> None:
+    """Blocking PostHog group_identify - runs in thread pool."""
+    try:
+        _posthog.group_identify(group_type, group_key, properties)
+    except Exception:
+        logger.exception("telemetry._do_group_identify failed")
+
+
+def _default_event_properties() -> dict:
+    """Cheap, process-local properties merged into every captured event.
+
+    Both lookups are in-memory/cached (no I/O): settings.version reads a
+    module-level string, and get_license_info() caches after its first call.
+    """
+    props: dict = {}
+    try:
+        props["app_version"] = settings.version
+    except Exception:
+        pass
+    try:
+        from app.ee.license import get_license_info
+        props["license_tier"] = get_license_info().tier
+    except Exception:
+        pass
+    return props
+
+
 class Telemetry:
     """Minimal server-side telemetry helper backed by PostHog.
 
@@ -102,7 +129,8 @@ class Telemetry:
         if not (cls._enabled() and _posthog is not None):
             return
         try:
-            props = dict(properties or {})
+            props = _default_event_properties()
+            props.update(properties or {})
             if org_id is not None:
                 props["org_id"] = str(org_id)
 
@@ -141,6 +169,57 @@ class Telemetry:
         except Exception:
             logger.exception("telemetry.identify failed")
 
+    @classmethod
+    async def group_identify(
+        cls,
+        group_type: str,
+        group_key: str,
+        properties: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Fire-and-forget PostHog group trait update. Never blocks the caller.
+
+        Sets traits (e.g. an org's email domain) on a PostHog group once, so
+        every event tagged with that group's key shows the trait without
+        resending it per-event.
+        """
+        if not (cls._enabled() and _posthog is not None):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            loop.run_in_executor(
+                _telemetry_executor,
+                _do_group_identify,
+                group_type,
+                str(group_key),
+                dict(properties or {}),
+            )
+        except Exception:
+            logger.exception("telemetry.group_identify failed")
+
 
 # Convenience alias for imports: from app.core.telemetry import telemetry
 telemetry = Telemetry
+
+# Free/consumer email providers excluded from org domain attribution — a
+# domain shared by millions of unrelated signups isn't a useful org signal
+# and would misrepresent unrelated orgs as the same "company".
+_FREE_EMAIL_DOMAINS = {
+    "gmail.com", "googlemail.com", "yahoo.com", "outlook.com", "hotmail.com",
+    "live.com", "icloud.com", "me.com", "aol.com", "protonmail.com",
+    "proton.me", "gmx.com", "yandex.com", "mail.com", "zoho.com",
+}
+
+
+def derive_org_domain(email: Optional[str]) -> Optional[str]:
+    """Derive a privacy-safe org identifier from a user's email.
+
+    Returns only the domain (never the local part or the full address), and
+    None for free/consumer providers so personal-email orgs aren't tagged
+    with a domain that doesn't identify a company.
+    """
+    if not email or "@" not in email:
+        return None
+    domain = email.rsplit("@", 1)[-1].strip().lower()
+    if not domain or domain in _FREE_EMAIL_DOMAINS:
+        return None
+    return domain

--- a/backend/app/services/connection_indexing_service.py
+++ b/backend/app/services/connection_indexing_service.py
@@ -730,6 +730,31 @@ class ConnectionIndexingService:
                 pass
         finally:
             _clear_cancel_event(indexing_id)
+            # Telemetry: schema/catalog sync finished, covers every completion
+            # branch above via this single finally. Runs before engine.dispose()
+            # so _new_session() is still backed by a live engine. Best-effort and
+            # fully isolated from the run's own outcome — this is already a
+            # background job, so nothing here adds request-path latency.
+            try:
+                from app.core.telemetry import telemetry
+                async with _new_session() as tel_db:
+                    fresh = await tel_db.get(ConnectionIndexing, indexing_id)
+                    if fresh is not None and fresh.status == ConnectionIndexingStatus.COMPLETED.value:
+                        conn = await tel_db.get(Connection, fresh.connection_id)
+                        stats = fresh.stats_json or {}
+                        await telemetry.capture(
+                            "data_source_schema_synced",
+                            {
+                                "connection_id": fresh.connection_id,
+                                "connection_type": conn.type if conn else None,
+                                "table_count": stats.get("table_count"),
+                                "item_noun": stats.get("item_noun"),
+                            },
+                            user_id=fresh.user_id,
+                            org_id=conn.organization_id if conn else None,
+                        )
+            except Exception:
+                logger.debug("indexing.telemetry_failed", exc_info=True)
             try:
                 await engine.dispose()
             except Exception:

--- a/backend/app/services/custom_query_service.py
+++ b/backend/app/services/custom_query_service.py
@@ -24,6 +24,7 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.scheduler import scheduler
+from app.core.telemetry import telemetry
 from app.data_sources.fast import artifacts, extractor, rls
 from app.ee.license import has_feature
 from app.data_sources.fast.fast_client import FastQueryClient, FastRelation
@@ -387,6 +388,23 @@ class CustomQueryService:
             db, connection, cq, activate_for_datasource_id=activate_for_datasource_id
         )
         self._schedule(connection.id, cq, timezone=await self._org_timezone(db, organization))
+
+        try:
+            await telemetry.capture(
+                "custom_query_created",
+                {
+                    "connection_id": str(connection.id),
+                    "connection_type": connection.type,
+                    "refresh_schedule_mode": refresh_schedule_mode,
+                    "refresh_interval_minutes": refresh_interval_minutes,
+                    "has_description": bool((description or "").strip()),
+                },
+                user_id=current_user.id if current_user else None,
+                org_id=str(organization.id) if organization else str(connection.organization_id),
+            )
+        except Exception:
+            pass
+
         return cq
 
     async def _activate_for_agents(

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -592,6 +592,11 @@ class DataSourceService:
             from app.models.connection_table import ConnectionTable
             from app.services.connection_service import ConnectionService
 
+            # Already-indexed connections know their table count synchronously;
+            # summed for telemetry below (a freshly-created connection's count
+            # isn't known yet — it lands later via data_source_schema_synced).
+            total_table_count = 0
+
             for conn_id in existing_connection_ids:
                 conn_result = await db.execute(
                     select(Connection).filter(
@@ -610,6 +615,7 @@ class DataSourceService:
                     select(func.count(ConnectionTable.id)).filter(ConnectionTable.connection_id == conn_id)
                 )
                 conn_table_count = conn_tables_result.scalar() or 0
+                total_table_count += conn_table_count
 
                 if conn_table_count == 0 and conn.auth_policy == "system_only":
                     # Kick off background indexing — the runner populates
@@ -757,6 +763,7 @@ class DataSourceService:
                     "use_llm_sync": bool(use_llm_sync),
                     "from_existing_connection": bool(existing_connection_ids),
                     "connection_count": len(connections_to_link) if connections_to_link else 1,
+                    "table_count": total_table_count if existing_connection_ids else None,
                 },
                 user_id=current_user.id,
                 org_id=organization.id,

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -30,7 +30,7 @@ from app.settings.config import settings
 from fastapi import Request
 from typing import Optional
 from app.settings.logging_config import get_logger
-from app.core.telemetry import telemetry
+from app.core.telemetry import telemetry, derive_org_domain
 
 logger = get_logger(__name__)
 
@@ -68,6 +68,9 @@ class OrganizationService:
                 user_id=current_user.id,
                 org_id=organization.id,
             )
+            domain = derive_org_domain(getattr(current_user, "email", None))
+            if domain:
+                await telemetry.group_identify("organization", str(organization.id), {"domain": domain})
         except Exception:
             pass
 
@@ -370,6 +373,12 @@ class OrganizationService:
                 user_id=current_user.id,
                 org_id=membership_with_user.organization_id,
             )
+            member_email = invitation_email or getattr(membership_with_user.user, "email", None)
+            domain = derive_org_domain(member_email)
+            if domain:
+                await telemetry.group_identify(
+                    "organization", str(membership_with_user.organization_id), {"domain": domain}
+                )
         except Exception:
             pass
         

--- a/backend/app/services/organization_settings_service.py
+++ b/backend/app/services/organization_settings_service.py
@@ -21,6 +21,7 @@ import hashlib
 from PIL import Image
 from io import BytesIO
 from app.ee.audit.service import audit_service
+from app.core.telemetry import telemetry
 
 
 class OrganizationSettingsService:
@@ -145,6 +146,7 @@ class OrganizationSettingsService:
             # Use dict() to ensure we have a mutable copy
             current_config = dict(settings.config)
             config_changed = False
+            changed_ai_features: list = []
 
             # Handle AI features updates
             if 'ai_features' in update_data['config']:
@@ -192,6 +194,7 @@ class OrganizationSettingsService:
 
                     if current_config['ai_features'][feature_name] != original_dict:
                         config_changed = True
+                        changed_ai_features.append((feature_name, current_feature_dict.get('value')))
 
 
             # Handle top-level feature updates
@@ -372,6 +375,30 @@ class OrganizationSettingsService:
                         invalidate_pii_cache(str(organization.id))
                     except Exception:
                         pass
+
+                # Telemetry: never the PII rule patterns/regexes themselves —
+                # just whether protection is on and how many rules exist.
+                try:
+                    for _feature_name, _feature_value in changed_ai_features:
+                        await telemetry.capture(
+                            "ai_feature_updated",
+                            {"feature_name": _feature_name, "new_value": _feature_value},
+                            user_id=current_user.id,
+                            org_id=organization.id,
+                        )
+                    if pii_changed:
+                        _pii_cfg = current_config.get('pii_protection') or {}
+                        await telemetry.capture(
+                            "pii_protection_updated",
+                            {
+                                "enabled": _pii_cfg.get("enabled"),
+                                "rule_count": len(_pii_cfg.get("custom_rules") or []),
+                            },
+                            user_id=current_user.id,
+                            org_id=organization.id,
+                        )
+                except Exception:
+                    pass
 
                 # Audit log
                 try:
@@ -1278,6 +1305,16 @@ class OrganizationSettingsService:
                 resource_type="organization_settings",
                 resource_id=str(settings.id),
                 details={"feature_name": feature_name, "value": new_value},
+            )
+        except Exception:
+            pass
+
+        try:
+            await telemetry.capture(
+                "ai_feature_updated",
+                {"feature_name": feature_name, "new_value": new_value},
+                user_id=current_user.id,
+                org_id=organization.id,
             )
         except Exception:
             pass

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -189,6 +189,11 @@ class ReportService:
             await SessionEventService.emit_safe(
                 db, report=report, kind=kind, user=current_user, commit=False, meta=meta,
             )
+            await self._capture_share_telemetry(
+                report=report, share_type=share_type, visibility=visibility,
+                shared_user_ids=shared_user_ids, shared_group_ids=shared_group_ids,
+                current_user=current_user, shared=True,
+            )
         else:
             kind = REPORT_UNPUBLISHED if is_conv else ARTIFACT_UNSHARED
             content = ("Conversation sharing was turned off" if is_conv
@@ -197,6 +202,32 @@ class ReportService:
                 db, report=report, kind=kind, user=current_user, commit=False,
                 content=content, meta={"visibility": "none", "share_type": share_type},
             )
+            await self._capture_share_telemetry(
+                report=report, share_type=share_type, visibility="none",
+                shared_user_ids=None, shared_group_ids=None,
+                current_user=current_user, shared=False,
+            )
+
+    async def _capture_share_telemetry(
+        self, *, report, share_type, visibility, shared_user_ids, shared_group_ids,
+        current_user, shared: bool,
+    ) -> None:
+        """Telemetry for conversation/artifact share toggles. Counts only —
+        never the resolved names built in _emit_share_event's shared_with."""
+        try:
+            event = f"{share_type}_{'shared' if shared else 'unshared'}"
+            await telemetry.capture(
+                event,
+                {
+                    "visibility": visibility,
+                    "shared_user_count": len(shared_user_ids) if shared_user_ids else 0,
+                    "shared_group_count": len(shared_group_ids) if shared_group_ids else 0,
+                },
+                user_id=current_user.id if current_user else None,
+                org_id=str(report.organization_id) if getattr(report, "organization_id", None) else None,
+            )
+        except Exception:
+            pass
 
     async def set_visibility(
         self,

--- a/backend/app/services/scheduled_prompt_service.py
+++ b/backend/app/services/scheduled_prompt_service.py
@@ -15,6 +15,7 @@ from app.schemas.scheduled_prompt_schema import ScheduledPromptCreate, Scheduled
 from app.core.scheduler import scheduler, cron_dow_to_apscheduler, claim_scheduled_run
 from app.services.notification_service import notification_service
 from app.settings.config import settings
+from app.core.telemetry import telemetry
 
 from apscheduler.jobstores.base import JobLookupError
 
@@ -117,6 +118,21 @@ class ScheduledPromptService:
             self._register_job(sp)
 
         logger.info(f"Created scheduled prompt {sp.id} for report {report_id}")
+        try:
+            await telemetry.capture(
+                "scheduled_prompt_created",
+                {
+                    "scheduled_prompt_id": str(sp.id),
+                    "report_id": str(report_id),
+                    "is_active": bool(sp.is_active),
+                    "spawn_new_report": bool(sp.spawn_new_report),
+                    "subscriber_count": len(subscribers) if subscribers else 0,
+                },
+                user_id=current_user.id,
+                org_id=organization.id,
+            )
+        except Exception:
+            pass
         return sp
 
     async def update_scheduled_prompt(

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -23,6 +23,7 @@ from app.schemas.webhook_schema import (
     TriggerRunSchema,
     TriggerRunListResponse,
 )
+from app.core.telemetry import telemetry
 from app.services.webhook_adapters.factory import WebhookAdapterFactory
 from app.settings.config import settings
 from app.settings.database import create_async_session_factory
@@ -246,6 +247,21 @@ class WebhookService:
         await db.refresh(wh)
         logger.info("Created trigger %s for user %s (source=%s mode=%s agents=%d)",
                     wh.id, current_user.id, wh.source, wh.mode, len(ds_rows))
+        try:
+            await telemetry.capture(
+                "trigger_created",
+                {
+                    "trigger_id": str(wh.id),
+                    "source": wh.source,
+                    "mode": wh.mode,
+                    "classify_enabled": bool(wh.classify_enabled),
+                    "agent_count": len(ds_rows),
+                },
+                user_id=current_user.id,
+                org_id=organization.id,
+            )
+        except Exception:
+            pass
         return self._to_schema(wh, secret=secret)  # secret shown once
 
     async def list_triggers(self, db, current_user: User, organization: Organization) -> list[WebhookSchema]:


### PR DESCRIPTION
## Summary
This PR adds extensive telemetry instrumentation across the platform to track user engagement with key features. The changes include new telemetry helpers, event capture points for agent execution, data source operations, organization management, and various feature toggles.

## Key Changes

### Core Telemetry Infrastructure
- Added `_do_group_identify()` function to support PostHog group trait updates (e.g., organization domain)
- Added `_default_event_properties()` to automatically include app version and license tier on all events
- Added `group_identify()` async method to the Telemetry class for fire-and-forget group trait updates
- Added `derive_org_domain()` utility to extract privacy-safe organization identifiers from email addresses, excluding free/consumer email providers

### Agent Execution Telemetry
- Track iteration count and tool call counts in-memory during agent execution
- Enhanced `agent_tool_finished` event with detailed tool execution metrics (status, duration, routing details for model routing)
- Enhanced `agent_execution_completed` event with comprehensive execution summary (iterations, tool call breakdown, token usage)

### Feature Configuration Telemetry
- Added telemetry capture for AI feature updates in organization settings
- Added telemetry capture for PII protection configuration changes (enabled status and rule count)
- Track feature changes both in bulk updates and individual feature updates

### Data Source & Integration Telemetry
- Added `data_source_schema_synced` event to track schema/catalog synchronization completion with table counts
- Added `custom_query_created` event to track custom query creation with connection type and refresh schedule details
- Added `trigger_created` event to track webhook trigger creation with source, mode, and agent count

### Sharing & Collaboration Telemetry
- Added telemetry for conversation/artifact sharing events (both shared and unshared states)
- Track visibility settings and counts of shared users/groups without capturing PII

### Organization Management Telemetry
- Added `scheduled_prompt_created` event to track scheduled prompt creation
- Enhanced organization creation and member addition to capture organization domain via group_identify
- Domain is derived from user email and only set for corporate domains (free email providers excluded)

## Implementation Details

- All telemetry operations are non-blocking and fire-and-forget to avoid impacting request latency
- Event properties are built defensively with try-catch blocks to prevent telemetry failures from affecting core functionality
- Sensitive data (email addresses, PII patterns, resolved share names) is never captured—only aggregated counts and configuration states
- Token usage and execution metrics are read from already-computed fields to avoid additional database queries
- Organization domain tracking uses group_identify to consolidate user/member events under a company identifier without exposing email addresses

https://claude.ai/code/session_01MTgY7gbanECUKUzvyJ1dG8