### PR TITLE
Judge viz coverage by id, not by the accessor's name

### DIFF
--- a/backend/app/ai/tools/implementations/_artifact_refs.py
+++ b/backend/app/ai/tools/implementations/_artifact_refs.py
@@ -32,6 +32,27 @@ VIZ_BY_ID_RE = re.compile(r"vizById\(\s*['\"]([0-9a-fA-F][0-9a-fA-F-]{10,40})['\
 VIZ_ITERATION_RE = re.compile(r"\b(?:viz|visualizations)\s*\.\s*(?:map|forEach)\b")
 
 
+def _quoted_id_refs(src: str, ids: List[str]) -> set:
+    """Payload ids that appear as a quoted string literal anywhere in the code.
+
+    Coverage asks "does the code bind this viz?", but `vizById(...)` is only
+    the RECOMMENDED spelling, not the only correct one — the runtime global is
+    literally a lookup by id over the same list, so
+    ``visualizations.find(v => v.id === "<uuid>")``, an ``{ "<uuid>": ... }``
+    map, or ``byId["<uuid>"]`` bind exactly as well. Matching the helper's
+    NAME rejected working dashboards in production (a create that bound all 8
+    payload vizs via `.find` was told it "references NONE of the
+    visualizations"), so coverage matches the ids themselves.
+
+    Only QUOTED ids count, so prose or a comment merely mentioning a uuid
+    binds nothing. The residual false-pass is an id quoted inside a comment
+    (`// was vizById("<uuid>")`) — rare, and it costs one unrendered viz,
+    where the false FAILURE it replaces discarded an entire valid artifact
+    and forced a full regeneration.
+    """
+    return {vid for vid in ids if re.search(r"['\"]" + re.escape(vid) + r"['\"]", src)}
+
+
 def _inside_string_or_comment(line: str, col: int) -> bool:
     """Heuristic: is column ``col`` of ``line`` inside a string literal or
     after a ``//`` line comment? Counts unescaped quote characters before the
@@ -149,6 +170,8 @@ def viz_reference_errors(code: str, artifact_data: Dict[str, Any]) -> List[str]:
     if ids and src.strip() and not VIZ_ITERATION_RE.search(src):
         referenced = set()
         referenced |= id_refs & known
+        # Any binding style counts, not just vizById() — see _quoted_id_refs.
+        referenced |= _quoted_id_refs(src, ids)
         for idx in positional_idxs:
             if idx < len(ids):
                 referenced.add(ids[idx])
@@ -159,7 +182,8 @@ def viz_reference_errors(code: str, artifact_data: Dict[str, Any]) -> List[str]:
                 errors.append(
                     "[viz refs] The code references NONE of the visualizations in this "
                     f"artifact's data payload ({names}) — the page renders no data. Bind "
-                    "each viz with vizById(\"<uuid>\") or render the whole list."
+                    "each viz by id (vizById(\"<uuid>\") is the recommended form) or render "
+                    "the whole list."
                 )
             else:
                 errors.append(

--- a/backend/tests/unit/test_artifact_refs.py
+++ b/backend/tests/unit/test_artifact_refs.py
@@ -146,6 +146,66 @@ def test_gate_tolerates_legacy_in_range_positional_code():
     assert viz_reference_errors(code, _payload()) == []
 
 
+# ── binding style: coverage must not depend on the accessor's NAME ──────────
+# Regression suite for a production incident (report 903c375a): a dashboard
+# that bound every payload viz via `.find(v => v.id === "<uuid>")` was rejected
+# with "The code references NONE of the visualizations", costing a full
+# regeneration. vizById() IS that lookup — see artifact-globals.js.
+
+def test_gate_accepts_find_by_id_as_binding():
+    """Attempt 2 of the incident: correct ids, inlined lookup. Must pass."""
+    code = "\n".join(
+        f'const v{n} = data.visualizations.find(v => v.id === "{vid}");'
+        for n, vid in enumerate(IDS)
+    )
+    assert viz_reference_errors(code, _payload()) == []
+
+
+def test_gate_accepts_id_keyed_map_and_bracket_lookup():
+    """Other spellings that bind by id without naming the helper."""
+    code = (
+        f'const BY_ID = {{ mom: "{IDS[0]}", ord: "{IDS[1]}" }};\n'
+        f'const churn = byId[\'{IDS[2]}\'];'
+    )
+    assert viz_reference_errors(code, _payload()) == []
+
+
+def test_gate_accepts_mixed_binding_styles():
+    code = (
+        f'const a = vizById("{IDS[0]}");\n'
+        f'const b = vizs.find(v => v.id === "{IDS[1]}");\n'
+        f'const c = lookup["{IDS[2]}"];'
+    )
+    assert viz_reference_errors(code, _payload()) == []
+
+
+def test_gate_still_flags_unknown_id_alongside_full_coverage():
+    """Attempt 1 of the incident: every payload viz bound correctly, plus one
+    invented id. The unknown-ref check is scoped to vizById() and must still
+    fire — that was a true positive worth keeping."""
+    ghost = "99999999-dead-beef-cccc-000000000009"
+    code = "\n".join(f'const v = vizById("{vid}");' for vid in IDS)
+    code += f'\nconst missing = vizById("{ghost}");'
+    errors = viz_reference_errors(code, _payload())
+    assert len(errors) == 1, errors
+    assert ghost in errors[0] and "no visualization with that id" in errors[0]
+
+
+def test_gate_still_flags_missing_viz_under_new_matching():
+    """Widening coverage must not mask a genuinely dropped chart."""
+    code = f'const a = vizs.find(v => v.id === "{IDS[0]}");'
+    errors = viz_reference_errors(code, _payload(titles=["Rev", "Orders", "Churn"]))
+    assert any(IDS[2] in e and "Churn" in e for e in errors)
+
+
+def test_gate_bare_unquoted_uuid_is_not_a_reference():
+    """A uuid must be a string literal to count — prose mentioning one does
+    not bind anything."""
+    code = f"// dashboard for {IDS[0]} {IDS[1]} {IDS[2]}\nconst x = <div>hi</div>;"
+    errors = viz_reference_errors(code, _payload())
+    assert any("NONE" in e for e in errors)
+
+
 def test_gate_empty_payload_and_empty_code():
     assert viz_reference_errors("", _payload()) == []
     assert viz_reference_errors("const x = 1;", {"visualizations": []}) == []


### PR DESCRIPTION
## The bug

The viz-reference gate asked *"does the code call `vizById()`?"* when it meant *"does the code bind this viz?"*. Those are not the same question — the runtime global is literally a lookup by id over the same list:

```js
// frontend/public/libs/artifact-globals.js
window.vizById = id => list.find(v => String(v.id) === String(id))
```

So `visualizations.find(v => v.id === "fac3fa3d-…")`, an `{ "fac3fa3d-…": ... }` map, and `byId["fac3fa3d-…"]` all bind exactly as well — and every one of them read as **zero coverage**.

## Observed in production

On report `903c375a`, a create that bound **all 8** payload visualizations by id via `.find` was rejected with:

> `[viz refs] The code references NONE of the visualizations in this artifact's data payload ("Active Users Month-over-Month" (vizById("fac3fa3d-…")), …) — the page renders no data.`

The code contained `"fac3fa3d-…"`. The error message quoted back the very uuids the code was using.

Worse, the gate had *caused* that spelling: the previous attempt bound all 8 correctly via `vizById` but also invented a 9th id, tripping the (correct) unknown-id check. The planner reacted by abandoning the helper — and the gate rejected that too. Net cost: two failed creates and a full regeneration, ~82s, for code that would have rendered.

## The fix

Coverage counts a payload id appearing as a **quoted string literal**, whatever the accessor. Deliberately unchanged:

- **Only quoted ids count** — prose or a comment merely mentioning a uuid still binds nothing.
- **Whole-list `map`/`forEach`** coverage is untouched.
- **The unknown-id check stays scoped to `vizById()`** — it caught a genuinely invented id in this same incident, and that is a true positive worth keeping.

## Verification

Replayed against the three real artifact versions from the incident:

| attempt | binding style | before | after |
|---|---|---|---|
| 1 | `vizById` ×8 correct + 1 invented id | failed | **fails** — exactly one error, naming the invented id |
| 2 | `.find(v => v.id === …)` ×8 correct | failed | **passes** |
| 3 | `vizById` ×8 correct (shipped) | completed | **passes** |

Six regression tests pin those shapes plus the cases widening must not mask — a genuinely dropped chart, and an unquoted uuid. 64 artifact-suite tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aKhfXooEvD8NWCuCA3hTd

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKhfXooEvD8NWCuCA3hTd)_