### PR TITLE
read_file: show the document, not just its text

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -586,7 +586,15 @@ class AgentV2:
                 if (getattr(f, 'content_type', '') or '').startswith('image/')
                 and not _is_connector(f)
             ]
-            self.analysis_files = [f for f in all_files if not (getattr(f, 'content_type', '') or '').startswith('image/')]
+            # "#source" rows are persist_source_document's viewer copies of
+            # original documents (the .pdf behind a .pdf.txt session file).
+            # They are linked to the report for the embed route, but they are
+            # not analyzable and must not rejoin the roster at init.
+            self.analysis_files = [
+                f for f in all_files
+                if not (getattr(f, 'content_type', '') or '').startswith('image/')
+                and not str(getattr(f, 'source_ref', '') or '').endswith('#source')
+            ]
         else:
             self.data_sources = []
             self.clients = {}

--- a/backend/app/ai/persisted_summary.py
+++ b/backend/app/ai/persisted_summary.py
@@ -507,6 +507,13 @@ def build_tool_context_summary(
             "image_file_ids",
             "pages_total",
             "pages_shown",
+            # The UI render contract (ReadFilePreview). Report read endpoints
+            # serve THIS projection rather than result_json, so a field missing
+            # here is invisible to the card no matter what the tool returned —
+            # which is exactly how the document preview vanished the moment a
+            # completed turn was refetched. Bounded: seven scalars, unlike the
+            # text/csv excerpts truncated below.
+            "preview",
             "error",
         ):
             if result_json.get(field) is not None:

--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -426,26 +426,31 @@ def render_pdf_pages_images(pdf_bytes: bytes, first: int, last: int, *, max_page
     Raises on an unreadable PDF."""
     import pypdfium2 as pdfium
     from app.ai.llm.image_utils import encode_pil_for_vision
+    from app.data_sources.clients._document_text import PDFIUM_LOCK
 
-    pdf = pdfium.PdfDocument(bytes(pdf_bytes))
-    try:
-        total = len(pdf)
-        first = max(1, int(first))
-        last = min(total, int(last))
-        out = []
-        for i in range(first - 1, last):
-            if len(out) >= max_pages:
-                break
-            page = pdf[i]
-            try:
-                bitmap = page.render(scale=dpi / 72.0)
-                pil = bitmap.to_pil()
-                out.append(encode_pil_for_vision(pil))
-            finally:
-                page.close()
-        return out, total
-    finally:
-        pdf.close()
+    # PDFium is not thread-safe; this runs on worker threads concurrently with
+    # text extraction (_document_text), so every PDFium sequence takes the
+    # shared lock.
+    with PDFIUM_LOCK:
+        pdf = pdfium.PdfDocument(bytes(pdf_bytes))
+        try:
+            total = len(pdf)
+            first = max(1, int(first))
+            last = min(total, int(last))
+            out = []
+            for i in range(first - 1, last):
+                if len(out) >= max_pages:
+                    break
+                page = pdf[i]
+                try:
+                    bitmap = page.render(scale=dpi / 72.0)
+                    pil = bitmap.to_pil()
+                    out.append(encode_pil_for_vision(pil))
+                finally:
+                    page.close()
+            return out, total
+        finally:
+            pdf.close()
 
 
 def render_file_payload(name: str, payload: Any, max_rows: int, max_chars: int) -> Dict[str, Any]:
@@ -555,6 +560,11 @@ def ext_for_mime(mime: Optional[str]) -> Optional[str]:
 # Picture files we can hand to a vision model as-is (normalized to PNG).
 _RENDERABLE_IMAGE_EXTS = {"png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif"}
 
+# The subset a BROWSER can render in an <img> tag. TIFF is the difference:
+# PIL decodes it for the vision path, but no mainstream browser displays it,
+# so a .tiff file id handed to the UI as an image produces a broken picture.
+_BROWSER_IMAGE_EXTS = _RENDERABLE_IMAGE_EXTS - {"tiff", "tif"}
+
 
 def is_picture_name(name: Optional[str]) -> bool:
     """True when this name is a picture the browser can render as-is.
@@ -562,11 +572,12 @@ def is_picture_name(name: Optional[str]) -> bool:
     Distinguishes "the source IS an image" from "the source was RENDERED to
     images": a page render of a PDF is a new artifact, while a re-encoded PNG
     is the same file the user already has. Callers use it to decide whether a
-    materialized image id may stand in for the source file id.
+    materialized image id may stand in for the source file id — so the test is
+    browser renderability, not merely "PIL can open it".
     """
     leaf = str(name or "").rsplit("/", 1)[-1]
     ext = leaf.rsplit(".", 1)[-1].lower() if "." in leaf else ""
-    return ext in _RENDERABLE_IMAGE_EXTS
+    return ext in _BROWSER_IMAGE_EXTS
 
 
 def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 150):
@@ -615,17 +626,19 @@ def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 
         if ext == "pdf":
             import pypdfium2 as pdfium
             from app.ai.llm.image_utils import encode_pil_for_vision
-            pdf = pdfium.PdfDocument(data)
-            try:
-                total = len(pdf)
-                out = []
-                for i in range(min(total, max_pages)):
-                    page = pdf[i]
-                    pil = page.render(scale=dpi / 72.0).to_pil()
-                    out.append(encode_pil_for_vision(pil))
-                return out, total
-            finally:
-                pdf.close()
+            from app.data_sources.clients._document_text import PDFIUM_LOCK
+            with PDFIUM_LOCK:
+                pdf = pdfium.PdfDocument(data)
+                try:
+                    total = len(pdf)
+                    out = []
+                    for i in range(min(total, max_pages)):
+                        page = pdf[i]
+                        pil = page.render(scale=dpi / 72.0).to_pil()
+                        out.append(encode_pil_for_vision(pil))
+                    return out, total
+                finally:
+                    pdf.close()
     except Exception as e:  # corrupt/locked file, unsupported image
         logger.info("render_file_images: could not render %s: %s", file_id, e)
     return [], 0
@@ -704,6 +717,16 @@ async def read_source_bytes(client, file_id: str) -> Tuple[bytes, str, Optional[
     return str(payload).encode("utf-8"), f"{leaf}.txt", "text/plain"
 
 
+def _append_analysis_file(runtime_ctx: Dict[str, Any], db_file) -> None:
+    """Add a just-attached file to the turn's live analysis roster (dedup)."""
+    try:
+        ef = runtime_ctx.get("excel_files")
+        if isinstance(ef, list) and all(getattr(x, "id", None) != db_file.id for x in ef):
+            ef.append(db_file)
+    except Exception as e:
+        logger.warning("attach_drive_file_to_session: excel_files refresh failed: %s", e)
+
+
 async def _find_cached_connector_file(
     db, *, report, connection_id: Optional[str], source_ref: Optional[str],
     source_kind: str,
@@ -748,6 +771,7 @@ async def attach_drive_file_to_session(
     source_kind: str = "connector",
     connection_id: Optional[str] = None,
     source_ref: Optional[str] = None,
+    analysis: bool = True,
 ) -> Optional[str]:
     """Materialize connector bytes as a File the code sandbox can read.
 
@@ -767,6 +791,12 @@ async def attach_drive_file_to_session(
     Returns the File row id, or None if the file wasn't attached (no report
     context, oversize, or persistence failed — non-fatal, caller still returns
     inline content).
+
+    ``analysis=False`` marks a file that exists for the VIEWER, not the code
+    sandbox (persist_source_document's original-document copies): it is still
+    linked to the report so the embed route and the refresh-in-place cache can
+    find it, but it must not join the analysis roster the model is told to run
+    inspect_data / create_data against.
     """
     db = runtime_ctx.get("db")
     report = runtime_ctx.get("report")
@@ -822,6 +852,31 @@ async def attach_drive_file_to_session(
 
         if cached is not None:
             path = cached.path
+            # Refresh is only worth its cost when the bytes actually changed.
+            # A model paging through one document re-persists it once per
+            # page_range read; without this check each of those rewrote the
+            # whole file, regenerated the preview and issued several commits
+            # for content that is byte-identical. Size first (free), full
+            # compare only on a size match.
+            unchanged = False
+            try:
+                if (
+                    cached.content_type == resolved_mime
+                    and cached.filename == filename
+                    and os.path.getsize(path) == len(content_bytes)
+                ):
+                    async with aiofiles.open(path, "rb") as fh:
+                        unchanged = (await fh.read()) == content_bytes
+            except OSError:
+                unchanged = False
+            if unchanged:
+                logger.info(
+                    "attach_drive_file_to_session: %s unchanged, reusing session file %s",
+                    filename, cached.id,
+                )
+                if analysis:
+                    _append_analysis_file(runtime_ctx, cached)
+                return str(cached.id)
             async with aiofiles.open(path, "wb") as fh:
                 await fh.write(content_bytes)
             cached.content_type = resolved_mime
@@ -875,12 +930,10 @@ async def attach_drive_file_to_session(
         # report.files and isn't refreshed mid-run, so a file materialized now
         # would be invisible to inspect_data / create_data called later THIS
         # turn. Append it to the live list (same object as agent.analysis_files).
-        try:
-            ef = runtime_ctx.get("excel_files")
-            if isinstance(ef, list) and all(getattr(x, "id", None) != db_file.id for x in ef):
-                ef.append(db_file)
-        except Exception as e:
-            logger.warning("attach_drive_file_to_session: excel_files refresh failed: %s", e)
+        # Viewer-only copies (analysis=False) stay out: a raw .pdf in the
+        # analysis roster invites read_excel_as_csv calls that can only fail.
+        if analysis:
+            _append_analysis_file(runtime_ctx, db_file)
 
         # Best-effort raw preview, same as upload path.
         try:
@@ -984,6 +1037,9 @@ async def persist_source_document(
             mime_type=raw_mime,
             connection_id=connection_id,
             source_ref=f"{file_id}#source",
+            # Viewer copy: the model analyzes the DERIVATIVE session file
+            # (.txt/.csv), never this raw original — keep it off the roster.
+            analysis=False,
         )
     except Exception as e:
         logger.warning("persist_source_document: failed for %s: %s", file_id, e)

--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -556,6 +556,19 @@ def ext_for_mime(mime: Optional[str]) -> Optional[str]:
 _RENDERABLE_IMAGE_EXTS = {"png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif"}
 
 
+def is_picture_name(name: Optional[str]) -> bool:
+    """True when this name is a picture the browser can render as-is.
+
+    Distinguishes "the source IS an image" from "the source was RENDERED to
+    images": a page render of a PDF is a new artifact, while a re-encoded PNG
+    is the same file the user already has. Callers use it to decide whether a
+    materialized image id may stand in for the source file id.
+    """
+    leaf = str(name or "").rsplit("/", 1)[-1]
+    ext = leaf.rsplit(".", 1)[-1].lower() if "." in leaf else ""
+    return ext in _RENDERABLE_IMAGE_EXTS
+
+
 def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 150):
     """Turn a *binary* file payload into page images for a vision model.
 
@@ -640,6 +653,55 @@ def allow_llm_see_data(runtime_ctx: Dict[str, Any]) -> bool:
 # Hard cap on auto-attach size. Larger files still return content inline but
 # don't get persisted — the agent should reach for a more specific reader.
 _ATTACH_MAX_BYTES = 50 * 1024 * 1024  # 50 MB
+
+# Hard cap on the ORIGINAL bytes kept so the UI can show the real document.
+# Deliberately below _ATTACH_MAX_BYTES: the preview copy is a convenience, and
+# a 40 MB scan is not worth a second copy on disk plus a full browser download
+# just to render one page. Oversize sources fall back to an on-demand fetch.
+_PREVIEW_MAX_BYTES = 25 * 1024 * 1024  # 25 MB
+
+
+async def read_source_bytes(client, file_id: str) -> Tuple[bytes, str, Optional[str]]:
+    """The file's ORIGINAL bytes + name + mime, unparsed.
+
+    Prefers the client's raw-bytes reader so callers persist a real .pdf/.xlsx
+    instead of a reparsed copy, and falls back to serializing whatever
+    ``read_file`` returns for clients that expose no such reader.
+
+    Clients disagree on the return shape — network_dir/s3/graph_drive/
+    google_drive hand back ``(bytes, name, mime)`` while OneNote returns bare
+    bytes — so normalize it here. Unpacking the bare-bytes form into three
+    names is a TypeError, which is exactly why this belongs in one place.
+    """
+    leaf = str(file_id or "").rsplit("/", 1)[-1] or "file"
+    if hasattr(client, "read_raw_bytes"):
+        import asyncio
+
+        raw = await asyncio.to_thread(client.read_raw_bytes, file_id)
+        if isinstance(raw, tuple):
+            content = raw[0]
+            name = raw[1] if len(raw) > 1 else ""
+            mime = raw[2] if len(raw) > 2 else None
+            return content, (name or leaf), mime
+        return raw, leaf, None
+
+    # No raw reader: reparse and serialize, so the caller still gets bytes.
+    import json
+
+    payload = await client.aread_file(file_id)
+    if isinstance(payload, pd.DataFrame):
+        buf = io.StringIO()
+        payload.to_csv(buf, index=False)
+        return buf.getvalue().encode("utf-8"), f"{leaf}.csv", "text/csv"
+    if isinstance(payload, (dict, list)):
+        return (
+            json.dumps(payload, default=str).encode("utf-8"),
+            f"{leaf}.json",
+            "application/json",
+        )
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload), leaf, None
+    return str(payload).encode("utf-8"), f"{leaf}.txt", "text/plain"
 
 
 async def _find_cached_connector_file(
@@ -841,4 +903,88 @@ async def attach_drive_file_to_session(
             await db.rollback()
         except Exception:
             pass
+        return None
+
+
+async def persist_source_document(
+    runtime_ctx: Dict[str, Any],
+    client,
+    file_id: str,
+    *,
+    connection_id: Optional[str] = None,
+    session_file=None,
+    raw_bytes: Optional[bytes] = None,
+    raw_name: Optional[str] = None,
+    raw_mime: Optional[str] = None,
+    reuse_existing: bool = False,
+) -> Optional[str]:
+    """File id holding the ORIGINAL document bytes, for the UI's viewer.
+
+    The session file a read normally produces is a DERIVATIVE — a PDF whose text
+    extracted becomes ``report.pdf.txt``, an xlsx becomes ``sales.csv`` — so it
+    is useless to an <iframe>. This keeps the real bytes alongside it, which is
+    what ``/files/{id}/embed#page=N`` needs to open the document at the page the
+    model actually read.
+
+    Session-file sources short-circuit: the original IS already a File, so its
+    own id comes back instead of a duplicate row.
+
+    ``source_ref`` deliberately differs from the rendered copy's (a bare
+    ``file_id``). attach_drive_file_to_session refreshes in place on a
+    (report, connection, ref) hit, so sharing the ref would overwrite the
+    .txt/.csv row the model was handed — silently breaking inspect_data /
+    create_data on the very id it is holding.
+
+    ``raw_bytes`` is the bytes the read ALREADY fetched (see DocumentText) —
+    always pass them when available. Without them this has to fetch the object
+    again, which on S3/SharePoint means downloading the whole file twice.
+
+    ``reuse_existing`` is for the content-cache hit path, where a matching
+    file_version proves the remote object is unchanged: an existing copy is
+    therefore still faithful and can be reused without any fetch at all.
+
+    Best-effort by contract: returns None and never raises when the source is
+    oversize, unreachable, or there is no report context. A missing preview must
+    never fail a read.
+    """
+    if session_file is not None:
+        return str(session_file.id)
+    try:
+        if reuse_existing and raw_bytes is None:
+            db = runtime_ctx.get("db")
+            report = runtime_ctx.get("report")
+            if db is not None and report is not None:
+                existing = await _find_cached_connector_file(
+                    db, report=report, connection_id=connection_id,
+                    source_ref=f"{file_id}#source", source_kind="connector",
+                )
+                if existing is not None:
+                    return str(existing.id)
+            # Nothing kept for THIS report yet — the content cache is keyed on
+            # (connection, file, version) and shared across reports, so a hit
+            # there says nothing about this report's files. Fall through and
+            # fetch once to seed it.
+        if raw_bytes is None:
+            raw_bytes, raw_name, raw_mime = await read_source_bytes(client, file_id)
+        if not raw_bytes:
+            return None
+        if len(raw_bytes) > _PREVIEW_MAX_BYTES:
+            logger.info(
+                "persist_source_document: %s skipped (%.1f MB > %d MB preview cap)",
+                file_id,
+                len(raw_bytes) / (1024 * 1024),
+                _PREVIEW_MAX_BYTES // (1024 * 1024),
+            )
+            return None
+        name = raw_name or str(file_id or "").rsplit("/", 1)[-1] or "file"
+        return await attach_drive_file_to_session(
+            runtime_ctx,
+            filename=name,
+            content_bytes=raw_bytes,
+            mime_type=raw_mime,
+            connection_id=connection_id,
+            source_ref=f"{file_id}#source",
+        )
+    except Exception as e:
+        logger.warning("persist_source_document: failed for %s: %s", file_id, e)
         return None

--- a/backend/app/ai/tools/implementations/attach_file.py
+++ b/backend/app/ai/tools/implementations/attach_file.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type
+from typing import Any, AsyncIterator, Dict, List, Optional, Type
 
 import aiofiles
 from pydantic import BaseModel
@@ -29,7 +29,11 @@ from app.data_sources.clients.base import Capability
 
 from app.data_sources.clients._file_source_common import GlobScopeError, storage_safe_name
 
-from ._file_tool_common import audit_file_access_denied, resolve_file_client
+from ._file_tool_common import (
+    audit_file_access_denied,
+    read_source_bytes,
+    resolve_file_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +92,7 @@ class AttachFileTool(Tool):
         results: List[AttachedFile] = []
         for fid in data.file_ids:
             try:
-                content, name, mime = await self._raw_bytes(client, fid)
+                content, name, mime = await read_source_bytes(client, fid)
                 session_file_id = await self._persist_durable(
                     runtime_ctx, filename=name, content=content, mime=mime,
                 )
@@ -128,27 +132,6 @@ class AttachFileTool(Tool):
             },
             "observation": {"summary": summary, "success": bool(ok)},
         })
-
-    async def _raw_bytes(self, client, file_id: str) -> Tuple[bytes, str, Optional[str]]:
-        """Prefer the client's raw-bytes reader (original file); otherwise
-        serialize whatever read_file returns so it still attaches."""
-        if hasattr(client, "read_raw_bytes"):
-            import asyncio
-            return await asyncio.to_thread(client.read_raw_bytes, file_id)
-        # Fallback: reparse via read_file and serialize.
-        import io
-        import json
-        import pandas as pd
-        payload = await client.aread_file(file_id)
-        base = str(file_id).split("/")[-1] or "file"
-        if isinstance(payload, pd.DataFrame):
-            buf = io.StringIO(); payload.to_csv(buf, index=False)
-            return buf.getvalue().encode("utf-8"), f"{base}.csv", "text/csv"
-        if isinstance(payload, (dict, list)):
-            return json.dumps(payload, default=str).encode("utf-8"), f"{base}.json", "application/json"
-        if isinstance(payload, (bytes, bytearray)):
-            return bytes(payload), base, None
-        return str(payload).encode("utf-8"), f"{base}.txt", "text/plain"
 
     async def _persist_durable(
         self, runtime_ctx: Dict[str, Any], *, filename: str, content: bytes, mime: Optional[str],

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -426,6 +426,12 @@ class ReadFileTool(Tool):
                 )
                 return
             shown = f"{paged.get('first')}-{paged.get('last')}"
+            # Bytes and name the client carried over from the fetch it already
+            # made (see the __doc_pages__ contract). Absent for network_dir,
+            # which extracts straight from disk — there the fallback re-read is
+            # local and free.
+            paged_raw = paged.get("raw")
+            paged_name = paged.get("name") or None
 
             # Scanned/image-only pages (no usable text), glyph-soup extractions
             # (text came back but it's garbled — subset font with a broken
@@ -445,10 +451,11 @@ class ReadFileTool(Tool):
             ):
                 import asyncio as _asyncio
 
-                raw_bytes = None
+                raw_bytes = paged_raw
                 try:
-                    raw = await _asyncio.to_thread(client.read_raw_bytes, data.file_id)
-                    raw_bytes = raw[0] if isinstance(raw, tuple) else raw
+                    if raw_bytes is None:
+                        raw = await _asyncio.to_thread(client.read_raw_bytes, data.file_id)
+                        raw_bytes = raw[0] if isinstance(raw, tuple) else raw
                     imgs, total = render_pdf_pages_images(raw_bytes, rng[0], rng[1])
                 except Exception as e:
                     imgs, total = [], paged.get("pages_total")
@@ -468,10 +475,12 @@ class ReadFileTool(Tool):
                         connection_id=data.connection_id,
                         session_file=session_file,
                         raw_bytes=raw_bytes,
+                        raw_name=paged_name,
                     )
                     output, observation = await self._finalize(
                         data, runtime_ctx,
-                        rendered={"content_type": "binary", "pages_shown": shown},
+                        rendered={"content_type": "binary", "pages_shown": shown,
+                                  "file_name": paged_name},
                         session_file_id=source_file_id,
                         image_pngs=[png for png, _mtype in imgs],
                         pages_total=total,
@@ -498,6 +507,8 @@ class ReadFileTool(Tool):
                 runtime_ctx, client, data.file_id,
                 connection_id=data.connection_id,
                 session_file=session_file,
+                raw_bytes=paged_raw,
+                raw_name=paged_name,
             )
             output, observation = await self._finalize(
                 data, runtime_ctx,
@@ -506,6 +517,7 @@ class ReadFileTool(Tool):
                     "text": paged.get("text") or "",
                     "pages_total": paged.get("pages_total"),
                     "pages_shown": shown,
+                    "file_name": paged_name,
                 },
                 session_file_id=source_file_id,
                 image_pngs=[],

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -145,7 +145,8 @@ def _content_details(output: Dict[str, Any], *, max_chars: int) -> str:
 
 
 def _build_preview(output: Dict[str, Any], *, preview_file_id: Optional[str],
-                   first_image_mime: Optional[str] = None) -> Dict[str, Any]:
+                   first_image_mime: Optional[str] = None,
+                   source_is_image: bool = False) -> Dict[str, Any]:
     """The UI contract for this read (see ReadFilePreview).
 
     A DOCUMENT always beats its page renders: when a scanned PDF is rasterized
@@ -164,6 +165,11 @@ def _build_preview(output: Dict[str, Any], *, preview_file_id: Optional[str],
         "pages_total": output.get("pages_total"),
         "image_file_ids": None,
         "truncated": False,
+        # True when the images are page RENDERS of a document, not the source
+        # picture itself. The card auto-shows real pictures (they ARE the
+        # content) but keeps derived galleries — a lossy rasterized stand-in —
+        # collapsed behind a click.
+        "derived": False,
     }
 
     # page_range reports "10-15"; the viewer opens at the first of them.
@@ -195,6 +201,9 @@ def _build_preview(output: Dict[str, Any], *, preview_file_id: Optional[str],
             # Renders are capped (render_file_images max_pages), so a gallery
             # showing fewer pages than the document has must say so.
             "truncated": bool(pages_total and len(image_ids) < pages_total),
+            # A picture source stays "the picture" even when the id points at
+            # a normalized re-encode; only document rasters count as derived.
+            "derived": not source_is_image,
         })
         return preview
 
@@ -697,13 +706,21 @@ class ReadFileTool(Tool):
                     model and getattr(model, "supports_vision", False)
                     and allow_llm_see_data(runtime_ctx)
                 )
+                # The read already fetched the original bytes once (source_raw,
+                # captured above) — S3/SharePoint/Drive carry them on the
+                # DocumentText payload. Re-fetching here made every as_images /
+                # garble escalation download the object a second time. Only
+                # path-backed sources (network_dir returns plain str) fall back
+                # to read_raw_bytes, where the re-read is a local file open.
                 raw_bytes = None
-                if vision_ok and hasattr(client, "read_raw_bytes"):
-                    try:
-                        raw = await asyncio.to_thread(client.read_raw_bytes, data.file_id)
-                        raw_bytes = raw[0] if isinstance(raw, tuple) else raw
-                    except Exception:
-                        raw_bytes = None
+                if vision_ok:
+                    raw_bytes = source_raw
+                    if raw_bytes is None and hasattr(client, "read_raw_bytes"):
+                        try:
+                            raw = await asyncio.to_thread(client.read_raw_bytes, data.file_id)
+                            raw_bytes = raw[0] if isinstance(raw, tuple) else raw
+                        except Exception:
+                            raw_bytes = None
                 # Render BEFORE discarding the text: conversion can fail (no
                 # soffice, missing format filter, corrupt file), and dropping
                 # readable text for a render that never materializes would be a
@@ -966,6 +983,7 @@ class ReadFileTool(Tool):
         output["preview"] = _build_preview(
             output, preview_file_id=preview_file_id,
             first_image_mime=first_image_mime,
+            source_is_image=source_is_image,
         )
 
         ct = output.get("content_type", "?")

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -477,11 +477,15 @@ class ReadFileTool(Tool):
                         raw_bytes=raw_bytes,
                         raw_name=paged_name,
                     )
+                    # source_file_id reaches the UI via preview_file_id only.
+                    # As session_file_id it would be a raw PDF advertised to
+                    # the model as inspect_data/read_excel_as_csv input — a
+                    # guaranteed parse failure.
                     output, observation = await self._finalize(
                         data, runtime_ctx,
                         rendered={"content_type": "binary", "pages_shown": shown,
                                   "file_name": paged_name},
-                        session_file_id=source_file_id,
+                        session_file_id=None,
                         image_pngs=[png for png, _mtype in imgs],
                         pages_total=total,
                         cached=False,
@@ -519,7 +523,7 @@ class ReadFileTool(Tool):
                     "pages_shown": shown,
                     "file_name": paged_name,
                 },
-                session_file_id=source_file_id,
+                session_file_id=None,
                 image_pngs=[],
                 pages_total=paged.get("pages_total"),
                 cached=False,

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -29,6 +29,8 @@ from ._file_tool_common import (
     attached_file_connections,
     audit_file_access_denied,
     describe_file_connections,
+    is_picture_name,
+    persist_source_document,
     render_file_images,
     render_file_payload,
     render_pdf_pages_images,
@@ -140,6 +142,68 @@ def _content_details(output: Dict[str, Any], *, max_chars: int) -> str:
         bits.append(f"full file is attached as session_file_id={sfid} (use inspect_data to analyze it)")
     bits.append("page the rest with windowed reads (offset/length) — do NOT re-run the same read")
     return shown + "\n[" + "; ".join(bits) + "]"
+
+
+def _build_preview(output: Dict[str, Any], *, preview_file_id: Optional[str],
+                   first_image_mime: Optional[str] = None) -> Dict[str, Any]:
+    """The UI contract for this read (see ReadFilePreview).
+
+    A DOCUMENT always beats its page renders: when a scanned PDF is rasterized
+    so a vision model can read it, the user is still shown the real PDF opened
+    at the page in question, not the PNG the model saw. `preview_file_id` is
+    only ever passed when it holds the ORIGINAL bytes.
+
+    Every branch returns the SAME keys — the frontend reads this as a fixed
+    shape, so an absent id must be an explicit null, not a missing field.
+    """
+    preview: Dict[str, Any] = {
+        "kind": "none",
+        "file_id": None,
+        "mime": None,
+        "target_page": None,
+        "pages_total": output.get("pages_total"),
+        "image_file_ids": None,
+        "truncated": False,
+    }
+
+    # page_range reports "10-15"; the viewer opens at the first of them.
+    target_page = None
+    shown = output.get("pages_shown")
+    if shown:
+        try:
+            target_page = int(str(shown).split("-", 1)[0])
+        except (TypeError, ValueError):
+            target_page = None
+
+    if preview_file_id and _doc_ext(output.get("file_name") or "") == "pdf":
+        preview.update({
+            "kind": "pdf",
+            "file_id": preview_file_id,
+            "mime": "application/pdf",
+            "target_page": target_page or 1,
+        })
+        return preview
+
+    image_ids = output.get("image_file_ids") or []
+    if image_ids:
+        pages_total = preview["pages_total"]
+        preview.update({
+            "kind": "image",
+            "file_id": image_ids[0],
+            "mime": first_image_mime or "image/png",
+            "image_file_ids": image_ids,
+            # Renders are capped (render_file_images max_pages), so a gallery
+            # showing fewer pages than the document has must say so.
+            "truncated": bool(pages_total and len(image_ids) < pages_total),
+        })
+        return preview
+
+    ct = output.get("content_type")
+    if ct == "tabular":
+        preview.update({"kind": "table", "truncated": bool(output.get("truncated"))})
+    elif ct in ("text", "json"):
+        preview.update({"kind": "text", "truncated": bool(output.get("truncated"))})
+    return preview
 
 
 class ReadFileTool(Tool):
@@ -380,7 +444,8 @@ class ReadFileTool(Tool):
                 and allow_llm_see_data(runtime_ctx)
             ):
                 import asyncio as _asyncio
-                import base64 as _b64
+
+                raw_bytes = None
                 try:
                     raw = await _asyncio.to_thread(client.read_raw_bytes, data.file_id)
                     raw_bytes = raw[0] if isinstance(raw, tuple) else raw
@@ -388,63 +453,70 @@ class ReadFileTool(Tool):
                 except Exception as e:
                     imgs, total = [], paged.get("pages_total")
                 if imgs:
-                    output = {
-                        "success": True,
-                        "connection_id": data.connection_id,
-                        "file_id": data.file_id,
-                        "content_type": "images",
-                        "image_count": len(imgs),
-                        "pages_total": total,
-                        "pages_shown": shown,
-                        "path": _display_path(data.file_id, client if session_file is not None else None) or None,
-                    }
-                    blocks = [
-                        {"data": _b64.b64encode(png).decode("utf-8"),
-                         "media_type": mtype, "source_type": "base64"}
-                        for png, mtype in imgs
-                    ]
                     reason = (
                         "as_images requested" if data.as_images
                         else "garbled text layer" if doc_text_is_usable(paged.get("text"))
                         else "no extractable text"
                     )
+                    # Keep the ORIGINAL document so the UI can open it at the
+                    # page that was read. The page PNGs stay vision-only — they
+                    # ride the observation as base64 and are NOT materialized
+                    # (attach_images=False), so paging through a long PDF can't
+                    # mint a File row per page.
+                    source_file_id = await persist_source_document(
+                        runtime_ctx, client, data.file_id,
+                        connection_id=data.connection_id,
+                        session_file=session_file,
+                        raw_bytes=raw_bytes,
+                    )
+                    output, observation = await self._finalize(
+                        data, runtime_ctx,
+                        rendered={"content_type": "binary", "pages_shown": shown},
+                        session_file_id=source_file_id,
+                        image_pngs=[png for png, _mtype in imgs],
+                        pages_total=total,
+                        cached=False,
+                        source_name=(
+                            getattr(client, "display_name", None)
+                            if session_file is not None else None
+                        ),
+                        attach_images=False,
+                        summary_note=reason,
+                        preview_file_id=source_file_id,
+                    )
                     yield ToolEndEvent(type="tool.end", payload={
-                        "output": output,
-                        "observation": {
-                            "summary": (
-                                f"Read pages {shown} of {total} from {data.file_id} "
-                                f"as image(s) for vision ({reason})"
-                            ),
-                            "success": True,
-                            "images": blocks,
-                        },
+                        "output": output, "observation": observation,
                     })
                     return
 
-            output = {
-                "success": True,
-                "connection_id": data.connection_id,
-                "file_id": data.file_id,
-                "content_type": "text",
-                "text": paged.get("text") or "",
-                "pages_total": paged.get("pages_total"),
-                "pages_shown": shown,
-                "path": _display_path(data.file_id, client if session_file is not None else None) or None,
-            }
-            name = (
-                getattr(client, "display_name", None) if session_file is not None
-                else _name_from_path_id(data.file_id)
+            # Same deal for a text page read: the slice goes to the model, the
+            # whole document is kept so the card can open it at that page.
+            # Deliberately no cache write — the cache key carries no page
+            # dimension, so storing a slice under the whole-file key would
+            # later be served back as the entire file.
+            source_file_id = await persist_source_document(
+                runtime_ctx, client, data.file_id,
+                connection_id=data.connection_id,
+                session_file=session_file,
             )
-            if name:
-                output["file_name"] = name
-            summary = (
-                f"Read pages {shown} of {paged.get('pages_total')} from {data.file_id}"
+            output, observation = await self._finalize(
+                data, runtime_ctx,
+                rendered={
+                    "content_type": "text",
+                    "text": paged.get("text") or "",
+                    "pages_total": paged.get("pages_total"),
+                    "pages_shown": shown,
+                },
+                session_file_id=source_file_id,
+                image_pngs=[],
+                pages_total=paged.get("pages_total"),
+                cached=False,
+                source_name=(
+                    getattr(client, "display_name", None)
+                    if session_file is not None else None
+                ),
+                preview_file_id=source_file_id,
             )
-            observation = {"summary": summary, "success": True}
-            if allow_llm_see_data(runtime_ctx):
-                details = _content_details(output, max_chars=_OBS_DETAILS_MAX_CHARS)
-                if details:
-                    observation["details"] = details
             yield ToolEndEvent(type="tool.end", payload={
                 "output": output, "observation": observation,
             })
@@ -495,10 +567,27 @@ class ReadFileTool(Tool):
                 session_file_id = await self._persist_rendered_session(
                     runtime_ctx, data.file_id, rendered,
                     connection_id=getattr(data, "connection_id", None))
+                # The cached entry carries the source's real name (opaque Graph
+                # ids have none of their own), which is what says whether there
+                # is a document worth showing.
+                cached_name = rendered.get("file_name") or _name_from_path_id(data.file_id)
+                if _doc_ext(cached_name or "") == "pdf":
+                    # A cache hit means file_version matched, so a copy already
+                    # kept for THIS report is still faithful — reuse it with no
+                    # fetch. The content cache is shared across reports, so a
+                    # report seeing this file for the first time still fetches.
+                    preview_file_id = await persist_source_document(
+                        runtime_ctx, client, data.file_id,
+                        connection_id=data.connection_id,
+                        session_file=session_file,
+                        reuse_existing=True,
+                    )
+                else:
+                    preview_file_id = None
                 output, observation = await self._finalize(
                     data, runtime_ctx, rendered=rendered, session_file_id=session_file_id,
                     image_pngs=cached.get("image_bytes") or [], pages_total=cached.get("pages_total"),
-                    cached=True,
+                    cached=True, preview_file_id=preview_file_id,
                 )
                 yield ToolEndEvent(type="tool.end", payload={"output": output, "observation": observation})
                 return
@@ -515,6 +604,14 @@ class ReadFileTool(Tool):
                 err = _fte(self._operation_name, _cn, e)
             yield self._fail_read(data, err)
             return
+
+        # The connector handed us the source bytes alongside the extracted text
+        # (DocumentText), from the one and only fetch. Captured here because the
+        # garbled-text escalation below reassigns `payload`. Re-downloading a
+        # 20 MB object from S3/SharePoint just to render a preview is not an
+        # acceptable cost, so this is the ONLY place the bytes come from.
+        source_raw = getattr(payload, "raw", None)
+        source_raw_mime = getattr(payload, "mime", "") or None
 
         # Note pages (OneNote) are text PLUS embedded media. The images are
         # separate Graph resources, not bytes inside the payload, so — unlike
@@ -533,8 +630,17 @@ class ReadFileTool(Tool):
             note_path = payload.get("path") or None
             payload = payload.get("text") or ""
 
+        # Dispatch on the file's real NAME. Opaque provider ids (Graph) carry no
+        # extension, so without the connector-supplied name a scanned PDF from
+        # SharePoint reached the renderer unidentifiable and never rendered —
+        # and the output carried no file_name for the UI to key off either.
+        render_name = (
+            getattr(client, "display_name", None) if session_file is not None
+            else payload_name(payload, data.file_id)
+        )
         rendered = render_file_payload(
-            name=None, payload=payload, max_rows=data.max_rows, max_chars=data.max_chars
+            name=render_name, payload=payload,
+            max_rows=data.max_rows, max_chars=data.max_chars,
         )
 
         # Garbled-text escalation for rich documents. Extraction can "succeed"
@@ -547,13 +653,6 @@ class ReadFileTool(Tool):
         # docx/pptx through LibreOffice; previously this was PDF-only, so
         # as_images on a Word file was silently a no-op.
         garble_note: Optional[str] = None
-        # Dispatch on the file's real NAME. Opaque provider ids (Graph) carry no
-        # extension, so without the connector-supplied name a scanned PDF from
-        # SharePoint reached the renderer unidentifiable and never rendered.
-        render_name = (
-            getattr(client, "display_name", None) if session_file is not None
-            else payload_name(payload, data.file_id)
-        )
         # Images rendered during escalation, reused below rather than rendered
         # twice — a LibreOffice conversion is far too expensive to repeat.
         prerendered: Optional[tuple] = None
@@ -605,7 +704,7 @@ class ReadFileTool(Tool):
                 if imgs:
                     payload = raw_bytes
                     rendered = {
-                        "file_name": rendered.get("file_name"),
+                        "file_name": rendered.get("file_name") or render_name,
                         "content_type": "binary",
                         "byte_count": len(raw_bytes),
                         "truncated": False,
@@ -632,6 +731,26 @@ class ReadFileTool(Tool):
                 runtime_ctx, file_id=data.file_id, payload=payload,
                 connection_id=getattr(data, "connection_id", None),
             )
+
+        # What the UI can actually open. A session file IS the upload, and a
+        # binary read already persisted the real bytes — both are viewable as
+        # they stand. A text-extracted document is the gap: its session file is
+        # a .txt derivative, so keep the original alongside it, reusing the
+        # bytes the read already fetched.
+        if session_file is not None or rendered.get("content_type") == "binary":
+            preview_file_id = session_file_id
+        elif _doc_ext(render_name) == "pdf":
+            preview_file_id = await persist_source_document(
+                runtime_ctx, client, data.file_id,
+                connection_id=data.connection_id,
+                raw_bytes=source_raw,
+                raw_name=render_name,
+                raw_mime=source_raw_mime or "application/pdf",
+            )
+        else:
+            # Office documents need a LibreOffice conversion before a browser
+            # can show them; that runs on demand, not on every read.
+            preview_file_id = None
 
         # Vision fallback: a file that couldn't be turned into text (scanned /
         # image-based / CID-font PDF, or a picture) comes back as binary — render
@@ -663,6 +782,13 @@ class ReadFileTool(Tool):
             ),
             attach_images=(session_file is None),
             summary_note=garble_note,
+            source_is_image=is_picture_name(render_name),
+            # Only when session_file_id holds the ORIGINAL bytes: a session file
+            # IS the upload, and a binary render persisted the real file. A
+            # text/tabular connector read stored a .txt/.csv derivative instead,
+            # which no viewer can open — that gap closes when connector
+            # documents get their originals kept.
+            preview_file_id=preview_file_id,
         )
 
         # Populate the cache. Skip un-rendered binary so a later vision-capable
@@ -677,7 +803,8 @@ class ReadFileTool(Tool):
         ):
             cache_rendered = {
                 k: v for k, v in output.items()
-                if k not in ("success", "connection_id", "file_id", "session_file_id", "image_file_ids")
+                if k not in ("success", "connection_id", "file_id", "session_file_id",
+                             "image_file_ids", "preview")
             }
             _file_cache.write(
                 data.connection_id, data.file_id, version,
@@ -737,12 +864,18 @@ class ReadFileTool(Tool):
 
     async def _finalize(self, data, runtime_ctx, *, rendered, session_file_id,
                         image_pngs, pages_total, cached, source_name=None,
-                        attach_images=True, summary_note=None):
+                        attach_images=True, summary_note=None,
+                        source_is_image=False, preview_file_id=None):
         """Assemble the tool output + observation from a rendered payload and any
         page images. Shared by the fresh-read and cache-hit paths so both emit an
         identical shape. Materializes page images as session files (unless the
         source is itself a session file — attach_images=False) and, when the
-        model supports vision, attaches them as observation image blocks."""
+        model supports vision, attaches them as observation image blocks.
+
+        ``source_is_image`` says the SOURCE is a picture, not merely that it was
+        rendered to one — see the image_file_ids fallback below.
+        ``preview_file_id`` is the File id holding the ORIGINAL document, when
+        one was kept; it is what lets the UI show a .pdf rather than a render."""
         output = {"success": True, "connection_id": data.connection_id, "file_id": data.file_id}
         output.update({k: v for k, v in (rendered or {}).items() if k != "_pages"})
         if output.get("file_name") is None:
@@ -763,6 +896,7 @@ class ReadFileTool(Tool):
             output["session_file_id"] = session_file_id
 
         observation_images = None
+        first_image_mime = None
         if image_pngs:
             import base64
             model = runtime_ctx.get("model")
@@ -788,6 +922,8 @@ class ReadFileTool(Tool):
                 # bytes themselves — a wrong declared media_type is a provider
                 # 400.
                 mime = sniff_image_mime(png)
+                if first_image_mime is None:
+                    first_image_mime = mime
                 ext = "jpg" if mime == "image/jpeg" else "png"
                 if attach_images:
                     fid = await attach_drive_file_to_session(
@@ -799,17 +935,32 @@ class ReadFileTool(Tool):
                 if supports_vision:
                     blocks.append({"data": base64.b64encode(png).decode("utf-8"),
                                    "media_type": mime, "source_type": "base64"})
-            if not attach_images and session_file_id:
+            if not attach_images and source_is_image and session_file_id:
                 # The source image is already a session file — point back at it
-                # instead of duplicating the bytes on every look.
+                # instead of duplicating the bytes on every look. Gated on the
+                # source actually BEING a picture: for a rendered document this
+                # id is the .pdf/.docx itself, and handing it back as an image
+                # id gives the UI a broken <img> and the model a wrong type.
                 file_ids = [session_file_id]
             if file_ids:
                 output["image_file_ids"] = file_ids
             if blocks:
                 observation_images = blocks
 
+        output["preview"] = _build_preview(
+            output, preview_file_id=preview_file_id,
+            first_image_mime=first_image_mime,
+        )
+
         ct = output.get("content_type", "?")
-        bits = [f"Read {data.file_id}", ct]
+        # A page-scoped read names its slice: "Read pages 10-15 of 120" is what
+        # makes paging progress legible to the model across turns.
+        shown_pages = output.get("pages_shown")
+        bits = [
+            f"Read pages {shown_pages} of {output.get('pages_total')} from {data.file_id}"
+            if shown_pages else f"Read {data.file_id}",
+            ct,
+        ]
         if ct == "tabular":
             bits.append(f"{output.get('row_count')} rows × {output.get('col_count')} cols")
         elif ct == "images":

--- a/backend/app/ai/tools/schemas/file_tools.py
+++ b/backend/app/ai/tools/schemas/file_tools.py
@@ -169,6 +169,50 @@ class ReadFileInput(BaseModel):
     title: Optional[str] = _title_field()
 
 
+class ReadFilePreview(BaseModel):
+    """What the UI should render for this read — decided server-side.
+
+    The frontend cannot work this out on its own: the session file a read
+    produces is often a DERIVATIVE of the source (report.pdf → report.pdf.txt,
+    sales.xlsx → sales.csv), so neither `file_name` nor `content_type` says
+    which file id to fetch or how to display it. This states it outright.
+
+    A document always beats its page renders. When a scanned PDF is rasterized
+    so a vision model can read it, the USER is still shown the real PDF opened
+    at the page in question — not the PNG the model saw.
+    """
+
+    kind: Literal["pdf", "image", "table", "text", "none"] = Field(
+        default="none",
+        description=(
+            "How to render: 'pdf' in a document viewer, 'image' as a picture / "
+            "page gallery, 'table' from the returned csv, 'text' as plain text, "
+            "'none' when there is nothing to show."
+        ),
+    )
+    file_id: Optional[str] = Field(
+        default=None,
+        description="File id the viewer should load. Null for 'table'/'text'/'none', which render from this result's own csv/text.",
+    )
+    mime: Optional[str] = Field(
+        default=None,
+        description="Authoritative content type of `file_id` — never infer it from file_name, which names the SOURCE and not the stored copy.",
+    )
+    target_page: Optional[int] = Field(
+        default=None,
+        description="1-based page the viewer should open at (from page_range). 1 when the whole document was read.",
+    )
+    pages_total: Optional[int] = None
+    image_file_ids: Optional[List[str]] = Field(
+        default=None,
+        description="Page-ordered image ids for a gallery, when kind='image'.",
+    )
+    truncated: bool = Field(
+        default=False,
+        description="The preview shows less than the whole file — a capped page render, or a row-limited table.",
+    )
+
+
 class ReadFileOutput(BaseModel):
     success: bool
     connection_id: Optional[str] = ""
@@ -253,6 +297,15 @@ class ReadFileOutput(BaseModel):
     pages_shown: Optional[str] = Field(
         default=None,
         description="The 1-based inclusive page range actually read, e.g. '10-15'. Compare with pages_total to continue paging.",
+    )
+    preview: Optional[ReadFilePreview] = Field(
+        default=None,
+        description=(
+            "UI ONLY — how the user's screen should render this read. IGNORE "
+            "it: it is not an input to any tool, and its `file_id` must never "
+            "be passed to inspect_data / create_data / read_excel_as_csv. Use "
+            "`session_file_id` for that."
+        ),
     )
     error: Optional[str] = None
 

--- a/backend/app/data_sources/clients/_document_text.py
+++ b/backend/app/data_sources/clients/_document_text.py
@@ -14,10 +14,20 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 import zipfile
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# PDFium (the native library behind pypdfium2) is not thread-safe, and
+# pypdfium2 adds no locking of its own. Extraction here and rasterization in
+# _file_tool_common both run on asyncio worker threads, so two concurrent PDF
+# reads would otherwise race inside the same native state. EVERY pypdfium2
+# call sequence — open, per-page work, close — must run while holding this
+# lock. Serializing PDF work is the accepted cost; a race can corrupt PDFium
+# state or segfault the whole process.
+PDFIUM_LOCK = threading.Lock()
 
 # pypdf is chatty on real-world PDFs ("Ignoring wrong pointing object",
 # "FloatObject invalid", …) — harmless recovery warnings that flood the logs
@@ -204,6 +214,8 @@ def _open_pdf(path: str):
 
     pypdfium2 is already a dependency — render_pdf_pages_images rasterizes
     pages with it — so this costs no new package.
+
+    Callers must hold PDFIUM_LOCK for the whole open→read→close sequence.
     """
     import pypdfium2 as pdfium
 
@@ -234,49 +246,51 @@ def extract_pdf_pages_text(path: str, first: int, last: int,
     extract_document_text, a targeted page read failing silently would strand
     the model in a retry loop.
     """
-    pdf = _open_pdf(path)
-    try:
-        pages_total = len(pdf)
-        first = max(1, int(first))
-        last = min(pages_total, int(last))
-        parts: list[str] = []
-        total = 0
-        for i in range(first - 1, last):
-            try:
-                t = _pdf_page_text(pdf, i)
-            except Exception:
-                t = ""
-            parts.append(t)
-            total += len(t)
-            if total >= max_chars:
-                break
-        return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
-    finally:
-        pdf.close()
+    with PDFIUM_LOCK:
+        pdf = _open_pdf(path)
+        try:
+            pages_total = len(pdf)
+            first = max(1, int(first))
+            last = min(pages_total, int(last))
+            parts: list[str] = []
+            total = 0
+            for i in range(first - 1, last):
+                try:
+                    t = _pdf_page_text(pdf, i)
+                except Exception:
+                    t = ""
+                parts.append(t)
+                total += len(t)
+                if total >= max_chars:
+                    break
+            return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
+        finally:
+            pdf.close()
 
 
 def _pdf(path: str, max_chars: int) -> str:
     # Search-oriented: a genuinely locked or corrupt file yields "" and is
     # skipped, unlike extract_pdf_pages_text where the caller wants the error.
-    try:
-        pdf = _open_pdf(path)
-    except Exception:
-        return ""
-    try:
-        parts: list[str] = []
-        total = 0
-        for i in range(min(len(pdf), _PDF_MAX_PAGES)):
-            try:
-                t = _pdf_page_text(pdf, i)
-            except Exception:
-                continue
-            parts.append(t)
-            total += len(t)
-            if total >= max_chars:
-                break
-        return "\n".join(parts)[:max_chars]
-    finally:
-        pdf.close()
+    with PDFIUM_LOCK:
+        try:
+            pdf = _open_pdf(path)
+        except Exception:
+            return ""
+        try:
+            parts: list[str] = []
+            total = 0
+            for i in range(min(len(pdf), _PDF_MAX_PAGES)):
+                try:
+                    t = _pdf_page_text(pdf, i)
+                except Exception:
+                    continue
+                parts.append(t)
+                total += len(t)
+                if total >= max_chars:
+                    break
+            return "\n".join(parts)[:max_chars]
+        finally:
+            pdf.close()
 
 
 # Match the visible-text runs in an OOXML part: <w:t> (Word) / <a:t>

--- a/backend/app/data_sources/clients/_document_text.py
+++ b/backend/app/data_sources/clients/_document_text.py
@@ -1,9 +1,10 @@
 """Best-effort plain-text extraction for rich document formats.
 
 Lets file sources make PDF / Word / PowerPoint content *searchable* and
-*readable* (not just opaque bytes). Dependency-light: PDF via pypdf, PPTX via
-python-pptx (both already project deps), DOCX by reading the OOXML zip directly
-(no python-docx needed).
+*readable* (not just opaque bytes). Dependency-light: PDF via PDFium
+(pypdfium2 — already used to rasterize pages, and the only extractor here that
+returns text in reading order rather than paint order; see _open_pdf), PPTX via
+python-pptx, DOCX by reading the OOXML zip directly (no python-docx needed).
 
 Every extractor is defensive — a corrupt/locked/oversized file or a missing
 optional lib yields "" rather than raising, so search over a mixed directory
@@ -18,10 +19,11 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# pypdf is very chatty on real-world PDFs ("Ignoring wrong pointing object",
+# pypdf is chatty on real-world PDFs ("Ignoring wrong pointing object",
 # "FloatObject invalid", …) — harmless recovery warnings that flood the logs
-# when scanning a whole directory. Silence them; genuine errors still surface
-# via our own try/except below.
+# when scanning a whole directory. It no longer extracts text here, but other
+# modules still import it, so the filter stays. Genuine errors surface via our
+# own try/except below.
 logging.getLogger("pypdf").setLevel(logging.ERROR)
 
 # Extensions this module can turn into text. Callers gate on this set.
@@ -183,6 +185,45 @@ def extract_document_text_from_bytes(data: bytes, name: str,
                 pass
 
 
+def _open_pdf(path: str):
+    """Open a PDF with PDFium. Raises on an unreadable / password-locked file.
+
+    PDFium — the engine Chromium renders PDFs with — returns text in LOGICAL
+    order. pypdf's extract_text() returns it in VISUAL order: the order the
+    glyphs happen to be painted in. For Latin scripts the two coincide, so the
+    difference was invisible. For Hebrew and Arabic the visual order reverses
+    every word on the line:
+
+        pypdf   ".1ומכירותנח  אלבומים  סקירת"
+        pdfium  ".1 סקירת אלבומים ומכירות"
+
+    Nothing downstream could catch that. The characters are all valid Hebrew,
+    correctly encoded, so doc_text_looks_garbled (which hunts for mojibake)
+    never fires and the model receives fluent-looking gibberish as if it were a
+    faithful read.
+
+    pypdfium2 is already a dependency — render_pdf_pages_images rasterizes
+    pages with it — so this costs no new package.
+    """
+    import pypdfium2 as pdfium
+
+    return pdfium.PdfDocument(path)
+
+
+def _pdf_page_text(pdf, index: int) -> str:
+    """Text of one page, normalized to \n newlines (PDFium emits \r\n)."""
+    page = pdf[index]
+    try:
+        textpage = page.get_textpage()
+        try:
+            raw = textpage.get_text_bounded() or ""
+        finally:
+            textpage.close()
+    finally:
+        page.close()
+    return raw.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def extract_pdf_pages_text(path: str, first: int, last: int,
                            max_chars: int = DEFAULT_MAX_CHARS) -> tuple:
     """Extract text for an inclusive 1-based page range of a PDF.
@@ -193,54 +234,49 @@ def extract_pdf_pages_text(path: str, first: int, last: int,
     extract_document_text, a targeted page read failing silently would strand
     the model in a retry loop.
     """
-    from pypdf import PdfReader
-
-    reader = PdfReader(path)
-    if getattr(reader, "is_encrypted", False):
-        reader.decrypt("")
-    pages_total = len(reader.pages)
-    first = max(1, int(first))
-    last = min(pages_total, int(last))
-    parts: list[str] = []
-    total = 0
-    for i in range(first - 1, last):
-        try:
-            t = reader.pages[i].extract_text() or ""
-        except Exception:
-            t = ""
-        parts.append(t)
-        total += len(t)
-        if total >= max_chars:
-            break
-    return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
+    pdf = _open_pdf(path)
+    try:
+        pages_total = len(pdf)
+        first = max(1, int(first))
+        last = min(pages_total, int(last))
+        parts: list[str] = []
+        total = 0
+        for i in range(first - 1, last):
+            try:
+                t = _pdf_page_text(pdf, i)
+            except Exception:
+                t = ""
+            parts.append(t)
+            total += len(t)
+            if total >= max_chars:
+                break
+        return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
+    finally:
+        pdf.close()
 
 
 def _pdf(path: str, max_chars: int) -> str:
-    from pypdf import PdfReader
-
-    reader = PdfReader(path)
-    # Encrypted PDFs: many use an empty owner password — try that before giving
-    # up so we can still read them. If it's genuinely locked, decrypt raises and
-    # the caller catches it (file skipped).
-    if getattr(reader, "is_encrypted", False):
-        try:
-            reader.decrypt("")
-        except Exception:
-            return ""
-    parts: list[str] = []
-    total = 0
-    for i, page in enumerate(reader.pages):
-        if i >= _PDF_MAX_PAGES:
-            break
-        try:
-            t = page.extract_text() or ""
-        except Exception:
-            continue
-        parts.append(t)
-        total += len(t)
-        if total >= max_chars:
-            break
-    return "\n".join(parts)[:max_chars]
+    # Search-oriented: a genuinely locked or corrupt file yields "" and is
+    # skipped, unlike extract_pdf_pages_text where the caller wants the error.
+    try:
+        pdf = _open_pdf(path)
+    except Exception:
+        return ""
+    try:
+        parts: list[str] = []
+        total = 0
+        for i in range(min(len(pdf), _PDF_MAX_PAGES)):
+            try:
+                t = _pdf_page_text(pdf, i)
+            except Exception:
+                continue
+            parts.append(t)
+            total += len(t)
+            if total >= max_chars:
+                break
+        return "\n".join(parts)[:max_chars]
+    finally:
+        pdf.close()
 
 
 # Match the visible-text runs in an OOXML part: <w:t> (Word) / <a:t>

--- a/backend/app/data_sources/clients/_file_source_common.py
+++ b/backend/app/data_sources/clients/_file_source_common.py
@@ -50,6 +50,36 @@ class NamedBytes(bytes):
         return obj
 
 
+class DocumentText(str):
+    """Extracted document text that remembers the bytes it came from.
+
+    The sibling of :class:`NamedBytes`, for the opposite outcome: extraction
+    SUCCEEDED, so the model gets text — but the UI still needs the original
+    file to show the user the actual document (a .pdf in a viewer, opened at
+    the page that was read). Without carrying the bytes here, the tool layer
+    would have to fetch the same object a SECOND time, a full extra download
+    from S3/SharePoint purely to render a preview.
+
+    Only the clients that already hold the bytes in memory when they extract
+    (graph_drive, google_drive, s3) wrap their result. network_dir extracts
+    straight from a local path and has nothing in hand, so it keeps returning
+    a plain str — re-reading a local file costs nothing, and holding every
+    document in memory for it would be a pure waste.
+
+    Subclassing ``str`` keeps every consumer working unchanged: isinstance
+    checks, ``len``, ``encode``, equality. Slicing returns a plain ``str``, so
+    the bytes can never leak into tool output or the context window.
+    """
+
+    def __new__(cls, text, raw: Optional[bytes] = None,
+                name: Optional[str] = None, mime: Optional[str] = None):
+        obj = super().__new__(cls, text)
+        obj.raw = raw
+        obj.name = name or ""
+        obj.mime = mime or ""
+        return obj
+
+
 def payload_name(payload, fallback: str = "") -> str:
     """Best display/dispatch name for a read payload: the connector-supplied
     name when the bytes carry one, else the caller's fallback (usually the

--- a/backend/app/data_sources/clients/google_drive_client.py
+++ b/backend/app/data_sources/clients/google_drive_client.py
@@ -21,7 +21,10 @@ from app.data_sources.clients._document_text import (
     doc_text_is_usable,
     extract_document_text_from_bytes,
 )
-from app.data_sources.clients._file_source_common import NamedBytes
+from app.data_sources.clients._file_source_common import (
+    DocumentText,
+    NamedBytes,
+)
 from app.data_sources.clients.base import Capability, DataSourceClient
 
 
@@ -285,7 +288,8 @@ class GoogleDriveClient(DataSourceClient):
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
             if doc_text_is_usable(text, ext):
-                return text
+                # Carry the bytes we already downloaded — see DocumentText.
+                return DocumentText(text, raw=content, name=name)
             return NamedBytes(content, name=name)
 
         from app.data_sources.clients.graph_drive_client import _trim_to_data

--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -34,6 +34,7 @@ from app.data_sources.clients._document_text import (
 )
 from app.data_sources.clients._file_source_common import (
     GlobScopeError,
+    DocumentText,
     NamedBytes,
     INDEX_NONE,
     globs_from_str,
@@ -888,7 +889,9 @@ class GraphDriveClient(DataSourceClient):
         if ext in DOC_EXTS:
             text = extract_document_text_from_bytes(content, name)
             if doc_text_is_usable(text, ext):
-                return text
+                # Carry the bytes we already downloaded: the tool layer shows
+                # the user the real document, and must not fetch it twice.
+                return DocumentText(text, raw=content, name=name, mime=mime)
             return NamedBytes(content, name=name, mime=mime)
 
         if ext == "csv":

--- a/backend/app/data_sources/clients/graph_drive_client.py
+++ b/backend/app/data_sources/clients/graph_drive_client.py
@@ -867,12 +867,20 @@ class GraphDriveClient(DataSourceClient):
             if ext != "pdf":
                 raise ValueError("page_range is supported for PDF files only.")
             text, pages_total = _extract_pdf_pages_from_bytes(content, name, page_range[0], page_range[1])
+                # The bytes this read already downloaded, carried like
+                # DocumentText.raw does for whole-file reads. Without them the
+                # tool layer fetches the same object a second time just to keep
+                # the original for the viewer — 2N downloads for N page reads.
+                # `name` rides along because an opaque provider id carries no
+                # filename of its own, and the preview needs the extension.
             return {
                 "__doc_pages__": True,
                 "text": text,
                 "pages_total": pages_total,
                 "first": max(1, page_range[0]),
                 "last": min(page_range[1], pages_total),
+                "raw": content,
+                "name": name,
             }
 
         if max_bytes and len(content) > max_bytes:
@@ -912,12 +920,22 @@ class GraphDriveClient(DataSourceClient):
     def read_raw_bytes(self, file_id: str):
         """Raw item bytes + name + mime, unparsed — for attach_file (persist
         the ORIGINAL file) and the read_file tool's PDF→images vision fallback.
-        Same access boundary as read_file: off-glob items are denied."""
-        drive_id = self._resolve_drive_id()
-        resolved_id = self._resolve_item_id(drive_id, file_id)
+        Same access boundary as read_file: off-glob items are denied.
+
+        Resolution goes through _locate, exactly as read_file does. It used to
+        call _resolve_drive_id/_resolve_item_id directly — the single-library
+        path — which cannot split the qualified ``drive|item`` id list_files
+        hands out on a multi-library connection. It fed the whole string in as
+        the item id and every call raised, silently: attach_file failed, the
+        as_images escalation became a no-op that returned the same unreadable
+        text, and the document preview never appeared."""
+        drive_id, resolved_id = self._locate(file_id)
         meta = self._get(f"/drives/{drive_id}/items/{resolved_id}")
         name = meta.get("name", "")
-        self._enforce_scope(self._rel_from_parent((meta.get("parentReference") or {}).get("path"), name))
+        # _scoped_path (not _rel_from_parent) for the same reason read_file uses
+        # it: across libraries the listed paths carry a library prefix, so the
+        # glob check must be given the prefixed form it was written against.
+        self._enforce_scope(self._scoped_path(drive_id, (meta.get("parentReference") or {}).get("path"), name))
         content = self._get_bytes(f"/drives/{drive_id}/items/{resolved_id}/content")
         return content, name, (meta.get("file") or {}).get("mimeType")
 

--- a/backend/app/data_sources/clients/s3_client.py
+++ b/backend/app/data_sources/clients/s3_client.py
@@ -339,12 +339,20 @@ class S3Client(DataSourceClient):
             text, pages_total = _extract_pdf_pages_from_bytes(
                 data, key, page_range[0], page_range[1]
             )
+                # The bytes this read already downloaded, carried like
+                # DocumentText.raw does for whole-file reads. Without them the
+                # tool layer fetches the same object a second time just to keep
+                # the original for the viewer — 2N downloads for N page reads.
+                # `name` rides along because an opaque provider id carries no
+                # filename of its own, and the preview needs the extension.
             return {
                 "__doc_pages__": True,
                 "text": text,
                 "pages_total": pages_total,
                 "first": max(1, page_range[0]),
                 "last": min(page_range[1], pages_total),
+                "raw": data,
+                "name": key.rsplit("/", 1)[-1],
             }
 
         # Structured read — pull the whole object (size-capped).

--- a/backend/app/data_sources/clients/s3_client.py
+++ b/backend/app/data_sources/clients/s3_client.py
@@ -47,6 +47,7 @@ from app.data_sources.clients._file_source_common import (
     INDEX_CONTENT,
     INDEX_NONE,
     GlobScopeError,
+    DocumentText,
     NamedBytes,
     globs_from_str,
     normalize_index_mode,
@@ -355,7 +356,8 @@ class S3Client(DataSourceClient):
             # Near-empty extraction on a rich doc (scanned / image-based / CID
             # font) → return raw bytes so the tool can render it for vision.
             if doc_text_is_usable(text, ext):
-                return text
+                # Carry the bytes we already fetched — see DocumentText.
+                return DocumentText(text, raw=data, name=key)
             return NamedBytes(data, name=key)
 
         if ext == "csv":

--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -143,16 +143,28 @@ def _content_disposition(kind: str, filename: str) -> str:
     a stem with no letters or digits left is replaced outright.
     """
     name = filename or "file"
+    # Control characters (CR/LF above all) survive an ascii encode and blow up
+    # header serialization in h11 — or worse, split the header. Strip them from
+    # the source name before either form is built.
+    name = "".join(c for c in name if c.isprintable())
+    if not name.strip():
+        name = "file"
     # A stray double quote would terminate the quoted-string early and corrupt
     # the header, so it goes before anything else looks at the name.
     ascii_name = name.encode("ascii", "ignore").decode("ascii").strip().replace('"', "")
+    # Backslash is the quoted-string escape character — a trailing one would
+    # escape the closing quote itself.
+    ascii_name = ascii_name.replace("\\", "")
     stem, dot, _ = ascii_name.rpartition(".")
     if not dot:
         stem = ascii_name
     if not re.search(r"[A-Za-z0-9]", stem):
         ext = name.rpartition(".")[2]
         ascii_name = f"file.{ext}" if ext.isalnum() else "file"
-    return f"{kind}; filename=\"{ascii_name}\"; filename*=UTF-8\'\'{quote(name)}"
+    # safe='' — quote()'s default keeps "/" literal, but "/" is not an
+    # attr-char in RFC 5987 ext-value, and connector names can be full paths
+    # ("reports/2024/annual.pdf"): strict parsers drop the whole filename*.
+    return f"{kind}; filename=\"{ascii_name}\"; filename*=UTF-8\'\'{quote(name, safe='')}"
 
 
 @router.get("/files", response_model=list[FileSchemaWithMetadata])

--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -5,6 +5,8 @@ from sqlalchemy import select
 from app.dependencies import get_db
 from typing import Optional
 import os
+import re
+from urllib.parse import quote
 
 from app.services.file_service import FileService
 from app.schemas.file_schema import FileSchema, FileSchemaWithMetadata, FileSchemaWithCompletionId
@@ -125,6 +127,34 @@ async def remove_file_from_report(file_id: str, report_id: str, current_user: Us
     )
     return result
 
+def _content_disposition(kind: str, filename: str) -> str:
+    """A Content-Disposition value that survives a non-Latin filename.
+
+    HTTP headers are latin-1, so interpolating a Hebrew / Cyrillic / CJK name
+    straight into `filename="…"` raises UnicodeEncodeError inside the ASGI
+    server and turns a perfectly readable file into a 500. That is exactly what
+    an <iframe> preview of "סקירת אלבומים ומכירות.pdf" hit.
+
+    Emit both RFC 6266 forms: a transliterated `filename=` that any client can
+    parse, plus `filename*=UTF-8''…` carrying the real name for those that
+    understand it. Same shape the report / agent-export / step download routes
+    already use. Transliteration can strip a name down to nothing but its
+    extension (".pdf"), which browsers save as a hidden extensionless file — so
+    a stem with no letters or digits left is replaced outright.
+    """
+    name = filename or "file"
+    # A stray double quote would terminate the quoted-string early and corrupt
+    # the header, so it goes before anything else looks at the name.
+    ascii_name = name.encode("ascii", "ignore").decode("ascii").strip().replace('"', "")
+    stem, dot, _ = ascii_name.rpartition(".")
+    if not dot:
+        stem = ascii_name
+    if not re.search(r"[A-Za-z0-9]", stem):
+        ext = name.rpartition(".")[2]
+        ascii_name = f"file.{ext}" if ext.isalnum() else "file"
+    return f"{kind}; filename=\"{ascii_name}\"; filename*=UTF-8\'\'{quote(name)}"
+
+
 @router.get("/files", response_model=list[FileSchemaWithMetadata])
 @requires_permission('manage_files')
 async def get_files(current_user: User = Depends(current_user), db: AsyncSession = Depends(get_async_db), organization: Organization = Depends(get_current_organization)):
@@ -184,7 +214,7 @@ async def get_file_content(file_id: str, request: Request, current_user: User = 
         content=content,
         media_type=file.content_type,
         headers={
-            "Content-Disposition": f'attachment; filename="{file.filename}"',
+            "Content-Disposition": _content_disposition("attachment", file.filename),
         },
     )
 
@@ -265,7 +295,7 @@ async def get_file_embed(
         media_type=file.content_type or "application/octet-stream",
         headers={
             # inline so <img>/<iframe> render it rather than downloading
-            "Content-Disposition": f'inline; filename="{file.filename or file_id}"',
+            "Content-Disposition": _content_disposition("inline", file.filename or file_id),
             "Cache-Control": "private, max-age=300",
         },
     )

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -1994,6 +1994,13 @@ class CompletionService:
                 .where(
                     report_file_association.c.report_id == report_id,
                     File.content_type.like("image/%"),
+                    # Only user uploads are "pending attachments" waiting to be
+                    # claimed by the message being sent. Tool-materialized files
+                    # (source_kind="connector": read_file page renders, picture
+                    # reads) also sit in report.files with a NULL completion_id,
+                    # and claiming them here showed them as attachments on the
+                    # NEXT unrelated user message.
+                    File.source_kind == "upload",
                 )
             )).scalars().all())
             if not image_file_ids:

--- a/backend/scripts/backfill_read_file_preview_projection.py
+++ b/backend/scripts/backfill_read_file_preview_projection.py
@@ -1,0 +1,99 @@
+"""Backfill the `preview` field into persisted read-tool projections.
+
+Report read endpoints serve `tool_execution.context_summary_json`, not
+`result_json` (see services/report_payload_projection.py). Projections written
+before `preview` joined the allowlist therefore render as plain text forever,
+even though `result_json` holds a perfectly good render contract — and nothing
+self-heals them: the ORM hook only fills a MISSING projection, and the read path
+sets the rebuilt value in memory without writing it back.
+
+Scoped deliberately to read_file / read_email / read_note. Bumping
+CONTEXT_SUMMARY_VERSION would invalidate create_data and write_csv too, whose
+projections exist precisely to avoid loading multi-megabyte row payloads on
+every report open — measured at ~2.8 ms per MB, repaid on every open because
+the rebuild is never persisted. These rows are small and capped (text is
+truncated at UI_FILE_PREVIEW_CHARS), so rewriting them once is cheap.
+
+Idempotent: rows whose projection already carries `preview` are skipped, so a
+re-run is a no-op.
+
+    python scripts/backfill_read_file_preview_projection.py --dry-run
+    python scripts/backfill_read_file_preview_projection.py
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: F401  - registers every ORM mapper
+from sqlalchemy import select
+
+from app.ai.persisted_summary import SUMMARIZED_TOOL_NAMES, build_tool_context_summary
+from app.dependencies import async_session_maker
+from app.models.tool_execution import ToolExecution
+
+READ_TOOLS = tuple(
+    name for name in ("read_file", "read_email", "read_note") if name in SUMMARIZED_TOOL_NAMES
+)
+BATCH = 200
+
+
+async def backfill(dry_run: bool) -> int:
+    updated = skipped = unfixable = 0
+
+    async with async_session_maker() as db:
+        rows = (
+            await db.execute(
+                select(ToolExecution).where(ToolExecution.tool_name.in_(READ_TOOLS))
+            )
+        ).scalars().all()
+
+        for i, execution in enumerate(rows, start=1):
+            result = execution.result_json
+            summary = execution.context_summary_json
+
+            if not isinstance(result, dict) or "preview" not in result:
+                # Predates the feature entirely — there is no contract to carry
+                # forward. Re-reading the file is the only cure, and that is a
+                # user action, not a migration.
+                unfixable += 1
+                continue
+            if isinstance(summary, dict) and "preview" in summary:
+                skipped += 1
+                continue
+
+            rebuilt = build_tool_context_summary(execution.tool_name, result)
+            if not isinstance(rebuilt, dict) or "preview" not in rebuilt:
+                unfixable += 1
+                continue
+
+            if not dry_run:
+                execution.context_summary_json = rebuilt
+            updated += 1
+
+            if not dry_run and i % BATCH == 0:
+                await db.commit()
+
+        if not dry_run:
+            await db.commit()
+
+    verb = "would update" if dry_run else "updated"
+    print(f"{verb}: {updated}")
+    print(f"already had preview (skipped): {skipped}")
+    print(f"no preview in result_json (needs a fresh read): {unfixable}")
+    return updated
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report without writing")
+    args = parser.parse_args()
+    asyncio.run(backfill(args.dry_run))
+
+
+if __name__ == "__main__":
+    cli()

--- a/backend/tests/unit/test_content_disposition_header.py
+++ b/backend/tests/unit/test_content_disposition_header.py
@@ -1,0 +1,65 @@
+"""A non-Latin filename must not 500 the file routes.
+
+HTTP headers are latin-1. Interpolating a Hebrew / Cyrillic / CJK filename
+straight into `Content-Disposition: inline; filename="…"` raises
+UnicodeEncodeError inside the ASGI server, and the client gets a 500 instead
+of the file. Hit for real by an <iframe> preview of a PDF named
+"סקירת אלבומים ומכירות.pdf": the error pointed at position 18, which is exactly
+where the filename starts in `inline; filename="`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.routes.file import _content_disposition
+
+# Names that broke, or that the transliteration fallback has to survive.
+NON_LATIN = [
+    "סקירת אלבומים ומכירות.pdf",   # the file from the bug report
+    "отчёт.xlsx",
+    "データ.csv",
+    "报告.pdf",
+    "café.txt",
+    "no-extension-שלום",
+]
+
+ASCII = ["report.pdf", "Book 7.xlsx", "a.b.c.txt"]
+
+
+@pytest.mark.parametrize("name", NON_LATIN + ASCII + ["", ".pdf", 'a"b.txt'])
+@pytest.mark.parametrize("kind", ["inline", "attachment"])
+def test_header_is_always_latin_1_encodable(kind, name):
+    """The invariant the ASGI server enforces — violating it is a 500."""
+    _content_disposition(kind, name).encode("latin-1")
+
+
+@pytest.mark.parametrize("name", NON_LATIN + ASCII + ["", ".pdf", 'a"b.txt'])
+def test_quoted_string_stays_well_formed(name):
+    """Exactly one quoted-string. An unescaped quote inside the name would
+    terminate it early and corrupt every parameter after it."""
+    assert _content_disposition("inline", name).count('"') == 2
+
+
+@pytest.mark.parametrize("name", NON_LATIN)
+def test_real_name_survives_in_the_rfc_5987_form(name):
+    """Transliteration is a fallback for old clients, not a rename — the true
+    name still has to reach the browser."""
+    from urllib.parse import quote
+
+    assert f"filename*=UTF-8''{quote(name)}" in _content_disposition("inline", name)
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("סקירת אלבומים ומכירות.pdf", 'filename="file.pdf"'),
+    ("отчёт.xlsx", 'filename="file.xlsx"'),
+    (".pdf", 'filename="file.pdf"'),
+])
+def test_fallback_keeps_a_usable_extension(name, expected):
+    """Stripping non-ASCII from "סקירת….pdf" leaves ".pdf" — which browsers
+    save as a hidden, extensionless file. A stem with nothing left must be
+    replaced outright rather than shipped as a dotfile."""
+    assert expected in _content_disposition("inline", name)
+
+
+def test_ascii_names_are_left_alone():
+    assert 'filename="report.pdf"' in _content_disposition("attachment", "report.pdf")

--- a/backend/tests/unit/test_content_disposition_header.py
+++ b/backend/tests/unit/test_content_disposition_header.py
@@ -63,3 +63,29 @@ def test_fallback_keeps_a_usable_extension(name, expected):
 
 def test_ascii_names_are_left_alone():
     assert 'filename="report.pdf"' in _content_disposition("attachment", "report.pdf")
+
+
+@pytest.mark.parametrize("name", [
+    "reports/2024/annual.pdf",       # connector ids are often full paths
+    "evil\r\nX-Injected: 1.pdf",     # CR/LF must never reach a header value
+    "tab\there.csv",
+])
+def test_control_chars_and_separators_cannot_break_the_header(name):
+    """CR/LF survive an ascii encode, and h11 rejects (or worse, splits) the
+    header at send time — the exact 500 class this helper exists to prevent."""
+    header = _content_disposition("attachment", name)
+    header.encode("latin-1")
+    assert "\r" not in header and "\n" not in header and "\t" not in header
+
+
+def test_slashes_are_percent_encoded_in_the_ext_value():
+    """"/" is not an attr-char in RFC 5987: strict parsers drop the whole
+    filename* when it appears literally. quote()'s default safe="/" kept it."""
+    header = _content_disposition("inline", "reports/2024/annual.pdf")
+    assert "filename*=UTF-8''reports%2F2024%2Fannual.pdf" in header
+
+
+def test_backslash_cannot_escape_the_closing_quote():
+    header = _content_disposition("attachment", 'trail\\')
+    assert header.count('"') == 2
+    assert '\\"' not in header

--- a/backend/tests/unit/test_pdf_reading_order.py
+++ b/backend/tests/unit/test_pdf_reading_order.py
@@ -1,0 +1,117 @@
+"""PDF text must come out in READING order, not in content-stream order.
+
+pypdf's extract_text() concatenates text runs in the order the content stream
+paints them. For Latin documents that is usually the reading order too, so the
+difference was invisible for years. For Hebrew and Arabic it is not: the
+extractor returned every line with its words reversed —
+
+    pypdf   ".1ומכירותנח  אלבומים  סקירת"
+    correct ".1 סקירת אלבומים ומכירות"
+
+— and nothing downstream could tell. Every character is valid, correctly
+encoded Hebrew, so doc_text_looks_garbled (which hunts for mojibake) never
+fires and the model is handed fluent-looking gibberish as a faithful read. The
+user sees confidently wrong answers about their own document.
+
+Extraction therefore goes through PDFium, the engine Chromium renders PDFs
+with, which reconstructs reading order from glyph positions.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from app.data_sources.clients._document_text import (
+    extract_document_text,
+    extract_pdf_pages_text,
+)
+
+
+def _pdf_with_runs(runs) -> bytes:
+    """A one-page PDF whose text runs are PAINTED in a different order than
+    they READ. `runs` is [(x, text)]; they are emitted in list order but
+    positioned by x, so stream order and reading order disagree — the same
+    divergence that reverses RTL words."""
+    body = "\n".join(
+        f"BT /F1 14 Tf {x} 700 Td ({text}) Tj ET" for x, text in runs
+    ).encode("ascii")
+
+    def obj(n, payload):
+        return f"{n} 0 obj\n".encode() + payload + b"\nendobj\n"
+
+    objs = [
+        obj(1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        obj(2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj(3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+               b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"),
+        obj(4, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+        obj(5, f"<< /Length {len(body)} >>\nstream\n".encode() + body + b"\nendstream"),
+    ]
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets = []
+    for o in objs:
+        offsets.append(out.tell())
+        out.write(o)
+    xref = out.tell()
+    out.write(f"xref\n0 {len(objs) + 1}\n".encode())
+    out.write(b"0000000000 65535 f \n")
+    for off in offsets:
+        out.write(f"{off:010d} 00000 n \n".encode())
+    out.write(f"trailer\n<< /Size {len(objs) + 1} /Root 1 0 R >>\n"
+              f"startxref\n{xref}\n%%EOF\n".encode())
+    return out.getvalue()
+
+
+# Painted right-to-left, so a stream-order extractor yields GAMMA…ALPHA…BETA.
+SCRAMBLED_RUNS = [(300, "GAMMA"), (50, "ALPHA"), (175, "BETA")]
+
+
+@pytest.fixture
+def scrambled_pdf(tmp_path):
+    p = tmp_path / "reading-order.pdf"
+    p.write_bytes(_pdf_with_runs(SCRAMBLED_RUNS))
+    return str(p)
+
+
+def test_whole_document_extraction_follows_reading_order(scrambled_pdf):
+    text = extract_document_text(scrambled_pdf, "reading-order.pdf")
+    assert text.index("ALPHA") < text.index("BETA") < text.index("GAMMA"), (
+        f"runs came back in paint order, not reading order: {text!r}"
+    )
+
+
+def test_page_range_extraction_follows_reading_order(scrambled_pdf):
+    """The page_range path is a separate extractor and regressed independently
+    — a Hebrew read scrambled the same way whether or not pages were named."""
+    text, pages_total = extract_pdf_pages_text(scrambled_pdf, 1, 1)
+    assert pages_total == 1
+    assert text.index("ALPHA") < text.index("BETA") < text.index("GAMMA"), (
+        f"runs came back in paint order, not reading order: {text!r}"
+    )
+
+
+def test_extraction_still_reads_plain_ltr_documents(tmp_path):
+    """The switch must not disturb the ordinary case."""
+    p = tmp_path / "plain.pdf"
+    p.write_bytes(_pdf_with_runs([(50, "Revenue"), (150, "grew"), (250, "sharply")]))
+    text = extract_document_text(str(p), "plain.pdf")
+    for word in ("Revenue", "grew", "sharply"):
+        assert word in text
+
+
+def test_page_range_raises_on_an_unreadable_pdf(tmp_path):
+    """extract_pdf_pages_text promises a real error rather than "" — a silent
+    empty read strands the model re-reading the same pages forever."""
+    p = tmp_path / "broken.pdf"
+    p.write_bytes(b"not a pdf at all")
+    with pytest.raises(Exception):
+        extract_pdf_pages_text(str(p), 1, 1)
+
+
+def test_whole_document_extraction_is_silent_on_an_unreadable_pdf(tmp_path):
+    """The search-oriented path skips bad files instead of failing a crawl."""
+    p = tmp_path / "broken.pdf"
+    p.write_bytes(b"not a pdf at all")
+    assert extract_document_text(str(p), "broken.pdf") == ""

--- a/backend/tests/unit/test_read_file_preview_projection.py
+++ b/backend/tests/unit/test_read_file_preview_projection.py
@@ -1,0 +1,99 @@
+"""The UI preview contract must survive the persisted projection.
+
+Report read endpoints do NOT serve `tool_execution.result_json` — the column is
+deferred and the durable `context_summary_json` projection is served in its
+place (see report_payload_projection.hydrate_tool_results_for_ui). A field
+missing from that projection's allowlist is therefore invisible to the card the
+moment a finished turn is refetched, even though the tool returned it and the
+database still holds it.
+
+That is exactly how the document preview disappeared: the live SSE payload
+carried `preview` and rendered the PDF, then the refetch served a projection
+without it and the card fell back to plain text. These tests pin both halves so
+the two payloads cannot drift apart again.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.ai.persisted_summary import (
+    SUMMARIZED_TOOL_NAMES,
+    build_tool_context_summary,
+)
+
+PREVIEW = {
+    "kind": "pdf",
+    "file_id": "SESSION-FILE-1",
+    "mime": "application/pdf",
+    "target_page": 7,
+    "pages_total": 42,
+    "image_file_ids": None,
+    "truncated": False,
+}
+
+
+def _read_result(**overrides):
+    base = {
+        "success": True,
+        "connection_id": "C1",
+        "file_id": "book.pdf",
+        "file_name": "book.pdf",
+        "path": "book.pdf",
+        "content_type": "text",
+        "text": "page body",
+        "session_file_id": "SESSION-FILE-1",
+        "preview": dict(PREVIEW),
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize("tool_name", ["read_file", "read_email", "read_note"])
+def test_preview_survives_the_projection(tool_name):
+    """Without this the card renders text after every refetch."""
+    projected = build_tool_context_summary(tool_name, _read_result())
+    assert projected["preview"] == PREVIEW
+
+
+def test_preview_is_copied_verbatim_not_summarized():
+    """`preview` is a render contract, not a data payload — truncating or
+    reshaping any field silently points the viewer at the wrong file or page."""
+    projected = build_tool_context_summary("read_file", _read_result())
+    assert projected["preview"]["file_id"] == "SESSION-FILE-1"
+    assert projected["preview"]["target_page"] == 7
+    assert projected["preview"]["mime"] == "application/pdf"
+
+
+def test_image_preview_keeps_its_gallery_ids():
+    result = _read_result(
+        content_type="images",
+        preview={**PREVIEW, "kind": "image", "image_file_ids": ["P1", "P2", "P3"]},
+    )
+    projected = build_tool_context_summary("read_file", result)
+    assert projected["preview"]["image_file_ids"] == ["P1", "P2", "P3"]
+
+
+def test_a_read_without_a_preview_projects_cleanly():
+    """Older executions predate the contract; their absence must not add a key
+    the frontend would then treat as a real (empty) preview."""
+    result = _read_result()
+    result.pop("preview")
+    projected = build_tool_context_summary("read_file", result)
+    assert "preview" not in projected
+
+
+def test_bulky_fields_are_still_bounded():
+    """The projection exists to stay small — adding `preview` must not have
+    relaxed the excerpt caps that justify serving it instead of result_json."""
+    from app.ai.persisted_summary import UI_FILE_PREVIEW_CHARS
+
+    projected = build_tool_context_summary(
+        "read_file", _read_result(text="x" * (UI_FILE_PREVIEW_CHARS * 3))
+    )
+    assert len(projected["text"]) == UI_FILE_PREVIEW_CHARS
+
+
+def test_read_file_is_actually_a_projected_tool():
+    """If read_file ever leaves this set the projection stops being consulted,
+    and these tests would pass while proving nothing."""
+    assert "read_file" in SUMMARIZED_TOOL_NAMES

--- a/backend/tests/unit/test_read_file_source_document.py
+++ b/backend/tests/unit/test_read_file_source_document.py
@@ -277,6 +277,41 @@ class TestPreviewContract:
         assert pv["kind"] == "image"
         assert pv["file_id"] == f.id
         assert pv["image_file_ids"] == [f.id]
+        # A picture IS the content — the card auto-shows it.
+        assert pv["derived"] is False
+
+    def test_document_renders_are_marked_derived(self):
+        """Rasterized pages of a document are a lossy stand-in; the flag lets
+        the card keep the gallery collapsed until the user asks for it."""
+        from app.ai.tools.implementations.read_file import _build_preview
+
+        pv = _build_preview(
+            {"image_file_ids": ["r1", "r2"], "pages_total": 2},
+            preview_file_id=None,
+        )
+        assert pv["kind"] == "image"
+        assert pv["derived"] is True
+
+    def test_a_source_picture_is_never_derived(self):
+        """Even when the id points at a normalized re-encode of the picture,
+        it is still the picture the user has — auto-show it."""
+        from app.ai.tools.implementations.read_file import _build_preview
+
+        pv = _build_preview(
+            {"image_file_ids": ["p1"]},
+            preview_file_id=None, source_is_image=True,
+        )
+        assert pv["kind"] == "image"
+        assert pv["derived"] is False
+
+    def test_non_image_previews_carry_derived_false(self):
+        from app.ai.tools.implementations.read_file import _build_preview
+
+        pv = _build_preview(
+            {"file_name": "a.pdf"}, preview_file_id="F1",
+        )
+        assert pv["kind"] == "pdf"
+        assert pv["derived"] is False
 
     @pytest.mark.asyncio
     async def test_tabular_read_previews_as_a_table(self, tmp_path):
@@ -387,6 +422,32 @@ class TestSingleFetch:
         pv = payload["output"]["preview"]
         assert pv["kind"] == "pdf"
         assert pv["file_id"] == "SRC-1"
+
+    @pytest.mark.asyncio
+    async def test_as_images_escalation_reuses_the_bytes_from_the_read(self):
+        """"Read as text, then re-read as_images" must not re-download: the
+        escalation renders from the bytes the read already carried
+        (DocumentText.raw), and read_raw_bytes stays untouched for remote
+        sources. RemoteLikeClient raises on any raw read, so a regression
+        fails loudly."""
+        pdf = build_multipage_pdf(PAGES)
+        client = self._remote_like(pdf)
+        model = MagicMock()
+        model.supports_vision = True
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")):
+            payload = await _run_read(
+                {"connection_id": "C1", "file_id": "01LZCXOPAQUE9F3",
+                 "as_images": True},
+                {"model": model},
+            )
+
+        assert client.reads == 1
+        assert client.raw_reads == 0
+        out = payload["output"]
+        assert out["content_type"] == "images"
+        # Vision received the rendered pages.
+        assert payload["observation"]["images"]
 
 
 class TestPageRangeReusesTheFetch:

--- a/backend/tests/unit/test_read_file_source_document.py
+++ b/backend/tests/unit/test_read_file_source_document.py
@@ -55,7 +55,11 @@ class TestSourceDocumentIsKept:
         )
         out = payload["output"]
         assert out["success"] is True
-        assert out["session_file_id"] == "SRC-1"
+        # The kept document is a VIEWER copy: it reaches the UI through
+        # preview.file_id only. As session_file_id it would be a raw PDF the
+        # output schema advertises as inspect_data / read_excel_as_csv input.
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == "SRC-1"
         # The page slice still reaches the model.
         assert out["pages_shown"] == "2-2" and out["pages_total"] == 3
         assert "UNIQUE-B" in (payload["observation"].get("details") or "")
@@ -64,6 +68,8 @@ class TestSourceDocumentIsKept:
         assert kw["content_bytes"].startswith(b"%PDF")
         assert kw["filename"] == "book.pdf"
         assert kw["mime_type"] == "application/pdf"
+        # Viewer copies stay off the analysis roster.
+        assert kw["analysis"] is False
 
     @pytest.mark.asyncio
     async def test_source_ref_cannot_clobber_the_rendered_copy(self, tmp_path):
@@ -80,15 +86,17 @@ class TestSourceDocumentIsKept:
 
     @pytest.mark.asyncio
     async def test_session_pdf_is_not_re_attached(self, tmp_path):
-        """A conversation attachment IS the original — echo its id instead of
-        minting a duplicate row on every page read."""
+        """A conversation attachment IS the original — the preview points at its
+        own id instead of minting a duplicate row on every page read."""
         f = _mk_file(tmp_path, "book.pdf", build_multipage_pdf(PAGES), "application/pdf")
         with patch(_ATTACH, new=AsyncMock(return_value="SHOULD-NOT-BE-USED")) as attach:
             payload = await _run_read(
                 {"connection_id": "", "file_id": f.id, "page_range": "2"},
                 _runtime_ctx([f]),
             )
-        assert payload["output"]["session_file_id"] == f.id
+        out = payload["output"]
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == f.id
         attach.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -126,7 +134,8 @@ class TestRasterizedDocumentsAreNotImages:
         )
         out = payload["output"]
         assert out["content_type"] == "images"
-        assert out["session_file_id"] == "SRC-1"
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == "SRC-1"
         assert "image_file_ids" not in out
         # Vision still received the rendered pages.
         assert payload["observation"]["images"]
@@ -197,6 +206,8 @@ class TestReadSourceBytesNormalizesClientShapes:
     [
         ("scan.PNG", True),
         ("photo.jpeg", True),
+        ("scan.tiff", False),  # PIL decodes TIFF but no mainstream browser renders it
+        ("scan.tif", False),
         ("report.pdf", False),
         ("deck.pptx", False),
         ("noextension", False),

--- a/backend/tests/unit/test_read_file_source_document.py
+++ b/backend/tests/unit/test_read_file_source_document.py
@@ -1,0 +1,378 @@
+"""read_file must leave behind the ORIGINAL document, not just a derivative.
+
+A page-scoped read used to return no file id at all: both `page_range`
+branches returned before `_persist_session_file` / `_finalize`, so the UI had
+nothing to open and the model got no handle back. These tests pin the fixed
+contract — the read keeps the real .pdf so the card can render it at the page
+that was actually read (/api/files/{id}/embed#page=N) — plus the two traps
+that make it subtle: the source_ref must not collide with the rendered copy,
+and a rasterized document must never be reported as an image.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.ai.tools.implementations import _file_tool_common as _ftc
+from app.ai.tools.implementations._file_tool_common import (
+    is_picture_name,
+    read_source_bytes,
+)
+from app.data_sources.clients.network_dir_client import NetworkDirClient
+from tests.unit.test_pdf_surrogate_sanitization import build_multipage_pdf
+from tests.unit.test_read_file_session_files import (
+    _mk_file,
+    _run_read,
+    _runtime_ctx,
+    _textless_pdf,
+)
+
+PAGES = ["Alpha page UNIQUE-A", "Bravo page UNIQUE-B", "Charlie page UNIQUE-C"]
+
+# Where persist_source_document reaches for the attach helper. read_file.py
+# holds its own reference for page images, so patching this one isolates the
+# source-document write from everything else the tool persists.
+_ATTACH = "app.ai.tools.implementations._file_tool_common.attach_drive_file_to_session"
+_RESOLVE = "app.ai.tools.implementations.read_file.resolve_file_client"
+
+
+async def _read_connector(tmp_path, tool_input, runtime_ctx=None, attach_id="SRC-1"):
+    client = NetworkDirClient(root_path=str(tmp_path))
+    with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+            patch(_ATTACH, new=AsyncMock(return_value=attach_id)) as attach:
+        payload = await _run_read(tool_input, runtime_ctx or {})
+    return payload, attach
+
+
+class TestSourceDocumentIsKept:
+    @pytest.mark.asyncio
+    async def test_page_range_keeps_the_real_pdf(self, tmp_path):
+        """The persisted bytes are the PDF itself — not the extracted text."""
+        (tmp_path / "book.pdf").write_bytes(build_multipage_pdf(PAGES))
+        payload, attach = await _read_connector(
+            tmp_path, {"connection_id": "C1", "file_id": "book.pdf", "page_range": "2"}
+        )
+        out = payload["output"]
+        assert out["success"] is True
+        assert out["session_file_id"] == "SRC-1"
+        # The page slice still reaches the model.
+        assert out["pages_shown"] == "2-2" and out["pages_total"] == 3
+        assert "UNIQUE-B" in (payload["observation"].get("details") or "")
+
+        kw = attach.await_args.kwargs
+        assert kw["content_bytes"].startswith(b"%PDF")
+        assert kw["filename"] == "book.pdf"
+        assert kw["mime_type"] == "application/pdf"
+
+    @pytest.mark.asyncio
+    async def test_source_ref_cannot_clobber_the_rendered_copy(self, tmp_path):
+        """The rendered .txt/.csv row is keyed on a bare file_id and is what the
+        model was handed; the source copy must key on something else or the
+        attach helper refreshes the wrong row in place."""
+        (tmp_path / "book.pdf").write_bytes(build_multipage_pdf(PAGES))
+        _, attach = await _read_connector(
+            tmp_path, {"connection_id": "C1", "file_id": "book.pdf", "page_range": "2"}
+        )
+        ref = attach.await_args.kwargs["source_ref"]
+        assert ref == "book.pdf#source"
+        assert ref != "book.pdf"
+
+    @pytest.mark.asyncio
+    async def test_session_pdf_is_not_re_attached(self, tmp_path):
+        """A conversation attachment IS the original — echo its id instead of
+        minting a duplicate row on every page read."""
+        f = _mk_file(tmp_path, "book.pdf", build_multipage_pdf(PAGES), "application/pdf")
+        with patch(_ATTACH, new=AsyncMock(return_value="SHOULD-NOT-BE-USED")) as attach:
+            payload = await _run_read(
+                {"connection_id": "", "file_id": f.id, "page_range": "2"},
+                _runtime_ctx([f]),
+            )
+        assert payload["output"]["session_file_id"] == f.id
+        attach.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_oversize_source_is_skipped_but_the_read_succeeds(
+        self, tmp_path, monkeypatch
+    ):
+        """Past the cap the preview copy is dropped — never the read itself."""
+        (tmp_path / "book.pdf").write_bytes(build_multipage_pdf(PAGES))
+        monkeypatch.setattr(_ftc, "_PREVIEW_MAX_BYTES", 10)
+        payload, attach = await _read_connector(
+            tmp_path, {"connection_id": "C1", "file_id": "book.pdf", "page_range": "2"}
+        )
+        out = payload["output"]
+        assert out["success"] is True
+        assert out.get("session_file_id") is None
+        assert out["pages_shown"] == "2-2"
+        attach.assert_not_awaited()
+
+
+class TestRasterizedDocumentsAreNotImages:
+    @pytest.mark.asyncio
+    async def test_document_id_never_lands_in_image_file_ids(self, tmp_path):
+        """A scanned PDF renders to page images for vision, but the file we keep
+        is the PDF. Reporting that id under image_file_ids gives the UI a broken
+        <img> and the model the wrong type."""
+        (tmp_path / "scan.pdf").write_bytes(
+            _textless_pdf([(200, 100), (300, 150), (400, 200)])
+        )
+        model = MagicMock()
+        model.supports_vision = True
+        payload, _ = await _read_connector(
+            tmp_path,
+            {"connection_id": "C1", "file_id": "scan.pdf", "page_range": "2"},
+            runtime_ctx={"model": model},
+        )
+        out = payload["output"]
+        assert out["content_type"] == "images"
+        assert out["session_file_id"] == "SRC-1"
+        assert "image_file_ids" not in out
+        # Vision still received the rendered pages.
+        assert payload["observation"]["images"]
+        assert out["pages_shown"] == "2-2"
+
+    @pytest.mark.asyncio
+    async def test_whole_file_session_pdf_is_not_reported_as_an_image(self, tmp_path):
+        """The direct regression: a scanned PDF attached to the conversation is
+        rasterized for vision, and its own File id used to come back as
+        image_file_ids — an id whose bytes are a PDF, not a picture."""
+        f = _mk_file(
+            tmp_path, "scan.pdf",
+            _textless_pdf([(200, 100), (300, 150)]), "application/pdf",
+        )
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        out = payload["output"]
+        assert out["content_type"] == "images"
+        assert out["session_file_id"] == f.id
+        assert "image_file_ids" not in out
+        assert payload["observation"]["images"]
+
+    @pytest.mark.asyncio
+    async def test_session_png_still_points_at_itself(self, tmp_path):
+        """The flip side: when the source genuinely IS a picture, its own id is
+        the right image id — re-attaching the bytes on every look would be
+        pure duplication. This is what the guard must NOT break."""
+        from tests.unit.test_read_file_session_files import _png_bytes
+
+        f = _mk_file(tmp_path, "shot.png", _png_bytes(64, 32), "image/png")
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        out = payload["output"]
+        assert out["content_type"] == "images"
+        assert out["image_file_ids"] == [f.id]
+
+
+class TestReadSourceBytesNormalizesClientShapes:
+    @pytest.mark.asyncio
+    async def test_tuple_returning_client(self):
+        class TupleClient:
+            def read_raw_bytes(self, file_id):
+                return b"%PDF-1.4", "real.pdf", "application/pdf"
+
+        content, name, mime = await read_source_bytes(TupleClient(), "docs/real.pdf")
+        assert (content, name, mime) == (b"%PDF-1.4", "real.pdf", "application/pdf")
+
+    @pytest.mark.asyncio
+    async def test_bare_bytes_client_does_not_raise(self):
+        """OneNote returns bare bytes. Unpacking that into three names is a
+        TypeError, which is what this normalization exists to prevent."""
+        class BareBytesClient:
+            def read_raw_bytes(self, file_id):
+                return b"<html>page</html>"
+
+        content, name, mime = await read_source_bytes(
+            BareBytesClient(), "Notebook/Section/Page"
+        )
+        assert content == b"<html>page</html>"
+        assert name == "Page"
+        assert mime is None
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("scan.PNG", True),
+        ("photo.jpeg", True),
+        ("report.pdf", False),
+        ("deck.pptx", False),
+        ("noextension", False),
+        (None, False),
+    ],
+)
+def test_is_picture_name(name, expected):
+    assert is_picture_name(name) is expected
+
+
+class TestPreviewContract:
+    """`preview` tells the UI what to render. The frontend must never have to
+    infer it: the stored session file is often a derivative of the source."""
+
+    @pytest.mark.asyncio
+    async def test_page_range_previews_the_pdf_at_that_page(self, tmp_path):
+        (tmp_path / "book.pdf").write_bytes(build_multipage_pdf(PAGES))
+        payload, _ = await _read_connector(
+            tmp_path, {"connection_id": "C1", "file_id": "book.pdf", "page_range": "2-3"}
+        )
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "pdf"
+        assert pv["file_id"] == "SRC-1"
+        assert pv["mime"] == "application/pdf"
+        assert pv["target_page"] == 2
+        assert pv["pages_total"] == 3
+
+    @pytest.mark.asyncio
+    async def test_scanned_pdf_previews_the_document_not_the_render(self, tmp_path):
+        """The requirement: even when the backend falls back to PNGs so the
+        model can see the pages, the USER gets the real document."""
+        (tmp_path / "scan.pdf").write_bytes(
+            _textless_pdf([(200, 100), (300, 150), (400, 200)])
+        )
+        model = MagicMock()
+        model.supports_vision = True
+        payload, _ = await _read_connector(
+            tmp_path,
+            {"connection_id": "C1", "file_id": "scan.pdf", "page_range": "2"},
+            runtime_ctx={"model": model},
+        )
+        out = payload["output"]
+        assert out["content_type"] == "images"       # what the model got
+        assert out["preview"]["kind"] == "pdf"       # what the user gets
+        assert out["preview"]["target_page"] == 2
+
+    @pytest.mark.asyncio
+    async def test_uploaded_pdf_previews_from_its_own_id(self, tmp_path):
+        f = _mk_file(tmp_path, "book.pdf", build_multipage_pdf(PAGES), "application/pdf")
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "pdf"
+        assert pv["file_id"] == f.id
+        assert pv["target_page"] == 1
+
+    @pytest.mark.asyncio
+    async def test_uploaded_png_previews_as_an_image(self, tmp_path):
+        from tests.unit.test_read_file_session_files import _png_bytes
+
+        f = _mk_file(tmp_path, "shot.png", _png_bytes(64, 32), "image/png")
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "image"
+        assert pv["file_id"] == f.id
+        assert pv["image_file_ids"] == [f.id]
+
+    @pytest.mark.asyncio
+    async def test_tabular_read_previews_as_a_table(self, tmp_path):
+        f = _mk_file(tmp_path, "sales.csv", b"a,b\n1,2\n3,4\n", "text/csv")
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "table"
+        # Rendered from this result's own csv — no file to fetch.
+        assert pv["file_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_text_read_previews_as_text(self, tmp_path):
+        f = _mk_file(tmp_path, "notes.txt", b"hello world", "text/plain")
+        payload = await _run_read(
+            {"connection_id": "", "file_id": f.id}, _runtime_ctx([f])
+        )
+        assert payload["output"]["preview"]["kind"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_preview_is_not_written_to_the_shared_cache(self, tmp_path):
+        """_file_cache is keyed on (connection, file, version) and NOT on report,
+        so a File id cached here would be served to a different report."""
+        from app.ai.tools.implementations import _file_cache
+
+        (tmp_path / "notes.txt").write_bytes(b"plain text body")
+        client = NetworkDirClient(root_path=str(tmp_path))
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")), \
+                patch.object(_file_cache, "write") as write:
+            await _run_read({"connection_id": "C1", "file_id": "notes.txt"}, {})
+        if write.call_args:
+            assert "preview" not in write.call_args.kwargs["rendered"]
+            assert "session_file_id" not in write.call_args.kwargs["rendered"]
+
+
+class TestSingleFetch:
+    """The read and the preview must share ONE download. Re-fetching a 20 MB
+    object from S3/SharePoint to render a preview is unacceptable overhead."""
+
+    @staticmethod
+    def _remote_like(pdf_bytes, name="book.pdf"):
+        """Mimics the s3 / graph_drive contract: one fetch returning extracted
+        text that still carries the bytes it came from."""
+        from app.data_sources.clients._file_source_common import DocumentText
+
+        class RemoteLikeClient:
+            def __init__(self):
+                self.reads = 0
+                self.raw_reads = 0
+
+            async def aread_file(self, file_id, **kwargs):
+                self.reads += 1
+                return DocumentText(
+                    "Bravo page UNIQUE-B", raw=pdf_bytes,
+                    name=name, mime="application/pdf",
+                )
+
+            async def afile_version(self, file_id):
+                return None
+
+            def read_raw_bytes(self, file_id):
+                self.raw_reads += 1
+                raise AssertionError(
+                    "second download: the bytes were already fetched by aread_file"
+                )
+
+        return RemoteLikeClient()
+
+    @pytest.mark.asyncio
+    async def test_preview_reuses_the_bytes_from_the_read(self):
+        pdf = build_multipage_pdf(PAGES)
+        client = self._remote_like(pdf)
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")) as attach:
+            # An OPAQUE provider id, as SharePoint/Drive hand out — the name has
+            # to come from the payload, not from parsing the id.
+            payload = await _run_read(
+                {"connection_id": "C1", "file_id": "01LZCXOPAQUE9F3"}, {}
+            )
+
+        assert client.reads == 1
+        assert client.raw_reads == 0
+
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "pdf"
+        assert pv["file_id"] == "SRC-1"
+        assert pv["target_page"] == 1
+
+        # The bytes stored under #source are the real PDF, not the extracted text.
+        source_writes = [
+            c for c in attach.await_args_list
+            if str(c.kwargs.get("source_ref", "")).endswith("#source")
+        ]
+        assert len(source_writes) == 1
+        assert source_writes[0].kwargs["content_bytes"] == pdf
+        assert source_writes[0].kwargs["filename"] == "book.pdf"
+
+    @pytest.mark.asyncio
+    async def test_local_source_without_carried_bytes_still_works(self, tmp_path):
+        """network_dir extracts straight from disk and carries nothing, so it
+        falls back to a re-read — free, because it never left the machine."""
+        (tmp_path / "book.pdf").write_bytes(build_multipage_pdf(PAGES))
+        payload, attach = await _read_connector(
+            tmp_path, {"connection_id": "C1", "file_id": "book.pdf"}
+        )
+        pv = payload["output"]["preview"]
+        assert pv["kind"] == "pdf"
+        assert pv["file_id"] == "SRC-1"

--- a/backend/tests/unit/test_read_file_source_document.py
+++ b/backend/tests/unit/test_read_file_source_document.py
@@ -376,3 +376,118 @@ class TestSingleFetch:
         pv = payload["output"]["preview"]
         assert pv["kind"] == "pdf"
         assert pv["file_id"] == "SRC-1"
+
+
+class TestPageRangeReusesTheFetch:
+    """A page read must not pay for the file twice.
+
+    Graph and S3 have no ranged-read API for this — the client downloads the
+    whole object and extracts the slice locally. Fetching it a second time to
+    keep the original for the viewer made paging through a document cost 2N
+    downloads for N page reads, so the bytes ride along on the result.
+    """
+
+    @staticmethod
+    def _paging_client(pdf_bytes, name="deck.pdf", carry=True):
+        """Mimics graph_drive/s3: one download per read_file, bytes carried on
+        the __doc_pages__ result. `carry=False` is the network_dir shape."""
+        class PagingClient:
+            def __init__(self):
+                self.reads = 0
+                self.raw_reads = 0
+
+            async def aread_file(self, file_id, page_range=None, **kw):
+                self.reads += 1
+                if page_range is None:
+                    raise AssertionError("page_range read expected")
+                out = {
+                    "__doc_pages__": True,
+                    "text": f"pages {page_range[0]}-{page_range[1]}",
+                    "pages_total": 15,
+                    "first": page_range[0],
+                    "last": page_range[1],
+                }
+                if carry:
+                    out["raw"] = pdf_bytes
+                    out["name"] = name
+                return out
+
+            async def afile_version(self, file_id):
+                return None
+
+            def read_raw_bytes(self, file_id):
+                self.raw_reads += 1
+                raise AssertionError(
+                    "second download: the page read already fetched this object"
+                )
+
+        return PagingClient()
+
+    @pytest.mark.asyncio
+    async def test_paging_costs_one_download_per_read(self):
+        pdf = build_multipage_pdf(PAGES)
+        client = self._paging_client(pdf)
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")):
+            for rng in ("1-5", "6-10", "11-15"):
+                payload = await _run_read(
+                    {"connection_id": "C1", "file_id": "01OPAQUEID", "page_range": rng}, {}
+                )
+                assert payload["output"]["success"] is True
+
+        assert client.reads == 3
+        assert client.raw_reads == 0
+
+    @pytest.mark.asyncio
+    async def test_carried_name_makes_the_preview_resolve(self):
+        """An opaque provider id carries no filename, and _build_preview keys the
+        pdf branch off the extension — so without the carried name the document
+        is fetched and stored and then never shown."""
+        pdf = build_multipage_pdf(PAGES)
+        client = self._paging_client(pdf)
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")):
+            payload = await _run_read(
+                {"connection_id": "C1", "file_id": "01OPAQUEID", "page_range": "4-6"}, {}
+            )
+        out = payload["output"]
+        assert out["file_name"] == "deck.pdf"
+        pv = out["preview"]
+        assert pv["kind"] == "pdf"
+        assert pv["file_id"] == "SRC-1"
+        assert pv["target_page"] == 4
+
+    @pytest.mark.asyncio
+    async def test_the_stored_bytes_are_the_real_pdf(self):
+        pdf = build_multipage_pdf(PAGES)
+        client = self._paging_client(pdf)
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")) as attach:
+            await _run_read(
+                {"connection_id": "C1", "file_id": "01OPAQUEID", "page_range": "2"}, {}
+            )
+        writes = [
+            c for c in attach.await_args_list
+            if str(c.kwargs.get("source_ref", "")).endswith("#source")
+        ]
+        assert len(writes) == 1
+        assert writes[0].kwargs["content_bytes"] == pdf
+        assert writes[0].kwargs["filename"] == "deck.pdf"
+
+    @pytest.mark.asyncio
+    async def test_a_client_that_carries_nothing_still_works(self):
+        """network_dir extracts straight from disk and carries no bytes; the
+        fallback re-read is local, so it stays a plain str result."""
+        pdf = build_multipage_pdf(PAGES)
+        client = self._paging_client(pdf, carry=False)
+
+        def local_reread(file_id):
+            return pdf, "deck.pdf", "application/pdf"
+        client.read_raw_bytes = local_reread
+
+        with patch(_RESOLVE, new=AsyncMock(return_value=(client, None))), \
+                patch(_ATTACH, new=AsyncMock(return_value="SRC-1")):
+            payload = await _run_read(
+                {"connection_id": "C1", "file_id": "book.pdf", "page_range": "2"}, {}
+            )
+        assert payload["output"]["preview"]["kind"] == "pdf"

--- a/frontend/components/FilePreview.vue
+++ b/frontend/components/FilePreview.vue
@@ -1,0 +1,186 @@
+<template>
+  <div ref="rootEl" class="w-full relative group/preview">
+    <!-- Opens the same file in the side panel. Hidden where no panel exists
+         (the share view), so the card never offers an action that does
+         nothing — `canExpand` is opt-in per host page. -->
+    <button
+      v-if="canExpand && !expanded"
+      type="button"
+      class="absolute top-2 end-2 z-10 p-1 rounded-md bg-white/90 dark:bg-gray-800/90 border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 opacity-0 group-hover/preview:opacity-100 focus:opacity-100 transition-opacity hover:text-gray-700 dark:hover:text-gray-200"
+      :title="$t('filePreview.openInPanel')"
+      :aria-label="$t('filePreview.openInPanel')"
+      @click="$emit('expand')"
+    >
+      <Icon name="heroicons:arrows-pointing-out" class="w-3.5 h-3.5" />
+    </button>
+
+    <!-- Document: the browser's own PDF viewer, opened at the page that was
+         read. Office files reach here only once converted server-side. -->
+    <template v-if="kind === 'pdf'">
+      <div
+        v-if="!embedUrl"
+        class="flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50"
+        :style="{ height: frameHeight }"
+      >
+        <Spinner v-if="pending || !visible" class="w-4 h-4 text-gray-400" />
+        <span v-else class="text-[11px] text-gray-400 dark:text-gray-500">
+          {{ $t('filePreview.unavailable') }}
+        </span>
+      </div>
+      <iframe
+        v-else
+        :src="frameSrc"
+        :title="name || $t('filePreview.document')"
+        class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white"
+        :style="{ height: frameHeight }"
+      />
+    </template>
+
+    <!-- Pictures, and page renders of a document we could not show natively. -->
+    <template v-else-if="kind === 'image'">
+      <div class="flex flex-col gap-1.5">
+        <AuthenticatedImage
+          v-if="visible && activeImageId"
+          :key="activeImageId"
+          :file-id="activeImageId"
+          :alt="name || ''"
+          :img-class="[
+            'rounded-lg border border-gray-200 dark:border-gray-700 object-contain cursor-zoom-in bg-white',
+            expanded ? 'max-h-[70vh] w-auto' : 'max-h-60 w-auto',
+          ].join(' ')"
+          @click="$emit('open', activeImageId)"
+        />
+
+        <!-- Page strip: only when there is more than one page to move between. -->
+        <div
+          v-if="!visible"
+          class="flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 h-40"
+        >
+          <Spinner class="w-4 h-4 text-gray-400" />
+        </div>
+
+        <div v-if="images.length > 1" class="flex items-center gap-1 flex-wrap">
+          <button
+            v-for="(id, i) in images"
+            :key="id"
+            type="button"
+            class="px-1.5 py-0.5 rounded text-[10px] border transition-colors"
+            :class="id === activeImageId
+              ? 'border-blue-400 text-blue-600 bg-blue-50 dark:bg-blue-900/30'
+              : 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'"
+            @click="activeIndex = i"
+          >
+            {{ $t('filePreview.pageN', { n: i + 1 }) }}
+          </button>
+          <span v-if="truncated && pagesTotal" class="text-[10px] text-gray-400 dark:text-gray-500 ms-1">
+            {{ $t('filePreview.ofTotalPages', { n: images.length, total: pagesTotal }) }}
+          </span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import Spinner from '~/components/Spinner.vue'
+import AuthenticatedImage from '~/components/AuthenticatedImage.vue'
+
+const props = withDefaults(defineProps<{
+  /** What to render. Comes from the backend's `preview.kind` — never inferred. */
+  kind: 'pdf' | 'image'
+  /** File to show. For 'image' this is the first of `imageFileIds`. */
+  fileId?: string | null
+  imageFileIds?: string[] | null
+  /** 1-based page the document viewer should open at. */
+  targetPage?: number | null
+  pagesTotal?: number | null
+  /** Fewer pages rendered than the document has. */
+  truncated?: boolean
+  name?: string | null
+  expanded?: boolean
+  /** Show the "open in side panel" affordance. Off unless the host page has
+   *  a panel to open into. */
+  canExpand?: boolean
+}>(), {
+  fileId: null,
+  imageFileIds: null,
+  targetPage: 1,
+  pagesTotal: null,
+  truncated: false,
+  name: '',
+  expanded: false,
+  canExpand: false,
+})
+
+defineEmits<{
+  (e: 'open', fileId: string): void
+  (e: 'expand'): void
+}>()
+
+const { getEmbedUrl } = useFileEmbedUrl()
+
+const embedUrl = ref('')
+const pending = ref(false)
+
+const images = computed<string[]>(() => props.imageFileIds || (props.fileId ? [props.fileId] : []))
+const activeIndex = ref(0)
+const activeImageId = computed(() => images.value[activeIndex.value] || images.value[0] || '')
+
+const frameHeight = computed(() => (props.expanded ? '70vh' : '260px'))
+// PDF Open Parameters, read by the browser's built-in viewer:
+//   page      open at the page the model actually read
+//   view=FitH fit the page WIDTH to the frame, not a zoomed-in corner
+//   navpanes=0 hide the thumbnail rail — it opens by default and eats roughly
+//             half a panel-sized frame, squeezing the document into what is
+//             left. Useless for the single-page documents this mostly shows,
+//             and the toolbar already carries page navigation.
+const frameSrc = computed(() =>
+  embedUrl.value
+    ? `${embedUrl.value}#page=${props.targetPage || 1}&view=FitH&navpanes=0`
+    : ''
+)
+
+// Lazy: a 30-turn conversation must not open 30 PDF frames on load. The frame
+// is only fetched once its card is near the viewport.
+const rootEl = ref<HTMLElement | null>(null)
+const visible = ref(false)
+let observer: IntersectionObserver | null = null
+
+function stopObserving() {
+  observer?.disconnect()
+  observer = null
+}
+
+onMounted(() => {
+  if (!rootEl.value || typeof IntersectionObserver === 'undefined') {
+    visible.value = true
+    return
+  }
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        visible.value = true
+        stopObserving()
+      }
+    },
+    { rootMargin: '300px' },
+  )
+  observer.observe(rootEl.value)
+})
+
+onUnmounted(stopObserving)
+
+async function load() {
+  if (!visible.value || props.kind !== 'pdf' || !props.fileId) return
+  pending.value = true
+  try {
+    embedUrl.value = await getEmbedUrl(props.fileId)
+  } finally {
+    pending.value = false
+  }
+}
+
+watch([visible, () => props.fileId, () => props.kind], load, { immediate: true })
+watch(() => props.imageFileIds, () => { activeIndex.value = 0 })
+</script>

--- a/frontend/components/FilePreview.vue
+++ b/frontend/components/FilePreview.vue
@@ -118,7 +118,7 @@ defineEmits<{
   (e: 'expand'): void
 }>()
 
-const { getEmbedUrl } = useFileEmbedUrl()
+const { getEmbedUrl, msUntilRefresh } = useFileEmbedUrl()
 
 const embedUrl = ref('')
 const pending = ref(false)
@@ -169,15 +169,38 @@ onMounted(() => {
   observer.observe(rootEl.value)
 })
 
-onUnmounted(stopObserving)
+// A mounted iframe keeps whatever token URL it was given, and `visible` never
+// flips back to false — so without this timer nothing would ever re-run load()
+// and a tab left open past the token's TTL showed a dead 403 frame. Re-mint
+// just after the cache's freshness window closes; the iframe src swaps
+// reactively through frameSrc.
+let refreshTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearRefreshTimer() {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+}
+
+onUnmounted(() => {
+  stopObserving()
+  clearRefreshTimer()
+})
 
 async function load() {
+  clearRefreshTimer()
   if (!visible.value || props.kind !== 'pdf' || !props.fileId) return
   pending.value = true
   try {
     embedUrl.value = await getEmbedUrl(props.fileId)
   } finally {
     pending.value = false
+  }
+  if (embedUrl.value && props.fileId) {
+    // +1s past the freshness cutoff so getEmbedUrl sees a stale entry and
+    // mints a new token instead of serving the same one back.
+    refreshTimer = setTimeout(load, msUntilRefresh(props.fileId) + 1000)
   }
 }
 

--- a/frontend/components/FilePreview.vue
+++ b/frontend/components/FilePreview.vue
@@ -17,18 +17,19 @@
     <!-- Document: the browser's own PDF viewer, opened at the page that was
          read. Office files reach here only once converted server-side. -->
     <template v-if="kind === 'pdf'">
+      <!-- Placeholder only while the token is still being minted. When the
+           mint failed outright, render nothing: the card's text path still
+           exists, and a permanent frame-sized "unavailable" box is worse
+           than no preview. -->
       <div
-        v-if="!embedUrl"
+        v-if="!embedUrl && (pending || !visible)"
         class="flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50"
         :style="{ height: frameHeight }"
       >
-        <Spinner v-if="pending || !visible" class="w-4 h-4 text-gray-400" />
-        <span v-else class="text-[11px] text-gray-400 dark:text-gray-500">
-          {{ $t('filePreview.unavailable') }}
-        </span>
+        <Spinner class="w-4 h-4 text-gray-400" />
       </div>
       <iframe
-        v-else
+        v-else-if="embedUrl"
         :src="frameSrc"
         :title="name || $t('filePreview.document')"
         class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white"

--- a/frontend/components/FileTablePreview.vue
+++ b/frontend/components/FileTablePreview.vue
@@ -1,0 +1,120 @@
+<template>
+  <div v-if="rows.length" class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+    <table class="w-full text-[11px] border-collapse">
+      <thead>
+        <tr class="bg-gray-50 dark:bg-gray-900/60">
+          <th
+            v-for="(h, i) in header"
+            :key="i"
+            class="px-2 py-1 text-start font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap border-b border-gray-200 dark:border-gray-700"
+            dir="auto"
+          >
+            {{ h }}
+          </th>
+          <th v-if="hiddenCols" class="px-2 py-1 text-start font-normal text-gray-400 whitespace-nowrap border-b border-gray-200 dark:border-gray-700">
+            +{{ hiddenCols }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(row, r) in rows"
+          :key="r"
+          class="odd:bg-white even:bg-gray-50/50 dark:odd:bg-transparent dark:even:bg-gray-900/30"
+        >
+          <td
+            v-for="(cell, c) in row"
+            :key="c"
+            class="px-2 py-1 text-start text-gray-700 dark:text-gray-300 whitespace-nowrap max-w-[220px] truncate"
+            :title="cell"
+            dir="auto"
+          >
+            {{ cell }}
+          </td>
+          <td v-if="hiddenCols" class="px-2 py-1 text-gray-300 dark:text-gray-600">…</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div v-if="footer" class="mt-1 text-[10px] text-gray-400 dark:text-gray-500">{{ footer }}</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = withDefaults(defineProps<{
+  csv?: string | null
+  /** The file's REAL row count, which differs from what `csv` holds when the
+   *  read was row-capped — the footer must not imply we are showing it all. */
+  rowCount?: number | null
+  colCount?: number | null
+  maxRows?: number
+  maxCols?: number
+}>(), {
+  csv: '',
+  rowCount: null,
+  colCount: null,
+  maxRows: 10,
+  maxCols: 8,
+})
+
+const { t } = useI18n()
+
+/**
+ * Minimal RFC-4180 parse: quoted fields may contain commas, newlines, and ""
+ * escapes. A naive split(',') mangles exactly the files people care about
+ * (addresses, descriptions, anything with a comma in it).
+ */
+function parseCsv(text: string, rowLimit: number): string[][] {
+  const out: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let quoted = false
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (quoted) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++ } else { quoted = false }
+      } else {
+        field += ch
+      }
+      continue
+    }
+    if (ch === '"') { quoted = true; continue }
+    if (ch === ',') { row.push(field); field = ''; continue }
+    if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && text[i + 1] === '\n') i++
+      row.push(field)
+      field = ''
+      out.push(row)
+      row = []
+      if (out.length > rowLimit) return out
+      continue
+    }
+    field += ch
+  }
+  if (field.length || row.length) { row.push(field); out.push(row) }
+  return out
+}
+
+// +1 for the header line.
+const parsed = computed(() => parseCsv(String(props.csv || ''), props.maxRows + 1))
+const header = computed(() => (parsed.value[0] || []).slice(0, props.maxCols))
+const rows = computed(() =>
+  parsed.value.slice(1, props.maxRows + 1).map((r) => r.slice(0, props.maxCols)),
+)
+
+const totalCols = computed(() => props.colCount ?? (parsed.value[0]?.length || 0))
+const hiddenCols = computed(() => Math.max(0, totalCols.value - props.maxCols))
+
+const footer = computed(() => {
+  if (!rows.value.length) return ''
+  const total = props.rowCount
+  if (total != null && total > rows.value.length) {
+    return t('filePreview.showingRows', { n: rows.value.length, total })
+  }
+  return ''
+})
+</script>

--- a/frontend/components/tools/ReadFileTool.vue
+++ b/frontend/components/tools/ReadFileTool.vue
@@ -29,7 +29,18 @@
     </Transition>
 
     <!-- Visual previews render on success without being asked, the way a
-         chart does in create_data; only plain text waits behind the chevron. -->
+         chart does in create_data; only plain text waits behind the chevron.
+         Exception: page-render galleries of a document (preview.derived) are
+         a lossy stand-in, so they wait behind an explicit click. -->
+    <button
+      v-if="derivedGalleryCollapsed"
+      type="button"
+      class="mb-2 text-[11px] px-2 py-1 rounded border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+      @click="galleryOpen = true"
+    >
+      <Icon name="heroicons-photo" class="w-3 h-3 inline align-text-bottom me-1" />
+      {{ $t('tools.readFile.showPagePreviews', { n: (preview.image_file_ids || []).length }) }}
+    </button>
     <Transition name="fade" appear>
       <div v-if="showVisualPreview" class="mb-2">
         <FilePreview
@@ -202,11 +213,27 @@ const previewText = computed(() => {
 // and content_type here cannot answer it. Older tool executions predate the
 // contract and simply get no visual preview.
 const preview = computed<any>(() => rj.value.preview || { kind: 'none' })
+
+// Document page renders (docx/pptx rasters and the like) auto-collapse; the
+// user opens them explicitly. Absent flag = older execution = old behavior.
+const galleryOpen = ref(false)
+const isDerivedGallery = computed(
+  () => preview.value.kind === 'image' && preview.value.derived === true,
+)
+const derivedGalleryCollapsed = computed(() =>
+  isDerivedGallery.value
+  && !galleryOpen.value
+  && !props.readonly
+  && status.value !== 'running'
+  && !errorMessage.value,
+)
+
 const showVisualPreview = computed(() => {
   if (status.value === 'running' || errorMessage.value) return false
   // Token-backed viewers need an authenticated user; guests get the
   // text-only card they had before previews existed.
   if (props.readonly) return preview.value.kind === 'table'
+  if (isDerivedGallery.value && !galleryOpen.value) return false
   return ['pdf', 'image', 'table'].includes(preview.value.kind)
 })
 

--- a/frontend/components/tools/ReadFileTool.vue
+++ b/frontend/components/tools/ReadFileTool.vue
@@ -4,7 +4,7 @@
       <div class="mb-2 flex items-center text-xs text-gray-500 dark:text-gray-400">
         <span v-if="status === 'running'" class="flex items-center">
           <Spinner class="w-3 h-3 me-1.5 shrink-0 text-gray-400" />
-          <span class="tool-shimmer">{{ modelTitle ? modelTitle + '…' : 'Reading ' + fileLabel + '…' }}</span>
+          <span class="tool-shimmer">{{ modelTitle ? modelTitle + '…' : $t('tools.readFile.reading', { name: fileLabel }) }}</span>
         </span>
         <span
           v-else
@@ -16,26 +16,57 @@
           <Icon v-if="expandable" :name="expanded ? 'heroicons-chevron-down' : 'heroicons-chevron-right'" class="w-3 h-3 me-1 text-gray-400 dark:text-gray-500 rtl-flip" />
           <DataSourceIcon v-if="connIcon" :type="connIcon.type" :connector-key="connIcon.connectorKey" class="w-3 h-3 me-1 shrink-0" />
           <Icon v-else name="heroicons-document-arrow-down" class="w-3 h-3 me-1 text-gray-400" />
-          <span>{{ modelTitle || ('Read ' + fileLabel) }}</span>
+          <span>{{ modelTitle || $t('tools.readFile.read', { name: fileLabel }) }}</span>
           <span v-if="contentType" class="ms-2 text-[10px] px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400">{{ contentType }}</span>
-          <span v-if="rowCount != null" class="ms-2 text-gray-400">{{ rowCount }} rows × {{ colCount }} cols</span>
-          <span v-if="truncated" class="ms-2 text-[10px] text-yellow-600">truncated</span>
+          <span v-if="rowCount != null" class="ms-2 text-gray-400">{{ $t('tools.readFile.rowsCols', { rows: rowCount, cols: colCount }) }}</span>
+          <span v-if="truncated" class="ms-2 text-[10px] text-yellow-600">{{ $t('tools.readFile.truncated') }}</span>
           <span v-if="windowed" class="ms-2 text-[10px] px-1 py-0.5 rounded bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">{{ windowLabel }}</span>
-          <span v-if="pagesShown" class="ms-2 text-[10px] px-1 py-0.5 rounded bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">pages {{ pagesShown }}<template v-if="pagesTotal"> / {{ pagesTotal }}</template></span>
+          <span v-if="pagesShown" class="ms-2 text-[10px] px-1 py-0.5 rounded bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">{{ pagesTotal
+            ? $t('tools.readFile.pagesOfTotal', { shown: pagesShown, total: pagesTotal })
+            : $t('tools.readFile.pages', { shown: pagesShown }) }}</span>
         </span>
       </div>
     </Transition>
 
+    <!-- Visual previews render on success without being asked, the way a
+         chart does in create_data; only plain text waits behind the chevron. -->
+    <Transition name="fade" appear>
+      <div v-if="showVisualPreview" class="mb-2">
+        <FilePreview
+          v-if="preview.kind === 'pdf' || preview.kind === 'image'"
+          :kind="preview.kind"
+          :file-id="preview.file_id"
+          :image-file-ids="preview.image_file_ids"
+          :target-page="preview.target_page"
+          :pages-total="preview.pages_total"
+          :truncated="preview.truncated"
+          :name="rj.file_name"
+          :expanded="expanded"
+          :can-expand="canExpand"
+          @open="openImage"
+          @expand="emitOpenPanel"
+        />
+        <FileTablePreview
+          v-else-if="preview.kind === 'table'"
+          :csv="rj.csv"
+          :row-count="rj.row_count"
+          :col-count="rj.col_count"
+        />
+      </div>
+    </Transition>
+
+    <ImagePreviewModal ref="imageModal" />
+
     <Transition name="fade" appear>
       <div v-if="expanded && expandable" class="text-xs text-gray-600 dark:text-gray-400">
         <div v-if="filePath" class="mb-1 text-[11px] text-gray-500 dark:text-gray-400">
-          <span class="text-gray-400 dark:text-gray-500">Path:</span>
+          <span class="text-gray-400 dark:text-gray-500">{{ $t('tools.readFile.pathLabel') }}</span>
           <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 break-all" dir="ltr">{{ filePath }}</code>
         </div>
-        <pre v-if="hasContent" class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
+        <pre v-if="hasContent && preview.kind !== 'table'" class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
         <div v-if="sessionFileId" class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
           <Icon name="heroicons-paper-clip" class="w-3 h-3 inline align-text-bottom me-0.5" />
-          Attached to this conversation as session file
+          {{ $t('tools.readFile.attachedAsSessionFile') }}
           <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ sessionFileId.slice(0, 8) }}…</code>
         </div>
         <ToolCallParams :params="toolExecution?.arguments_json" />
@@ -50,6 +81,9 @@
 import { computed, ref } from 'vue'
 import Spinner from '~/components/Spinner.vue'
 import ToolCallParams from '~/components/tools/ToolCallParams.vue'
+import FilePreview from '~/components/FilePreview.vue'
+import FileTablePreview from '~/components/FileTablePreview.vue'
+import ImagePreviewModal from '~/components/ImagePreviewModal.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import { useToolConnectionIcon, FILE_SOURCE_TYPES, fileToolNoun } from '~/composables/useToolConnectionIcon'
 
@@ -62,7 +96,26 @@ interface ToolExecution {
   arguments_json?: any
 }
 
-const props = defineProps<{ toolExecution: ToolExecution; dataSources?: any[] }>()
+const props = withDefaults(defineProps<{
+  toolExecution: ToolExecution
+  dataSources?: any[]
+  /** Host page has a side panel to open documents into. */
+  canExpand?: boolean
+}>(), { canExpand: false })
+
+// Only documents and images earn the panel — a ten-row table is already fully
+// readable in the card, and half a screen of it is just noise.
+const emit = defineEmits<{ (e: 'openFilePreview', payload: any): void }>()
+function emitOpenPanel() {
+  emit('openFilePreview', {
+    fileId: preview.value.file_id,
+    kind: preview.value.kind,
+    targetPage: preview.value.target_page,
+    pagesTotal: preview.value.pages_total,
+    imageFileIds: preview.value.image_file_ids,
+    name: rj.value.file_name || '',
+  })
+}
 // files / emails / pages — same card, source-appropriate noun.
 const noun = computed(() => fileToolNoun(props.toolExecution?.tool_name))
 
@@ -137,6 +190,22 @@ const previewText = computed(() => {
   if (rj.value.byte_count) return `(binary, ${rj.value.byte_count} bytes)`
   return ''
 })
+
+// The server decides what to render — the stored session file is often a
+// derivative of the source (report.pdf -> report.pdf.txt), so the file name
+// and content_type here cannot answer it. Older tool executions predate the
+// contract and simply get no visual preview.
+const preview = computed<any>(() => rj.value.preview || { kind: 'none' })
+const showVisualPreview = computed(() =>
+  status.value !== 'running'
+  && !errorMessage.value
+  && ['pdf', 'image', 'table'].includes(preview.value.kind),
+)
+
+const imageModal = ref<any>(null)
+function openImage(fileId: string) {
+  imageModal.value?.open({ id: fileId, filename: rj.value.file_name || '' })
+}
 
 const expanded = ref(false)
 </script>

--- a/frontend/components/tools/ReadFileTool.vue
+++ b/frontend/components/tools/ReadFileTool.vue
@@ -101,7 +101,13 @@ const props = withDefaults(defineProps<{
   dataSources?: any[]
   /** Host page has a side panel to open documents into. */
   canExpand?: boolean
-}>(), { canExpand: false })
+  /** Anonymous/share view (`/c/[token]` passes true). PDF and image previews
+   *  authorize via `/embed_token` / `/content`, which require a signed-in
+   *  user — for guests they 401 and the card would show a permanent
+   *  "Preview unavailable" box. The inline CSV table carries its own data,
+   *  so it stays. */
+  readonly?: boolean
+}>(), { canExpand: false, readonly: false })
 
 // Only documents and images earn the panel — a ten-row table is already fully
 // readable in the card, and half a screen of it is just noise.
@@ -196,11 +202,13 @@ const previewText = computed(() => {
 // and content_type here cannot answer it. Older tool executions predate the
 // contract and simply get no visual preview.
 const preview = computed<any>(() => rj.value.preview || { kind: 'none' })
-const showVisualPreview = computed(() =>
-  status.value !== 'running'
-  && !errorMessage.value
-  && ['pdf', 'image', 'table'].includes(preview.value.kind),
-)
+const showVisualPreview = computed(() => {
+  if (status.value === 'running' || errorMessage.value) return false
+  // Token-backed viewers need an authenticated user; guests get the
+  // text-only card they had before previews existed.
+  if (props.readonly) return preview.value.kind === 'table'
+  return ['pdf', 'image', 'table'].includes(preview.value.kind)
+})
 
 const imageModal = ref<any>(null)
 function openImage(fileId: string) {

--- a/frontend/composables/useFileEmbedUrl.ts
+++ b/frontend/composables/useFileEmbedUrl.ts
@@ -1,0 +1,48 @@
+/**
+ * Short-lived, file-scoped URLs for <iframe> / <img> sources.
+ *
+ * `/api/files/{id}/content` serves `Content-Disposition: attachment`, so an
+ * iframe pointed at it downloads the file instead of rendering it. `/embed`
+ * serves the same bytes `inline` and authorizes with a capability token in the
+ * query string — which is also what makes `#page=N` work: the browser's native
+ * PDF viewer reads that fragment, and a `blob:` URL does not pass it through
+ * reliably across browsers.
+ *
+ * Tokens are minted per render and live an hour (backend core/file_tokens.py),
+ * so they are cached here and re-minted a few minutes BEFORE expiry rather than
+ * on failure — a chat tab left open overnight would otherwise show a dead frame
+ * with no way to know it needs refreshing.
+ */
+const TOKEN_TTL_MS = 60 * 60 * 1000
+const REFRESH_MARGIN_MS = 5 * 60 * 1000
+
+const cache = new Map<string, { url: string; mintedAt: number }>()
+
+export function useFileEmbedUrl() {
+  async function getEmbedUrl(fileId: string): Promise<string> {
+    if (!fileId) return ''
+
+    const hit = cache.get(fileId)
+    if (hit && Date.now() - hit.mintedAt < TOKEN_TTL_MS - REFRESH_MARGIN_MS) {
+      return hit.url
+    }
+
+    try {
+      const { data } = await useMyFetch<any>(`/api/files/${fileId}/embed_token`)
+      const url = (data.value as any)?.url || ''
+      if (!url) return ''
+      cache.set(fileId, { url, mintedAt: Date.now() })
+      return url
+    } catch (e) {
+      console.error('[useFileEmbedUrl] failed to mint embed token for', fileId, e)
+      return ''
+    }
+  }
+
+  /** Drop a cached token — for a retry after the server rejected one. */
+  function invalidate(fileId: string) {
+    cache.delete(fileId)
+  }
+
+  return { getEmbedUrl, invalidate }
+}

--- a/frontend/composables/useFileEmbedUrl.ts
+++ b/frontend/composables/useFileEmbedUrl.ts
@@ -44,5 +44,17 @@ export function useFileEmbedUrl() {
     cache.delete(fileId)
   }
 
-  return { getEmbedUrl, invalidate }
+  /**
+   * How long the current token for `fileId` is still considered fresh.
+   * Mounted frames use this to schedule a re-mint just after the freshness
+   * window closes — the "re-minted a few minutes BEFORE expiry" promise above
+   * is theirs to keep, since a cache check alone only runs on fresh mounts.
+   */
+  function msUntilRefresh(fileId: string): number {
+    const hit = cache.get(fileId)
+    if (!hit) return 0
+    return Math.max(0, TOKEN_TTL_MS - REFRESH_MARGIN_MS - (Date.now() - hit.mintedAt))
+  }
+
+  return { getEmbedUrl, invalidate, msUntilRefresh }
 }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1032,6 +1032,7 @@
 					:pages-total="panelFile.pagesTotal"
 					:name="panelFile.name"
 					:expanded="true"
+					@open="(fid: string) => openImagePreview({ id: fid, filename: panelFile?.name || '' })"
 				/>
 			</div>
 		</template>

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -397,6 +397,8 @@
 													:data-sources="report?.data_sources"
 													:report-id="report_id"
 													:system-completion-id="m.system_completion_id || m.id"
+													:can-expand="!isMobile"
+													@openFilePreview="openFilePreview"
 													@addWidget="handleAddWidgetFromPreview"
 													@refreshDashboard="refreshDashboardFast"
 													@toggleSplitScreen="toggleSplitScreen"
@@ -910,6 +912,25 @@
 					<Icon v-else name="heroicons:cog-6-tooth" class="w-3.5 h-3.5" />
 					{{ currentAgents.length > 1 ? $t('reportView.tabAgents') : (currentAgents[0]?.name || $t('reportView.tabAgent')) }}
 				</button>
+				<!-- Only while a file is open. Carries its own dismiss so there is
+				     an obvious way back to the dashboard. -->
+				<button
+					v-if="panelFile"
+					@click="rightPanelView = 'file'"
+					class="flex items-center gap-1.5 ps-3 pe-2 py-1.5 text-xs font-medium rounded-lg transition-colors max-w-[220px]"
+					:class="rightPanelView === 'file'
+						? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800'
+						: 'text-gray-400 hover:text-gray-600'"
+				>
+					<Icon :name="panelFile.kind === 'image' ? 'heroicons:photo' : 'heroicons:document-text'" class="w-3.5 h-3.5 shrink-0" />
+					<span class="truncate">{{ panelFile.name || $t('filePreview.document') }}</span>
+					<Icon
+						name="heroicons:x-mark"
+						class="w-3 h-3 shrink-0 hover:text-gray-700 dark:hover:text-gray-200"
+						:aria-label="$t('filePreview.closeFilePanel')"
+						@click.stop="closeFilePanel"
+					/>
+				</button>
 			</div>
 			<button
 				@click="toggleSplitScreen"
@@ -997,6 +1018,21 @@
 			<!-- Empty state for grid view -->
 			<div v-else-if="rightPanelView === 'grid' && reportLoaded && !(visualizations || []).length" class="p-4 text-center text-gray-500 dark:text-gray-400 h-full">
 				No dashboard items yet.
+			</div>
+
+			<!-- A document or image opened from a read_file card. Reuses the
+			     same viewer the card renders, at panel size. -->
+			<div v-else-if="rightPanelView === 'file' && panelFile" class="h-full overflow-auto p-3">
+				<FilePreview
+					:key="panelFile.fileId"
+					:kind="panelFile.kind"
+					:file-id="panelFile.fileId"
+					:image-file-ids="panelFile.imageFileIds"
+					:target-page="panelFile.targetPage"
+					:pages-total="panelFile.pagesTotal"
+					:name="panelFile.name"
+					:expanded="true"
+				/>
 			</div>
 		</template>
 	</SplitScreenLayout>
@@ -2243,7 +2279,51 @@ const prefillText = ref('')
 watch(() => report.value?.mode, (m) => { if (m) currentPromptMode.value = m === 'training' ? 'training' : 'chat' }, { immediate: true })
 
 // Right panel view mode
-const rightPanelView = ref<'grid' | 'artifact' | 'agent' | 'summary'>('artifact')
+const rightPanelView = ref<'grid' | 'artifact' | 'agent' | 'summary' | 'file'>('artifact')
+
+// A document/image opened from a read_file card into the side panel. Transient
+// by nature — it exists only while a file is selected, which is why it gets a
+// conditional tab rather than a permanent one. Switching tabs keeps it so the
+// user can come back; the tab's close button is what clears it.
+const panelFile = ref<{
+	fileId: string
+	kind: 'pdf' | 'image'
+	targetPage?: number | null
+	pagesTotal?: number | null
+	imageFileIds?: string[] | null
+	name?: string
+} | null>(null)
+
+function openFilePreview(payload: any) {
+	if (!payload?.fileId) return
+	panelFile.value = payload
+	// Mobile keeps the inline/modal behaviour — mobileView is a separate closed
+	// union and opening a second surface there is its own piece of work.
+	if (isMobile.value) return
+	if (!isSplitScreen.value) toggleSplitScreen()
+	rightPanelView.value = 'file'
+}
+
+// Chat pane width as a fraction of the window, per panel view. A document
+// viewer earns the most room: while a PDF is open, reading it IS the task.
+// 280 matches the floor the manual resizer enforces, so a narrow window can
+// never programmatically produce a pane the user could not drag back.
+const PANEL_LEFT_RATIO: Record<string, number> = {
+	summary: 0.55,
+	agent: 0.45,
+}
+const DEFAULT_LEFT_RATIO = 0.37
+const MIN_LEFT_PANEL_WIDTH = 280
+
+function leftWidthFor(view: string): number {
+	const ratio = PANEL_LEFT_RATIO[view] ?? DEFAULT_LEFT_RATIO
+	return Math.max(MIN_LEFT_PANEL_WIDTH, Math.round(window.innerWidth * ratio))
+}
+
+function closeFilePanel() {
+	panelFile.value = null
+	if (rightPanelView.value === 'file') rightPanelView.value = 'artifact'
+}
 
 // Mobile view mode (full-screen single section on narrow screens)
 const mobileView = ref<'chat' | 'summary' | 'dashboard' | 'agent'>('chat')
@@ -2646,16 +2726,9 @@ watch(() => isSplitScreen.value, () => {
 // Adjust left panel width based on active right panel tab
 watch(rightPanelView, (view) => {
     if (!isSplitScreen.value || isResizing.value) return
-    const windowWidth = window.innerWidth
-    if (view === 'summary') {
-        leftPanelWidth.value = Math.round(windowWidth * 0.55)
-    } else if (view === 'agent') {
-        leftPanelWidth.value = Math.round(windowWidth * 0.45)
-        collapseSidebar()
-    } else {
-        leftPanelWidth.value = Math.round(windowWidth * 0.37)
-        collapseSidebar()
-    }
+    leftPanelWidth.value = leftWidthFor(view)
+    // Summary keeps the sidebar; every other view wants the horizontal room.
+    if (view !== 'summary') collapseSidebar()
 })
 
 function goBack() {
@@ -4286,12 +4359,7 @@ function toggleSplitScreen() {
 	nextTick(() => {
 		isSplitScreen.value = !isSplitScreen.value
 		if (isSplitScreen.value) {
-			const windowWidth = window.innerWidth
-			leftPanelWidth.value = rightPanelView.value === 'summary'
-				? Math.round(windowWidth * 0.55)
-				: rightPanelView.value === 'agent'
-				? Math.round(windowWidth * 0.45)
-				: Math.round(windowWidth * 0.37)
+			leftPanelWidth.value = leftWidthFor(rightPanelView.value)
 			collapseSidebar()
 		}
         safeScrollToBottom()

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "تمت قراءة الصفحة",
       "snapshotting": "جارٍ قراءة الصفحة",
       "working": "جارٍ التصفح"
+    },
+    "readFile": {
+      "reading": "جارٍ قراءة {name}…",
+      "read": "تمت قراءة {name}",
+      "rowsCols": "{rows} صف × {cols} عمود",
+      "truncated": "مقتطع",
+      "pages": "صفحات {shown}",
+      "pagesOfTotal": "صفحات {shown} / {total}",
+      "pathLabel": "المسار:",
+      "attachedAsSessionFile": "مُرفق بهذه المحادثة كملف جلسة"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "إنشاء Webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "عام"
+  },
+  "filePreview": {
+    "unavailable": "المعاينة غير متوفرة",
+    "document": "مستند",
+    "pageN": "صفحة {n}",
+    "ofTotalPages": "{n} من {total} صفحة",
+    "showingRows": "عرض {n} من {total} صف",
+    "openInPanel": "فتح في اللوحة الجانبية",
+    "closeFilePanel": "إغلاق الملف"
   }
 }

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -1497,7 +1497,8 @@
       "pages": "صفحات {shown}",
       "pagesOfTotal": "صفحات {shown} / {total}",
       "pathLabel": "المسار:",
-      "attachedAsSessionFile": "مُرفق بهذه المحادثة كملف جلسة"
+      "attachedAsSessionFile": "مُرفق بهذه المحادثة كملف جلسة",
+      "showPagePreviews": "عرض معاينات الصفحات ({n})"
     }
   },
   "entityCreate": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Seite gelesen",
       "snapshotting": "Seite wird gelesen",
       "working": "Browsen"
+    },
+    "readFile": {
+      "reading": "{name} wird gelesen…",
+      "read": "{name} gelesen",
+      "rowsCols": "{rows} Zeilen × {cols} Spalten",
+      "truncated": "gekürzt",
+      "pages": "Seiten {shown}",
+      "pagesOfTotal": "Seiten {shown} / {total}",
+      "pathLabel": "Pfad:",
+      "attachedAsSessionFile": "Dieser Unterhaltung als Sitzungsdatei angehängt"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Webhook erstellen",
     "defaultName": "Webhook",
     "sourceGeneric": "Allgemein"
+  },
+  "filePreview": {
+    "unavailable": "Vorschau nicht verfügbar",
+    "document": "Dokument",
+    "pageN": "Seite {n}",
+    "ofTotalPages": "{n} von {total} Seiten",
+    "showingRows": "{n} von {total} Zeilen angezeigt",
+    "openInPanel": "In der Seitenleiste öffnen",
+    "closeFilePanel": "Datei schließen"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -1497,7 +1497,8 @@
       "pages": "Seiten {shown}",
       "pagesOfTotal": "Seiten {shown} / {total}",
       "pathLabel": "Pfad:",
-      "attachedAsSessionFile": "Dieser Unterhaltung als Sitzungsdatei angehängt"
+      "attachedAsSessionFile": "Dieser Unterhaltung als Sitzungsdatei angehängt",
+      "showPagePreviews": "Seitenvorschauen anzeigen ({n})"
     }
   },
   "entityCreate": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1526,6 +1526,16 @@
       "moreShown": "+{count} more shown to the agent",
       "filesSkippedSingular": "{count} file skipped ({reasons})",
       "filesSkippedPlural": "{count} files skipped ({reasons})"
+    },
+    "readFile": {
+      "reading": "Reading {name}…",
+      "read": "Read {name}",
+      "rowsCols": "{rows} rows × {cols} cols",
+      "truncated": "truncated",
+      "pages": "pages {shown}",
+      "pagesOfTotal": "pages {shown} / {total}",
+      "pathLabel": "Path:",
+      "attachedAsSessionFile": "Attached to this conversation as session file"
     }
   },
   "entityCreate": {
@@ -4732,5 +4742,14 @@
     "createButton": "Create webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Generic"
+  },
+  "filePreview": {
+    "unavailable": "Preview unavailable",
+    "document": "Document",
+    "pageN": "Page {n}",
+    "ofTotalPages": "{n} of {total} pages",
+    "showingRows": "Showing {n} of {total} rows",
+    "openInPanel": "Open in side panel",
+    "closeFilePanel": "Close file"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1535,7 +1535,8 @@
       "pages": "pages {shown}",
       "pagesOfTotal": "pages {shown} / {total}",
       "pathLabel": "Path:",
-      "attachedAsSessionFile": "Attached to this conversation as session file"
+      "attachedAsSessionFile": "Attached to this conversation as session file",
+      "showPagePreviews": "Show page previews ({n})"
     }
   },
   "entityCreate": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -1509,7 +1509,8 @@
       "pages": "páginas {shown}",
       "pagesOfTotal": "páginas {shown} / {total}",
       "pathLabel": "Ruta:",
-      "attachedAsSessionFile": "Adjuntado a esta conversación como archivo de sesión"
+      "attachedAsSessionFile": "Adjuntado a esta conversación como archivo de sesión",
+      "showPagePreviews": "Mostrar vistas previas de páginas ({n})"
     }
   },
   "entityCreate": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -1500,6 +1500,16 @@
       "snapshotted": "Página leída",
       "snapshotting": "Leyendo la página",
       "working": "Navegando"
+    },
+    "readFile": {
+      "reading": "Leyendo {name}…",
+      "read": "Leído {name}",
+      "rowsCols": "{rows} filas × {cols} columnas",
+      "truncated": "truncado",
+      "pages": "páginas {shown}",
+      "pagesOfTotal": "páginas {shown} / {total}",
+      "pathLabel": "Ruta:",
+      "attachedAsSessionFile": "Adjuntado a esta conversación como archivo de sesión"
     }
   },
   "entityCreate": {
@@ -4734,5 +4744,14 @@
     "createButton": "Crear webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Genérico"
+  },
+  "filePreview": {
+    "unavailable": "Vista previa no disponible",
+    "document": "Documento",
+    "pageN": "Página {n}",
+    "ofTotalPages": "{n} de {total} páginas",
+    "showingRows": "Mostrando {n} de {total} filas",
+    "openInPanel": "Abrir en el panel lateral",
+    "closeFilePanel": "Cerrar archivo"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1497,7 +1497,8 @@
       "pages": "pages {shown}",
       "pagesOfTotal": "pages {shown} / {total}",
       "pathLabel": "Chemin :",
-      "attachedAsSessionFile": "Joint à cette conversation en tant que fichier de session"
+      "attachedAsSessionFile": "Joint à cette conversation en tant que fichier de session",
+      "showPagePreviews": "Afficher les aperçus des pages ({n})"
     }
   },
   "entityCreate": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Page lue",
       "snapshotting": "Lecture de la page",
       "working": "Navigation"
+    },
+    "readFile": {
+      "reading": "Lecture de {name}…",
+      "read": "{name} lu",
+      "rowsCols": "{rows} lignes × {cols} colonnes",
+      "truncated": "tronqué",
+      "pages": "pages {shown}",
+      "pagesOfTotal": "pages {shown} / {total}",
+      "pathLabel": "Chemin :",
+      "attachedAsSessionFile": "Joint à cette conversation en tant que fichier de session"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Créer le webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Générique"
+  },
+  "filePreview": {
+    "unavailable": "Aperçu indisponible",
+    "document": "Document",
+    "pageN": "Page {n}",
+    "ofTotalPages": "{n} sur {total} pages",
+    "showingRows": "Affichage de {n} sur {total} lignes",
+    "openInPanel": "Ouvrir dans le panneau latéral",
+    "closeFilePanel": "Fermer le fichier"
   }
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -1500,6 +1500,16 @@
       "snapshotted": "הדף נקרא",
       "snapshotting": "קורא את הדף",
       "working": "גולש"
+    },
+    "readFile": {
+      "reading": "קורא את {name}…",
+      "read": "נקרא {name}",
+      "rowsCols": "{rows} שורות × {cols} עמודות",
+      "truncated": "נחתך",
+      "pages": "עמודים {shown}",
+      "pagesOfTotal": "עמודים {shown} / {total}",
+      "pathLabel": "נתיב:",
+      "attachedAsSessionFile": "צורף לשיחה זו כקובץ סשן"
     }
   },
   "entityCreate": {
@@ -4734,5 +4744,14 @@
     "createButton": "יצירת Webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "כללי"
+  },
+  "filePreview": {
+    "unavailable": "התצוגה המקדימה אינה זמינה",
+    "document": "מסמך",
+    "pageN": "עמוד {n}",
+    "ofTotalPages": "{n} מתוך {total} עמודים",
+    "showingRows": "מוצגות {n} מתוך {total} שורות",
+    "openInPanel": "פתיחה בפאנל הצדדי",
+    "closeFilePanel": "סגירת הקובץ"
   }
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -1509,7 +1509,8 @@
       "pages": "עמודים {shown}",
       "pagesOfTotal": "עמודים {shown} / {total}",
       "pathLabel": "נתיב:",
-      "attachedAsSessionFile": "צורף לשיחה זו כקובץ סשן"
+      "attachedAsSessionFile": "צורף לשיחה זו כקובץ סשן",
+      "showPagePreviews": "הצג תצוגות מקדימות של עמודים ({n})"
     }
   },
   "entityCreate": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Pagina letta",
       "snapshotting": "Lettura della pagina",
       "working": "Navigazione"
+    },
+    "readFile": {
+      "reading": "Lettura di {name}…",
+      "read": "Letto {name}",
+      "rowsCols": "{rows} righe × {cols} colonne",
+      "truncated": "troncato",
+      "pages": "pagine {shown}",
+      "pagesOfTotal": "pagine {shown} / {total}",
+      "pathLabel": "Percorso:",
+      "attachedAsSessionFile": "Allegato a questa conversazione come file di sessione"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Crea webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Generico"
+  },
+  "filePreview": {
+    "unavailable": "Anteprima non disponibile",
+    "document": "Documento",
+    "pageN": "Pagina {n}",
+    "ofTotalPages": "{n} di {total} pagine",
+    "showingRows": "Visualizzate {n} di {total} righe",
+    "openInPanel": "Apri nel pannello laterale",
+    "closeFilePanel": "Chiudi file"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -1497,7 +1497,8 @@
       "pages": "pagine {shown}",
       "pagesOfTotal": "pagine {shown} / {total}",
       "pathLabel": "Percorso:",
-      "attachedAsSessionFile": "Allegato a questa conversazione come file di sessione"
+      "attachedAsSessionFile": "Allegato a questa conversazione come file di sessione",
+      "showPagePreviews": "Mostra anteprime delle pagine ({n})"
     }
   },
   "entityCreate": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Página lida",
       "snapshotting": "Lendo a página",
       "working": "Navegando"
+    },
+    "readFile": {
+      "reading": "A ler {name}…",
+      "read": "Lido {name}",
+      "rowsCols": "{rows} linhas × {cols} colunas",
+      "truncated": "truncado",
+      "pages": "páginas {shown}",
+      "pagesOfTotal": "páginas {shown} / {total}",
+      "pathLabel": "Caminho:",
+      "attachedAsSessionFile": "Anexado a esta conversa como ficheiro de sessão"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Criar webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Genérico"
+  },
+  "filePreview": {
+    "unavailable": "Pré-visualização indisponível",
+    "document": "Documento",
+    "pageN": "Página {n}",
+    "ofTotalPages": "{n} de {total} páginas",
+    "showingRows": "A mostrar {n} de {total} linhas",
+    "openInPanel": "Abrir no painel lateral",
+    "closeFilePanel": "Fechar ficheiro"
   }
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1497,7 +1497,8 @@
       "pages": "páginas {shown}",
       "pagesOfTotal": "páginas {shown} / {total}",
       "pathLabel": "Caminho:",
-      "attachedAsSessionFile": "Anexado a esta conversa como ficheiro de sessão"
+      "attachedAsSessionFile": "Anexado a esta conversa como ficheiro de sessão",
+      "showPagePreviews": "Mostrar pré-visualizações de páginas ({n})"
     }
   },
   "entityCreate": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Страница прочитана",
       "snapshotting": "Читает страницу",
       "working": "Работает в браузере"
+    },
+    "readFile": {
+      "reading": "Чтение {name}…",
+      "read": "Прочитано {name}",
+      "rowsCols": "{rows} строк × {cols} столбцов",
+      "truncated": "усечено",
+      "pages": "стр. {shown}",
+      "pagesOfTotal": "стр. {shown} / {total}",
+      "pathLabel": "Путь:",
+      "attachedAsSessionFile": "Прикреплено к этому диалогу как файл сессии"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Создать webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Обычный"
+  },
+  "filePreview": {
+    "unavailable": "Предпросмотр недоступен",
+    "document": "Документ",
+    "pageN": "Стр. {n}",
+    "ofTotalPages": "{n} из {total} страниц",
+    "showingRows": "Показано {n} из {total} строк",
+    "openInPanel": "Открыть в боковой панели",
+    "closeFilePanel": "Закрыть файл"
   }
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1497,7 +1497,8 @@
       "pages": "стр. {shown}",
       "pagesOfTotal": "стр. {shown} / {total}",
       "pathLabel": "Путь:",
-      "attachedAsSessionFile": "Прикреплено к этому диалогу как файл сессии"
+      "attachedAsSessionFile": "Прикреплено к этому диалогу как файл сессии",
+      "showPagePreviews": "Показать предпросмотр страниц ({n})"
     }
   },
   "entityCreate": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -1488,6 +1488,16 @@
       "snapshotted": "Läste sidan",
       "snapshotting": "Läser sidan",
       "working": "Surfar"
+    },
+    "readFile": {
+      "reading": "Läser {name}…",
+      "read": "Läste {name}",
+      "rowsCols": "{rows} rader × {cols} kolumner",
+      "truncated": "avkortad",
+      "pages": "sidor {shown}",
+      "pagesOfTotal": "sidor {shown} / {total}",
+      "pathLabel": "Sökväg:",
+      "attachedAsSessionFile": "Bifogad till denna konversation som sessionsfil"
     }
   },
   "entityCreate": {
@@ -4736,5 +4746,14 @@
     "createButton": "Skapa webhook",
     "defaultName": "Webhook",
     "sourceGeneric": "Allmän"
+  },
+  "filePreview": {
+    "unavailable": "Förhandsgranskning ej tillgänglig",
+    "document": "Dokument",
+    "pageN": "Sida {n}",
+    "ofTotalPages": "{n} av {total} sidor",
+    "showingRows": "Visar {n} av {total} rader",
+    "openInPanel": "Öppna i sidopanelen",
+    "closeFilePanel": "Stäng filen"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -1497,7 +1497,8 @@
       "pages": "sidor {shown}",
       "pagesOfTotal": "sidor {shown} / {total}",
       "pathLabel": "Sökväg:",
-      "attachedAsSessionFile": "Bifogad till denna konversation som sessionsfil"
+      "attachedAsSessionFile": "Bifogad till denna konversation som sessionsfil",
+      "showPagePreviews": "Visa sidförhandsvisningar ({n})"
     }
   },
   "entityCreate": {


### PR DESCRIPTION
## What

`read_file` cards rendered a text excerpt even when the file was a PDF, spreadsheet or image. The result now carries an explicit `preview` contract and the card renders the real file.

| file | card shows |
|---|---|
| PDF (incl. `page_range`, scanned) | the PDF, opened at the page the model read |
| Excel / CSV | compact HTML table |
| PNG / JPEG | image, click to expand |
| Word / PowerPoint | text only — needs LibreOffice conversion, deferred |

**A document always beats its page renders.** A scanned PDF is rasterized so a vision model can read it, but the user is still shown the PDF at the right page.

Verified end-to-end against a live SharePoint connection: 9 of 10 real files preview correctly.

## Three defects fixed along the way

**`Content-Disposition` 500'd on non-Latin filenames.** HTTP headers are latin-1, and the filename was interpolated straight in, so any file named in Hebrew/Cyrillic/CJK returned `UnicodeEncodeError` on both the download and embed routes. Now emits both RFC 6266 forms, matching the pattern already used by the report/export routes.

**PDF text came out of `pypdf` in paint order**, which reverses every word of an RTL line. The characters are all valid, correctly-encoded Hebrew — just in the wrong order — so no garble heuristic could catch it and the model answered confidently wrong about the user's own document. Extraction moved to PDFium, already a dependency via `pypdfium2`. Identical output on Latin documents.

**`preview` was dropped by the persisted UI projection.** Report read endpoints serve `context_summary_json`, not `result_json`, so the preview rendered live and then vanished the moment a finished turn was refetched. Added to the allowlist.

Backfilled with a targeted script rather than bumping `CONTEXT_SUMMARY_VERSION`: that would invalidate `create_data`/`write_csv` projections too and reload their row payloads on **every** report open — measured at ~2.8 ms/MB, and never persisted, so the cost repeats forever.

## No second download

Connector clients already held the file bytes in memory when they extracted text and then discarded them. `DocumentText` carries them through (mirroring the existing `NamedBytes`), so the original document is stored for the viewer without re-fetching — confirmed against real SharePoint. `network_dir` keeps returning a plain `str`; re-reading a local file is free and holding every document in memory would not be.

## Notes

- `/embed` (inline) backs the PDF iframe; `/content` sets `attachment` and would download instead of render.
- Previews lazy-mount on scroll — a long conversation must not open dozens of iframes.
- New UI strings added to all 10 locales; layout uses logical properties for RTL.

## Verification

- 240+ backend tests; the new suites were confirmed to fail on `main` so they cover real defects
- Frontend build clean, code confirmed present in the shipped bundle
- Live checks against the running app and a real SharePoint tenant

Not yet exercised in a browser end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
