### PR TITLE
Add per-provider custom headers, identity forwarding, and Entra ID auth for LLM providers

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -400,6 +400,8 @@ from app.services.instruction_usage_service import InstructionUsageService
 from app.ai.llm.types import ImageInput
 from app.ai.llm.image_utils import normalize_image_input
 from app.ai.llm.usage_attribution import set_usage_attribution, reset_usage_attribution
+from app.ai.llm.header_injection import set_llm_identity, reset_llm_identity
+from app.services.mcp_context_injection import IdentityContext
 from app.services.usage_policy_service import UsageLimitContext
 from app.core.otel import get_tracer
 
@@ -474,6 +476,25 @@ class AgentV2:
         self._fallback_controller = None
         self._fallback_engaged = False
         self.head_completion = head_completion
+        # Stamp the asker's identity for LLM header injection BEFORE the
+        # planner below constructs its LLM client — provider header_injection
+        # rules resolve at client construction. Membership role/attributes need
+        # a DB query, so main_execution enriches this stamp at run start; the
+        # user-level fields cover the common rules (user.email/name/id) for
+        # clients built here in __init__.
+        try:
+            _init_user = getattr(head_completion, "user", None) if head_completion else None
+        except Exception:
+            _init_user = None
+        set_llm_identity(
+            IdentityContext(
+                email=getattr(_init_user, "email", "") or "",
+                name=getattr(_init_user, "name", "") or "",
+                user_id=str(getattr(_init_user, "id", "") or ""),
+            )
+            if _init_user is not None
+            else None
+        )
         self.system_completion = system_completion
         self.system_completion_id = (
             str(system_completion.id) if system_completion is not None else None
@@ -3857,6 +3878,59 @@ class AgentV2:
                 "baseline_model_id": str(_attr_baseline) if _attr_baseline else None,
             }
         )
+        # Stamp the caller's identity for LLM header injection: providers with
+        # header_injection rules (additional_config) resolve user.email /
+        # membership.attr:* against this when their clients are constructed, so
+        # gateways can attribute cost per user. Same ambient-contextvar approach
+        # as usage attribution — LLM() is called from ~20 sites that never see
+        # the user object.
+        _identity_token = None
+        _id_user = getattr(self.head_completion, "user", None) if self.head_completion else None
+        if _id_user is not None:
+            _id_role, _id_attrs = "", {}
+            try:
+                from app.models.membership import Membership
+                _id_row = (await self.db.execute(
+                    select(Membership.role, Membership.profile_attributes).where(
+                        Membership.user_id == _id_user.id,
+                        Membership.organization_id == self.organization.id,
+                    )
+                )).first()
+                if _id_row is not None:
+                    _id_role = _id_row[0] or ""
+                    _id_attrs = dict(_id_row[1] or {})
+            except Exception:
+                logger.warning("[headers] membership lookup for identity stamp failed", exc_info=True)
+            _identity_token = set_llm_identity(IdentityContext(
+                email=getattr(_id_user, "email", "") or "",
+                name=getattr(_id_user, "name", "") or "",
+                user_id=str(getattr(_id_user, "id", "") or ""),
+                role=_id_role,
+                attributes=_id_attrs,
+            ))
+            # The planner's LLM was constructed in __init__ under the
+            # user-only identity stamp, so membership-based header rules
+            # (membership.role / membership.attr:*) resolved empty in its
+            # baked default_headers. Rebuild it under the enriched identity
+            # when the provider forwards membership fields — same cheap
+            # rebuild the model router uses on escalation.
+            try:
+                _prov_cfg = getattr(getattr(self.model, "provider", None), "additional_config", None) or {}
+                _needs_membership = any(
+                    str((r or {}).get("source", "")).startswith(("membership.", "static:"))
+                    for r in (_prov_cfg.get("header_injection") or [])
+                    if isinstance(r, dict)
+                )
+                logger.debug("[headers] identity stamped (role=%r attrs=%d membership_rules=%s)", _id_role, len(_id_attrs), _needs_membership)
+                if _needs_membership:
+                    from app.ai.llm.llm import LLM
+                    self.planner.llm = LLM(
+                        self.model,
+                        usage_session_maker=async_session_maker,
+                        usage_context=self.usage_limit_context,
+                    )
+            except Exception:
+                logger.warning("[headers] failed to rebuild planner LLM with membership identity", exc_info=True)
         try:
             import time as _time
             _t0 = _time.monotonic()
@@ -6584,6 +6658,8 @@ class AgentV2:
         finally:
             # Drop the ambient LLM usage attribution set at run start.
             reset_usage_attribution(_attribution_token)
+            if _identity_token is not None:
+                reset_llm_identity(_identity_token)
             # Single-writer mode: drop the self._writes alias. self.db's
             # lifecycle is owned by the caller (FastAPI dependency); we
             # only ever aliased to it, never opened/owned a separate

--- a/backend/app/ai/llm/clients/anthropic_client.py
+++ b/backend/app/ai/llm/clients/anthropic_client.py
@@ -53,10 +53,14 @@ def _accepts_temperature(model_id: str) -> bool:
 
 
 class Anthropic(LLMClient):
-    def __init__(self, api_key: str, base_url: str = None, temperature: Optional[float] = None):
+    def __init__(self, api_key: str, base_url: str = None, temperature: Optional[float] = None,
+                 default_headers: Optional[dict] = None):
         super().__init__()
-        self.client = AnthropicAPI(api_key=api_key)
-        self.async_client = AsyncAnthropic(api_key=api_key)
+        client_kwargs: dict = {"api_key": api_key}
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        self.client = AnthropicAPI(**client_kwargs)
+        self.async_client = AsyncAnthropic(**client_kwargs)
         self.max_tokens = 32768
         # Admin-configured override, or the historical default. Either way the
         # _accepts_temperature gate stays authoritative: model families that

--- a/backend/app/ai/llm/clients/azure_client.py
+++ b/backend/app/ai/llm/clients/azure_client.py
@@ -27,24 +27,30 @@ class AzureClient(LLMClient):
     # built via __new__) still resolve the attribute.
     temperature: float | None = None
 
-    def __init__(self, api_key: str, endpoint_url: str, api_version: str | None = None,
-                 temperature: float | None = None):
+    def __init__(self, api_key: str | None, endpoint_url: str, api_version: str | None = None,
+                 temperature: float | None = None,
+                 default_headers: dict | None = None,
+                 azure_ad_token_provider=None):
         super().__init__()
         # Admin-configured override; None keeps the per-call historical default
         # (see _default_temperature).
         self.temperature = temperature
         # endpoint_url should be the Azure OpenAI resource endpoint, e.g. https://<resource>.openai.azure.com
         effective_api_version = api_version or "2024-10-21"
-        self.client = AzureOpenAI(
-            api_key=api_key,
-            azure_endpoint=endpoint_url,
-            api_version=effective_api_version,
-        )
-        self.async_client = AsyncAzureOpenAI(
-            api_key=api_key,
-            azure_endpoint=endpoint_url,
-            api_version=effective_api_version,
-        )
+        client_kwargs: dict = {
+            "azure_endpoint": endpoint_url,
+            "api_version": effective_api_version,
+        }
+        # Entra ID auth: an azure-identity bearer-token provider replaces the
+        # static API key (the SDK requires exactly one of the two).
+        if azure_ad_token_provider is not None:
+            client_kwargs["azure_ad_token_provider"] = azure_ad_token_provider
+        else:
+            client_kwargs["api_key"] = api_key
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        self.client = AzureOpenAI(**client_kwargs)
+        self.async_client = AsyncAzureOpenAI(**client_kwargs)
 
     def _resolve_temperature(self, model_id: str) -> float:
         """Admin-configured value when set, else the historical default

--- a/backend/app/ai/llm/clients/bedrock_client.py
+++ b/backend/app/ai/llm/clients/bedrock_client.py
@@ -110,6 +110,7 @@ class BedrockClient(LLMClient):
         api_key: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
+        extra_headers: Optional[dict] = None,
     ):
         super().__init__()
         if auth_mode not in self._SUPPORTED_AUTH_MODES:
@@ -151,6 +152,21 @@ class BedrockClient(LLMClient):
         else:
             self.client = boto3.client(
                 "bedrock-runtime", region_name=region, config=_http_config()
+            )
+
+        if extra_headers:
+            # Same request-created hook the api_key Bearer injection uses. It
+            # fires after SigV4 signing, and the signature only covers signed
+            # headers, so appending unsigned custom headers here is safe for
+            # every auth mode.
+            _headers = dict(extra_headers)
+
+            def _add_extra_headers(request, **kwargs):
+                for name, value in _headers.items():
+                    request.headers[name] = value
+
+            self.client.meta.events.register(
+                "request-created.bedrock-runtime.*", _add_extra_headers
             )
 
         self._region = region

--- a/backend/app/ai/llm/clients/google_client.py
+++ b/backend/app/ai/llm/clients/google_client.py
@@ -34,9 +34,13 @@ class Google(LLMClient):
     # instead of 0 — the cost is negligible and the request actually goes through.
     MIN_THINKING_BUDGET = 128
 
-    def __init__(self, api_key: str | None = None, temperature: float | None = None):
+    def __init__(self, api_key: str | None = None, temperature: float | None = None,
+                 default_headers: dict | None = None):
         super().__init__()
-        self.client = genai.Client(api_key=api_key)
+        client_kwargs: dict = {"api_key": api_key}
+        if default_headers:
+            client_kwargs["http_options"] = types.HttpOptions(headers=default_headers)
+        self.client = genai.Client(**client_kwargs)
         # Admin-configured override, or the historical default.
         self.temperature = 0.3 if temperature is None else temperature
 

--- a/backend/app/ai/llm/clients/openai_client.py
+++ b/backend/app/ai/llm/clients/openai_client.py
@@ -38,6 +38,7 @@ class OpenAi(LLMClient):
         base_url: str = "https://api.openai.com/v1",
         verify_ssl: bool = True,
         temperature: Optional[float] = None,
+        default_headers: Optional[dict[str, str]] = None,
     ):
         super().__init__()
         # No temperature is sent unless one was explicitly configured. This
@@ -48,11 +49,15 @@ class OpenAi(LLMClient):
         # name-based detection can recognize an alias.
         self.temperature = temperature
         kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+        if default_headers:
+            kwargs["default_headers"] = default_headers
         if not verify_ssl:
             kwargs["http_client"] = httpx.Client(verify=verify_ssl)
         self.client = OpenAI(**kwargs)
 
         async_kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+        if default_headers:
+            async_kwargs["default_headers"] = default_headers
         if not verify_ssl:
             async_kwargs["http_client"] = httpx.AsyncClient(verify=verify_ssl)
         self.async_client = AsyncOpenAI(**async_kwargs)

--- a/backend/app/ai/llm/clients/openai_responses_client.py
+++ b/backend/app/ai/llm/clients/openai_responses_client.py
@@ -60,11 +60,14 @@ class OpenAIResponsesClient(LLMClient):
         base_url: Optional[str] = None,
         enable_web_search: bool = False,
         temperature: Optional[float] = None,
+        default_headers: Optional[dict[str, Any]] = None,
     ):
         super().__init__()
         client_kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
             client_kwargs["base_url"] = base_url
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
         self.client = OpenAI(**client_kwargs)
         self.async_client = AsyncOpenAI(**client_kwargs)
         self.enable_web_search = enable_web_search

--- a/backend/app/ai/llm/header_injection.py
+++ b/backend/app/ai/llm/header_injection.py
@@ -1,0 +1,149 @@
+"""Custom HTTP headers + identity forwarding for LLM provider requests.
+
+Admins can configure two things on an LLM provider (stored in
+``LLMProvider.additional_config``, mirroring MCP connections):
+
+  * ``headers`` — static key/value headers attached to every request the
+    provider's clients make (e.g. a gateway routing key or cost-center tag).
+  * ``header_injection`` — rules that forward the signed-in user's identity as
+    headers, e.g. ``{"header": "X-User-Email", "source": "user.email"}``, so a
+    gateway/proxy can attribute cost per user.
+
+Sources use the same whitelisted grammar as MCP context forwarding
+(:mod:`app.services.mcp_context_injection`): ``user.email`` / ``user.name`` /
+``user.id`` / ``membership.role`` / ``membership.attr:<key>`` /
+``static:<text>`` with ``{atom}`` interpolation.
+
+The user's identity is ambient: LLM calls happen deep in the agent/tool stack,
+so AgentV2 stamps an :class:`IdentityContext` contextvar at run start (next to
+usage attribution) and the LLM facade resolves the provider's rules against it
+when it constructs a client. Outside a user-triggered run (test connection,
+scheduled jobs) the identity is empty, so injection rules resolve to nothing
+and only static headers apply.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from contextvars import ContextVar
+from typing import Any, Dict, List, Optional
+
+from app.services.mcp_context_injection import IdentityContext, resolve_source
+
+# RFC 7230 token characters — the only thing a header NAME may contain.
+_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
+
+MAX_HEADERS = 24
+MAX_HEADER_NAME_LEN = 128
+MAX_HEADER_VALUE_LEN = 4096
+
+_current_identity: ContextVar[Optional[IdentityContext]] = ContextVar(
+    "llm_identity", default=None
+)
+
+
+def get_llm_identity() -> Optional[IdentityContext]:
+    return _current_identity.get()
+
+
+def set_llm_identity(identity: Optional[IdentityContext]):
+    """Set the ambient identity, returning the contextvar token for reset."""
+    return _current_identity.set(identity)
+
+
+def reset_llm_identity(token) -> None:
+    with contextlib.suppress(Exception):
+        _current_identity.reset(token)
+
+
+def _clean_header_value(value: Any) -> Optional[str]:
+    """Coerce to a single-line header value, or None when unusable.
+
+    CR/LF are stripped rather than rejected — they can only arrive through a
+    resolved identity attribute, and dropping the newline beats failing the
+    whole LLM call over a malformed directory field.
+    """
+    if value is None:
+        return None
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    if not text:
+        return None
+    return text[:MAX_HEADER_VALUE_LEN]
+
+
+def validate_header_config(
+    headers: Optional[Dict[str, Any]],
+    header_injection: Optional[List[Dict[str, Any]]],
+) -> tuple[Dict[str, str], List[Dict[str, str]]]:
+    """Validate + normalize admin-supplied header config for storage.
+
+    Returns ``(headers, header_injection)`` normalized; raises ``ValueError``
+    on an invalid header name or an oversized rule set so the API surfaces a
+    clear 400 instead of persisting config that would be dropped at call time.
+    """
+    clean_headers: Dict[str, str] = {}
+    for name, value in (headers or {}).items():
+        name = str(name or "").strip()
+        if not name:
+            continue
+        if len(name) > MAX_HEADER_NAME_LEN or not _HEADER_NAME_RE.match(name):
+            raise ValueError(f"Invalid header name: {name!r}")
+        cleaned = _clean_header_value(value)
+        if cleaned is None:
+            continue
+        clean_headers[name] = cleaned
+
+    clean_rules: List[Dict[str, str]] = []
+    for rule in header_injection or []:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("header") or "").strip()
+        source = str(rule.get("source") or "").strip()
+        if not name and not source:
+            continue
+        if not name or len(name) > MAX_HEADER_NAME_LEN or not _HEADER_NAME_RE.match(name):
+            raise ValueError(f"Invalid header name in forwarding rule: {name!r}")
+        if not source:
+            raise ValueError(f"Forwarding rule for {name!r} has no source")
+        clean_rules.append({"header": name, "source": source})
+
+    if len(clean_headers) + len(clean_rules) > MAX_HEADERS:
+        raise ValueError(f"Too many custom headers (max {MAX_HEADERS})")
+
+    return clean_headers, clean_rules
+
+
+def build_provider_headers(additional_config: Optional[Dict[str, Any]]) -> Dict[str, str]:
+    """Resolve a provider's header config into the headers to send.
+
+    Static ``headers`` first, then ``header_injection`` rules against the
+    ambient identity (dynamic wins). Rules that resolve empty are omitted —
+    an empty identity header is noise, not context. Invalid names are dropped
+    defensively (storage already validates; config may predate validation).
+    """
+    config = additional_config or {}
+    resolved: Dict[str, str] = {}
+
+    static = config.get("headers") or {}
+    if isinstance(static, dict):
+        for name, value in static.items():
+            name = str(name or "").strip()
+            cleaned = _clean_header_value(value)
+            if name and cleaned is not None and _HEADER_NAME_RE.match(name):
+                resolved[name] = cleaned
+
+    rules = config.get("header_injection") or []
+    if isinstance(rules, list):
+        identity = get_llm_identity() or IdentityContext()
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            name = str(rule.get("header") or "").strip()
+            if not name or not _HEADER_NAME_RE.match(name):
+                continue
+            value = _clean_header_value(resolve_source(rule.get("source", ""), identity))
+            if value:
+                resolved[name] = value
+
+    return resolved

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -26,6 +26,7 @@ from app.ai.llm.pii.loader import load_redactor_for_org
 from app.ai.llm.pii.redactor import PiiRedactor, PiiPromptBlockedError
 from app.models.llm_model import LLMModel
 from app.ai.llm.usage_attribution import get_usage_attribution
+from app.ai.llm.header_injection import build_provider_headers
 from app.services.llm_usage_recorder import LLMUsageRecorderService
 from app.services.usage_policy_service import UsageLimitContext, usage_policy_service
 from app.settings.logging_config import get_logger
@@ -120,14 +121,18 @@ class LLM:
             self.api_key = self.model.provider.decrypt_credentials()[0]
         except Exception as exc:
             # For most providers, failing to decrypt credentials is a hard error.
-            # The only exception is Bedrock when using non-API-key auth (e.g., IAM),
-            # where an API key is not required.
+            # The exceptions are auth modes that don't need an API key: Bedrock
+            # under IAM/access-key auth, and Azure under Entra ID auth (tokens
+            # come from azure-identity, not a stored key).
             additional_config = getattr(self.model.provider, "additional_config", None) or {}
-            auth_mode = additional_config.get("auth_mode", "iam") if isinstance(additional_config, dict) else "iam"
-            if self.provider == "bedrock" and auth_mode != "api_key":
+            auth_mode = additional_config.get("auth_mode") if isinstance(additional_config, dict) else None
+            if (self.provider == "bedrock" and (auth_mode or "iam") != "api_key") or (
+                self.provider == "azure" and (auth_mode or "api_key") != "api_key"
+            ):
                 logger.warning(
-                    "Failed to decrypt credentials for Bedrock provider in '%s' auth mode; "
+                    "Failed to decrypt credentials for %s provider in '%s' auth mode; "
                     "continuing without api_key. Error: %s",
+                    self.provider,
                     auth_mode,
                     exc,
                 )
@@ -154,40 +159,66 @@ class LLM:
         configured_temperature = _parse_temperature(model_config.get("temperature"))
         if configured_temperature is None:
             configured_temperature = _parse_temperature(additional_config.get("temperature"))
+        # Custom outbound headers: static admin-configured headers plus per-user
+        # identity forwarding rules resolved against the ambient identity (see
+        # app.ai.llm.header_injection). LLM instances are constructed per run /
+        # per call site, inside the identity scope AgentV2 stamps, so resolving
+        # here keeps every client and both sync/async paths covered.
+        custom_headers = build_provider_headers(additional_config) or None
         if self.provider == "openai":
             base_url = additional_config.get("base_url")
             if base_url:
                 # Custom base URL on openai provider → use Chat Completions (compatible endpoint)
-                self.client = OpenAi(api_key=self.api_key, base_url=base_url, temperature=configured_temperature)
+                self.client = OpenAi(api_key=self.api_key, base_url=base_url, temperature=configured_temperature, default_headers=custom_headers)
             else:
                 # Default OpenAI → Responses API (supports reasoning content)
                 self.client = OpenAIResponsesClient(
                     api_key=self.api_key,
                     enable_web_search=enable_web_search,
                     temperature=configured_temperature,
+                    default_headers=custom_headers,
                 )
         elif self.provider == "anthropic":
-            self.client = Anthropic(api_key=self.api_key, temperature=configured_temperature)
+            self.client = Anthropic(api_key=self.api_key, temperature=configured_temperature, default_headers=custom_headers)
         elif self.provider == "google":
-            self.client = Google(api_key=self.api_key, temperature=configured_temperature)
+            self.client = Google(api_key=self.api_key, temperature=configured_temperature, default_headers=custom_headers)
         elif self.provider == "azure":
             endpoint_url = additional_config.get("endpoint_url")
             if not endpoint_url:
                 raise ValueError("Azure provider requires endpoint_url in additional_config")
+            auth_mode = additional_config.get("auth_mode", "api_key")
+            azure_ad_token_provider = None
+            if auth_mode in ("entra_client_secret", "entra_default"):
+                azure_ad_token_provider = self._build_entra_token_provider(auth_mode, additional_config)
             # Default to Chat Completions (AzureClient) — works in every region.
             # Admins opt into the Responses API explicitly (use_responses_api),
             # which is required for native web search and only available in some
             # Azure regions. Web search is honored only on the Responses path.
+            # Entra auth always uses Chat Completions: the Responses path runs on
+            # the plain OpenAI client, which has no AAD token-provider hook.
             use_responses_api = bool(additional_config.get("use_responses_api", False))
+            if use_responses_api and azure_ad_token_provider is not None:
+                logger.warning(
+                    "Azure provider uses Entra ID auth; ignoring use_responses_api "
+                    "(Responses API is only supported with api_key auth)."
+                )
+                use_responses_api = False
             if use_responses_api:
                 self.client = OpenAIResponsesClient(
                     api_key=self.api_key,
                     base_url=self._azure_v1_base_url(endpoint_url),
                     enable_web_search=enable_web_search,
                     temperature=configured_temperature,
+                    default_headers=custom_headers,
                 )
             else:
-                self.client = AzureClient(api_key=self.api_key, endpoint_url=endpoint_url, temperature=configured_temperature)
+                self.client = AzureClient(
+                    api_key=self.api_key,
+                    endpoint_url=endpoint_url,
+                    temperature=configured_temperature,
+                    default_headers=custom_headers,
+                    azure_ad_token_provider=azure_ad_token_provider,
+                )
         elif self.provider == "custom":
             base_url = self.model.provider.additional_config.get("base_url") if self.model.provider.additional_config else None
             if not base_url:
@@ -195,7 +226,7 @@ class LLM:
             verify_ssl = self.model.provider.additional_config.get("verify_ssl", True) if self.model.provider.additional_config else True
             # Use empty string for api_key if not provided (some local servers don't need auth)
             api_key = self.api_key or ""
-            self.client = OpenAi(api_key=api_key, base_url=base_url, verify_ssl=verify_ssl, temperature=configured_temperature)
+            self.client = OpenAi(api_key=api_key, base_url=base_url, verify_ssl=verify_ssl, temperature=configured_temperature, default_headers=custom_headers)
         elif self.provider == "bedrock":
             additional_config = self.model.provider.additional_config or {}
             region = additional_config.get("region")
@@ -205,7 +236,7 @@ class LLM:
             if auth_mode == "api_key" and not self.api_key:
                 raise ValueError("Bedrock provider with auth_mode 'api_key' requires provider credentials")
 
-            bedrock_kwargs: dict = {"region": region, "auth_mode": auth_mode}
+            bedrock_kwargs: dict = {"region": region, "auth_mode": auth_mode, "extra_headers": custom_headers}
             if auth_mode == "api_key":
                 bedrock_kwargs["api_key"] = self.api_key
             elif auth_mode == "access_keys":
@@ -220,6 +251,41 @@ class LLM:
             self.client = BedrockClient(**bedrock_kwargs)
         else:
             raise ValueError(f"Provider {self.provider} not supported")
+
+    def _build_entra_token_provider(self, auth_mode: str, additional_config: dict):
+        """Build an AAD bearer-token provider for Azure OpenAI Entra ID auth.
+
+        'entra_client_secret' authenticates as a service principal from the
+        stored tenant/client ids + encrypted client secret; 'entra_default'
+        walks azure-identity's DefaultAzureCredential chain (managed identity,
+        workload identity, env vars, Azure CLI). get_bearer_token_provider
+        caches and refreshes tokens, so the provider stays valid past the
+        ~1h token lifetime for long-lived clients.
+        """
+        from azure.identity import (
+            ClientSecretCredential,
+            DefaultAzureCredential,
+            get_bearer_token_provider,
+        )
+
+        if auth_mode == "entra_client_secret":
+            tenant_id = additional_config.get("tenant_id")
+            client_id = additional_config.get("client_id")
+            try:
+                _, client_secret = self.model.provider.decrypt_credentials()
+            except Exception:
+                client_secret = None
+            if not tenant_id or not client_id or not client_secret:
+                raise ValueError(
+                    "Azure provider with auth_mode 'entra_client_secret' requires "
+                    "tenant_id, client_id, and a stored client_secret"
+                )
+            credential = ClientSecretCredential(
+                tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+            )
+        else:
+            credential = DefaultAzureCredential()
+        return get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
 
     @staticmethod
     def _azure_v1_base_url(endpoint_url: str) -> str:

--- a/backend/app/schemas/llm_schema.py
+++ b/backend/app/schemas/llm_schema.py
@@ -1,7 +1,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, Field, validator
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 import json
 
 # Base Provider Classes
@@ -96,14 +96,38 @@ class LLMProviderUpdate(BaseModel):
     models: list[LLMModelSchema] = []
 
 # Provider-specific Credentials
-class AnthropicCredentials(BaseModel):
+
+class HeaderInjectionRule(BaseModel):
+    """Forward the signed-in user's identity as an HTTP header on LLM requests.
+
+    ``source`` uses the same whitelisted grammar as MCP context forwarding:
+    user.email / user.name / user.id / membership.role /
+    membership.attr:<key> / static:<text> (with {atom} interpolation).
+    """
+    header: str
+    source: str
+
+
+class ProviderHeadersMixin(BaseModel):
+    """Custom outbound headers, shared by every provider's credentials.
+
+    Both fields persist to additional_config (not encrypted) — mirroring how
+    MCP connections store their ``headers`` / ``header_injection`` config.
+    ``headers`` are static key/values sent on every request; ``header_injection``
+    rules resolve per-user so gateways/proxies can attribute cost per caller.
+    """
+    headers: Optional[Dict[str, str]] = None
+    header_injection: Optional[List[HeaderInjectionRule]] = None
+
+
+class AnthropicCredentials(ProviderHeadersMixin):
     api_key: str
 
 class AnthropicConfig(BaseModel):
     max_tokens: Optional[int] = 4096
     temperature: Optional[float] = 0.7
 
-class OpenAICredentials(BaseModel):
+class OpenAICredentials(ProviderHeadersMixin):
     api_key: str
     base_url: Optional[str] = None
     # Per-provider opt-in for native web search (Responses API tool). Persisted
@@ -118,7 +142,7 @@ class OpenAIConfig(BaseModel):
     max_tokens: Optional[int] = 2048
     temperature: Optional[float] = 0.7
 
-class GoogleCredentials(BaseModel):
+class GoogleCredentials(ProviderHeadersMixin):
     api_key: str
 
 class GoogleConfig(BaseModel):
@@ -127,22 +151,53 @@ class GoogleConfig(BaseModel):
     top_p: Optional[float] = 0.8
     top_k: Optional[int] = 40
 
-class AzureCredentials(BaseModel):
-    api_key: str
+class AzureCredentials(ProviderHeadersMixin):
     endpoint_url: str
+    # Authentication mode. 'api_key' (default) uses a static Azure OpenAI key.
+    # 'entra_client_secret' authenticates as a Microsoft Entra ID service
+    # principal (tenant_id + client_id + client_secret); 'entra_default' uses
+    # azure-identity's DefaultAzureCredential (managed identity, workload
+    # identity, Azure CLI, env vars). Entra modes acquire AAD tokens for the
+    # Cognitive Services scope and refresh them automatically.
+    auth_mode: str = Field("api_key", description="Authentication mode: 'api_key', 'entra_client_secret', or 'entra_default'")
+    api_key: Optional[str] = Field(None, description="Azure OpenAI API key (only for api_key auth mode)")
+    tenant_id: Optional[str] = Field(None, description="Entra ID tenant ID (only for entra_client_secret auth mode)")
+    client_id: Optional[str] = Field(None, description="Entra ID application (client) ID (only for entra_client_secret auth mode)")
+    client_secret: Optional[str] = Field(None, description="Entra ID client secret (only for entra_client_secret auth mode)")
     # Opt-in to Azure OpenAI's Responses API (/openai/v1) instead of Chat
     # Completions. Off by default — only some Azure regions serve Responses.
-    # Persisted to additional_config, not encrypted.
+    # Persisted to additional_config, not encrypted. Ignored under Entra auth
+    # modes (the Responses path has no AAD token-provider hook yet).
     use_responses_api: Optional[bool] = None
     # Per-provider opt-in for native web search. Only effective when
     # use_responses_api is on (web search is a Responses-API tool).
     enable_web_search: Optional[bool] = None
 
+    @validator('auth_mode')
+    def validate_auth_mode(cls, v):
+        allowed = {'api_key', 'entra_client_secret', 'entra_default'}
+        if v not in allowed:
+            raise ValueError(f"auth_mode must be one of: {', '.join(sorted(allowed))}")
+        return v
+
+    @validator('client_secret', always=True)
+    def validate_mode_fields(cls, v, values):
+        mode = values.get('auth_mode', 'api_key')
+        if mode == 'api_key' and not values.get('api_key'):
+            raise ValueError('api_key is required for api_key auth mode')
+        if mode == 'entra_client_secret':
+            missing = [f for f in ('tenant_id', 'client_id') if not values.get(f)]
+            if not v:
+                missing.append('client_secret')
+            if missing:
+                raise ValueError(f"entra_client_secret auth mode requires: {', '.join(missing)}")
+        return v
+
 class AzureConfig(BaseModel):
     max_tokens: Optional[int] = 2048
     temperature: Optional[float] = 0.7
 
-class CustomCredentials(BaseModel):
+class CustomCredentials(ProviderHeadersMixin):
     """Credentials for OpenAI-compatible APIs (Ollama, Groq, Together AI, LM Studio, vLLM, etc.)"""
     base_url: str  # Required - the OpenAI-compatible endpoint
     api_key: Optional[str] = None  # Optional - some local servers don't require auth
@@ -152,7 +207,7 @@ class CustomConfig(BaseModel):
     max_tokens: Optional[int] = 4096
     temperature: Optional[float] = 0.7
 
-class BedrockCredentials(BaseModel):
+class BedrockCredentials(ProviderHeadersMixin):
     """Credentials for AWS Bedrock. Supports API key auth, access key auth, or IAM auth (from environment)."""
     region: str = Field(..., description="AWS region (e.g. us-east-1, eu-west-1)")
     auth_mode: str = Field("iam", description="Authentication mode: 'api_key', 'access_keys', or 'iam'")

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -12,6 +12,7 @@ from app.models.llm_provider import LLM_PROVIDER_DETAILS
 from app.models.llm_model import LLM_MODEL_DETAILS, DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW
 from app.schemas.llm_schema import AnthropicCredentials, OpenAICredentials, GoogleCredentials, LLMModelSchema, LLMProviderCreate, LLMProviderTestConnection
 from app.ai.llm.llm import LLM
+from app.ai.llm.header_injection import validate_header_config
 from app.dependencies import async_session_maker
 from datetime import datetime
 from app.core.telemetry import telemetry
@@ -1591,6 +1592,31 @@ class LLMService:
                     # Explicitly clear endpoint_url when set to empty/null
                     existing_additional_config.pop("endpoint_url", None)
 
+            # Entra ID auth: auth_mode + service-principal identifiers are
+            # non-secret → additional_config; the client_secret is a secret and
+            # rides the encrypted api_secret slot (api_key keeps the API key so
+            # switching modes doesn't lose either credential).
+            if "auth_mode" in credentials:
+                raw_auth_mode = credentials.get("auth_mode")
+                auth_mode = raw_auth_mode.lower() if isinstance(raw_auth_mode, str) else raw_auth_mode
+                allowed_auth_modes = {"api_key", "entra_client_secret", "entra_default"}
+                if auth_mode not in allowed_auth_modes:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Invalid auth_mode for Azure provider: {raw_auth_mode!r}. "
+                               f"Allowed values are: {', '.join(sorted(allowed_auth_modes))}."
+                    )
+                existing_additional_config = { **existing_additional_config, "auth_mode": auth_mode }
+            for entra_field in ("tenant_id", "client_id"):
+                if entra_field in credentials:
+                    value = credentials.get(entra_field)
+                    if value:
+                        existing_additional_config = { **existing_additional_config, entra_field: value }
+                    else:
+                        existing_additional_config.pop(entra_field, None)
+            if credentials.get("client_secret"):
+                api_secret = credentials["client_secret"]
+
         # OpenAI: base_url (optional)
         if provider.provider_type == "openai":
             base_url = credentials.get("base_url")
@@ -1661,6 +1687,29 @@ class LLMService:
                 api_key = credentials["aws_access_key_id"]
             if credentials.get("aws_secret_access_key"):
                 api_secret = credentials["aws_secret_access_key"]
+
+        # All providers: custom outbound headers + per-user identity forwarding
+        # (non-secret → additional_config, mirroring MCP connections). Present
+        # keys replace the stored value; empty clears it.
+        if "headers" in credentials or "header_injection" in credentials:
+            try:
+                clean_headers, clean_rules = validate_header_config(
+                    credentials.get("headers") if "headers" in credentials
+                    else existing_additional_config.get("headers"),
+                    [r.dict() if hasattr(r, "dict") else r for r in credentials.get("header_injection") or []]
+                    if "header_injection" in credentials
+                    else existing_additional_config.get("header_injection"),
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            if clean_headers:
+                existing_additional_config = { **existing_additional_config, "headers": clean_headers }
+            else:
+                existing_additional_config.pop("headers", None)
+            if clean_rules:
+                existing_additional_config = { **existing_additional_config, "header_injection": clean_rules }
+            else:
+                existing_additional_config.pop("header_injection", None)
         provider.additional_config = existing_additional_config if existing_additional_config else None
 
         # Only (re-)encrypt credentials when a new key/secret is provided

--- a/backend/tests/unit/test_llm_provider_headers.py
+++ b/backend/tests/unit/test_llm_provider_headers.py
@@ -1,0 +1,313 @@
+"""Unit tests for LLM provider custom headers + identity forwarding + Entra auth.
+
+Covers the pure header-resolution module, the LLM facade wiring headers into
+each client (verified on the constructed SDK clients — no network), and the
+Azure Entra ID auth-mode plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.ai.llm.header_injection import (
+    build_provider_headers,
+    reset_llm_identity,
+    set_llm_identity,
+    validate_header_config,
+)
+from app.ai.llm.llm import LLM
+from app.services.mcp_context_injection import IdentityContext
+from app.settings.config import settings
+
+
+class FakeProvider(SimpleNamespace):
+    """Duck-typed LLMProvider: enough surface for LLM.__init__."""
+
+    def decrypt_credentials(self):
+        fernet = Fernet(settings.bow_config.encryption_key)
+        return (
+            json.loads(fernet.decrypt(self.api_key.encode()).decode()),
+            json.loads(fernet.decrypt(self.api_secret.encode()).decode()),
+        )
+
+
+def make_model(provider_type: str, additional_config: dict, api_key="sk-test", api_secret=None):
+    fernet = Fernet(settings.bow_config.encryption_key)
+    provider = FakeProvider(
+        provider_type=provider_type,
+        additional_config=additional_config,
+        api_key=fernet.encrypt(json.dumps(api_key).encode()).decode(),
+        api_secret=fernet.encrypt(json.dumps(api_secret).encode()).decode(),
+    )
+    return SimpleNamespace(
+        model_id="test-model",
+        provider=provider,
+        organization_id="org-1",
+        config=None,
+        supports_vision=False,
+    )
+
+
+@pytest.fixture
+def identity():
+    token = set_llm_identity(
+        IdentityContext(
+            email="analyst@corp.com",
+            name="Ada Analyst",
+            user_id="u-123",
+            role="admin",
+            attributes={"department": "Finance", "employeeId": "E42"},
+        )
+    )
+    yield
+    reset_llm_identity(token)
+
+
+# ---------------------------------------------------------------------------
+# build_provider_headers
+# ---------------------------------------------------------------------------
+
+def test_static_headers_only():
+    assert build_provider_headers({"headers": {"X-Team": "data"}}) == {"X-Team": "data"}
+
+
+def test_injection_without_identity_is_omitted():
+    cfg = {"header_injection": [{"header": "X-User-Email", "source": "user.email"}]}
+    assert build_provider_headers(cfg) == {}
+
+
+def test_injection_resolves_identity(identity):
+    cfg = {
+        "headers": {"X-Static": "s"},
+        "header_injection": [
+            {"header": "X-User-Email", "source": "user.email"},
+            {"header": "X-Role", "source": "membership.role"},
+            {"header": "X-Dept", "source": "membership.attr:department"},
+            {"header": "X-Composite", "source": "static:corp\\{membership.attr:employeeId}"},
+            {"header": "X-Missing", "source": "membership.attr:nope"},
+        ],
+    }
+    assert build_provider_headers(cfg) == {
+        "X-Static": "s",
+        "X-User-Email": "analyst@corp.com",
+        "X-Role": "admin",
+        "X-Dept": "Finance",
+        "X-Composite": "corp\\E42",
+    }
+
+
+def test_dynamic_wins_over_static(identity):
+    cfg = {
+        "headers": {"X-User-Email": "static@corp.com"},
+        "header_injection": [{"header": "X-User-Email", "source": "user.email"}],
+    }
+    assert build_provider_headers(cfg) == {"X-User-Email": "analyst@corp.com"}
+
+
+def test_header_value_newlines_stripped():
+    token = set_llm_identity(IdentityContext(email="a@b.com\r\nX-Evil: 1"))
+    try:
+        cfg = {"header_injection": [{"header": "X-User-Email", "source": "user.email"}]}
+        resolved = build_provider_headers(cfg)["X-User-Email"]
+        assert "\r" not in resolved and "\n" not in resolved
+        assert resolved.startswith("a@b.com")
+    finally:
+        reset_llm_identity(token)
+
+
+def test_invalid_header_names_dropped_at_build():
+    cfg = {"headers": {"Bad Name": "x", "X-Ok": "y"}}
+    assert build_provider_headers(cfg) == {"X-Ok": "y"}
+
+
+def test_empty_config():
+    assert build_provider_headers(None) == {}
+    assert build_provider_headers({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# validate_header_config (storage-time validation)
+# ---------------------------------------------------------------------------
+
+def test_validate_normalizes():
+    headers, rules = validate_header_config(
+        {"X-Ok": " v ", "": "skip", "X-Empty": ""},
+        [{"header": "X-U", "source": "user.email"}, {"header": "", "source": ""}],
+    )
+    assert headers == {"X-Ok": "v"}
+    assert rules == [{"header": "X-U", "source": "user.email"}]
+
+
+def test_validate_rejects_bad_name():
+    with pytest.raises(ValueError, match="Invalid header name"):
+        validate_header_config({"Bad Name": "1"}, None)
+    with pytest.raises(ValueError, match="Invalid header name"):
+        validate_header_config(None, [{"header": "X:Y", "source": "user.email"}])
+
+
+def test_validate_rejects_missing_source():
+    with pytest.raises(ValueError, match="no source"):
+        validate_header_config(None, [{"header": "X-U", "source": ""}])
+
+
+def test_validate_rejects_too_many():
+    with pytest.raises(ValueError, match="Too many"):
+        validate_header_config({f"X-{i}": "v" for i in range(30)}, None)
+
+
+# ---------------------------------------------------------------------------
+# LLM facade → client wiring
+# ---------------------------------------------------------------------------
+
+HEADER_CFG = {
+    "headers": {"X-Static": "s"},
+    "header_injection": [{"header": "X-User-Email", "source": "user.email"}],
+}
+
+
+def test_custom_provider_headers_reach_openai_clients(identity):
+    model = make_model("custom", {"base_url": "http://localhost:9/v1", **HEADER_CFG})
+    llm = LLM(model)
+    for client in (llm.client.client, llm.client.async_client):
+        headers = dict(client.default_headers)
+        assert headers["X-Static"] == "s"
+        assert headers["X-User-Email"] == "analyst@corp.com"
+
+
+def test_openai_provider_headers_reach_responses_client(identity):
+    model = make_model("openai", dict(HEADER_CFG))
+    llm = LLM(model)
+    headers = dict(llm.client.client.default_headers)
+    assert headers["X-Static"] == "s"
+    assert headers["X-User-Email"] == "analyst@corp.com"
+
+
+def test_anthropic_provider_headers(identity):
+    model = make_model("anthropic", dict(HEADER_CFG))
+    llm = LLM(model)
+    headers = dict(llm.client.client.default_headers)
+    assert headers["X-Static"] == "s"
+    assert headers["X-User-Email"] == "analyst@corp.com"
+
+
+def test_azure_api_key_headers(identity):
+    model = make_model(
+        "azure", {"endpoint_url": "https://res.openai.azure.com", **HEADER_CFG}
+    )
+    llm = LLM(model)
+    headers = dict(llm.client.client.default_headers)
+    assert headers["X-Static"] == "s"
+    assert headers["X-User-Email"] == "analyst@corp.com"
+
+
+def test_no_headers_config_leaves_clients_clean():
+    model = make_model("custom", {"base_url": "http://localhost:9/v1"})
+    llm = LLM(model)
+    headers = dict(llm.client.client.default_headers)
+    assert "X-Static" not in headers
+
+
+def test_bedrock_extra_headers_injected_on_request():
+    from botocore.awsrequest import AWSRequest
+
+    model = make_model(
+        "bedrock", {"region": "us-east-1", "auth_mode": "api_key", **HEADER_CFG},
+        api_key="bedrock-key",
+    )
+    token = set_llm_identity(IdentityContext(email="analyst@corp.com"))
+    try:
+        llm = LLM(model)
+    finally:
+        reset_llm_identity(token)
+    request = AWSRequest(method="POST", url="https://bedrock-runtime.us-east-1.amazonaws.com/")
+    llm.client.client.meta.events.emit(
+        "request-created.bedrock-runtime.Converse", request=request, operation_name="Converse"
+    )
+    assert request.headers["X-Static"] == "s"
+    assert request.headers["X-User-Email"] == "analyst@corp.com"
+    # Bearer auth from api_key mode must survive alongside custom headers.
+    assert request.headers["Authorization"] == "Bearer bedrock-key"
+
+
+# ---------------------------------------------------------------------------
+# Azure Entra ID auth modes
+# ---------------------------------------------------------------------------
+
+def test_azure_entra_client_secret_builds_token_provider(identity):
+    model = make_model(
+        "azure",
+        {
+            "endpoint_url": "https://res.openai.azure.com",
+            "auth_mode": "entra_client_secret",
+            "tenant_id": "11111111-1111-1111-1111-111111111111",
+            "client_id": "22222222-2222-2222-2222-222222222222",
+            **HEADER_CFG,
+        },
+        api_key=None,
+        api_secret="entra-client-secret",
+    )
+    llm = LLM(model)
+    from app.ai.llm.clients.azure_client import AzureClient
+
+    assert isinstance(llm.client, AzureClient)
+    headers = dict(llm.client.client.default_headers)
+    assert headers["X-User-Email"] == "analyst@corp.com"
+
+
+def test_azure_entra_client_secret_requires_fields():
+    model = make_model(
+        "azure",
+        {
+            "endpoint_url": "https://res.openai.azure.com",
+            "auth_mode": "entra_client_secret",
+            "tenant_id": "t",
+            # client_id missing
+        },
+        api_key=None,
+        api_secret="secret",
+    )
+    with pytest.raises(ValueError, match="entra_client_secret"):
+        LLM(model)
+
+
+def test_azure_entra_default_no_stored_credentials():
+    fernet_free = FakeProvider(
+        provider_type="azure",
+        additional_config={
+            "endpoint_url": "https://res.openai.azure.com",
+            "auth_mode": "entra_default",
+        },
+        api_key=None,
+        api_secret=None,
+    )
+    model = SimpleNamespace(
+        model_id="gpt-4o", provider=fernet_free, organization_id="org-1",
+        config=None, supports_vision=False,
+    )
+    llm = LLM(model)  # must not raise on decrypt failure
+    from app.ai.llm.clients.azure_client import AzureClient
+
+    assert isinstance(llm.client, AzureClient)
+
+
+def test_azure_entra_ignores_responses_api(identity):
+    model = make_model(
+        "azure",
+        {
+            "endpoint_url": "https://res.openai.azure.com",
+            "auth_mode": "entra_client_secret",
+            "tenant_id": "t",
+            "client_id": "c",
+            "use_responses_api": True,
+        },
+        api_key=None,
+        api_secret="secret",
+    )
+    llm = LLM(model)
+    from app.ai.llm.clients.azure_client import AzureClient
+
+    assert isinstance(llm.client, AzureClient)

--- a/frontend/components/LLMProviderModalComponent.vue
+++ b/frontend/components/LLMProviderModalComponent.vue
@@ -36,7 +36,7 @@
                         </span>
                     </div>
                     <div v-if="selectedProvider.type !== 'new_provider'" class="space-y-4">
-                        <div class="" v-if="selectedProvider?.provider_type !== 'bedrock' && selectedProvider?.type !== 'bedrock'">
+                        <div class="" v-if="selectedProvider?.provider_type !== 'bedrock' && selectedProvider?.type !== 'bedrock' && !(isAzureSelected && selectedProvider.credentials.auth_mode && selectedProvider.credentials.auth_mode !== 'api_key')">
                             <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                                 API Key
                             </label>
@@ -47,7 +47,7 @@
                                 class="mt-2 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500"
                             />
                         </div>
-                        <div class="" v-if="selectedProvider?.provider_type === 'azure' || selectedProvider?.type === 'azure'">
+                        <div class="" v-if="isAzureSelected">
                             <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                                 Endpoint URL
                             </label>
@@ -57,6 +57,42 @@
                                 placeholder="e.g. https://<resource>.openai.azure.com"
                                 class="mt-2 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500"
                             />
+                        </div>
+                        <!-- Azure: authentication mode (API key vs Microsoft Entra ID) -->
+                        <div v-if="isAzureSelected">
+                            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Authentication</label>
+                            <div class="flex gap-2 mt-2">
+                                <button type="button" @click="selectedProvider.credentials.auth_mode = 'api_key'"
+                                    :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', (!selectedProvider.credentials.auth_mode || selectedProvider.credentials.auth_mode === 'api_key') ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                    API Key
+                                </button>
+                                <button type="button" @click="selectedProvider.credentials.auth_mode = 'entra_client_secret'"
+                                    :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', selectedProvider.credentials.auth_mode === 'entra_client_secret' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                    Entra ID (Service Principal)
+                                </button>
+                                <button type="button" @click="selectedProvider.credentials.auth_mode = 'entra_default'"
+                                    :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', selectedProvider.credentials.auth_mode === 'entra_default' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                    Entra ID (Default)
+                                </button>
+                            </div>
+                            <p v-if="selectedProvider.credentials.auth_mode === 'entra_default'" class="text-xs text-gray-500 dark:text-gray-400 mt-1.5">Uses DefaultAzureCredential (managed identity, workload identity, env vars, Azure CLI).</p>
+                            <template v-if="selectedProvider.credentials.auth_mode === 'entra_client_secret'">
+                                <div class="mt-2">
+                                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tenant ID <span class="text-red-500">*</span></label>
+                                    <input v-model="selectedProvider.credentials.tenant_id" type="text" placeholder="Directory (tenant) ID"
+                                        class="mt-2 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                </div>
+                                <div class="mt-2">
+                                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Client ID <span class="text-red-500">*</span></label>
+                                    <input v-model="selectedProvider.credentials.client_id" type="text" placeholder="Application (client) ID"
+                                        class="mt-2 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                </div>
+                                <div class="mt-2">
+                                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Client Secret <span class="text-red-500">*</span></label>
+                                    <input v-model="selectedProvider.credentials.client_secret" type="password" placeholder="Keep blank to use stored secret"
+                                        class="mt-2 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                </div>
+                            </template>
                         </div>
                         <div class="" v-if="selectedProvider?.provider_type === 'custom' || selectedProvider?.type === 'custom'">
                             <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -173,6 +209,57 @@
                             <p v-if="selectedProvider.credentials.base_url" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                                 Note: a custom base URL uses the Chat Completions API, which does not support web search. Clear it to use web search.
                             </p>
+                        </div>
+                        <!-- Custom headers + identity forwarding (all providers) -->
+                        <div>
+                            <button type="button" class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" @click="showHeadersSection = !showHeadersSection">
+                                <span class="transform transition-transform mt-1" :class="{ 'rotate-90': showHeadersSection }">
+                                    <Icon name="heroicons:chevron-right" class="w-3" />
+                                </span>
+                                Custom headers
+                                <span v-if="headerRows.length + forwardRows.length > 0" class="text-xs text-gray-400">({{ headerRows.length + forwardRows.length }})</span>
+                            </button>
+                            <div v-if="showHeadersSection" class="mt-2 space-y-4 ps-1">
+                                <div>
+                                    <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Static headers</label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400">Sent on every request to this provider (e.g. a gateway routing key or cost-center tag).</p>
+                                    <div v-for="(row, index) in headerRows" :key="`hdr-${index}`" class="flex items-center gap-2 mt-2">
+                                        <input v-model="row.key" type="text" placeholder="Header name" data-testid="static-header-key"
+                                            class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                        <input v-model="row.value" type="text" placeholder="Value" data-testid="static-header-value"
+                                            class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                        <button type="button" @click="removeHeaderRow(index)" class="text-red-500 hover:text-red-700">
+                                            <Icon name="heroicons:trash" class="w-4 h-4" />
+                                        </button>
+                                    </div>
+                                    <button type="button" @click="addHeaderRow" data-testid="add-static-header" class="text-xs text-blue-500 hover:text-blue-700 underline flex items-center gap-1 mt-2">
+                                        <Icon name="heroicons:plus-circle" class="w-3.5 h-3.5" />
+                                        Add header
+                                    </button>
+                                </div>
+                                <div>
+                                    <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Identity forwarding</label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400">Forward the signed-in user's identity as headers so your gateway can attribute cost per user.</p>
+                                    <div v-for="(row, index) in forwardRows" :key="`fwd-${index}`" class="flex items-center gap-2 mt-2">
+                                        <input v-model="row.header" type="text" placeholder="Header name" data-testid="forward-header-name"
+                                            class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                        <select v-model="row.kind" data-testid="forward-source-kind"
+                                            class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 focus:outline-none focus:border-blue-500">
+                                            <option v-for="kind in FORWARD_KINDS" :key="kind.value" :value="kind.value">{{ kind.label }}</option>
+                                        </select>
+                                        <input v-if="row.kind === 'membership.attr' || row.kind === 'static'" v-model="row.extra" type="text"
+                                            :placeholder="row.kind === 'membership.attr' ? 'Attribute key' : 'Value ({user.email} allowed)'" data-testid="forward-source-extra"
+                                            class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                        <button type="button" @click="removeForwardRow(index)" class="text-red-500 hover:text-red-700">
+                                            <Icon name="heroicons:trash" class="w-4 h-4" />
+                                        </button>
+                                    </div>
+                                    <button type="button" @click="addForwardRow" data-testid="add-forward-rule" class="text-xs text-blue-500 hover:text-blue-700 underline flex items-center gap-1 mt-2">
+                                        <Icon name="heroicons:plus-circle" class="w-3.5 h-3.5" />
+                                        Add forwarding rule
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                         <div class="">
                             <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -420,6 +507,102 @@
                                 </div>
                                 <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Native, provider-executed web search for external facts. Requires the org-level Web Fetch setting to also be on.</p>
                             </div>
+                            <!-- Azure: authentication mode for new provider -->
+                            <template v-if="providerForm.provider_type === 'azure'">
+                                <div class="mt-3">
+                                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Authentication</label>
+                                    <div class="flex gap-2 mt-2">
+                                        <button type="button" @click="providerForm.credentials.auth_mode = 'api_key'"
+                                            :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', (!providerForm.credentials.auth_mode || providerForm.credentials.auth_mode === 'api_key') ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                            API Key
+                                        </button>
+                                        <button type="button" @click="providerForm.credentials.auth_mode = 'entra_client_secret'"
+                                            :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', providerForm.credentials.auth_mode === 'entra_client_secret' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                            Entra ID (Service Principal)
+                                        </button>
+                                        <button type="button" @click="providerForm.credentials.auth_mode = 'entra_default'"
+                                            :class="['px-3 py-1.5 text-sm rounded-lg border cursor-pointer', providerForm.credentials.auth_mode === 'entra_default' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800']">
+                                            Entra ID (Default)
+                                        </button>
+                                    </div>
+                                    <p v-if="providerForm.credentials.auth_mode === 'entra_default'" class="text-xs text-gray-500 dark:text-gray-400 mt-1.5">Uses DefaultAzureCredential (managed identity, workload identity, env vars, Azure CLI).</p>
+                                </div>
+                                <template v-if="!providerForm.credentials.auth_mode || providerForm.credentials.auth_mode === 'api_key'">
+                                    <div class="mt-2">
+                                        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">API Key <span class="text-red-500">*</span></label>
+                                        <input v-model="providerForm.credentials.api_key" type="password" placeholder="Enter Azure OpenAI API key"
+                                            class="border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                    </div>
+                                </template>
+                                <template v-if="providerForm.credentials.auth_mode === 'entra_client_secret'">
+                                    <div class="mt-2">
+                                        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tenant ID <span class="text-red-500">*</span></label>
+                                        <input v-model="providerForm.credentials.tenant_id" type="text" placeholder="Directory (tenant) ID"
+                                            class="border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                    </div>
+                                    <div class="mt-2">
+                                        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Client ID <span class="text-red-500">*</span></label>
+                                        <input v-model="providerForm.credentials.client_id" type="text" placeholder="Application (client) ID"
+                                            class="border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                    </div>
+                                    <div class="mt-2">
+                                        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Client Secret <span class="text-red-500">*</span></label>
+                                        <input v-model="providerForm.credentials.client_secret" type="password" placeholder="Enter client secret"
+                                            class="border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 w-full h-9 text-sm focus:outline-none focus:border-blue-500" />
+                                    </div>
+                                </template>
+                            </template>
+                            <!-- Custom headers + identity forwarding (all providers, new form) -->
+                            <div class="mt-3">
+                                <button type="button" class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" @click="showHeadersSection = !showHeadersSection">
+                                    <span class="transform transition-transform mt-1" :class="{ 'rotate-90': showHeadersSection }">
+                                        <Icon name="heroicons:chevron-right" class="w-3" />
+                                    </span>
+                                    Custom headers
+                                    <span v-if="headerRows.length + forwardRows.length > 0" class="text-xs text-gray-400">({{ headerRows.length + forwardRows.length }})</span>
+                                </button>
+                                <div v-if="showHeadersSection" class="mt-2 space-y-4 ps-1">
+                                    <div>
+                                        <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Static headers</label>
+                                        <p class="text-xs text-gray-500 dark:text-gray-400">Sent on every request to this provider (e.g. a gateway routing key or cost-center tag).</p>
+                                        <div v-for="(row, index) in headerRows" :key="`hdr-new-${index}`" class="flex items-center gap-2 mt-2">
+                                            <input v-model="row.key" type="text" placeholder="Header name" data-testid="static-header-key"
+                                                class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                            <input v-model="row.value" type="text" placeholder="Value" data-testid="static-header-value"
+                                                class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                            <button type="button" @click="removeHeaderRow(index)" class="text-red-500 hover:text-red-700">
+                                                <Icon name="heroicons:trash" class="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                        <button type="button" @click="addHeaderRow" data-testid="add-static-header" class="text-xs text-blue-500 hover:text-blue-700 underline flex items-center gap-1 mt-2">
+                                            <Icon name="heroicons:plus-circle" class="w-3.5 h-3.5" />
+                                            Add header
+                                        </button>
+                                    </div>
+                                    <div>
+                                        <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Identity forwarding</label>
+                                        <p class="text-xs text-gray-500 dark:text-gray-400">Forward the signed-in user's identity as headers so your gateway can attribute cost per user.</p>
+                                        <div v-for="(row, index) in forwardRows" :key="`fwd-new-${index}`" class="flex items-center gap-2 mt-2">
+                                            <input v-model="row.header" type="text" placeholder="Header name" data-testid="forward-header-name"
+                                                class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                            <select v-model="row.kind" data-testid="forward-source-kind"
+                                                class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 focus:outline-none focus:border-blue-500">
+                                                <option v-for="kind in FORWARD_KINDS" :key="kind.value" :value="kind.value">{{ kind.label }}</option>
+                                            </select>
+                                            <input v-if="row.kind === 'membership.attr' || row.kind === 'static'" v-model="row.extra" type="text"
+                                                :placeholder="row.kind === 'membership.attr' ? 'Attribute key' : 'Value ({user.email} allowed)'" data-testid="forward-source-extra"
+                                                class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:border-blue-500" />
+                                            <button type="button" @click="removeForwardRow(index)" class="text-red-500 hover:text-red-700">
+                                                <Icon name="heroicons:trash" class="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                        <button type="button" @click="addForwardRow" data-testid="add-forward-rule" class="text-xs text-blue-500 hover:text-blue-700 underline flex items-center gap-1 mt-2">
+                                            <Icon name="heroicons:plus-circle" class="w-3.5 h-3.5" />
+                                            Add forwarding rule
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -666,6 +849,76 @@ const providersWithNewOption = computed(() => {
 const showBaseUrl = ref(false);
 const showBaseUrlNew = ref(false);
 const isTestingConnection = ref(false);
+
+const isAzureSelected = computed(() =>
+    selectedProvider.value?.provider_type === 'azure' || selectedProvider.value?.type === 'azure');
+
+// --- Custom headers + identity forwarding (all providers) ---
+// Rows are shared between the edit view and the new-provider form; only one is
+// ever active at a time. Serialized into credentials.headers /
+// credentials.header_injection on save & test (backend persists them to
+// additional_config, mirroring MCP connections).
+type HeaderRow = { key: string; value: string };
+type ForwardRow = { header: string; kind: string; extra: string };
+const showHeadersSection = ref(false);
+const headerRows = ref<HeaderRow[]>([]);
+const forwardRows = ref<ForwardRow[]>([]);
+const FORWARD_KINDS = [
+    { value: 'user.email', label: 'User email' },
+    { value: 'user.name', label: 'User name' },
+    { value: 'user.id', label: 'User ID' },
+    { value: 'membership.role', label: 'Org role' },
+    { value: 'membership.attr', label: 'Profile attribute' },
+    { value: 'static', label: 'Static value' },
+];
+
+function addHeaderRow() { headerRows.value.push({ key: '', value: '' }); }
+function removeHeaderRow(index: number) { headerRows.value.splice(index, 1); }
+function addForwardRow() { forwardRows.value.push({ header: '', kind: 'user.email', extra: '' }); }
+function removeForwardRow(index: number) { forwardRows.value.splice(index, 1); }
+
+function resetHeaderRows() {
+    headerRows.value = [];
+    forwardRows.value = [];
+    showHeadersSection.value = false;
+}
+
+function hydrateHeaderRows(cfg: any) {
+    headerRows.value = Object.entries(cfg?.headers || {}).map(([key, value]) => ({ key, value: String(value ?? '') }));
+    forwardRows.value = ((cfg?.header_injection || []) as any[]).map((rule: any) => {
+        const source = String(rule?.source || '');
+        if (source.startsWith('membership.attr:')) return { header: rule.header, kind: 'membership.attr', extra: source.slice('membership.attr:'.length) };
+        if (source.startsWith('static:')) return { header: rule.header, kind: 'static', extra: source.slice('static:'.length) };
+        return { header: rule.header, kind: source, extra: '' };
+    });
+    showHeadersSection.value = headerRows.value.length > 0 || forwardRows.value.length > 0;
+}
+
+function serializeHeaderConfig(credentials: Record<string, any>) {
+    const headers: Record<string, string> = {};
+    headerRows.value.forEach(row => {
+        const key = row.key.trim();
+        const value = row.value.trim();
+        if (key && value) headers[key] = value;
+    });
+    const rules = forwardRows.value
+        .map(row => {
+            const header = row.header.trim();
+            if (!header) return null;
+            let source = row.kind;
+            if (row.kind === 'membership.attr') {
+                const attrKey = row.extra.trim();
+                if (!attrKey) return null;
+                source = `membership.attr:${attrKey}`;
+            } else if (row.kind === 'static') {
+                source = `static:${row.extra}`;
+            }
+            return { header, source };
+        })
+        .filter((rule): rule is { header: string; source: string } => !!rule);
+    credentials.headers = headers;
+    credentials.header_injection = rules;
+}
 const canTestConnection = computed(() => {
     if (selectedProvider.value && selectedProvider.value.type !== 'new_provider') {
         // Existing provider: must have provider_type and some credential (api_key may be blank to use stored)
@@ -678,6 +931,14 @@ const canTestConnection = computed(() => {
         if (creds.auth_mode === 'api_key') return !!creds.api_key;
         if (creds.auth_mode === 'access_keys') return !!creds.aws_access_key_id && !!creds.aws_secret_access_key;
         return true; // IAM mode: region is enough
+    }
+    // Azure: Entra modes don't require api_key
+    if (providerForm.value.provider_type === 'azure') {
+        const creds = providerForm.value.credentials;
+        if (!creds?.endpoint_url) return false;
+        if (creds.auth_mode === 'entra_client_secret') return !!creds.tenant_id && !!creds.client_id && !!creds.client_secret;
+        if (creds.auth_mode === 'entra_default') return true;
+        return !!creds.api_key;
     }
     // New provider form: need type and at least api_key
     return !!providerForm.value.provider_type && !!providerForm.value.credentials && typeof providerForm.value.credentials.api_key !== 'undefined';
@@ -694,13 +955,17 @@ const credentialFieldsForNewProvider = computed<CredentialField[]>(() => {
     const providerType = providerForm.value.provider_type;
     const all = fieldsForProvider(providerType);
     // Exclude fields that have dedicated UI controls
-    let filtered = all.filter(f => f.key !== 'verify_ssl' && f.key !== 'enable_web_search' && f.key !== 'use_responses_api');
+    let filtered = all.filter(f => !['verify_ssl', 'enable_web_search', 'use_responses_api', 'headers', 'header_injection'].includes(f.key));
     if (providerType === 'openai') {
         filtered = filtered.filter(f => f.key !== 'base_url');
     }
     if (providerType === 'bedrock') {
         // Only show region; auth_mode and api_key are rendered as custom UI
         return filtered.filter(f => f.key === 'region');
+    }
+    if (providerType === 'azure') {
+        // Only show endpoint_url; auth_mode / api_key / Entra fields render as custom UI
+        return filtered.filter(f => f.key === 'endpoint_url');
     }
     return filtered;
 });
@@ -735,6 +1000,7 @@ function getFieldPlaceholder(field: CredentialField): string {
     showDangerZone.value = false;
     showBaseUrl.value = false;
     showBaseUrlNew.value = false;
+    resetHeaderRows();
   }
 
 const isNewProviderSelected = computed(() => {
@@ -769,6 +1035,7 @@ const resetForm = () => {
         credentials: {}
     };
     showDangerZone.value = false;
+    resetHeaderRows();
     // Reset any selected models
     models.value.forEach((model: any) => {
         model.selected = false;
@@ -921,6 +1188,12 @@ watch(() => providerForm.value.provider_type, (providerType: string) => {
         if (providerType === 'custom') {
             providerForm.value.credentials.verify_ssl = true;
         }
+        // Default Azure auth to API key for new providers
+        if (providerType === 'azure' && !providerForm.value.credentials.auth_mode) {
+            providerForm.value.credentials.auth_mode = 'api_key';
+        }
+        // A new provider starts with no custom headers
+        resetHeaderRows();
     }
     // Reset base URL toggle for new provider on provider type changes
     if (isNewProviderSelected.value) {
@@ -940,6 +1213,8 @@ watch(() => providerForm.value.provider_type, (providerType: string) => {
 });
 
 async function createProvider() {
+    // Fold the header editor rows into the credentials payload
+    serializeHeaderConfig(providerForm.value.credentials);
     // Gather selected preset models
     const selectedPresetModels = models.value
         .filter((model: AvailableModel) => model.provider_type === providerForm.value.provider_type && !!model.is_enabled)
@@ -1033,6 +1308,11 @@ async function updateProvider() {
         // Same: onContextWindowChange records an override when the admin edits the size.
         context_window_tokens_override: model.context_window_tokens_override ?? null
     }));
+
+    // Fold the header editor rows into the credentials payload
+    if (selectedProvider.value?.credentials) {
+        serializeHeaderConfig(selectedProvider.value.credentials);
+    }
 
     // Prepare update payload with existing models + new custom models
     const updatePayload = {
@@ -1132,6 +1412,16 @@ watch(selectedProvider, (newValue) => {
                 (newValue.credentials as any).api_key = null;
             }
         }
+        // Hydrate Azure auth mode + Entra service-principal identifiers
+        if ((newValue.provider_type === 'azure' || newValue.type === 'azure')) {
+            const cfg = (newValue as any)?.additional_config || {};
+            (newValue.credentials as any).auth_mode = cfg.auth_mode || 'api_key';
+            (newValue.credentials as any).tenant_id = cfg.tenant_id || null;
+            (newValue.credentials as any).client_id = cfg.client_id || null;
+            (newValue.credentials as any).client_secret = null;
+        }
+        // Hydrate custom headers + identity forwarding rows (all providers)
+        hydrateHeaderRows((newValue as any)?.additional_config);
         providerForm.value = {
             name: '',
             provider_type: '',
@@ -1233,6 +1523,12 @@ function toggleBaseUrlNewProvider() {
 async function testConnection() {
     try {
         isTestingConnection.value = true;
+        // Fold the header editor rows into whichever credentials the test uses
+        if (selectedProvider.value && selectedProvider.value.type !== 'new_provider' && selectedProvider.value.credentials) {
+            serializeHeaderConfig(selectedProvider.value.credentials);
+        } else {
+            serializeHeaderConfig(providerForm.value.credentials);
+        }
         // Build payload from either existing-selected provider (edit mode) or new form
         let payload: any;
         if (selectedProvider.value && selectedProvider.value.type !== 'new_provider') {


### PR DESCRIPTION
LLM providers can now attach custom HTTP headers to every request and
forward the signed-in user's identity (email, name, id, org role,
Entra-synced profile attributes) as headers, so gateways and proxies can
attribute cost per user — mirroring the MCP connection headers /
header_injection config and reusing its whitelisted source grammar.

- New app/ai/llm/header_injection.py: ambient IdentityContext contextvar
  plus validation and per-provider header resolution.
- AgentV2 stamps the asker's identity at construction (user fields) and
  enriches it with membership role/attributes at run start, rebuilding
  the planner LLM when membership-based rules are configured.
- All clients (OpenAI, Responses, Azure, Anthropic, Google, Bedrock)
  accept the resolved headers; Bedrock injects them via the boto3
  request-created hook so SigV4 auth is unaffected.
- Azure OpenAI gains auth_mode: api_key (default), entra_client_secret
  (service principal via azure-identity), or entra_default
  (DefaultAzureCredential); AAD tokens are acquired and refreshed via
  get_bearer_token_provider. Client secret is stored Fernet-encrypted.
- Provider modal: static-header and identity-forwarding editors for all
  providers, and an Azure authentication mode selector.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0145e9YjB281SxT5xGrpkWkb