### PR TITLE
Fix delegated Power BI / Fabric sources for parameterized + personalized dashboards

### DIFF
--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -294,10 +294,37 @@ class SchemaContextBuilder:
                 for c in cols:
                     cols_by_table.setdefault(str(c.user_data_source_table_id), []).append(c)
 
+                # Canonical enrichment lookup for the overlay tables, WITHOUT the
+                # active filter. For a user_required source the canonical catalog
+                # is built by the service principal, which by design has no access
+                # to a delegated dataset — so its canonical row is typically
+                # inactive or absent (see canonical_by_name, filtered to
+                # is_active==True). The overlay's is_accessible flag is the real
+                # per-user access authority here; the canonical row is used only
+                # to enrich column/relationship descriptors, so load it directly
+                # by name regardless of is_active rather than dropping the table.
+                overlay_names = [n for n in visible_table_names if n]
+                canonical_all_by_name: Dict[str, DataSourceTable] = dict(canonical_by_name)
+                missing_names = [n for n in overlay_names if n not in canonical_all_by_name]
+                if missing_names:
+                    enrich_q = await self.db.execute(
+                        select(DataSourceTable)
+                        .options(
+                            selectinload(DataSourceTable.connection_table)
+                            .selectinload(ConnectionTable.connection)
+                        )
+                        .where(
+                            DataSourceTable.datasource_id == str(ds.id),
+                            DataSourceTable.name.in_(missing_names),
+                        )
+                    )
+                    for t in enrich_q.scalars().all():
+                        canonical_all_by_name.setdefault(getattr(t, 'name', ''), t)
+
                 for ot in overlay_tables:
                     name = getattr(ot, 'table_name', '') or ''
                     overlay_cols = cols_by_table.get(str(ot.id), [])
-                    base = canonical_by_name.get(name)
+                    base = canonical_all_by_name.get(name)
                     # The overlay decides WHICH columns this user may see; the
                     # canonical row describes WHAT they are. Column descriptors
                     # (measure role, hidden flag, return type) are model-level
@@ -343,11 +370,15 @@ class SchemaContextBuilder:
                             "description": None,
                             "metadata": safe_meta,
                         })
-                    # Respect canonical table's is_active status (default False if not found)
-                    canonical_is_active = bool(getattr(base, 'is_active', False)) if base is not None else False
-                    # Skip inactive tables when active_only is True
-                    if active_only and not canonical_is_active:
-                        continue
+                    # The overlay is the per-user access authority: this table
+                    # came from the is_accessible==True overlay query above, so
+                    # the user can provably query it right now. The canonical
+                    # is_active flag is unreliable for a user_required source
+                    # (service principal has no access → canonical stays
+                    # inactive), so do NOT gate the user's own accessible table
+                    # on it — that dropped every delegated-source table and left
+                    # the agent with an empty schema. Emit as active.
+                    canonical_is_active = True
                     pks = getattr(base, 'pks', []) if base is not None else []
                     fks = [
                         fk for fk in (getattr(base, 'fks', None) or [])

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Dict, Any
 import re
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlalchemy import select, func, and_
+from sqlalchemy import select, func, and_, or_
 from app.ai.context.sections.tables_schema_section import TablesSchemaContext, MCPToolItem
 from app.schemas.data_source_schema import DataSourceSummarySchema
 from app.ai.prompt_formatters import Table as PromptTable, TableColumn as PromptTableColumn, ForeignKey as PromptForeignKey
@@ -307,7 +307,7 @@ class SchemaContextBuilder:
                 canonical_all_by_name: Dict[str, DataSourceTable] = dict(canonical_by_name)
                 missing_names = [n for n in overlay_names if n not in canonical_all_by_name]
                 if missing_names:
-                    enrich_q = await self.db.execute(
+                    enrich_query = (
                         select(DataSourceTable)
                         .options(
                             selectinload(DataSourceTable.connection_table)
@@ -318,8 +318,29 @@ class SchemaContextBuilder:
                             DataSourceTable.name.in_(missing_names),
                         )
                     )
+                    # Honor the connection_ids contract the main query applies:
+                    # enrich only from rows on a target connection or unlinked
+                    # rows (a delegated dataset's canonical row is typically
+                    # unlinked). Never pull a row owned by another named
+                    # connection — that would mis-attribute the overlay table.
+                    if connection_ids:
+                        conn_id_set = set(str(x) for x in connection_ids)
+                        enrich_query = (
+                            enrich_query
+                            .outerjoin(
+                                ConnectionTable,
+                                DataSourceTable.connection_table_id == ConnectionTable.id,
+                            )
+                            .where(or_(
+                                ConnectionTable.connection_id.in_(conn_id_set),
+                                DataSourceTable.connection_table_id.is_(None),
+                            ))
+                        )
+                    enrich_q = await self.db.execute(enrich_query)
+                    # DataSourceTable.name is non-null; key directly (avoid an
+                    # empty-string bucket collapsing distinct rows).
                     for t in enrich_q.scalars().all():
-                        canonical_all_by_name.setdefault(getattr(t, 'name', ''), t)
+                        canonical_all_by_name.setdefault(t.name, t)
 
                 for ot in overlay_tables:
                     name = getattr(ot, 'table_name', '') or ''

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -110,6 +110,28 @@ from app.schemas.instruction_schema import InstructionCreate
 from app.core.telemetry import telemetry
 from app.ee.audit.service import audit_service
 
+
+def normalize_overlay_fks(fks) -> list:
+    """Serialize a table's foreign keys into JSON-storable dicts.
+
+    fks may arrive as pydantic ForeignKey objects (from a Table prompt
+    formatter) whose nested TableColumn values are NOT JSON serializable.
+    Persisting them into DataSourceTable.fks (a JSON column) raised "Object of
+    type ForeignKey is not JSON serializable" and aborted the entire per-user
+    overlay upsert for any dataset with relationships — so a delegated Power BI
+    / Fabric model with FKs could never build an overlay. Dicts pass through.
+    """
+    out = []
+    for fk in (fks or []):
+        if isinstance(fk, dict):
+            out.append(fk)
+        elif hasattr(fk, "model_dump"):
+            out.append(fk.model_dump(mode="json"))
+        elif hasattr(fk, "dict"):
+            out.append(fk.dict())
+    return out
+
+
 class DataSourceService:
 
     def __init__(self):
@@ -3908,7 +3930,7 @@ class DataSourceService:
                 normalized[name] = {
                     "columns": normalize_columns(t.get("columns", [])),
                     "pks": normalize_columns(t.get("pks", [])),
-                    "fks": t.get("fks", []) or [],
+                    "fks": normalize_overlay_fks(t.get("fks", [])),
                     "metadata_json": t.get("metadata_json"),
                 }
             else:
@@ -3918,7 +3940,7 @@ class DataSourceService:
                 normalized[name] = {
                     "columns": normalize_columns(getattr(t, "columns", [])),
                     "pks": normalize_columns(getattr(t, "pks", [])),
-                    "fks": getattr(t, "fks", []) or [],
+                    "fks": normalize_overlay_fks(getattr(t, "fks", [])),
                     "metadata_json": getattr(t, "metadata_json", None),
                 }
 

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -2557,7 +2557,7 @@ class DataSourceService:
 
             client = ClientClass(**allowed)
             self._attach_client_quota_metadata(client, data_source, conn, key)
-            await self._attach_stored_table_metadata(db, client, data_source, conn)
+            await self._attach_stored_table_metadata(db, client, data_source, conn, current_user=current_user)
             clients[key] = client
 
             # Accelerated (FAST) relations for this connection, exposed as a
@@ -2629,7 +2629,7 @@ class DataSourceService:
             list(rows), connection_name=connection.name, identity=identity
         )
 
-    async def _attach_stored_table_metadata(self, db: AsyncSession, client, data_source: DataSource, connection) -> None:
+    async def _attach_stored_table_metadata(self, db: AsyncSession, client, data_source: DataSource, connection, current_user=None) -> None:
         """Inject the persisted (indexed) table metadata into clients that
         resolve query targets from it.
 
@@ -2659,20 +2659,48 @@ class DataSourceService:
             # Attaching an unlinked row to a sibling connection's client is
             # harmless — resolution is by name, and a name it does not own simply
             # will not match (this is what the old no-rows fallback already did).
+            # NB: no is_active filter. This map only resolves a query target
+            # (table name → dataset GUID); it grants no access — the delegated
+            # token still gates executeQueries. On a user_required source the
+            # canonical row for a delegated dataset is inactive (the service
+            # principal that indexed the catalog has no access to it), so an
+            # is_active filter left the map empty and every viewer run failed
+            # with "Could not resolve Power BI dataset". The GUID is present on
+            # the inactive row, so keep it.
             rows = (await db.execute(
                 select(DataSourceTable.name, DataSourceTable.metadata_json)
                 .outerjoin(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
                 .where(
                     DataSourceTable.datasource_id == str(data_source.id),
-                    DataSourceTable.is_active == True,
                     or_(
                         ConnectionTable.connection_id == str(connection.id),
                         DataSourceTable.connection_table_id.is_(None),
                     ),
                 )
             )).all()
+            attach = {name: metadata_json for name, metadata_json in rows}
+
+            # Merge the executing user's overlay metadata. A delegated dataset
+            # can enter the catalog ONLY through a user's own discovery, so for
+            # a viewer whose overlay carries the GUID but whose canonical row is
+            # missing entirely, the overlay is the sole source of the mapping.
+            # Overlay values win — they were discovered under this user's creds.
+            if current_user is not None:
+                from app.models.user_data_source_overlay import UserDataSourceTable
+                ov = (await db.execute(
+                    select(UserDataSourceTable.table_name, UserDataSourceTable.metadata_json)
+                    .where(
+                        UserDataSourceTable.data_source_id == str(data_source.id),
+                        UserDataSourceTable.user_id == str(current_user.id),
+                        UserDataSourceTable.is_accessible == True,
+                    )
+                )).all()
+                for name, metadata_json in ov:
+                    if metadata_json:
+                        attach[name] = metadata_json
+
             client.attach_table_metadata(
-                [{"name": name, "metadata_json": metadata_json} for name, metadata_json in rows]
+                [{"name": name, "metadata_json": metadata_json} for name, metadata_json in attach.items()]
             )
         except Exception:
             # Non-fatal: the client falls back to live discovery.

--- a/backend/tests/unit/test_attach_table_metadata_delegated.py
+++ b/backend/tests/unit/test_attach_table_metadata_delegated.py
@@ -1,0 +1,109 @@
+"""Query-target metadata (table name → Power BI dataset GUID) must reach the
+client even when the canonical catalog row is inactive, and must include the
+executing user's overlay.
+
+Confirmed against a live Power BI verify-rls dataset: a shared dashboard's
+per-viewer run failed with "Could not resolve Power BI dataset for table
+'rls_sales/Sales'". The canonical DataSourceTable carried the correct datasetId
+but was is_active=False (the service principal that indexes the catalog has no
+access to a delegated dataset), and _attach_stored_table_metadata filtered on
+is_active==True — so the resolution map was empty and every viewer run failed.
+
+The map only resolves a query target; access is still enforced by the delegated
+token at executeQueries time. So it must include inactive canonical rows and the
+executing user's overlay rows.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import main  # noqa: F401 — registers all mappers
+from app.models.base import BaseSchema
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.data_source import DataSource
+from app.models.connection import Connection
+from app.models.datasource_table import DataSourceTable
+from app.models.user_data_source_overlay import UserDataSourceTable
+from app.services.data_source_service import DataSourceService
+
+
+class _FakeClient:
+    def __init__(self):
+        self.attached = None
+
+    def attach_table_metadata(self, tables):
+        self.attached = tables
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseSchema.metadata.create_all)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db, *, canonical_active):
+    org = Organization(name="o")
+    user = User(name="u", email="u@x.com", hashed_password="x")
+    db.add_all([org, user])
+    await db.flush()
+    ds = DataSource(name="PowerBI verify-rls", organization_id=str(org.id), is_active=True)
+    db.add(ds)
+    await db.flush()
+    conn = Connection(name="c", type="powerbi", config={}, is_active=True,
+                      auth_policy="user_required", organization_id=str(org.id))
+    conn.data_sources.append(ds)
+    db.add(conn)
+    canon = DataSourceTable(
+        name="rls_sales/Sales", datasource_id=str(ds.id), is_active=canonical_active,
+        columns=[{"name": "id", "dtype": "Integer"}], pks=[], fks=[],
+        metadata_json={"powerbi": {"datasetId": "443cb0b4", "workspaceId": "ws-1"}},
+    )
+    db.add(canon)
+    ot = UserDataSourceTable(
+        data_source_id=str(ds.id), user_id=str(user.id),
+        table_name="rls_sales/Sales", is_accessible=True, status="accessible",
+        metadata_json={"powerbi": {"datasetId": "443cb0b4", "workspaceId": "ws-1"}},
+    )
+    db.add(ot)
+    await db.flush()
+    return org, user, ds, conn
+
+
+@pytest.mark.asyncio
+async def test_inactive_canonical_metadata_still_attached(db):
+    org, user, ds, conn = await _seed(db, canonical_active=False)
+    client = _FakeClient()
+    await DataSourceService()._attach_stored_table_metadata(
+        db, client, ds, conn, current_user=user)
+    names = {t["name"] for t in (client.attached or [])}
+    assert "rls_sales/Sales" in names, (
+        "delegated table's dataset-GUID metadata dropped because canonical is inactive")
+    meta = next(t["metadata_json"] for t in client.attached if t["name"] == "rls_sales/Sales")
+    assert (meta or {}).get("powerbi", {}).get("datasetId") == "443cb0b4"
+
+
+@pytest.mark.asyncio
+async def test_overlay_only_table_is_attached(db):
+    """A delegated dataset with no canonical row at all — only the user's
+    overlay carries the GUID — must still resolve."""
+    org, user, ds, conn = await _seed(db, canonical_active=False)
+    # Remove the canonical row entirely; overlay is the sole source.
+    canon = (await db.execute(
+        DataSourceTable.__table__.select().where(
+            DataSourceTable.datasource_id == str(ds.id))
+    )).first()
+    await db.execute(DataSourceTable.__table__.delete().where(
+        DataSourceTable.datasource_id == str(ds.id)))
+    await db.flush()
+    client = _FakeClient()
+    await DataSourceService()._attach_stored_table_metadata(
+        db, client, ds, conn, current_user=user)
+    names = {t["name"] for t in (client.attached or [])}
+    assert "rls_sales/Sales" in names

--- a/backend/tests/unit/test_attach_table_metadata_delegated.py
+++ b/backend/tests/unit/test_attach_table_metadata_delegated.py
@@ -94,11 +94,13 @@ async def test_overlay_only_table_is_attached(db):
     """A delegated dataset with no canonical row at all — only the user's
     overlay carries the GUID — must still resolve."""
     org, user, ds, conn = await _seed(db, canonical_active=False)
-    # Remove the canonical row entirely; overlay is the sole source.
+    # Precondition: a canonical row exists; then remove it so the overlay is
+    # the sole source of the GUID.
     canon = (await db.execute(
         DataSourceTable.__table__.select().where(
             DataSourceTable.datasource_id == str(ds.id))
     )).first()
+    assert canon is not None
     await db.execute(DataSourceTable.__table__.delete().where(
         DataSourceTable.datasource_id == str(ds.id)))
     await db.flush()

--- a/backend/tests/unit/test_overlay_fk_serialization.py
+++ b/backend/tests/unit/test_overlay_fk_serialization.py
@@ -1,0 +1,44 @@
+"""A delegated dataset's foreign keys must serialize into the overlay.
+
+Confirmed against a live Power BI dataset with relationships (FleetOps): the
+per-user overlay upsert crashed with "Object of type ForeignKey is not JSON
+serializable" because the table's fks stayed as pydantic ForeignKey objects on
+their way into DataSourceTable.fks (a JSON column). Columns and pks were
+normalized; fks were not. Any modeled dataset with relationships could never
+build a delegated overlay — blocking the owner from authoring over it.
+"""
+import json
+
+from app.ai.prompt_formatters import Table, TableColumn, ForeignKey
+from app.services.data_source_service import normalize_overlay_fks
+
+
+def _fk():
+    return ForeignKey(
+        column=TableColumn(name="vehicle_id", dtype="Integer"),
+        references_name="FleetOps/dim_vehicle",
+        references_column=TableColumn(name="id", dtype="Integer"),
+    )
+
+
+def test_foreignkey_objects_become_json_serializable_dicts():
+    out = normalize_overlay_fks([_fk()])
+    # Must survive the JSON column round-trip that previously raised.
+    json.dumps(out)
+    assert isinstance(out[0], dict)
+    assert out[0]["references_name"] == "FleetOps/dim_vehicle"
+    assert out[0]["column"]["name"] == "vehicle_id"
+
+
+def test_dicts_pass_through_and_empty_is_safe():
+    d = [{"column": {"name": "x"}, "references_name": "T", "references_column": {"name": "id"}}]
+    assert normalize_overlay_fks(d) == d
+    assert normalize_overlay_fks([]) == []
+    assert normalize_overlay_fks(None) == []
+
+
+def test_table_fks_from_prompt_formatter_serialize():
+    t = Table(name="FleetOps/fact_service_event",
+              columns=[TableColumn(name="vehicle_id", dtype="Integer")],
+              pks=[], fks=[_fk()])
+    json.dumps(normalize_overlay_fks(t.fks))

--- a/backend/tests/unit/test_overlay_inactive_canonical_context.py
+++ b/backend/tests/unit/test_overlay_inactive_canonical_context.py
@@ -1,0 +1,107 @@
+"""A delegated (user_required) source must not vanish from the agent's schema
+context just because its canonical catalog is inactive.
+
+Root cause (confirmed end-to-end against a live Power BI verify-rls dataset):
+the org-level canonical catalog is indexed by the service principal, which by
+design has NO access to a delegated dataset — so the canonical DataSourceTable
+row is inactive (or absent). The overlay branch gated the user's own,
+provably-accessible overlay table on that canonical is_active flag and the
+active_only filter, so build() returned ZERO tables. The owner then could not
+build any query (the model correctly reported "no tables available").
+
+The overlay's is_accessible flag is the per-user access authority; this test
+pins that an accessible overlay table surfaces even when its canonical row is
+inactive.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import main  # noqa: F401 — registers all mappers
+from app.models.base import BaseSchema
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.data_source import DataSource
+from app.models.connection import Connection
+from app.models.datasource_table import DataSourceTable
+from app.models.user_data_source_overlay import UserDataSourceTable, UserDataSourceColumn
+from app.ai.context.builders.schema_context_builder import SchemaContextBuilder
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseSchema.metadata.create_all)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db):
+    org = Organization(name="o")
+    user = User(name="u", email="u@x.com", hashed_password="x")
+    db.add_all([org, user])
+    await db.flush()
+    ds = DataSource(name="PowerBI verify-rls",
+                    organization_id=str(org.id), is_active=True)
+    db.add(ds)
+    await db.flush()
+    conn = Connection(name="c", type="powerbi", config={}, is_active=True,
+                      auth_policy="user_required", organization_id=str(org.id))
+    conn.data_sources.append(ds)  # M:N via domain_connection
+    db.add(conn)
+    # Canonical row is INACTIVE — the service principal cannot see the
+    # delegated dataset, exactly as observed against verify-rls.
+    canon = DataSourceTable(
+        name="rls_sales/Sales", datasource_id=str(ds.id), is_active=False,
+        columns=[{"name": "id", "dtype": "Integer"},
+                 {"name": "Region", "dtype": "Text"},
+                 {"name": "Amount", "dtype": "Number"}],
+        pks=[], fks=[],
+    )
+    db.add(canon)
+    # The user's overlay: accessible.
+    ot = UserDataSourceTable(
+        data_source_id=str(ds.id), user_id=str(user.id),
+        table_name="rls_sales/Sales", is_accessible=True, status="accessible",
+    )
+    db.add(ot)
+    await db.flush()
+    for cn, dt in (("id", "Integer"), ("Region", "Text"), ("Amount", "Number")):
+        db.add(UserDataSourceColumn(user_data_source_table_id=str(ot.id),
+                                    column_name=cn, is_accessible=True, data_type=dt))
+    await db.flush()
+    # connections must be loadable off the ds for _resolve_user_access / gating
+    await db.refresh(ds, attribute_names=["connections"])
+    return org, user, ds
+
+
+@pytest.mark.asyncio
+async def test_accessible_overlay_table_surfaces_despite_inactive_canonical(db, monkeypatch):
+    org, user, ds = await _seed(db)
+
+    builder = SchemaContextBuilder(db, [ds], org, None, user=user)
+    # Isolate the overlay-rendering path under test: the user has proven
+    # access (own delegated creds), so _resolve_user_access → 'user'.
+    async def _user_access(_ds):
+        return "user"
+    monkeypatch.setattr(builder, "_resolve_user_access", _user_access)
+
+    ctx = await builder.build(with_stats=False)
+
+    tables = [getattr(t, "name", None)
+              for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])]
+    assert "rls_sales/Sales" in tables, (
+        "accessible overlay table dropped because its canonical row is inactive")
+
+    # And the user's columns are carried through (from the overlay, enriched
+    # by the canonical dtypes).
+    cols = [c
+            for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])
+            if getattr(t, "name", None) == "rls_sales/Sales"
+            for c in (getattr(t, "columns", []) or [])]
+    names = {getattr(c, "name", None) for c in cols}
+    assert {"id", "Region", "Amount"} <= names


### PR DESCRIPTION
## Summary

End-to-end testing of the parameterized-queries / personalized-artifacts feature (merged in #1004) against a **live Power BI tenant with real RLS** surfaced three bugs that together made the whole feature unusable on any delegated (`user_required`) Power BI / Fabric source — exactly the sources it was built for. All three are fixed here, each with a regression test, and each verified end-to-end.

The test scenario: a `rls_sales` dataset where `demo1` sees US-only rows ($9,000) and `demo2` sees EMEA-only rows ($4,600) via Power BI RLS, plus a `FleetOps` dataset `demo1` can read and `demo2` cannot.

## Bugs fixed

**1. Owner could not author queries — the agent saw zero tables** (`schema_context_builder.py`)
A `user_required` source's canonical catalog is indexed by the service principal, which by design has no access to a delegated dataset, so the canonical `DataSourceTable` row is inactive. The per-user overlay branch gated the user's own, provably-accessible overlay table on that canonical `is_active` flag, so `build()` returned no tables and the model correctly reported "no tables available." The overlay's `is_accessible` is now the authority: overlay tables load their canonical row for enrichment regardless of `is_active`, and an accessible overlay table is treated as active.

**2. Shared dashboards failed for every viewer — "Could not resolve Power BI dataset"** (`data_source_service.py`, `_attach_stored_table_metadata`)
The client resolves a query target (table name → dataset GUID) from a metadata map that was built filtering `DataSourceTable.is_active == True`. On a delegated source the canonical row is inactive, so the map was empty and resolution fell through to a live workspace crawl — which finds nothing for a viewer who has dataset-level access but is not a workspace member. The map only resolves a name to a GUID (access is still enforced by the delegated token), so it now keeps inactive rows and merges the executing user's overlay metadata.

**3. Overlays crashed for any modeled dataset — "ForeignKey is not JSON serializable"** (`data_source_service.py`, overlay normalize)
Columns and pks were normalized before being written to the JSON overlay columns, but fks were passed through as pydantic `ForeignKey` objects, so the flush aborted the entire overlay upsert for any dataset with relationships. A flat single-table dataset hid it; a star schema (FleetOps) surfaced it. fks are now serialized via a `normalize_overlay_fks` helper.

## Verification (live Power BI, delegated tokens for demo1/demo2)

- **Owner builds a parameterized query** over `rls_sales` → 3 US rows, `region` param declared (was completely blocked by bug 1).
- **Share to a member without access** (FleetOps) → member sees "No data available", zero leak of the owner's rows; member's own delegated run fails (no access).
- **Share to a member with access** (`rls_sales`) → member sees their **own EMEA rows** and the region control scoped to EMEA (was blocked by bug 2).
- **Identity / per-viewer** → the same dashboard shows demo1 US / demo2 EMEA, with the owner's snapshot withheld from the viewer.

## Tests

- `test_overlay_inactive_canonical_context.py` — accessible overlay table surfaces despite an inactive canonical
- `test_attach_table_metadata_delegated.py` — dataset-GUID metadata attaches from inactive canonical and from the user's overlay
- `test_overlay_fk_serialization.py` — foreign keys serialize into the overlay
- Regression sweep of the overlay / schema-context / powerbi suites: 224 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4imhKobKeNyW3ZYRas1Ay)_