### PR TITLE
Add Opus 5 to models that reject sampling parameters

### DIFF
--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -34,11 +34,12 @@ _STOP_REASON_MAP = {
 }
 
 # Model families that reject sampling parameters (temperature/top_p/top_k)
-# with a 400. Sonnet 5 / Opus 4.7 / Opus 4.8 / Fable 5 removed them from the
-# API — prompting is the steering mechanism there. Older models (4.6 and
-# earlier) still accept temperature.
+# with a 400. Sonnet 5 / Opus 5 / Opus 4.7 / Opus 4.8 / Fable 5 removed them
+# from the API — prompting is the steering mechanism there. Older models (4.6
+# and earlier) still accept temperature.
 _NO_SAMPLING_PARAM_TAGS = (
     "sonnet-5",
+    "opus-5",
     "opus-4-7",
     "opus-4-8",
     "fable-5",


### PR DESCRIPTION
## Summary
Updated the Anthropic client to recognize Opus 5 as a model that rejects sampling parameters (temperature, top_p, top_k) in API requests.

## Changes
- Added `"opus-5"` to the `_NO_SAMPLING_PARAM_TAGS` tuple to prevent sending sampling parameters to Opus 5 models
- Updated the comment to reflect that Opus 5 (in addition to Sonnet 5, Opus 4.7, Opus 4.8, and Fable 5) uses prompting as the steering mechanism instead of sampling parameters

## Details
Opus 5 follows the same API behavior as other recent Anthropic models where sampling parameters are not accepted and will result in a 400 error. The model relies on prompt engineering for output steering rather than temperature/top_p/top_k controls.

https://claude.ai/code/session_01QbpiBnMhRqnYFMjQsmZB3Y