### PR TITLE
Catalog sync: stop force-disabling ex-catalog models on customer providers

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -2260,14 +2260,23 @@ class LLMService:
             model_data = catalog_by_id.get(model.model_id)
             if not model.is_preset:
                 continue
-            # Preset row whose id left the catalog: the provider retired the
-            # model, so every call to it is a permanent 404 that no retry or
-            # fallback can heal. Disable it and surrender the default flags —
-            # the promotion below then moves the org onto the catalog's current
-            # default instead of leaving it pinned to a dead id. Custom models
-            # (skipped above) stay untouched; the row itself is kept so history
-            # and usage records still resolve.
+            # Preset row whose id left the catalog. On a BOW-managed preset
+            # provider the catalog is an exhaustive mirror, so a missing id
+            # means the provider retired the model and every call to it is a
+            # permanent 404 that no retry or fallback can heal: disable it and
+            # surrender the default flags — the promotion below then moves the
+            # org onto the catalog's current default instead of leaving it
+            # pinned to a dead id. On a customer-managed provider the catalog
+            # is only a curated subset — ids that fell out of it (e.g. older
+            # dated Anthropic snapshots) are usually still perfectly valid at
+            # the provider, and force-disabling them on every models-list load
+            # would silently revert the admin's enable toggle forever. Leave
+            # those rows exactly as the admin set them. Custom models (skipped
+            # above) stay untouched; the row itself is kept so history and
+            # usage records still resolve.
             if not model_data:
+                if customer_managed:
+                    continue
                 model.is_enabled = False
                 model.is_default = False
                 model.is_small_default = False

--- a/backend/tests/e2e/test_llm_catalog_autoadd.py
+++ b/backend/tests/e2e/test_llm_catalog_autoadd.py
@@ -11,6 +11,9 @@ Proves, for a customer-managed (non-preset) provider:
   * the org's default/small-default stay exactly where the admin put them,
   * a model the admin soft-deleted is a tombstone — never resurrected,
   * a model the admin disabled stays disabled (no enabled-state sync),
+  * a preset row whose model id is no longer in the catalog (e.g. an older
+    dated Anthropic snapshot) keeps the admin's enabled/default choices —
+    the sync must not force-disable it on every models-list load,
   * provider types with no catalog entries (the OpenAI-compatible "custom"
     type) are left completely untouched.
 
@@ -193,3 +196,102 @@ def test_deleted_and_disabled_choices_survive_resync(
     models = _by_id(get_models(token, org_id))
     assert victim not in models
     assert models[disabled]["is_enabled"] is False
+
+
+# A preset model id that used to ship in the catalog but no longer does —
+# still a perfectly valid id at the provider, just not curated any more.
+EX_CATALOG_MODEL_ID = "claude-opus-4-6"
+assert EX_CATALOG_MODEL_ID not in {m["model_id"] for m in LLM_MODEL_DETAILS}
+
+
+async def _seed_ex_catalog_model(org_id, provider_id, enabled):
+    async with async_session_maker() as db:
+        db.add(LLMModel(
+            organization_id=org_id,
+            provider_id=provider_id,
+            name="Claude 4.6 Opus",
+            model_id=EX_CATALOG_MODEL_ID,
+            is_preset=True,
+            is_enabled=enabled,
+            context_window_tokens=200_000,
+        ))
+        await db.commit()
+
+
+@pytest.mark.e2e
+def test_ex_catalog_model_keeps_admin_toggle_on_customer_provider(
+    create_user, login_user, whoami, get_models, test_client
+):
+    """A preset row whose id fell out of the curated catalog stays exactly as
+    the admin set it on a customer-managed provider. Before the fix the sync
+    force-disabled it on every GET /llm/models, so enabling it through the UI
+    silently reverted ("Could not update model" for the customer)."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+    headers = {"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)}
+
+    provider_id = _run(_seed_customer_anthropic(org_id))
+    _run(_seed_ex_catalog_model(org_id, provider_id, enabled=False))
+
+    # The sync leaves the disabled ex-catalog row disabled...
+    models = _by_id(get_models(token, org_id))
+    assert models[EX_CATALOG_MODEL_ID]["is_enabled"] is False
+
+    # ...and the admin can enable it, and the choice SURVIVES the next syncs.
+    resp = test_client.post(
+        f"/api/llm/models/{models[EX_CATALOG_MODEL_ID]['id']}/toggle",
+        params={"enabled": True},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    for _ in range(2):
+        models = _by_id(get_models(token, org_id))
+        assert models[EX_CATALOG_MODEL_ID]["is_enabled"] is True, (
+            "sync force-disabled an ex-catalog model the admin enabled"
+        )
+
+    # It can also be made the org default, and the default sticks.
+    resp = test_client.post(
+        f"/api/llm/models/{models[EX_CATALOG_MODEL_ID]['id']}/set_default",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    models = _by_id(get_models(token, org_id))
+    assert models[EX_CATALOG_MODEL_ID]["is_default"] is True, (
+        "sync re-pointed the org default away from an ex-catalog model"
+    )
+
+
+@pytest.mark.e2e
+def test_ex_catalog_model_still_disabled_on_preset_provider(
+    create_user, login_user, whoami, get_models, test_client
+):
+    """On a BOW-managed preset provider the catalog IS exhaustive, so a row
+    whose id left it really is retired: the sync keeps disabling it."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    async def _seed_preset_anthropic():
+        async with async_session_maker() as db:
+            provider = LLMProvider(
+                organization_id=org_id,
+                name="claude",
+                provider_type="anthropic",
+                is_preset=True,
+                is_enabled=True,
+                use_preset_credentials=True,
+            )
+            db.add(provider)
+            await db.flush()
+            await db.commit()
+            return str(provider.id)
+
+    provider_id = _run(_seed_preset_anthropic())
+    _run(_seed_ex_catalog_model(org_id, provider_id, enabled=True))
+
+    models = _by_id(get_models(token, org_id))
+    assert models[EX_CATALOG_MODEL_ID]["is_enabled"] is False, (
+        "retired model on a preset provider was not disabled by the sync"
+    )

--- a/frontend/components/LLMsComponent.vue
+++ b/frontend/components/LLMsComponent.vue
@@ -677,6 +677,12 @@ const openAddProvider = () => {
     providerModalOpen.value = true;
 };
 
+const updateErrorDetail = (response: any): string => {
+    const errAny = (response.error as any);
+    const err = (errAny && (errAny.value || errAny)) || {};
+    return String(err?.data?.detail || err?.data?.message || err?.message || 'Could not update model');
+};
+
 const setDefaultModel = async (modelId: string, small = false) => {
     const response = await useMyFetch(`/llm/models/${modelId}/set_default`, {
         method: 'POST',
@@ -693,7 +699,7 @@ const setDefaultModel = async (modelId: string, small = false) => {
     else {
         toast.add({
             title: 'Error',
-            description: 'Could not update model',
+            description: updateErrorDetail(response),
             color: 'red'
         });
     }
@@ -713,9 +719,12 @@ const toggleModel = async (modelId: string, enabled: boolean) => {
         });
     }
     else {
+        // Refresh so the toggle reflects the server's actual state instead of
+        // staying flipped on a rejected change.
+        await getModels();
         toast.add({
             title: 'Error',
-            description: 'Could not update model',
+            description: updateErrorDetail(response),
             color: 'red'
         });
     }


### PR DESCRIPTION
Customers could not update their models: on bring-your-own-key providers,
every GET /llm/models re-disabled any preset model whose id is no longer
in the curated catalog (e.g. dated Anthropic snapshots like
claude-opus-4-5-20251101 or claude-sonnet-4-6). Enabling such a model
appeared to work and then silently reverted on the very next models-list
load, and setting it as default failed with the generic 'Could not update
model' toast.

The retirement force-disable assumed a missing catalog id means the
provider retired the model. That holds for BOW-managed preset providers,
where the catalog is an exhaustive mirror, but the catalog is only a
curated subset of what a customer's own API key can reach — so on
customer-managed providers the admin's enabled/default choices now stand
for ex-catalog rows, matching the sync's existing 'admin choices win'
semantics. Preset providers keep disabling truly retired ids.

Also surface the backend's error detail in the toggle/set-default toasts
(instead of the fixed generic message) and refresh the list on a rejected
toggle so the switch doesn't stay flipped client-side.

e2e: an ex-catalog model on a customer provider keeps an admin-set enable
across repeated syncs and can be made default; on a preset provider it is
still disabled. The new customer-provider test fails on the previous sync
behavior.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JjyNSzPQNwDU77zb8reHvK