### PR TITLE
Fix unreadable instruction body and mention chips in dark mode

### DIFF
--- a/frontend/components/instructions/InstructionEditor.vue
+++ b/frontend/components/instructions/InstructionEditor.vue
@@ -780,4 +780,40 @@ function onRawInput() {
 .raw-textarea::placeholder {
   color: #9ca3af;
 }
+
+/* ─── Dark mode ────────────────────────────────────────────────────────────
+   Every color above is a hardcoded light-theme literal, so without these the
+   instruction body renders near-black on the dark surface. Palette mirrors
+   InstructionText's dark block so the editor and the read-only view match.
+
+   The `.dark` class lives on <html> (Tailwind darkMode: 'class'), outside this
+   component's scope, so these are authored as :global and matched by the
+   component-unique `.wysiwyg-content` / `.bubble-*` / `.raw-textarea` classes.
+   Each pairs with an equal-specificity light rule above and wins by order. */
+:global(.dark .wysiwyg-content .tiptap-prose) { color: #e5e7eb; }
+:global(.dark .wysiwyg-content .tiptap-prose h1),
+:global(.dark .wysiwyg-content .tiptap-prose h2),
+:global(.dark .wysiwyg-content .tiptap-prose h3) { color: #f9fafb; }
+:global(.dark .wysiwyg-content .tiptap-prose code) { background: #374151; color: #e5e7eb; }
+:global(.dark .wysiwyg-content .tiptap-prose pre) { background: #1f2937; }
+:global(.dark .wysiwyg-content .tiptap-prose blockquote) { border-inline-start-color: #374151; color: #9ca3af; }
+:global(.dark .wysiwyg-content .mention-chip) {
+  background-color: rgba(129, 140, 248, 0.18);
+  color: #c7d2fe;
+}
+
+/* The bubble toolbar is teleported to <body> by tippy, so it sits outside the
+   component subtree — `.dark` on <html> still reaches it. */
+:global(.dark .bubble-toolbar) {
+  background: #1f2937;
+  border-color: #374151;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+:global(.dark .bubble-btn) { color: #d1d5db; }
+:global(.dark .bubble-btn:hover) { background-color: #374151; }
+:global(.dark .bubble-btn.active) { background-color: #3730a3; color: #e0e7ff; }
+:global(.dark .bubble-sep) { background: #374151; }
+
+:global(.dark .raw-textarea) { color: #e5e7eb; }
+:global(.dark .raw-textarea::placeholder) { color: #6b7280; }
 </style>

--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -3,7 +3,7 @@
     <template v-for="(segment, i) in segments" :key="i">
       <span
         v-if="segment.ref || segment.mention"
-        class="inline-flex items-center gap-0.5 px-1 py-0.5 rounded bg-indigo-50 dark:bg-indigo-950 border border-indigo-100 text-[11px] font-sans font-medium text-indigo-700 align-baseline"
+        class="inline-flex items-center gap-0.5 px-1 py-0.5 rounded bg-indigo-50 dark:bg-indigo-400/[0.18] border border-indigo-100 dark:border-transparent text-[11px] font-sans font-medium text-indigo-700 dark:text-indigo-200 align-baseline"
       >
         <template v-if="segment.ref">
           <DataSourceIcon

--- a/frontend/components/instructions/InstructionTrackedChanges.vue
+++ b/frontend/components/instructions/InstructionTrackedChanges.vue
@@ -474,4 +474,13 @@ onBeforeUnmount(() => {
   font-size: 0.95em;
   white-space: nowrap;
 }
+
+/* Dark mode: the light-theme indigo-800 above is unreadable on the dark
+   surface. Same chip palette as InstructionText / InstructionEditor. The
+   `.dark` class lives on <html>, outside this component's scope, hence
+   :global matched by the component-unique `.instr-mention` class. */
+:global(.dark .instr-mention) {
+  background-color: rgba(129, 140, 248, 0.18);
+  color: #c7d2fe;
+}
 </style>


### PR DESCRIPTION
InstructionEditor hardcoded every color as a light-theme literal with no dark-mode overrides, so the instruction body rendered near-black on the dark surface — invisible in both the report side panel and the Agents page. Only the @mention chips stayed visible, since they carry their own indigo color. Add a dark block mirroring InstructionText's palette so the editor and the read-only view match: body text, headings, inline code, code blocks, blockquotes, mention chips, the raw-markdown textarea, and the floating bubble toolbar (white-on-dark before this).

InstructionText's plain-text mention chip had the same gap: border-indigo-100 (#e0e7ff, near-white) with no dark variant put a bright rim around every chip, and text-indigo-700 left the label muddy. Align its dark colors with the markdown-mode chip so both rendering paths look identical.

Same one-rule fix for the mention chip in InstructionTrackedChanges.