### PR TITLE
Add page_range support for PDF reads in GraphDriveClient

### DIFF
--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -18,7 +18,7 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 import httpx
@@ -30,6 +30,7 @@ from app.data_sources.clients._document_text import (
     DOC_EXTS,
     doc_text_is_usable,
     extract_document_text_from_bytes,
+    extract_pdf_pages_text,
 )
 from app.data_sources.clients._file_source_common import (
     GlobScopeError,
@@ -72,6 +73,27 @@ def _ext(name: str) -> str:
     if not name or "." not in name:
         return ""
     return name.rsplit(".", 1)[-1].lower()
+
+
+def _extract_pdf_pages_from_bytes(data: bytes, name: str, first: int, last: int) -> tuple:
+    """Page-range PDF extraction over in-memory Graph bytes via a temp file
+    (the extractor dispatches on filename). Same approach as the S3 client's
+    helper of the same name."""
+    import os
+    import tempfile
+
+    tmp = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as fh:
+            fh.write(data)
+            tmp = fh.name
+        return extract_pdf_pages_text(tmp, first, last)
+    finally:
+        if tmp:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
 
 
 def _trim_to_data(df: "pd.DataFrame") -> "pd.DataFrame":
@@ -812,7 +834,14 @@ class GraphDriveClient(DataSourceClient):
             )
         return self._resolve_drive_id(), raw_id
 
-    def read_file(self, file_id: str, sheet: Optional[str] = None, max_bytes: Optional[int] = None, **_) -> Any:
+    def read_file(
+        self,
+        file_id: str,
+        sheet: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+        page_range: Optional[Tuple[int, int]] = None,
+        **_,
+    ) -> Any:
         # Routes to the owning library AND resolves a filename → item id (the
         # LLM frequently passes "Book 7.xlsx" where an opaque id is expected,
         # which Graph rejects with 400).
@@ -828,6 +857,23 @@ class GraphDriveClient(DataSourceClient):
         self._enforce_scope(self._scoped_path(drive_id, (meta.get("parentReference") or {}).get("path"), name))
         ext = _ext(name)
         content = self._get_bytes(f"/drives/{drive_id}/items/{resolved_id}/content")
+
+        # Page-range read for PDFs — same sentinel contract as network_dir/s3.
+        # Graph has no ranged read API for this; the file is already fully
+        # downloaded above, so extraction is the same local pypdf pass those
+        # clients use.
+        if page_range is not None:
+            if ext != "pdf":
+                raise ValueError("page_range is supported for PDF files only.")
+            text, pages_total = _extract_pdf_pages_from_bytes(content, name, page_range[0], page_range[1])
+            return {
+                "__doc_pages__": True,
+                "text": text,
+                "pages_total": pages_total,
+                "first": max(1, page_range[0]),
+                "last": min(page_range[1], pages_total),
+            }
+
         if max_bytes and len(content) > max_bytes:
             content = content[:max_bytes]
 

--- a/backend/tests/unit/test_graph_drive_page_range.py
+++ b/backend/tests/unit/test_graph_drive_page_range.py
@@ -1,0 +1,62 @@
+"""SharePoint/OneDrive (Graph) reads must support page_range for PDFs, the
+same as the S3 and network_dir clients.
+
+Before this fix, GraphDriveClient.read_file accepted (and silently dropped)
+a page_range kwarg via **_, even though it already downloads the full file
+body before doing anything else — the same shape S3/network_dir use before
+slicing out pages with pypdf. The read_file tool's generic fallback then
+reported "This connection does not support page_range reads.", which read
+as a platform limitation of SharePoint/Graph rather than an unwired code
+path.
+
+Run:
+    cd backend && python -m pytest tests/unit/test_graph_drive_page_range.py -v
+"""
+import pytest
+
+from app.data_sources.clients.graph_drive_client import GraphDriveClient
+from tests.unit.test_pdf_surrogate_sanitization import build_multipage_pdf
+
+SITE = "contoso.sharepoint.com,site-guid,web-guid"
+PAGES = ["UNIQUE-A", "UNIQUE-B", "UNIQUE-C"]
+
+
+def _client():
+    c = GraphDriveClient(
+        site_url="https://contoso.sharepoint.com/sites/hr",
+        mode="sharepoint", access_token="tok",
+    )
+    c._site_id = SITE
+
+    def _get(path, **_ignored):
+        if path == f"/sites/{SITE}/drive":
+            return {"id": "drv-docs", "name": "Documents"}
+        if path == "/drives/drv-docs/items/p1":
+            return {
+                "id": "p1", "name": "handbook.pdf",
+                "file": {"mimeType": "application/pdf"},
+                "parentReference": {"path": "/drives/drv-docs/root:"},
+            }
+        raise ValueError(f"Graph {path} → 404 not found")
+
+    c._get = _get
+    c._get_bytes = lambda path: build_multipage_pdf(PAGES)
+    return c
+
+
+def test_graph_drive_page_range_read():
+    paged = _client().read_file("p1", page_range=(2, 3))
+    assert paged["__doc_pages__"] is True
+    assert paged["pages_total"] == 3
+    assert "UNIQUE-B" in paged["text"] and "UNIQUE-C" in paged["text"]
+    assert "UNIQUE-A" not in paged["text"]
+
+
+def test_graph_drive_page_range_rejected_for_non_pdf():
+    c = _client()
+    c._get = lambda path, **_ignored: {
+        "id": "x1", "name": "notes.txt", "file": {"mimeType": "text/plain"},
+        "parentReference": {"path": "/drives/drv-docs/root:"},
+    } if path == "/drives/drv-docs/items/x1" else (_ for _ in ()).throw(ValueError(path))
+    with pytest.raises(ValueError):
+        c.read_file("x1", page_range=(1, 2))


### PR DESCRIPTION
## Summary
Implement page_range parameter support for PDF file reads in GraphDriveClient (SharePoint/OneDrive), bringing feature parity with S3 and network_dir clients.

## Key Changes
- Added `page_range` parameter to `GraphDriveClient.read_file()` method signature
- Implemented `_extract_pdf_pages_from_bytes()` helper function to extract specific pages from in-memory PDF data using a temporary file (matching the approach used by S3 client)
- Added validation to reject page_range requests for non-PDF files
- Returns page-range read results in the same format as other clients: `__doc_pages__`, `text`, `pages_total`, `first`, and `last` fields
- Added comprehensive unit tests covering both successful page-range reads and rejection of non-PDF files

## Implementation Details
- The GraphDriveClient already downloads the full file body before processing, so page extraction uses the same local pypdf approach as S3/network_dir clients
- Page extraction is performed on in-memory bytes via a temporary file since the extraction utility dispatches on filename
- Temporary files are properly cleaned up in a finally block to prevent resource leaks
- The implementation maintains backward compatibility by accepting but ignoring other kwargs via `**_`

https://claude.ai/code/session_017c38v788XiBr8Ksfcpg5c8