### PR TITLE
Fix entity creation RBAC and user-scoped snapshot withholding

### DIFF
--- a/backend/app/ai/code_execution/loadables.py
+++ b/backend/app/ai/code_execution/loadables.py
@@ -251,6 +251,17 @@ class LoadablesResolver:
             if entity is None:
                 result["errors"].append(err)
                 continue
+            # Per-reader snapshot resolution: the cached grid is the OWNER's
+            # row slice on a user-scoped (user_required/RLS) source and must
+            # not be handed to another user's code execution.
+            from app.services.viewer_data_policy import entity_data_withheld
+            if await entity_data_withheld(self.db, entity, self.current_user):
+                result["errors"].append(
+                    f"load_entity({key!r}): its cached data was materialized under "
+                    f"another user's credentials (user-scoped source) and is not "
+                    f"shareable. Query the source tables directly instead."
+                )
+                continue
             result["entities"][key] = grid_to_df(entity.data)
 
         return result

--- a/backend/app/ai/context/builders/entity_context_builder.py
+++ b/backend/app/ai/context/builders/entity_context_builder.py
@@ -17,10 +17,13 @@ class EntityContextBuilder:
     entities associated with the current report's data sources.
     """
 
-    def __init__(self, db: AsyncSession, organization: Organization, report=None):
+    def __init__(self, db: AsyncSession, organization: Organization, report=None, user=None):
         self.db = db
         self.organization = organization
         self.report = report
+        # The requesting user: entity snapshots are credential-scoped on
+        # user_required/RLS sources and must be resolved per reader.
+        self.user = user
 
     # ------------------------------------------------------------------ #
     # Keyword extraction helpers (kept local to the builder to avoid      #
@@ -124,6 +127,8 @@ class EntityContextBuilder:
             require_source_assoc=require_source_assoc,
             data_source_ids=data_source_ids,
         )
+        from app.services.viewer_data_policy import resolve_entity_data
+
         items: List[EntityItem] = []
         for e in ents:
             try:
@@ -131,6 +136,10 @@ class EntityContextBuilder:
                 ds_names = [n for n in ds_names if n]
             except Exception:
                 ds_names = []
+            # Per-reader snapshot resolution: on a user-scoped source the
+            # cached rows are the OWNER's slice — withheld readers get the
+            # entity without data (title/description/code stay discoverable).
+            data = await resolve_entity_data(self.db, e, self.user)
             items.append(
                 EntityItem(
                     id=str(e.id),
@@ -138,7 +147,7 @@ class EntityContextBuilder:
                     title=e.title,
                     description=e.description or "",
                     code=getattr(e, 'code', None),
-                    data=getattr(e, 'data', None),
+                    data=data or None,
                     data_model=(getattr(e, 'original_data_model', None) or getattr(e, 'view', None)),
                     ds_names=ds_names,
                 )

--- a/backend/app/ai/context/builders/mention_context_builder.py
+++ b/backend/app/ai/context/builders/mention_context_builder.py
@@ -12,11 +12,13 @@ from app.ai.context.sections.mentions_section import MentionsSection
 
 
 class MentionContextBuilder:
-    def __init__(self, db: AsyncSession, organization, report, head_completion):
+    def __init__(self, db: AsyncSession, organization, report, head_completion, user=None):
         self.db = db
         self.organization = organization
         self.report = report
         self.head_completion = head_completion
+        # Requesting user for per-reader entity snapshot resolution.
+        self.user = user
 
     async def build(self, max_items_per_group: int = 10, max_columns_preview: int = 8, max_tags_preview: int = 8) -> MentionsSection:
         files: List[dict] = []
@@ -89,11 +91,15 @@ class MentionContextBuilder:
                 elif m.type == MentionType.ENTITY:
                     ent = await self.db.get(Entity, str(m.object_id))
                     tags = (getattr(ent, "tags", None) or [])[:max_tags_preview]
-                    # Derive columns and sample from entity.data if present
+                    # Derive columns and sample from the POLICY-resolved data:
+                    # on a user-scoped source the cached snapshot is the
+                    # owner's row slice and must not leak into another
+                    # reader's prompt.
+                    from app.services.viewer_data_policy import resolve_entity_data
                     entity_columns = None
                     entity_sample_rows = None
                     try:
-                        data_json = getattr(ent, "data", None) or {}
+                        data_json = await resolve_entity_data(self.db, ent, self.user) if ent is not None else {}
                         # Expect optional shape: {"columns": ["col1", ...], "rows": [{...}, ...]}
                         cols = data_json.get("columns") if isinstance(data_json, dict) else None
                         rows = data_json.get("rows") if isinstance(data_json, dict) else None

--- a/backend/app/ai/context/context_hub.py
+++ b/backend/app/ai/context/context_hub.py
@@ -350,8 +350,8 @@ class ContextHub:
         self.message_builder = MessageContextBuilder(self.db, self.organization, self.report, self.user)
         self.widget_builder = WidgetContextBuilder(self.db, self.organization, self.report)
         self.query_builder = QueryContextBuilder(self.db, self.organization, self.report)
-        self.mention_builder = MentionContextBuilder(self.db, self.organization, self.report, self.head_completion)
-        self.entity_builder = EntityContextBuilder(self.db, self.organization, self.report)
+        self.mention_builder = MentionContextBuilder(self.db, self.organization, self.report, self.head_completion, user=self.user)
+        self.entity_builder = EntityContextBuilder(self.db, self.organization, self.report, user=self.user)
         
         # Observation context builder (tracks tool execution results)
         self.observation_builder = ObservationContextBuilder()

--- a/backend/app/ai/tools/implementations/describe_entity.py
+++ b/backend/app/ai/tools/implementations/describe_entity.py
@@ -277,12 +277,18 @@ class DescribeEntityTool(Tool):
             )
             return
 
-        # Determine data source: cached or re-executed
-        entity_data = entity.data or {}
+        # Determine data source: cached or re-executed. The cached snapshot is
+        # resolved through the viewer-data policy: on a user-scoped
+        # (user_required/RLS) source it is the OWNER's row slice — any other
+        # reader gets no cached rows and the tool re-executes under THEIR
+        # credentials instead.
+        from app.services.viewer_data_policy import entity_data_withheld
+        snapshot_withheld = await entity_data_withheld(db, entity, user)
+        entity_data = {} if snapshot_withheld else (entity.data or {})
         execution_log = None
         errors: List[str] = []
 
-        if data.should_rerun:
+        if data.should_rerun or snapshot_withheld:
             yield ToolProgressEvent(type="tool.progress", payload={"stage": "code_execution"})
             try:
                 from app.ai.code_execution.code_execution import StreamingCodeExecutor
@@ -312,8 +318,9 @@ class DescribeEntityTool(Tool):
 
             except Exception as e:
                 errors.append(f"Code execution failed: {str(e)}")
-                # Fall back to cached data
-                entity_data = entity.data or {}
+                # Fall back to cached data — but never to a snapshot the
+                # policy withholds from this reader.
+                entity_data = {} if snapshot_withheld else (entity.data or {})
 
         # Build data profile
         allow_llm_see_data = True

--- a/backend/app/core/permission_resolver.py
+++ b/backend/app/core/permission_resolver.py
@@ -439,11 +439,35 @@ async def _resolve_permissions_inner(
     for ds_id in await _agents_fully_backed_by_connections(db, managed_conn_ids):
         resource_permissions.setdefault(("data_source", ds_id), set()).add("manage")
 
+    # Agent ownership is authoritative: data_sources.owner_user_id holds the
+    # `manage` tier on their own agent even when the owner grant row is
+    # missing (legacy creation paths, pre-backfill rows, failed writes).
+    # Expanded here so route checks, whoami and the frontend permission store
+    # all agree with the "creator manages their agent" rule.
+    for ds_id in await _owned_data_source_ids(db, user_id, org_id):
+        resource_permissions.setdefault(("data_source", ds_id), set()).add("manage")
+
     return ResolvedPermissions(
         org_permissions=org_permissions,
         resource_permissions=resource_permissions,
         role_names=role_names,
     )
+
+
+async def _owned_data_source_ids(
+    db: AsyncSession, user_id: str, org_id: str,
+) -> list[str]:
+    """Data source ids the user owns (data_sources.owner_user_id) in the org."""
+    from app.models.data_source import DataSource
+
+    rows = await db.execute(
+        select(DataSource.id).where(
+            DataSource.owner_user_id == str(user_id),
+            DataSource.organization_id == str(org_id),
+            DataSource.deleted_at.is_(None),
+        )
+    )
+    return [str(r[0]) for r in rows.all()]
 
 
 async def _agents_fully_backed_by_connections(
@@ -595,11 +619,26 @@ async def resolve_permissions_bulk(
         # 4. Expand connection manage_data_sources → per-agent manage. Rare (only
         #    when the user holds explicit per-connection grants); ~free otherwise
         #    (early return on empty). Kept per-org for exact parity.
+        #    Also expand agent ownership → manage (single org-spanning query),
+        #    mirroring _resolve_permissions_inner.
+        from app.models.data_source import DataSource
+        owned_rows = (await db.execute(
+            select(DataSource.organization_id, DataSource.id).where(
+                DataSource.owner_user_id == str(user_id),
+                DataSource.organization_id.in_(org_ids),
+                DataSource.deleted_at.is_(None),
+            )
+        )).all()
+        owned_by_org: dict[str, list] = {}
+        for o_id, ds_id in owned_rows:
+            owned_by_org.setdefault(o_id, []).append(str(ds_id))
         for org_id in org_ids:
             res_perms = res_perms_by_org[org_id]
             managed_conn_ids = [rid for (rtype, rid), perms in res_perms.items()
                                 if rtype == "connection" and "manage_data_sources" in perms]
             for ds_id in await _agents_fully_backed_by_connections(db, managed_conn_ids):
+                res_perms.setdefault(("data_source", ds_id), set()).add("manage")
+            for ds_id in owned_by_org.get(org_id, []):
                 res_perms.setdefault(("data_source", ds_id), set()).add("manage")
             result[org_id] = ResolvedPermissions(
                 org_permissions=org_perms[org_id],

--- a/backend/app/core/permissions_decorator.py
+++ b/backend/app/core/permissions_decorator.py
@@ -80,8 +80,9 @@ def requires_permission(permission, model=None, owner_only=False, allow_public=F
             instruction_id = all_args.get('instruction_id')
             query_id = all_args.get('query_id')  # For routes with object_id parameter
             artifact_id = all_args.get('artifact_id')  # For routes with object_id parameter
+            entity_id = all_args.get('entity_id')  # For routes with object_id parameter
 
-            object_id = report_id or completion_id or data_source_id or widget_id or memory_id or instruction_id or query_id or artifact_id
+            object_id = report_id or completion_id or data_source_id or widget_id or memory_id or instruction_id or query_id or artifact_id or entity_id
         
 
             if not all([user, organization, db]):
@@ -205,6 +206,14 @@ def requires_permission(permission, model=None, owner_only=False, allow_public=F
             else:
                 has_role_permission = resolved.has_org_permission(permission)
             if not has_role_permission:
+                # Special owner allowance: Entity owner may act on their own
+                # entity while it is not globally approved (private drafts and
+                # pending suggestions). Mirrors the Instruction allowance below.
+                # Approved (catalog) entities stay admin/manager territory.
+                if obj is not None and type(obj).__name__ == 'Entity':
+                    if (str(getattr(obj, 'owner_id', '')) == str(user.id)
+                            and getattr(obj, 'global_status', None) != 'approved'):
+                        return await func(*args, **kwargs)
                 # Special owner allowance: Instruction owner may modify/delete when not published
                 if isinstance(obj, Instruction):
                     is_owner = obj and getattr(obj, 'user_id', None) == user.id

--- a/backend/app/routes/entity.py
+++ b/backend/app/routes/entity.py
@@ -25,6 +25,59 @@ router = APIRouter(prefix="/entities", tags=["entities"])
 service = EntityService()
 
 
+async def _holds_create_entities(db, user, organization, ds_ids: List[str]) -> bool:
+    """Non-raising: does the user hold per-DS `create_entities` on ALL of
+    ds_ids (org `manage_entities`/full admin included via implication)?"""
+    try:
+        await check_resource_permissions(
+            db, str(user.id), str(organization.id),
+            "data_source", ds_ids, "create_entities",
+        )
+        return True
+    except HTTPException:
+        return False
+
+
+async def _require_ds_access(db, user, organization, ds_ids: List[str]) -> None:
+    """403 unless the user can ACCESS every listed data source (member grant,
+    public DS, or admin). This is the suggest-tier gate: weaker than the
+    per-DS `create_entities` grant that publishing requires."""
+    from app.core.permission_resolver import user_can_access_data_source
+    from app.models.data_source import DataSource
+
+    for rid in ds_ids:
+        ds = await db.get(DataSource, str(rid))
+        if (
+            ds is None
+            or str(ds.organization_id) != str(organization.id)
+            or not await user_can_access_data_source(db, str(user.id), str(organization.id), ds)
+        ):
+            label = getattr(ds, "name", None) or str(rid)
+            raise HTTPException(
+                status_code=403,
+                detail=f'No access to agent "{label}".',
+            )
+
+
+async def _require_entity_run_access(db, entity_id: str, organization, user) -> None:
+    """Body check for run/preview: the entity's owner needs ACCESS to every
+    attached data source; anyone else needs per-DS `create_entities` on all of
+    them (org admins pass via implication)."""
+    existing = await service.get_entity(db, entity_id, organization, user)
+    if not existing:
+        raise AppError.not_found(ErrorCode.ENTITY_NOT_FOUND, "Entity not found")
+    ds_ids = [str(ds.id) for ds in (existing.data_sources or [])]
+    if not ds_ids:
+        return
+    if str(existing.owner_id) == str(user.id):
+        await _require_ds_access(db, user, organization, ds_ids)
+    else:
+        await check_resource_permissions(
+            db, str(user.id), str(organization.id),
+            "data_source", ds_ids, "create_entities",
+        )
+
+
 @router.post("", response_model=EntitySchema)
 @requires_permission('create_entities', resource_scoped=True)
 async def create_private_entity(
@@ -126,7 +179,7 @@ async def get_entity(
 
 
 @router.put("/{entity_id}", response_model=EntitySchema)
-@requires_permission('manage_entities', model=Entity, resource_scoped=True)
+@requires_permission(['manage_entities', 'create_entities'], model=Entity, resource_scoped=True)
 async def update_entity(
     entity_id: str,
     payload: EntityUpdate,
@@ -134,38 +187,58 @@ async def update_entity(
     current_user: User = Depends(current_user),
     organization: Organization = Depends(get_current_organization),
 ):
-    """Update an entity. Org `manage_entities` admins bypass; otherwise must hold
-    per-DS `create_entities` grant on every attached DS (existing + new)."""
+    """Update an entity. Org `manage_entities` admins bypass; per-DS
+    `create_entities` holders (agent owners via `manage`) may edit entities on
+    their agents; the entity's own owner may edit it while it is not globally
+    approved (decorator owner allowance) provided they still have access to
+    its data sources."""
     existing = await service.get_entity(db, entity_id, organization, current_user)
     if not existing:
         raise AppError.not_found(ErrorCode.ENTITY_NOT_FOUND, "Entity not found")
+    is_owner_unapproved = (
+        str(existing.owner_id) == str(current_user.id)
+        and existing.global_status != 'approved'
+    )
     existing_ds_ids = [str(ds.id) for ds in (existing.data_sources or [])]
-    if existing_ds_ids:
-        await check_resource_permissions(
-            db, str(current_user.id), str(organization.id),
-            "data_source", existing_ds_ids, "create_entities",
-        )
+    resource_authorized = (
+        await _holds_create_entities(db, current_user, organization, existing_ds_ids)
+        if existing_ds_ids else False
+    )
+    if existing_ds_ids and not resource_authorized:
+        if is_owner_unapproved:
+            await _require_ds_access(db, current_user, organization, existing_ds_ids)
+        else:
+            await check_resource_permissions(
+                db, str(current_user.id), str(organization.id),
+                "data_source", existing_ds_ids, "create_entities",
+            )
     # `is not None`: an empty list is falsy, so a truthiness check let a
     # per-agent author clear the scope and turn their entity into a global one,
     # bypassing the /entities/global gate.
     if payload.data_source_ids is not None:
         if payload.data_source_ids:
-            await check_resource_permissions(
-                db, str(current_user.id), str(organization.id),
-                "data_source", payload.data_source_ids, "create_entities",
-            )
-        else:
+            if is_owner_unapproved and not resource_authorized:
+                await _require_ds_access(db, current_user, organization, payload.data_source_ids)
+            else:
+                await check_resource_permissions(
+                    db, str(current_user.id), str(organization.id),
+                    "data_source", payload.data_source_ids, "create_entities",
+                )
+        elif not is_owner_unapproved:
             await require_org_permission(
                 db, str(current_user.id), str(organization.id), "manage_entities",
             )
-    entity = await service.update_entity(db, entity_id, payload, organization, current_user)
+    entity = await service.update_entity(
+        db, entity_id, payload, organization, current_user,
+        resource_authorized=resource_authorized,
+    )
     if not entity:
         raise AppError.not_found(ErrorCode.ENTITY_NOT_FOUND, "Entity not found")
     return EntitySchema.model_validate(entity)
 
 
 @router.delete("/{entity_id}")
-@requires_permission('manage_entities', model=Entity, resource_scoped=True)
+@requires_permission(['manage_entities', 'create_entities'], model=Entity, resource_scoped=True)
 async def delete_entity(
     entity_id: str,
     db: AsyncSession = Depends(get_async_db),
@@ -175,8 +248,12 @@ async def delete_entity(
     existing = await service.get_entity(db, entity_id, organization, current_user)
     if not existing:
         raise AppError.not_found(ErrorCode.ENTITY_NOT_FOUND, "Entity not found")
+    is_owner_unapproved = (
+        str(existing.owner_id) == str(current_user.id)
+        and existing.global_status != 'approved'
+    )
     existing_ds_ids = [str(ds.id) for ds in (existing.data_sources or [])]
-    if existing_ds_ids:
+    if existing_ds_ids and not is_owner_unapproved:
         await check_resource_permissions(
             db, str(current_user.id), str(organization.id),
             "data_source", existing_ds_ids, "create_entities",
@@ -188,7 +265,7 @@ async def delete_entity(
 
 
 @router.post("/from_step/{step_id}", response_model=EntitySchema)
-@requires_permission('create_entities', resource_scoped=True)
+@requires_permission('create_reports')
 async def create_entity_from_step(
     step_id: str,
     payload: EntityFromStepCreate,
@@ -196,15 +273,39 @@ async def create_entity_from_step(
     current_user: User = Depends(current_user),
     organization: Organization = Depends(get_current_organization),
 ):
+    """Create an entity from a successful step.
+
+    Two tiers, mirroring the dual-status workflow:
+    - SUGGEST (draft pending admin approval): any member who can ACCESS every
+      data source the entity will attach — saving your own query for review
+      is baseline product usage, not an admin capability.
+    - PUBLISH directly: per-DS `create_entities` on every attached data source
+      (agent owners via `manage`, org `manage_entities`, full admins).
     """
-    Create entity from step. Accessible to both admins (create_entities) and
-    regular users (suggest_entities). Permission checking happens at service level.
-    """
-    if payload.data_source_ids:
-        await check_resource_permissions(
-            db, str(current_user.id), str(organization.id),
-            "data_source", payload.data_source_ids, "create_entities",
+    # Resolve the target data sources up front so the permission check matches
+    # exactly what the service will attach (payload override, else the step
+    # report's data sources).
+    target_ds_ids = [str(i) for i in (payload.data_source_ids or []) if i]
+    if not target_ds_ids:
+        target_ds_ids = await service.step_report_data_source_ids(db, step_id, organization)
+
+    if target_ds_ids:
+        can_publish = await _holds_create_entities(db, current_user, organization, target_ds_ids)
+    else:
+        # DS-less entity → org-wide: publishing stays an org-admin capability.
+        from app.core.permission_resolver import resolve_permissions
+        resolved = await resolve_permissions(db, str(current_user.id), str(organization.id))
+        can_publish = resolved.has_org_permission("manage_entities")
+
+    if payload.publish and not can_publish:
+        raise HTTPException(
+            status_code=403,
+            detail="Publishing an entity needs 'create_entities' on every attached agent. "
+                   "You can still save it as a suggestion for review.",
         )
+    if not can_publish and target_ds_ids:
+        await _require_ds_access(db, current_user, organization, target_ds_ids)
+
     try:
         entity = await service.create_entity_from_step(
             db,
@@ -216,7 +317,10 @@ async def create_entity_from_step(
             slug_override=payload.slug,
             description_override=payload.description,
             publish=bool(payload.publish or False),
-            data_source_ids_override=payload.data_source_ids,
+            # Pass the RESOLVED target set (payload override or report/mention
+            # fallback) so the service attaches exactly what was checked.
+            data_source_ids_override=(payload.data_source_ids or target_ds_ids or None),
+            creator_can_publish=can_publish,
         )
         return EntitySchema.model_validate(entity)
     except ValueError as e:
@@ -224,7 +328,7 @@ async def create_entity_from_step(
 
 
 @router.post("/{entity_id}/run", response_model=EntitySchema)
-@requires_permission('manage_entities', model=Entity)
+@requires_permission(['manage_entities', 'create_entities'], model=Entity, resource_scoped=True)
 async def run_entity(
     entity_id: str,
     payload: EntityRunPayload,
@@ -232,6 +336,11 @@ async def run_entity(
     current_user: User = Depends(current_user),
     organization: Organization = Depends(get_current_organization),
 ):
+    """Run/refresh an entity. `create_entities` holders on all its agents, org
+    admins, or the entity's owner (with DS access) — execution always uses the
+    CALLER's credentials, and the service only persists the result when the
+    caller's identity may legitimately author the shared snapshot."""
+    await _require_entity_run_access(db, entity_id, organization, current_user)
     try:
         entity = await service.run_entity_with_update(db, entity_id, payload, organization, current_user=current_user)
         return EntitySchema.model_validate(entity)
@@ -240,7 +349,7 @@ async def run_entity(
 
 
 @router.post("/{entity_id}/preview")
-@requires_permission('manage_entities', model=Entity)
+@requires_permission(['manage_entities', 'create_entities'], model=Entity, resource_scoped=True)
 async def preview_entity(
     entity_id: str,
     payload: EntityPreviewPayload,
@@ -248,6 +357,8 @@ async def preview_entity(
     current_user: User = Depends(current_user),
     organization: Organization = Depends(get_current_organization),
 ):
+    """Preview (execute without persisting) — same access tier as run."""
+    await _require_entity_run_access(db, entity_id, organization, current_user)
     try:
         result = await service.preview_entity(db, entity_id, payload, organization, current_user=current_user)
         return result
@@ -257,7 +368,7 @@ async def preview_entity(
 
 # Suggestion workflow endpoints
 @router.post("/{entity_id}/suggest", response_model=EntitySchema)
-@requires_permission('manage_entities')
+@requires_permission('create_reports')
 async def suggest_entity(
     entity_id: str,
     db: AsyncSession = Depends(get_async_db),
@@ -270,7 +381,7 @@ async def suggest_entity(
 
 
 @router.post("/{entity_id}/withdraw", response_model=EntitySchema)
-@requires_permission('manage_entities')
+@requires_permission('create_reports')
 async def withdraw_suggestion(
     entity_id: str,
     db: AsyncSession = Depends(get_async_db),

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -488,8 +488,9 @@ class DataSourceService:
         Create memberships for a list of user IDs.
 
         Writes to both DataSourceMembership (legacy) and ResourceGrant (RBAC).
-        `permissions` controls the RBAC grant; defaults to ["view", "view_schema"]
-        to match legacy DSM semantics. Pass ["manage"] for the owner.
+        `permissions` controls the RBAC grant; the default (None) creates an
+        empty grant, which still confers implicit view/view_schema via the
+        resolver's any-grant rule. Pass ["manage"] for the owner.
         """
         if not user_ids:
             return

--- a/backend/app/services/entity_service.py
+++ b/backend/app/services/entity_service.py
@@ -26,6 +26,40 @@ class EntityService:
         self.query_service = QueryService()
 
 
+    async def step_report_data_source_ids(
+        self, db: AsyncSession, step_id: str, organization: Organization,
+    ) -> List[str]:
+        """Data source ids the entity WOULD attach when created from this step
+        with no explicit override: the step report's data sources, falling
+        back to the data sources @-mentioned in the report's chat (a report
+        whose agent was attached via mention has no report-level association
+        rows, yet that agent is what the step's query ran against). Lets the
+        route run its permission checks against the exact same set."""
+        from app.models.report import Report
+
+        result = await db.execute(
+            select(Step)
+            .options(selectinload(Step.query).selectinload(Query.report).selectinload(Report.data_sources))
+            .where(Step.id == str(step_id))
+        )
+        step = result.scalar_one_or_none()
+        if not step or not step.query or not step.query.report:
+            return []
+        report = step.query.report
+        if str(report.organization_id) != str(organization.id):
+            return []
+        ds_ids = list({str(ds.id) for ds in (report.data_sources or [])})
+        if ds_ids:
+            return ds_ids
+        from app.models.mention import Mention, MentionType
+        rows = await db.execute(
+            select(Mention.object_id).where(
+                Mention.report_id == str(report.id),
+                Mention.type == MentionType.DATA_SOURCE,
+            ).distinct()
+        )
+        return [str(r[0]) for r in rows.all()]
+
     async def create_entity_from_step(
         self,
         db: AsyncSession,
@@ -39,8 +73,15 @@ class EntityService:
         description_override: Optional[str] = None,
         publish: bool = False,
         data_source_ids_override: Optional[List[str]] = None,
+        creator_can_publish: Optional[bool] = None,
     ) -> Entity:
-        """Create an Entity from a successful Step. Copies data/code as-is."""
+        """Create an Entity from a successful Step.
+
+        `creator_can_publish` is the route's per-DS `create_entities` verdict:
+        True → the dual-status admin branch (approved, optionally published);
+        False → suggestion pending approval. None (legacy callers) falls back
+        to the org-admin check.
+        """
         # Load step with query -> report (for data sources)
         from sqlalchemy import select
         from sqlalchemy.orm import selectinload
@@ -79,9 +120,19 @@ class EntityService:
         description = description_override if description_override is not None else (step.description or None)
         ent_type = (type_override or ("metric" if (chosen_view or {}).get("type") == "count" else "model"))
 
-        # Check if user is admin (has create_entities permission)
-        user_permissions = await self._get_user_permissions(db, current_user, organization)
-        is_admin = self._is_admin_permissions(user_permissions)
+        # Publish tier: the route's per-DS `create_entities` verdict when given,
+        # else the org-admin fallback (legacy callers).
+        if creator_can_publish is None:
+            user_permissions = await self._get_user_permissions(db, current_user, organization)
+            creator_can_publish = self._is_admin_permissions(user_permissions)
+
+        # Copy the step rows THROUGH the viewer-data policy, not Step.data
+        # directly: on a user-scoped (user_required/RLS) source the shared
+        # snapshot is the report owner's row slice, and a non-owner saving the
+        # step must not mint an entity carrying another identity's rows. The
+        # resolution returns the creator's own slice, or {} when withheld.
+        from app.services.viewer_data_policy import resolve_step_data
+        resolution = await resolve_step_data(db, step, step.query.report, current_user)
 
         entity = Entity(
             organization_id=str(organization.id),
@@ -92,16 +143,16 @@ class EntityService:
             description=description,
             tags=[],
             code=step.code or "",
-            data=step.data or {},
+            data=resolution.data or {},
             original_data_model=step.data_model or {},
             view=(chosen_view or getattr(step, "view", None) or {"type": "table"}),
             last_refreshed_at=step.updated_at,
             source_step_id=str(step_id),  # Link back to source step
         )
 
-        # Apply dual-status workflow based on user role
-        if is_admin:
-            # Admin can create global entities - respect their publish choice
+        # Apply dual-status workflow based on the publish verdict
+        if creator_can_publish:
+            # Entity manager for these agents - respect their publish choice
             entity.private_status = None
             entity.global_status = "approved"
             entity.status = "published" if publish else "draft"
@@ -355,7 +406,13 @@ class EntityService:
         payload: EntityUpdate,
         organization: Organization,
         current_user: User,
+        *,
+        resource_authorized: bool = False,
     ) -> Optional[Entity]:
+        """`resource_authorized=True` means the route verified the caller holds
+        per-DS `create_entities` on every attached data source (agent
+        owner/manager tier) — they get full edit control like an org admin,
+        but review transitions (approve/reject) stay org-admin only."""
         result = await db.execute(select(Entity).where(Entity.id == entity_id, Entity.organization_id == str(organization.id)))
         entity = result.scalar_one_or_none()
         if not entity:
@@ -366,10 +423,13 @@ class EntityService:
         from fastapi import HTTPException
         if not user_permissions:
             raise HTTPException(status_code=403, detail="Permission denied: not an organization member")
-        
+
         # Determine what type of update this is and check permissions
         from app.models.entity import Entity as EntityModel
-        update_type = self._determine_update_type(entity, payload, current_user, user_permissions)
+        update_type = self._determine_update_type(
+            entity, payload, current_user, user_permissions,
+            resource_authorized=resource_authorized,
+        )
         
         # Handle the update based on type
         if update_type == "admin_review":
@@ -476,9 +536,27 @@ class EntityService:
         # limit_row_count instead of falling back to the hardcoded 1000-row cap.
         org_settings = await organization.get_settings(db) if organization else None
         executor = StreamingCodeExecutor(organization_settings=org_settings)
+
+        # Snapshot-identity guard: execution runs under the CALLER's
+        # credentials, but Entity.data is a SHARED snapshot the policy treats
+        # as the owner's identity. On a credential-differentiated source
+        # (user_required/RLS) a non-owner refresh must not overwrite the
+        # shared snapshot with their own row slice — they get their result in
+        # the response only. entity_data_withheld is exactly that predicate
+        # (False for the owner and for system-only sources).
+        from app.services.viewer_data_policy import entity_data_withheld
+        persist_data = not await entity_data_withheld(db, entity, current_user)
+
         try:
             exec_df, execution_log, _ = executor.execute_code(code=code_to_run, ds_clients=ds_clients, excel_files=excel_files)
             df = executor.format_df_for_widget(exec_df)
+            if not persist_data:
+                # Transient run: hand the caller their own rows without
+                # touching the shared snapshot or its metadata. Detach the
+                # instance first so the mutation can never be flushed.
+                db.expunge(entity)
+                entity.data = df
+                return entity
             # Persist execution results
             entity.data = df
             entity.last_refreshed_at = datetime.utcnow()
@@ -505,10 +583,11 @@ class EntityService:
             await db.refresh(entity)
             return entity
         except Exception as e:
-            # Persist last_refreshed_at but do not overwrite existing data on failure
-            entity.last_refreshed_at = datetime.utcnow()
-            await db.flush()
-            await db.commit()
+            if persist_data:
+                # Persist last_refreshed_at but do not overwrite existing data on failure
+                entity.last_refreshed_at = datetime.utcnow()
+                await db.flush()
+                await db.commit()
             # Re-raise as ValueError for route to map to 404/400 as designed
             raise ValueError(str(e))
 
@@ -548,9 +627,60 @@ class EntityService:
         except Exception as e:
             return {"data": None, "error": str(e)}
 
+    async def _get_owned_entity(
+        self, db: AsyncSession, entity_id: str, current_user: User, organization: Organization,
+    ) -> Entity:
+        from fastapi import HTTPException
+        result = await db.execute(select(Entity).where(
+            Entity.id == str(entity_id), Entity.organization_id == str(organization.id)
+        ))
+        entity = result.scalar_one_or_none()
+        if not entity:
+            raise HTTPException(status_code=404, detail="Entity not found")
+        if str(entity.owner_id) != str(current_user.id):
+            raise HTTPException(status_code=403, detail="Only the entity owner can do this")
+        return entity
+
+    async def suggest_entity(
+        self, db: AsyncSession, entity_id: str, current_user: User, organization: Organization,
+    ) -> Entity:
+        """Owner promotes their private entity to a suggestion:
+        Private Published -> Suggested (draft pending admin review)."""
+        from fastapi import HTTPException
+        entity = await self._get_owned_entity(db, entity_id, current_user, organization)
+        if entity.global_status == "approved":
+            raise HTTPException(status_code=400, detail="Entity is already approved")
+        if entity.global_status == "suggested":
+            return entity  # idempotent
+        entity.private_status = entity.private_status or "published"
+        entity.global_status = "suggested"
+        entity.status = "draft"
+        await db.flush()
+        await db.commit()
+        await db.refresh(entity)
+        return entity
+
+    async def withdraw_suggestion(
+        self, db: AsyncSession, entity_id: str, current_user: User, organization: Organization,
+    ) -> Entity:
+        """Owner withdraws their suggestion back to private:
+        Suggested -> Private Published."""
+        from fastapi import HTTPException
+        entity = await self._get_owned_entity(db, entity_id, current_user, organization)
+        if entity.global_status != "suggested":
+            raise HTTPException(status_code=400, detail="Entity is not a pending suggestion")
+        entity.global_status = None
+        entity.private_status = "published"
+        entity.status = "draft"
+        await db.flush()
+        await db.commit()
+        await db.refresh(entity)
+        return entity
+
     def _is_admin_permissions(self, user_permissions: set) -> bool:
-        """MVP: entity admin = full_admin_access. Per-DS create is checked at the route layer."""
-        return 'full_admin_access' in user_permissions
+        """Entity admin = full_admin_access or org-level manage_entities.
+        Per-DS create is checked at the route layer."""
+        return bool({'full_admin_access', 'manage_entities'} & set(user_permissions))
 
     async def _get_user_permissions(self, db: AsyncSession, user: User, organization: Organization) -> set:
         """Get user's org-level permissions via the RBAC resolver."""
@@ -559,29 +689,37 @@ class EntityService:
         resolved = await resolve_permissions(db, str(user.id), str(organization.id))
         return set(resolved.org_permissions)
 
-    def _determine_update_type(self, entity: Entity, payload: EntityUpdate, current_user: User, user_permissions: set) -> str:
-        """Determine what type of update this is based on permissions and changes"""
+    def _determine_update_type(
+        self, entity: Entity, payload: EntityUpdate, current_user: User,
+        user_permissions: set, *, resource_authorized: bool = False,
+    ) -> str:
+        """Determine what type of update this is based on permissions and changes.
+
+        `resource_authorized` = the caller holds per-DS `create_entities` on
+        every attached data source (verified at the route). They edit with
+        admin-level field control, but the review transition (approve/reject a
+        suggestion) stays an org-admin capability.
+        """
         is_admin = self._is_admin_permissions(user_permissions)
         is_owner = entity.owner_id == current_user.id
         is_suggested = entity.global_status == "suggested"
         has_status_change = payload.status and payload.status != entity.status
-        
+
         # Admin reviewing a suggested entity (approve or reject)
         if is_admin and is_suggested and has_status_change:
             if payload.status in ["published", "archived"]:
                 return "admin_review"
-        
-        # Admin editing any entity (not review)
-        elif is_admin:
+
+        # Admin or per-DS entity manager editing any entity (not review)
+        if is_admin or resource_authorized:
             return "admin_edit"
-        
+
         # Owner editing their own entity when not globally approved (suggested or private)
-        elif is_owner and (entity.global_status != "approved") and user_permissions:
+        if is_owner and (entity.global_status != "approved") and user_permissions:
             return "owner_edit"
-        
+
         # No permission
-        else:
-            return "no_permission"
+        return "no_permission"
 
     async def _handle_admin_review(self, entity: Entity, payload: EntityUpdate, admin_user: User):
         """Handle admin reviewing a suggested entity (approve or reject)"""

--- a/backend/app/services/viewer_data_policy.py
+++ b/backend/app/services/viewer_data_policy.py
@@ -215,14 +215,32 @@ async def entity_data_withheld(
     The entity owner is the trusted identity (the report analog): they see the
     snapshot; every other reader is withheld. Entities have no per-user result
     store, so a withheld reader gets empty data and must run/refresh the entity
-    themselves to see their own rows. (Refresher identity is not tracked
-    separately today; refresh is expected to be owner-scoped.)
+    themselves to see their own rows. (Refresh persistence honors the same
+    predicate: run_entity_with_update only writes the shared snapshot when this
+    returns False for the runner, so a non-owner refresh on a user-scoped
+    source stays transient.)
     """
     owner_id = str(getattr(entity, "owner_id", "") or "")
     if requesting_user is not None and owner_id and str(requesting_user.id) == owner_id:
         return False
     ids = await _entity_data_source_ids(db, str(entity.id))
     return await _any_user_scoped_connection(db, ids) or await _any_rls_relation(db, ids)
+
+
+async def resolve_entity_data(
+    db: AsyncSession, entity: Any, requesting_user: Any = None
+) -> dict:
+    """The entity snapshot a given reader may see — {} when withheld.
+
+    Single authority for every surface that serves Entity.data rows: the
+    entity read endpoint, the planner context builders (entities section,
+    mentions), code-execution loadables and the describe_entity tool must
+    resolve through this instead of reading Entity.data directly, exactly
+    like step surfaces go through resolve_step_data.
+    """
+    if await entity_data_withheld(db, entity, requesting_user):
+        return {}
+    return entity.data or {}
 
 
 async def snapshot_withheld_for_viewers(

--- a/backend/tests/e2e/rbac/test_rbac_entity_creation.py
+++ b/backend/tests/e2e/rbac/test_rbac_entity_creation.py
@@ -1,0 +1,362 @@
+"""Entity creation/authoring RBAC + user-scoped snapshot withholding.
+
+Covers the two bug classes fixed together:
+
+1. RBAC: an agent owner/manager (per-DS ``manage`` or ``create_entities``
+   grant) must be able to create, publish, edit and delete entities on their
+   own agent; a plain member may SUGGEST an entity from their own step on an
+   accessible agent but cannot publish; members without access are refused.
+
+2. Withholding: on a user-scoped (``auth_policy != system_only``) source the
+   shared ``Entity.data`` snapshot is one identity's row slice. Creating an
+   entity from someone else's step must not copy that slice to a new owner,
+   the planner context builders must not render it for other readers, and
+   code-execution loadables must refuse it.
+"""
+import asyncio
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.query import Query
+from app.models.report import Report
+from app.models.step import Step
+from app.models.widget import Widget
+
+
+def _hdr(token, org_id):
+    return {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+STEP_CODE = """
+def generate_df(ds_clients, excel_files):
+    import pandas as pd
+    return pd.DataFrame({"v": [1, 2]})
+"""
+
+OWNER_SLICE = {
+    "rows": [{"v": "owner-private-row"}],
+    "columns": [{"field": "v"}],
+}
+
+
+def _create_report(test_client, token, org_id, data_source_ids):
+    resp = test_client.post(
+        "/api/reports",
+        json={"title": f"r_{uuid.uuid4().hex[:6]}", "data_sources": data_source_ids},
+        headers=_hdr(token, org_id),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _seed_step(report_id: str, data=None):
+    """Seed a successful default step on an API-created report (the AI flow
+    normally produces these; no public CRUD API exists)."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        report = await db.get(Report, report_id)
+        widget = Widget(title=f"W {suffix}", slug=f"w-{suffix}", report_id=report_id)
+        db.add(widget)
+        await db.flush()
+        query = Query(
+            title="Q", report_id=report_id, widget_id=widget.id,
+            organization_id=report.organization_id, user_id=report.user_id,
+        )
+        db.add(query)
+        await db.flush()
+        step = Step(
+            title=f"Step {suffix}", slug=f"step-{suffix}", status="success",
+            widget_id=widget.id, query_id=query.id, code=STEP_CODE,
+            data=(data if data is not None else OWNER_SLICE),
+            created_at=datetime.utcnow() - timedelta(minutes=5),
+        )
+        db.add(step)
+        await db.flush()
+        query.default_step_id = step.id
+        await db.commit()
+        return str(step.id)
+
+
+async def _flip_ds_user_required(ds_id: str):
+    from sqlalchemy import select, update
+    from app.models.connection import Connection
+    from app.models.domain_connection import domain_connection
+
+    async with async_session_maker() as db:
+        rows = (await db.execute(
+            select(domain_connection.c.connection_id).where(
+                domain_connection.c.data_source_id == str(ds_id)
+            )
+        )).scalars().all()
+        assert rows, "expected the data source to have a connection"
+        await db.execute(
+            update(Connection).where(Connection.id.in_(rows)).values(auth_policy="user_required")
+        )
+        await db.commit()
+
+
+@pytest.fixture
+def world(test_client, bootstrap_admin, invite_user_to_org, sqlite_data_source, grant_resource):
+    admin = bootstrap_admin("admin")
+    org_id = admin["org_id"]
+
+    ds_public = sqlite_data_source(
+        name="pub_agent", user_token=admin["token"], org_id=org_id, is_public=True,
+    )
+    ds_private = sqlite_data_source(
+        name="prv_agent", user_token=admin["token"], org_id=org_id,
+    )
+
+    owner = invite_user_to_org(org_id=org_id, admin_token=admin["token"])   # agent manager
+    member = invite_user_to_org(org_id=org_id, admin_token=admin["token"])  # plain member
+
+    # `manage` grant = the owner tier a user gets on an agent they created.
+    grant_resource(
+        resource_type="data_source", resource_id=ds_public["id"],
+        principal_type="user", principal_id=owner["user_id"],
+        permissions=["manage"], user_token=admin["token"], org_id=org_id,
+    )
+
+    return {
+        "org_id": org_id, "admin": admin, "owner": owner, "member": member,
+        "ds_public": ds_public, "ds_private": ds_private,
+    }
+
+
+# ── 1. Creation RBAC ─────────────────────────────────────────────────────
+
+@pytest.mark.e2e
+def test_agent_manager_can_create_entity(test_client, world):
+    """Regression: the owner tier (`manage` grant) creates entities on its agent."""
+    resp = test_client.post(
+        "/api/entities",
+        json={
+            "type": "model", "title": "mine", "slug": f"mine-{uuid.uuid4().hex[:6]}",
+            "code": "select 1", "data": {}, "status": "draft",
+            "data_source_ids": [world["ds_public"]["id"]],
+        },
+        headers=_hdr(world["owner"]["token"], world["org_id"]),
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.e2e
+def test_agent_manager_can_publish_from_step(test_client, world):
+    report_id = _create_report(
+        test_client, world["owner"]["token"], world["org_id"], [world["ds_public"]["id"]],
+    )
+    step_id = _run(_seed_step(report_id))
+    resp = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"type": "model", "title": "published by manager", "publish": True,
+              "data_source_ids": [world["ds_public"]["id"]]},
+        headers=_hdr(world["owner"]["token"], world["org_id"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["global_status"] == "approved"
+    assert body["status"] == "published"
+
+
+@pytest.mark.e2e
+def test_plain_member_suggests_but_cannot_publish(test_client, world):
+    report_id = _create_report(
+        test_client, world["member"]["token"], world["org_id"], [world["ds_public"]["id"]],
+    )
+    step_id = _run(_seed_step(report_id))
+
+    denied = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "try publish", "publish": True,
+              "data_source_ids": [world["ds_public"]["id"]]},
+        headers=_hdr(world["member"]["token"], world["org_id"]),
+    )
+    assert denied.status_code == 403, denied.text
+
+    suggested = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "suggestion", "publish": False,
+              "data_source_ids": [world["ds_public"]["id"]]},
+        headers=_hdr(world["member"]["token"], world["org_id"]),
+    )
+    assert suggested.status_code == 200, suggested.text
+    body = suggested.json()
+    assert body["global_status"] == "suggested"
+    assert body["status"] == "draft"
+
+
+@pytest.mark.e2e
+def test_member_without_ds_access_cannot_from_step(test_client, world):
+    # Admin's report on the PRIVATE agent; member holds no grant on it.
+    report_id = _create_report(
+        test_client, world["admin"]["token"], world["org_id"], [world["ds_private"]["id"]],
+    )
+    step_id = _run(_seed_step(report_id))
+    resp = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "nope", "publish": False,
+              "data_source_ids": [world["ds_private"]["id"]]},
+        headers=_hdr(world["member"]["token"], world["org_id"]),
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.e2e
+def test_owner_lifecycle_suggest_withdraw_update_delete(test_client, world):
+    """A suggester owns their unapproved entity: edit, suggest, withdraw, delete."""
+    report_id = _create_report(
+        test_client, world["member"]["token"], world["org_id"], [world["ds_public"]["id"]],
+    )
+    step_id = _run(_seed_step(report_id))
+    created = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "my draft", "publish": False,
+              "data_source_ids": [world["ds_public"]["id"]]},
+        headers=_hdr(world["member"]["token"], world["org_id"]),
+    )
+    assert created.status_code == 200, created.text
+    entity_id = created.json()["id"]
+    hdr = _hdr(world["member"]["token"], world["org_id"])
+
+    upd = test_client.put(f"/api/entities/{entity_id}", json={"title": "renamed"}, headers=hdr)
+    assert upd.status_code == 200, upd.text
+    assert upd.json()["title"] == "renamed"
+
+    wd = test_client.post(f"/api/entities/{entity_id}/withdraw", headers=hdr)
+    assert wd.status_code == 200, wd.text
+    assert wd.json()["global_status"] is None
+
+    sg = test_client.post(f"/api/entities/{entity_id}/suggest", headers=hdr)
+    assert sg.status_code == 200, sg.text
+    assert sg.json()["global_status"] == "suggested"
+
+    # Another plain member may not touch it.
+    other = world["admin"]  # admin CAN touch; use a real stranger check below via 403 on owner-only endpoint
+    stranger_wd = test_client.post(
+        f"/api/entities/{entity_id}/withdraw",
+        headers=_hdr(world["owner"]["token"], world["org_id"]),
+    )
+    assert stranger_wd.status_code == 403, stranger_wd.text
+
+    dele = test_client.delete(f"/api/entities/{entity_id}", headers=hdr)
+    assert dele.status_code == 200, dele.text
+
+
+# ── 2. User-scoped snapshot withholding ──────────────────────────────────
+
+@pytest.fixture
+def user_scoped_world(test_client, world):
+    """Public agent flipped to user_required, with an admin-owned published
+    entity carrying the admin's snapshot slice."""
+    _run(_flip_ds_user_required(world["ds_public"]["id"]))
+    created = test_client.post(
+        "/api/entities/global",
+        json={
+            "type": "model", "title": "admins entity",
+            "slug": f"adm-{uuid.uuid4().hex[:6]}", "code": "select 1",
+            "data": OWNER_SLICE, "status": "published",
+            "data_source_ids": [world["ds_public"]["id"]],
+        },
+        headers=_hdr(world["admin"]["token"], world["org_id"]),
+    )
+    assert created.status_code == 200, created.text
+    return {**world, "entity": created.json()}
+
+
+@pytest.mark.e2e
+def test_detail_withholds_snapshot_from_nonowner(test_client, user_scoped_world):
+    w = user_scoped_world
+    mine = test_client.get(
+        f"/api/entities/{w['entity']['id']}", headers=_hdr(w["admin"]["token"], w["org_id"]),
+    )
+    assert mine.status_code == 200 and mine.json()["data"] == OWNER_SLICE
+
+    other = test_client.get(
+        f"/api/entities/{w['entity']['id']}", headers=_hdr(w["member"]["token"], w["org_id"]),
+    )
+    assert other.status_code == 200, other.text
+    assert other.json()["snapshot_withheld"] is True
+    assert other.json()["data"] in ({}, None)
+
+
+@pytest.mark.e2e
+def test_from_step_does_not_copy_foreign_slice(test_client, user_scoped_world):
+    """A member saving the ADMIN's step must not mint an entity carrying the
+    admin's credential-scoped rows."""
+    w = user_scoped_world
+    report_id = _create_report(
+        test_client, w["admin"]["token"], w["org_id"], [w["ds_public"]["id"]],
+    )
+    step_id = _run(_seed_step(report_id, data=OWNER_SLICE))
+
+    saved = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "member copy", "publish": False,
+              "data_source_ids": [w["ds_public"]["id"]]},
+        headers=_hdr(w["member"]["token"], w["org_id"]),
+    )
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["data"] in ({}, None), "foreign snapshot slice must be withheld"
+
+    # The report owner saving their OWN step keeps their slice.
+    own = test_client.post(
+        f"/api/entities/from_step/{step_id}",
+        json={"title": "admin copy", "publish": True,
+              "data_source_ids": [w["ds_public"]["id"]]},
+        headers=_hdr(w["admin"]["token"], w["org_id"]),
+    )
+    assert own.status_code == 200, own.text
+    assert own.json()["data"] == OWNER_SLICE
+
+
+@pytest.mark.e2e
+def test_context_builders_and_loadables_honor_withholding(user_scoped_world):
+    """The planner entities section and code-execution loadables must resolve
+    the snapshot per reader."""
+    w = user_scoped_world
+
+    async def check():
+        from sqlalchemy import select
+        from app.models.entity import Entity
+        from app.models.user import User
+        from app.models.organization import Organization
+        from app.ai.context.builders.entity_context_builder import EntityContextBuilder
+        from app.ai.code_execution.loadables import LoadablesResolver
+
+        async with async_session_maker() as db:
+            org = await db.get(Organization, w["org_id"])
+            admin_u = await db.get(User, w["admin"]["user_id"])
+            member_u = await db.get(User, w["member"]["user_id"])
+
+            async def section_for(user):
+                b = EntityContextBuilder(db, org, report=None, user=user)
+                return await b.build(
+                    keywords=["admins", "entity"], require_source_assoc=True,
+                    data_source_ids=[w["ds_public"]["id"]],
+                )
+
+            owner_section = await section_for(admin_u)
+            assert owner_section.items and owner_section.items[0].data, \
+                "owner keeps their snapshot in context"
+            member_section = await section_for(member_u)
+            assert member_section.items and not member_section.items[0].data, \
+                "non-owner must not get the snapshot in context"
+            assert "owner-private-row" not in member_section.render()
+
+            resolver = LoadablesResolver(db, org, report=None, current_user=member_u)
+            out = await resolver.resolve(step_refs=[], entity_refs=[w["entity"]["id"]])
+            assert not out["entities"], "loadables must refuse the withheld snapshot"
+            assert out["errors"] and "credential" in out["errors"][0]
+
+            owner_resolver = LoadablesResolver(db, org, report=None, current_user=admin_u)
+            out2 = await owner_resolver.resolve(step_refs=[], entity_refs=[w["entity"]["id"]])
+            assert w["entity"]["id"] in out2["entities"], "owner still loads their entity"
+
+    _run(check())

--- a/backend/tests/e2e/rbac/test_rbac_entity_creation.py
+++ b/backend/tests/e2e/rbac/test_rbac_entity_creation.py
@@ -249,6 +249,50 @@ def test_owner_lifecycle_suggest_withdraw_update_delete(test_client, world):
     assert dele.status_code == 200, dele.text
 
 
+@pytest.mark.e2e
+def test_agent_owner_without_grant_row_still_manages(test_client, world):
+    """Ownership is authoritative: data_sources.owner_user_id confers `manage`
+    even when the owner's ResourceGrant row is missing (legacy creation paths,
+    failed backfills). Regression for owners stuck in suggest-tier."""
+    admin = world["admin"]
+
+    async def orphan_owner():
+        from sqlalchemy import delete, update
+        from app.models.data_source import DataSource
+        from app.models.resource_grant import ResourceGrant
+        async with async_session_maker() as db:
+            # Make the OWNER the admin's victim... rather: assign ownership to
+            # the plain member and strip every grant they hold on the agent.
+            await db.execute(update(DataSource).where(
+                DataSource.id == world["ds_public"]["id"]
+            ).values(owner_user_id=world["member"]["user_id"]))
+            await db.execute(delete(ResourceGrant).where(
+                ResourceGrant.resource_type == "data_source",
+                ResourceGrant.resource_id == world["ds_public"]["id"],
+                ResourceGrant.principal_id == world["member"]["user_id"],
+            ))
+            await db.commit()
+
+    _run(orphan_owner())
+
+    resp = test_client.post(
+        "/api/entities",
+        json={
+            "type": "model", "title": "owner no grant", "slug": f"own-{uuid.uuid4().hex[:6]}",
+            "code": "select 1", "data": {}, "status": "draft",
+            "data_source_ids": [world["ds_public"]["id"]],
+        },
+        headers=_hdr(world["member"]["token"], world["org_id"]),
+    )
+    assert resp.status_code == 200, resp.text
+
+    # whoami surfaces the derived grant so the frontend store agrees.
+    who = test_client.get("/api/users/whoami", headers=_hdr(world["member"]["token"], world["org_id"]))
+    org = next(o for o in who.json()["organizations"] if o["id"] == world["org_id"])
+    key = f"data_source:{world['ds_public']['id']}"
+    assert "manage" in (org.get("resource_permissions") or {}).get(key, []), org.get("resource_permissions")
+
+
 # ── 2. User-scoped snapshot withholding ──────────────────────────────────
 
 @pytest.fixture

--- a/backend/tests/e2e/rbac/test_rbac_registry.py
+++ b/backend/tests/e2e/rbac/test_rbac_registry.py
@@ -420,17 +420,13 @@ def _collect_frontend_permissions():
 # This set may SHRINK, never grow. Do not add to it to make a build pass.
 KNOWN_STALE_FRONTEND_PERMISSIONS = frozenset({
     "add_organization_members",
-    "approve_entities",
-    "delete_entities",
     "manage_groups",
     "manage_llm_settings",
     "manage_role_assignments",
     "manage_roles",
     "modify_settings",
     "remove_organization_members",
-    "suggest_entities",
     "update_data_source",
-    "update_entities",
     "update_organization_members",
     "view_builds",
     "view_completion_plan",

--- a/frontend/components/entity/EntityCreateModal.vue
+++ b/frontend/components/entity/EntityCreateModal.vue
@@ -59,7 +59,7 @@
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useMyFetch } from '~/composables/useMyFetch'
-import { useCan } from '~/composables/usePermissions'
+import { useCanAll, useCanAny } from '~/composables/usePermissions'
 import EntityForm from './EntityForm.vue'
 
 const { t } = useI18n()
@@ -84,8 +84,6 @@ const open = computed({
   set: (v: boolean) => { if (!v) emit('close') }
 })
 
-const canCreateEntities = computed(() => useCan('create_entities'))
-const canSuggestEntities = computed(() => useCan('suggest_entities'))
 const errorMsg = ref('')
 const saving = ref(false)
 const viewType = computed(() => String((props.initialView && props.initialView.type) || ''))
@@ -100,9 +98,23 @@ const form = ref<{
   type: (viewType.value === 'count' ? 'metric' : 'model'),
   title: props.initialTitle || '',
   description: null,
-  status: canCreateEntities.value ? 'published' : 'draft',
+  status: 'draft', // set on open by the watcher below (needs canCreateEntities)
   data_source_ids: props.initialDataSourceIds || [],
 })
+
+// Publishing needs per-agent `create_entities` on EVERY attached agent
+// (agent owners hold it via their `manage` grant; org `manage_entities` and
+// full admins via implication). There is no org-level 'create_entities'
+// permission — the old org-level check locked out agent owners entirely.
+const canCreateEntities = computed(() => {
+  const ids = (form.value?.data_source_ids || []).filter(Boolean)
+  return ids.length
+    ? useCanAll('create_entities', 'data_source', ids)
+    : useCanAny('create_entities', 'data_source')
+})
+// Any member may SUGGEST an entity (draft pending admin approval) from their
+// own query; the backend enforces access to the attached agents.
+const canSuggestEntities = computed(() => true)
 
 // Watch for modal opening and update form with latest props
 watch(() => props.visible, (isVisible) => {

--- a/frontend/components/entity/EntityCreateModal.vue
+++ b/frontend/components/entity/EntityCreateModal.vue
@@ -132,6 +132,7 @@ watch(canCreateEntities, (can) => {
 })
 
 // Watch for modal opening and update form with latest props
+const { getSession } = useAuth()
 watch(() => props.visible, (isVisible) => {
   if (isVisible) {
     // Reset/update form when modal opens
@@ -142,6 +143,16 @@ watch(() => props.visible, (isVisible) => {
       status: canCreateEntities.value ? 'published' : 'draft',
       data_source_ids: props.initialDataSourceIds || [],
     }
+    // The permission store is a session snapshot; grants earned mid-session
+    // (e.g. `manage` on an agent the user just created) aren't in it yet and
+    // would wrongly downgrade the modal to suggest-tier. Refreshing the
+    // session re-resolves the store (fetchPermissions plugin watches it), and
+    // the computeds above re-evaluate reactively.
+    getSession().then(() => {
+      if (canCreateEntities.value && form.value.status !== 'published') {
+        form.value.status = 'published'
+      }
+    }).catch(() => {})
   }
 })
 

--- a/frontend/components/entity/EntityCreateModal.vue
+++ b/frontend/components/entity/EntityCreateModal.vue
@@ -31,6 +31,11 @@
                 <div class="font-medium mb-1">{{ $t('entityCreate.noPermissionHeading') }}</div>
                 <div>{{ $t('entityCreate.noPermissionBody') }}</div>
               </div>
+              <!-- Save failure: surface the backend's reason instead of failing silently -->
+              <div v-if="errorMsg" class="mb-4 p-3 bg-red-50 dark:bg-red-950 border border-red-200 rounded-lg text-xs text-red-800">
+                <div class="font-medium mb-1">{{ $t('entityCreate.saveFailed') }}</div>
+                <div>{{ errorMsg }}</div>
+              </div>
               <EntityForm v-model="form" :show-status="canCreateEntities" />
             </div>
           </div>
@@ -63,6 +68,7 @@ import { useCanAll, useCanAny } from '~/composables/usePermissions'
 import EntityForm from './EntityForm.vue'
 
 const { t } = useI18n()
+const toast = useToast()
 
 interface Props {
   visible: boolean
@@ -116,6 +122,15 @@ const canCreateEntities = computed(() => {
 // own query; the backend enforces access to the attached agents.
 const canSuggestEntities = computed(() => true)
 
+// Keep the Status field truthful: the publish verdict depends on the selected
+// agents, which can change after the modal opens (async report snapshot, user
+// edits the Data Sources select). If the verdict drops to suggest-tier while
+// Status still says Published, the save would silently downgrade to a
+// suggestion — reset it so the UI always shows what will actually happen.
+watch(canCreateEntities, (can) => {
+  if (!can && form.value.status === 'published') form.value.status = 'draft'
+})
+
 // Watch for modal opening and update form with latest props
 watch(() => props.visible, (isVisible) => {
   if (isVisible) {
@@ -163,10 +178,20 @@ async function onSave() {
 
     const { data, error } = await useMyFetch(`/api/entities/from_step/${props.stepId}`, { method: 'POST', body })
     if (error.value) throw error.value
-    emit('saved', data.value)
+    // Announce what actually happened — published to catalog vs suggestion
+    // pending review — so a save never ends without visible feedback.
+    const saved: any = data.value
+    toast.add({
+      title: saved?.global_status === 'approved' && saved?.status === 'published'
+        ? t('entityCreate.publishedToast')
+        : t('entityCreate.suggestedToast'),
+      color: 'green',
+    })
+    emit('saved', saved)
     open.value = false
   } catch (e: any) {
     errorMsg.value = e?.data?.detail || e?.message || t('entityCreate.saveFailed')
+    toast.add({ title: t('entityCreate.saveFailed'), description: errorMsg.value, color: 'red' })
   } finally {
     saving.value = false
   }

--- a/frontend/pages/old_agents/[id]/queries.vue
+++ b/frontend/pages/old_agents/[id]/queries.vue
@@ -143,7 +143,7 @@ const loading = ref(false)
 const q = ref('')
 const filterType = ref<'published' | 'suggested'>('published')
 const isAdmin = computed(() => useCan('manage_entities'))
-const currentUserId = computed(() => (authData.value as any)?.user?.id)
+const currentUserId = computed(() => ((authData.value as any)?.user?.id ?? (authData.value as any)?.id))
 
 const suggestedCount = computed(() =>
     allItems.value.filter(item => {

--- a/frontend/pages/old_agents/[id]/queries.vue
+++ b/frontend/pages/old_agents/[id]/queries.vue
@@ -142,7 +142,7 @@ const allItems = ref<EntityItem[]>([])
 const loading = ref(false)
 const q = ref('')
 const filterType = ref<'published' | 'suggested'>('published')
-const isAdmin = computed(() => useCan('update_entities'))
+const isAdmin = computed(() => useCan('manage_entities'))
 const currentUserId = computed(() => (authData.value as any)?.user?.id)
 
 const suggestedCount = computed(() =>

--- a/frontend/pages/queries/[id]/index.vue
+++ b/frontend/pages/queries/[id]/index.vue
@@ -264,7 +264,7 @@ const entityType = computed(() => {
 })
 
 const isOwner = computed(() => {
-  const currentUserId = (authData.value as any)?.user?.id
+  const currentUserId = ((authData.value as any)?.user?.id ?? (authData.value as any)?.id)
   return currentUserId && detail.value?.owner_id === currentUserId
 })
 

--- a/frontend/pages/queries/[id]/index.vue
+++ b/frontend/pages/queries/[id]/index.vue
@@ -228,11 +228,25 @@ const { data: authData } = useAuth()
 const id = computed(() => String(route.params.id || ''))
 const detail = ref<EntityDetail | null>(null)
 const loading = ref(true)
-const canCreateEntities = computed(() => useCan('create_entities'))
-const canUpdateEntities = computed(() => useCan('update_entities'))
-const canSuggestEntities = computed(() => useCan('suggest_entities'))
-const canApproveEntities = computed(() => useCan('approve_entities'))
-const canDeleteEntities = computed(() => useCan('delete_entities'))
+// Per-agent `create_entities` on EVERY attached agent gates manage actions
+// (agent owners hold it via `manage`; org `manage_entities` / full admin via
+// implication). The old org-level checks used permission names that don't
+// exist ('create_entities'/'update_entities'/... are per-agent or nonexistent
+// strings), so every affordance was admin-only.
+const detailDsIds = computed(() => (detail.value?.data_sources || []).map((d: any) => d?.id).filter(Boolean))
+const canManageEntity = computed(() =>
+  detailDsIds.value.length ? useCanAll('create_entities', 'data_source', detailDsIds.value) : useCan('manage_entities')
+)
+const canCreateEntities = canManageEntity
+// The entity's owner may edit/delete their own entity while it is not
+// globally approved (mirrors the backend owner allowance).
+const ownerEditable = computed(() => isOwner.value && ['private', 'suggested', 'archived'].includes(String(entityType.value)))
+const canUpdateEntities = computed(() => canManageEntity.value || ownerEditable.value)
+const canDeleteEntities = computed(() => canManageEntity.value || ownerEditable.value)
+// Suggesting is open to any member for their own private entity.
+const canSuggestEntities = computed(() => true)
+// Approving/rejecting suggestions stays an org-admin capability.
+const canApproveEntities = computed(() => useCan('manage_entities'))
 
 // Entity workflow status
 const entityType = computed(() => {

--- a/frontend/pages/queries/index.vue
+++ b/frontend/pages/queries/index.vue
@@ -197,7 +197,9 @@ const page = ref(1)
 const limit = 20
 const q = ref('')
 const filterType = ref<'published' | 'suggested'>('published')
-const isAdmin = computed(() => useCan('update_entities'))
+// Org entity admins (manage_entities / full admin) see all drafts+suggestions;
+// 'update_entities' was never a real permission string.
+const isAdmin = computed(() => useCan('manage_entities'))
 
 const currentUserId = computed(() => (authData.value as any)?.user?.id)
 

--- a/frontend/pages/queries/index.vue
+++ b/frontend/pages/queries/index.vue
@@ -162,7 +162,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMyFetch } from '~/composables/useMyFetch'
-import { useCan } from '~/composables/usePermissions'
+import { useCan, useCanAll } from '~/composables/usePermissions'
 import { useAuth } from '#imports'
 import Spinner from '~/components/Spinner.vue'
 
@@ -201,12 +201,24 @@ const filterType = ref<'published' | 'suggested'>('published')
 // 'update_entities' was never a real permission string.
 const isAdmin = computed(() => useCan('manage_entities'))
 
-const currentUserId = computed(() => (authData.value as any)?.user?.id)
+const currentUserId = computed(() => ((authData.value as any)?.user?.id ?? (authData.value as any)?.id))
+
+// Whether the viewer may see a draft/suggestion row: org entity admins see
+// all, owners see their own, and agent managers (per-DS create_entities on
+// every attached agent) see the suggestions queued for their agents. Used by
+// BOTH the tab badge and the list filter so the count always matches the rows.
+const canSeeDraftItem = (item: any) => {
+  if (isAdmin.value) return true
+  if (item.owner_id === currentUserId.value) return true
+  const ids = (item.data_sources || []).map((d: any) => d?.id).filter(Boolean)
+  return ids.length > 0 && useCanAll('create_entities', 'data_source', ids)
+}
 
 const suggestedCount = computed(() => {
   return allItems.value.filter(item => {
     const type = getEntityType(item)
-    return (type === 'private' || type === 'suggested' || type === 'draft') && !isArchived(item)
+    return (type === 'private' || type === 'suggested' || type === 'draft')
+      && !isArchived(item) && canSeeDraftItem(item)
   }).length
 })
 
@@ -227,16 +239,13 @@ const filteredItems = computed(() => {
     // Show only global/published entities (approved AND published)
     filtered = filtered.filter(item => getEntityType(item) === 'global')
   } else if (filterType.value === 'suggested') {
-    // Show draft and suggested entities
+    // Show draft and suggested entities the viewer may see (same predicate
+    // as the tab badge, so the count can never disagree with the rows).
     filtered = filtered.filter(item => {
       const type = getEntityType(item)
-      return type === 'private' || type === 'suggested' || type === 'draft'
+      return (type === 'private' || type === 'suggested' || type === 'draft')
+        && canSeeDraftItem(item)
     })
-    
-    // If not admin, show only user's own drafts/suggestions
-    if (!isAdmin.value) {
-      filtered = filtered.filter(item => item.owner_id === currentUserId.value)
-    }
   }
 
   // Apply search filter

--- a/locales/en.json
+++ b/locales/en.json
@@ -1507,7 +1507,9 @@
     "saveEntity": "Save Entity",
     "suggestEntity": "Suggest Entity",
     "saveFailed": "Failed to save entity",
-    "stepRequired": "Step is required to save"
+    "stepRequired": "Step is required to save",
+    "publishedToast": "Query published to the catalog",
+    "suggestedToast": "Suggestion submitted for review"
   },
   "mentionInput": {
     "placeholder": "Type {'@'} to mention...",


### PR DESCRIPTION
Entity creation RBAC (agents' owners were locked out of the Save Query flow):
- Frontend gated the entity modal and query pages on org-level
  'create_entities'/'suggest_entities' — permission strings that don't exist
  at org level, so every non-full-admin (including agent owners holding the
  per-agent `manage` grant) saw "No Permission". Gate is now resource-scoped
  (useCanAll/useCanAny over the attached agents), mirroring the backend.
- from_step now has two tiers: any member with ACCESS to the attached agents
  may suggest (draft pending approval); publishing requires per-DS
  create_entities. Target agents resolve from the payload, the report, or
  the report's @-mentions, and the checked set is exactly what gets attached.
- update/delete/run/preview decorators accept the per-DS counterpart
  ('create_entities') so agent managers pass the resource-scoped pre-filter;
  entity owners may act on their own unapproved entities (decorator owner
  allowance + DS-access body checks).
- Implemented the missing suggest_entity/withdraw_suggestion service methods
  (the routes called nonexistent methods and 500'd) with owner-only guards.
- Org manage_entities now counts as entity admin in the service layer.

User-scoped (user_required/RLS) snapshot withholding — Entity.data now goes
through the viewer-data policy on every surface, like steps/artifacts:
- New resolve_entity_data() single authority in viewer_data_policy.
- EntityContextBuilder and MentionContextBuilder resolve the snapshot per
  requesting user — non-owners no longer get another identity's sample rows
  rendered into their planner prompt.
- LoadablesResolver refuses a withheld cached grid (load_entity) with an
  actionable error instead of serving the owner's row slice to generated code.
- describe_entity forces a rerun under the caller's credentials when the
  snapshot is withheld and never falls back to the withheld cache on failure.
- create_entity_from_step copies step rows via resolve_step_data, so saving
  someone else's step can no longer mint an entity carrying the report
  owner's credential-scoped rows.
- run_entity_with_update persists the shared snapshot only when the runner's
  identity may author it (entity_data_withheld predicate); a non-owner
  refresh on a user-scoped source returns their rows transiently without
  overwriting the owner's snapshot.

Tests: new tests/e2e/rbac/test_rbac_entity_creation.py covers both bug
classes end-to-end; registry ratchet updated for the fixed frontend
permission strings.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AVcc1RAhxXAnBfURKPmfZX