### PR TITLE
fix(deps): bump GitPython 3.1.58 → 3.1.60 to fix critical argument in…

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1382,14 +1382,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.60"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/14/e6b1a48d831755a53c2029351fcef82e70db4a08f338daefe29d8d0cf31c/gitpython-3.1.60.tar.gz", hash = "sha256:e936431879fa85581b4311fa63492ea52251909e2d655b6529c704c904ddcc24", size = 230793, upload-time = "2026-08-25T18:33:46.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/71/63/ba28697918b7c190af9f3f21940d03e8814e25dd4ddd39d6929f3a553995/gitpython-3.1.60-py3-none-any.whl", hash = "sha256:39548bffb8fa0f3a548133348868bb4838e79d73283052207dc97781a569b6b4", size = 221893, upload-time = "2026-08-25T18:33:44.75Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…jection

Snyk flagged GitPython 3.1.58 with 1 critical + 3 high vulnerabilities (SNYK-PYTHON-GITPYTHON-19256804 and related): Arbitrary Argument Injection, External Control of File Name or Path, and Directory Traversal — all fixed in 3.1.59+. The repo pins `gitpython>=3.1.57,<3.2`, so this is a lockfile-only bump to 3.1.60 (latest in range).

app/services/git_service.py calls git.cmd.Git().ls_remote(repo_url) with a user-supplied URL, the exact path the CVE addresses; 3.1.60 rejects injected options with UnsafeOptionError.


Claude-Session: https://claude.ai/code/session_014FPdk2qGgj5oaaGueZHCDo