### PR TITLE
fix(llm): keep admin-set model pricing across catalog re-syncs

### DIFF
--- a/backend/alembic/versions/pricovr01_add_pricing_override_to_llm_models.py
+++ b/backend/alembic/versions/pricovr01_add_pricing_override_to_llm_models.py
@@ -1,0 +1,37 @@
+"""add pricing override columns to llm_models
+
+Revision ID: pricovr01
+Revises: evalsuitefk01
+Create Date: 2026-08-20 12:00:00.000000
+
+Adds nullable input/output_cost_per_million_tokens_usd_override columns to
+llm_models so admin-set pricing survives catalog re-syncs. NULL means "follow
+the catalog" (LLM_MODEL_DETAILS); a value is an explicit override set through
+the pricing endpoint. The existing input/output_cost_per_million_tokens_usd
+columns stay the resolved values the cost console and Auto-router read —
+previously the models-list catalog sync rewrote them from the catalog on
+every load, silently reverting admin corrections.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'pricovr01'
+down_revision: Union[str, None] = 'evalsuitefk01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('llm_models', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('input_cost_per_million_tokens_usd_override', sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column('output_cost_per_million_tokens_usd_override', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('llm_models', schema=None) as batch_op:
+        batch_op.drop_column('output_cost_per_million_tokens_usd_override')
+        batch_op.drop_column('input_cost_per_million_tokens_usd_override')

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -268,6 +268,12 @@ class LLMModel(BaseSchema):
     # Pricing (USD per million tokens)
     input_cost_per_million_tokens_usd = Column(Float, nullable=True)
     output_cost_per_million_tokens_usd = Column(Float, nullable=True)
+    # Manual admin pricing overrides. NULL = follow the catalog (LLM_MODEL_DETAILS);
+    # a value = admin-set via the pricing endpoint (e.g. a negotiated or corrected
+    # rate), persisted across catalog re-syncs. The two columns above stay the
+    # resolved values the cost console and Auto-router savings math read.
+    input_cost_per_million_tokens_usd_override = Column(Float, nullable=True)
+    output_cost_per_million_tokens_usd_override = Column(Float, nullable=True)
     
     provider_id = Column(String, ForeignKey('llm_providers.id'), nullable=False)
     provider = relationship("LLMProvider", back_populates="models", lazy="selectin")

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1168,9 +1168,13 @@ class LLMService:
         if not model:
             raise HTTPException(status_code=404, detail="Model not found")
 
+        # Store the admin's rate as an override (so catalog re-syncs never
+        # revert it) and as the resolved value everything else reads.
         if input_cost is not None:
+            model.input_cost_per_million_tokens_usd_override = float(input_cost)
             model.input_cost_per_million_tokens_usd = float(input_cost)
         if output_cost is not None:
+            model.output_cost_per_million_tokens_usd_override = float(output_cost)
             model.output_cost_per_million_tokens_usd = float(output_cost)
         await db.commit()
 
@@ -1482,9 +1486,15 @@ class LLMService:
                 if model_details.get("max_output_tokens") is not None:
                     db_model.max_output_tokens = model_details["max_output_tokens"]
                 if model_details.get("input_cost_per_million_tokens_usd") is not None:
-                    db_model.input_cost_per_million_tokens_usd = model_details["input_cost_per_million_tokens_usd"]
+                    db_model.input_cost_per_million_tokens_usd = self._resolve_cost(
+                        db_model.input_cost_per_million_tokens_usd_override,
+                        model_details["input_cost_per_million_tokens_usd"],
+                    )
                 if model_details.get("output_cost_per_million_tokens_usd") is not None:
-                    db_model.output_cost_per_million_tokens_usd = model_details["output_cost_per_million_tokens_usd"]
+                    db_model.output_cost_per_million_tokens_usd = self._resolve_cost(
+                        db_model.output_cost_per_million_tokens_usd_override,
+                        model_details["output_cost_per_million_tokens_usd"],
+                    )
                 db_model.supports_vision = self._resolve_supports_vision(
                     vision_override, model_details.get("supports_vision", False)
                 )
@@ -1716,9 +1726,15 @@ class LLMService:
                         if catalog.get("max_output_tokens") is not None:
                             db_model.max_output_tokens = catalog["max_output_tokens"]
                         if catalog.get("input_cost_per_million_tokens_usd") is not None:
-                            db_model.input_cost_per_million_tokens_usd = catalog["input_cost_per_million_tokens_usd"]
+                            db_model.input_cost_per_million_tokens_usd = self._resolve_cost(
+                                db_model.input_cost_per_million_tokens_usd_override,
+                                catalog["input_cost_per_million_tokens_usd"],
+                            )
                         if catalog.get("output_cost_per_million_tokens_usd") is not None:
-                            db_model.output_cost_per_million_tokens_usd = catalog["output_cost_per_million_tokens_usd"]
+                            db_model.output_cost_per_million_tokens_usd = self._resolve_cost(
+                                db_model.output_cost_per_million_tokens_usd_override,
+                                catalog["output_cost_per_million_tokens_usd"],
+                            )
                     catalog_vision = catalog.get("supports_vision", False) if catalog else db_model.supports_vision
                     db_model.supports_vision = self._resolve_supports_vision(
                         db_model.supports_vision_override, catalog_vision
@@ -2191,6 +2207,13 @@ class LLMService:
         return catalog_value
 
     @staticmethod
+    def _resolve_cost(override, catalog_value):
+        """Effective per-million-token USD cost: a non-null admin override always wins over the catalog."""
+        if override is not None:
+            return float(override)
+        return catalog_value
+
+    @staticmethod
     def _apply_catalog_model_details(model: LLMModel, model_data: dict, *, sync_enabled: bool = False) -> None:
         model.name = model_data["name"]
         model.is_preset = model_data.get("is_preset", True)
@@ -2208,8 +2231,15 @@ class LLMService:
         )
         if "max_output_tokens" in model_data:
             model.max_output_tokens = model_data.get("max_output_tokens")
-        model.input_cost_per_million_tokens_usd = model_data.get("input_cost_per_million_tokens_usd")
-        model.output_cost_per_million_tokens_usd = model_data.get("output_cost_per_million_tokens_usd")
+        # Same for pricing: an admin-corrected rate survives catalog re-syncs.
+        model.input_cost_per_million_tokens_usd = LLMService._resolve_cost(
+            getattr(model, "input_cost_per_million_tokens_usd_override", None),
+            model_data.get("input_cost_per_million_tokens_usd"),
+        )
+        model.output_cost_per_million_tokens_usd = LLMService._resolve_cost(
+            getattr(model, "output_cost_per_million_tokens_usd_override", None),
+            model_data.get("output_cost_per_million_tokens_usd"),
+        )
 
     async def _sync_provider_with_latest_models(
         self,

--- a/backend/tests/unit/test_llm_pricing_override.py
+++ b/backend/tests/unit/test_llm_pricing_override.py
@@ -1,0 +1,80 @@
+"""Admin-set model pricing must survive catalog re-syncs.
+
+The models-list endpoint syncs every catalog-type provider on each load and
+refreshes preset rows from LLM_MODEL_DETAILS. Pricing set through the pricing
+endpoint is stored as an override that wins over the catalog value, mirroring
+supports_vision_override / context_window_tokens_override.
+"""
+import app.models  # noqa: F401  (register every mapper before instantiating)
+from app.models.llm_model import LLMModel
+from app.services.llm_service import LLMService
+
+
+CATALOG_ENTRY = {
+    "name": "Claude 4.5 Haiku",
+    "model_id": "claude-haiku-4-5-20251001",
+    "is_preset": True,
+    "is_enabled": True,
+    "supports_vision": True,
+    "context_window_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_million_tokens_usd": 1,
+    "output_cost_per_million_tokens_usd": 5.00,
+}
+
+
+def _preset_model(**overrides) -> LLMModel:
+    model = LLMModel(
+        name="Claude 4.5 Haiku",
+        model_id="claude-haiku-4-5-20251001",
+        is_preset=True,
+        is_enabled=True,
+    )
+    for key, value in overrides.items():
+        setattr(model, key, value)
+    return model
+
+
+def test_resolve_cost_prefers_override():
+    assert LLMService._resolve_cost(3.33, 1) == 3.33
+    assert LLMService._resolve_cost(0.0, 1) == 0.0
+    assert LLMService._resolve_cost(None, 1) == 1
+    assert LLMService._resolve_cost(None, None) is None
+
+
+def test_catalog_sync_without_override_follows_catalog():
+    model = _preset_model(
+        input_cost_per_million_tokens_usd=999.0,
+        output_cost_per_million_tokens_usd=999.0,
+    )
+
+    LLMService._apply_catalog_model_details(model, CATALOG_ENTRY)
+
+    assert model.input_cost_per_million_tokens_usd == 1
+    assert model.output_cost_per_million_tokens_usd == 5.00
+
+
+def test_catalog_sync_preserves_admin_pricing_override():
+    model = _preset_model(
+        input_cost_per_million_tokens_usd=3.33,
+        output_cost_per_million_tokens_usd=9.99,
+        input_cost_per_million_tokens_usd_override=3.33,
+        output_cost_per_million_tokens_usd_override=9.99,
+    )
+
+    LLMService._apply_catalog_model_details(model, CATALOG_ENTRY)
+
+    assert model.input_cost_per_million_tokens_usd == 3.33
+    assert model.output_cost_per_million_tokens_usd == 9.99
+
+
+def test_catalog_sync_respects_partial_override():
+    model = _preset_model(
+        input_cost_per_million_tokens_usd=4.0,
+        input_cost_per_million_tokens_usd_override=4.0,
+    )
+
+    LLMService._apply_catalog_model_details(model, CATALOG_ENTRY)
+
+    assert model.input_cost_per_million_tokens_usd == 4.0
+    assert model.output_cost_per_million_tokens_usd == 5.00


### PR DESCRIPTION
## Summary

Admin-set model pricing (`POST /api/llm/models/{id}/pricing`) was silently reverted to catalog values on the next models-list load. `GET /api/llm/models` runs a catalog sync per provider, and `_apply_catalog_model_details` unconditionally rewrote `input/output_cost_per_million_tokens_usd` from `LLM_MODEL_DETAILS`. This has been failing `tests/e2e/rbac/test_auto_model_routing.py::test_pricing_set_persists_and_rejects_negative` on main (both sqlite and postgres CI jobs) since the catalog sync was extended to customer-created providers (#990/#991) — previously the sync ran only for preset providers, so the test's customer provider never got stomped.

Beyond the test: the reverted prices also silently corrupt the cost console and Auto-router savings math those fields feed, with the API confirming a value that then vanishes.

## The fix

Follow the existing convention for admin overrides that survive catalog re-syncs (`supports_vision_override`, `context_window_tokens_override`):

- New nullable columns `input_cost_per_million_tokens_usd_override` / `output_cost_per_million_tokens_usd_override` on `llm_models` (migration `pricovr01`, batch-alter, downgrade included). NULL = follow the catalog; a value = admin-set.
- `set_pricing` writes the override plus the resolved value everything else reads.
- A `_resolve_cost` helper applies override-over-catalog at every sync path that refreshes preset pricing: `_apply_catalog_model_details` (the models-list sync — the regression) and the two provider-update paths.

## Verification

- Red→green: `test_pricing_set_persists_and_rejects_negative` fails on base (`assert 1.0 == 3.33`), passes with the fix; the full `test_auto_model_routing.py` file passes (14/14).
- New unit tests (`tests/unit/test_llm_pricing_override.py`): override wins, no-override follows catalog, partial override, `0.0` respected as an explicit override.
- LLM regression surface green: `test_llm_catalog_autoadd`, `test_llm_context_window_override`, `test_llm_vision_toggle`, `test_llm_temperature_override`, `test_model_router`, `test_console_metrics`, `test_rbac_llm_models`, `test_report_default_llm_model`, `test_user_default_llm_model` (71 passed; the 5 `test_llm_providers.py` failures require a real `OPENAI_API_KEY_TEST` and fail identically without this change).
- Alembic upgrade/downgrade round-trip verified on sqlite.

No backfill: pre-existing admin-set prices are indistinguishable from catalog-stomped values (the bug reverted them on every list load anyway), so overrides start taking effect from the next admin edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWmUi8saYqwNY7paYJbVLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWmUi8saYqwNY7paYJbVLr)_