### PR TITLE
CreateData: never attach defaultFilters to table views

### DIFF
--- a/backend/app/ai/tools/implementations/create_data.py
+++ b/backend/app/ai/tools/implementations/create_data.py
@@ -647,7 +647,12 @@ def build_view_from_data_model(
         return ViewSchema(view=view)
 
     if chart_type == "table":
-        view = TableView(title=title, defaultFilters=default_filters)
+        # No defaultFilters on tables: the query already returned exactly the
+        # rows to show, and the inference pass's row-narrowing filters exist to
+        # pick the one row a single-value card renders. Attached to a table
+        # they silently hide rows (e.g. 1 of 31 shown) with no way to undo it
+        # from the filter UI.
+        view = TableView(title=title)
         return ViewSchema(view=view)
 
     # Presentation formatting for single-value cards (validated upstream by

--- a/backend/tests/unit/test_create_data_card_guard.py
+++ b/backend/tests/unit/test_create_data_card_guard.py
@@ -286,6 +286,31 @@ class TestDisplayFormatting:
         assert out["type"] == "metric_card"
         assert out["display"] == {"format": "currency", "currency": "ILS"}
 
+    def test_table_view_never_carries_default_filters(self):
+        # Inference-emitted row-narrowing filters are a single-value-card
+        # mechanism; on a table they'd hide rows the query deliberately
+        # returned (e.g. 1 of 31 shown, un-clearable from the filter UI).
+        dm = {
+            "type": "table",
+            "series": [],
+            "filters": [{"column": "פרויקט", "operator": "equals", "value": "P404"}],
+        }
+        view = build_view_from_data_model(dm, title="t", palette_theme="default")
+        v = view.model_dump(exclude_none=True)["view"]
+        assert v.get("defaultFilters", []) == []
+
+    def test_metric_card_view_keeps_default_filters(self):
+        dm = {
+            "type": "metric_card",
+            "series": [{"name": "Revenue", "value": "ערך"}],
+            "filters": [{"column": "מדד", "operator": "equals", "value": "מכר"}],
+        }
+        view = build_view_from_data_model(dm, title="t", palette_theme="default")
+        v = view.model_dump(exclude_none=True)["view"]
+        assert v["defaultFilters"] == [
+            {"column": "מדד", "operator": "equals", "value": "מכר"}
+        ]
+
     def test_invalid_display_ignored_by_view_builder(self):
         dm = {
             "type": "metric_card",

--- a/frontend/components/dashboard/regular/RegularWidgetView.vue
+++ b/frontend/components/dashboard/regular/RegularWidgetView.vue
@@ -83,6 +83,18 @@ function handleFilterUpdate(ev: Event) {
 
 onMounted(() => {
   window.addEventListener('filter:updated', handleFilterUpdate)
+
+  // Defaults seeded during setup were broadcast before this component's
+  // children (the filter popover) registered their listeners, so that event
+  // was lost and the popover showed "No filters applied" over filtered rows.
+  // Re-broadcast once now that children have mounted.
+  if (filters.value.length > 0) {
+    try {
+      window.dispatchEvent(new CustomEvent('filter:updated', {
+        detail: { reportId: reportId.value, filters: filters.value, source: filterInstanceId }
+      }))
+    } catch {}
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/components/tools/ToolWidgetPreview.vue
+++ b/frontend/components/tools/ToolWidgetPreview.vue
@@ -374,7 +374,6 @@ import VisualizationFilter from '@/components/dashboard/VisualizationFilter.vue'
 import {
   parseColumnKey,
   evaluateFilters as sharedEvaluateFilters,
-  evaluateOperator,
   type FilterGroup
 } from '~/composables/useSharedFilters'
 
@@ -526,24 +525,15 @@ const activeFilterCount = computed(() => {
   return count
 })
 
-// Apply shared filters to get filtered rows
+// Apply shared filters to get filtered rows. The view's defaultFilters are NOT
+// applied directly here: they reach this computed only through the seeded
+// shared-filter state (seedDefaultFiltersFromView), so the filter popover shows
+// them and Clear/removing the condition actually restores the rows. First-paint
+// correctness for single-value cards is preserved because the seed watcher runs
+// synchronously (immediate) during setup, before the first render.
 const filteredRows = computed(() => {
-  let rows = effectiveStep.value?.data?.rows
+  const rows = effectiveStep.value?.data?.rows
   if (!Array.isArray(rows)) return []
-
-  // Apply the view's own defaultFilters directly. The standalone preview has no
-  // dashboard shared-filter pipeline guaranteed to be ready on first paint, so
-  // relying solely on the seeded shared filters races: a single-value card over
-  // a melted/long KPI table (Metric | Value | Format) would otherwise render
-  // row 0 / a sum of every metric instead of the asked-for row. Dashboards do
-  // not use this component (they filter rows upstream), so this is safe and does
-  // not interfere with user-overridable shared filters there.
-  const v = normalizedView.value as any
-  const viewInner = v?.view || v
-  const defaults = Array.isArray(viewInner?.defaultFilters) ? viewInner.defaultFilters : []
-  if (defaults.length) {
-    rows = rows.filter((row: any) => defaults.every((f: any) => matchDefaultFilter(row, f)))
-  }
 
   if (sharedFilters.value.length === 0 || !visualizationId.value) return rows
 
@@ -551,16 +541,6 @@ const filteredRows = computed(() => {
     sharedEvaluateFilters(row, sharedFilters.value, visualizationId.value)
   )
 })
-
-// Lightweight evaluator for a view's plain-column defaultFilters (no vizId
-// prefix). Delegates to the shared operator semantics so default filters and
-// user filters agree on whitespace/number/case normalization.
-function matchDefaultFilter(row: any, f: any): boolean {
-  if (!row || !f || !f.column) return true
-  const key = Object.keys(row).find(k => k.toLowerCase() === String(f.column).toLowerCase())
-  if (key === undefined) return true
-  return evaluateOperator(row[key], String(f.operator || 'equals'), f.value, f.value2)
-}
 
 // Normalize the view to ensure it's in the v2 format { view: {...}, version: 'v2' }
 const normalizedView = computed(() => {
@@ -580,10 +560,24 @@ const normalizedView = computed(() => {
 // seed once per viz id so clearing filters doesn't re-seed.
 // ------------------------------------------------------------------
 const seededDefaultsFor = ref<Set<string>>(new Set())
+const lastSeededVizId = ref<string | null>(null)
 
 function seedDefaultFiltersFromView() {
   const vizId = visualizationId.value
   if (!vizId || seededDefaultsFor.value.has(vizId)) return
+
+  // The visualization id can change after hydration (synthetic `viz-<id>`
+  // fallback -> real visualization id). Drop the conditions we seeded under the
+  // previous id so they don't linger as ghost state nobody can see or remove.
+  if (lastSeededVizId.value && lastSeededVizId.value !== vizId) {
+    const staleId = lastSeededVizId.value
+    sharedFilters.value = sharedFilters.value
+      .map(g => ({
+        ...g,
+        conditions: g.conditions.filter(c => parseColumnKey(c.column).vizId !== staleId)
+      }))
+      .filter(g => g.conditions.length > 0)
+  }
 
   const v = normalizedView.value as any
   const viewInner = v?.view || v
@@ -623,6 +617,7 @@ function seedDefaultFiltersFromView() {
   const next = [...sharedFilters.value, group]
   sharedFilters.value = next
   seededDefaultsFor.value.add(vizId)
+  lastSeededVizId.value = vizId
 
   // Broadcast so VisualizationFilter/FilterBuilder receive the seeded state
   try {
@@ -1147,6 +1142,18 @@ function broadcastDefaultStep(step: any) {
 onMounted(() => {
   // Listen for shared filter updates from VisualizationFilter and FilterBuilder
   window.addEventListener('filter:updated', handleSharedFilterUpdate as any)
+
+  // Defaults seeded during setup were broadcast before children (the filter
+  // popover) registered their listeners, so that event was lost. Re-broadcast
+  // once now — children have mounted by the time the parent's onMounted runs —
+  // so the popover shows the seeded conditions and can remove them.
+  if (sharedFilters.value.length > 0) {
+    try {
+      window.dispatchEvent(new CustomEvent('filter:updated', {
+        detail: { reportId: reportId.value, filters: sharedFilters.value, source: filterInstanceId }
+      }))
+    } catch {}
+  }
 
   // Track which viz IDs are in the active artifact (for "Added to Dashboard" state)
   function handleArtifactVizIds(ev: Event) {

--- a/frontend/composables/useSharedFilters.ts
+++ b/frontend/composables/useSharedFilters.ts
@@ -226,22 +226,24 @@ export function evaluateCondition(row: any, condition: FilterCondition, targetVi
 
 export function evaluateFilters(row: any, groups: FilterGroup[], targetVizId?: string): boolean {
   if (!groups.length) return true
-  
-  // Check if any condition applies to this visualization
-  const hasRelevantConditions = groups.some(group =>
-    group.conditions.some(cond => {
-      const { vizId } = parseColumnKey(cond.column)
-      return vizId === targetVizId
-    })
-  )
-  
+
+  // Only groups that actually carry conditions for this visualization take part
+  // in the OR. A group holding solely another viz's conditions would otherwise
+  // evaluate as all-skipped -> true, and one such group ORs every row back in,
+  // silently disabling filtering for every other visualization on the page.
+  const relevantGroups = targetVizId
+    ? groups.filter(group =>
+        group.conditions.some(cond => parseColumnKey(cond.column).vizId === targetVizId)
+      )
+    : groups
+
   // If no conditions apply, don't filter
-  if (targetVizId && !hasRelevantConditions) {
+  if (!relevantGroups.length) {
     return true
   }
-  
+
   // OR across groups, AND within group
-  return groups.some(group =>
+  return relevantGroups.some(group =>
     group.conditions.every(cond => evaluateCondition(row, cond, targetVizId))
   )
 }


### PR DESCRIPTION
Inference-emitted row-narrowing filters exist so a single-value card can
pick the one row it renders. Attached to a table view they silently hide
rows the query deliberately returned (e.g. 1 of 31 shown), and the direct
defaultFilters application in the widget preview cannot be undone from
the filter UI, which still shows 'No filters applied'.

Tables render exactly what the query returned, so the table branch of
build_view_from_data_model now drops defaultFilters. Cards keep them,
validated by ensure_single_value_card_renderable.

Verified in the local sandbox: a seeded 31-row per-project table with an
inference filter in its data_model reproduced the 1/31 symptom with the
old view payload and renders all 31 rows with the fixed builder.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYxeRqVeeyExnBuBW38wbk