### PR TITLE
monday: id-based joins for connected boards

### DIFF
--- a/backend/app/data_sources/clients/monday_client.py
+++ b/backend/app/data_sources/clients/monday_client.py
@@ -90,6 +90,13 @@ _TYPE_MAP = {
 # Column types whose settings carry an index→label map that rules filter by.
 _LABELED_TYPES = {"status", "dropdown"}
 
+# Column types that link to items and expose `linked_item_ids` — each gets a
+# companion "<Column> (item_ids)" DataFrame column for precise id-based joins
+# (display names are ambiguous: duplicates exist and multi-link cells are
+# comma-joined).
+_LINKED_ID_TYPES = {"board_relation", "dependency"}
+_ITEM_IDS_SUFFIX = " (item_ids)"
+
 
 class MondayClient(DataSourceClient):
 
@@ -472,6 +479,18 @@ class MondayClient(DataSourceClient):
             table_column = TableColumn(name=col_name, dtype=dtype, description="; ".join(parts))
             columns.append(table_column)
 
+            if column.get("type") in _LINKED_ID_TYPES:
+                # Companion ids column: the joinable counterpart of the
+                # display-name column (query results carry both).
+                ids_column = TableColumn(
+                    name=f"{col_name}{_ITEM_IDS_SUFFIX}",
+                    dtype="list[int]",
+                    description=f"item ids of the items linked in {col_name!r}; "
+                                "explode and merge on the linked board's item_id",
+                )
+                seen.add(ids_column.name)
+                columns.append(ids_column)
+
             if column.get("type") == "board_relation":
                 try:
                     settings = json.loads(column.get("settings_str") or "{}")
@@ -479,7 +498,7 @@ class MondayClient(DataSourceClient):
                         linked_name = board_names_by_id.get(str(linked_id))
                         if linked_name:
                             fks.append(ForeignKey(
-                                column=table_column,
+                                column=ids_column,
                                 references_name=linked_name,
                                 references_column=TableColumn(name="item_id", dtype="int"),
                             ))
@@ -596,6 +615,12 @@ class MondayClient(DataSourceClient):
             if str(ref).lower() in self._BASE_COLUMNS:
                 continue
             column = by_key.get(str(ref)) or by_key.get(str(ref).lower())
+            if column is None and str(ref).lower().endswith(_ITEM_IDS_SUFFIX):
+                # The schema publishes "<Column> (item_ids)" companions for
+                # linked columns — selecting one selects its parent column
+                # (the companion is emitted alongside it).
+                base = str(ref)[:-len(_ITEM_IDS_SUFFIX)]
+                column = by_key.get(base) or by_key.get(base.lower())
             if column is None:
                 missing.append(str(ref))
             elif column not in selected:
@@ -662,8 +687,8 @@ class MondayClient(DataSourceClient):
     # such column reads as None in query results.
     _COLUMN_VALUE_FRAGMENTS = (
         " ... on MirrorValue { display_value }"
-        " ... on BoardRelationValue { display_value }"
-        " ... on DependencyValue { display_value }"
+        " ... on BoardRelationValue { display_value linked_item_ids }"
+        " ... on DependencyValue { display_value linked_item_ids }"
         " ... on SubtasksValue { display_value }"
     )
 
@@ -714,14 +739,22 @@ class MondayClient(DataSourceClient):
         return items[:limit]
 
     def _items_to_df(self, items: List[dict], selected: List[dict]) -> pd.DataFrame:
-        # DataFrame column name per board column: title, disambiguated like the schema.
+        # DataFrame column name per board column: title, disambiguated like the
+        # schema. Linked columns (connect-boards, dependency) additionally get
+        # a "<Column> (item_ids)" companion carrying the linked item ids, so
+        # joins run on ids instead of ambiguous display names.
         names: Dict[str, str] = {}
+        id_companions: Dict[str, str] = {}
         seen = {"item_id", "name", "group"}
         for column in selected:
             title = column.get("title") or column["id"]
             name = title if title not in seen else f"{title} ({column['id']})"
             seen.add(name)
             names[column["id"]] = name
+            if column.get("type") in _LINKED_ID_TYPES:
+                companion = f"{name}{_ITEM_IDS_SUFFIX}"
+                seen.add(companion)
+                id_companions[column["id"]] = companion
 
         rows = []
         for item in items:
@@ -735,12 +768,20 @@ class MondayClient(DataSourceClient):
                 if target is None:
                     continue
                 row[target] = self._cell_value(value)
+                companion = id_companions.get(value.get("id"))
+                if companion is not None:
+                    row[companion] = [int(i) for i in value.get("linked_item_ids") or []]
             rows.append(row)
 
         # Deterministic shape regardless of returned values: base columns +
-        # every selected column, in board order (a column that is empty on all
-        # returned items would otherwise vanish from the frame).
-        expected = ["item_id", "name", "group"] + list(names.values())
+        # every selected column (each linked column followed by its ids
+        # companion), in board order (a column that is empty on all returned
+        # items would otherwise vanish from the frame).
+        expected = ["item_id", "name", "group"]
+        for column_id, name in names.items():
+            expected.append(name)
+            if column_id in id_companions:
+                expected.append(id_companions[column_id])
         frame = pd.DataFrame(rows)
         if frame.empty:
             return pd.DataFrame(columns=expected)
@@ -815,18 +856,30 @@ class MondayClient(DataSourceClient):
         Status columns hold label text ("Done"), date columns "YYYY-MM-DD"
         strings (parse with pd.to_datetime), timeline "YYYY-MM-DD - YYYY-MM-DD".
         Connect-boards / mirror / dependency / subitems columns hold the
-        comma-separated display names of the linked items.
+        comma-separated display names of the linked items. Connect-boards and
+        dependency columns ALSO come with a companion column
+        "<Column> (item_ids)" holding the linked monday item ids as a list —
+        always join on it, never on display names (names duplicate).
 
         Date/number comparisons in `rules` are unreliable in the monday API —
         fetch the rows (set `limit` high enough) and filter/aggregate in pandas
         instead. Do NOT try to join boards in the API; fetch each board and
-        merge in pandas on item name or a connect-boards column.
+        merge in pandas: explode the "<Column> (item_ids)" companion and merge
+        it against the linked board's `item_id` (the schema's foreign keys show
+        which board each connect-boards column links to). Mirror columns are
+        display text only and cannot be joined on.
 
         Examples:
         ```python
         df = client.execute_query('{"board": "Engineering Bug Tracker", "columns": ["Status", "Priority", "Due Date"], "rules": [{"column_id": "Status", "compare_value": ["Done"], "operator": "not_any_of"}], "limit": 1000}')
         df = client.execute_query('{"board": "Sales Pipeline Q3", "limit": 2000}')
         df["Amount"] = pd.to_numeric(df["Amount"], errors="coerce")  # numbers columns are already float; only needed for text columns
+        # cross-board join via a connect-boards column:
+        deals = client.execute_query('{"board": "Sales Pipeline Q3", "limit": 2000}')
+        accounts = client.execute_query('{"board": "Accounts", "limit": 2000}')
+        joined = (deals.explode("Account (item_ids)")
+                       .merge(accounts, left_on="Account (item_ids)", right_on="item_id",
+                              how="left", suffixes=("", " (Account)")))
         ```
         """
         return text

--- a/backend/tests/unit/test_monday_client.py
+++ b/backend/tests/unit/test_monday_client.py
@@ -235,10 +235,12 @@ def test_get_schemas_shape(monkeypatch):
     assert main.metadata_json["board_id"] == "111"
     assert main.metadata_json["hierarchy_type"] == "classic"
 
-    # board_relation -> FK to the linked board's table name
+    # board_relation -> companion ids column + FK from it to the linked table
+    assert columns["Account (item_ids)"].dtype == "list[int]"
     assert len(main.fks) == 1
     assert main.fks[0].references_name == "Accounts"
-    assert main.fks[0].column.name == "Account"
+    assert main.fks[0].column.name == "Account (item_ids)"
+    assert main.fks[0].references_column.name == "item_id"
 
 
 def test_get_schemas_scoping(monkeypatch):
@@ -405,7 +407,8 @@ def test_execute_query_flattening_and_pagination(monkeypatch):
     fake_post(monkeypatch, boards_responder(ALL_BOARDS))
     df = MondayClient(api_token="t").execute_query(json.dumps({"board": "Sales Pipeline", "limit": 10}))
     assert list(df.columns) == [
-        "item_id", "name", "group", "Status", "Amount", "Due Date", "Approved", "Priority", "Account",
+        "item_id", "name", "group", "Status", "Amount", "Due Date", "Approved", "Priority",
+        "Account", "Account (item_ids)",
     ]
     # both pages fetched through the cursor
     assert len(df) == 3
@@ -478,7 +481,7 @@ def test_execute_query_relation_columns_use_display_value(monkeypatch):
     }
     page = {"cursor": None, "items": [item(1, "Deal", [
         {"id": "rel_1", "text": None, "value": "{}", "type": "board_relation",
-         "display_value": "Acme Corp, Globex"},
+         "display_value": "Acme Corp, Globex", "linked_item_ids": ["901", "902"]},
         {"id": "mirror_1", "text": "", "value": None, "type": "mirror",
          "display_value": "Active"},
     ])]}
@@ -498,10 +501,56 @@ def test_execute_query_relation_columns_use_display_value(monkeypatch):
     fake_post(monkeypatch, responder)
     df = MondayClient(api_token="t").execute_query(json.dumps({"board": "Linked Board", "limit": 5}))
     assert df.iloc[0]["Account"] == "Acme Corp, Globex"
+    assert df.iloc[0]["Account (item_ids)"] == [901, 902]
     assert df.iloc[0]["Account Status"] == "Active"
     items_query = next(q for q in calls if "items_page" in q)
-    for fragment in ["MirrorValue", "BoardRelationValue", "DependencyValue", "SubtasksValue"]:
-        assert f"... on {fragment} {{ display_value }}" in items_query
+    assert "... on MirrorValue { display_value }" in items_query
+    assert "... on SubtasksValue { display_value }" in items_query
+    for fragment in ["BoardRelationValue", "DependencyValue"]:
+        assert f"... on {fragment} {{ display_value linked_item_ids }}" in items_query
+
+
+def test_execute_query_item_ids_companion_selectable_and_joinable(monkeypatch):
+    """Selecting the '<Column> (item_ids)' companion published in the schema
+    must select the parent column, and the companion must support the
+    documented explode-and-merge join on the linked board's item_id."""
+    board = {
+        **BOARD_LINKED,
+        "id": "777",
+        "name": "Linked Board",
+        "columns": [
+            {"id": "name", "title": "Name", "type": "name", "settings_str": "{}"},
+            {"id": "rel_1", "title": "Account", "type": "board_relation",
+             "settings_str": json.dumps({"boardIds": [222]})},
+        ],
+    }
+    page = {"cursor": None, "items": [
+        item(1, "Deal A", [{"id": "rel_1", "text": None, "value": "{}", "type": "board_relation",
+                            "display_value": "Acme", "linked_item_ids": ["10"]}]),
+        item(2, "Deal B", [{"id": "rel_1", "text": None, "value": "{}", "type": "board_relation",
+                            "display_value": "Acme, Globex", "linked_item_ids": ["10", "11"]}]),
+    ]}
+
+    def responder(query, variables):
+        if "workspaces (limit" in query:
+            return FakeResponse({"data": {"workspaces": []}})
+        if "boards (limit: $limit, page: $page" in query:
+            return FakeResponse({"data": {"boards": [board] if variables.get("page", 1) == 1 else []}})
+        if "items_page" in query:
+            return FakeResponse({"data": {"boards": [{"items_page": page}]}})
+        raise AssertionError(query)
+
+    fake_post(monkeypatch, responder)
+    df = MondayClient(api_token="t").execute_query(json.dumps(
+        {"board": "Linked Board", "columns": ["Account (item_ids)"], "limit": 5}))
+    assert list(df.columns) == ["item_id", "name", "group", "Account", "Account (item_ids)"]
+
+    accounts = pd.DataFrame({"item_id": [10, 11], "name": ["Acme", "Globex"]})
+    joined = (df.explode("Account (item_ids)")
+                .merge(accounts, left_on="Account (item_ids)", right_on="item_id",
+                       how="left", suffixes=("", " (Account)")))
+    assert len(joined) == 3  # Deal A -> Acme; Deal B -> Acme + Globex
+    assert sorted(joined["name (Account)"]) == ["Acme", "Acme", "Globex"]
 
 
 def test_execute_query_bad_specs(monkeypatch):


### PR DESCRIPTION
## Why

Customer request: first-class Connected Boards support ("a lookup column to an item on another board"). After #1012, connect-boards columns return the linked items' *display names* — but joining boards on names is ambiguous (names repeat) and multi-link cells are comma-joined strings. The monday API exposes `linked_item_ids` on `BoardRelationValue` and `DependencyValue`; this PR surfaces it so cross-board joins run on ids.

## What

`backend/app/data_sources/clients/monday_client.py`:
- Every connect-boards / dependency column now emits a companion **`"<Column> (item_ids)"`** DataFrame column holding the linked item ids as a `list[int]` (fragments now request `display_value linked_item_ids`).
- The published schema lists the companion column, and the `board_relation` **foreign key now points from the companion to the linked table's `item_id`** — the id column is the joinable one the FK semantics always meant.
- Selecting `"<Column> (item_ids)"` in a query spec resolves to its parent column (the companion is emitted alongside it).
- The query system prompt documents the join recipe — explode the companion, merge on the linked board's `item_id` — with a worked example, and notes mirror columns remain display-text only (the API exposes no ids for mirrors).

## Validation

- **Unit**: `tests/unit/test_monday_client.py` — 22 pass, including new regressions for the companion column + retargeted FK in the schema, ids in query results, companion-name selection, and the documented explode-and-merge join producing correct row multiplicity.
- **Live** (monday trial account, two linked boards): schema carries `Linked Account (item_ids)` with the FK targeting the linked table; query results carry the real linked id; the exact prompt-documented join returns the linked item (`Task 1 → "Linked target item"`).

Follow-up to #1007 / #1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA)_