### PR TITLE
Chat with a shared dashboard from /r/{id} — owner-controlled scope

### DIFF
--- a/backend/alembic/versions/artchat01_add_artifact_chat_settings.py
+++ b/backend/alembic/versions/artchat01_add_artifact_chat_settings.py
@@ -1,0 +1,30 @@
+"""add artifact chat settings to reports
+
+Revision ID: artchat01
+Revises: durctx01
+Create Date: 2026-08-28 00:00:00.000000
+
+Chat on the shared artifact page /r/{id}: owner-controlled toggle plus the
+agent (data source) allowlist viewer chat may query. Viewer threads live on
+hidden child reports (report_type='artifact_chat'), which needs no schema
+change — report_type already exists.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'artchat01'
+down_revision: Union[str, None] = 'durctx01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('reports', sa.Column('artifact_chat_enabled', sa.Boolean(), nullable=False, server_default='0'))
+    op.add_column('reports', sa.Column('artifact_chat_data_source_ids', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('reports', 'artifact_chat_data_source_ids')
+    op.drop_column('reports', 'artifact_chat_enabled')

--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -408,6 +408,25 @@ from app.core.otel import get_tracer
 INDEX_LIMIT = 1000  # Number of tables to include in the index
 tracer = get_tracer(__name__)
 
+# Tools available to shared-artifact viewer chat (report_type='artifact_chat').
+# Read/query only: the viewer may ask questions and run fresh queries against
+# the agents the owner shared, but never mutate the dashboard, message anyone,
+# schedule anything, or change agent scope. Everything else is filtered out of
+# the catalog before the planner ever sees it.
+ARTIFACT_CHAT_TOOL_ALLOWLIST = {
+    "clarify",
+    "describe_tables",
+    "describe_entity",
+    "create_data",       # run a fresh query inside the viewer's own thread
+    "inspect_data",
+    "read_query",
+    "read_artifact",
+    "list_files",
+    "read_file",
+    "grep_files",
+    "search_files",
+}
+
 
 class AgentV2:
     """Enhanced orchestrator with intelligent research/action flow."""
@@ -786,6 +805,16 @@ class AgentV2:
         self._notes_enabled = bool(getattr(notes_enabled_cfg, "value", False)) if notes_enabled_cfg is not None else False
         if not self._notes_enabled:
             all_catalog_dicts = [t for t in all_catalog_dicts if t['name'] not in ('create_note', 'edit_note')]
+
+        # Shared-artifact viewer chat runs read/query-only: no artifact or
+        # dashboard mutations, no comms, no automation, no agent-scope tools
+        # (the roster is a server-synced hard scope — see ArtifactChatService).
+        # Keyed on the report's own type so no caller can forget to pass it.
+        if getattr(self.report, 'report_type', 'regular') == 'artifact_chat':
+            all_catalog_dicts = [
+                t for t in all_catalog_dicts
+                if t['name'] in ARTIFACT_CHAT_TOOL_ALLOWLIST
+            ]
 
         # Remove duplicates (for tools with category="both")
         seen_tools = set()

--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -357,10 +357,50 @@ CRITICAL: assistant_message and final_answer are mutually exclusive. Never set b
         return prompt
     
     @staticmethod
+    def _format_artifact_chat_context(ctx) -> str:
+        """Context for shared-artifact viewer chat (/r/{id} bubble).
+
+        In data-only scope the dashboard's visualization data is inlined here —
+        it is the ONLY data surface the conversation has. In agents scope the
+        block just anchors the conversation to the dashboard; data comes from
+        the attached agents via the normal query tools.
+        """
+        if not ctx:
+            return ''
+        lines: List[str] = ['<artifact_chat_context>']
+        lines.append('  You are answering questions from a VIEWER of a shared dashboard, not its owner. Keep answers concise and grounded in the dashboard.')
+        title = ctx.get('artifact_title') or ctx.get('source_report_title')
+        if title:
+            lines.append(f'  Dashboard: {json.dumps(title)}')
+        if ctx.get('scope') == 'data_only':
+            lines.append("  Scope: the dashboard's own data ONLY (below). You have no query tools and no other data access — if a question needs data beyond this, say so plainly.")
+            for viz in ctx.get('visualizations') or []:
+                lines.append('  <visualization>')
+                lines.append(f'    title: {json.dumps(viz.get("title"))}')
+                cols = viz.get('columns') or []
+                if cols:
+                    lines.append(f'    columns: {json.dumps(cols)}')
+                total = viz.get('total_rows')
+                rows = viz.get('rows') or []
+                shown = len(rows)
+                if total is not None and total > shown:
+                    lines.append(f'    rows (showing {shown} of {total}):')
+                else:
+                    lines.append('    rows:')
+                lines.append(f'    {json.dumps(rows)}')
+                lines.append('  </visualization>')
+        else:
+            lines.append('  Scope: you may query the attached agents (read-only) to answer questions about this dashboard.')
+        lines.append('</artifact_chat_context>')
+        return '\n'.join(lines)
+
+    @staticmethod
     def _format_platform_context(planner_input: PlannerInput) -> str:
         """Render platform-specific context (e.g. Excel selection) for injection into the prompt."""
         ctx = getattr(planner_input, 'platform_context', None)
         platform = planner_input.external_platform
+        if platform == 'artifact_chat':
+            return PromptBuilder._format_artifact_chat_context(ctx)
         if platform != 'excel':
             return ''
 

--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -369,6 +369,7 @@ CRITICAL: assistant_message and final_answer are mutually exclusive. Never set b
             return ''
         lines: List[str] = ['<artifact_chat_context>']
         lines.append('  You are answering questions from a VIEWER of a shared dashboard, not its owner. Keep answers concise and grounded in the dashboard.')
+        lines.append('  TEXT-ONLY SURFACE: the viewer chats in a small text bubble and sees ONLY your text replies — tool outputs, tables, and widgets you produce are NOT visible to them. Every answer must be self-contained: present the relevant data inline as short markdown lists or tables. NEVER refer to a table or result as "above", "available", or "shown" — nothing but your text is shown. For large results, include the most relevant rows (up to ~20) inline and say how many rows the full result has.')
         title = ctx.get('artifact_title') or ctx.get('source_report_title')
         if title:
             lines.append(f'  Dashboard: {json.dumps(title)}')

--- a/backend/app/ai/tools/implementations/agent_focus_common.py
+++ b/backend/app/ai/tools/implementations/agent_focus_common.py
@@ -101,6 +101,12 @@ async def resolve_run_agents(db, organization: Any, user: Any, report: Any) -> L
         # agent the user can reach.
         return []
     attached = list(getattr(report, "data_sources", None) or [])
+    # Artifact-chat threads are never Auto: their roster is the owner-allowed ∩
+    # viewer-accessible intersection synced per message, and empty means
+    # "dashboard data only" — widening to everything the viewer can access
+    # would hand a shared-dashboard chat far more than the owner shared.
+    if not attached and getattr(report, "report_type", "regular") == "artifact_chat":
+        return []
     agents = attached if attached else await accessible_agents(db, organization, user)
     return [ds for ds in agents if DataSourceService.is_execution_live(ds)]
 
@@ -163,6 +169,10 @@ async def resolve_candidate_agents(
     attached = list(getattr(report, "data_sources", None) or [])
     attached_ids = {str(ds.id) for ds in attached}
     if not attached:
+        # Artifact-chat threads never widen to Auto (see resolve_run_agents);
+        # their focus tools are filtered out anyway — defense in depth.
+        if getattr(report, "report_type", "regular") == "artifact_chat":
+            return [], "attached", set()
         # Auto: the working set is everything accessible; nothing needs attach.
         agents = await accessible_agents(db, organization, user)
         return agents, "accessible", {str(a.id) for a in agents}

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -57,6 +57,18 @@ class Report(BaseSchema):
     # the tab is a presentation choice, not a data boundary.
     include_data_tab = Column(Boolean, nullable=False, default=True, server_default='1')
 
+    # Chat on the shared artifact page /r/{id}. Off by default; only meaningful
+    # while artifact_visibility != 'none'. Viewer conversations never touch this
+    # report's own transcript — each viewer gets a hidden child report
+    # (report_type='artifact_chat', forked_from_id=this) holding their thread.
+    artifact_chat_enabled = Column(Boolean, nullable=False, default=False, server_default='0')
+    # Which agents (data sources) artifact-page chat may query, chosen by the
+    # owner. null = inherit this report's attached roster; [] = no agents
+    # (answers come from the artifact's own data only); a list = explicit
+    # subset. Never Auto: a viewer's chat can only narrow from here — the
+    # effective set is this ∩ the viewer's own accessible agents.
+    artifact_chat_data_source_ids = Column(JSON, nullable=True, default=None)
+
     cron_schedule = Column(String, nullable=True)
     # Rerun the artifact's queries when a viewer opens the shared report page
     # (/r/{id}). Independent of cron_schedule — a report can refresh on view

--- a/backend/app/routes/artifact_chat.py
+++ b/backend/app/routes/artifact_chat.py
@@ -1,0 +1,215 @@
+"""Chat endpoints for the shared artifact page /r/{id}.
+
+Deliberately OUTSIDE the owner-only /api/reports/{id}/completions surface:
+sharing a dashboard never grants the owner's transcript. These routes gate on
+the same artifact visibility as the rest of /r/{id}, require a signed-in org
+member, and operate on the viewer's own hidden chat report
+(report_type='artifact_chat') — see ArtifactChatService.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload, lazyload
+
+from app.core.auth import current_user, current_user_optional
+from app.dependencies import get_async_db
+from app.models.data_source import DataSource
+from app.models.organization import Organization
+from app.models.report import Report
+from app.models.user import User
+from app.schemas.completion_v2_schema import CompletionCreate
+from app.services.artifact_chat_service import artifact_chat_service
+from app.services.completion_service import CompletionService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["artifact-chat"])
+
+completion_service = CompletionService()
+
+
+async def _load_source_report(db: AsyncSession, report_id: str) -> Report:
+    report = (await db.execute(
+        select(Report)
+        .options(
+            lazyload("*"),
+            selectinload(Report.data_sources).options(
+                lazyload("*"),
+                selectinload(DataSource.connections).options(lazyload("*")),
+            ),
+        )
+        .where(
+            Report.id == report_id,
+            Report.report_type == 'regular',
+            Report.deleted_at.is_(None),
+        )
+    )).unique().scalar_one_or_none()
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+    return report
+
+
+async def _load_org(db: AsyncSession, report: Report) -> Organization:
+    org = await db.get(Organization, str(report.organization_id))
+    if not org:
+        raise HTTPException(status_code=404, detail="Report not found")
+    return org
+
+
+@router.get("/r/{report_id}/chat")
+async def get_chat_status(
+    report_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: User | None = Depends(current_user_optional),
+):
+    """Availability + scope for the chat bubble. Never creates anything.
+
+    Anonymous callers on a visible report get {available: false,
+    reason: 'auth_required'} instead of a 401 so the page can render a
+    sign-in prompt inside the bubble.
+    """
+    report = await _load_source_report(db, report_id)
+    org = await _load_org(db, report)
+
+    try:
+        await artifact_chat_service.ensure_chat_access(db, report, user)
+    except HTTPException as e:
+        # Visibility check runs first inside ensure_chat_access, so a 401
+        # here means "sign in and try again", never "hidden report" (those
+        # 404). A 403 for a signed-in caller is either the toggle being off
+        # or a non-member — both render as an unavailable bubble.
+        if user is None and e.status_code == 401:
+            return {"enabled": True, "available": False, "reason": "auth_required"}
+        if e.status_code == 403 and user is not None:
+            reason = "disabled" if "not enabled" in str(e.detail) else "not_member"
+            return {"enabled": reason != "disabled", "available": False, "reason": reason}
+        raise
+
+    agent_ids = await artifact_chat_service.effective_agent_ids(db, report, org, user)
+    agents_by_id = {str(ds.id): ds for ds in (report.data_sources or [])}
+    agent_names = []
+    for aid in agent_ids:
+        ds = agents_by_id.get(aid)
+        if ds is None:
+            ds = await db.get(DataSource, aid)
+        if ds is not None:
+            agent_names.append({"id": aid, "name": ds.name})
+
+    chat_report = (await db.execute(
+        select(Report.id).where(
+            Report.report_type == 'artifact_chat',
+            Report.forked_from_id == str(report.id),
+            Report.user_id == str(user.id),
+            Report.deleted_at.is_(None),
+        ).limit(1)
+    )).scalar_one_or_none()
+
+    return {
+        "enabled": True,
+        "available": True,
+        "reason": None,
+        "scope": "agents" if agent_ids else "data_only",
+        "agents": agent_names,
+        "chat_report_id": str(chat_report) if chat_report else None,
+    }
+
+
+@router.post("/r/{report_id}/chat/completions")
+async def create_chat_completion(
+    report_id: str,
+    completion: CompletionCreate,
+    db: AsyncSession = Depends(get_async_db),
+    user: User = Depends(current_user),
+):
+    """Send a message into the viewer's own chat thread. Always streams SSE.
+
+    Access, scope and roster are re-resolved on every message, so unsharing,
+    disabling chat, or narrowing the agent allowlist applies immediately.
+    """
+    report = await _load_source_report(db, report_id)
+    org = await _load_org(db, report)
+    await artifact_chat_service.ensure_chat_access(db, report, user)
+
+    agent_ids = await artifact_chat_service.effective_agent_ids(db, report, org, user)
+    chat_report = await artifact_chat_service.resolve_chat_report(db, report, user, agent_ids)
+
+    # Server-side prompt hardening: viewer chat is plain text into the chat
+    # report — platform identity and context are ours, and widget/step
+    # targeting or queueing make no sense here.
+    if completion.prompt is None or not (completion.prompt.content or "").strip():
+        raise HTTPException(status_code=400, detail="Message content is required")
+    completion.prompt.widget_id = None
+    completion.prompt.step_id = None
+    completion.prompt.mode = 'chat'
+    completion.prompt.platform = 'artifact_chat'
+    completion.prompt.platform_context = await artifact_chat_service.build_platform_context(
+        db, report, agent_ids
+    )
+    try:
+        completion.queue = False
+    except Exception:
+        pass
+
+    return await completion_service.create_completion_stream(
+        db, str(chat_report.id), completion, user, org,
+    )
+
+
+@router.get("/r/{report_id}/chat/completions")
+async def get_chat_completions(
+    report_id: str,
+    limit: int = 20,
+    before: str | None = None,
+    db: AsyncSession = Depends(get_async_db),
+    user: User = Depends(current_user),
+):
+    """The viewer's own thread (v2 blocks). Empty before the first message."""
+    report = await _load_source_report(db, report_id)
+    org = await _load_org(db, report)
+    await artifact_chat_service.ensure_chat_access(db, report, user)
+
+    chat_report_id = (await db.execute(
+        select(Report.id).where(
+            Report.report_type == 'artifact_chat',
+            Report.forked_from_id == str(report.id),
+            Report.user_id == str(user.id),
+            Report.deleted_at.is_(None),
+        ).limit(1)
+    )).scalar_one_or_none()
+    if not chat_report_id:
+        return {"report_id": None, "completions": [], "total_completions": 0}
+
+    return await completion_service.get_completions_v2(
+        db, str(chat_report_id), org, user, limit=limit, before=before
+    )
+
+
+@router.get("/r/{report_id}/chat/completions/{completion_id}/stream")
+async def watch_chat_completion(
+    report_id: str,
+    completion_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: User = Depends(current_user),
+):
+    """Re-attachable SSE watch for a completion in the viewer's own thread."""
+    report = await _load_source_report(db, report_id)
+    org = await _load_org(db, report)
+    await artifact_chat_service.ensure_chat_access(db, report, user)
+
+    chat_report_id = (await db.execute(
+        select(Report.id).where(
+            Report.report_type == 'artifact_chat',
+            Report.forked_from_id == str(report.id),
+            Report.user_id == str(user.id),
+            Report.deleted_at.is_(None),
+        ).limit(1)
+    )).scalar_one_or_none()
+    if not chat_report_id:
+        raise HTTPException(status_code=404, detail="No chat thread")
+
+    return await completion_service.watch_completion_stream(
+        db, str(chat_report_id), completion_id, user, org
+    )

--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -307,6 +307,40 @@ async def get_report_shares(
     return await report_service.get_shares(db, report_id, share_type)
 
 
+@router.get("/reports/{report_id}/artifact_chat/agents")
+@requires_permission('publish_reports', model=Report, owner_only=True)
+async def get_artifact_chat_agents(
+    report_id: str,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Candidate agents for the ShareModal's chat scope picker: the agents this
+    report actually uses — its attached roster, or (for Auto reports) the
+    agents recovered from its tool executions. See
+    ArtifactChatService.candidate_agent_ids."""
+    from sqlalchemy.orm import selectinload, lazyload
+    from app.models.data_source import DataSource
+    from app.services.artifact_chat_service import artifact_chat_service
+
+    report = (await db.execute(
+        select(Report)
+        .options(lazyload("*"), selectinload(Report.data_sources).options(lazyload("*")))
+        .where(Report.id == report_id)
+    )).unique().scalar_one_or_none()
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    agent_ids = await artifact_chat_service.candidate_agent_ids(db, report)
+    by_id = {str(ds.id): ds for ds in (report.data_sources or [])}
+    agents = []
+    for aid in agent_ids:
+        ds = by_id.get(aid) or await db.get(DataSource, aid)
+        if ds is not None and ds.deleted_at is None:
+            agents.append({"id": str(ds.id), "name": ds.name})
+    return {"agents": agents}
+
+
 @router.post("/reports/{report_id}/fork", response_model=ForkResponse)
 @requires_permission('create_reports')
 async def fork_report(

--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -287,6 +287,8 @@ async def set_report_visibility(
         run_identity=payload.run_identity,
         shared_group_ids=payload.shared_group_ids,
         include_data_tab=payload.include_data_tab,
+        artifact_chat_enabled=payload.artifact_chat_enabled,
+        artifact_chat_data_source_ids=payload.artifact_chat_data_source_ids,
     )
 
 

--- a/backend/app/schemas/report_schema.py
+++ b/backend/app/schemas/report_schema.py
@@ -47,7 +47,7 @@ class ReportSchema(ReportBase):
     id: str
     status: Literal["draft", "published", "archived"]
     slug: str
-    report_type: Literal["regular", "test"]
+    report_type: Literal["regular", "test", "artifact_chat"]
     widgets: List[WidgetSchema] = []
     dashboard_layout_versions: List[DashboardLayoutVersionSchema] = []
     data_sources: List[DataSourceReportSchema] = []
@@ -96,6 +96,12 @@ class ReportSchema(ReportBase):
     # Show the Data tab (the queries behind the report) to viewers of the
     # shared artifact page. Artifact sharing only.
     include_data_tab: bool = True
+    # Chat on the shared artifact page /r/{id}. This schema also serves the
+    # public GET /r/{id}, so the shared page reads the flag directly.
+    artifact_chat_enabled: bool = False
+    # Owner's agent allowlist for artifact-page chat: null = inherit the
+    # report's attached roster, [] = dashboard data only, list = subset.
+    artifact_chat_data_source_ids: Optional[List[str]] = None
     # True when the report reads an RLS-enabled relation: viewers always run
     # under their own identity and 'run on my behalf' (creator mode) is blocked.
     has_rls: bool = False
@@ -191,6 +197,13 @@ class ReportVisibilityUpdate(BaseModel):
     # Artifact sharing only: show viewers the Data tab on /r/{id}.
     # Omitted = leave unchanged (same semantics as run_identity).
     include_data_tab: Optional[bool] = None
+    # Artifact sharing only: allow viewers of /r/{id} to chat with the report.
+    # Omitted = leave unchanged.
+    artifact_chat_enabled: Optional[bool] = None
+    # Artifact sharing only: which agents chat may query. Sentinel-aware:
+    # omitted = leave unchanged; [] = dashboard data only; ["*"] = reset to
+    # inherit the report's attached roster (null); a list = explicit subset.
+    artifact_chat_data_source_ids: Optional[List[str]] = None
 
 
 class ViewerRunResultSchema(BaseModel):

--- a/backend/app/services/artifact_chat_service.py
+++ b/backend/app/services/artifact_chat_service.py
@@ -68,19 +68,81 @@ class ArtifactChatService:
         )).scalar_one_or_none()
         return row is not None
 
+    async def candidate_agent_ids(self, db, report: Report) -> list[str]:
+        """The agents this report actually uses — the owner-side inheritance base.
+
+        A manually-attached roster is authoritative. An Auto report (empty
+        roster) has no attachment rows, but its runs still used concrete
+        agents: recover them from the report's tool executions (connection_id /
+        data_source_id arguments), falling back to the focused set. Never
+        widens to "everything accessible" — that would share more than the
+        dashboard ever used.
+        """
+        import json as _json
+
+        roster = [str(ds.id) for ds in (report.data_sources or [])]
+        if roster:
+            return roster
+
+        from app.models.agent_execution import AgentExecution
+        from app.models.tool_execution import ToolExecution
+        from app.models.data_source import DataSource
+
+        rows = (await db.execute(
+            select(ToolExecution.arguments_json)
+            .join(AgentExecution, ToolExecution.agent_execution_id == AgentExecution.id)
+            .where(AgentExecution.report_id == str(report.id))
+        )).scalars().all()
+        conn_ids: set[str] = set()
+        ds_ids: set[str] = set()
+        for raw in rows:
+            try:
+                args = raw if isinstance(raw, dict) else _json.loads(raw or "{}")
+            except Exception:
+                continue
+            cid = args.get("connection_id")
+            if cid:
+                conn_ids.add(str(cid))
+            for key in ("data_source_id",):
+                if args.get(key):
+                    ds_ids.add(str(args[key]))
+            for key in ("data_source_ids", "agent_ids"):
+                vals = args.get(key)
+                if isinstance(vals, list):
+                    ds_ids.update(str(v) for v in vals)
+        if conn_ids:
+            from app.models.domain_connection import domain_connection
+            conn_rows = (await db.execute(
+                select(domain_connection.c.data_source_id)
+                .where(domain_connection.c.connection_id.in_(list(conn_ids)))
+            )).scalars().all()
+            ds_ids.update(str(x) for x in conn_rows)
+        if ds_ids:
+            valid = (await db.execute(
+                select(DataSource.id).where(
+                    DataSource.id.in_(list(ds_ids)),
+                    DataSource.organization_id == str(report.organization_id),
+                    DataSource.deleted_at.is_(None),
+                )
+            )).scalars().all()
+            if valid:
+                return [str(x) for x in valid]
+
+        return [str(x) for x in (getattr(report, 'focused_data_source_ids', None) or [])]
+
     async def effective_agent_ids(self, db, report: Report, organization, user) -> list[str]:
         """owner allowlist ∩ viewer-accessible agents, both live.
 
-        The owner side: artifact_chat_data_source_ids, or the source report's
-        attached roster when null. Never Auto — an owner who attached nothing
-        and picked nothing shares dashboard data only.
+        The owner side: artifact_chat_data_source_ids, or — when null — the
+        agents the report actually uses (roster, or recovered from its runs
+        for Auto reports; see candidate_agent_ids). Never Auto-wide.
         """
         from app.ai.tools.implementations.agent_focus_common import accessible_agents
         from app.services.data_source_service import DataSourceService
 
         allowed = getattr(report, 'artifact_chat_data_source_ids', None)
         if allowed is None:
-            allowed_ids = {str(ds.id) for ds in (report.data_sources or [])}
+            allowed_ids = set(await self.candidate_agent_ids(db, report))
         else:
             allowed_ids = {str(x) for x in allowed}
         if not allowed_ids:

--- a/backend/app/services/artifact_chat_service.py
+++ b/backend/app/services/artifact_chat_service.py
@@ -1,0 +1,187 @@
+"""Chat on the shared artifact page /r/{id}.
+
+A viewer's conversation never touches the source report's transcript: each
+(source report, viewer) pair gets one hidden child report with
+report_type='artifact_chat' and forked_from_id=source. Because every listing,
+search and agent surface already filters report_type == 'regular', these
+threads are invisible everywhere except the /r/{id}/chat endpoints.
+
+Scope model: the owner's allowlist (artifact_chat_data_source_ids; null =
+the source report's attached roster) is intersected per message with the
+agents the viewer can access themselves. The intersection becomes the chat
+report's attached roster — a manual hard scope for the agent pipeline. An
+empty intersection means "dashboard data only": no agents are attached, no
+schema enters context, and the planner answers from the artifact's own
+visualization data injected as platform context.
+"""
+
+import logging
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from app.models.report import Report
+from app.models.report_data_source_association import report_data_source_association
+
+logger = logging.getLogger(__name__)
+
+# Rows per visualization injected into the data-only chat context. Keeps the
+# prompt bounded on large dashboards while staying complete for typical ones.
+MAX_CONTEXT_ROWS_PER_VIZ = 100
+
+
+class ArtifactChatService:
+
+    async def ensure_chat_access(self, db, report: Report, user) -> None:
+        """Gate every /r/{id}/chat call. Raises 401/403/404.
+
+        Order matters: the visibility check first (it 404s reports the caller
+        may not even know exist), then auth, then the chat toggle, then org
+        membership — chat runs the org's LLM and (optionally) its agents, so
+        it stays an org-member surface even on public reports.
+        """
+        from app.services.report_service import ReportService
+
+        await ReportService()._check_visibility(db, report, 'artifact_visibility', user)
+
+        if user is None:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        if not getattr(report, 'artifact_chat_enabled', False):
+            raise HTTPException(status_code=403, detail="Chat is not enabled on this report")
+
+        if not await self._is_org_member(db, user, report.organization_id):
+            raise HTTPException(
+                status_code=403,
+                detail="Chat is available to members of this workspace only",
+            )
+
+    @staticmethod
+    async def _is_org_member(db, user, organization_id) -> bool:
+        from app.models.membership import Membership
+        row = (await db.execute(
+            select(Membership.id).where(
+                Membership.user_id == str(user.id),
+                Membership.organization_id == str(organization_id),
+            ).limit(1)
+        )).scalar_one_or_none()
+        return row is not None
+
+    async def effective_agent_ids(self, db, report: Report, organization, user) -> list[str]:
+        """owner allowlist ∩ viewer-accessible agents, both live.
+
+        The owner side: artifact_chat_data_source_ids, or the source report's
+        attached roster when null. Never Auto — an owner who attached nothing
+        and picked nothing shares dashboard data only.
+        """
+        from app.ai.tools.implementations.agent_focus_common import accessible_agents
+        from app.services.data_source_service import DataSourceService
+
+        allowed = getattr(report, 'artifact_chat_data_source_ids', None)
+        if allowed is None:
+            allowed_ids = {str(ds.id) for ds in (report.data_sources or [])}
+        else:
+            allowed_ids = {str(x) for x in allowed}
+        if not allowed_ids:
+            return []
+
+        viewer_agents = await accessible_agents(db, organization, user)
+        return [
+            str(ds.id) for ds in viewer_agents
+            if str(ds.id) in allowed_ids and DataSourceService.is_execution_live(ds)
+        ]
+
+    async def resolve_chat_report(self, db, source: Report, user, agent_ids: list[str]) -> Report:
+        """Get-or-create this viewer's chat report and sync its roster.
+
+        The roster is re-synced on every message so owner allowlist edits and
+        viewer grant changes apply immediately. The chat report's empty roster
+        is NOT Auto (resolve_run_agents special-cases report_type='artifact_chat').
+        """
+        chat_report = (await db.execute(
+            select(Report).where(
+                Report.report_type == 'artifact_chat',
+                Report.forked_from_id == str(source.id),
+                Report.user_id == str(user.id),
+                Report.deleted_at.is_(None),
+            ).limit(1)
+        )).scalar_one_or_none()
+
+        if chat_report is None:
+            chat_report = Report(
+                title=f"Chat: {source.title or 'Untitled report'}",
+                slug=f"artifact-chat-{uuid.uuid4().hex[:12]}",
+                status='draft',
+                report_type='artifact_chat',
+                mode='chat',
+                model_id=source.model_id,
+                user_id=str(user.id),
+                organization_id=str(source.organization_id),
+                forked_from_id=str(source.id),
+            )
+            db.add(chat_report)
+            await db.flush()
+
+        # Sync roster to the effective set (idempotent).
+        current_rows = (await db.execute(
+            select(report_data_source_association.c.data_source_id).where(
+                report_data_source_association.c.report_id == str(chat_report.id)
+            )
+        )).all()
+        current = {str(r[0]) for r in current_rows}
+        target = set(agent_ids)
+        for ds_id in target - current:
+            await db.execute(report_data_source_association.insert().values(
+                report_id=str(chat_report.id), data_source_id=ds_id,
+            ))
+        if current - target:
+            await db.execute(report_data_source_association.delete().where(
+                report_data_source_association.c.report_id == str(chat_report.id),
+                report_data_source_association.c.data_source_id.in_(list(current - target)),
+            ))
+        await db.commit()
+        return chat_report
+
+    async def build_platform_context(self, db, source: Report, agent_ids: list[str]) -> dict:
+        """The artifact-chat platform_context injected into the planner prompt.
+
+        Always carries the dashboard's identity; in data-only mode (no agents)
+        it also carries the artifact's visualization data — resolved LIVE from
+        the source report's latest artifact, never copied, so it is exactly as
+        fresh as the dashboard itself.
+        """
+        from app.models.artifact import Artifact
+        from app.services.artifact_payload import collect_visualizations
+
+        ctx: dict = {
+            "source_report_title": source.title,
+            "scope": "agents" if agent_ids else "data_only",
+        }
+
+        artifact = (await db.execute(
+            select(Artifact)
+            .where(Artifact.report_id == str(source.id), Artifact.deleted_at.is_(None))
+            .order_by(Artifact.created_at.desc())
+            .limit(1)
+        )).scalar_one_or_none()
+        if artifact is None:
+            return ctx
+
+        ctx["artifact_title"] = artifact.title
+
+        if not agent_ids:
+            viz_payload = await collect_visualizations(db, artifact)
+            ctx["visualizations"] = [
+                {
+                    "title": v.get("title"),
+                    "columns": v.get("columns") or [],
+                    "rows": (v.get("rows") or [])[:MAX_CONTEXT_ROWS_PER_VIZ],
+                    "total_rows": len(v.get("rows") or []),
+                }
+                for v in viz_payload
+            ]
+        return ctx
+
+
+artifact_chat_service = ArtifactChatService()

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -701,6 +701,8 @@ class ReportService:
             conversation_visibility=getattr(report, "conversation_visibility", "none") or "none",
             shared_run_identity=getattr(report, "shared_run_identity", "viewer") or "viewer",
             include_data_tab=bool(getattr(report, "include_data_tab", True)),
+            artifact_chat_enabled=bool(getattr(report, "artifact_chat_enabled", False)),
+            artifact_chat_data_source_ids=getattr(report, "artifact_chat_data_source_ids", None),
             artifact_shared_user_ids=[
                 str(s.user_id) for s in (report.shares or [])
                 if s.share_type == 'artifact' and s.user_id and s.deleted_at is None

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -242,6 +242,8 @@ class ReportService:
         run_identity: str | None = None,
         shared_group_ids: list[str] | None = None,
         include_data_tab: bool | None = None,
+        artifact_chat_enabled: bool | None = None,
+        artifact_chat_data_source_ids: list[str] | None = None,
     ) -> dict:
         """Set visibility for artifact or conversation sharing.
 
@@ -302,6 +304,32 @@ class ReportService:
         # rather than writing a setting that means nothing there.
         if share_type == 'artifact' and include_data_tab is not None:
             report.include_data_tab = bool(include_data_tab)
+
+        # Artifact-only chat settings, same omit-means-unchanged semantics.
+        if share_type == 'artifact' and artifact_chat_enabled is not None:
+            report.artifact_chat_enabled = bool(artifact_chat_enabled)
+        if share_type == 'artifact' and artifact_chat_data_source_ids is not None:
+            if artifact_chat_data_source_ids == ["*"]:
+                # Sentinel: reset to "inherit the report's attached roster".
+                report.artifact_chat_data_source_ids = None
+            else:
+                # Validate every id is a data source of this org; anything else
+                # (typo, foreign org) must not end up in the allowlist.
+                from app.models.data_source import DataSource
+                ids = [str(x) for x in artifact_chat_data_source_ids]
+                if ids:
+                    valid_rows = (await db.execute(
+                        select(DataSource.id).where(
+                            DataSource.id.in_(ids),
+                            DataSource.organization_id == str(organization.id),
+                            DataSource.deleted_at.is_(None),
+                        )
+                    )).all()
+                    valid_ids = {str(r[0]) for r in valid_rows}
+                    unknown = [i for i in ids if i not in valid_ids]
+                    if unknown:
+                        raise HTTPException(status_code=400, detail="Unknown data source in artifact_chat_data_source_ids")
+                report.artifact_chat_data_source_ids = ids
 
         # Sync legacy fields for backward compatibility
         if share_type == 'artifact':

--- a/backend/main.py
+++ b/backend/main.py
@@ -51,6 +51,7 @@ from app.ee.audit.tool_audit import start_tool_audit_worker, stop_tool_audit_wor
 
 from app.routes import (
     report,
+    artifact_chat,
     project,
     test,
     widget,
@@ -256,6 +257,7 @@ app.include_router(agent_reliability.router, prefix="/api")
 app.include_router(review.router, prefix="/api")
 app.include_router(notification.router, prefix="/api")
 app.include_router(report.router, prefix="/api")
+app.include_router(artifact_chat.router, prefix="/api")
 app.include_router(project.router, prefix="/api")
 app.include_router(scheduled_prompt.router, prefix="/api")
 app.include_router(prompt_routes.router, prefix="/api")

--- a/frontend/components/ShareModal.vue
+++ b/frontend/components/ShareModal.vue
@@ -75,13 +75,13 @@
             <!-- Include Data Tab option (dashboards only): whether viewers of
                  the shared artifact page see the Data tab listing the queries
                  behind the report. The conversation share has no such tab. -->
-            <div v-if="shareType === 'artifact' && isShared" class="flex items-start gap-3 mb-6 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <UCheckbox v-model="includeDataTab" size="sm" :disabled="isSaving"
-                    @update:model-value="onIncludeDataTabChange" />
+            <div v-if="shareType === 'artifact' && isShared" class="flex items-start justify-between gap-3 mb-6 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
                 <div class="flex flex-col min-w-0 flex-1">
                     <span class="text-xs font-medium text-gray-700 dark:text-gray-300">{{ $t('share.includeDataTab') }}</span>
                     <span class="text-[11px] text-gray-400">{{ $t('share.includeDataTabDesc') }}</span>
                 </div>
+                <UToggle v-model="includeDataTab" size="sm" :disabled="isSaving" class="flex-shrink-0 mt-0.5"
+                    @update:model-value="onIncludeDataTabChange" />
             </div>
 
             <!-- Chat on the shared artifact page (dashboards only): the owner's
@@ -431,7 +431,16 @@ const fetchVisibility = async () => {
                 chatEnabled.value = data.artifact_chat_enabled === true
                 if (props.report) props.report.artifact_chat_enabled = data.artifact_chat_enabled
             }
-            reportAgents.value = (data.data_sources || []).map((ds: any) => ({ id: ds.id, name: ds.name }))
+            // Candidate agents = what the report actually uses (attached
+            // roster, or recovered from its runs for Auto reports) — not the
+            // raw attachment list, which is empty under Auto.
+            try {
+                const agentsRes = await useMyFetch(`/reports/${props.report.id}/artifact_chat/agents`)
+                const payload = agentsRes.data.value as any
+                reportAgents.value = (payload?.agents || []).map((a: any) => ({ id: a.id, name: a.name }))
+            } catch {
+                reportAgents.value = (data.data_sources || []).map((ds: any) => ({ id: ds.id, name: ds.name }))
+            }
             const storedIds = data.artifact_chat_data_source_ids
             if (storedIds === null || storedIds === undefined) {
                 chatScope.value = reportAgents.value.length > 0 ? 'agents' : 'data_only'

--- a/frontend/components/ShareModal.vue
+++ b/frontend/components/ShareModal.vue
@@ -84,6 +84,48 @@
                 </div>
             </div>
 
+            <!-- Chat on the shared artifact page (dashboards only): the owner's
+                 toggle plus the agent scope viewer chat may query. Viewer
+                 threads are private per viewer and never touch this report's
+                 own conversation. -->
+            <div v-if="shareType === 'artifact' && isShared" class="mb-6 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg" data-testid="chat-settings">
+                <div class="flex items-start justify-between gap-3">
+                    <div class="flex flex-col min-w-0">
+                        <span class="text-xs font-medium text-gray-700 dark:text-gray-300">{{ $t('share.allowChat') }}</span>
+                        <span class="text-[11px] text-gray-400">{{ $t('share.allowChatDesc') }}</span>
+                    </div>
+                    <UToggle v-model="chatEnabled" size="sm" :disabled="isSaving" class="flex-shrink-0 mt-0.5"
+                        data-testid="chat-enabled-toggle" @update:model-value="onChatEnabledChange" />
+                </div>
+                <div v-if="chatEnabled" class="mt-3 space-y-2">
+                    <label class="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider block">{{ $t('share.chatScope') }}</label>
+                    <label class="flex items-start gap-2 cursor-pointer" data-testid="chat-scope-agents">
+                        <input type="radio" value="agents" v-model="chatScope" :disabled="isSaving || reportAgents.length === 0"
+                            class="mt-0.5" @change="onChatScopeChange" />
+                        <span class="flex flex-col">
+                            <span class="text-xs text-gray-700 dark:text-gray-300">{{ $t('share.chatScopeAgents') }}</span>
+                            <span class="text-[11px] text-gray-400">{{ $t('share.chatScopeAgentsDesc') }}</span>
+                        </span>
+                    </label>
+                    <div v-if="chatScope === 'agents' && reportAgents.length > 0" class="ms-6 space-y-1">
+                        <label v-for="agent in reportAgents" :key="agent.id" class="flex items-center gap-2 cursor-pointer">
+                            <input type="checkbox" :value="agent.id" v-model="chatAgentIds" :disabled="isSaving"
+                                @change="onChatAgentsChange" />
+                            <span class="text-xs text-gray-600 dark:text-gray-400">{{ agent.name }}</span>
+                        </label>
+                    </div>
+                    <label class="flex items-start gap-2 cursor-pointer" data-testid="chat-scope-data-only">
+                        <input type="radio" value="data_only" v-model="chatScope" :disabled="isSaving"
+                            class="mt-0.5" @change="onChatScopeChange" />
+                        <span class="flex flex-col">
+                            <span class="text-xs text-gray-700 dark:text-gray-300">{{ $t('share.chatScopeDataOnly') }}</span>
+                            <span class="text-[11px] text-gray-400">{{ $t('share.chatScopeDataOnlyDesc') }}</span>
+                        </span>
+                    </label>
+                    <p v-if="reportAgents.length === 0" class="text-[11px] text-gray-400">{{ $t('share.chatNoAgents') }}</p>
+                </div>
+            </div>
+
             <!-- Viewer run identity (dashboards only): whose credentials a
                  viewer's "Run" uses. Results are always stored per viewer.
                  Only shown when the choice exists — user-scoped sources
@@ -203,6 +245,15 @@ const sharedEntries = ref<any[]>([])
 const copied = ref(false)
 // Include Data Tab when sharing (show historical execution data)
 const includeDataTab = ref(true)
+
+// Chat on the shared artifact page: toggle + agent scope. Scope maps onto the
+// backend's artifact_chat_data_source_ids: 'agents' with everything checked =
+// null (inherit the roster, sent as the ["*"] reset sentinel), a subset = that
+// list, 'data_only' = [].
+const chatEnabled = ref(false)
+const chatScope = ref<'agents' | 'data_only'>('agents')
+const chatAgentIds = ref<string[]>([])
+const reportAgents = ref<{ id: string; name: string }[]>([])
 
 const currentVisibility = ref('none')
 const conversationShareToken = ref<string | null>(null)
@@ -376,6 +427,22 @@ const fetchVisibility = async () => {
                 includeDataTab.value = data.include_data_tab !== false
                 if (props.report) props.report.include_data_tab = data.include_data_tab
             }
+            if (data.artifact_chat_enabled !== undefined) {
+                chatEnabled.value = data.artifact_chat_enabled === true
+                if (props.report) props.report.artifact_chat_enabled = data.artifact_chat_enabled
+            }
+            reportAgents.value = (data.data_sources || []).map((ds: any) => ({ id: ds.id, name: ds.name }))
+            const storedIds = data.artifact_chat_data_source_ids
+            if (storedIds === null || storedIds === undefined) {
+                chatScope.value = reportAgents.value.length > 0 ? 'agents' : 'data_only'
+                chatAgentIds.value = reportAgents.value.map(a => a.id)
+            } else if (Array.isArray(storedIds) && storedIds.length === 0) {
+                chatScope.value = 'data_only'
+                chatAgentIds.value = reportAgents.value.map(a => a.id)
+            } else {
+                chatScope.value = 'agents'
+                chatAgentIds.value = storedIds
+            }
             if (data.conversation_share_token !== undefined) {
                 conversationShareToken.value = data.conversation_share_token
                 if (props.report) props.report.conversation_share_token = data.conversation_share_token
@@ -482,6 +549,53 @@ const onIncludeDataTabChange = async (value: boolean) => {
     }
 }
 
+// One PUT per chat-settings change, mirroring onIncludeDataTabChange: resend
+// the current visibility unchanged and only the field being written.
+const saveChatSettings = async (body: Record<string, any>, revert: () => void) => {
+    isSaving.value = true
+    try {
+        const res = await useMyFetch(`/reports/${props.report.id}/visibility/artifact`, {
+            method: 'PUT',
+            body: { visibility: currentVisibility.value, ...body },
+        })
+        if (res.error.value) throw res.error.value
+        toast.add({ title: t('share.sharingUpdated'), color: 'green' })
+    } catch {
+        revert()
+        toast.add({ title: t('share.sharingFailed'), color: 'red' })
+    } finally {
+        isSaving.value = false
+    }
+}
+
+const chatScopeIdsPayload = (): string[] => {
+    if (chatScope.value === 'data_only') return []
+    const all = reportAgents.value.map(a => a.id)
+    const picked = chatAgentIds.value.filter(id => all.includes(id))
+    // Everything checked = inherit the roster (["*"] resets to null server-side).
+    if (picked.length === all.length && all.length > 0) return ['*']
+    return picked
+}
+
+const onChatEnabledChange = async (value: boolean) => {
+    if (props.report) props.report.artifact_chat_enabled = value
+    await saveChatSettings(
+        { artifact_chat_enabled: value },
+        () => { chatEnabled.value = !value; if (props.report) props.report.artifact_chat_enabled = !value },
+    )
+}
+
+const onChatScopeChange = async () => {
+    if (chatScope.value === 'agents' && chatAgentIds.value.length === 0) {
+        chatAgentIds.value = reportAgents.value.map(a => a.id)
+    }
+    await saveChatSettings({ artifact_chat_data_source_ids: chatScopeIdsPayload() }, () => {})
+}
+
+const onChatAgentsChange = async () => {
+    await saveChatSettings({ artifact_chat_data_source_ids: chatScopeIdsPayload() }, () => {})
+}
+
 const onVisibilityChange = async (value: string) => {
     const prev = props.report?.[visibilityField.value] || 'none'
     if (value === prev) return
@@ -546,6 +660,7 @@ const openModal = async () => {
     conversationShareToken.value = props.report?.conversation_share_token ?? null
     runAsCreator.value = props.report?.shared_run_identity === 'creator'
     includeDataTab.value = props.report?.include_data_tab !== false
+    chatEnabled.value = props.report?.artifact_chat_enabled === true
     await Promise.all([fetchMembers(), fetchGroups(), fetchVisibility(), fetchShares()])
 }
 

--- a/frontend/components/report/ArtifactChatBubble.vue
+++ b/frontend/components/report/ArtifactChatBubble.vue
@@ -60,8 +60,8 @@
                                     <MDC :value="block.content" />
                                 </div>
                                 <div v-else-if="block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
-                                    <Icon :name="block.status === 'in_progress' ? 'heroicons:arrow-path' : (block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check')"
-                                        :class="['w-3 h-3', block.status === 'in_progress' ? 'animate-spin' : '']" />
+                                    <Spinner v-if="block.status === 'in_progress'" class="w-3 h-3" />
+                                    <Icon v-else :name="block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check'" class="w-3 h-3" />
                                     <span class="truncate max-w-[280px]">{{ block.title }}</span>
                                 </div>
                             </template>
@@ -70,9 +70,8 @@
                             </div>
                         </div>
                     </template>
-                    <div v-if="isStreaming && !streamHasBlocks" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
-                        <Icon name="heroicons:arrow-path" class="w-3 h-3 animate-spin" />
-                        <span>Thinking...</span>
+                    <div v-if="isStreaming && !streamHasBlocks" class="flex items-center ps-1">
+                        <Spinner class="w-4 h-4" />
                     </div>
                 </div>
 
@@ -112,6 +111,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
+import Spinner from '~/components/Spinner.vue'
 
 const props = defineProps<{ reportId: string; raised?: boolean }>()
 
@@ -162,6 +162,9 @@ async function loadHistory() {
 function orderedBlocks(msg: any) {
     return (msg.completion_blocks || [])
         .slice()
+        // Planner bookkeeping blocks ("Planning (action)" etc.) are noise in a
+        // compact bubble — the spinner placeholder already covers "working".
+        .filter((b: any) => b.content || (b.title && !/^planning/i.test(b.title)))
         .sort((a: any, b: any) => (a.block_index ?? 0) - (b.block_index ?? 0))
 }
 

--- a/frontend/components/report/ArtifactChatBubble.vue
+++ b/frontend/components/report/ArtifactChatBubble.vue
@@ -59,17 +59,10 @@
                                 <div v-if="block.content" class="bg-gray-100 dark:bg-gray-800 rounded-2xl rounded-bl-md px-3 py-2 max-w-[95%] text-xs text-gray-800 dark:text-gray-200 chat-md">
                                     <MDC :value="block.content" />
                                 </div>
-                                <!-- Tool blocks render with the same components as the
-                                     report/conversation pages, read-only. -->
-                                <div v-else-if="block.tool_execution && getToolComponent(block.tool_execution.tool_name)"
-                                    class="w-full text-xs overflow-x-auto">
-                                    <component
-                                        :is="getToolComponent(block.tool_execution.tool_name)"
-                                        :key="`${block.id}:${block.tool_execution.id || 'noid'}`"
-                                        :tool-execution="block.tool_execution"
-                                        :readonly="true"
-                                    />
-                                </div>
+                                <!-- Tool activity stays a thin status line: this is a
+                                     text-only surface (Teams-style) — the agent is
+                                     instructed to present all data inline in its answer,
+                                     so tool outputs never need their own UI here. -->
                                 <div v-else-if="block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
                                     <Spinner v-if="block.status === 'in_progress'" class="w-3 h-3" />
                                     <Icon v-else :name="block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check'" class="w-3 h-3" />
@@ -123,37 +116,6 @@
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
 import Spinner from '~/components/Spinner.vue'
-// The same tool renderers the report and shared-conversation pages use —
-// scoped to the artifact-chat tool allowlist (see ARTIFACT_CHAT_TOOL_ALLOWLIST
-// in backend/app/ai/agent_v2.py).
-import CreateDataTool from '~/components/tools/CreateDataTool.vue'
-import DescribeTablesTool from '~/components/tools/DescribeTablesTool.vue'
-import DescribeEntityTool from '~/components/tools/DescribeEntityTool.vue'
-import ReadQueryTool from '~/components/tools/ReadQueryTool.vue'
-import ReadArtifactTool from '~/components/tools/ReadArtifactTool.vue'
-import InspectDataTool from '~/components/tools/InspectDataTool.vue'
-import SearchFilesTool from '~/components/tools/SearchFilesTool.vue'
-import GrepFilesTool from '~/components/tools/GrepFilesTool.vue'
-import ListFilesTool from '~/components/tools/ListFilesTool.vue'
-import ReadFileTool from '~/components/tools/ReadFileTool.vue'
-import ClarifyTool from '~/components/tools/ClarifyTool.vue'
-
-function getToolComponent(toolName: string) {
-    switch (toolName) {
-        case 'create_data': return CreateDataTool
-        case 'describe_tables': return DescribeTablesTool
-        case 'describe_entity': return DescribeEntityTool
-        case 'read_query': return ReadQueryTool
-        case 'read_artifact': return ReadArtifactTool
-        case 'inspect_data': return InspectDataTool
-        case 'search_files': return SearchFilesTool
-        case 'grep_files': return GrepFilesTool
-        case 'list_files': return ListFilesTool
-        case 'read_file': return ReadFileTool
-        case 'clarify': return ClarifyTool
-        default: return null
-    }
-}
 
 const props = defineProps<{ reportId: string; raised?: boolean }>()
 

--- a/frontend/components/report/ArtifactChatBubble.vue
+++ b/frontend/components/report/ArtifactChatBubble.vue
@@ -1,0 +1,271 @@
+<template>
+    <!-- Floating chat for the shared artifact page /r/{id}. Small on purpose:
+         a bubble that opens a single-thread panel. The thread is private to
+         this viewer (backend keeps it on a hidden per-viewer chat report). -->
+    <!-- `raised` clears the "Made with Bag of words" badge pinned bottom-end. -->
+    <div :class="['fixed end-4 z-[1001] flex flex-col items-end', raised ? 'bottom-16' : 'bottom-4']" data-testid="artifact-chat">
+        <!-- Panel -->
+        <div v-if="open"
+            class="mb-3 w-[360px] max-w-[calc(100vw-2rem)] h-[480px] max-h-[calc(100dvh-7rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl flex flex-col overflow-hidden"
+            data-testid="artifact-chat-panel">
+            <!-- Header -->
+            <div class="flex items-center justify-between px-3 py-2 border-b border-gray-100 dark:border-gray-800 flex-shrink-0">
+                <div class="flex items-center gap-2 min-w-0">
+                    <Icon name="heroicons:chat-bubble-left-right" class="w-4 h-4 text-blue-600 flex-shrink-0" />
+                    <span class="text-xs font-medium text-gray-700 dark:text-gray-300 truncate">Ask about this dashboard</span>
+                </div>
+                <button @click="open = false" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                    <Icon name="heroicons:x-mark" class="w-4 h-4" />
+                </button>
+            </div>
+
+            <!-- Sign-in required -->
+            <div v-if="status && !status.available && status.reason === 'auth_required'"
+                class="flex-1 flex flex-col items-center justify-center px-6 text-center" data-testid="chat-signin-prompt">
+                <Icon name="heroicons:lock-closed" class="w-8 h-8 text-gray-300 mb-3" />
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">Sign in to ask questions about this dashboard.</p>
+                <a :href="`/users/sign-in?redirect=/r/${reportId}`"
+                    class="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">Sign in</a>
+            </div>
+
+            <!-- Not available (non-member etc.) -->
+            <div v-else-if="status && !status.available"
+                class="flex-1 flex flex-col items-center justify-center px-6 text-center" data-testid="chat-unavailable">
+                <Icon name="heroicons:no-symbol" class="w-8 h-8 text-gray-300 mb-3" />
+                <p class="text-xs text-gray-500 dark:text-gray-400">Chat is available to members of this workspace only.</p>
+            </div>
+
+            <!-- Thread -->
+            <template v-else>
+                <div ref="scrollEl" class="flex-1 overflow-y-auto px-3 py-3 space-y-3" data-testid="chat-messages">
+                    <div v-if="messages.length === 0 && !isStreaming" class="text-center mt-10 px-4">
+                        <Icon name="heroicons:sparkles" class="w-6 h-6 text-gray-300 mx-auto mb-2" />
+                        <p class="text-xs text-gray-400">
+                            {{ status?.scope === 'data_only'
+                                ? "Ask about the data on this dashboard."
+                                : "Ask about this dashboard — I can also run live queries to dig deeper." }}
+                        </p>
+                    </div>
+                    <template v-for="msg in messages" :key="msg.id">
+                        <!-- User message -->
+                        <div v-if="msg.role === 'user'" class="flex justify-end">
+                            <div class="bg-blue-600 text-white text-xs rounded-2xl rounded-br-md px-3 py-2 max-w-[85%] whitespace-pre-wrap break-words">
+                                {{ msg.prompt?.content }}
+                            </div>
+                        </div>
+                        <!-- Assistant message: tool activity lines + markdown content blocks -->
+                        <div v-else class="flex flex-col gap-1.5 items-start" :data-completion-id="msg.id">
+                            <template v-for="block in orderedBlocks(msg)" :key="block.id">
+                                <div v-if="block.content" class="bg-gray-100 dark:bg-gray-800 rounded-2xl rounded-bl-md px-3 py-2 max-w-[95%] text-xs text-gray-800 dark:text-gray-200 chat-md">
+                                    <MDC :value="block.content" />
+                                </div>
+                                <div v-else-if="block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
+                                    <Icon :name="block.status === 'in_progress' ? 'heroicons:arrow-path' : (block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check')"
+                                        :class="['w-3 h-3', block.status === 'in_progress' ? 'animate-spin' : '']" />
+                                    <span class="truncate max-w-[280px]">{{ block.title }}</span>
+                                </div>
+                            </template>
+                            <div v-if="msg.status === 'error' && !hasContent(msg)" class="text-[11px] text-red-400 ps-1">
+                                Something went wrong. Try again.
+                            </div>
+                        </div>
+                    </template>
+                    <div v-if="isStreaming && !streamHasBlocks" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
+                        <Icon name="heroicons:arrow-path" class="w-3 h-3 animate-spin" />
+                        <span>Thinking...</span>
+                    </div>
+                </div>
+
+                <!-- Composer -->
+                <div class="border-t border-gray-100 dark:border-gray-800 p-2 flex-shrink-0">
+                    <div class="flex items-end gap-1.5">
+                        <textarea ref="inputEl" v-model="draft" rows="1"
+                            class="flex-1 resize-none text-xs border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-2 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500 max-h-24"
+                            :placeholder="isStreaming ? 'Answering...' : 'Ask a question...'"
+                            :disabled="isStreaming"
+                            data-testid="chat-input"
+                            @keydown.enter.exact.prevent="send" />
+                        <button @click="send" :disabled="isStreaming || !draft.trim()"
+                            class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center hover:bg-blue-700 disabled:opacity-40"
+                            data-testid="chat-send">
+                            <Icon name="heroicons:paper-airplane" class="w-3.5 h-3.5" />
+                        </button>
+                    </div>
+                    <p v-if="status?.scope === 'agents' && status?.agents?.length" class="text-[10px] text-gray-300 dark:text-gray-600 mt-1 ps-1 truncate">
+                        Can query: {{ status.agents.map((a: any) => a.name).join(', ') }}
+                    </p>
+                    <p v-else-if="status?.scope === 'data_only'" class="text-[10px] text-gray-300 dark:text-gray-600 mt-1 ps-1">
+                        Answers from dashboard data only
+                    </p>
+                </div>
+            </template>
+        </div>
+
+        <!-- Bubble button -->
+        <button @click="toggle"
+            class="w-12 h-12 rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700 flex items-center justify-center transition-transform hover:scale-105"
+            data-testid="artifact-chat-bubble" aria-label="Chat about this dashboard">
+            <Icon :name="open ? 'heroicons:chevron-down' : 'heroicons:chat-bubble-oval-left-ellipsis'" class="w-6 h-6" />
+        </button>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick } from 'vue'
+
+const props = defineProps<{ reportId: string; raised?: boolean }>()
+
+const open = ref(false)
+const status = ref<any>(null)
+const messages = ref<any[]>([])
+const draft = ref('')
+const isStreaming = ref(false)
+const streamHasBlocks = ref(false)
+const scrollEl = ref<HTMLElement | null>(null)
+const inputEl = ref<HTMLTextAreaElement | null>(null)
+let initialized = false
+
+const toggle = async () => {
+    open.value = !open.value
+    if (open.value && !initialized) {
+        initialized = true
+        await Promise.all([loadStatus(), loadHistory()])
+    }
+    if (open.value) nextTick(() => inputEl.value?.focus())
+}
+
+async function loadStatus() {
+    try {
+        const { data, error } = await useMyFetch(`/r/${props.reportId}/chat`)
+        if (error.value) {
+            status.value = { available: false, reason: 'error' }
+            return
+        }
+        status.value = data.value
+    } catch {
+        status.value = { available: false, reason: 'error' }
+    }
+}
+
+async function loadHistory() {
+    try {
+        const { data, error } = await useMyFetch(`/r/${props.reportId}/chat/completions?limit=30`)
+        if (error.value || !data.value) return
+        const list = (data.value as any).completions || []
+        messages.value = list
+            .slice()
+            .sort((a: any, b: any) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+        scrollToBottom()
+    } catch { /* thread just renders empty */ }
+}
+
+function orderedBlocks(msg: any) {
+    return (msg.completion_blocks || [])
+        .slice()
+        .sort((a: any, b: any) => (a.block_index ?? 0) - (b.block_index ?? 0))
+}
+
+function hasContent(msg: any) {
+    return (msg.completion_blocks || []).some((b: any) => b.content)
+}
+
+function scrollToBottom() {
+    nextTick(() => {
+        if (scrollEl.value) scrollEl.value.scrollTop = scrollEl.value.scrollHeight
+    })
+}
+
+async function send() {
+    const content = draft.value.trim()
+    if (!content || isStreaming.value) return
+    draft.value = ''
+    isStreaming.value = true
+    streamHasBlocks.value = false
+
+    // Optimistic user message + assistant placeholder the SSE events fill in.
+    const userMsg = { id: `local-user-${Date.now()}`, role: 'user', status: 'success', prompt: { content }, created_at: new Date().toISOString() }
+    const assistantMsg = ref<any>({ id: `local-sys-${Date.now()}`, role: 'system', status: 'in_progress', completion_blocks: [], created_at: new Date().toISOString() })
+    messages.value.push(userMsg, assistantMsg.value)
+    scrollToBottom()
+
+    try {
+        const res: any = await useMyFetch(`/r/${props.reportId}/chat/completions`, {
+            method: 'POST',
+            stream: true,
+            body: JSON.stringify({ prompt: { content }, stream: true }),
+            headers: { 'Content-Type': 'application/json' },
+        } as any)
+        const response: Response = res.data
+        const reader = response.body!.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buffer += decoder.decode(value, { stream: true })
+            // SSE frames are separated by a blank line.
+            const frames = buffer.split('\n\n')
+            buffer = frames.pop() || ''
+            for (const frame of frames) {
+                const dataLine = frame.split('\n').find(l => l.startsWith('data: '))
+                if (!dataLine) continue
+                let evt: any
+                try { evt = JSON.parse(dataLine.slice(6)) } catch { continue }
+                handleEvent(evt, assistantMsg.value)
+            }
+        }
+    } catch (e) {
+        assistantMsg.value.status = 'error'
+        console.error('Artifact chat stream failed:', e)
+    } finally {
+        isStreaming.value = false
+        // Reconcile with the server's persisted thread (final block content,
+        // real ids) — the stream is progressive, history is authoritative.
+        await loadHistory()
+    }
+}
+
+function handleEvent(evt: any, assistantMsg: any) {
+    const kind = evt.event
+    if (kind === 'block.upsert' && evt.data?.block) {
+        const block = evt.data.block
+        streamHasBlocks.value = true
+        const blocks = assistantMsg.completion_blocks
+        const idx = blocks.findIndex((b: any) => b.id === block.id)
+        if (idx >= 0) blocks[idx] = block
+        else blocks.push(block)
+        scrollToBottom()
+    } else if (kind === 'block.delta.text' && evt.data?.block_id) {
+        // Full overwrite snapshot for a block's text field.
+        const b = assistantMsg.completion_blocks.find((x: any) => x.id === evt.data.block_id)
+        if (b && evt.data.field === 'content' && evt.data.text) {
+            b.content = evt.data.text
+            streamHasBlocks.value = true
+            scrollToBottom()
+        }
+    } else if (kind === 'block.delta.token' && evt.data?.block_id) {
+        // Per-token append for the typing effect.
+        const b = assistantMsg.completion_blocks.find((x: any) => x.id === evt.data.block_id)
+        if (b && evt.data.field === 'content' && evt.data.token) {
+            b.content = (b.content || '') + String(evt.data.token)
+            streamHasBlocks.value = true
+            scrollToBottom()
+        }
+    } else if (kind === 'completion.finished') {
+        assistantMsg.status = evt.data?.status || 'success'
+    } else if (kind === 'completion.error') {
+        assistantMsg.status = 'error'
+    }
+}
+</script>
+
+<style scoped>
+.chat-md :deep(p) { margin: 0 0 0.4rem 0; }
+.chat-md :deep(p:last-child) { margin-bottom: 0; }
+.chat-md :deep(ul), .chat-md :deep(ol) { margin: 0.2rem 0 0.4rem 1rem; list-style: disc; }
+.chat-md :deep(ol) { list-style: decimal; }
+.chat-md :deep(table) { font-size: 11px; border-collapse: collapse; margin: 0.3rem 0; }
+.chat-md :deep(th), .chat-md :deep(td) { border: 1px solid rgb(209 213 219 / 0.6); padding: 2px 6px; }
+.chat-md :deep(code) { background: rgb(0 0 0 / 0.06); border-radius: 3px; padding: 0 3px; font-size: 11px; }
+.chat-md :deep(pre) { overflow-x: auto; background: rgb(0 0 0 / 0.05); border-radius: 6px; padding: 6px; margin: 0.3rem 0; }
+</style>

--- a/frontend/components/report/ArtifactChatBubble.vue
+++ b/frontend/components/report/ArtifactChatBubble.vue
@@ -55,15 +55,30 @@
                         </div>
                         <!-- Assistant message: tool activity lines + markdown content blocks -->
                         <div v-else class="flex flex-col gap-1.5 items-start" :data-completion-id="msg.id">
+                            <!-- A block can carry BOTH the agent's narration and a tool
+                                 call ("I'll search the sales files" + search_files), so
+                                 content and the tool line render together, in that order —
+                                 same as the report page. -->
                             <template v-for="block in orderedBlocks(msg)" :key="block.id">
                                 <div v-if="block.content" class="bg-gray-100 dark:bg-gray-800 rounded-2xl rounded-bl-md px-3 py-2 max-w-[95%] text-xs text-gray-800 dark:text-gray-200 chat-md">
                                     <MDC :value="block.content" />
                                 </div>
-                                <!-- Tool activity stays a thin status line: this is a
-                                     text-only surface (Teams-style) — the agent is
-                                     instructed to present all data inline in its answer,
-                                     so tool outputs never need their own UI here. -->
-                                <div v-else-if="block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
+                                <!-- Tool activity: the collapsed-header look of the report
+                                     page's tool components ("Created data — Revenue by
+                                     region"), but never expandable. This is a text-only
+                                     surface (Teams-style) — the answer itself carries the
+                                     data, so tool results need no UI of their own here. -->
+                                <div v-if="block.tool_execution" class="flex items-center text-[11px] text-gray-500 dark:text-gray-400 ps-1 min-w-0 max-w-full">
+                                    <Spinner v-if="block.status === 'in_progress'" class="w-3 h-3 me-1.5 text-gray-400 flex-shrink-0" />
+                                    <Icon v-else-if="block.status === 'error'" name="heroicons-exclamation-circle" class="w-3 h-3 me-1.5 text-amber-500 flex-shrink-0" />
+                                    <Icon v-else name="heroicons-check" class="w-3 h-3 me-1.5 text-green-500 flex-shrink-0" />
+                                    <span class="flex-shrink-0" :class="block.status === 'in_progress' ? 'tool-shimmer' : 'text-gray-700 dark:text-gray-300'">
+                                        {{ toolLabel(block) }}
+                                    </span>
+                                    <span v-if="toolDetail(block)" class="ms-1 text-gray-400 truncate">— {{ toolDetail(block) }}</span>
+                                    <span v-if="toolDuration(block)" class="ms-1.5 text-gray-400 flex-shrink-0">{{ toolDuration(block) }}</span>
+                                </div>
+                                <div v-else-if="!block.content && block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
                                     <Spinner v-if="block.status === 'in_progress'" class="w-3 h-3" />
                                     <Icon v-else :name="block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check'" class="w-3 h-3" />
                                     <span class="truncate max-w-[280px]">{{ block.title }}</span>
@@ -163,12 +178,51 @@ async function loadHistory() {
     } catch { /* thread just renders empty */ }
 }
 
+// Verb labels matching the report page's tool headers, for the tools in the
+// artifact-chat allowlist (ARTIFACT_CHAT_TOOL_ALLOWLIST, backend). Unknown
+// tools fall back to a prettified tool_name so a new tool never renders blank.
+const TOOL_LABELS: Record<string, { running: string; done: string }> = {
+    create_data: { running: 'Creating data', done: 'Created data' },
+    describe_tables: { running: 'Describing tables', done: 'Described tables' },
+    describe_entity: { running: 'Reading entity', done: 'Read entity' },
+    read_query: { running: 'Reading query', done: 'Read query' },
+    read_artifact: { running: 'Reading dashboard', done: 'Read dashboard' },
+    inspect_data: { running: 'Inspecting data', done: 'Inspected data' },
+    search_files: { running: 'Searching files', done: 'Searched files' },
+    grep_files: { running: 'Searching files', done: 'Searched files' },
+    list_files: { running: 'Listing files', done: 'Listed files' },
+    read_file: { running: 'Reading file', done: 'Read file' },
+    clarify: { running: 'Asking a question', done: 'Asked a question' },
+}
+
+function toolLabel(block: any): string {
+    const name = block.tool_execution?.tool_name || ''
+    const entry = TOOL_LABELS[name]
+    if (entry) return block.status === 'in_progress' ? entry.running : entry.done
+    return name.replace(/_/g, ' ').replace(/^./, (c: string) => c.toUpperCase())
+}
+
+// The tool's own human title ("Finding sales.csv", "Revenue by region").
+// Deliberately NOT block.title — that is planner bookkeeping
+// ("Planning (research) → search_files") and never reads well here.
+function toolDetail(block: any): string {
+    const detail = block.tool_execution?.arguments_json?.title || ''
+    return detail && detail.toLowerCase() !== toolLabel(block).toLowerCase() ? detail : ''
+}
+
+// Sub-second calls are the norm; a "0.1s" on every line is just noise.
+function toolDuration(block: any): string {
+    const ms = block.tool_execution?.duration_ms ?? block.duration_ms
+    if (!ms || ms < 1000 || block.status === 'in_progress') return ''
+    return `${(ms / 1000).toFixed(1)}s`
+}
+
 function orderedBlocks(msg: any) {
     return (msg.completion_blocks || [])
         .slice()
         // Planner bookkeeping blocks ("Planning (action)" etc.) are noise in a
         // compact bubble — the spinner placeholder already covers "working".
-        .filter((b: any) => b.content || (b.title && !/^planning/i.test(b.title)))
+        .filter((b: any) => b.content || b.tool_execution || (b.title && !/^planning/i.test(b.title)))
         .sort((a: any, b: any) => (a.block_index ?? 0) - (b.block_index ?? 0))
 }
 
@@ -285,4 +339,18 @@ function handleEvent(evt: any, assistantMsg: any) {
 .chat-md :deep(th), .chat-md :deep(td) { border: 1px solid rgb(209 213 219 / 0.6); padding: 2px 6px; }
 .chat-md :deep(code) { background: rgb(0 0 0 / 0.06); border-radius: 3px; padding: 0 3px; font-size: 11px; }
 .chat-md :deep(pre) { overflow-x: auto; background: rgb(0 0 0 / 0.05); border-radius: 6px; padding: 6px; margin: 0.3rem 0; }
+
+/* Same shimmer as the report page's tool headers (see CreateDataTool.vue). */
+.tool-shimmer {
+    background: linear-gradient(90deg, #888 0%, #999 25%, #ccc 50%, #999 75%, #888 100%);
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: chat-shimmer 2s linear infinite;
+}
+@keyframes chat-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
 </style>

--- a/frontend/components/report/ArtifactChatBubble.vue
+++ b/frontend/components/report/ArtifactChatBubble.vue
@@ -59,6 +59,17 @@
                                 <div v-if="block.content" class="bg-gray-100 dark:bg-gray-800 rounded-2xl rounded-bl-md px-3 py-2 max-w-[95%] text-xs text-gray-800 dark:text-gray-200 chat-md">
                                     <MDC :value="block.content" />
                                 </div>
+                                <!-- Tool blocks render with the same components as the
+                                     report/conversation pages, read-only. -->
+                                <div v-else-if="block.tool_execution && getToolComponent(block.tool_execution.tool_name)"
+                                    class="w-full text-xs overflow-x-auto">
+                                    <component
+                                        :is="getToolComponent(block.tool_execution.tool_name)"
+                                        :key="`${block.id}:${block.tool_execution.id || 'noid'}`"
+                                        :tool-execution="block.tool_execution"
+                                        :readonly="true"
+                                    />
+                                </div>
                                 <div v-else-if="block.title" class="flex items-center gap-1.5 text-[11px] text-gray-400 ps-1">
                                     <Spinner v-if="block.status === 'in_progress'" class="w-3 h-3" />
                                     <Icon v-else :name="block.status === 'error' ? 'heroicons:exclamation-triangle' : 'heroicons:check'" class="w-3 h-3" />
@@ -112,6 +123,37 @@
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
 import Spinner from '~/components/Spinner.vue'
+// The same tool renderers the report and shared-conversation pages use —
+// scoped to the artifact-chat tool allowlist (see ARTIFACT_CHAT_TOOL_ALLOWLIST
+// in backend/app/ai/agent_v2.py).
+import CreateDataTool from '~/components/tools/CreateDataTool.vue'
+import DescribeTablesTool from '~/components/tools/DescribeTablesTool.vue'
+import DescribeEntityTool from '~/components/tools/DescribeEntityTool.vue'
+import ReadQueryTool from '~/components/tools/ReadQueryTool.vue'
+import ReadArtifactTool from '~/components/tools/ReadArtifactTool.vue'
+import InspectDataTool from '~/components/tools/InspectDataTool.vue'
+import SearchFilesTool from '~/components/tools/SearchFilesTool.vue'
+import GrepFilesTool from '~/components/tools/GrepFilesTool.vue'
+import ListFilesTool from '~/components/tools/ListFilesTool.vue'
+import ReadFileTool from '~/components/tools/ReadFileTool.vue'
+import ClarifyTool from '~/components/tools/ClarifyTool.vue'
+
+function getToolComponent(toolName: string) {
+    switch (toolName) {
+        case 'create_data': return CreateDataTool
+        case 'describe_tables': return DescribeTablesTool
+        case 'describe_entity': return DescribeEntityTool
+        case 'read_query': return ReadQueryTool
+        case 'read_artifact': return ReadArtifactTool
+        case 'inspect_data': return InspectDataTool
+        case 'search_files': return SearchFilesTool
+        case 'grep_files': return GrepFilesTool
+        case 'list_files': return ListFilesTool
+        case 'read_file': return ReadFileTool
+        case 'clarify': return ClarifyTool
+        default: return null
+    }
+}
 
 const props = defineProps<{ reportId: string; raised?: boolean }>()
 
@@ -228,22 +270,32 @@ async function send() {
     }
 }
 
+// The trailing spinner shows whenever the agent is working with nothing
+// visibly in progress: before the first visible block, and between rounds
+// (a tool finished, the next planner call hasn't produced anything yet).
+// Planner bookkeeping blocks are invisible (orderedBlocks filters them), so
+// they must not count as "in progress" here either.
+function refreshWaitSpinner(assistantMsg: any) {
+    const visible = orderedBlocks(assistantMsg)
+    streamHasBlocks.value = visible.some((b: any) => b.status === 'in_progress')
+}
+
 function handleEvent(evt: any, assistantMsg: any) {
     const kind = evt.event
     if (kind === 'block.upsert' && evt.data?.block) {
         const block = evt.data.block
-        streamHasBlocks.value = true
         const blocks = assistantMsg.completion_blocks
         const idx = blocks.findIndex((b: any) => b.id === block.id)
         if (idx >= 0) blocks[idx] = block
         else blocks.push(block)
+        refreshWaitSpinner(assistantMsg)
         scrollToBottom()
     } else if (kind === 'block.delta.text' && evt.data?.block_id) {
         // Full overwrite snapshot for a block's text field.
         const b = assistantMsg.completion_blocks.find((x: any) => x.id === evt.data.block_id)
         if (b && evt.data.field === 'content' && evt.data.text) {
             b.content = evt.data.text
-            streamHasBlocks.value = true
+            refreshWaitSpinner(assistantMsg)
             scrollToBottom()
         }
     } else if (kind === 'block.delta.token' && evt.data?.block_id) {
@@ -251,7 +303,7 @@ function handleEvent(evt: any, assistantMsg: any) {
         const b = assistantMsg.completion_blocks.find((x: any) => x.id === evt.data.block_id)
         if (b && evt.data.field === 'content' && evt.data.token) {
             b.content = (b.content || '') + String(evt.data.token)
-            streamHasBlocks.value = true
+            refreshWaitSpinner(assistantMsg)
             scrollToBottom()
         }
     } else if (kind === 'completion.finished') {

--- a/frontend/pages/r/[id]/index.vue
+++ b/frontend/pages/r/[id]/index.vue
@@ -249,6 +249,14 @@
                 </div>
             </div>
         </div>
+
+        <!-- Floating chat (owner setting; the bubble itself resolves per-viewer
+             availability — sign-in prompt for anonymous, member check inside) -->
+        <ArtifactChatBubble
+            v-if="reportLoaded && report?.artifact_chat_enabled"
+            :report-id="String($route.params.id)"
+            :raised="report.general?.bow_credit !== false"
+        />
     </div>
 </template>
 
@@ -259,6 +267,7 @@ import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue';
 import SlideViewer from '~/components/dashboard/SlideViewer.vue';
 import DocViewer from '~/components/dashboard/DocViewer.vue';
 import ViewerRunGate from '~/components/dashboard/ViewerRunGate.vue';
+import ArtifactChatBubble from '~/components/report/ArtifactChatBubble.vue';
 import { buildArtifactIframeHtml, isHtmlSlidesCode } from '~/utils/artifactIframe';
 
 const route = useRoute();

--- a/locales/en.json
+++ b/locales/en.json
@@ -3168,7 +3168,15 @@
     "userNotFound": "User not found in organization",
     "copyFailed": "Failed to copy",
     "includeDataTab": "Include Data Tab",
-    "includeDataTabDesc": "Recipients will see the complete data history and process used to generate this report"
+    "includeDataTabDesc": "Recipients will see the complete data history and process used to generate this report",
+    "allowChat": "Allow chat",
+    "allowChatDesc": "Signed-in workspace members can ask questions about this dashboard",
+    "chatScope": "Chat can use",
+    "chatScopeAgents": "Report agents",
+    "chatScopeAgentsDesc": "Chat may run live read-only queries against the selected agents",
+    "chatScopeDataOnly": "Dashboard data only",
+    "chatScopeDataOnlyDesc": "Chat answers only from the data already on this dashboard",
+    "chatNoAgents": "No agents are attached to this report — chat will answer from dashboard data only."
   },
   "publish": {
     "published": "Published",


### PR DESCRIPTION
Owners can enable chat on the shared artifact page and choose what it may
use: the report's agents (read-only live queries, per-agent selection) or
the dashboard's own data only. Viewer conversations are fully isolated —
each (report, viewer) pair gets a hidden child report
(report_type='artifact_chat', forked_from_id=source) so the owner's
transcript is never exposed and viewer threads never appear in listings,
search, or the agent's tools (everything already allowlists 'regular').

Backend:
- reports.artifact_chat_enabled + artifact_chat_data_source_ids (null =
  inherit roster, [] = dashboard data only, ["*"] PUT sentinel resets to
  null), written through the artifact visibility PUT
- /r/{id}/chat routes (status, streamed completions, history, watch):
  signed-in org members only, artifact visibility + chat toggle re-checked
  on every message so unsharing/disabling applies immediately
- Effective agents = owner allowlist ∩ viewer-accessible, synced as the
  chat report's roster per message; empty roster on artifact_chat reports
  is never Auto (resolve_run_agents guard)
- Read/query-only tool allowlist for artifact_chat reports keyed on the
  report type in AgentV2; dashboard visualization data injected via
  platform_context in data-only scope, resolved live from the latest
  artifact (nothing copied, nothing stale)

Frontend:
- ShareModal: Allow chat toggle + "Chat can use" scope (agents with
  per-agent checkboxes / dashboard data only)
- Floating chat bubble on /r/{id}: SSE-streamed thread, per-viewer
  history, sign-in prompt for anonymous visitors

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DWYpzHnzexJVVh5VbU1oyU