### PR TITLE
fix(rtl): use dominant-direction estimation for mixed-language markdown

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder_v3.py
+++ b/backend/app/ai/agents/planner/prompt_builder_v3.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional
 
 from app.ai.llm.types import Message, ToolSpec
 from app.ai.context.parts import TextPart as _TextPart
+from app.ai.prompt_language import language_directive_body
 from app.schemas.ai.planner import PlannerInput, PlannerInputV3, ToolDescriptor
 
 from . import transcript_bridge
@@ -290,6 +291,13 @@ class PromptBuilderV3:
         )
         rca_notes_bit = ", recording verdicts in notes as they land" if _notes_on else ""
 
+        # Mirror-the-user's-language rule (same body as the legacy planner /
+        # reporter / answer agents). The org locale only serves as the fallback
+        # for messages too short to detect a language from — it is org-level
+        # config, stable for the session, so it keeps the system prompt
+        # cache-friendly.
+        language_text = language_directive_body(getattr(planner_input, "locale", None))
+
         # NOTE: do NOT embed wall-clock time in the system prompt — it would
         # invalidate Anthropic's prompt cache on every call. The current date
         # is rendered into the per-turn user message instead (see
@@ -356,6 +364,9 @@ DASHBOARDS
 
 DOCUMENTS
 - "report", "analysis", "write-up", "memo", "root cause", "summarize in a doc" → `create_doc`: YOU author polished markdown with citations for every number, embedding live charts via `{{viz:<uuid>}}` — create the data FIRST, then the doc (structure and mermaid rules are in the tool's description). "dashboard", "monitor", "track" → `create_artifact`. Genuinely ambiguous → dashboard, with the written summary in your final message. Write docs in the user's language. Edit docs with `edit_doc` (read_artifact first unless the current markdown is in context).
+
+LANGUAGE
+{language_text}
 
 COMMUNICATION
 - Final text (no tool call) is the complete answer: plain language, markdown OK, summarize findings — don't dump raw widget data.

--- a/backend/app/ai/prompt_language.py
+++ b/backend/app/ai/prompt_language.py
@@ -48,6 +48,35 @@ def resolve_locale(organization_settings: Optional[OrganizationSettingsConfig]) 
     return default
 
 
+def language_directive_body(locale: Optional[str] = None) -> str:
+    """The mirror-the-user's-language rule, without a header.
+
+    ``locale`` is the org locale code used only as the fallback for messages
+    too short or ambiguous to detect a language from; None falls back to the
+    system default locale. Callers wrap this in whatever header matches their
+    prompt's formatting (``build_language_directive`` for markdown-styled
+    prompts, PromptBuilderV3 for its caps-header style).
+    """
+    if not locale:
+        locale = settings.bow_config.i18n.default_locale
+    fallback = _LOCALE_NAMES.get(locale, locale)
+    return (
+        f"ALWAYS respond in the same language as the user's most recent message. "
+        f"Detect the language from the user's message itself and reply in that "
+        f"language. This takes priority over the language of everything else in "
+        f"context: tool output, fetched web pages, database rows, table and "
+        f"column names, schemas, and any organization instructions written in "
+        f"another language. If the user writes in Hebrew, respond in Hebrew, even "
+        f"when the data or page content is in English; if the user writes in "
+        f"English, respond in English, even when the data or page content is in "
+        f"another language. If the user switches languages mid-conversation, "
+        f"switch with them. When the user's message is too short or ambiguous to "
+        f"determine a language (for example a bare number or a URL), default to "
+        f"{fallback}. Always keep code, SQL, column names, identifiers, and JSON "
+        f"field names in English."
+    )
+
+
 def build_language_directive(organization_settings: Optional[OrganizationSettingsConfig]) -> str:
     """Return a system-prompt snippet that pins the response language.
 
@@ -62,20 +91,4 @@ def build_language_directive(organization_settings: Optional[OrganizationSetting
     directive is present.
     """
     locale = resolve_locale(organization_settings)
-    fallback = _LOCALE_NAMES.get(locale, locale)
-    return (
-        f"\n\n**Language**:\n"
-        f"ALWAYS respond in the same language as the user's most recent message. "
-        f"Detect the language from the user's message itself and reply in that "
-        f"language. This takes priority over the language of everything else in "
-        f"context: tool output, fetched web pages, database rows, table and "
-        f"column names, schemas, and any organization instructions written in "
-        f"another language. If the user writes in Hebrew, respond in Hebrew, even "
-        f"when the data or page content is in English; if the user writes in "
-        f"English, respond in English, even when the data or page content is in "
-        f"another language. If the user switches languages mid-conversation, "
-        f"switch with them. When the user's message is too short or ambiguous to "
-        f"determine a language (for example a bare number or a URL), default to "
-        f"{fallback}. Always keep code, SQL, column names, identifiers, and JSON "
-        f"field names in English.\n"
-    )
+    return f"\n\n**Language**:\n{language_directive_body(locale)}\n"

--- a/backend/tests/unit/test_prompt_language.py
+++ b/backend/tests/unit/test_prompt_language.py
@@ -44,3 +44,37 @@ def test_org_locale_is_only_the_ambiguous_fallback():
         assert "Hebrew" in directive
         # ...but the primary rule still mirrors the user.
         assert "most recent message" in directive.lower()
+
+
+def _v3_system(**kwargs) -> str:
+    from app.ai.agents.planner.prompt_builder_v3 import PromptBuilderV3
+    from app.schemas.ai.planner import PlannerInput
+
+    defaults = dict(
+        user_message="hello",
+        organization_name="Acme",
+        organization_ai_analyst_name="Analyst",
+    )
+    defaults.update(kwargs)
+    return PromptBuilderV3._build_system(PlannerInput(**defaults))
+
+
+def test_planner_v3_system_prompt_carries_the_language_directive():
+    # Regression guard: PlannerV3 is the default planner and its final text IS
+    # the user-facing answer, so its system prompt must carry the same
+    # mirror-the-user's-language rule as the legacy planner/answer agents.
+    # Without it, a Hebrew question against an English system prompt and
+    # English schemas gets an English reply.
+    system = _v3_system()
+    assert "LANGUAGE" in system
+    assert "ALWAYS respond in the same language as the user's most recent message" in system
+
+
+def test_planner_v3_language_fallback_uses_org_locale():
+    # The org locale names only the fallback for ambiguous messages; the
+    # primary rule still mirrors the user's message.
+    system = _v3_system(locale="he")
+    assert "Hebrew" in system
+    assert "most recent message" in system.lower()
+    # No locale -> the system default (English) is the ambiguous fallback.
+    assert "default to English" in _v3_system()

--- a/frontend/assets/css/rtl.css
+++ b/frontend/assets/css/rtl.css
@@ -130,22 +130,26 @@
 [dir="rtl"] .markstream-vue .text-right { text-align: end; }
 
 /* 7b. Mixed-locale markdown: UI locale is LTR but the assistant answered
- *     in Hebrew/Arabic (or vice-versa). Text alignment works because each
- *     innermost <p dir="auto"> resolves independently, but the <li>/<ol>
- *     around it can't see through nested `dir="auto"` descendants per the
- *     HTML spec's auto-directionality algorithm — so markers stay on the
- *     LTR edge. There is no pure-CSS fix (`:dir()` follows the same spec
- *     rule). The `useMarkdownAutoDir` composable scans textContent itself
- *     and sets an explicit `dir="rtl"` / `dir="ltr"` on every ol/ul/li
- *     inside `.markdown-wrapper`; these rules swap padding to the correct
+ *     in Hebrew/Arabic (or vice-versa). The <li>/<ol> can't see through
+ *     nested `dir="auto"` descendants per the HTML spec's auto-directionality
+ *     algorithm — so markers stay on the LTR edge. There is no pure-CSS fix
+ *     (`:dir()` follows the same spec rule). The `useMarkdownAutoDir`
+ *     composable estimates each block's dominant direction from its text and
+ *     sets an explicit `dir="rtl"` / `dir="ltr"` on markdown block elements
+ *     inside `.markdown-wrapper` / `.markdown-content` (the latter covers
+ *     thinking/reasoning boxes); these rules swap list padding to the correct
  *     edge based on that attribute regardless of the document direction. */
 .markdown-wrapper ol[dir="rtl"],
-.markdown-wrapper ul[dir="rtl"] {
+.markdown-wrapper ul[dir="rtl"],
+.markdown-content ol[dir="rtl"],
+.markdown-content ul[dir="rtl"] {
   padding-left: 0 !important;
   padding-right: 1.625em !important;
 }
 .markdown-wrapper ol[dir="ltr"],
-.markdown-wrapper ul[dir="ltr"] {
+.markdown-wrapper ul[dir="ltr"],
+.markdown-content ol[dir="ltr"],
+.markdown-content ul[dir="ltr"] {
   padding-left: 1.625em !important;
   padding-right: 0 !important;
 }

--- a/frontend/composables/useMarkdownAutoDir.ts
+++ b/frontend/composables/useMarkdownAutoDir.ts
@@ -1,42 +1,94 @@
 /**
- * Auto-direction helper for markdown-rendered lists.
+ * Auto-direction helper for markdown-rendered chat content.
  *
- * Problem: markstream-vue emits `<ol>/<ul>` with no dir, `<li dir="auto">`,
- * `<p dir="auto">`. Per HTML spec, a `dir="auto"` element's first-strong-char
- * scan EXCLUDES descendants that have their own `dir` attribute. So the
- * innermost `<p>` resolves correctly (e.g. RTL) but the surrounding `<li>`
- * and `<ol>` — looking past the `<p>`'s `dir="auto"` — see no strong chars
- * of their own and fall back to LTR. The list marker follows the <li>'s
- * direction, so markers render on the wrong edge for mixed-locale content.
+ * Problem 1 (lists): markstream-vue emits `<ol>/<ul>` with no dir,
+ * `<li dir="auto">`, `<p dir="auto">`. Per HTML spec, a `dir="auto"` element's
+ * first-strong-char scan EXCLUDES descendants that have their own `dir`
+ * attribute. So the innermost `<p>` resolves correctly (e.g. RTL) but the
+ * surrounding `<li>` and `<ol>` — looking past the `<p>`'s `dir="auto"` — see
+ * no strong chars of their own and fall back to LTR. The list marker follows
+ * the <li>'s direction, so markers render on the wrong edge for mixed-locale
+ * content. `:dir()` and `:has(:dir())` follow the same spec algorithm, so
+ * there is no pure-CSS fix.
  *
- * `:dir()` and `:has(:dir())` follow the same spec algorithm, so there is no
- * pure-CSS fix. We inspect `textContent` ourselves (which DOES see through
- * nested `dir="auto"`) and set an explicit `dir` attribute on each list
- * element. The RTL stylesheet has a matching `[dir="rtl"]` rule on
- * `.markstream-vue ol[dir="rtl"]` etc. that swaps the padding side.
+ * Problem 2 (paragraphs/headings): `dir="auto"` resolves from the FIRST
+ * strong character only. Hebrew/Arabic analysis answers constantly open a
+ * sentence with a Latin token — a system name, a ticket id, a column in
+ * inline code, a bolded English term — which flips the entire paragraph to
+ * LTR even when the rest of it is RTL prose.
+ *
+ * Fix for both: estimate the DOMINANT direction ourselves (word-based count
+ * of strong-RTL vs strong-LTR words, skipping code/pre, RTL winning at ≥40%
+ * — RTL text embeds far more Latin tokens than the reverse) and set an
+ * explicit `dir` attribute on each block element inside a markdown surface.
+ * The RTL stylesheet has matching `[dir="rtl"]` rules on list elements that
+ * swap the marker padding side, and the chat pages' CSS switches stamped
+ * elements from `unicode-bidi: plaintext` to `isolate` so the explicit dir
+ * governs alignment.
  */
 
 const RTL_CHAR = /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFC]/
-const LTR_CHAR = /[A-Za-z\u00C0-\u024F\u0370-\u05BF\u0900-\u10FF]/
+const LTR_CHAR = /[A-Za-z\u00C0-\u024F]/
 
-function firstStrongDir(text: string): 'rtl' | 'ltr' | null {
-  if (!text) return null
-  for (const ch of text) {
+// Block elements whose direction we manage, inside any markdown surface
+// (`.markdown-wrapper` chat containers and `.markdown-content` markstream
+// roots — the latter also covers thinking/reasoning boxes).
+const BLOCK_SELECTOR = 'ol, ul, li, p, h1, h2, h3, h4, h5, h6, blockquote, table'
+const SCOPE_SELECTOR = '.markdown-wrapper, .markdown-content'
+// RTL wins below 50% because RTL prose routinely embeds Latin identifiers,
+// acronyms and URLs; mostly-Latin text with a stray RTL word stays LTR.
+const RTL_WORD_THRESHOLD = 0.4
+
+function wordDir(word: string): 'rtl' | 'ltr' | null {
+  for (const ch of word) {
     if (RTL_CHAR.test(ch)) return 'rtl'
-    if (/[A-Za-z\u00C0-\u024F]/.test(ch)) return 'ltr'
+    if (LTR_CHAR.test(ch)) return 'ltr'
   }
   return null
 }
 
+// Dominant direction of an element's visible text. Counts whole words by
+// their first strong character (Closure-style estimation) instead of taking
+// the element's single first strong char. Code spans are direction-neutral
+// identifiers, not prose — exclude them from the vote.
+export function dominantDir(el: Element): 'rtl' | 'ltr' | null {
+  let rtl = 0
+  let ltr = 0
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = (node as Text).parentElement
+      return parent && parent.closest('code, pre')
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT
+    },
+  })
+  let node: Node | null
+  while ((node = walker.nextNode())) {
+    for (const word of (node.textContent || '').split(/\s+/)) {
+      const d = wordDir(word)
+      if (d === 'rtl') rtl++
+      else if (d === 'ltr') ltr++
+    }
+  }
+  const total = rtl + ltr
+  if (total === 0) return null
+  return rtl / total >= RTL_WORD_THRESHOLD ? 'rtl' : 'ltr'
+}
+
 function applyDir(el: Element) {
-  const dir = firstStrongDir(el.textContent || '')
+  const dir = dominantDir(el)
   if (!dir) return
   if (el.getAttribute('dir') !== dir) el.setAttribute('dir', dir)
 }
 
+function inScope(el: Element): boolean {
+  return !!el.closest(SCOPE_SELECTOR)
+}
+
 function scan(root: ParentNode) {
-  const lists = root.querySelectorAll('.markdown-wrapper ol, .markdown-wrapper ul, .markdown-wrapper li')
-  lists.forEach(applyDir)
+  root.querySelectorAll(BLOCK_SELECTOR).forEach((el) => {
+    if (inScope(el)) applyDir(el)
+  })
 }
 
 export function useMarkdownAutoDir() {
@@ -57,33 +109,54 @@ export function useMarkdownAutoDir() {
 
   const observer = new MutationObserver((mutations) => {
     for (const m of mutations) {
-      // Text changes under a list element — re-evaluate the enclosing list/li.
+      // Vue patches can restore markstream's static `dir="auto"` — re-stamp.
+      if (m.type === 'attributes') {
+        const el = m.target as Element
+        if (el.matches?.(BLOCK_SELECTOR) && inScope(el)) schedule(el)
+        continue
+      }
+      // Text changes — re-evaluate every managed ancestor (streaming can
+      // shift a paragraph's dominant direction as more words arrive).
       if (m.type === 'characterData') {
         let node: Node | null = m.target
         while (node && node !== document.body) {
           if (node.nodeType === 1) {
             const el = node as Element
-            if (el.matches?.('ol, ul, li') && el.closest('.markdown-wrapper')) {
-              schedule(el)
-            }
+            if (el.matches?.(BLOCK_SELECTOR) && inScope(el)) schedule(el)
           }
           node = node.parentNode
         }
         continue
       }
       m.addedNodes.forEach((n) => {
+        // Typewriter streaming appends bare text nodes — re-evaluate the
+        // block they landed in (a paragraph's dominant direction can flip
+        // as more words arrive).
+        if (n.nodeType === 3) {
+          const parentBlock = n.parentElement?.closest?.(BLOCK_SELECTOR)
+          if (parentBlock && inScope(parentBlock)) schedule(parentBlock)
+          return
+        }
         if (n.nodeType !== 1) return
         const el = n as Element
-        if (el.matches?.('ol, ul, li') && el.closest?.('.markdown-wrapper')) schedule(el)
-        el.querySelectorAll?.('.markdown-wrapper ol, .markdown-wrapper ul, .markdown-wrapper li').forEach((child) => schedule(child))
-        // And re-scan any list ancestor whose text just grew.
-        const parentList = el.parentElement?.closest?.('ol, ul, li')
-        if (parentList && parentList.closest('.markdown-wrapper')) schedule(parentList)
+        if (el.matches?.(BLOCK_SELECTOR) && inScope(el)) schedule(el)
+        el.querySelectorAll?.(BLOCK_SELECTOR).forEach((child) => {
+          if (inScope(child)) schedule(child)
+        })
+        // And re-scan any managed ancestor whose content just grew.
+        const parentBlock = el.parentElement?.closest?.(BLOCK_SELECTOR)
+        if (parentBlock && inScope(parentBlock)) schedule(parentBlock)
       })
     }
   })
 
-  observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['dir'],
+  })
   scan(document)
 
   return {

--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -969,6 +969,15 @@ onUnmounted(() => {
     blockquote { @apply border-l-4 border-gray-200 pl-4 italic my-4; unicode-bidi: plaintext; }
     table { @apply w-full border-collapse mb-4; unicode-bidi: plaintext; }
     table th, table td { @apply border border-gray-200 p-2 text-xs bg-white; unicode-bidi: plaintext; }
+
+    /* useMarkdownAutoDir stamps an explicit dir (dominant-direction estimate)
+       on these blocks; once stamped, isolate replaces plaintext so the stamped
+       dir governs alignment — plaintext keeps re-resolving from the first
+       strong character, which is exactly what mis-aligns an RTL sentence that
+       opens with a Latin token (see composables/useMarkdownAutoDir.ts). */
+    :where(p, h1, h2, h3, h4, h5, h6, ul, ol, li, blockquote, table):is([dir="rtl"], [dir="ltr"]) {
+        unicode-bidi: isolate;
+    }
 }
 
 /* Fade transitions */

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -5460,6 +5460,15 @@ onMounted(async () => {
 	blockquote { @apply border-l-4 border-gray-200 pl-4 italic my-4; unicode-bidi: plaintext; }
 	table { @apply w-full border-collapse mb-4; unicode-bidi: plaintext; }
 	table th, table td { @apply border border-gray-200 p-2 text-xs bg-white; unicode-bidi: plaintext; }
+
+	/* useMarkdownAutoDir stamps an explicit dir (dominant-direction estimate)
+	   on these blocks; once stamped, isolate replaces plaintext so the stamped
+	   dir governs alignment — plaintext keeps re-resolving from the first
+	   strong character, which is exactly what mis-aligns an RTL sentence that
+	   opens with a Latin token (see composables/useMarkdownAutoDir.ts). */
+	:where(p, h1, h2, h3, h4, h5, h6, ul, ol, li, blockquote, table):is([dir="rtl"], [dir="ltr"]) {
+		unicode-bidi: isolate;
+	}
 }
 
 


### PR DESCRIPTION
dir="auto" resolves from the first strong character only, so a Hebrew
paragraph or bullet that opens with a Latin token (a system name, a
ticket id, an inline-code column, a bolded English term) flipped the
entire line to LTR — left-aligned with scrambled reading order — even
when the rest of it is RTL prose. This is the dominant pattern in
analysis answers, which constantly lead sentences with English
identifiers.

Extend useMarkdownAutoDir beyond list markers: estimate each markdown
block's dominant direction by counting strong-RTL vs strong-LTR words
(code/pre excluded from the vote, RTL winning at >=40% since RTL prose
routinely embeds Latin tokens) and stamp an explicit dir on
p/headings/lists/blockquote/table inside .markdown-wrapper and
.markdown-content (the latter also covers thinking boxes). The observer
now also handles bare text-node appends from typewriter streaming and
re-stamps when a Vue patch restores the library's static dir="auto".

Once a block carries an explicit dir, switch it from
unicode-bidi: plaintext to isolate in both chat views — plaintext keeps
re-resolving from the first strong character, which is exactly the
failure being fixed — and extend the rtl.css list-padding rules to the
.markdown-content scope.

Verified in Chromium against the real markstream-vue renderer and page
CSS: Hebrew-dominant paragraphs/bullets opening with Latin tokens now
right-align with markers on the right edge, English-only and
mostly-English content is unchanged, and direction settles correctly
during typewriter streaming.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UWUhNHzG9v34cpDGqCCbvu