### PR TITLE
Fix Auto-agent report reruns resolving to an empty client set

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1236,9 +1236,15 @@ class ReportService:
             # step — client construction resolves credentials (and for ODBC
             # sources pays a connection handshake) per data source.
             from app.services.data_source_service import DataSourceService
+            from app.ai.tools.implementations.agent_focus_common import resolve_run_agents
             ds_service = DataSourceService()
             db_clients = {}
-            for data_source in report.data_sources:
+            # Auto (an unattached report) is a mode, not an empty set: resolve
+            # it against the run user's accessible agents exactly like the
+            # interactive path does, so saved step code that references
+            # "<Agent>:<Connection>" client keys finds them on rerun too.
+            run_agents = await resolve_run_agents(db, organization, current_user, report)
+            for data_source in run_agents:
                 try:
                     ds_clients = await ds_service.construct_clients(db, data_source, current_user=current_user)
                     db_clients.update(ds_clients)
@@ -1293,8 +1299,13 @@ class ReportService:
                     logger.warning(f"Failed to run widget {widget.id}: {e}; continuing")
                     continue
 
-        # Update last_run_at timestamp on the already-loaded ORM model
-        report.last_run_at = datetime.utcnow()
+        # Update last_run_at on the already-loaded ORM model — but only when
+        # the run actually produced something (or there was nothing to run).
+        # A fully-failed run must not stamp the report as fresh: the artifact
+        # would show stale data under a new timestamp, and the refresh-on-view
+        # staleness gate would then suppress retries for a whole interval.
+        if steps_total == 0 or steps_succeeded > 0:
+            report.last_run_at = datetime.utcnow()
         await db.commit()
 
         # Regenerate the artifact thumbnail in background — only when some
@@ -1441,10 +1452,14 @@ class ReportService:
         # a user_required connection) is reported; steps on other sources
         # still run.
         from app.services.data_source_service import DataSourceService
+        from app.ai.tools.implementations.agent_focus_common import resolve_run_agents
         ds_service = DataSourceService()
         db_clients: dict = {}
         data_source_errors: list[dict] = []
-        for data_source in report.data_sources:
+        # Auto (an unattached report) resolves like the interactive path — the
+        # credential user's accessible agents — instead of to an empty set.
+        run_agents = await resolve_run_agents(db, organization, credential_user, report)
+        for data_source in run_agents:
             try:
                 ds_clients = await ds_service.construct_clients(db, data_source, current_user=credential_user)
                 db_clients.update(ds_clients)

--- a/backend/tests/e2e/test_repro_auto_agent_rerun.py
+++ b/backend/tests/e2e/test_repro_auto_agent_rerun.py
@@ -1,0 +1,145 @@
+"""
+Reproduction: scheduled/refresh reruns of an "Auto"-agent report fail with a
+KeyError and still report success.
+
+PromptBoxV2 stores the Auto agent selector as an EMPTY agent list — the report
+row gets no report_data_source associations. Interactive runs treat that as a
+mode ("resolve the running user's accessible agents at run time", see
+agent_focus_common.resolve_run_agents), so saved step code happily references
+`ds_clients["<Agent>:<Connection>"]` for an agent that was never attached.
+
+Report reruns (rerun_report_steps / viewer_rerun_report_steps in
+report_service.py) instead iterate `report.data_sources` directly. Under Auto
+that list is empty, so `db_clients == {}`, every step KeyErrors on its client,
+yet the endpoint returns HTTP 200 and advances report.last_run_at — the shared
+artifact shows stale data with a fresh timestamp.
+
+This test asserts the DESIRED behavior (rerun resolves Auto the same way the
+interactive path does), so it FAILS while the bug is present.
+
+Run:
+    cd backend
+    uv run pytest tests/e2e/test_repro_auto_agent_rerun.py -v
+"""
+import asyncio
+import uuid
+
+import pytest
+
+from app.dependencies import async_session_maker
+from app.models.artifact import Artifact
+from app.models.organization import Organization
+from app.models.query import Query
+from app.models.report import Report
+from app.models.step import Step
+from app.models.user import User
+from app.models.visualization import Visualization
+from app.models.widget import Widget
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _interactive_client_keys(report_id: str):
+    """What the INTERACTIVE path resolves for this report — Auto resolves to
+    the running user's accessible agents and builds their clients."""
+    from app.ai.tools.implementations.agent_focus_common import (
+        prepare_run_agents, report_selection_is_auto,
+    )
+    async with async_session_maker() as db:
+        report = await db.get(Report, report_id)
+        org = await db.get(Organization, str(report.organization_id))
+        user = await db.get(User, str(report.user_id))
+        assert report_selection_is_auto(report), "expected an Auto (unattached) report"
+        agents, clients = await prepare_run_agents(db, org, user, report)
+        return [a.name for a in agents], sorted(clients.keys())
+
+
+async def _seed_artifact_step(report_id: str, step_code: str):
+    """One-query artifact dashboard whose default step runs `step_code`
+    (mirrors tests/e2e/test_report_rerun_artifact.py seeding)."""
+    suffix = uuid.uuid4().hex[:8]
+    async with async_session_maker() as db:
+        report = await db.get(Report, report_id)
+        org_id, user_id = report.organization_id, report.user_id
+
+        widget = Widget(title=f"W {suffix}", slug=f"w-{suffix}", report_id=report_id)
+        db.add(widget)
+        await db.flush()
+
+        query = Query(title="Q", report_id=report_id, widget_id=widget.id,
+                      organization_id=org_id, user_id=user_id)
+        db.add(query)
+        await db.flush()
+
+        step = Step(title="Default", slug=f"default-{suffix}", status="success",
+                    widget_id=widget.id, query_id=query.id, code=step_code, data=None)
+        db.add(step)
+        await db.flush()
+        query.default_step_id = step.id
+
+        viz = Visualization(title="Viz", status="success", report_id=report_id,
+                            query_id=query.id, view={"type": "bar_chart"})
+        db.add(viz)
+        await db.flush()
+
+        db.add(Artifact(report_id=report_id, user_id=user_id, organization_id=org_id,
+                        title="Dashboard", mode="page", version=1, status="completed",
+                        content={"code": "function App() {}",
+                                 "visualization_ids": [str(viz.id)]}))
+        await db.commit()
+        return {"query_id": str(query.id), "step_id": str(step.id)}
+
+
+async def _read_step(step_id: str):
+    async with async_session_maker() as db:
+        step = await db.get(Step, step_id)
+        return {"status": step.status, "data": step.data}
+
+
+@pytest.mark.e2e
+def test_rerun_resolves_auto_agents_like_the_interactive_path(
+    create_report, create_user, login_user, whoami, rerun_report, get_report,
+    install_demo_data_source,
+):
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    # The org has an agent the user can access...
+    install_demo_data_source(demo_id="chinook", user_token=token, org_id=org_id)
+
+    # ...but the report is created with the Auto selector: data_sources=[]
+    # (exactly what PromptBoxV2 submits for Auto).
+    report = create_report(title="Auto report", user_token=token, org_id=org_id,
+                           data_sources=[])
+
+    # Interactive resolution finds the agent and builds its clients — this is
+    # the context the saved step code was generated in.
+    agent_names, client_keys = _run(_interactive_client_keys(report["id"]))
+    assert agent_names and client_keys, (
+        "sanity: interactive Auto resolution should find the demo agent")
+    ds_key = client_keys[0]  # "<Agent>:<Connection>" — same shape as 'Reservations-V2:QVD_Input'
+
+    # Saved step code references that client by key, like production coder output.
+    step_code = f'''
+def generate_df(ds_clients, excel_files):
+    client = ds_clients["{ds_key}"]
+    return client.execute_query("SELECT Name AS genre FROM Genre ORDER BY GenreId LIMIT 3")
+'''
+    seeded = _run(_seed_artifact_step(report["id"], step_code))
+
+    body = rerun_report(report["id"], user_token=token, org_id=org_id)
+
+    # DESIRED: the rerun resolves Auto exactly like the interactive path and
+    # the step succeeds. BUG TODAY: db_clients is {}, the step fails with
+    # KeyError '<Agent>:<Connection>', yet HTTP 200 + last_run_at advance.
+    step_after = _run(_read_step(seeded["step_id"]))
+    assert body["steps_succeeded"] == 1, (
+        f"rerun response: {body!r}; step after rerun: {step_after!r} "
+        f"(interactive path resolved clients {client_keys!r} for the same report/user)")
+    assert (step_after["data"] or {}).get("rows"), "step data was not refreshed"
+
+    refreshed = get_report(report["id"], user_token=token, org_id=org_id)
+    assert refreshed["last_run_at"] is not None

--- a/backend/tests/e2e/test_repro_auto_agent_rerun.py
+++ b/backend/tests/e2e/test_repro_auto_agent_rerun.py
@@ -14,8 +14,9 @@ that list is empty, so `db_clients == {}`, every step KeyErrors on its client,
 yet the endpoint returns HTTP 200 and advances report.last_run_at — the shared
 artifact shows stale data with a fresh timestamp.
 
-This test asserts the DESIRED behavior (rerun resolves Auto the same way the
-interactive path does), so it FAILS while the bug is present.
+This test asserts the fixed behavior (rerun resolves Auto the same way the
+interactive path does, via agent_focus_common.resolve_run_agents) and acts as
+the regression guard for it.
 
 Run:
     cd backend
@@ -132,9 +133,9 @@ def generate_df(ds_clients, excel_files):
 
     body = rerun_report(report["id"], user_token=token, org_id=org_id)
 
-    # DESIRED: the rerun resolves Auto exactly like the interactive path and
-    # the step succeeds. BUG TODAY: db_clients is {}, the step fails with
-    # KeyError '<Agent>:<Connection>', yet HTTP 200 + last_run_at advance.
+    # The rerun must resolve Auto exactly like the interactive path and the
+    # step must succeed. (The original bug: db_clients was {}, the step failed
+    # with KeyError '<Agent>:<Connection>', yet HTTP 200 + last_run_at advance.)
     step_after = _run(_read_step(seeded["step_id"]))
     assert body["steps_succeeded"] == 1, (
         f"rerun response: {body!r}; step after rerun: {step_after!r} "
@@ -143,3 +144,33 @@ def generate_df(ds_clients, excel_files):
 
     refreshed = get_report(report["id"], user_token=token, org_id=org_id)
     assert refreshed["last_run_at"] is not None
+
+
+FAILING_CODE = """
+def generate_df(ds_clients, excel_files):
+    raise RuntimeError("simulated upstream failure")
+"""
+
+
+@pytest.mark.e2e
+def test_fully_failed_rerun_does_not_advance_last_run_at(
+    create_report, create_user, login_user, whoami, rerun_report, get_report,
+):
+    """A run where EVERY step failed must not stamp the report as fresh:
+    stale data under a new timestamp hides the failure, and the
+    refresh-on-view staleness gate would suppress retries for an interval."""
+    user = create_user()
+    token = login_user(user["email"], user["password"])
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    report = create_report(title="All failing", user_token=token, org_id=org_id,
+                           data_sources=[])
+    _run(_seed_artifact_step(report["id"], FAILING_CODE))
+
+    body = rerun_report(report["id"], user_token=token, org_id=org_id)
+    assert body["steps_total"] == 1
+    assert body["steps_failed"] == 1
+
+    refreshed = get_report(report["id"], user_token=token, org_id=org_id)
+    assert refreshed["last_run_at"] is None, (
+        "a fully-failed rerun advanced last_run_at")


### PR DESCRIPTION
## Problem

A report created with the **Auto** agent selector (PromptBoxV2 submits `data_sources: []`) stores no `report_data_source` rows — Auto is a mode, resolved at run time. The interactive path handles this via `agent_focus_common.resolve_run_agents` ("an unattached report resolves to the running user's accessible agents"), but the report rerun paths did not:

- `rerun_report_steps` and `viewer_rerun_report_steps` built `db_clients` by iterating `report.data_sources` directly — empty under Auto — so every saved step failed with a `KeyError` on its `'<Agent>:<Connection>'` client key (e.g. `'Reservations-V2:QVD_Input'`).
- The endpoint still returned HTTP 200 and advanced `report.last_run_at`, leaving stale data under a fresh timestamp — and, for `refresh_on_view` reports, suppressing retries for a whole staleness-gate interval.

This hit scheduled refreshes, refresh-on-view, interactive "Refresh Dashboard", and viewer reruns alike (owner-context refresh failed the same way — it was never an admin-vs-owner issue).

## Fix

- Both rerun paths now resolve the run's agents through `resolve_run_agents`, under the identity whose credentials already execute the steps (interactive caller / schedule creator / owner on the owner path; the resolved `credential_user` on the viewer path). Auto reruns therefore see the same clients the interactive path built when the step code was generated; manual selections behave as before (plus the same `is_execution_live` filter interactive runs apply).
- `report.last_run_at` is only advanced when the run produced something (or had nothing to run). A fully-failed run no longer stamps the report fresh.

## Reproduction / verification

`backend/tests/e2e/test_repro_auto_agent_rerun.py`:
- `test_rerun_resolves_auto_agents_like_the_interactive_path` — installs the Chinook demo agent, creates an Auto report, verifies interactive resolution produces the client keys, seeds an artifact step referencing `ds_clients["<Agent>:<Connection>"]`, and asserts the rerun succeeds. Failed before this fix with `Reran 0/1 report steps (1 failed)` while `last_run_at` advanced; passes now.
- `test_fully_failed_rerun_does_not_advance_last_run_at` — guards the timestamp fix.

All existing rerun/refresh suites pass: `test_report_rerun_artifact.py`, `test_report_refresh_on_view.py` (14 passed total with the new tests).

## Follow-up (not in this PR)

Persisting per-step data-source provenance from `create_data` (it already computes `data_source_ids` from `resolved_tables` for its audit log) would let reruns build clients for exactly the sources the steps need, instead of every accessible agent under Auto, and produce precise errors when access was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtkQmwrjXD6KwbiD8aC66h

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtkQmwrjXD6KwbiD8aC66h)_