### PR TITLE
monday: relation-family columns no longer read as empty

### DIFF
--- a/backend/app/data_sources/clients/monday_client.py
+++ b/backend/app/data_sources/clients/monday_client.py
@@ -655,10 +655,23 @@ class MondayClient(DataSourceClient):
                 translated.append(value)
         return translated
 
+    # Relation-family column values (mirror, connect-boards, dependency,
+    # subitems) return an EMPTY `text` — their display string lives on the
+    # type-specific `display_value` field (verified live; monday's own SDK and
+    # Airbyte's connector request the same fragments). Without these, every
+    # such column reads as None in query results.
+    _COLUMN_VALUE_FRAGMENTS = (
+        " ... on MirrorValue { display_value }"
+        " ... on BoardRelationValue { display_value }"
+        " ... on DependencyValue { display_value }"
+        " ... on SubtasksValue { display_value }"
+    )
+
     def _fetch_items(self, board_id, column_ids: List[str], query_params: Optional[dict], limit: int) -> List[dict]:
         items: List[dict] = []
         item_fields = (
-            "id name group { title } column_values (ids: $cols) { id text value type }"
+            "id name group { title } column_values (ids: $cols) { id text value type"
+            + self._COLUMN_VALUE_FRAGMENTS + " }"
             if column_ids else "id name group { title }"
         )
         first_page = min(PAGE_SIZE, limit)
@@ -736,9 +749,13 @@ class MondayClient(DataSourceClient):
     @staticmethod
     def _cell_value(value: dict):
         """One typed scalar per cell. `text` is monday's display string; typed
-        columns parse it (or the raw JSON `value`) into a real dtype."""
+        columns parse it (or the raw JSON `value`) into a real dtype.
+        Relation-family columns carry their display string in `display_value`
+        instead of `text` (which comes back empty) — backfill it."""
         kind = value.get("type")
         text = value.get("text")
+        if text in (None, "") and value.get("display_value"):
+            text = value["display_value"]
         if kind == "numbers":
             if text in (None, ""):
                 return None
@@ -797,6 +814,8 @@ class MondayClient(DataSourceClient):
         timeline, dropdown, …) → display TEXT strings; empty cells → None.
         Status columns hold label text ("Done"), date columns "YYYY-MM-DD"
         strings (parse with pd.to_datetime), timeline "YYYY-MM-DD - YYYY-MM-DD".
+        Connect-boards / mirror / dependency / subitems columns hold the
+        comma-separated display names of the linked items.
 
         Date/number comparisons in `rules` are unreliable in the monday API —
         fetch the rows (set `limit` high enough) and filter/aggregate in pandas

--- a/backend/tests/unit/test_monday_client.py
+++ b/backend/tests/unit/test_monday_client.py
@@ -461,6 +461,49 @@ def test_execute_query_accepts_base_columns_in_selection(monkeypatch):
     assert items_call["variables"]["cols"] == ["color_1"]  # only the board column is fetched
 
 
+def test_execute_query_relation_columns_use_display_value(monkeypatch):
+    """Mirror / connect-boards / dependency / subitems column values return an
+    EMPTY `text` — their display string is on the type-specific
+    `display_value` field. The items query must request the fragments and the
+    cell parser must backfill text from display_value."""
+    board = {
+        **BOARD_LINKED,
+        "id": "777",
+        "name": "Linked Board",
+        "columns": [
+            {"id": "name", "title": "Name", "type": "name", "settings_str": "{}"},
+            {"id": "rel_1", "title": "Account", "type": "board_relation", "settings_str": "{}"},
+            {"id": "mirror_1", "title": "Account Status", "type": "mirror", "settings_str": "{}"},
+        ],
+    }
+    page = {"cursor": None, "items": [item(1, "Deal", [
+        {"id": "rel_1", "text": None, "value": "{}", "type": "board_relation",
+         "display_value": "Acme Corp, Globex"},
+        {"id": "mirror_1", "text": "", "value": None, "type": "mirror",
+         "display_value": "Active"},
+    ])]}
+
+    calls = []
+
+    def responder(query, variables):
+        calls.append(query)
+        if "workspaces (limit" in query:
+            return FakeResponse({"data": {"workspaces": []}})
+        if "boards (limit: $limit, page: $page" in query:
+            return FakeResponse({"data": {"boards": [board] if variables.get("page", 1) == 1 else []}})
+        if "items_page" in query:
+            return FakeResponse({"data": {"boards": [{"items_page": page}]}})
+        raise AssertionError(query)
+
+    fake_post(monkeypatch, responder)
+    df = MondayClient(api_token="t").execute_query(json.dumps({"board": "Linked Board", "limit": 5}))
+    assert df.iloc[0]["Account"] == "Acme Corp, Globex"
+    assert df.iloc[0]["Account Status"] == "Active"
+    items_query = next(q for q in calls if "items_page" in q)
+    for fragment in ["MirrorValue", "BoardRelationValue", "DependencyValue", "SubtasksValue"]:
+        assert f"... on {fragment} {{ display_value }}" in items_query
+
+
 def test_execute_query_bad_specs(monkeypatch):
     fake_post(monkeypatch, boards_responder(ALL_BOARDS))
     client = MondayClient(api_token="t")


### PR DESCRIPTION
## Why

Follow-up from the monday connector investigation (#1007). Mirror, connect-boards (`board_relation`), dependency, and subitems column values return an **empty `text`** from the monday API — their display string lives on the type-specific `display_value` field. `execute_query` only read `text`, so every such column silently came back `None` in DataFrames — while the published schema advertises `board_relation` columns as foreign keys and the system prompt explicitly tells the model to "merge boards in pandas on a connect-boards column." Confirmed live, and cross-confirmed against monday's official Python SDK and Airbyte's monday connector, both of which request the same typed fragments.

## What

`backend/app/data_sources/clients/monday_client.py`:
- The items query now requests `... on MirrorValue { display_value }`, `BoardRelationValue`, `DependencyValue`, and `SubtasksValue` fragments (all four types carry `display_value` per monday's GraphQL schema).
- `_cell_value` backfills `text` from `display_value` when `text` is empty, so relation columns hold the comma-separated display names of linked items — same normalization Airbyte uses.
- The query system prompt documents the shape ("connect-boards / mirror / dependency / subitems columns hold the comma-separated display names of the linked items").

## Validation

- **Unit**: `tests/unit/test_monday_client.py` — 21 pass, including a new regression asserting the fragments are requested and that `board_relation`/`mirror` cells resolve from `display_value`.
- **Live** (monday trial account): a real subitems column now renders `"child task"` (previously `None`), and a freshly created connect-boards column linked to another board's item renders `"Linked target item"` (previously `None`) through the full `execute_query` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA)_