### PR TITLE
Fix stale e2e export helper broken by the request param on export route

### DIFF
--- a/backend/tests/e2e/test_html_export_offline.py
+++ b/backend/tests/e2e/test_html_export_offline.py
@@ -569,11 +569,19 @@ def test_download_filenames_survive_non_latin_titles(title, expected_name, expec
 # snapshot to someone who could not open the dashboard in the first place.
 
 async def _export_public(report_id: str, artifact_id=None, user=None):
+    from starlette.requests import Request
+
     from app.routes.report import export_public_report_html
 
+    # The route takes the raw Request only to enrich best-effort audit logging;
+    # a minimal ASGI scope stands in for it here.
+    request = Request({
+        "type": "http", "method": "GET", "path": "/", "headers": [],
+        "query_string": b"", "client": ("127.0.0.1", 0),
+    })
     async with async_session_maker() as db:
         return await export_public_report_html(
-            report_id=report_id, artifact_id=artifact_id, db=db, user=user,
+            report_id=report_id, request=request, artifact_id=artifact_id, db=db, user=user,
         )
 
 


### PR DESCRIPTION
## Why

The offline-HTML export route (`export_public_report_html`, from the export-dashboard-as-HTML feature in #1010) gained a required `request: Request` parameter, but the public-export e2e helper in `tests/e2e/test_html_export_offline.py` still calls the route without it. Result: `test_public_export_is_refused_when_the_dashboard_is_not_shared` and `test_public_export_rejects_an_artifact_from_another_report` fail with `TypeError` on **every** `e2e-tests (sqlite)` run — on main and on every PR — since #1010 landed. (It surfaced late because recent PRs were merged before their ~50-minute e2e runs completed.)

This commit was pushed to the #1013 branch minutes after that PR merged, so it never reached main — this PR carries it rebased onto current main. (My comment on #1013 claiming the fix was included there is superseded by this PR.)

## What

`tests/e2e/test_html_export_offline.py`: the `_export_public` helper now passes a minimal ASGI-scope `Request` — the route uses it only to enrich best-effort audit logging.

## Validation

`uv run pytest tests/e2e/test_html_export_offline.py` on this branch: **9 passed, 7 skipped** (the two previously failing gate tests pass; skips are the chromium/export-libs-gated legs, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxfBPeF6g7yW9MBfwQ4tcA)_