### PR TITLE
AppDynamics perf (keep-alive + app cache, ~10x) and truncated tool table tickers

### DIFF
--- a/backend/app/data_sources/clients/appdynamics_client.py
+++ b/backend/app/data_sources/clients/appdynamics_client.py
@@ -50,6 +50,9 @@ FLOW_TIER_LIMIT = 200        # max tiers browsed per app when deriving flows
 SUMMARY_APP_LIMIT = 25       # apps named in catalog descriptions
 SUMMARY_EDGE_LIMIT = 60      # flow edges embedded in the catalog description
 TOKEN_EXPIRY_SLACK = 30      # refresh OAuth tokens this many seconds early
+APP_CACHE_TTL = 30           # seconds to reuse the applications list — every
+                             # execute_query resolves apps first, and topology
+                             # does not churn at sub-minute granularity
 
 # Matches "Call-HTTP to Discovered backend call \"X\"", "Call-JDBC to X", etc.
 _EXTERNAL_CALL_RE = re.compile(
@@ -220,6 +223,9 @@ class AppDynamicsClient(DataSourceClient):
         # sequential calls, and without connection reuse each one pays a full
         # TCP+TLS handshake (~700ms against a SaaS controller).
         self._session: Optional[requests.Session] = None
+        # Short-TTL applications-list cache (see APP_CACHE_TTL).
+        self._apps_cache: Optional[List[dict]] = None
+        self._apps_cache_at: float = 0.0
 
     def _http(self) -> requests.Session:
         if self._session is None:
@@ -567,7 +573,12 @@ class AppDynamicsClient(DataSourceClient):
     # ── helpers ───────────────────────────────────────────────────────────────
 
     def _list_applications(self) -> List[dict]:
-        return list(self._get("rest/applications") or [])
+        if self._apps_cache is not None and time.time() - self._apps_cache_at < APP_CACHE_TTL:
+            return self._apps_cache
+        apps = list(self._get("rest/applications") or [])
+        self._apps_cache = apps
+        self._apps_cache_at = time.time()
+        return apps
 
     def _resolve_apps(self, application) -> List[dict]:
         """Resolve the spec's `application` (name or id) to app dicts; when

--- a/backend/app/data_sources/clients/appdynamics_client.py
+++ b/backend/app/data_sources/clients/appdynamics_client.py
@@ -216,6 +216,15 @@ class AppDynamicsClient(DataSourceClient):
         # OAuth token cache (api_client auth only).
         self._token: Optional[str] = None
         self._token_expiry: float = 0.0
+        # Shared session for HTTP keep-alive: schema discovery makes many
+        # sequential calls, and without connection reuse each one pays a full
+        # TCP+TLS handshake (~700ms against a SaaS controller).
+        self._session: Optional[requests.Session] = None
+
+    def _http(self) -> requests.Session:
+        if self._session is None:
+            self._session = requests.Session()
+        return self._session
 
     @property
     def description(self):
@@ -240,7 +249,7 @@ class AppDynamicsClient(DataSourceClient):
     def _fetch_token(self) -> str:
         url = f"{self.base_url}/controller/api/oauth/access_token"
         try:
-            resp = requests.post(
+            resp = self._http().post(
                 url,
                 data={
                     "grant_type": "client_credentials",
@@ -296,8 +305,8 @@ class AppDynamicsClient(DataSourceClient):
         for attempt in (0, 1):
             kwargs = self._request_kwargs()
             try:
-                resp = requests.get(url, params=q, verify=self.verify_ssl,
-                                    timeout=HTTP_TIMEOUT, **kwargs)
+                resp = self._http().get(url, params=q, verify=self.verify_ssl,
+                                        timeout=HTTP_TIMEOUT, **kwargs)
             except requests.exceptions.SSLError as e:
                 raise RuntimeError(
                     f"AppDynamics TLS error: {e}. Enable 'Skip TLS verification' "

--- a/backend/tests/unit/test_appdynamics_client.py
+++ b/backend/tests/unit/test_appdynamics_client.py
@@ -159,6 +159,33 @@ def test_single_session_reused_across_calls(patch_requests):
     assert fake.sessions_created == 1, "keep-alive requires one shared Session"
 
 
+def test_applications_list_cached_across_queries(patch_requests, monkeypatch):
+    fake = patch_requests({
+        "/rest/applications": APPS,
+        "/100/tiers": TIERS_100,
+        "/200/tiers": TIERS_200,
+        "/100/nodes": [], "/200/nodes": [],
+    })
+    c = _client()
+    c.execute_query('{"table": "tiers"}')
+    c.execute_query('{"table": "nodes"}')
+    app_calls = [u for _, u, _, _, _ in fake.calls if u.endswith("/rest/applications")]
+    assert len(app_calls) == 1, "applications list must be cached within the TTL"
+
+    # After the TTL expires the list is refetched. (Capture the real clock
+    # first — appdynamics_client.time IS the stdlib module, so patching its
+    # `time` attribute would otherwise make the lambda call itself.)
+    import time as _time
+    real_time = _time.time
+    monkeypatch.setattr(
+        "app.data_sources.clients.appdynamics_client.time.time",
+        lambda: real_time() + 3600,
+    )
+    c.execute_query('{"table": "tiers"}')
+    app_calls = [u for _, u, _, _, _ in fake.calls if u.endswith("/rest/applications")]
+    assert len(app_calls) == 2
+
+
 def test_output_json_on_every_call(patch_requests):
     fake = patch_requests({
         "/rest/applications": APPS,

--- a/backend/tests/unit/test_appdynamics_client.py
+++ b/backend/tests/unit/test_appdynamics_client.py
@@ -50,6 +50,25 @@ class _FakeRequests:
         self.routes = routes
         self.token_responses = list(token_responses or [])
         self.calls = []   # (method, url, params, auth, headers)
+        self.sessions_created = 0
+
+    def Session(self):
+        # The client keeps ONE requests.Session for HTTP keep-alive; route its
+        # get/post back through this fake and count instantiations.
+        self.sessions_created += 1
+        fake = self
+
+        class _S:
+            def get(self, *a, **kw):
+                return fake.get(*a, **kw)
+
+            def post(self, *a, **kw):
+                return fake.post(*a, **kw)
+
+            def close(self):
+                pass
+
+        return _S()
 
     def _route(self, url):
         for suffix, val in self.routes.items():
@@ -125,6 +144,19 @@ def test_basic_auth_tuple_sent(patch_requests):
     method, url, params, auth, headers = fake.calls[0]
     assert auth == ("svc_bow@customer1", "pw")
     assert headers is None
+
+
+def test_single_session_reused_across_calls(patch_requests):
+    fake = patch_requests({
+        "/rest/applications": APPS,
+        "/tiers": TIERS_100,
+        "/metrics": [],
+    })
+    c = _client()
+    c.test_connection()
+    c.execute_query('{"table": "service_flows", "application": "retail-banking"}')
+    assert len(fake.calls) >= 3
+    assert fake.sessions_created == 1, "keep-alive requires one shared Session"
 
 
 def test_output_json_on_every_call(patch_requests):

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -16,17 +16,18 @@
         <span v-if="groupedTables.length" class="inline-flex items-center flex-wrap">
           <template v-for="(group, gidx) in groupedTables" :key="gidx">
             <span v-if="gidx > 0" class="ms-1 text-gray-300 dark:text-gray-600">|</span>
-            <DataSourceIcon :type="group.type" class="h-2.5 ms-1" :title="group.names.join(', ')" />
-            <span class="ms-1 text-gray-500 dark:text-gray-400 inline-flex items-center flex-wrap">
-              <span v-for="(nm, nidx) in group.names" :key="nidx" class="inline-flex items-center">
+            <DataSourceIcon :type="group.type" class="h-2.5 ms-1" :title="group.title" />
+            <span class="ms-1 text-gray-500 dark:text-gray-400 inline-flex items-center flex-wrap" :title="group.title">
+              <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                 <UIcon
                   v-if="isCached(nm)"
                   name="heroicons-bolt"
                   class="w-2.5 h-2.5 me-0.5 text-amber-500 flex-shrink-0"
                   title="Cached locally — this read did not query the source"
                 />
-                <span>{{ nm }}</span><span v-if="nidx < group.names.length - 1">,&nbsp;</span>
+                <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
               </span>
+              <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
             </span>
           </template>
         </span>
@@ -161,6 +162,7 @@
 
 <script setup lang="ts">
 import { useCachedTableNames } from '~/composables/useFastTable'
+import { groupToolTables, type ToolTableGroup } from '~/composables/useToolTables'
 import { computed, ref, reactive } from 'vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 import QueryCodeEditorModal from '~/components/tools/QueryCodeEditorModal.vue'
@@ -388,25 +390,9 @@ const executedOnCache = computed(() => {
 })
 const isCached = (n: string) => isCachedTable(n) || executedOnCache.value
 
-const groupedTables = computed<Array<{ type: string; names: string[] }>>(() => {
-  const aj = (props.toolExecution as any)?.arguments_json || {}
-  if (!Array.isArray(aj.tables_by_source)) return []
-  const groups: Record<string, string[]> = {}
-  for (const group of aj.tables_by_source) {
-    let connType = 'resource'
-    if (group.data_source_id && props.dataSources?.length) {
-      const ds = props.dataSources.find((d) => d.id === group.data_source_id)
-      if (ds) {
-        connType = ds.connections?.[0]?.type || ds.type || ds.data_source_type || 'resource'
-      }
-    }
-    if (!groups[connType]) groups[connType] = []
-    if (Array.isArray(group.tables)) {
-      groups[connType].push(...group.tables)
-    }
-  }
-  return Object.entries(groups).map(([type, names]) => ({ type, names }))
-})
+const groupedTables = computed<ToolTableGroup[]>(() =>
+  groupToolTables((props.toolExecution as any)?.arguments_json, props.dataSources)
+)
 
 // Hide the data preview by default for small table results (< 10 rows).
 // The agent describes these in its text answer, so the inline table is

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -27,7 +27,7 @@
                 />
                 <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
               </span>
-              <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
+              <UTooltip v-if="group.more" :text="group.moreTitle"><span class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span></UTooltip>
             </span>
           </template>
         </span>

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -27,7 +27,7 @@
                 />
                 <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
               </span>
-              <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
+              <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
             </span>
           </template>
         </span>

--- a/frontend/components/tools/InspectDataTool.vue
+++ b/frontend/components/tools/InspectDataTool.vue
@@ -24,7 +24,7 @@
                     />
                     <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
-                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
+                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
                 </span>
               </template>
             </span>
@@ -49,7 +49,7 @@
                     />
                     <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
-                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
+                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
                 </span>
               </template>
             </span>

--- a/frontend/components/tools/InspectDataTool.vue
+++ b/frontend/components/tools/InspectDataTool.vue
@@ -14,16 +14,17 @@
               <template v-for="(group, gidx) in groupedTables" :key="gidx">
                 <span v-if="gidx > 0" class="text-gray-300 dark:text-gray-600">|</span>
                 <DataSourceIcon :type="group.type" class="h-2" />
-                <span class="inline-flex items-center flex-wrap">
-                  <span v-for="(nm, nidx) in group.names" :key="nidx" class="inline-flex items-center">
+                <span class="inline-flex items-center flex-wrap" :title="group.title">
+                  <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                     <UIcon
                       v-if="isCached(nm)"
                       name="heroicons-bolt"
                       class="w-2.5 h-2.5 me-0.5 text-amber-500 flex-shrink-0"
                       title="Cached locally — this read did not query the source"
                     />
-                    <span>{{ nm }}</span><span v-if="nidx < group.names.length - 1">,&nbsp;</span>
+                    <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
+                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
                 </span>
               </template>
             </span>
@@ -38,16 +39,17 @@
               <template v-for="(group, gidx) in groupedTables" :key="gidx">
                 <span v-if="gidx > 0" class="text-gray-300 dark:text-gray-600">|</span>
                 <DataSourceIcon :type="group.type" class="h-2.5" />
-                <span class="inline-flex items-center flex-wrap">
-                  <span v-for="(nm, nidx) in group.names" :key="nidx" class="inline-flex items-center">
+                <span class="inline-flex items-center flex-wrap" :title="group.title">
+                  <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                     <UIcon
                       v-if="isCached(nm)"
                       name="heroicons-bolt"
                       class="w-2.5 h-2.5 me-0.5 text-amber-500 flex-shrink-0"
                       title="Cached locally — this read did not query the source"
                     />
-                    <span>{{ nm }}</span><span v-if="nidx < group.names.length - 1">,&nbsp;</span>
+                    <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
+                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span>
                 </span>
               </template>
             </span>
@@ -132,6 +134,7 @@
 
 <script setup lang="ts">
 import { useCachedTableNames } from '~/composables/useFastTable'
+import { groupToolTables, type ToolTableGroup } from '~/composables/useToolTables'
 import { computed, ref } from 'vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import Spinner from '~/components/Spinner.vue'
@@ -231,27 +234,9 @@ const executedOnCache = computed(() => {
 })
 const isCached = (n: string) => isCachedTable(n) || executedOnCache.value
 
-const groupedTables = computed<Array<{ type: string; names: string[] }>>(() => {
-  const aj = props.toolExecution?.arguments_json || {}
-  if (!Array.isArray(aj.tables_by_source)) return []
-
-  const groups: Record<string, string[]> = {}
-  for (const group of aj.tables_by_source) {
-    let connType = 'resource'
-    if (group.data_source_id && props.dataSources?.length) {
-      const ds = props.dataSources.find((d) => d.id === group.data_source_id)
-      if (ds) {
-        connType = ds.connections?.[0]?.type || ds.type || ds.data_source_type || 'resource'
-      }
-    }
-    if (!groups[connType]) groups[connType] = []
-    if (Array.isArray(group.tables)) {
-      groups[connType].push(...group.tables)
-    }
-  }
-
-  return Object.entries(groups).map(([type, names]) => ({ type, names }))
-})
+const groupedTables = computed<ToolTableGroup[]>(() =>
+  groupToolTables(props.toolExecution?.arguments_json, props.dataSources)
+)
 
 function toggleExpanded() {
   if (status.value !== 'running') {

--- a/frontend/components/tools/InspectDataTool.vue
+++ b/frontend/components/tools/InspectDataTool.vue
@@ -24,7 +24,7 @@
                     />
                     <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
-                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
+                  <UTooltip v-if="group.more" :text="group.moreTitle"><span class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span></UTooltip>
                 </span>
               </template>
             </span>
@@ -49,7 +49,7 @@
                     />
                     <span>{{ nm }}</span><span v-if="nidx < group.visible.length - 1">,&nbsp;</span>
                   </span>
-                  <span v-if="group.more" class="text-gray-400 dark:text-gray-500 cursor-help" :title="group.moreTitle">&nbsp;+{{ group.more }}</span>
+                  <UTooltip v-if="group.more" :text="group.moreTitle"><span class="text-gray-400 dark:text-gray-500">&nbsp;+{{ group.more }}</span></UTooltip>
                 </span>
               </template>
             </span>

--- a/frontend/composables/useToolTables.ts
+++ b/frontend/composables/useToolTables.ts
@@ -10,6 +10,7 @@ export interface ToolTableGroup {
   visible: string[]    // first MAX_VISIBLE_TABLES names for the ticker line
   more: number         // how many names were truncated (0 = none)
   title: string        // full comma-joined list for :title
+  moreTitle: string    // the truncated names — hover tooltip for the "+N" chip
 }
 
 export const MAX_VISIBLE_TABLES = 3
@@ -44,13 +45,18 @@ export function groupToolTables(
     }
   }
 
-  return Object.entries(groups).map(([type, names]) => ({
-    type,
-    names,
+  return Object.entries(groups).map(([type, names]) => {
     // Truncate per source group. When exactly one name would be hidden,
     // just show it — "+1" costs the same width as the name it hides.
-    visible: names.length > maxVisible + 1 ? names.slice(0, maxVisible) : names,
-    more: names.length > maxVisible + 1 ? names.length - maxVisible : 0,
-    title: names.join(', '),
-  }))
+    const truncate = names.length > maxVisible + 1
+    const visible = truncate ? names.slice(0, maxVisible) : names
+    return {
+      type,
+      names,
+      visible,
+      more: truncate ? names.length - maxVisible : 0,
+      title: names.join(', '),
+      moreTitle: truncate ? names.slice(maxVisible).join(', ') : '',
+    }
+  })
 }

--- a/frontend/composables/useToolTables.ts
+++ b/frontend/composables/useToolTables.ts
@@ -1,0 +1,56 @@
+// Shared table-list display logic for data tools (InspectDataTool,
+// CreateDataTool). Groups the planner's `tables_by_source` argument by
+// connection type and truncates long lists for the one-line ticker —
+// "applications, tiers +6" instead of ten wrapping names. The full list
+// stays reachable via the group's `title` tooltip.
+
+export interface ToolTableGroup {
+  type: string
+  names: string[]      // full list (tooltip / expanded views)
+  visible: string[]    // first MAX_VISIBLE_TABLES names for the ticker line
+  more: number         // how many names were truncated (0 = none)
+  title: string        // full comma-joined list for :title
+}
+
+export const MAX_VISIBLE_TABLES = 3
+
+interface DataSourceLike {
+  id: string
+  type?: string
+  data_source_type?: string
+  connections?: Array<{ id: string; type: string }>
+}
+
+export function groupToolTables(
+  argumentsJson: any,
+  dataSources?: DataSourceLike[],
+  maxVisible: number = MAX_VISIBLE_TABLES,
+): ToolTableGroup[] {
+  const aj = argumentsJson || {}
+  if (!Array.isArray(aj.tables_by_source)) return []
+
+  const groups: Record<string, string[]> = {}
+  for (const group of aj.tables_by_source) {
+    let connType = 'resource'
+    if (group.data_source_id && dataSources?.length) {
+      const ds = dataSources.find((d) => d.id === group.data_source_id)
+      if (ds) {
+        connType = ds.connections?.[0]?.type || ds.type || ds.data_source_type || 'resource'
+      }
+    }
+    if (!groups[connType]) groups[connType] = []
+    if (Array.isArray(group.tables)) {
+      groups[connType].push(...group.tables)
+    }
+  }
+
+  return Object.entries(groups).map(([type, names]) => ({
+    type,
+    names,
+    // Truncate per source group. When exactly one name would be hidden,
+    // just show it — "+1" costs the same width as the name it hides.
+    visible: names.length > maxVisible + 1 ? names.slice(0, maxVisible) : names,
+    more: names.length > maxVisible + 1 ? names.length - maxVisible : 0,
+    title: names.join(', '),
+  }))
+}


### PR DESCRIPTION
## Summary

Follow-ups to #987, motivated by production logs/screenshots from real usage:

1. **HTTP keep-alive via one shared `requests.Session`** (AppDynamics client) — bare `requests.get/post` opened a fresh HTTPS connection per REST call (~700ms TLS handshake each against a SaaS controller).
2. **Applications-list cache, 30s TTL** (AppDynamics client) — every `execute_query` resolved applications first, so multi-table inspects paid one redundant `GET /rest/applications` per query. `test_connection` still probes fresh.
3. **Truncated table lists in Inspect/CreateData tool tickers** (frontend) — the one-line status printed every table name; an 8-table AppDynamics inspect wrapped into a paragraph. Now shows the first 3 names per source group + "+N" (full list in the tooltip; "+1" is skipped when showing the name costs the same width). The duplicated `tables_by_source` grouping logic in the two components is extracted into a shared `useToolTables` composable.

**Client perf measured live against a real SaaS controller (26.7.0, two applications, 10 tiers):**
- schema discovery + service-map enrichment: **30s → 2.6s**
- 5-table estate-wide inspect: **~16s → 3.6s**

## Testing

- `tests/unit/test_appdynamics_client.py`: **26 passed** — incl. a single-session regression test and an app-cache test (one fetch within TTL, refetch after expiry).
- Live timing verified against the seeded trial controller (numbers above).
- Frontend: Nuxt dev server compiles the changed components cleanly; display logic is a pure computed over the same `tables_by_source` payload (no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzJx5YMAqwG1LiXqWKKYMU