### PR TITLE
Fix Postgres 500 on HTML export (JSON-column SELECT DISTINCT)

### DIFF
--- a/backend/app/services/artifact_payload.py
+++ b/backend/app/services/artifact_payload.py
@@ -201,13 +201,17 @@ async def collect_params(db, artifact) -> dict[str, Any]:
     from app.models.visualization import Visualization
     from app.schemas.param_schema import parse_param_specs
 
+    # No SELECT DISTINCT here: Query.parameters (and the joined-loaded
+    # organization_settings.config) are Postgres `json`, which has no equality
+    # operator, so a whole-row DISTINCT raises UndefinedFunctionError on
+    # Postgres (SQLite silently allows it). The join fans out one row per
+    # visualization, so dedupe the Query identities in Python instead.
     result = await db.execute(
         select(Query)
         .join(Visualization, Visualization.query_id == Query.id)
         .where(Visualization.report_id == artifact.report_id)
-        .distinct()
     )
-    queries = list(result.scalars().all())
+    queries = list(result.scalars().unique().all())
 
     by_name: dict[str, dict[str, Any]] = {}
     options: dict[str, list[dict[str, Any]]] = {}


### PR DESCRIPTION
## Problem

The public HTML export (`GET /r/{id}/export_html`, added in #1010) returns **500 on Postgres**:

```
asyncpg.exceptions.UndefinedFunctionError: could not identify an equality operator for type json
```

`collect_params` (`backend/app/services/artifact_payload.py`) runs `SELECT DISTINCT` over full `Query` rows, which include two `json`-typed columns — `queries.parameters` and the joined-loaded `organization_settings.config`. Postgres `json` has **no equality operator** (only `jsonb` does), so a whole-row `DISTINCT` fails.

SQLite doesn't enforce this, so it passed in dev and in the `sqlite` CI job. The `postgres` e2e job never caught it because the offline-export tests skip when the vendored JS libs aren't present.

## Fix

Drop the SQL `DISTINCT` — it was only there to collapse the one-row-per-visualization fan-out from the join — and dedupe `Query` identities in Python via `scalars().unique()` instead. No JSON column ever enters an equality comparison.

```python
select(Query)
  .join(Visualization, Visualization.query_id == Query.id)
  .where(Visualization.report_id == artifact.report_id)
# .distinct()  ← removed
...
queries = list(result.scalars().unique().all())
```

Behavior is unchanged on SQLite; this only moves de-duplication from SQL to Python, which fixes Postgres.

## Verification

- Root cause reproduced from the production traceback (`export_public_report_html` → `build_standalone_html` → `collect_params` at `artifact_payload.py:204`).
- `python -m ast` parse check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vs2wZEBA2tcbf6DLhin3Lu)_