### PR TITLE
Add viewer identity (current_user) to artifact rendering

### DIFF
--- a/backend/app/ai/tools/implementations/_sandbox_context.py
+++ b/backend/app/ai/tools/implementations/_sandbox_context.py
@@ -144,3 +144,90 @@ SANDBOX_RUNTIME_OBSERVATION = (
     "All globals (React, echarts, EChart, LoadingSpinner, useArtifactData, useFilters, useState, useEffect, useRef, useMemo, useCallback) are always available at runtime. "
     "NEVER destructure hooks from React (e.g. 'const { useState } = React') — Babel standalone cannot parse it. Use hooks directly as globals."
 )
+
+
+# ---------------------------------------------------------------------------
+# Identity context: injected into create/edit artifact generation prompts
+# (page mode) so the model can resolve identity intent against the org's
+# real vocabulary instead of guessing group names / attribute keys.
+# ---------------------------------------------------------------------------
+
+# The requester's example object shows the SHAPE; a handful of groups is
+# plenty for that (the runtime payload itself is capped separately).
+IDENTITY_EXAMPLE_MAX_GROUPS = 10
+# Org-wide group names let the model match groups the requester isn't in
+# (e.g. "show this section to Finance"). Capped — never the full directory.
+IDENTITY_ORG_MAX_GROUPS = 30
+
+
+async def build_identity_context(db, user, organization) -> str:
+    """Prompt section describing viewer identity for this org.
+
+    Contains the requesting user's own current_user object as ONE EXAMPLE
+    (their data, their generation request — same trust boundary as the rest
+    of the planner context) plus the org's group-name vocabulary. Values must
+    never be hardcoded by the model — the section says so explicitly, and the
+    validation render (current_user=null) surfaces baked-in names.
+
+    Returns "" on any failure or missing context: identity flavor must never
+    break artifact generation.
+    """
+    if db is None or user is None or organization is None:
+        return ""
+    try:
+        import json as _json
+
+        from sqlalchemy import select
+
+        from app.models.group import Group
+        from app.models.group_membership import GroupMembership
+        from app.models.membership import Membership
+
+        result = await db.execute(
+            select(Membership).where(
+                Membership.user_id == str(user.id),
+                Membership.organization_id == str(organization.id),
+            )
+        )
+        membership = result.scalars().first()
+
+        result = await db.execute(
+            select(Group.name)
+            .join(GroupMembership, GroupMembership.group_id == Group.id)
+            .where(
+                GroupMembership.user_id == str(user.id),
+                Group.organization_id == str(organization.id),
+            )
+            .order_by(Group.name)
+            .limit(IDENTITY_EXAMPLE_MAX_GROUPS)
+        )
+        user_groups = [r[0] for r in result.all()]
+
+        result = await db.execute(
+            select(Group.name)
+            .where(Group.organization_id == str(organization.id))
+            .order_by(Group.name)
+            .limit(IDENTITY_ORG_MAX_GROUPS)
+        )
+        org_groups = [r[0] for r in result.all()]
+
+        example = {
+            "id": str(user.id),
+            "name": getattr(user, "name", None),
+            "email": getattr(user, "email", None),
+            "role": membership.role if membership else None,
+            "profile_attributes": (membership.profile_attributes if membership else None) or None,
+            "groups": user_groups,
+        }
+        org_groups_line = (
+            f"\nOrg groups (first {IDENTITY_ORG_MAX_GROUPS}): {', '.join(org_groups)}"
+            if org_groups
+            else ""
+        )
+        return f"""
+**Viewer identity (current_user):** The requesting user's own object, as ONE EXAMPLE — every viewer gets their own values at render time, and anonymous viewers get `null`:
+{_json.dumps(example, default=str)}{org_groups_line}
+Use the example ONLY to learn the shape and which keys/groups exist in this org. NEVER hardcode these values into the artifact — always read `useCurrentUser()` at runtime (`u?.name`, `u?.groups`) so each viewer sees their own version, and keep every access null-guarded.
+Group checks are EXACT, case-sensitive string matches against the names above. When the user refers to a group loosely ("the leadership team", "managers"), find the closest name in the org groups list and use that EXACT string (e.g. `(u?.groups || []).includes('Leadership')`) — never the user's paraphrase. Only use a name outside the list if the user typed it verbatim and nothing in the list plausibly matches."""
+    except Exception:
+        return ""

--- a/backend/app/ai/tools/implementations/_sandbox_context.py
+++ b/backend/app/ai/tools/implementations/_sandbox_context.py
@@ -54,14 +54,15 @@ references to any of them.
   - `report`: `{ id, title, theme }`
   - `visualizations`: array of `{ id, title, view, rows, columns, dataModel }`
   - `files`: array of `{ id, content_type, filename }` — embedded images/PDFs; render each with `<BowFile id={...} />`
-  - `current_user`: the VIEWING user, or `null` — `{ id, name, email, image_url, role, profile_attributes }`. Injected fresh per viewer at render time (never baked into the artifact), so the same dashboard can greet each viewer personally.
+  - `current_user`: the VIEWING user, or `null` — `{ id, name, email, image_url, role, profile_attributes, groups }`. Injected fresh per viewer at render time (never baked into the artifact), so the same dashboard can greet each viewer personally.
   - Always handle the `null` (loading) state before accessing data
 
 • **useCurrentUser()** — Global React hook for the viewing user
-  - Shortcut for `useArtifactData()?.current_user`. Returns `{ id, name, email, image_url, role, profile_attributes }` or `null`.
+  - Shortcut for `useArtifactData()?.current_user`. Returns `{ id, name, email, image_url, role, profile_attributes, groups }` or `null`.
   - **`current_user` MAY BE `null`** (anonymous public viewers, preview renders) and EVERY field inside it may be `null`. ALWAYS guard: `Hello{u?.name ? ', ' + u.name : ''}` — NEVER `u.name` bare. The artifact must render perfectly with `current_user = null`.
   - `role` is the user's organization role (e.g. 'admin', 'member'); `profile_attributes` is a free-form object of identity-provider attributes (e.g. jobTitle, department) whose keys DEPEND ON THE ORG — never assume a key exists.
-  - Use for DISPLAY-ONLY personalization: greetings ("Welcome back, Yochay"), showing the viewer's role/department, tailoring copy. It is NOT access control — all data in ARTIFACT_DATA is present regardless, so never claim to hide/protect data with it.
+  - `groups`: array of the viewer's org group NAMES (alphabetical, server-capped — a member of many groups sees a truncated list). May be `[]`, missing, or `null` — guard with `(u?.groups || []).includes('Sales')`. Group names are org-defined; only reference a group by name if the user's request names it.
+  - Use for DISPLAY-ONLY personalization: greetings ("Welcome back, Yochay"), showing the viewer's role/department/groups, group- or role-conditional sections, tailoring copy. It is NOT access control — all data in ARTIFACT_DATA is present regardless, so never claim to hide/protect data with it.
   - **DEFENSIVE CODING**: Row values, column fields, and nested properties can be `null`/`undefined`. ALWAYS guard before calling string methods like `.includes()`, `.toLowerCase()`, `.startsWith()`, etc. Use optional chaining (`?.`) or convert first: `String(val || '')`. Example: `(row.name || '').includes('x')` instead of `row.name.includes('x')`.
 
 • **useFilters()** — Global React hook for cross-visualization filtering
@@ -123,7 +124,7 @@ SANDBOX_RUNTIME_OBSERVATION = (
     "do NOT redefine, import, or remove references to them: "
     "React (v18), ReactDOM, echarts (v5), Tailwind CSS (v3.4), Babel (JSX transpilation), "
     "useArtifactData() hook (returns { report, visualizations, files, current_user } or null while loading), "
-    "useCurrentUser() hook (the viewing user { id, name, email, image_url, role, profile_attributes } or null for "
+    "useCurrentUser() hook (the viewing user { id, name, email, image_url, role, profile_attributes, groups } or null for "
     "anonymous viewers/preview renders — injected per viewer at render time, every field nullable, guard all access; "
     "display-only personalization, not access control), "
     "useFilters() hook (returns { filters, setFilter, resetFilters, filterRows } "

--- a/backend/app/ai/tools/implementations/_sandbox_context.py
+++ b/backend/app/ai/tools/implementations/_sandbox_context.py
@@ -50,11 +50,18 @@ references to any of them.
   - Code must be wrapped in `<script type="text/babel">...</script>`
 
 • **useArtifactData()** — Global React hook
-  - Returns `null` while data is loading, then `{ report, visualizations, files }`
+  - Returns `null` while data is loading, then `{ report, visualizations, files, current_user }`
   - `report`: `{ id, title, theme }`
   - `visualizations`: array of `{ id, title, view, rows, columns, dataModel }`
   - `files`: array of `{ id, content_type, filename }` — embedded images/PDFs; render each with `<BowFile id={...} />`
+  - `current_user`: the VIEWING user, or `null` — `{ id, name, email, image_url, role, profile_attributes }`. Injected fresh per viewer at render time (never baked into the artifact), so the same dashboard can greet each viewer personally.
   - Always handle the `null` (loading) state before accessing data
+
+• **useCurrentUser()** — Global React hook for the viewing user
+  - Shortcut for `useArtifactData()?.current_user`. Returns `{ id, name, email, image_url, role, profile_attributes }` or `null`.
+  - **`current_user` MAY BE `null`** (anonymous public viewers, preview renders) and EVERY field inside it may be `null`. ALWAYS guard: `Hello{u?.name ? ', ' + u.name : ''}` — NEVER `u.name` bare. The artifact must render perfectly with `current_user = null`.
+  - `role` is the user's organization role (e.g. 'admin', 'member'); `profile_attributes` is a free-form object of identity-provider attributes (e.g. jobTitle, department) whose keys DEPEND ON THE ORG — never assume a key exists.
+  - Use for DISPLAY-ONLY personalization: greetings ("Welcome back, Yochay"), showing the viewer's role/department, tailoring copy. It is NOT access control — all data in ARTIFACT_DATA is present regardless, so never claim to hide/protect data with it.
   - **DEFENSIVE CODING**: Row values, column fields, and nested properties can be `null`/`undefined`. ALWAYS guard before calling string methods like `.includes()`, `.toLowerCase()`, `.startsWith()`, etc. Use optional chaining (`?.`) or convert first: `String(val || '')`. Example: `(row.name || '').includes('x')` instead of `row.name.includes('x')`.
 
 • **useFilters()** — Global React hook for cross-visualization filtering
@@ -115,7 +122,10 @@ SANDBOX_RUNTIME_OBSERVATION = (
     "This code runs inside a sandboxed iframe that pre-loads these globals — "
     "do NOT redefine, import, or remove references to them: "
     "React (v18), ReactDOM, echarts (v5), Tailwind CSS (v3.4), Babel (JSX transpilation), "
-    "useArtifactData() hook (returns { report, visualizations } or null while loading), "
+    "useArtifactData() hook (returns { report, visualizations, files, current_user } or null while loading), "
+    "useCurrentUser() hook (the viewing user { id, name, email, image_url, role, profile_attributes } or null for "
+    "anonymous viewers/preview renders — injected per viewer at render time, every field nullable, guard all access; "
+    "display-only personalization, not access control), "
     "useFilters() hook (returns { filters, setFilter, resetFilters, filterRows } "
     "for cross-visualization filtering — no auto column detection, LLM chooses which columns to filter "
     "using dtype and unique_count from viz.columns (e.g. dtype 'object' + unique_count < 50 → FilterSelect, "

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -1263,6 +1263,11 @@ Output the FULL corrected code in a ```python code block. No explanations, no di
                     "theme": getattr(report, "theme", None) if report else None,
                 },
                 "visualizations": visualizations,
+                # Headless validation renders anonymously on purpose: identity
+                # is per-viewer, injected by the host at render time, and this
+                # exercises the null-guard path in every artifact before it is
+                # persisted.
+                "current_user": None,
             }
             # Inline embedded files as data URIs so the headless render
             # (which has no auth context) can show images/PDFs via <BowFile>.

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -35,7 +35,7 @@ from app.services.thumbnail_service import ThumbnailService
 from app.services.artifact_libs import get_inline_scripts
 from app.ai.code_execution.pptx_executor import PptxCodeExecutor, PptxPreviewService
 from sqlalchemy import desc
-from app.ai.tools.implementations._sandbox_context import SANDBOX_RUNTIME_PROMPT
+from app.ai.tools.implementations._sandbox_context import SANDBOX_RUNTIME_PROMPT, build_identity_context
 from app.ai.tools.implementations._artifact_images import load_image_bytes
 from app.ai.prompt_language import build_language_directive
 
@@ -1092,12 +1092,20 @@ Output the FULL corrected code in a ```python code block. No explanations, no di
         # Build the prompt for generating React code
         yield ToolProgressEvent(type="tool.progress", payload={"stage": "building_prompt"})
 
+        # Identity vocabulary for page mode: the requester's current_user as an
+        # example + org group names, so identity intent ("show to Finance",
+        # "greet by department") resolves against real names instead of guesses.
+        identity_context = ""
+        if data.mode == "page":
+            identity_context = await build_identity_context(db, user, organization)
+
         prompt = self._build_prompt(
             user_prompt=data.prompt,
             title=data.title,
             mode=data.mode,
             viz_profiles=viz_profiles,
             instructions_context=instructions_context,
+            identity_context=identity_context,
             report_title=getattr(report, 'title', None) if report else None,
             allow_llm_see_data=allow_llm_see_data,
             messages_context=messages_context,
@@ -2271,6 +2279,7 @@ Rules: `<script type="text/babel">` wrapper. `useArtifactData()` for data. `<ECh
         image_count: int = 0,
         organization_settings: Any = None,
         files: Optional[List[Dict[str, Any]]] = None,
+        identity_context: str = "",
     ) -> str:
         """Build the dynamic user prompt for page/dashboard generation.
 
@@ -2313,7 +2322,7 @@ Design request (primary specification — takes precedence when it conflicts wit
 {images_context}
 {files_context}
 {f"**Organization Instructions:**{chr(10)}{instructions_context}" if instructions_context else ""}
-
+{identity_context}
 {f"**Conversation History:**{chr(10)}{messages_context}" if messages_context else ""}
 {language_directive}
 
@@ -2350,6 +2359,7 @@ Now create the dashboard:"""
         image_count: int = 0,
         organization_settings: Any = None,
         files: Optional[List[Dict[str, Any]]] = None,
+        identity_context: str = "",
     ) -> str:
         """Build the prompt for generating artifact code. Dispatches to mode-specific builders."""
         if mode == "slides":
@@ -2376,6 +2386,7 @@ Now create the dashboard:"""
             image_count=image_count,
             organization_settings=organization_settings,
             files=files,
+            identity_context=identity_context,
         )
 
     def _extract_code(self, response: str, mode: str = "page") -> str:

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -1230,6 +1230,9 @@ Re-emit corrected SEARCH/REPLACE blocks for the SAME edit. Copy SEARCH text exac
                     "theme": getattr(report, "theme", None) if report else None,
                 },
                 "visualizations": visualizations,
+                # Anonymous on purpose — see create_artifact: validation must
+                # exercise the current_user=null path.
+                "current_user": None,
             }
             if merged_files:
                 try:

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -35,7 +35,7 @@ from app.models.artifact import Artifact
 from app.models.visualization import Visualization
 from app.models.query import Query
 from app.dependencies import async_session_maker
-from app.ai.tools.implementations._sandbox_context import SANDBOX_RUNTIME_PROMPT
+from app.ai.tools.implementations._sandbox_context import SANDBOX_RUNTIME_PROMPT, build_identity_context
 from app.ai.prompt_language import build_language_directive
 
 logger = logging.getLogger(__name__)
@@ -359,6 +359,7 @@ class EditArtifactTool(Tool):
         files: Optional[List[Dict[str, Any]]] = None,
         removed_vizs: Optional[List[Dict[str, str]]] = None,
         prev_render_errors: Optional[List[str]] = None,
+        identity_context: str = "",
     ) -> str:
         """Build the dynamic user prompt for editing existing artifact code.
 
@@ -430,6 +431,7 @@ EDIT REQUEST (primary specification — follow exactly)
 {images_context}
 {files_context}
 {f"**Organization Instructions:**{chr(10)}{instructions_context}" if instructions_context else ""}
+{identity_context}
 {language_directive}
 {removed_section}{render_errors_section}
 EXISTING DASHBOARD CODE:
@@ -1017,12 +1019,20 @@ Re-emit corrected SEARCH/REPLACE blocks for the SAME edit. Copy SEARCH text exac
         # edit sees the exact failure instead of a planner paraphrase.
         prev_render_errors = list(getattr(artifact, "render_errors", None) or [])
 
+        # Identity vocabulary (page mode): same section create_artifact injects.
+        identity_context = ""
+        if artifact.mode == "page":
+            identity_context = await build_identity_context(
+                db, runtime_ctx.get("user"), runtime_ctx.get("organization")
+            )
+
         prompt = self._build_edit_prompt(
             existing_code=existing_code,
             edit_prompt=data.edit_prompt,
             mode=artifact.mode,
             viz_profiles=viz_profiles,
             instructions_context=instructions_context,
+            identity_context=identity_context,
             messages_context=messages_context,
             report_title=getattr(report, 'title', None) if report else None,
             image_count=len(completion_images),

--- a/backend/app/ai/tools/mcp/app_tools.py
+++ b/backend/app/ai/tools/mcp/app_tools.py
@@ -19,8 +19,35 @@ from app.models.visualization import Visualization
 from app.models.query import Query
 from app.models.step import Step
 from app.models.artifact import Artifact
+from app.models.membership import Membership
 
 logger = logging.getLogger(__name__)
+
+
+async def _build_viewer_context(
+    db: AsyncSession, user: Optional[User], organization: Optional[Organization]
+) -> Optional[Dict[str, Any]]:
+    """ARTIFACT_DATA.current_user for MCP app rendering — same shape as
+    GET /users/me/viewer_context. None when there is no authenticated user."""
+    if user is None:
+        return None
+    membership = None
+    if organization is not None:
+        result = await db.execute(
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == organization.id,
+            )
+        )
+        membership = result.scalars().first()
+    return {
+        "id": str(user.id),
+        "name": user.name,
+        "email": user.email,
+        "image_url": getattr(user, "image_url", None),
+        "role": membership.role if membership else None,
+        "profile_attributes": (membership.profile_attributes if membership else None) or None,
+    }
 
 
 class GetVisualizationMCPTool(MCPTool):
@@ -194,4 +221,5 @@ class GetArtifactDataMCPTool(MCPTool):
             "code": code,
             "mode": artifact.mode or "page",
             "visualizations": visualizations,
+            "current_user": await _build_viewer_context(db, user, organization),
         }

--- a/backend/app/ai/tools/mcp/app_tools.py
+++ b/backend/app/ai/tools/mcp/app_tools.py
@@ -40,6 +40,10 @@ async def _build_viewer_context(
             )
         )
         membership = result.scalars().first()
+    groups: List[str] = []
+    if organization is not None:
+        from app.routes.user_profile import _resolve_viewer_groups
+        groups = await _resolve_viewer_groups(db, str(user.id), str(organization.id))
     return {
         "id": str(user.id),
         "name": user.name,
@@ -47,6 +51,7 @@ async def _build_viewer_context(
         "image_url": getattr(user, "image_url", None),
         "role": membership.role if membership else None,
         "profile_attributes": (membership.profile_attributes if membership else None) or None,
+        "groups": groups,
     }
 
 

--- a/backend/app/routes/user_profile.py
+++ b/backend/app/routes/user_profile.py
@@ -149,6 +149,43 @@ async def get_my_viewer_context(
     )
 
 
+@router.get("/users/{user_id}/viewer_context", response_model=ViewerContextSchema)
+async def get_member_viewer_context(
+    user_id: str,
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Viewer context of another member of the active organization, for the
+    artifact 'View as' preview. Gated on org membership on both sides: the
+    caller must belong to the org (view_members is baseline for members), and
+    the target must have a membership here — same fields, same exclusions as
+    /users/me/viewer_context."""
+    caller_membership = await _get_current_membership(db, current_user, organization)
+    if not caller_membership:
+        raise HTTPException(status_code=403, detail="Not a member of this organization")
+    result = await db.execute(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.organization_id == organization.id,
+        )
+    )
+    membership = result.scalars().first()
+    if not membership:
+        raise HTTPException(status_code=404, detail="Member not found in this organization")
+    target = await db.get(User, user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    return ViewerContextSchema(
+        id=str(target.id),
+        name=target.name,
+        email=target.email,
+        image_url=target.image_url,
+        role=membership.role,
+        profile_attributes=membership.profile_attributes or None,
+    )
+
+
 class UserDefaultModelSchema(BaseModel):
     # LLMModel.id (not the provider model string). None = follow the org default.
     model_id: Optional[str] = None

--- a/backend/app/routes/user_profile.py
+++ b/backend/app/routes/user_profile.py
@@ -114,6 +114,41 @@ async def update_my_instructions(
     return UserInstructionsSchema(note=membership.note, memory=membership.memory)
 
 
+class ViewerContextSchema(BaseModel):
+    # Identity payload injected into artifact iframes as ARTIFACT_DATA.current_user.
+    # Deliberately minimal: identity + org role + IdP-synced profile attributes.
+    # Membership secrets/preferences (invite_token, note, memory, default_*)
+    # must never be added here — this object reaches LLM-generated sandbox code.
+    id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    image_url: Optional[str] = None
+    # None when the viewer has no membership in the active organization.
+    role: Optional[str] = None
+    profile_attributes: Optional[dict] = None
+
+
+@router.get("/users/me/viewer_context", response_model=ViewerContextSchema)
+async def get_my_viewer_context(
+    current_user: User = Depends(current_user),
+    organization: Organization = Depends(get_current_organization),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Canonical viewer identity for artifact rendering (ARTIFACT_DATA.current_user).
+
+    All artifact host surfaces (ArtifactFrame, /r/[id]) fetch this one shape;
+    anonymous viewers never reach it (401) and render with current_user=null."""
+    membership = await _get_current_membership(db, current_user, organization)
+    return ViewerContextSchema(
+        id=str(current_user.id),
+        name=current_user.name,
+        email=current_user.email,
+        image_url=current_user.image_url,
+        role=membership.role if membership else None,
+        profile_attributes=(membership.profile_attributes if membership else None) or None,
+    )
+
+
 class UserDefaultModelSchema(BaseModel):
     # LLMModel.id (not the provider model string). None = follow the org default.
     model_id: Optional[str] = None

--- a/backend/app/routes/user_profile.py
+++ b/backend/app/routes/user_profile.py
@@ -114,6 +114,13 @@ async def update_my_instructions(
     return UserInstructionsSchema(note=membership.note, memory=membership.memory)
 
 
+# Hard cap on group names in the viewer payload. The payload rides into every
+# artifact render AND into the sandbox prompt's mental model — an IdP-synced
+# org can carry hundreds of groups per user, which would eat context for no
+# rendering value. Alphabetical order keeps the truncation deterministic.
+VIEWER_CONTEXT_MAX_GROUPS = 20
+
+
 class ViewerContextSchema(BaseModel):
     # Identity payload injected into artifact iframes as ARTIFACT_DATA.current_user.
     # Deliberately minimal: identity + org role + IdP-synced profile attributes.
@@ -126,6 +133,29 @@ class ViewerContextSchema(BaseModel):
     # None when the viewer has no membership in the active organization.
     role: Optional[str] = None
     profile_attributes: Optional[dict] = None
+    # Org group NAMES (not ids/external ids), alphabetical, capped at
+    # VIEWER_CONTEXT_MAX_GROUPS. Empty list when the user is in none.
+    groups: list[str] = []
+
+
+async def _resolve_viewer_groups(
+    db: AsyncSession, user_id: str, organization_id: str
+) -> list[str]:
+    """Group names for the viewer payload: alphabetical, capped."""
+    from app.models.group import Group
+    from app.models.group_membership import GroupMembership
+
+    result = await db.execute(
+        select(Group.name)
+        .join(GroupMembership, GroupMembership.group_id == Group.id)
+        .where(
+            GroupMembership.user_id == str(user_id),
+            Group.organization_id == str(organization_id),
+        )
+        .order_by(Group.name)
+        .limit(VIEWER_CONTEXT_MAX_GROUPS)
+    )
+    return [r[0] for r in result.all()]
 
 
 @router.get("/users/me/viewer_context", response_model=ViewerContextSchema)
@@ -146,6 +176,7 @@ async def get_my_viewer_context(
         image_url=current_user.image_url,
         role=membership.role if membership else None,
         profile_attributes=(membership.profile_attributes if membership else None) or None,
+        groups=await _resolve_viewer_groups(db, str(current_user.id), str(organization.id)),
     )
 
 
@@ -183,6 +214,7 @@ async def get_member_viewer_context(
         image_url=target.image_url,
         role=membership.role,
         profile_attributes=membership.profile_attributes or None,
+        groups=await _resolve_viewer_groups(db, str(target.id), str(organization.id)),
     )
 
 

--- a/backend/app/services/report_pdf_service.py
+++ b/backend/app/services/report_pdf_service.py
@@ -766,6 +766,8 @@ class ReportPdfService:
             },
             "visualizations": visualizations,
             "files": files or [],
+            # PDF exports are shareable documents — render anonymously.
+            "current_user": None,
         }
         data_json = json.dumps(artifact_data, default=str)
 

--- a/backend/app/services/thumbnail_service.py
+++ b/backend/app/services/thumbnail_service.py
@@ -328,6 +328,9 @@ class ThumbnailService:
                 "theme": report_theme,
             },
             "visualizations": visualizations,
+            # Thumbnails are shared assets — always render anonymously so no
+            # viewer's identity gets baked into an image other users see.
+            "current_user": None,
         }
         data_json = json.dumps(artifact_data, default=str)
 

--- a/backend/tests/unit/test_artifact_viewer_identity.py
+++ b/backend/tests/unit/test_artifact_viewer_identity.py
@@ -61,6 +61,26 @@ def test_viewer_groups_are_capped():
     assert "limit(VIEWER_CONTEXT_MAX_GROUPS)" in src
 
 
+def test_identity_context_never_breaks_generation():
+    """build_identity_context must degrade to '' on missing context or DB
+    failure — identity flavor can never fail artifact creation."""
+    import asyncio
+    from app.ai.tools.implementations._sandbox_context import build_identity_context
+
+    class ExplodingDB:
+        async def execute(self, *a, **k):
+            raise RuntimeError("db down")
+
+    class Obj:
+        id = "u1"
+        name = "X"
+        email = "x@y.z"
+
+    assert asyncio.run(build_identity_context(None, Obj(), Obj())) == ""
+    assert asyncio.run(build_identity_context(ExplodingDB(), None, Obj())) == ""
+    assert asyncio.run(build_identity_context(ExplodingDB(), Obj(), Obj())) == ""
+
+
 def _extract_artifact_data(html: str) -> dict:
     m = re.search(r"window\.ARTIFACT_DATA\s*=\s*(\{.*?\});", html, re.S)
     assert m, "window.ARTIFACT_DATA not found in rendered HTML"

--- a/backend/tests/unit/test_artifact_viewer_identity.py
+++ b/backend/tests/unit/test_artifact_viewer_identity.py
@@ -1,0 +1,67 @@
+"""Viewer identity (ARTIFACT_DATA.current_user) contract tests.
+
+The viewer object is injected per render by the host surfaces; these tests pin
+the three server-side guarantees:
+  1. The prompt contract teaches generated code about current_user and its
+     null-guarding rules.
+  2. ViewerContextSchema exposes exactly the intended fields — membership
+     secrets (invite_token) and preferences (note, memory, defaults) must
+     never reach the sandbox iframe.
+  3. Server-side renderers (thumbnails) inject current_user=null so shared
+     assets never bake in a viewer's identity and the null path is exercised.
+"""
+
+import json
+import re
+
+from app.ai.tools.implementations._sandbox_context import (
+    SANDBOX_RUNTIME_PROMPT,
+    SANDBOX_RUNTIME_OBSERVATION,
+)
+from app.routes.user_profile import ViewerContextSchema
+from app.services.thumbnail_service import ThumbnailService
+
+
+def test_prompt_documents_current_user_contract():
+    assert "current_user" in SANDBOX_RUNTIME_PROMPT
+    assert "useCurrentUser()" in SANDBOX_RUNTIME_PROMPT
+    # The null-guarding rule is the load-bearing part of the contract
+    assert "MAY BE `null`" in SANDBOX_RUNTIME_PROMPT
+    assert "profile_attributes" in SANDBOX_RUNTIME_PROMPT
+    # Observation contract (read_artifact / planner) carries it too
+    assert "current_user" in SANDBOX_RUNTIME_OBSERVATION
+    assert "useCurrentUser()" in SANDBOX_RUNTIME_OBSERVATION
+
+
+def test_viewer_context_schema_exposes_only_safe_fields():
+    fields = set(ViewerContextSchema.model_fields.keys())
+    assert fields == {"id", "name", "email", "image_url", "role", "profile_attributes"}
+    # Regression guard: these must never be added — the object reaches
+    # LLM-generated sandbox code in the browser.
+    for forbidden in ("invite_token", "note", "memory", "default_llm_model_id",
+                      "default_data_source_ids"):
+        assert forbidden not in fields
+
+
+def _extract_artifact_data(html: str) -> dict:
+    m = re.search(r"window\.ARTIFACT_DATA\s*=\s*(\{.*?\});", html, re.S)
+    assert m, "window.ARTIFACT_DATA not found in rendered HTML"
+    return json.loads(m.group(1))
+
+
+def test_thumbnail_html_renders_anonymous(monkeypatch):
+    # Vendored libs may be absent in CI checkouts; the assertion is about the
+    # injected data, not the script bundle.
+    import app.services.thumbnail_service as ts
+    monkeypatch.setattr(ts, "get_inline_scripts", lambda mode: "")
+    html = ThumbnailService()._build_thumbnail_html(
+        report_id="r1",
+        report_title="T",
+        report_theme=None,
+        artifact_code="<script></script>",
+        visualizations=[],
+        mode="page",
+    )
+    data = _extract_artifact_data(html)
+    assert "current_user" in data
+    assert data["current_user"] is None

--- a/backend/tests/unit/test_artifact_viewer_identity.py
+++ b/backend/tests/unit/test_artifact_viewer_identity.py
@@ -18,7 +18,11 @@ from app.ai.tools.implementations._sandbox_context import (
     SANDBOX_RUNTIME_PROMPT,
     SANDBOX_RUNTIME_OBSERVATION,
 )
-from app.routes.user_profile import ViewerContextSchema
+from app.routes.user_profile import (
+    ViewerContextSchema,
+    VIEWER_CONTEXT_MAX_GROUPS,
+    _resolve_viewer_groups,
+)
 from app.services.thumbnail_service import ThumbnailService
 
 
@@ -35,12 +39,26 @@ def test_prompt_documents_current_user_contract():
 
 def test_viewer_context_schema_exposes_only_safe_fields():
     fields = set(ViewerContextSchema.model_fields.keys())
-    assert fields == {"id", "name", "email", "image_url", "role", "profile_attributes"}
+    assert fields == {"id", "name", "email", "image_url", "role", "profile_attributes", "groups"}
     # Regression guard: these must never be added — the object reaches
     # LLM-generated sandbox code in the browser.
     for forbidden in ("invite_token", "note", "memory", "default_llm_model_id",
                       "default_data_source_ids"):
         assert forbidden not in fields
+
+
+def test_prompt_documents_groups_contract():
+    assert "groups" in SANDBOX_RUNTIME_PROMPT
+    assert "server-capped" in SANDBOX_RUNTIME_PROMPT
+
+
+def test_viewer_groups_are_capped():
+    """The SQL LIMIT is the cap; pin the constant so a payload can never carry
+    an unbounded group list into every artifact render."""
+    assert 1 <= VIEWER_CONTEXT_MAX_GROUPS <= 50
+    import inspect
+    src = inspect.getsource(_resolve_viewer_groups)
+    assert "limit(VIEWER_CONTEXT_MAX_GROUPS)" in src
 
 
 def _extract_artifact_data(html: str) -> dict:

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -134,6 +134,26 @@
           </a>
         </UTooltip>
 
+        <!-- View as (page artifacts only): preview the dashboard as an
+             anonymous viewer. Identity-only — data is unaffected. -->
+        <UTooltip
+          v-if="canViewAs"
+          :text="viewAsAnonymous ? 'Back to your view' : 'View as anonymous viewer — previews personalization, not data access'"
+        >
+          <button
+            @click="toggleViewAs"
+            :class="[
+              'text-lg items-center flex gap-1 px-2 py-1 rounded transition-colors',
+              viewAsAnonymous
+                ? 'bg-indigo-50 dark:bg-indigo-950 text-indigo-600 ring-1 ring-indigo-300'
+                : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+            ]"
+          >
+            <Icon :name="viewAsAnonymous ? 'heroicons:eye-slash' : 'heroicons:eye'" class="w-3.5 h-3.5" :class="viewAsAnonymous ? 'text-indigo-600' : 'text-gray-500 dark:text-gray-400'" />
+            <span v-if="viewAsAnonymous" class="text-xs text-indigo-600 font-medium">Anonymous</span>
+          </button>
+        </UTooltip>
+
         <!-- Share Dashboard -->
         <ShareModal v-if="report" :report="report" share-type="artifact" title="Share Dashboard" />
       </div>
@@ -141,6 +161,16 @@
 
     <!-- Iframe Container -->
     <div class="flex-1 min-h-0 relative bg-white dark:bg-gray-900">
+      <!-- View-as banner: keep the simulated view unmistakable, and be honest
+           about its scope (identity only — data is not re-scoped). -->
+      <div
+        v-if="viewAsAnonymous && canViewAs"
+        class="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-600 text-white shadow-lg text-xs"
+      >
+        <Icon name="heroicons:eye" class="w-3.5 h-3.5" />
+        <span>Viewing as anonymous — previews personalization only, not data access</span>
+        <button @click="toggleViewAs" class="font-semibold underline underline-offset-2 hover:text-indigo-200">Exit</button>
+      </div>
       <!-- Loading State -->
       <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900">
         <div class="flex flex-col items-center gap-3">
@@ -632,6 +662,24 @@ async function fetchViewerContext() {
   }
 }
 
+// "View as" preview (page artifacts): render the dashboard as an anonymous
+// viewer would see it. IDENTITY ONLY — current_user becomes null, but the
+// data payload is untouched: per-viewer data scoping happens server-side
+// (viewer runs / RLS), so this must never be presented as an access check.
+const viewAsAnonymous = ref(false);
+const canViewAs = computed(() =>
+  selectedArtifact.value?.mode === 'page' && !isPendingArtifact.value && !snapshotWithheld.value);
+const effectiveViewerContext = computed(() =>
+  viewAsAnonymous.value ? null : viewerContext.value);
+function toggleViewAs() {
+  viewAsAnonymous.value = !viewAsAnonymous.value;
+}
+// Swapping identity re-sends data into an already-mounted iframe (srcdoc also
+// recomputes, but postMessage covers the no-reload path).
+watch(viewAsAnonymous, () => {
+  if (iframeReady.value) sendDataToIframe();
+});
+
 const iframeRef = ref<HTMLIFrameElement | null>(null);
 const isLoading = ref(true);
 const dataReady = ref(false);  // Guards iframeSrcdoc to prevent rendering before data loads
@@ -1041,6 +1089,7 @@ watch(selectedArtifactId, async (newId, oldId) => {
   if (oldId === undefined) return;
   iframeError.value = null;
   iframeReady.value = false;
+  viewAsAnonymous.value = false;
   if (isPolishMode.value) exitPolishMode();
   await fetchSelectedArtifact();
   // Only refetch data if this is a user-initiated change (not initial load)
@@ -1082,7 +1131,7 @@ function sendDataToIframe() {
     report: toRaw(reportData.value),
     visualizations: toRaw(visualizationsData.value),
     files: toRaw(filesData.value),
-    current_user: toRaw(viewerContext.value)
+    current_user: toRaw(effectiveViewerContext.value)
   }));
 
   try {
@@ -1532,7 +1581,7 @@ const iframeSrcdoc = computed(() => {
       report: reportData.value,
       visualizations: visualizationsData.value,
       files: filesData.value,
-      current_user: viewerContext.value,
+      current_user: effectiveViewerContext.value,
     },
     code: artifactCode,
     mode: selectedArtifact.value?.mode || 'page',

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -134,25 +134,34 @@
           </a>
         </UTooltip>
 
-        <!-- View as (page artifacts only): preview the dashboard as an
-             anonymous viewer. Identity-only — data is unaffected. -->
-        <UTooltip
+        <!-- View as (page artifacts only): preview the dashboard as another
+             viewer — anonymous or any org member, searchable by name/email.
+             Identity-only — data is unaffected. -->
+        <USelectMenu
           v-if="canViewAs"
-          :text="viewAsAnonymous ? 'Back to your view' : 'View as anonymous user'"
+          v-model="viewAsMode"
+          :options="viewAsOptions"
+          value-attribute="value"
+          option-attribute="label"
+          searchable
+          :search-attributes="['label', 'email']"
+          searchable-placeholder="Search members by name or email..."
+          size="xs"
+          class="min-w-[130px]"
         >
-          <button
-            @click="toggleViewAs"
-            :class="[
-              'text-lg items-center flex gap-1 px-2 py-1 rounded transition-colors',
-              viewAsAnonymous
-                ? 'bg-indigo-50 dark:bg-indigo-950 text-indigo-600 ring-1 ring-indigo-300'
-                : 'hover:bg-gray-100 dark:hover:bg-gray-700'
-            ]"
-          >
-            <Icon :name="viewAsAnonymous ? 'heroicons:eye-slash' : 'heroicons:eye'" class="w-3.5 h-3.5" :class="viewAsAnonymous ? 'text-indigo-600' : 'text-gray-500 dark:text-gray-400'" />
-            <span v-if="viewAsAnonymous" class="text-xs text-indigo-600 font-medium">Anonymous</span>
-          </button>
-        </UTooltip>
+          <template #label>
+            <span class="flex items-center gap-1 text-xs" :class="viewAsMode !== 'you' ? 'text-indigo-600 font-medium' : ''">
+              <Icon name="heroicons:eye" class="w-3.5 h-3.5" />
+              {{ viewAsLabel }}
+            </span>
+          </template>
+          <template #option="{ option }">
+            <div class="flex flex-col">
+              <span class="text-xs">{{ option.label }}</span>
+              <span v-if="option.email" class="text-[10px] text-gray-400">{{ option.email }}</span>
+            </div>
+          </template>
+        </USelectMenu>
 
         <!-- Share Dashboard -->
         <ShareModal v-if="report" :report="report" share-type="artifact" title="Share Dashboard" />
@@ -164,12 +173,12 @@
       <!-- View-as banner: keep the simulated view unmistakable, and be honest
            about its scope (identity only — data is not re-scoped). -->
       <div
-        v-if="viewAsAnonymous && canViewAs"
+        v-if="viewAsMode !== 'you' && canViewAs"
         class="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-600 text-white shadow-lg text-xs"
       >
         <Icon name="heroicons:eye" class="w-3.5 h-3.5" />
-        <span>Viewing as anonymous user</span>
-        <button @click="toggleViewAs" class="font-semibold underline underline-offset-2 hover:text-indigo-200">Exit</button>
+        <span>Viewing as {{ viewAsLabel }}</span>
+        <button @click="viewAsMode = 'you'" class="font-semibold underline underline-offset-2 hover:text-indigo-200">Exit</button>
       </div>
       <!-- Loading State -->
       <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900">
@@ -662,21 +671,70 @@ async function fetchViewerContext() {
   }
 }
 
-// "View as" preview (page artifacts): render the dashboard as an anonymous
-// viewer would see it. IDENTITY ONLY — current_user becomes null, but the
-// data payload is untouched: per-viewer data scoping happens server-side
-// (viewer runs / RLS), so this must never be presented as an access check.
-const viewAsAnonymous = ref(false);
+// "View as" preview (page artifacts): render the dashboard as another viewer
+// would see it — anonymous, or any org member (picked by name/email search).
+// IDENTITY ONLY — current_user is swapped, but the data payload is untouched:
+// per-viewer data scoping happens server-side (viewer runs / RLS), so this
+// must never be presented as an access check.
+const viewAsMode = ref<string>('you');  // 'you' | 'anonymous' | <member user_id>
+const previewViewer = ref<any>(null);   // fetched context of the picked member
+const membersList = ref<any[]>([]);
 const canViewAs = computed(() =>
   selectedArtifact.value?.mode === 'page' && !isPendingArtifact.value && !snapshotWithheld.value);
-const effectiveViewerContext = computed(() =>
-  viewAsAnonymous.value ? null : viewerContext.value);
-function toggleViewAs() {
-  viewAsAnonymous.value = !viewAsAnonymous.value;
+
+const viewAsOptions = computed(() => [
+  { value: 'you', label: 'You', email: (viewerContext.value?.email as string) || '' },
+  { value: 'anonymous', label: 'Anonymous user', email: '' },
+  ...membersList.value
+    .filter((m: any) => m.user?.id && String(m.user.id) !== String(viewerContext.value?.id))
+    .map((m: any) => ({
+      value: String(m.user.id),
+      label: m.user.name || m.user.email || m.email || 'Member',
+      email: m.user.email || m.email || '',
+    })),
+]);
+
+const viewAsLabel = computed(() => {
+  if (viewAsMode.value === 'you') return 'View as';
+  if (viewAsMode.value === 'anonymous') return 'Anonymous user';
+  const opt = viewAsOptions.value.find(o => o.value === viewAsMode.value);
+  return opt?.label || 'Member';
+});
+
+const effectiveViewerContext = computed(() => {
+  if (viewAsMode.value === 'anonymous') return null;
+  if (viewAsMode.value === 'you') return viewerContext.value;
+  // A member is picked but their context hasn't resolved yet → render
+  // anonymously rather than as the wrong person.
+  return previewViewer.value;
+});
+
+// Members load lazily, once, when the picker becomes available.
+let membersFetched = false;
+async function fetchMembersList() {
+  if (membersFetched || !organization.value?.id) return;
+  membersFetched = true;
+  try {
+    const { data } = await useMyFetch(`/api/organizations/${organization.value.id}/members`);
+    membersList.value = Array.isArray(data.value) ? (data.value as any[]) : [];
+  } catch {
+    membersList.value = [];
+  }
 }
-// Swapping identity re-sends data into an already-mounted iframe (srcdoc also
-// recomputes, but postMessage covers the no-reload path).
-watch(viewAsAnonymous, () => {
+watch(canViewAs, (v) => { if (v) fetchMembersList(); }, { immediate: true });
+
+watch(viewAsMode, async (mode) => {
+  previewViewer.value = null;
+  if (mode !== 'you' && mode !== 'anonymous') {
+    try {
+      const { data } = await useMyFetch(`/api/users/${mode}/viewer_context`);
+      previewViewer.value = data.value || null;
+    } catch {
+      previewViewer.value = null;
+    }
+  }
+  // Swapping identity re-sends data into an already-mounted iframe (srcdoc
+  // also recomputes, but postMessage covers the no-reload path).
   if (iframeReady.value) sendDataToIframe();
 });
 
@@ -1089,7 +1147,7 @@ watch(selectedArtifactId, async (newId, oldId) => {
   if (oldId === undefined) return;
   iframeError.value = null;
   iframeReady.value = false;
-  viewAsAnonymous.value = false;
+  viewAsMode.value = 'you';
   if (isPolishMode.value) exitPolishMode();
   await fetchSelectedArtifact();
   // Only refetch data if this is a user-initiated change (not initial load)

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -671,73 +671,6 @@ async function fetchViewerContext() {
   }
 }
 
-// "View as" preview (page artifacts): render the dashboard as another viewer
-// would see it — anonymous, or any org member (picked by name/email search).
-// IDENTITY ONLY — current_user is swapped, but the data payload is untouched:
-// per-viewer data scoping happens server-side (viewer runs / RLS), so this
-// must never be presented as an access check.
-const viewAsMode = ref<string>('you');  // 'you' | 'anonymous' | <member user_id>
-const previewViewer = ref<any>(null);   // fetched context of the picked member
-const membersList = ref<any[]>([]);
-const canViewAs = computed(() =>
-  selectedArtifact.value?.mode === 'page' && !isPendingArtifact.value && !snapshotWithheld.value);
-
-const viewAsOptions = computed(() => [
-  { value: 'you', label: 'You', email: (viewerContext.value?.email as string) || '' },
-  { value: 'anonymous', label: 'Anonymous user', email: '' },
-  ...membersList.value
-    .filter((m: any) => m.user?.id && String(m.user.id) !== String(viewerContext.value?.id))
-    .map((m: any) => ({
-      value: String(m.user.id),
-      label: m.user.name || m.user.email || m.email || 'Member',
-      email: m.user.email || m.email || '',
-    })),
-]);
-
-const viewAsLabel = computed(() => {
-  if (viewAsMode.value === 'you') return 'View as';
-  if (viewAsMode.value === 'anonymous') return 'Anonymous user';
-  const opt = viewAsOptions.value.find(o => o.value === viewAsMode.value);
-  return opt?.label || 'Member';
-});
-
-const effectiveViewerContext = computed(() => {
-  if (viewAsMode.value === 'anonymous') return null;
-  if (viewAsMode.value === 'you') return viewerContext.value;
-  // A member is picked but their context hasn't resolved yet → render
-  // anonymously rather than as the wrong person.
-  return previewViewer.value;
-});
-
-// Members load lazily, once, when the picker becomes available.
-let membersFetched = false;
-async function fetchMembersList() {
-  if (membersFetched || !organization.value?.id) return;
-  membersFetched = true;
-  try {
-    const { data } = await useMyFetch(`/api/organizations/${organization.value.id}/members`);
-    membersList.value = Array.isArray(data.value) ? (data.value as any[]) : [];
-  } catch {
-    membersList.value = [];
-  }
-}
-watch(canViewAs, (v) => { if (v) fetchMembersList(); }, { immediate: true });
-
-watch(viewAsMode, async (mode) => {
-  previewViewer.value = null;
-  if (mode !== 'you' && mode !== 'anonymous') {
-    try {
-      const { data } = await useMyFetch(`/api/users/${mode}/viewer_context`);
-      previewViewer.value = data.value || null;
-    } catch {
-      previewViewer.value = null;
-    }
-  }
-  // Swapping identity re-sends data into an already-mounted iframe (srcdoc
-  // also recomputes, but postMessage covers the no-reload path).
-  if (iframeReady.value) sendDataToIframe();
-});
-
 const iframeRef = ref<HTMLIFrameElement | null>(null);
 const isLoading = ref(true);
 const dataReady = ref(false);  // Guards iframeSrcdoc to prevent rendering before data loads
@@ -910,6 +843,76 @@ async function runAsViewer() {
     isViewerRunning.value = false;
   }
 }
+
+// "View as" preview (page artifacts): render the dashboard as another viewer
+// would see it — anonymous, or any org member (picked by name/email search).
+// IDENTITY ONLY — current_user is swapped, but the data payload is untouched:
+// per-viewer data scoping happens server-side (viewer runs / RLS), so this
+// must never be presented as an access check.
+// NOTE: declared after selectedArtifact/isPendingArtifact/snapshotWithheld —
+// the immediate watch below evaluates canViewAs during setup, so the refs it
+// reads must already be initialized.
+const viewAsMode = ref<string>('you');  // 'you' | 'anonymous' | <member user_id>
+const previewViewer = ref<any>(null);   // fetched context of the picked member
+const membersList = ref<any[]>([]);
+const canViewAs = computed(() =>
+  selectedArtifact.value?.mode === 'page' && !isPendingArtifact.value && !snapshotWithheld.value);
+
+const viewAsOptions = computed(() => [
+  { value: 'you', label: 'You', email: (viewerContext.value?.email as string) || '' },
+  { value: 'anonymous', label: 'Anonymous user', email: '' },
+  ...membersList.value
+    .filter((m: any) => m.user?.id && String(m.user.id) !== String(viewerContext.value?.id))
+    .map((m: any) => ({
+      value: String(m.user.id),
+      label: m.user.name || m.user.email || m.email || 'Member',
+      email: m.user.email || m.email || '',
+    })),
+]);
+
+const viewAsLabel = computed(() => {
+  if (viewAsMode.value === 'you') return 'View as';
+  if (viewAsMode.value === 'anonymous') return 'Anonymous user';
+  const opt = viewAsOptions.value.find(o => o.value === viewAsMode.value);
+  return opt?.label || 'Member';
+});
+
+const effectiveViewerContext = computed(() => {
+  if (viewAsMode.value === 'anonymous') return null;
+  if (viewAsMode.value === 'you') return viewerContext.value;
+  // A member is picked but their context hasn't resolved yet → render
+  // anonymously rather than as the wrong person.
+  return previewViewer.value;
+});
+
+// Members load lazily, once, when the picker becomes available.
+let membersFetched = false;
+async function fetchMembersList() {
+  if (membersFetched || !organization.value?.id) return;
+  membersFetched = true;
+  try {
+    const { data } = await useMyFetch(`/api/organizations/${organization.value.id}/members`);
+    membersList.value = Array.isArray(data.value) ? (data.value as any[]) : [];
+  } catch {
+    membersList.value = [];
+  }
+}
+watch(canViewAs, (v) => { if (v) fetchMembersList(); }, { immediate: true });
+
+watch(viewAsMode, async (mode) => {
+  previewViewer.value = null;
+  if (mode !== 'you' && mode !== 'anonymous') {
+    try {
+      const { data } = await useMyFetch(`/api/users/${mode}/viewer_context`);
+      previewViewer.value = data.value || null;
+    } catch {
+      previewViewer.value = null;
+    }
+  }
+  // Swapping identity re-sends data into an already-mounted iframe (srcdoc
+  // also recomputes, but postMessage covers the no-reload path).
+  if (iframeReady.value) sendDataToIframe();
+});
 
 // Docs open in edit mode by default for the report owner; everyone else gets
 // the read-only viewer. Keyed on the loaded artifact so mode + ownership are

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -138,7 +138,7 @@
              anonymous viewer. Identity-only — data is unaffected. -->
         <UTooltip
           v-if="canViewAs"
-          :text="viewAsAnonymous ? 'Back to your view' : 'View as anonymous viewer — previews personalization, not data access'"
+          :text="viewAsAnonymous ? 'Back to your view' : 'View as anonymous user'"
         >
           <button
             @click="toggleViewAs"
@@ -168,7 +168,7 @@
         class="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-600 text-white shadow-lg text-xs"
       >
         <Icon name="heroicons:eye" class="w-3.5 h-3.5" />
-        <span>Viewing as anonymous — previews personalization only, not data access</span>
+        <span>Viewing as anonymous user</span>
         <button @click="toggleViewAs" class="font-semibold underline underline-offset-2 hover:text-indigo-200">Exit</button>
       </div>
       <!-- Loading State -->

--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -619,6 +619,19 @@ async function exportPptx() {
   }
 }
 
+// Viewer identity for ARTIFACT_DATA.current_user (per-render, never stored on
+// the artifact). null until fetched — and stays null on any failure so the
+// dashboard renders anonymously instead of blocking.
+const viewerContext = ref<any>(null);
+async function fetchViewerContext() {
+  try {
+    const { data } = await useMyFetch('/api/users/me/viewer_context');
+    viewerContext.value = data.value || null;
+  } catch {
+    viewerContext.value = null;
+  }
+}
+
 const iframeRef = ref<HTMLIFrameElement | null>(null);
 const isLoading = ref(true);
 const dataReady = ref(false);  // Guards iframeSrcdoc to prevent rendering before data loads
@@ -943,8 +956,9 @@ onMounted(async () => {
   window.addEventListener('artifact:select', handleArtifactSelect);
   window.addEventListener('artifact:created', handleArtifactCreated);
 
-  // First fetch artifact list to know which artifact is selected
-  await fetchArtifactsList();
+  // First fetch artifact list to know which artifact is selected (viewer
+  // identity in parallel — it gates nothing, a failure just renders anonymous)
+  await Promise.all([fetchArtifactsList(), fetchViewerContext()]);
 
   // Load the selected artifact exactly once after initial selection. The
   // report page already fetched the latest artifact; reuse that object when
@@ -1067,7 +1081,8 @@ function sendDataToIframe() {
   const payload = JSON.parse(JSON.stringify({
     report: toRaw(reportData.value),
     visualizations: toRaw(visualizationsData.value),
-    files: toRaw(filesData.value)
+    files: toRaw(filesData.value),
+    current_user: toRaw(viewerContext.value)
   }));
 
   try {
@@ -1517,6 +1532,7 @@ const iframeSrcdoc = computed(() => {
       report: reportData.value,
       visualizations: visualizationsData.value,
       files: filesData.value,
+      current_user: viewerContext.value,
     },
     code: artifactCode,
     mode: selectedArtifact.value?.mode || 'page',

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -273,6 +273,17 @@ const report = ref<any>({
 });
 
 const artifact = ref<any>(null);
+// Viewer identity for ARTIFACT_DATA.current_user. Stays null for anonymous
+// viewers (401) or any fetch failure — the artifact renders anonymously.
+const viewerContext = ref<any>(null);
+async function fetchViewerContext() {
+    try {
+        const { data } = await useMyFetch('/api/users/me/viewer_context');
+        viewerContext.value = data.value || null;
+    } catch {
+        viewerContext.value = null;
+    }
+}
 const visualizationsData = ref<any[]>([]);
 const filesData = ref<any[]>([]);
 const hasArtifacts = ref(false);
@@ -714,7 +725,8 @@ const iframeSrcdoc = computed(() => {
                 theme: report.value.theme_name || report.value.report_theme_name
             },
             visualizations: visualizationsData.value,
-            files: filesData.value
+            files: filesData.value,
+            current_user: viewerContext.value
         },
         code: artifactCode,
         mode: artifact.value?.mode || 'page',
@@ -782,10 +794,12 @@ async function refreshOnView() {
 }
 
 onMounted(async () => {
-    // Load report and artifact in parallel first
+    // Load report and artifact in parallel first (viewer identity alongside —
+    // it gates nothing; anonymous viewers just get current_user=null)
     await Promise.all([
         loadReport(),
-        loadArtifact()
+        loadArtifact(),
+        fetchViewerContext()
     ]);
 
     // Load visualization data with artifact filter (if artifact exists)

--- a/frontend/public/libs/artifact-globals.js
+++ b/frontend/public/libs/artifact-globals.js
@@ -22,6 +22,16 @@
     return window.ARTIFACT_DATA;
   };
 
+  // ── useCurrentUser() ────────────────────────────────────────────────────────
+  // The viewing user, injected by the host as ARTIFACT_DATA.current_user:
+  // { id, name, email, image_url, role, profile_attributes } — every field
+  // nullable. Returns null for anonymous viewers and headless renders, so
+  // callers must guard: useCurrentUser()?.name.
+  window.useCurrentUser = function() {
+    var data = window.ARTIFACT_DATA || {};
+    return data.current_user || null;
+  };
+
   // ── LoadingSpinner ──────────────────────────────────────────────────────────
   window.LoadingSpinner = function(props) {
     var size = props && props.size ? props.size : 24;

--- a/frontend/public/mcp-artifact-app.html
+++ b/frontend/public/mcp-artifact-app.html
@@ -325,10 +325,13 @@
             return;
           }
 
-          // Set visualization data (same shape as ARTIFACT_DATA)
+          // Set visualization data (same shape as ARTIFACT_DATA).
+          // current_user is the authenticated MCP user (or null) — same
+          // viewer-identity contract as the in-app iframe.
           setArtifactData({
             report: data.report,
-            visualizations: data.visualizations
+            visualizations: data.visualizations,
+            current_user: data.current_user || null
           });
 
           // Inject the LLM-generated artifact code

--- a/frontend/utils/artifactIframe.ts
+++ b/frontend/utils/artifactIframe.ts
@@ -18,7 +18,7 @@
  * code ("DataTable is not defined"). Bump this whenever artifact-globals.js
  * gains or changes a global.
  */
-export const ARTIFACT_GLOBALS_VERSION = '2';
+export const ARTIFACT_GLOBALS_VERSION = '3';
 
 export interface ArtifactIframeFile {
   id: string;
@@ -28,11 +28,28 @@ export interface ArtifactIframeFile {
   dataUri?: string;
 }
 
+/**
+ * Viewer identity injected per render (never stored on the artifact).
+ * Shape mirrors GET /users/me/viewer_context. null/undefined = anonymous
+ * viewer (public token pages, headless validation/thumbnail renders).
+ */
+export interface ArtifactViewerContext {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image_url?: string | null;
+  role?: string | null;
+  profile_attributes?: Record<string, unknown> | null;
+}
+
 export interface ArtifactIframeData {
   report: unknown;
   visualizations: unknown[];
   /** Embedded images/PDFs, rendered by the <BowFile> sandbox global. */
   files?: ArtifactIframeFile[];
+  /** The viewing user, or null when anonymous. Every field is nullable —
+   *  generated code must guard (current_user?.name). Display-only. */
+  current_user?: ArtifactViewerContext | null;
 }
 
 export interface ArtifactIframeOptions {

--- a/frontend/utils/artifactIframe.ts
+++ b/frontend/utils/artifactIframe.ts
@@ -40,6 +40,8 @@ export interface ArtifactViewerContext {
   image_url?: string | null;
   role?: string | null;
   profile_attributes?: Record<string, unknown> | null;
+  /** Org group names, alphabetical, server-capped. Empty/missing when none. */
+  groups?: string[] | null;
 }
 
 export interface ArtifactIframeData {


### PR DESCRIPTION
Artifacts can now personalize per viewer: the host injects
ARTIFACT_DATA.current_user ({ id, name, email, image_url, role,
profile_attributes }) fresh at render time, and generated code reads it
via useCurrentUser() / useArtifactData().current_user.

- New GET /users/me/viewer_context: canonical identity payload (User +
  current-org Membership role/profile_attributes). Membership secrets
  and preferences are deliberately excluded.
- ArtifactFrame and /r/[id] fetch it per render and pass it in both the
  iframe srcdoc and the ARTIFACT_DATA postMessage; anonymous viewers and
  fetch failures degrade to current_user=null.
- Server-side renderers (create/edit validation, thumbnails, PDF export)
  always render with current_user=null so shared assets never bake in a
  viewer's identity and every artifact's null-guard path is exercised at
  validation time.
- MCP get_artifact_data returns the authenticated MCP user's context.
- Sandbox prompt/observation contracts document the field with hard
  null-guard rules; artifact-globals gains useCurrentUser() (cache
  version bumped).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017a7xQFxCXwGXTqvi2drikE