### PR TITLE
fix(agent): bound completion checklist reviews

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -362,6 +362,7 @@ from app.ai.run_control import (
     apply_failure_strategy_policy,
     evaluate_completion_gate,
     load_run_completion_checklist,
+    should_reject_completion,
 )
 from app.ai.context import ContextHub, ContextBuildSpec
 from app.ai.context.context_hub import DEFAULT_CONTEXT_LIMITS
@@ -4051,9 +4052,9 @@ class AgentV2:
             approach_failures = ApproachFailureTracker(threshold=3)
 
             # Rejected end_turn attempts while a current-run Plan still has
-            # unchecked items. The global step limit remains the safety bound.
+            # unchecked items. This has its own small liveness bound; the
+            # global step limit must never be the checklist escape hatch.
             completion_review_count = 0
-            substantive_tool_rounds = 0
             
             # Circuit breaker for repeated successful actions (infinite success loop)
             # Training mode needs more headroom — iterative create_data calls are expected
@@ -4636,12 +4637,12 @@ class AgentV2:
                                 )
                                 _completion_gate = evaluate_completion_gate(
                                     _checklist,
-                                    # Once work has crossed into a genuinely
-                                    # multi-step run, absence of a Plan is
-                                    # itself an unfinished completion contract.
-                                    plan_required=substantive_tool_rounds >= 3,
+                                    plan_required=False,
                                 )
-                                if not _completion_gate.accepted:
+                                if should_reject_completion(
+                                    _completion_gate,
+                                    prior_rejections=completion_review_count,
+                                ):
                                     completion_review_count += 1
                                     analysis_done = False
                                     decision.analysis_complete = False
@@ -4650,10 +4651,7 @@ class AgentV2:
                                     self._last_assistant_text = ""
                                     observation = {
                                         "summary": (
-                                            "Completion was not accepted because this multi-step run "
-                                            "has no current Plan checklist."
-                                            if _completion_gate.reason == "missing_plan"
-                                            else "Completion was not accepted because the current Plan "
+                                            "Completion was not accepted because the current Plan "
                                             "note still has unchecked required items."
                                         ),
                                         "completion_review": {
@@ -4663,14 +4661,47 @@ class AgentV2:
                                             "unchecked_items": list(_checklist.pending_items),
                                         },
                                         "instruction": (
-                                            "Continue the task. If the Plan is missing, create a note "
-                                            "titled exactly `Plan` with the remaining requirements. "
-                                            "Complete that work and use edit_note to check off each "
-                                            "item only when supported by the evidence already gathered."
+                                            "Continue the task. Complete the pending work and use "
+                                            "edit_note to check off each item only when supported by "
+                                            "the evidence already gathered."
                                         ),
                                     }
+                                    # Keep rejected completion candidates in the
+                                    # DB even though their UI skeleton is
+                                    # cancelled. Without this, repeated reviews
+                                    # disappear and a 100-step loop looks like a
+                                    # handful of ordinary actions over SSH.
+                                    try:
+                                        if decision_seq is None:
+                                            decision_seq = await self.project_manager.next_seq(
+                                                self.db, self.current_execution
+                                            )
+                                        await self.project_manager.save_plan_decision_from_model(
+                                            self.db,
+                                            agent_execution=self.current_execution,
+                                            seq=decision_seq,
+                                            loop_index=loop_index,
+                                            planner_decision_model=decision,
+                                            phase="completion_review",
+                                        )
+                                    except Exception as _review_persist_exc:
+                                        logger.warning(
+                                            "[agent] completion review persistence failed "
+                                            "(loop=%s): %r",
+                                            loop_index,
+                                            _review_persist_exc,
+                                        )
                                     await _cancel_skeleton_block("unfinished_plan_checklist")
                                     break
+                                if not _completion_gate.accepted:
+                                    logger.warning(
+                                        "[agent] accepting completion after %d checklist "
+                                        "rejections to preserve run liveness "
+                                        "(execution=%s, pending=%d)",
+                                        completion_review_count,
+                                        getattr(self.current_execution, "id", None),
+                                        len(_checklist.pending_items),
+                                    )
                         
                             # Retry flow: invalid planner output OR underlying LLM error
                             if getattr(decision, "error", None):
@@ -5786,13 +5817,6 @@ class AgentV2:
                             )
 
                             # ---- Aggregate outcomes (in action order, matching serial semantics) ----
-                            if any(
-                                isinstance(_o, dict)
-                                and not _o.get("skipped")
-                                and _o.get("tool_name") not in _BOOKKEEPING_TOOLS
-                                for _o in outcomes
-                            ):
-                                substantive_tool_rounds += 1
                             apply_failure_strategy_policy(
                                 approach_failures,
                                 round_index=loop_index,

--- a/backend/app/ai/run_control.py
+++ b/backend/app/ai/run_control.py
@@ -21,6 +21,7 @@ from app.models.note import Note
 _CHECKBOX_RE = re.compile(
     r"^\s*[-*+]\s+\[(?P<mark>[ xX])\]\s+(?P<label>.+?)\s*$"
 )
+MAX_COMPLETION_REJECTIONS = 2
 
 
 def _observation_failed(observation: Any) -> bool:
@@ -153,11 +154,25 @@ def evaluate_completion_gate(
     checklist: CompletionChecklist, *, plan_required: bool
 ) -> CompletionGateDecision:
     """Decide whether a planner end-turn may become run success."""
-    if plan_required and not checklist.found:
-        return CompletionGateDecision(accepted=False, reason="missing_plan")
+    # ``plan_required`` remains in the signature for caller compatibility, but
+    # a missing Plan can never be a hard completion blocker. Production showed
+    # that retroactively requiring one after useful work creates a liveness
+    # deadlock when the planner keeps requesting end_turn. An existing Plan is
+    # still a deterministic contract and its unchecked items remain enforceable.
+    _ = plan_required
     if checklist.pending_items:
         return CompletionGateDecision(accepted=False, reason="unchecked_plan")
     return CompletionGateDecision(accepted=True)
+
+
+def should_reject_completion(
+    decision: CompletionGateDecision,
+    *,
+    prior_rejections: int,
+    max_rejections: int = MAX_COMPLETION_REJECTIONS,
+) -> bool:
+    """Bound checklist review so the completion gate cannot exhaust a run."""
+    return not decision.accepted and prior_rejections < max(0, int(max_rejections))
 
 
 def completion_checklist_for_notes(

--- a/backend/tests/unit/test_agent_run_control.py
+++ b/backend/tests/unit/test_agent_run_control.py
@@ -13,6 +13,7 @@ from app.ai.run_control import (
     apply_failure_strategy_policy,
     completion_checklist_for_notes,
     evaluate_completion_gate,
+    should_reject_completion,
 )
 
 
@@ -114,12 +115,24 @@ def test_fully_checked_current_plan_allows_completion():
     assert evaluate_completion_gate(status, plan_required=True).accepted is True
 
 
-def test_multistep_run_requires_a_plan_but_simple_run_does_not():
+def test_missing_plan_never_blocks_completion():
     no_plan = completion_checklist_for_notes([], execution_id="run-current")
 
     multistep = evaluate_completion_gate(no_plan, plan_required=True)
     simple = evaluate_completion_gate(no_plan, plan_required=False)
 
-    assert multistep.accepted is False
-    assert multistep.reason == "missing_plan"
+    assert multistep.accepted is True
     assert simple.accepted is True
+
+
+def test_unchecked_plan_rejections_are_bounded_for_liveness():
+    unchecked = completion_checklist_for_notes(
+        [_Note("Plan", "- [ ] verify the final requirement")],
+        execution_id="run-current",
+    )
+    gate = evaluate_completion_gate(unchecked, plan_required=True)
+
+    assert gate.accepted is False
+    assert should_reject_completion(gate, prior_rejections=0) is True
+    assert should_reject_completion(gate, prior_rejections=1) is True
+    assert should_reject_completion(gate, prior_rejections=2) is False

--- a/docs/feedback-loops/agent-run-completion-control.md
+++ b/docs/feedback-loops/agent-run-completion-control.md
@@ -63,6 +63,7 @@ KeyError: 'retry_exhausted'
 ModuleNotFoundError: No module named 'app.ai.run_control'
 TimeoutError: quiet code generation/query produced no heartbeat
 TimeoutError: heartbeat stream ignored the unobserved hard-timeout task
+ImportError: missing bounded completion-review policy
 ```
 
 The existing observation instead contained `analysis_complete=True` and a
@@ -81,10 +82,12 @@ approaches, current-run notes, or an unfinished completion contract.
 3. Notes titled exactly `Plan`, authored by the agent in the current
    `agent_execution_id`, form the deterministic completion checklist. Old-run,
    user-authored, and non-Plan notes cannot block completion.
-4. A planner end-turn is rejected when the Plan has unchecked items. After
-   three substantive tool rounds, a missing Plan is also rejected. The rejected
-   answer is not persisted as success; the outer loop calls the planner again
-   with the missing work.
+4. A planner end-turn is rejected when an existing Plan has unchecked items.
+   Missing Plan notes never block completion: there is no deterministic
+   checklist to enforce. Unchecked Plans get at most two review attempts before
+   liveness wins, so the checklist gate cannot consume the global step budget.
+   Rejected candidates are persisted with `phase=completion_review` so the loop
+   remains visible in production diagnostics.
 5. Agent-authored notes preserve the live execution ID, so the gate reviews
    only the checklist created by the run that is trying to finish.
 6. Generated-code callers share a 30-second heartbeat during both code
@@ -162,10 +165,24 @@ reconciliation` and does not contain the rejected `Premature answer`.
 - Only three adjacent failures of the same normalized approach trigger the
   strategy-change warning, and even then the run remains active.
 - Simple tasks without a Plan still finish normally.
-- Multi-step work cannot finish without a current-run Plan, and an existing
-  Plan cannot finish while required text checklist items remain unchecked.
+- Missing Plans never deadlock completion. Existing unchecked Plans trigger at
+  most two reconciliation loops, and each rejection is persisted for audit.
 - Explicit control tools and product policies that intentionally end or pause
   a turn retain their existing behavior; this change targets ordinary errors
   and premature planner completion.
 - Quiet codegen and warehouse execution remain visibly in their current stage,
   reset the idle watchdog, and remain bounded by the hard deadline.
+
+## Production regression caught after the first fix
+
+Report `6439421c-dc4c-4dad-ba64-bbd355a5d701` on production version `0.0.543`
+completed 18/18 tool executions successfully, updated the target instruction
+through v17, and then failed after 846 seconds with `planner_step_limit`.
+The run used all 100 planner iterations but persisted only 11 action decisions
+and zero notes. The missing iterations were completion candidates repeatedly
+rejected by the new `plan_required` rule, then deleted with their UI skeletons.
+
+This proved two liveness/observability defects in the first fix: a Plan could be
+required retroactively after useful work, and `completion_review_count` had no
+bound. The follow-up regression tests require missing Plans to pass immediately
+and cap unchecked-Plan rejection at two attempts.


### PR DESCRIPTION
## Orientation

**Review ask:** Confirm that completion remains plan-aware without letting the checklist gate consume the entire 100-step planner budget.

## Executive summary

A production RCA run kept working successfully but eventually failed at the 100-step planner limit. The completion gate repeatedly rejected terminal answers because no persisted Plan existed, even though all 18 tool calls had succeeded. This change makes a missing Plan non-blocking, bounds reviews of an existing incomplete Plan to two rejections, and preserves rejected completion decisions for diagnosis.

Production evidence: [report 6439421c-dc4c-4dad-ba64-bbd355a5d701](https://app.bagofwords.com/reports/6439421c-dc4c-4dad-ba64-bbd355a5d701)

## Product impact

| Before | After |
|---|---|
| A long run without a Plan could reject completion until the 100-step limit | Missing Plan never blocks completion |
| An existing unchecked Plan could cause an unbounded review loop | At most two completion rejections per run |
| Rejected completion candidates disappeared from persisted decision history | Rejections are saved as `completion_review` decisions |

## Technical flow

```mermaid
flowchart LR
    A["Model proposes completion"] --> B{"Existing unchecked Plan?"}
    B -- "No / no Plan" --> D["Accept completion"]
    B -- "Yes" --> C{"Fewer than 2 prior rejections?"}
    C -- "Yes" --> E["Persist review and continue planner"]
    C -- "No" --> D
```

## Reviewer decision box

- **Scope:** Backend completion control, unit tests, and feedback-loop evidence only.
- **Behavioral decision:** Liveness wins after two checklist review attempts.
- **Risk:** An agent may finish with unchecked items after two explicit opportunities to reconcile them.
- **Rollback:** Revert `e330e11f`.
- **UI impact:** None.
- **Migration/config:** None.

## Evidence KPI

- Full backend unit suite: **3,600 collected, all passing**
- Focused completion-control, tool-runner, concurrent-dispatch, and notes tests: **passing**
- `git diff --check`: **passing**
- Production verification: pending deployment; the linked report is the pre-fix reproducer
- CI and automated review: pending

## Root cause

The completion gate treated the absence of a persisted Plan as proof that work was incomplete. Each rejected terminal decision restarted the planner, but review attempts had no separate bound. In the production run this consumed roughly 89 planner iterations and ended at `planner_step_limit` despite successful tools.

## Context map

- `backend/app/ai/run_control.py` — completion-gate policy and rejection bound
- `backend/app/ai/agent_v2.py` — applies the gate, persists review decisions, and guarantees forward progress
- `backend/tests/unit/test_agent_run_control.py` — missing-Plan and bounded-rejection regression coverage
- `docs/feedback-loops/agent-run-completion-control.md` — reproduce → fix → verify record
