### PR TITLE
Replay tool results across completion boundaries via transcript hydration

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -608,6 +608,10 @@ class AgentV2:
         # and signatures, which a reconstruction cannot do. Only consumed when
         # the transcript path is enabled; otherwise it is inert bookkeeping.
         self.transcript = Transcript()
+        # Tool results replayed from earlier completions, and the completions
+        # they cover (the conversation renderer must not digest those again).
+        self._hydrated_turns: list = []
+        self._hydrated_completion_ids: set = set()
         # Parts recorded since the last flush — one planner step's worth.
         self._pending_transcript: list = []
         # Narration from the decision being executed, attached to the assistant
@@ -2040,6 +2044,7 @@ class AgentV2:
                             summary=observation.get("summary", "") if observation else "",
                             error_message=_observation_error_message(observation),
                             success=bool(observation and not _observation_failed(observation) and not _is_stopped),
+                            observation=observation,
                         )
                     except Exception as _fin_err:
                         logger.warning(f"Knowledge harness: finish_tool_execution failed: {_fin_err!r}")
@@ -3911,6 +3916,30 @@ class AgentV2:
             except Exception:
                 logger.exception("initial instruction scope failed; leaving full scope")
 
+            # Replay recent tool results so this run starts knowing what the last
+            # few turns actually found, instead of a one-line digest of it. Runs
+            # BEFORE the context refresh: the conversation renderer must already
+            # know which completions the transcript owns, or their results would
+            # render twice -- once as a replayed tool_result, once as a digest.
+            try:
+                from app.ai.context.transcript_hydration import hydrate_transcript
+                _exclude = {str(self.system_completion.id)} if self.system_completion else set()
+                _hy = await hydrate_transcript(
+                    self.db,
+                    report_id=str(self.report.id),
+                    exclude_completion_ids=_exclude,
+                )
+                self._hydrated_turns = _hy.get("turns") or []
+                self._hydrated_completion_ids = _hy.get("completion_ids") or set()
+                if getattr(self.context_hub, "message_builder", None) is not None:
+                    self.context_hub.message_builder.suppressed_tool_completion_ids = (
+                        self._hydrated_completion_ids
+                    )
+            except Exception:
+                logger.warning("[hydration] skipped", exc_info=True)
+                self._hydrated_turns = []
+                self._hydrated_completion_ids = set()
+
             # Prime static and refresh warm in parallel for faster startup
             # Pass prompt_text to enable intelligent instruction search
             with tracer.start_as_current_span("agent.context_initial_load") as span:
@@ -4292,6 +4321,7 @@ class AgentV2:
                             last_observation=observation,
                             past_observations=self.context_hub.observation_builder.tool_observations,
                             transcript=self.transcript,
+                            hydrated_turns=self._hydrated_turns,
                             provider_name=getattr(getattr(self.model, "provider", None), "provider_type", None),
                             context_window_tokens=getattr(self.model, "context_window_tokens", None),
                             external_platform=self.platform,
@@ -5569,6 +5599,7 @@ class AgentV2:
                                             error_message=_error_msg,
                                             success=_success_flag,
                                             sub_timings_json=tool_sub_timings,
+                                            observation=observation,
                                         )
                                     except AttributeError:
                                         # Fallback if helper isn't wired yet — keep behavior
@@ -5584,6 +5615,7 @@ class AgentV2:
                                             context_snapshot_id=None,
                                             success=_success_flag,
                                             sub_timings_json=tool_sub_timings,
+                                            observation=observation,
                                         )
 
                                     # Save post-tool context snapshot in background (not user-facing, not needed for next loop).

--- a/backend/app/ai/agents/planner/transcript_bridge.py
+++ b/backend/app/ai/agents/planner/transcript_bridge.py
@@ -163,6 +163,12 @@ def build_transcript(planner_input: Any, static_context: str, ask: str) -> Trans
     t = Transcript()
     if static_context:
         t.add_user_text(static_context)
+    # Earlier completions' tool results, before the ask: the run's own steps
+    # continue after it, so the whole thing reads in chronological order and
+    # turn 0 stays the byte-stable cache prefix.
+    hydrated = getattr(planner_input, "hydrated_turns", None)
+    if hydrated:
+        t.turns.extend(hydrated)
     if ask:
         t.add_user_text(ask)
 

--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -29,6 +29,7 @@ from app.ai.context.summary_write_through import (
     TERMINAL_TOOL_EXECUTION_STATUSES,
     persist_tool_context_projections,
 )
+from app.ai.persisted_summary import SUMMARIZED_TOOL_NAMES
 
 
 def _json_value(value: Any) -> Any:
@@ -765,6 +766,10 @@ class MessageContextBuilder:
         # refreshes. This matters for old read_query rows whose full JSON can
         # take PostgreSQL seconds to parse even when SQL returns only a digest.
         self._terminal_tool_context_cache: Dict[str, Any] = {}
+        # Completions whose tool results are replayed as real tool_result turns
+        # by transcript hydration. Their digests are suppressed here so one
+        # result never appears twice in two different shapes.
+        self.suppressed_tool_completion_ids: set = set()
 
     async def _protected_head_completions(self):
         """The report's opening exchange (never folded into the compaction
@@ -968,10 +973,17 @@ class MessageContextBuilder:
                 created_step_id=row.created_step_id,
                 error_message=row.error_message,
                 updated_at=row.updated_at,
-                # New executions carry the exact bounded history projection in
+                # Row-heavy tools carry the exact bounded history projection in
                 # a separate small column. Historical rows use the behavior-
                 # preserving JSON projection once, then write it through.
-                result_json=_json_value(row.context_summary_json),
+                # Every OTHER tool now also has a context_summary_json (it holds
+                # the observation, for cross-turn replay), but its digest
+                # functions read the real result_json shape -- so only the
+                # row-heavy set substitutes the projection here.
+                result_json=(
+                    _json_value(row.context_summary_json)
+                    if row.tool_name in SUMMARIZED_TOOL_NAMES else None
+                ),
             )
 
         newly_loaded_ids = [
@@ -995,6 +1007,7 @@ class MessageContextBuilder:
             execution_id
             for execution_id in newly_loaded_ids
             if isinstance(loaded[execution_id].context_summary_json, dict)
+            and loaded[execution_id].tool_name in SUMMARIZED_TOOL_NAMES
         }
         projected_ids = set(read_query_ids) | set(create_data_ids) | summarized_ids
         regular_ids = [
@@ -1334,8 +1347,9 @@ class MessageContextBuilder:
                     if block.content and block.content.strip():
                         system_parts.append(f"Response: {block.content.strip()}")
                     
-                    # Add tool execution details if available
-                    if block.tool_execution_id:
+                    # Add tool execution details if available. Skipped when the
+                    # transcript already replays this completion's results.
+                    if block.tool_execution_id and str(completion.id) not in self.suppressed_tool_completion_ids:
                         tool_execution = await self._load_tool_execution_for_context(block.tool_execution_id)
                         
                         if tool_execution:
@@ -1957,7 +1971,8 @@ class MessageContextBuilder:
 
             tool_exec_ids = [
                 str(b.tool_execution_id)
-                for blks in blocks_by_completion.values()
+                for cid, blks in blocks_by_completion.items()
+                if cid not in self.suppressed_tool_completion_ids
                 for b in blks
                 if getattr(b, 'tool_execution_id', None)
             ]
@@ -2078,7 +2093,12 @@ class MessageContextBuilder:
                         system_parts.append(f"Thinking: {block.reasoning.strip()}")
                     if block.content and block.content.strip():
                         system_parts.append(f"Response: {block.content.strip()}")
-                    if block.tool_execution_id:
+                    # Skipped when the transcript already replays this
+                    # completion's tool results as real tool_result turns.
+                    if (
+                        block.tool_execution_id
+                        and str(completion.id) not in self.suppressed_tool_completion_ids
+                    ):
                         tool_execution = tool_exec_by_id.get(str(block.tool_execution_id))
                         if tool_execution:
                             tool_info = f"Tool: {tool_execution.tool_name}"

--- a/backend/app/ai/context/transcript_hydration.py
+++ b/backend/app/ai/context/transcript_hydration.py
@@ -1,0 +1,229 @@
+"""Seed a run's transcript with tool results from earlier completions.
+
+Tool results live in memory for exactly one completion: ``ObservationContextBuilder``
+is constructed per run, so the moment a new user turn starts, everything the
+previous run learned is gone from the model's view and only a one-line digest
+survives in the rendered conversation. A run that was interrupted loses it the
+same way -- not because the kill discarded anything, but because the boundary
+does.
+
+This module replays the recent past as real tool_use/tool_result turns, from the
+bounded ``context_summary_json`` column each tool now writes when it finishes.
+The transcript's existing decay ladder then governs cost: hydrated results are
+oldest, so ``fit_to_budget`` demotes them first, and nothing here changes the
+token ceiling.
+
+Reads one narrow column set -- never ``result_json``, whose row-heavy payloads
+take seconds to parse -- so hydration stays off the latency path.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import lazyload
+
+from app.ai.context.parts import (
+    Outcome,
+    TextPart,
+    ToolCallPart,
+    ToolResultPart,
+    Turn,
+    estimate_tokens,
+)
+from app.settings.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Completions to look back over. Bounded independently of the token budget so a
+# quiet report cannot drag in arbitrarily old work.
+HYDRATION_COMPLETIONS = 5
+# Ceiling on what hydration may add. Whichever limit binds first wins, so a
+# tool-heavy history cannot blow up the prompt before the ladder even runs.
+HYDRATION_TOKEN_BUDGET = 20_000
+
+_SUCCESS_STATUSES = frozenset({"success", "completed"})
+
+
+def enabled() -> bool:
+    """On by default; ``BOW_TRANSCRIPT_HYDRATION=0`` restores the pre-hydration
+    behaviour (prior turns visible only as conversation digests). The switch
+    exists because this changes what every multi-turn request carries."""
+    flag = os.environ.get("BOW_TRANSCRIPT_HYDRATION")
+    if flag is None or flag == "":
+        return True
+    return flag.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _content_for(tool_name: str, summary_json: Any, result_summary: Optional[str]) -> str:
+    """The model-visible body for one historical result.
+
+    Prefers the persisted observation (what the model actually saw), then the
+    row-heavy projection, then the one-line summary. Never falls back to
+    result_json: that payload is the tool's *output*, a different shape, and
+    re-deriving from it is exactly the drift this replaces.
+    """
+    if isinstance(summary_json, dict):
+        observation = summary_json.get("observation")
+        if isinstance(observation, dict) and observation:
+            return json.dumps(observation, default=str)
+        projection = {k: v for k, v in summary_json.items() if k != "version"}
+        if projection:
+            return json.dumps(projection, default=str)
+    return result_summary or ""
+
+
+async def hydrate_transcript(
+    db,
+    *,
+    report_id: str,
+    exclude_completion_ids: set[str],
+    completions: int = HYDRATION_COMPLETIONS,
+    token_budget: int = HYDRATION_TOKEN_BUDGET,
+) -> dict:
+    """Build replayable turns from earlier completions' tool results.
+
+    Returns ``turns`` (chronological, to be spliced between the static context
+    and the ask) and ``completion_ids`` -- the completions the transcript now
+    owns. The caller must stop the conversation renderer from digesting those
+    same executions, or every result appears twice in two different shapes.
+    """
+    from app.models.completion import Completion
+    from app.models.completion_block import CompletionBlock
+    from app.models.tool_execution import ToolExecution
+
+    stats = {"completion_ids": set(), "turns": [], "results": 0, "tokens": 0}
+    if not enabled():
+        return stats
+
+    try:
+        rows = (await db.execute(
+            select(Completion.id, Completion.created_at)
+            .options(lazyload("*"))
+            .filter(Completion.report_id == report_id)
+            .filter(Completion.role == "system")
+            .filter(Completion.status != "queued")
+            .filter(Completion.deleted_at.is_(None))
+            .order_by(Completion.created_at.desc())
+            .limit(completions + len(exclude_completion_ids))
+        )).all()
+    except Exception:
+        logger.warning("[hydration] completion lookup failed", exc_info=True)
+        return stats
+
+    ordered = [
+        (str(cid), created_at) for cid, created_at in rows
+        if str(cid) not in exclude_completion_ids
+    ][:completions]
+    if not ordered:
+        return stats
+
+    try:
+        block_rows = (await db.execute(
+            select(
+                CompletionBlock.completion_id,
+                CompletionBlock.block_index,
+                ToolExecution.id,
+                ToolExecution.tool_name,
+                ToolExecution.arguments_json,
+                ToolExecution.status,
+                ToolExecution.result_summary,
+                ToolExecution.error_message,
+                ToolExecution.context_summary_json,
+            )
+            .join(ToolExecution, ToolExecution.id == CompletionBlock.tool_execution_id)
+            .filter(CompletionBlock.completion_id.in_([cid for cid, _ in ordered]))
+            .order_by(CompletionBlock.block_index.asc())
+        )).all()
+    except Exception:
+        logger.warning("[hydration] tool execution lookup failed", exc_info=True)
+        return stats
+
+    by_completion: dict[str, list] = {}
+    for row in block_rows:
+        by_completion.setdefault(str(row[0]), []).append(row)
+
+    # Walk newest-first so the budget keeps the most recent history, then flip
+    # back to chronological before splicing in.
+    hydrated: list[Turn] = []
+    spent = 0
+    covered: set[str] = set()
+
+    for cid, created_at in ordered:  # ordered is newest-first
+        rows_for = by_completion.get(cid) or []
+        if not rows_for:
+            continue
+        calls, results = [], []
+        batch_tokens = 0
+        for row in rows_for:
+            (_, _, te_id, tool_name, arguments_json, status,
+             result_summary, error_message, summary_json) = row
+            call_id = f"te_{te_id}"
+            content = _content_for(tool_name, summary_json, result_summary)
+            if not content and not error_message:
+                continue
+            if status in _SUCCESS_STATUSES:
+                outcome = Outcome.SUCCESS
+            elif status == "error":
+                outcome = Outcome.FAILED
+            else:
+                # Never ran to completion -- say so rather than let a gap read
+                # as a silent success.
+                outcome = Outcome.INTERRUPTED
+                content = content or (
+                    error_message or "The call was interrupted before it produced a result."
+                )
+            args = arguments_json if isinstance(arguments_json, dict) else {}
+            calls.append(ToolCallPart(id=call_id, tool_name=tool_name, args=args))
+            part = ToolResultPart(
+                call_id=call_id,
+                tool_name=tool_name,
+                outcome=outcome,
+                content=content,
+                digest=result_summary or None,
+                tokens=estimate_tokens(content),
+            )
+            results.append(part)
+            batch_tokens += part.tokens
+
+        if not calls:
+            continue
+        if spent + batch_tokens > token_budget and hydrated:
+            logger.info(
+                "[hydration] stopped at budget: %d/%d tokens, %d completions covered",
+                spent, token_budget, len(covered),
+            )
+            break
+
+        label = "[earlier turn"
+        try:
+            label += f" — {created_at.strftime('%H:%M')}"
+        except Exception:
+            pass
+        label += "]"
+
+        # Prepend (newest processed first, so each older batch goes in front).
+        hydrated[0:0] = [
+            Turn(role="user", parts=[TextPart(text=label)]),
+            Turn(role="assistant", parts=list(calls)),
+            Turn(role="user", parts=list(results)),
+        ]
+        spent += batch_tokens
+        covered.add(cid)
+        stats["results"] += len(results)
+
+    if not hydrated:
+        return stats
+
+    stats.update({
+        "completion_ids": covered,
+        "turns": hydrated,
+        "tokens": spent,
+    })
+    logger.info(
+        "[hydration] seeded %d turns / %d results / ~%d tokens from %d completion(s)",
+        len(hydrated), stats["results"], spent, len(covered),
+    )
+    return stats

--- a/backend/app/ai/persisted_summary.py
+++ b/backend/app/ai/persisted_summary.py
@@ -9,6 +9,7 @@ of megabytes merely to recover a one-line digest.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from app.ai.data_preview import (
@@ -37,6 +38,80 @@ SUMMARIZED_TOOL_NAMES = frozenset(
         "read_note",
     }
 )
+
+# Cross-turn observation retention.
+#
+# The observation is what the model actually SAW when the tool ran. Only the
+# row-heavy tools above get a purpose-built projection; every other tool used to
+# project nothing, so a later turn could only re-derive an approximation from
+# ``result_json`` -- which holds the tool's ``output``, a different payload. That
+# re-derivation drifts (an inspect_data observation carries ``summary``; its
+# output does not), so the model lost detail it had already paid for.
+#
+# Persisting the observation keeps the real result replayable across turns and
+# across an interrupted run. Bounds below keep one pathological result (e.g. a
+# large inlined MCP payload) from dominating a rehydrated transcript.
+OBSERVATION_FIELD_MAX_CHARS = 4_000
+OBSERVATION_TOTAL_MAX_CHARS = 12_000
+# Vision payloads are re-sent as image blocks within their own run and must not
+# be replayed from history; the marker keeps the fact of the image legible.
+OBSERVATION_DROPPED_KEYS = ("images", "images_provided_as_vision")
+
+
+def _clamp_text(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit] + f"\u2026 [truncated, {len(value)} chars total]"
+
+
+def bounded_observation(observation: Any) -> dict[str, Any] | None:
+    """Bound one observation for durable storage.
+
+    Copies rather than mutates: the live observation is shared by reference with
+    ObservationContextBuilder, which compacts entries in place as the run
+    proceeds. Building a new dict here snapshots the value at full fidelity
+    before that happens.
+    """
+    if not isinstance(observation, dict) or not observation:
+        return None
+
+    bounded: dict[str, Any] = {}
+    for key, value in observation.items():
+        if key in OBSERVATION_DROPPED_KEYS:
+            continue
+        if isinstance(value, str):
+            bounded[key] = _clamp_text(value, OBSERVATION_FIELD_MAX_CHARS)
+        else:
+            bounded[key] = value
+
+    if any(observation.get(key) for key in OBSERVATION_DROPPED_KEYS):
+        bounded["images_elided"] = (
+            "image(s) were produced and shown when this call ran - "
+            "re-view with read_file if needed"
+        )
+
+    # Whole-observation ceiling. Serializing is the only honest measure of what
+    # a nested structure costs; drop the largest remaining fields until it fits
+    # rather than truncating mid-JSON.
+    try:
+        while len(json.dumps(bounded, default=str)) > OBSERVATION_TOTAL_MAX_CHARS:
+            droppable = [
+                k for k in bounded
+                if k not in ("summary", "success", "error", "images_elided")
+            ]
+            if not droppable:
+                break
+            widest = max(
+                droppable,
+                key=lambda k: len(json.dumps(bounded[k], default=str)),
+            )
+            size = len(json.dumps(bounded[widest], default=str))
+            del bounded[widest]
+            bounded[f"{widest}_elided"] = f"{size} chars elided from history"
+    except Exception:
+        pass
+
+    return bounded or None
 
 
 def _column_projection(columns: Any) -> list[dict[str, Any]]:
@@ -220,17 +295,27 @@ def _tool_ui_preview(item: dict[str, Any]) -> dict[str, Any]:
 def build_tool_context_summary(
     tool_name: Any,
     result_json: Any,
+    observation: Any = None,
 ) -> dict[str, Any] | None:
-    """Return the immutable prompt projection for row-heavy tool results.
+    """Return the immutable prompt projection for a tool result.
 
     The returned dictionaries intentionally match the lightweight result shapes
     MessageContextBuilder already renders, so switching storage does not change
     the generated context text.
-    """
-    if not isinstance(result_json, dict):
-        return None
 
+    Row-heavy tools keep their purpose-built projections (report cards read
+    them, and their previews are already bounded). Every other tool projects its
+    ``observation`` instead, so later turns replay what the model actually saw.
+    """
     name = str(tool_name or "")
+
+    if not isinstance(result_json, dict):
+        # An observation-only tool stores no result_json at all. Its observation
+        # is still the whole story, so project that rather than nothing.
+        bounded = bounded_observation(observation)
+        if bounded is None:
+            return None
+        return {"version": CONTEXT_SUMMARY_VERSION, "observation": bounded}
     if name == "create_data":
         preview = _preview_shape(result_json, include_first_row=True)
         stats = result_json.get("stats") if isinstance(result_json.get("stats"), dict) else {}
@@ -349,4 +434,11 @@ def build_tool_context_summary(
                 projection[field] = value[:UI_FILE_PREVIEW_CHARS]
         return projection
 
-    return None
+    # Every remaining tool: keep the observation itself. This is the path that
+    # gives cross-turn memory to inspect_data, execute_mcp, the artifact tools
+    # and the rest -- previously they projected nothing and history had to
+    # re-derive a digest from a payload that was never the observation.
+    bounded = bounded_observation(observation)
+    if bounded is None:
+        return None
+    return {"version": CONTEXT_SUMMARY_VERSION, "observation": bounded}

--- a/backend/app/models/tool_execution.py
+++ b/backend/app/models/tool_execution.py
@@ -62,8 +62,17 @@ class ToolExecution(BaseSchema):
 
 
 def before_write_tool_context_summary(mapper, connection, target):
-    """Snapshot row-heavy tool context when its canonical result is written."""
+    """Snapshot row-heavy tool context when its canonical result is written.
+
+    Only fills a summary that nobody set. The agent loop projects the richer
+    one from the live observation when it finishes a tool
+    (``_configure_finished_tool_execution``); this hook sees only result_json,
+    so rebuilding here would replace that with a strictly poorer value -- and
+    for observation-only tools, with nothing at all.
+    """
     try:
+        if target.context_summary_json is not None:
+            return
         state = inspect(target)
         if state.attrs.result_json.history.has_changes():
             from app.ai.persisted_summary import build_tool_context_summary

--- a/backend/app/project_manager.py
+++ b/backend/app/project_manager.py
@@ -1070,6 +1070,7 @@ class ProjectManager:
         sub_timings_json: dict | None = None,
         context_snapshot_id: str | None = None,
         token_usage_json: dict | None = None,
+        observation: dict | None = None,
     ):
         """Mutate an in-memory ToolExecution to its finished state (no DB I/O).
 
@@ -1118,6 +1119,21 @@ class ProjectManager:
             pass
         tool_execution.error_message = error_message
         tool_execution.token_usage_json = token_usage_json
+        # Snapshot the observation NOW. It is shared by reference with
+        # ObservationContextBuilder, which compacts older entries in place as the
+        # run proceeds -- and the DB flush happens later, so serializing at flush
+        # time would persist an already-stripped value. The mapper-level
+        # before_write hook cannot do this: it only sees result_json, which holds
+        # the tool's output, not the observation.
+        try:
+            from app.ai.persisted_summary import build_tool_context_summary
+            summary_json = build_tool_context_summary(
+                tool_execution.tool_name, result_json, observation
+            )
+            if summary_json is not None:
+                tool_execution.context_summary_json = summary_json
+        except Exception:
+            logger.warning("tool context summary projection failed", exc_info=True)
         tool_execution.context_snapshot_id = context_snapshot_id
         tool_execution.sub_timings_json = sub_timings_json
         return tool_execution
@@ -1254,6 +1270,18 @@ class ProjectManager:
         tool_execution.token_usage_json = token_usage_json
         tool_execution.context_snapshot_id = context_snapshot_id
         tool_execution.sub_timings_json = sub_timings_json
+        # Same projection as the main loop: this path (knowledge harness and the
+        # legacy fallback) must not be the one place a tool's observation is
+        # dropped, or those tools alone lose their cross-turn memory.
+        try:
+            from app.ai.persisted_summary import build_tool_context_summary
+            summary_json = build_tool_context_summary(
+                tool_execution.tool_name, result_json, observation
+            )
+            if summary_json is not None:
+                tool_execution.context_summary_json = summary_json
+        except Exception:
+            logger.warning("tool context summary projection failed", exc_info=True)
         db.add(tool_execution)
         await self._commit_with_timeout(db, "finish_tool_execution")
         await self._refresh_with_timeout(db, tool_execution, "finish_tool_execution")
@@ -1333,7 +1361,8 @@ class ProjectManager:
                                                error_message: str | None = None,
                                                context_snapshot_id: str | None = None,
                                                success: bool = True,
-                                               sub_timings_json: dict | None = None):
+                                               sub_timings_json: dict | None = None,
+                                               observation: dict | None = None):
         # Handle result_model appropriately
         if result_model and hasattr(result_model, 'model_dump'):
             # Pydantic model - convert to dict

--- a/backend/app/schemas/ai/planner.py
+++ b/backend/app/schemas/ai/planner.py
@@ -218,6 +218,10 @@ class PlannerInput(BaseModel):
     # provider's OWN tool_use ids and signatures, which a reconstruction from
     # observations cannot. Preferred over the bridge when present.
     transcript: Optional[Any] = None
+    # Replayed tool results from earlier completions (see
+    # context/transcript_hydration.py). Spliced between the static context and
+    # the ask so history stays chronological.
+    hydrated_turns: Optional[Any] = None
     # Provider serving this iteration — gates replay of provider-opaque state
     # (tool-call / thinking signatures), which must never cross a mid-run
     # fallback to a different provider.

--- a/backend/tests/unit/test_observation_retention.py
+++ b/backend/tests/unit/test_observation_retention.py
@@ -1,0 +1,75 @@
+"""Tool observations must survive the completion boundary.
+
+An observation is what the model SAW when a tool ran. It used to live only in
+the per-run ObservationContextBuilder, so the next turn -- and any turn after an
+interrupted run -- saw only a re-derived digest. These tests pin the three
+properties that fix depends on.
+"""
+import json
+
+import pytest
+
+from app.ai.persisted_summary import (
+    SUMMARIZED_TOOL_NAMES,
+    OBSERVATION_TOTAL_MAX_CHARS,
+    build_tool_context_summary,
+    bounded_observation,
+)
+
+
+def test_observation_is_projected_for_a_non_row_heavy_tool():
+    # inspect_data's `output` carries no summary at all; only the observation
+    # does. Re-deriving history from output is what lost the detail.
+    out = {"success": True, "code": "SELECT 1", "execution_log": "x" * 50}
+    obs = {"summary": "Inspection finished", "details": "order_id | status", "success": True}
+    summary = build_tool_context_summary("inspect_data", out, obs)
+    assert summary["observation"]["summary"] == "Inspection finished"
+    assert "order_id" in summary["observation"]["details"]
+
+
+def test_observation_only_tool_still_projects_without_result_json():
+    summary = build_tool_context_summary("search_mcps", None, {"summary": "found 3"})
+    assert summary["observation"]["summary"] == "found 3"
+
+
+def test_row_heavy_tools_keep_their_purpose_built_projection():
+    # Report cards read these; swapping in the observation would both bloat the
+    # column and break the UI contract.
+    summary = build_tool_context_summary(
+        "create_data",
+        {"success": True, "data_preview": {"columns": [{"field": "a"}], "rows": [{"a": 1}], "row_count": 1}},
+        {"summary": "ignored here"},
+    )
+    assert "data_preview" in summary
+    assert "observation" not in summary
+
+
+@pytest.mark.parametrize("tool", sorted(SUMMARIZED_TOOL_NAMES))
+def test_row_heavy_set_is_unchanged_by_an_observation(tool):
+    a = build_tool_context_summary(tool, {"success": True}, None)
+    b = build_tool_context_summary(tool, {"success": True}, {"summary": "x", "details": "y" * 100})
+    assert a == b
+
+
+def test_images_are_elided_but_their_existence_is_recorded():
+    # Vision payloads are re-sent as image blocks within their own run; replaying
+    # base64 from history is both expensive and invalid. Silence would read as
+    # "no image was produced", so leave a marker.
+    obs = {"summary": "saw it", "images": [{"data": "AAAA" * 500}]}
+    bounded = bounded_observation(obs)
+    assert "images" not in bounded
+    assert "images_elided" in bounded
+
+
+def test_a_pathological_observation_is_bounded():
+    obs = {"summary": "big", "payload": "z" * 400_000}
+    bounded = bounded_observation(obs)
+    assert len(json.dumps(bounded)) < OBSERVATION_TOTAL_MAX_CHARS + 2_000
+    # The identifying fields survive the trim; only bulk goes.
+    assert bounded["summary"] == "big"
+
+
+def test_empty_observation_projects_nothing():
+    assert bounded_observation({}) is None
+    assert bounded_observation(None) is None
+    assert build_tool_context_summary("inspect_data", None, None) is None

--- a/backend/tests/unit/test_transcript_hydration.py
+++ b/backend/tests/unit/test_transcript_hydration.py
@@ -1,0 +1,117 @@
+"""Earlier completions' tool results must reach the next run's transcript.
+
+The case that motivated this: a run is interrupted after N tools. Those N
+results are already committed, but the next turn used to see only a digest of
+them -- and after a hard kill, the completion never even leaves 'in_progress'.
+Hydration must include both interrupted shapes, not just cleanly finished runs.
+"""
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.ai.context.parts import Outcome, ToolResultPart
+from app.ai.context.transcript_hydration import hydrate_transcript, _content_for
+
+
+def _uid():
+    return str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def db():
+    # Completion.sigkill is declared nullable=False with default=None, which
+    # metadata.create_all takes literally; the migrated schema this runs against
+    # in production allows NULL (an un-killed run has no kill time). Relax it
+    # here so the fixture matches the real table rather than the declaration.
+    from app.models.completion import Completion as _C
+    _C.__table__.c.sigkill.nullable = True
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db, *, completion_status, tool_status="success"):
+    """One report, one system completion, one block pointing at one tool."""
+    from app.models.report import Report
+    from app.models.completion import Completion
+    from app.models.completion_block import CompletionBlock
+    from app.models.tool_execution import ToolExecution
+    from app.models.agent_execution import AgentExecution
+
+    report_id, comp_id, exec_id, te_id = _uid(), _uid(), _uid(), _uid()
+    db.add(Report(id=report_id, title="t", slug="t-" + report_id[:8],
+                  organization_id=_uid(), user_id=_uid()))
+    db.add(Completion(id=comp_id, report_id=report_id, role="system", status=completion_status))
+    db.add(AgentExecution(id=exec_id, completion_id=comp_id, status="in_progress"))
+    db.add(ToolExecution(
+        id=te_id, agent_execution_id=exec_id, tool_name="inspect_data",
+        arguments_json={"q": "orders"}, status=tool_status, success=(tool_status == "success"),
+        result_summary="Inspection finished",
+        context_summary_json={"version": 2, "observation": {
+            "summary": "Inspection finished",
+            "details": "order_id | order_status | gross_amount\n1 | paid | 12.5",
+        }},
+    ))
+    db.add(CompletionBlock(id=_uid(), completion_id=comp_id, agent_execution_id=exec_id,
+                           source_type="tool", title="Inspected orders", block_index=0, tool_execution_id=te_id,
+                           status="completed"))
+    await db.commit()
+    return report_id, comp_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["success", "stopped", "in_progress"])
+async def test_completions_hydrate_whatever_their_ending(db, status):
+    """'stopped' is the stop button; 'in_progress' is a run whose process was
+    killed and which therefore never reached its finalizer."""
+    report_id, comp_id = await _seed(db, completion_status=status)
+    result = await hydrate_transcript(db, report_id=report_id, exclude_completion_ids=set())
+
+    assert comp_id in result["completion_ids"], f"{status} completion was dropped"
+    assert result["results"] == 1
+    bodies = [p.content for t in result["turns"] for p in t.parts if isinstance(p, ToolResultPart)]
+    assert any("order_status" in b for b in bodies), "observation body did not survive"
+
+
+@pytest.mark.asyncio
+async def test_the_current_run_is_not_replayed_to_itself(db):
+    report_id, comp_id = await _seed(db, completion_status="in_progress")
+    result = await hydrate_transcript(db, report_id=report_id, exclude_completion_ids={comp_id})
+    assert result["completion_ids"] == set()
+    assert result["turns"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_tool_that_never_finished_is_marked_interrupted(db):
+    """An elided result must never be mistakable for a successful one."""
+    report_id, _ = await _seed(db, completion_status="in_progress", tool_status="in_progress")
+    result = await hydrate_transcript(db, report_id=report_id, exclude_completion_ids=set())
+    parts = [p for t in result["turns"] for p in t.parts if isinstance(p, ToolResultPart)]
+    assert parts and parts[0].outcome is Outcome.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_the_token_budget_is_honoured(db):
+    report_id, _ = await _seed(db, completion_status="success")
+    result = await hydrate_transcript(db, report_id=report_id, exclude_completion_ids=set(), token_budget=1)
+    # The first batch is always admitted (there is nothing to fall back to);
+    # what matters is that the walk stops instead of running away.
+    assert result["tokens"] <= 2000
+
+
+def test_content_prefers_the_observation_over_the_bare_summary():
+    body = _content_for("inspect_data", {"version": 2, "observation": {"summary": "s", "details": "d"}}, "fallback")
+    assert "details" in body and "fallback" not in body
+
+
+def test_content_falls_back_to_the_summary_when_nothing_was_persisted():
+    assert _content_for("inspect_data", None, "just the summary") == "just the summary"


### PR DESCRIPTION
## Summary

This change enables tool results from earlier completions to be replayed in subsequent turns, preserving the model's knowledge across completion boundaries. Previously, when a run was interrupted or a new turn started, the model could only see a one-line digest of prior tool results. Now, the actual tool observations are persisted and replayed as real tool_use/tool_result turns in the transcript.

## Key Changes

- **New transcript hydration module** (`transcript_hydration.py`): Replays recent tool results from earlier completions as authentic turns in the transcript. Looks back up to 5 completions with a 20K token budget, respecting the existing decay ladder for cost management.

- **Observation persistence** (`persisted_summary.py`): 
  - Added `bounded_observation()` to safely persist tool observations with field and total size limits
  - Extended `build_tool_context_summary()` to project observations for all tools, not just row-heavy ones
  - Row-heavy tools (create_data, read_query, etc.) retain their purpose-built projections; all others now store their observation for cross-turn replay

- **Agent loop integration** (`agent_v2.py`):
  - Calls `hydrate_transcript()` before context refresh to load prior results
  - Tracks hydrated turns and completion IDs to prevent double-rendering
  - Passes observation to tool execution finish handlers

- **Tool execution tracking** (`tool_execution.py`, `project_manager.py`):
  - Snapshots observations when tools finish via `_configure_finished_tool_execution()`
  - Ensures observation is captured before ObservationContextBuilder compacts it
  - Applies same projection logic in both main loop and knowledge harness paths

- **Context builder updates** (`message_context_builder.py`):
  - Suppresses digests for completions whose results are replayed as transcript turns
  - Only substitutes context_summary_json for row-heavy tools; others use real result_json

- **Planner integration** (`transcript_bridge.py`, `planner.py`):
  - Hydrated turns inserted before the ask to maintain chronological order
  - Transcript field added to PlannerInput for native transcript support

## Implementation Details

- **Selective hydration**: Only includes completions with status != "queued" and not deleted; excludes the current run to avoid self-reference
- **Budget-aware**: Processes newest completions first so budget cuts oldest history; first batch always admitted to ensure at least some context
- **Interrupted run handling**: Marks tools that never finished as INTERRUPTED outcome rather than silent success
- **Image elision**: Vision payloads are excluded from replay (re-sent as image blocks in the same run) but marked as elided to preserve context
- **Observation-only tools**: Tools without result_json (e.g., search_mcps) now project their observation instead of nothing
- **Bounded storage**: Observations clamped to 4K per field and 12K total to prevent pathological payloads from dominating history

## Testing

Added comprehensive test coverage for:
- Hydration of various completion statuses (success, stopped, in_progress)
- Exclusion of current run from replay
- Interrupted tool marking
- Token budget enforcement
- Observation preference hierarchy
- Row-heavy tool projection preservation
- Image elision with markers
- Pathological observation bounding

https://claude.ai/code/session_01T2HrFKW8wyVcH6d8rRLkH2