### PR TITLE
Add per-platform toggle to disable the new-conversation-report announcement

### DIFF
--- a/backend/app/schemas/organization_settings_schema.py
+++ b/backend/app/schemas/organization_settings_schema.py
@@ -292,6 +292,18 @@ class OrganizationSettingsConfig(BaseModel):
     whatsapp_session_max_age_hours: int = 24
     google_chat_session_max_age_hours: int = 120
 
+    # Whether the bot announces "I've started a new conversation report" (with a
+    # link) when a message on an external channel creates a fresh report. Plain
+    # per-platform bools (not FeatureConfig) so they surface in each channel's
+    # integration modal on the Channels settings page. WhatsApp has no flag: it
+    # never sends the announcement (see ExternalPlatformManager). The explicit
+    # "new" command confirmation is always sent regardless — it is the only
+    # feedback that command gets.
+    slack_announce_new_report: bool = True
+    teams_announce_new_report: bool = True
+    google_chat_announce_new_report: bool = True
+    email_announce_new_report: bool = True
+
     # Org-wide default automation policy for agent reliability (the
     # self-learning loop). A plain dict matching AgentAutomationPolicy; agents
     # inherit this and may override per-agent via

--- a/backend/app/services/external_platform_manager.py
+++ b/backend/app/services/external_platform_manager.py
@@ -343,6 +343,43 @@ class ExternalPlatformManager:
             return default
         return hours if hours > 0 else default
 
+    async def _get_announce_new_report(
+        self,
+        db: AsyncSession,
+        organization_id: str,
+        platform_type: str,
+    ) -> bool:
+        """Return whether the org wants the "new conversation report" announcement.
+
+        Reads ``{platform_type}_announce_new_report`` from the org's settings
+        (editable in each channel's integration modal), defaulting to the schema
+        default (True) when unset or invalid. WhatsApp has no such setting — the
+        announcement is never sent there.
+        """
+        from app.models.organization_settings import OrganizationSettings
+        from app.schemas.organization_settings_schema import OrganizationSettingsConfig
+        from sqlalchemy import select
+
+        key = f"{platform_type}_announce_new_report"
+        default = getattr(OrganizationSettingsConfig(), key, True)
+        try:
+            result = await db.execute(
+                select(OrganizationSettings)
+                .filter(OrganizationSettings.organization_id == organization_id)
+            )
+            org_settings = result.scalar_one_or_none()
+            value = org_settings.get_config(key, default) if org_settings else default
+            # Tolerate FeatureConfig-shaped storage ({'value': b, ...}).
+            if isinstance(value, dict):
+                value = value.get("value")
+            if not isinstance(value, bool):
+                return default
+        except Exception:
+            # The announcement is auxiliary — never let its lookup break
+            # message handling.
+            return default
+        return value
+
     async def _find_recent_platform_report(
         self,
         db: AsyncSession,
@@ -639,10 +676,14 @@ class ExternalPlatformManager:
                 max_age_hours=wa_max_age_hours,
             )
 
-            if created and platform_type != "whatsapp":
+            if created and platform_type != "whatsapp" and await self._get_announce_new_report(
+                db, organization.id, platform_type
+            ):
                 # WhatsApp intentionally skips the "new report" announcement — with
                 # 24h report reuse it would only fire on the first message of a
-                # window, and the URL adds noise to a 1:1 chat.
+                # window, and the URL adds noise to a 1:1 chat. Other platforms
+                # send it unless the org turned off {platform}_announce_new_report
+                # in the channel's integration settings.
                 report_url = f"{settings.bow_config.base_url}/reports/{report.id}"
                 # Send the "new report" message in the thread
                 # For channel mentions, respond in the channel; for DMs, open a DM

--- a/backend/app/services/organization_settings_service.py
+++ b/backend/app/services/organization_settings_service.py
@@ -301,6 +301,18 @@ class OrganizationSettingsService:
                             )
                         # Normalize so a {'value': N} payload is stored as the bare int.
                         value_update = new_value
+                    # Bool check for the per-platform "announce new conversation
+                    # report" toggles (plain-bool settings, edited from the
+                    # Channels page integration modals).
+                    if key in ('slack_announce_new_report', 'teams_announce_new_report', 'google_chat_announce_new_report', 'email_announce_new_report'):
+                        new_value = value_update.get('value') if isinstance(value_update, dict) else value_update
+                        if not isinstance(new_value, bool):
+                            raise HTTPException(
+                                status_code=400,
+                                detail="Announce new report must be a boolean."
+                            )
+                        # Normalize so a {'value': b} payload is stored as the bare bool.
+                        value_update = new_value
                     # Get current config dict from DB or default from schema
                     current_value_dict = current_config.get(key)
                     is_feature = False

--- a/backend/tests/unit/test_announce_new_report_config.py
+++ b/backend/tests/unit/test_announce_new_report_config.py
@@ -1,0 +1,259 @@
+"""Unit tests for the per-platform "announce new conversation report" toggle.
+
+When a message on an external channel creates a fresh report, the bot replies
+with "I've started a new conversation report" plus a link. Orgs can switch
+that announcement off per platform via ``{platform}_announce_new_report``
+(edited in each channel's integration modal). These tests cover the settings
+lookup (defaults and fallbacks), the send/suppress behavior in the message
+flow, and the update-side bool validation.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.organization_settings import OrganizationSettings
+from app.services.external_platform_manager import ExternalPlatformManager
+from app.services.organization_settings_service import OrganizationSettingsService
+
+ANNOUNCE_KEYS = [
+    "slack_announce_new_report",
+    "teams_announce_new_report",
+    "google_chat_announce_new_report",
+    "email_announce_new_report",
+]
+
+ANNOUNCE_PLATFORMS = ["slack", "teams", "google_chat", "email"]
+
+
+@pytest.fixture(autouse=True)
+def _principal_belongs_to_org():
+    """The manager re-checks org membership on every verified message; the
+    mocked DB would fail that check and divert every test into the
+    access-revoked path. Stub it to True."""
+    with patch(
+        "app.core.permission_resolver.principal_belongs_to_org",
+        new=AsyncMock(return_value=True),
+    ):
+        yield
+
+
+def _db_returning_settings(settings_row):
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=settings_row)
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    return db
+
+
+# --- settings lookup ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ANNOUNCE_PLATFORMS)
+async def test_defaults_to_true_when_no_settings_row(platform):
+    m = ExternalPlatformManager()
+    db = _db_returning_settings(None)
+    assert await m._get_announce_new_report(db, "org1", platform) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ANNOUNCE_PLATFORMS)
+async def test_defaults_to_true_when_key_absent_from_config(platform):
+    m = ExternalPlatformManager()
+    db = _db_returning_settings(OrganizationSettings(config={}))
+    assert await m._get_announce_new_report(db, "org1", platform) is True
+
+
+@pytest.mark.asyncio
+async def test_configured_false_wins():
+    m = ExternalPlatformManager()
+    db = _db_returning_settings(
+        OrganizationSettings(config={"slack_announce_new_report": False})
+    )
+    assert await m._get_announce_new_report(db, "org1", "slack") is False
+
+
+@pytest.mark.asyncio
+async def test_feature_config_shaped_value_is_unwrapped():
+    m = ExternalPlatformManager()
+    db = _db_returning_settings(
+        OrganizationSettings(config={"teams_announce_new_report": {"value": False}})
+    )
+    assert await m._get_announce_new_report(db, "org1", "teams") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", ["abc", 0, 1, None, {"value": "x"}])
+async def test_invalid_stored_values_fall_back_to_default(bad_value):
+    m = ExternalPlatformManager()
+    db = _db_returning_settings(
+        OrganizationSettings(config={"slack_announce_new_report": bad_value})
+    )
+    assert await m._get_announce_new_report(db, "org1", "slack") is True
+
+
+# --- message flow: send vs suppress ------------------------------------------
+
+
+def _manager():
+    m = ExternalPlatformManager()
+    m.mapping_service.get_user_by_id = AsyncMock(
+        return_value=SimpleNamespace(id="u1", name="Alice")
+    )
+    m.organization_service.get_organization = AsyncMock(
+        return_value=SimpleNamespace(id="org1")
+    )
+    m.completion_service.create_completion = AsyncMock()
+    return m
+
+
+def _data(platform, channel_type):
+    return {
+        "platform_type": platform,
+        "message_text": "show me sales",
+        "thread_ts": "conv-123",
+        "message_ts": "msg-1",
+        "channel_id": "conv-123",
+        "channel_type": channel_type,
+        "is_thread_reply": False,
+    }
+
+
+def _mapping(platform):
+    return SimpleNamespace(
+        app_user_id="u1",
+        organization_id="org1",
+        external_user_id="ext-user-1",
+        platform_type=platform,
+        platform_id="plat-1",
+    )
+
+
+def _adapter():
+    return SimpleNamespace(add_reaction=AsyncMock(), send_dm_in_thread=AsyncMock())
+
+
+def _plain_db():
+    return _db_returning_settings(None)
+
+
+async def _run_flow(m, adapter, platform, channel_type, announce):
+    fresh = SimpleNamespace(id="R1", title="Chat with Alice")
+    with patch.object(
+        m, "_get_announce_new_report", new=AsyncMock(return_value=announce)
+    ), patch.object(
+        m, "_get_session_max_age_hours", new=AsyncMock(return_value=24)
+    ), patch.object(
+        m, "_get_or_create_conversation_report", new=AsyncMock(return_value=(fresh, True))
+    ), patch.object(
+        m, "_find_recent_platform_report", new=AsyncMock(return_value=None)
+    ):
+        return await m._process_verified_message(
+            _plain_db(), adapter, _data(platform, channel_type), _mapping(platform)
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform,channel_type", [("slack", "im"), ("teams", "personal")])
+async def test_announcement_sent_when_enabled(platform, channel_type):
+    m = _manager()
+    adapter = _adapter()
+    res = await _run_flow(m, adapter, platform, channel_type, announce=True)
+    assert res["action"] == "message_processed"
+    assert adapter.send_dm_in_thread.await_count == 1
+    assert "new conversation report" in adapter.send_dm_in_thread.await_args.args[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform,channel_type", [("slack", "im"), ("teams", "personal")])
+async def test_announcement_suppressed_when_disabled(platform, channel_type):
+    m = _manager()
+    adapter = _adapter()
+    res = await _run_flow(m, adapter, platform, channel_type, announce=False)
+    assert res["action"] == "message_processed"
+    assert adapter.send_dm_in_thread.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_never_announces_regardless_of_setting():
+    m = _manager()
+    adapter = _adapter()
+    res = await _run_flow(m, adapter, "whatsapp", "im", announce=True)
+    assert res["action"] == "message_processed"
+    assert adapter.send_dm_in_thread.await_count == 0
+
+
+# --- update-side validation ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key", ANNOUNCE_KEYS)
+@pytest.mark.parametrize("bad_value", [0, 1, "true", None, 3.5])
+async def test_update_rejects_non_bool(key, bad_value):
+    from app.schemas.organization_settings_schema import OrganizationSettingsUpdate
+
+    service = OrganizationSettingsService()
+    settings_row = OrganizationSettings(config={key: True})
+
+    with patch.object(service, "get_settings", new=AsyncMock(return_value=settings_row)):
+        with pytest.raises(HTTPException) as exc:
+            await service.update_settings(
+                MagicMock(),
+                SimpleNamespace(id="org1"),
+                SimpleNamespace(id="u1"),
+                OrganizationSettingsUpdate(config={key: bad_value}),
+            )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_accepts_bool():
+    from app.schemas.organization_settings_schema import OrganizationSettingsUpdate
+
+    service = OrganizationSettingsService()
+    settings_row = OrganizationSettings(config={"slack_announce_new_report": True})
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    with patch.object(service, "get_settings", new=AsyncMock(return_value=settings_row)), \
+         patch("app.services.organization_settings_service.audit_service") as audit:
+        audit.log = AsyncMock()
+        result = await service.update_settings(
+            db,
+            SimpleNamespace(id="org1"),
+            SimpleNamespace(id="u1"),
+            OrganizationSettingsUpdate(config={"slack_announce_new_report": False}),
+        )
+
+    assert result.config["slack_announce_new_report"] is False
+    assert db.commit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_normalizes_feature_shaped_payload():
+    """A {'value': b} payload (ai_settings-style) is stored as the bare bool."""
+    from app.schemas.organization_settings_schema import OrganizationSettingsUpdate
+
+    service = OrganizationSettingsService()
+    settings_row = OrganizationSettings(config={"teams_announce_new_report": True})
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    with patch.object(service, "get_settings", new=AsyncMock(return_value=settings_row)), \
+         patch("app.services.organization_settings_service.audit_service") as audit:
+        audit.log = AsyncMock()
+        result = await service.update_settings(
+            db,
+            SimpleNamespace(id="org1"),
+            SimpleNamespace(id="u1"),
+            OrganizationSettingsUpdate(config={"teams_announce_new_report": {"value": False}}),
+        )
+
+    assert result.config["teams_announce_new_report"] is False

--- a/frontend/components/EmailIntegrationModal.vue
+++ b/frontend/components/EmailIntegrationModal.vue
@@ -27,6 +27,25 @@
             <span class="font-medium">{{ formatDate(integrationData?.created_at) }}</span></div>
         </div>
       </div>
+      <!-- New conversation announcement -->
+      <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 mb-4">
+        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{{ $t('settings.integrations.channels.common.announceNewReportTitle') }}</h3>
+        <label class="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            v-model="announceNewReport"
+            :disabled="savingAnnounce"
+            @change="saveAnnounceNewReport"
+            class="mt-0.5"
+            data-testid="announce-new-report-toggle"
+          />
+          <span class="text-sm">
+            <span class="font-medium">{{ $t('settings.integrations.channels.common.announceNewReportLabel') }}</span>
+            <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ $t('settings.integrations.channels.common.announceNewReportDesc') }}</span>
+          </span>
+        </label>
+      </div>
+
       <div class="flex gap-2">
         <UButton color="gray" variant="soft" :loading="testing" @click="test">{{ $t('settings.integrations.channels.common.testConnection') }}</UButton>
         <UButton color="red" variant="soft" @click="disconnect">{{ $t('settings.integrations.channels.common.disconnect') }}</UButton>
@@ -215,7 +234,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 
 const props = defineProps<{
   integrated: boolean
@@ -226,6 +245,44 @@ const props = defineProps<{
 const emit = defineEmits(['close', 'updated'])
 const toast = useToast()
 const { t } = useI18n()
+
+// "New conversation report" announcement (org setting, per platform).
+// Default mirrors the backend schema default (on).
+const announceNewReport = ref<boolean>(true)
+const savingAnnounce = ref(false)
+
+async function loadAnnounceNewReport() {
+  const res = await useMyFetch('/api/organization/settings')
+  if (res.status.value === 'success') {
+    const v = (res.data.value as any)?.config?.email_announce_new_report
+    if (typeof v === 'boolean') announceNewReport.value = v
+  }
+}
+
+async function saveAnnounceNewReport() {
+  savingAnnounce.value = true
+  const res = await useMyFetch('/api/organization/settings', {
+    method: 'PUT',
+    body: { config: { email_announce_new_report: announceNewReport.value } },
+  })
+  savingAnnounce.value = false
+  if (res.status.value === 'success') {
+    toast.add({
+      title: announceNewReport.value ? t('settings.integrations.channels.common.announceNewReportEnabled') : t('settings.integrations.channels.common.announceNewReportDisabled'),
+      color: 'green',
+    })
+  } else {
+    announceNewReport.value = !announceNewReport.value
+    toast.add({
+      title: t('settings.integrations.channels.common.failedToUpdateSetting'),
+      description: (res.error.value as any)?.data?.detail || (res.error.value as any)?.message,
+      color: 'red',
+    })
+  }
+}
+
+onMounted(() => { if (props.integrated) loadAnnounceNewReport() })
+watch(() => props.integrated, (v) => { if (v) loadAnnounceNewReport() })
 
 const cfg = computed(() => props.integrationData?.platform_config || null)
 

--- a/frontend/components/GoogleChatIntegrationModal.vue
+++ b/frontend/components/GoogleChatIntegrationModal.vue
@@ -85,6 +85,25 @@
           </div>
         </div>
 
+        <!-- New conversation announcement -->
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{{ $t('settings.integrations.channels.common.announceNewReportTitle') }}</h3>
+          <label class="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              v-model="announceNewReport"
+              :disabled="savingAnnounce"
+              @change="saveAnnounceNewReport"
+              class="mt-0.5"
+              data-testid="announce-new-report-toggle"
+            />
+            <span class="text-sm">
+              <span class="font-medium">{{ $t('settings.integrations.channels.common.announceNewReportLabel') }}</span>
+              <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ $t('settings.integrations.channels.common.announceNewReportDesc') }}</span>
+            </span>
+          </label>
+        </div>
+
         <UButton
           color="red"
           variant="soft"
@@ -148,11 +167,40 @@
   const sessionMaxAgeHours = ref<number>(120)
   const savingSessionMaxAge = ref(false)
 
+  // "New conversation report" announcement (org setting, per platform).
+  // Default mirrors the backend schema default (on).
+  const announceNewReport = ref<boolean>(true)
+  const savingAnnounce = ref(false)
+
   async function loadSessionMaxAge() {
     const res = await useMyFetch('/api/organization/settings')
     if (res.status.value === 'success') {
       const v = (res.data.value as any)?.config?.google_chat_session_max_age_hours
       if (typeof v === 'number' && v > 0) sessionMaxAgeHours.value = v
+      const a = (res.data.value as any)?.config?.google_chat_announce_new_report
+      if (typeof a === 'boolean') announceNewReport.value = a
+    }
+  }
+
+  async function saveAnnounceNewReport() {
+    savingAnnounce.value = true
+    const res = await useMyFetch('/api/organization/settings', {
+      method: 'PUT',
+      body: { config: { google_chat_announce_new_report: announceNewReport.value } },
+    })
+    savingAnnounce.value = false
+    if (res.status.value === 'success') {
+      toast.add({
+        title: announceNewReport.value ? t('settings.integrations.channels.common.announceNewReportEnabled') : t('settings.integrations.channels.common.announceNewReportDisabled'),
+        color: 'green',
+      })
+    } else {
+      announceNewReport.value = !announceNewReport.value
+      toast.add({
+        title: t('settings.integrations.channels.common.failedToUpdateSetting'),
+        description: (res.error.value as any)?.data?.detail || (res.error.value as any)?.message,
+        color: 'red',
+      })
     }
   }
 

--- a/frontend/components/SlackIntegrationModal.vue
+++ b/frontend/components/SlackIntegrationModal.vue
@@ -67,6 +67,25 @@
           </label>
         </div>
 
+        <!-- New conversation announcement -->
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{{ $t('settings.integrations.channels.common.announceNewReportTitle') }}</h3>
+          <label class="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              v-model="announceNewReport"
+              :disabled="savingAnnounce"
+              @change="saveAnnounceNewReport"
+              class="mt-0.5"
+              data-testid="announce-new-report-toggle"
+            />
+            <span class="text-sm">
+              <span class="font-medium">{{ $t('settings.integrations.channels.common.announceNewReportLabel') }}</span>
+              <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ $t('settings.integrations.channels.common.announceNewReportDesc') }}</span>
+            </span>
+          </label>
+        </div>
+
         <UButton
           color="red"
           variant="soft"
@@ -137,7 +156,7 @@
   </template>
   
   <script setup lang="ts">
-  import { ref, watch } from 'vue'
+  import { ref, watch, onMounted } from 'vue'
   const props = defineProps<{
     integrated: boolean
     integrationData?: any
@@ -189,6 +208,44 @@
       })
     }
   }
+
+  // "New conversation report" announcement (org setting, per platform).
+  // Default mirrors the backend schema default (on).
+  const announceNewReport = ref<boolean>(true)
+  const savingAnnounce = ref(false)
+
+  async function loadAnnounceNewReport() {
+    const res = await useMyFetch('/api/organization/settings')
+    if (res.status.value === 'success') {
+      const v = (res.data.value as any)?.config?.slack_announce_new_report
+      if (typeof v === 'boolean') announceNewReport.value = v
+    }
+  }
+
+  async function saveAnnounceNewReport() {
+    savingAnnounce.value = true
+    const res = await useMyFetch('/api/organization/settings', {
+      method: 'PUT',
+      body: { config: { slack_announce_new_report: announceNewReport.value } },
+    })
+    savingAnnounce.value = false
+    if (res.status.value === 'success') {
+      toast.add({
+        title: announceNewReport.value ? t('settings.integrations.channels.common.announceNewReportEnabled') : t('settings.integrations.channels.common.announceNewReportDisabled'),
+        color: 'green',
+      })
+    } else {
+      announceNewReport.value = !announceNewReport.value
+      toast.add({
+        title: t('settings.integrations.channels.common.failedToUpdateSetting'),
+        description: (res.error.value as any)?.data?.detail || (res.error.value as any)?.message,
+        color: 'red',
+      })
+    }
+  }
+
+  onMounted(() => { if (props.integrated) loadAnnounceNewReport() })
+  watch(() => props.integrated, (v) => { if (v) loadAnnounceNewReport() })
 
   const _df = useFormatDate()
   function formatDate(dateString: string | undefined) {

--- a/frontend/components/TeamsIntegrationModal.vue
+++ b/frontend/components/TeamsIntegrationModal.vue
@@ -84,6 +84,25 @@
           </div>
         </div>
 
+        <!-- New conversation announcement -->
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 mb-4">
+          <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{{ $t('settings.integrations.channels.common.announceNewReportTitle') }}</h3>
+          <label class="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              v-model="announceNewReport"
+              :disabled="savingAnnounce"
+              @change="saveAnnounceNewReport"
+              class="mt-0.5"
+              data-testid="announce-new-report-toggle"
+            />
+            <span class="text-sm">
+              <span class="font-medium">{{ $t('settings.integrations.channels.common.announceNewReportLabel') }}</span>
+              <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ $t('settings.integrations.channels.common.announceNewReportDesc') }}</span>
+            </span>
+          </label>
+        </div>
+
         <UButton
           color="red"
           variant="soft"
@@ -139,11 +158,40 @@
   const sessionMaxAgeHours = ref<number>(120)
   const savingSessionMaxAge = ref(false)
 
+  // "New conversation report" announcement (org setting, per platform).
+  // Default mirrors the backend schema default (on).
+  const announceNewReport = ref<boolean>(true)
+  const savingAnnounce = ref(false)
+
   async function loadSessionMaxAge() {
     const res = await useMyFetch('/api/organization/settings')
     if (res.status.value === 'success') {
       const v = (res.data.value as any)?.config?.teams_session_max_age_hours
       if (typeof v === 'number' && v > 0) sessionMaxAgeHours.value = v
+      const a = (res.data.value as any)?.config?.teams_announce_new_report
+      if (typeof a === 'boolean') announceNewReport.value = a
+    }
+  }
+
+  async function saveAnnounceNewReport() {
+    savingAnnounce.value = true
+    const res = await useMyFetch('/api/organization/settings', {
+      method: 'PUT',
+      body: { config: { teams_announce_new_report: announceNewReport.value } },
+    })
+    savingAnnounce.value = false
+    if (res.status.value === 'success') {
+      toast.add({
+        title: announceNewReport.value ? t('settings.integrations.channels.common.announceNewReportEnabled') : t('settings.integrations.channels.common.announceNewReportDisabled'),
+        color: 'green',
+      })
+    } else {
+      announceNewReport.value = !announceNewReport.value
+      toast.add({
+        title: t('settings.integrations.channels.common.failedToUpdateSetting'),
+        description: (res.error.value as any)?.data?.detail || (res.error.value as any)?.message,
+        color: 'red',
+      })
     }
   }
 

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "جلسة المحادثة",
           "hoursSuffix": "ساعات",
           "sessionStalenessSaved": "تم تحديث نافذة الجلسة",
-          "sessionStalenessInvalid": "أدخل عددًا صحيحًا بين 1 و720 ساعة"
+          "sessionStalenessInvalid": "أدخل عددًا صحيحًا بين 1 و720 ساعة",
+          "announceNewReportTitle": "الإعلان عن محادثة جديدة",
+          "announceNewReportLabel": "الإعلان عن تقارير المحادثات الجديدة",
+          "announceNewReportDesc": "عندما تبدأ رسالة تقرير محادثة جديدًا، يرد البوت برسالة \"لقد بدأت تقرير محادثة جديدًا\" مع رابط إليه. أوقف التفعيل لتخطي هذه الرسالة.",
+          "announceNewReportEnabled": "تم تفعيل الإعلان عن التقارير الجديدة",
+          "announceNewReportDisabled": "تم إيقاف الإعلان عن التقارير الجديدة"
         },
         "slack": {
           "title": "تكامل Slack",

--- a/locales/de.json
+++ b/locales/de.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Konversationssitzung",
           "hoursSuffix": "Stunden",
           "sessionStalenessSaved": "Sitzungsfenster aktualisiert",
-          "sessionStalenessInvalid": "Geben Sie eine ganze Zahl zwischen 1 und 720 Stunden ein"
+          "sessionStalenessInvalid": "Geben Sie eine ganze Zahl zwischen 1 und 720 Stunden ein",
+          "announceNewReportTitle": "Ankündigung neuer Unterhaltungen",
+          "announceNewReportLabel": "Neue Konversationsberichte ankündigen",
+          "announceNewReportDesc": "Wenn eine Nachricht einen neuen Konversationsbericht startet, antwortet der Bot mit einer Nachricht „Ich habe einen neuen Konversationsbericht gestartet“ samt Link. Deaktivieren, um diese Nachricht zu überspringen.",
+          "announceNewReportEnabled": "Ankündigung neuer Berichte aktiviert",
+          "announceNewReportDisabled": "Ankündigung neuer Berichte deaktiviert"
         },
         "slack": {
           "title": "Slack-Integration",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1989,7 +1989,12 @@
           "sessionStalenessTitle": "Conversation session",
           "hoursSuffix": "hours",
           "sessionStalenessSaved": "Conversation session window updated",
-          "sessionStalenessInvalid": "Enter a whole number between 1 and 720 hours"
+          "sessionStalenessInvalid": "Enter a whole number between 1 and 720 hours",
+          "announceNewReportTitle": "New conversation announcement",
+          "announceNewReportLabel": "Announce new conversation reports",
+          "announceNewReportDesc": "When a message starts a new conversation report, reply with an \"I've started a new conversation report\" message linking to it. Turn off to skip that message.",
+          "announceNewReportEnabled": "New report announcement enabled",
+          "announceNewReportDisabled": "New report announcement disabled"
         },
         "slack": {
           "title": "Slack Integration",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1914,7 +1914,12 @@
           "sessionStalenessTitle": "Sesión de conversación",
           "hoursSuffix": "horas",
           "sessionStalenessSaved": "Ventana de sesión actualizada",
-          "sessionStalenessInvalid": "Introduce un número entero entre 1 y 720 horas"
+          "sessionStalenessInvalid": "Introduce un número entero entre 1 y 720 horas",
+          "announceNewReportTitle": "Anuncio de nueva conversación",
+          "announceNewReportLabel": "Anunciar nuevos informes de conversación",
+          "announceNewReportDesc": "Cuando un mensaje inicia un nuevo informe de conversación, el bot responde con un mensaje \"He iniciado un nuevo informe de conversación\" con un enlace. Desactívalo para omitir ese mensaje.",
+          "announceNewReportEnabled": "Anuncio de nuevos informes activado",
+          "announceNewReportDisabled": "Anuncio de nuevos informes desactivado"
         },
         "slack": {
           "title": "Integración con Slack",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Session de conversation",
           "hoursSuffix": "heures",
           "sessionStalenessSaved": "Fenêtre de session mise à jour",
-          "sessionStalenessInvalid": "Saisissez un nombre entier entre 1 et 720 heures"
+          "sessionStalenessInvalid": "Saisissez un nombre entier entre 1 et 720 heures",
+          "announceNewReportTitle": "Annonce de nouvelle conversation",
+          "announceNewReportLabel": "Annoncer les nouveaux rapports de conversation",
+          "announceNewReportDesc": "Lorsqu'un message démarre un nouveau rapport de conversation, le bot répond par un message « J'ai démarré un nouveau rapport de conversation » avec un lien. Désactivez pour ignorer ce message.",
+          "announceNewReportEnabled": "Annonce des nouveaux rapports activée",
+          "announceNewReportDisabled": "Annonce des nouveaux rapports désactivée"
         },
         "slack": {
           "title": "Intégration Slack",

--- a/locales/he.json
+++ b/locales/he.json
@@ -1914,7 +1914,12 @@
           "sessionStalenessTitle": "חלון השיחה",
           "hoursSuffix": "שעות",
           "sessionStalenessSaved": "חלון השיחה עודכן",
-          "sessionStalenessInvalid": "יש להזין מספר שלם בין 1 ל-720 שעות"
+          "sessionStalenessInvalid": "יש להזין מספר שלם בין 1 ל-720 שעות",
+          "announceNewReportTitle": "הכרזה על שיחה חדשה",
+          "announceNewReportLabel": "הכרזה על דוחות שיחה חדשים",
+          "announceNewReportDesc": "כאשר הודעה פותחת דוח שיחה חדש, הבוט משיב בהודעת \"פתחתי דוח שיחה חדש\" עם קישור. כבו כדי לדלג על ההודעה.",
+          "announceNewReportEnabled": "הכרזה על דוחות חדשים הופעלה",
+          "announceNewReportDisabled": "הכרזה על דוחות חדשים כובתה"
         },
         "slack": {
           "title": "אינטגרציית Slack",

--- a/locales/it.json
+++ b/locales/it.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Sessione di conversazione",
           "hoursSuffix": "ore",
           "sessionStalenessSaved": "Finestra di sessione aggiornata",
-          "sessionStalenessInvalid": "Inserisci un numero intero tra 1 e 720 ore"
+          "sessionStalenessInvalid": "Inserisci un numero intero tra 1 e 720 ore",
+          "announceNewReportTitle": "Annuncio di nuova conversazione",
+          "announceNewReportLabel": "Annuncia i nuovi report di conversazione",
+          "announceNewReportDesc": "Quando un messaggio avvia un nuovo report di conversazione, il bot risponde con un messaggio \"Ho avviato un nuovo report di conversazione\" con un link. Disattiva per saltare questo messaggio.",
+          "announceNewReportEnabled": "Annuncio dei nuovi report attivato",
+          "announceNewReportDisabled": "Annuncio dei nuovi report disattivato"
         },
         "slack": {
           "title": "Integrazione Slack",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Sessão de conversa",
           "hoursSuffix": "horas",
           "sessionStalenessSaved": "Janela de sessão atualizada",
-          "sessionStalenessInvalid": "Insira um número inteiro entre 1 e 720 horas"
+          "sessionStalenessInvalid": "Insira um número inteiro entre 1 e 720 horas",
+          "announceNewReportTitle": "Anúncio de nova conversa",
+          "announceNewReportLabel": "Anunciar novos relatórios de conversa",
+          "announceNewReportDesc": "Quando uma mensagem inicia um novo relatório de conversa, o bot responde com uma mensagem \"Iniciei um novo relatório de conversa\" com um link. Desative para pular essa mensagem.",
+          "announceNewReportEnabled": "Anúncio de novos relatórios ativado",
+          "announceNewReportDisabled": "Anúncio de novos relatórios desativado"
         },
         "slack": {
           "title": "Integração com Slack",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Сессия разговора",
           "hoursSuffix": "часов",
           "sessionStalenessSaved": "Окно сессии обновлено",
-          "sessionStalenessInvalid": "Введите целое число от 1 до 720 часов"
+          "sessionStalenessInvalid": "Введите целое число от 1 до 720 часов",
+          "announceNewReportTitle": "Уведомление о новом диалоге",
+          "announceNewReportLabel": "Сообщать о новых отчётах диалога",
+          "announceNewReportDesc": "Когда сообщение создаёт новый отчёт диалога, бот отвечает сообщением «Я начал новый отчёт диалога» со ссылкой. Отключите, чтобы пропустить это сообщение.",
+          "announceNewReportEnabled": "Уведомление о новых отчётах включено",
+          "announceNewReportDisabled": "Уведомление о новых отчётах отключено"
         },
         "slack": {
           "title": "Интеграция со Slack",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -1834,7 +1834,12 @@
           "sessionStalenessTitle": "Konversationssession",
           "hoursSuffix": "timmar",
           "sessionStalenessSaved": "Sessionsfönstret uppdaterat",
-          "sessionStalenessInvalid": "Ange ett heltal mellan 1 och 720 timmar"
+          "sessionStalenessInvalid": "Ange ett heltal mellan 1 och 720 timmar",
+          "announceNewReportTitle": "Avisering om ny konversation",
+          "announceNewReportLabel": "Avisera nya konversationsrapporter",
+          "announceNewReportDesc": "När ett meddelande startar en ny konversationsrapport svarar boten med meddelandet \"Jag har startat en ny konversationsrapport\" med en länk. Stäng av för att hoppa över meddelandet.",
+          "announceNewReportEnabled": "Avisering om nya rapporter aktiverad",
+          "announceNewReportDisabled": "Avisering om nya rapporter inaktiverad"
         },
         "slack": {
           "title": "Slack-integration",


### PR DESCRIPTION
Orgs can now turn off the "I've started a new conversation report" message
per external channel (Slack, Teams, Google Chat, email) via new
{platform}_announce_new_report org settings, surfaced as a checkbox in each
channel's integration modal. Defaults stay on; WhatsApp keeps never sending
it; the explicit "new" command confirmation is always sent.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CBtiWm3EXBgJ7KVez3Qz9n