### PR TITLE
read_file previews: fix thread-safety, attachment attribution, and preview edge cases

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -586,7 +586,15 @@ class AgentV2:
                 if (getattr(f, 'content_type', '') or '').startswith('image/')
                 and not _is_connector(f)
             ]
-            self.analysis_files = [f for f in all_files if not (getattr(f, 'content_type', '') or '').startswith('image/')]
+            # "#source" rows are persist_source_document's viewer copies of
+            # original documents (the .pdf behind a .pdf.txt session file).
+            # They are linked to the report for the embed route, but they are
+            # not analyzable and must not rejoin the roster at init.
+            self.analysis_files = [
+                f for f in all_files
+                if not (getattr(f, 'content_type', '') or '').startswith('image/')
+                and not str(getattr(f, 'source_ref', '') or '').endswith('#source')
+            ]
         else:
             self.data_sources = []
             self.clients = {}

--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -426,26 +426,31 @@ def render_pdf_pages_images(pdf_bytes: bytes, first: int, last: int, *, max_page
     Raises on an unreadable PDF."""
     import pypdfium2 as pdfium
     from app.ai.llm.image_utils import encode_pil_for_vision
+    from app.data_sources.clients._document_text import PDFIUM_LOCK
 
-    pdf = pdfium.PdfDocument(bytes(pdf_bytes))
-    try:
-        total = len(pdf)
-        first = max(1, int(first))
-        last = min(total, int(last))
-        out = []
-        for i in range(first - 1, last):
-            if len(out) >= max_pages:
-                break
-            page = pdf[i]
-            try:
-                bitmap = page.render(scale=dpi / 72.0)
-                pil = bitmap.to_pil()
-                out.append(encode_pil_for_vision(pil))
-            finally:
-                page.close()
-        return out, total
-    finally:
-        pdf.close()
+    # PDFium is not thread-safe; this runs on worker threads concurrently with
+    # text extraction (_document_text), so every PDFium sequence takes the
+    # shared lock.
+    with PDFIUM_LOCK:
+        pdf = pdfium.PdfDocument(bytes(pdf_bytes))
+        try:
+            total = len(pdf)
+            first = max(1, int(first))
+            last = min(total, int(last))
+            out = []
+            for i in range(first - 1, last):
+                if len(out) >= max_pages:
+                    break
+                page = pdf[i]
+                try:
+                    bitmap = page.render(scale=dpi / 72.0)
+                    pil = bitmap.to_pil()
+                    out.append(encode_pil_for_vision(pil))
+                finally:
+                    page.close()
+            return out, total
+        finally:
+            pdf.close()
 
 
 def render_file_payload(name: str, payload: Any, max_rows: int, max_chars: int) -> Dict[str, Any]:
@@ -555,6 +560,11 @@ def ext_for_mime(mime: Optional[str]) -> Optional[str]:
 # Picture files we can hand to a vision model as-is (normalized to PNG).
 _RENDERABLE_IMAGE_EXTS = {"png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif"}
 
+# The subset a BROWSER can render in an <img> tag. TIFF is the difference:
+# PIL decodes it for the vision path, but no mainstream browser displays it,
+# so a .tiff file id handed to the UI as an image produces a broken picture.
+_BROWSER_IMAGE_EXTS = _RENDERABLE_IMAGE_EXTS - {"tiff", "tif"}
+
 
 def is_picture_name(name: Optional[str]) -> bool:
     """True when this name is a picture the browser can render as-is.
@@ -562,11 +572,12 @@ def is_picture_name(name: Optional[str]) -> bool:
     Distinguishes "the source IS an image" from "the source was RENDERED to
     images": a page render of a PDF is a new artifact, while a re-encoded PNG
     is the same file the user already has. Callers use it to decide whether a
-    materialized image id may stand in for the source file id.
+    materialized image id may stand in for the source file id — so the test is
+    browser renderability, not merely "PIL can open it".
     """
     leaf = str(name or "").rsplit("/", 1)[-1]
     ext = leaf.rsplit(".", 1)[-1].lower() if "." in leaf else ""
-    return ext in _RENDERABLE_IMAGE_EXTS
+    return ext in _BROWSER_IMAGE_EXTS
 
 
 def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 150):
@@ -615,17 +626,19 @@ def render_file_images(file_id: str, payload, *, max_pages: int = 8, dpi: int = 
         if ext == "pdf":
             import pypdfium2 as pdfium
             from app.ai.llm.image_utils import encode_pil_for_vision
-            pdf = pdfium.PdfDocument(data)
-            try:
-                total = len(pdf)
-                out = []
-                for i in range(min(total, max_pages)):
-                    page = pdf[i]
-                    pil = page.render(scale=dpi / 72.0).to_pil()
-                    out.append(encode_pil_for_vision(pil))
-                return out, total
-            finally:
-                pdf.close()
+            from app.data_sources.clients._document_text import PDFIUM_LOCK
+            with PDFIUM_LOCK:
+                pdf = pdfium.PdfDocument(data)
+                try:
+                    total = len(pdf)
+                    out = []
+                    for i in range(min(total, max_pages)):
+                        page = pdf[i]
+                        pil = page.render(scale=dpi / 72.0).to_pil()
+                        out.append(encode_pil_for_vision(pil))
+                    return out, total
+                finally:
+                    pdf.close()
     except Exception as e:  # corrupt/locked file, unsupported image
         logger.info("render_file_images: could not render %s: %s", file_id, e)
     return [], 0
@@ -704,6 +717,16 @@ async def read_source_bytes(client, file_id: str) -> Tuple[bytes, str, Optional[
     return str(payload).encode("utf-8"), f"{leaf}.txt", "text/plain"
 
 
+def _append_analysis_file(runtime_ctx: Dict[str, Any], db_file) -> None:
+    """Add a just-attached file to the turn's live analysis roster (dedup)."""
+    try:
+        ef = runtime_ctx.get("excel_files")
+        if isinstance(ef, list) and all(getattr(x, "id", None) != db_file.id for x in ef):
+            ef.append(db_file)
+    except Exception as e:
+        logger.warning("attach_drive_file_to_session: excel_files refresh failed: %s", e)
+
+
 async def _find_cached_connector_file(
     db, *, report, connection_id: Optional[str], source_ref: Optional[str],
     source_kind: str,
@@ -748,6 +771,7 @@ async def attach_drive_file_to_session(
     source_kind: str = "connector",
     connection_id: Optional[str] = None,
     source_ref: Optional[str] = None,
+    analysis: bool = True,
 ) -> Optional[str]:
     """Materialize connector bytes as a File the code sandbox can read.
 
@@ -767,6 +791,12 @@ async def attach_drive_file_to_session(
     Returns the File row id, or None if the file wasn't attached (no report
     context, oversize, or persistence failed — non-fatal, caller still returns
     inline content).
+
+    ``analysis=False`` marks a file that exists for the VIEWER, not the code
+    sandbox (persist_source_document's original-document copies): it is still
+    linked to the report so the embed route and the refresh-in-place cache can
+    find it, but it must not join the analysis roster the model is told to run
+    inspect_data / create_data against.
     """
     db = runtime_ctx.get("db")
     report = runtime_ctx.get("report")
@@ -822,6 +852,31 @@ async def attach_drive_file_to_session(
 
         if cached is not None:
             path = cached.path
+            # Refresh is only worth its cost when the bytes actually changed.
+            # A model paging through one document re-persists it once per
+            # page_range read; without this check each of those rewrote the
+            # whole file, regenerated the preview and issued several commits
+            # for content that is byte-identical. Size first (free), full
+            # compare only on a size match.
+            unchanged = False
+            try:
+                if (
+                    cached.content_type == resolved_mime
+                    and cached.filename == filename
+                    and os.path.getsize(path) == len(content_bytes)
+                ):
+                    async with aiofiles.open(path, "rb") as fh:
+                        unchanged = (await fh.read()) == content_bytes
+            except OSError:
+                unchanged = False
+            if unchanged:
+                logger.info(
+                    "attach_drive_file_to_session: %s unchanged, reusing session file %s",
+                    filename, cached.id,
+                )
+                if analysis:
+                    _append_analysis_file(runtime_ctx, cached)
+                return str(cached.id)
             async with aiofiles.open(path, "wb") as fh:
                 await fh.write(content_bytes)
             cached.content_type = resolved_mime
@@ -875,12 +930,10 @@ async def attach_drive_file_to_session(
         # report.files and isn't refreshed mid-run, so a file materialized now
         # would be invisible to inspect_data / create_data called later THIS
         # turn. Append it to the live list (same object as agent.analysis_files).
-        try:
-            ef = runtime_ctx.get("excel_files")
-            if isinstance(ef, list) and all(getattr(x, "id", None) != db_file.id for x in ef):
-                ef.append(db_file)
-        except Exception as e:
-            logger.warning("attach_drive_file_to_session: excel_files refresh failed: %s", e)
+        # Viewer-only copies (analysis=False) stay out: a raw .pdf in the
+        # analysis roster invites read_excel_as_csv calls that can only fail.
+        if analysis:
+            _append_analysis_file(runtime_ctx, db_file)
 
         # Best-effort raw preview, same as upload path.
         try:
@@ -984,6 +1037,9 @@ async def persist_source_document(
             mime_type=raw_mime,
             connection_id=connection_id,
             source_ref=f"{file_id}#source",
+            # Viewer copy: the model analyzes the DERIVATIVE session file
+            # (.txt/.csv), never this raw original — keep it off the roster.
+            analysis=False,
         )
     except Exception as e:
         logger.warning("persist_source_document: failed for %s: %s", file_id, e)

--- a/backend/app/ai/tools/implementations/read_file.py
+++ b/backend/app/ai/tools/implementations/read_file.py
@@ -477,11 +477,15 @@ class ReadFileTool(Tool):
                         raw_bytes=raw_bytes,
                         raw_name=paged_name,
                     )
+                    # source_file_id reaches the UI via preview_file_id only.
+                    # As session_file_id it would be a raw PDF advertised to
+                    # the model as inspect_data/read_excel_as_csv input — a
+                    # guaranteed parse failure.
                     output, observation = await self._finalize(
                         data, runtime_ctx,
                         rendered={"content_type": "binary", "pages_shown": shown,
                                   "file_name": paged_name},
-                        session_file_id=source_file_id,
+                        session_file_id=None,
                         image_pngs=[png for png, _mtype in imgs],
                         pages_total=total,
                         cached=False,
@@ -519,7 +523,7 @@ class ReadFileTool(Tool):
                     "pages_shown": shown,
                     "file_name": paged_name,
                 },
-                session_file_id=source_file_id,
+                session_file_id=None,
                 image_pngs=[],
                 pages_total=paged.get("pages_total"),
                 cached=False,

--- a/backend/app/data_sources/clients/_document_text.py
+++ b/backend/app/data_sources/clients/_document_text.py
@@ -14,10 +14,20 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 import zipfile
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# PDFium (the native library behind pypdfium2) is not thread-safe, and
+# pypdfium2 adds no locking of its own. Extraction here and rasterization in
+# _file_tool_common both run on asyncio worker threads, so two concurrent PDF
+# reads would otherwise race inside the same native state. EVERY pypdfium2
+# call sequence — open, per-page work, close — must run while holding this
+# lock. Serializing PDF work is the accepted cost; a race can corrupt PDFium
+# state or segfault the whole process.
+PDFIUM_LOCK = threading.Lock()
 
 # pypdf is chatty on real-world PDFs ("Ignoring wrong pointing object",
 # "FloatObject invalid", …) — harmless recovery warnings that flood the logs
@@ -204,6 +214,8 @@ def _open_pdf(path: str):
 
     pypdfium2 is already a dependency — render_pdf_pages_images rasterizes
     pages with it — so this costs no new package.
+
+    Callers must hold PDFIUM_LOCK for the whole open→read→close sequence.
     """
     import pypdfium2 as pdfium
 
@@ -234,49 +246,51 @@ def extract_pdf_pages_text(path: str, first: int, last: int,
     extract_document_text, a targeted page read failing silently would strand
     the model in a retry loop.
     """
-    pdf = _open_pdf(path)
-    try:
-        pages_total = len(pdf)
-        first = max(1, int(first))
-        last = min(pages_total, int(last))
-        parts: list[str] = []
-        total = 0
-        for i in range(first - 1, last):
-            try:
-                t = _pdf_page_text(pdf, i)
-            except Exception:
-                t = ""
-            parts.append(t)
-            total += len(t)
-            if total >= max_chars:
-                break
-        return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
-    finally:
-        pdf.close()
+    with PDFIUM_LOCK:
+        pdf = _open_pdf(path)
+        try:
+            pages_total = len(pdf)
+            first = max(1, int(first))
+            last = min(pages_total, int(last))
+            parts: list[str] = []
+            total = 0
+            for i in range(first - 1, last):
+                try:
+                    t = _pdf_page_text(pdf, i)
+                except Exception:
+                    t = ""
+                parts.append(t)
+                total += len(t)
+                if total >= max_chars:
+                    break
+            return sanitize_extracted_text("\n".join(parts)[:max_chars]), pages_total
+        finally:
+            pdf.close()
 
 
 def _pdf(path: str, max_chars: int) -> str:
     # Search-oriented: a genuinely locked or corrupt file yields "" and is
     # skipped, unlike extract_pdf_pages_text where the caller wants the error.
-    try:
-        pdf = _open_pdf(path)
-    except Exception:
-        return ""
-    try:
-        parts: list[str] = []
-        total = 0
-        for i in range(min(len(pdf), _PDF_MAX_PAGES)):
-            try:
-                t = _pdf_page_text(pdf, i)
-            except Exception:
-                continue
-            parts.append(t)
-            total += len(t)
-            if total >= max_chars:
-                break
-        return "\n".join(parts)[:max_chars]
-    finally:
-        pdf.close()
+    with PDFIUM_LOCK:
+        try:
+            pdf = _open_pdf(path)
+        except Exception:
+            return ""
+        try:
+            parts: list[str] = []
+            total = 0
+            for i in range(min(len(pdf), _PDF_MAX_PAGES)):
+                try:
+                    t = _pdf_page_text(pdf, i)
+                except Exception:
+                    continue
+                parts.append(t)
+                total += len(t)
+                if total >= max_chars:
+                    break
+            return "\n".join(parts)[:max_chars]
+        finally:
+            pdf.close()
 
 
 # Match the visible-text runs in an OOXML part: <w:t> (Word) / <a:t>

--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -143,16 +143,28 @@ def _content_disposition(kind: str, filename: str) -> str:
     a stem with no letters or digits left is replaced outright.
     """
     name = filename or "file"
+    # Control characters (CR/LF above all) survive an ascii encode and blow up
+    # header serialization in h11 — or worse, split the header. Strip them from
+    # the source name before either form is built.
+    name = "".join(c for c in name if c.isprintable())
+    if not name.strip():
+        name = "file"
     # A stray double quote would terminate the quoted-string early and corrupt
     # the header, so it goes before anything else looks at the name.
     ascii_name = name.encode("ascii", "ignore").decode("ascii").strip().replace('"', "")
+    # Backslash is the quoted-string escape character — a trailing one would
+    # escape the closing quote itself.
+    ascii_name = ascii_name.replace("\\", "")
     stem, dot, _ = ascii_name.rpartition(".")
     if not dot:
         stem = ascii_name
     if not re.search(r"[A-Za-z0-9]", stem):
         ext = name.rpartition(".")[2]
         ascii_name = f"file.{ext}" if ext.isalnum() else "file"
-    return f"{kind}; filename=\"{ascii_name}\"; filename*=UTF-8\'\'{quote(name)}"
+    # safe='' — quote()'s default keeps "/" literal, but "/" is not an
+    # attr-char in RFC 5987 ext-value, and connector names can be full paths
+    # ("reports/2024/annual.pdf"): strict parsers drop the whole filename*.
+    return f"{kind}; filename=\"{ascii_name}\"; filename*=UTF-8\'\'{quote(name, safe='')}"
 
 
 @router.get("/files", response_model=list[FileSchemaWithMetadata])

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -1994,6 +1994,13 @@ class CompletionService:
                 .where(
                     report_file_association.c.report_id == report_id,
                     File.content_type.like("image/%"),
+                    # Only user uploads are "pending attachments" waiting to be
+                    # claimed by the message being sent. Tool-materialized files
+                    # (source_kind="connector": read_file page renders, picture
+                    # reads) also sit in report.files with a NULL completion_id,
+                    # and claiming them here showed them as attachments on the
+                    # NEXT unrelated user message.
+                    File.source_kind == "upload",
                 )
             )).scalars().all())
             if not image_file_ids:

--- a/backend/tests/unit/test_content_disposition_header.py
+++ b/backend/tests/unit/test_content_disposition_header.py
@@ -63,3 +63,29 @@ def test_fallback_keeps_a_usable_extension(name, expected):
 
 def test_ascii_names_are_left_alone():
     assert 'filename="report.pdf"' in _content_disposition("attachment", "report.pdf")
+
+
+@pytest.mark.parametrize("name", [
+    "reports/2024/annual.pdf",       # connector ids are often full paths
+    "evil\r\nX-Injected: 1.pdf",     # CR/LF must never reach a header value
+    "tab\there.csv",
+])
+def test_control_chars_and_separators_cannot_break_the_header(name):
+    """CR/LF survive an ascii encode, and h11 rejects (or worse, splits) the
+    header at send time — the exact 500 class this helper exists to prevent."""
+    header = _content_disposition("attachment", name)
+    header.encode("latin-1")
+    assert "\r" not in header and "\n" not in header and "\t" not in header
+
+
+def test_slashes_are_percent_encoded_in_the_ext_value():
+    """"/" is not an attr-char in RFC 5987: strict parsers drop the whole
+    filename* when it appears literally. quote()'s default safe="/" kept it."""
+    header = _content_disposition("inline", "reports/2024/annual.pdf")
+    assert "filename*=UTF-8''reports%2F2024%2Fannual.pdf" in header
+
+
+def test_backslash_cannot_escape_the_closing_quote():
+    header = _content_disposition("attachment", 'trail\\')
+    assert header.count('"') == 2
+    assert '\\"' not in header

--- a/backend/tests/unit/test_read_file_source_document.py
+++ b/backend/tests/unit/test_read_file_source_document.py
@@ -55,7 +55,11 @@ class TestSourceDocumentIsKept:
         )
         out = payload["output"]
         assert out["success"] is True
-        assert out["session_file_id"] == "SRC-1"
+        # The kept document is a VIEWER copy: it reaches the UI through
+        # preview.file_id only. As session_file_id it would be a raw PDF the
+        # output schema advertises as inspect_data / read_excel_as_csv input.
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == "SRC-1"
         # The page slice still reaches the model.
         assert out["pages_shown"] == "2-2" and out["pages_total"] == 3
         assert "UNIQUE-B" in (payload["observation"].get("details") or "")
@@ -64,6 +68,8 @@ class TestSourceDocumentIsKept:
         assert kw["content_bytes"].startswith(b"%PDF")
         assert kw["filename"] == "book.pdf"
         assert kw["mime_type"] == "application/pdf"
+        # Viewer copies stay off the analysis roster.
+        assert kw["analysis"] is False
 
     @pytest.mark.asyncio
     async def test_source_ref_cannot_clobber_the_rendered_copy(self, tmp_path):
@@ -80,15 +86,17 @@ class TestSourceDocumentIsKept:
 
     @pytest.mark.asyncio
     async def test_session_pdf_is_not_re_attached(self, tmp_path):
-        """A conversation attachment IS the original — echo its id instead of
-        minting a duplicate row on every page read."""
+        """A conversation attachment IS the original — the preview points at its
+        own id instead of minting a duplicate row on every page read."""
         f = _mk_file(tmp_path, "book.pdf", build_multipage_pdf(PAGES), "application/pdf")
         with patch(_ATTACH, new=AsyncMock(return_value="SHOULD-NOT-BE-USED")) as attach:
             payload = await _run_read(
                 {"connection_id": "", "file_id": f.id, "page_range": "2"},
                 _runtime_ctx([f]),
             )
-        assert payload["output"]["session_file_id"] == f.id
+        out = payload["output"]
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == f.id
         attach.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -126,7 +134,8 @@ class TestRasterizedDocumentsAreNotImages:
         )
         out = payload["output"]
         assert out["content_type"] == "images"
-        assert out["session_file_id"] == "SRC-1"
+        assert "session_file_id" not in out
+        assert out["preview"]["file_id"] == "SRC-1"
         assert "image_file_ids" not in out
         # Vision still received the rendered pages.
         assert payload["observation"]["images"]
@@ -197,6 +206,8 @@ class TestReadSourceBytesNormalizesClientShapes:
     [
         ("scan.PNG", True),
         ("photo.jpeg", True),
+        ("scan.tiff", False),  # PIL decodes TIFF but no mainstream browser renders it
+        ("scan.tif", False),
         ("report.pdf", False),
         ("deck.pptx", False),
         ("noextension", False),

--- a/frontend/components/FilePreview.vue
+++ b/frontend/components/FilePreview.vue
@@ -118,7 +118,7 @@ defineEmits<{
   (e: 'expand'): void
 }>()
 
-const { getEmbedUrl } = useFileEmbedUrl()
+const { getEmbedUrl, msUntilRefresh } = useFileEmbedUrl()
 
 const embedUrl = ref('')
 const pending = ref(false)
@@ -169,15 +169,38 @@ onMounted(() => {
   observer.observe(rootEl.value)
 })
 
-onUnmounted(stopObserving)
+// A mounted iframe keeps whatever token URL it was given, and `visible` never
+// flips back to false — so without this timer nothing would ever re-run load()
+// and a tab left open past the token's TTL showed a dead 403 frame. Re-mint
+// just after the cache's freshness window closes; the iframe src swaps
+// reactively through frameSrc.
+let refreshTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearRefreshTimer() {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+}
+
+onUnmounted(() => {
+  stopObserving()
+  clearRefreshTimer()
+})
 
 async function load() {
+  clearRefreshTimer()
   if (!visible.value || props.kind !== 'pdf' || !props.fileId) return
   pending.value = true
   try {
     embedUrl.value = await getEmbedUrl(props.fileId)
   } finally {
     pending.value = false
+  }
+  if (embedUrl.value && props.fileId) {
+    // +1s past the freshness cutoff so getEmbedUrl sees a stale entry and
+    // mints a new token instead of serving the same one back.
+    refreshTimer = setTimeout(load, msUntilRefresh(props.fileId) + 1000)
   }
 }
 

--- a/frontend/composables/useFileEmbedUrl.ts
+++ b/frontend/composables/useFileEmbedUrl.ts
@@ -44,5 +44,17 @@ export function useFileEmbedUrl() {
     cache.delete(fileId)
   }
 
-  return { getEmbedUrl, invalidate }
+  /**
+   * How long the current token for `fileId` is still considered fresh.
+   * Mounted frames use this to schedule a re-mint just after the freshness
+   * window closes — the "re-minted a few minutes BEFORE expiry" promise above
+   * is theirs to keep, since a cache check alone only runs on fresh mounts.
+   */
+  function msUntilRefresh(fileId: string): number {
+    const hit = cache.get(fileId)
+    if (!hit) return 0
+    return Math.max(0, TOKEN_TTL_MS - REFRESH_MARGIN_MS - (Date.now() - hit.mintedAt))
+  }
+
+  return { getEmbedUrl, invalidate, msUntilRefresh }
 }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -1032,6 +1032,7 @@
 					:pages-total="panelFile.pagesTotal"
 					:name="panelFile.name"
 					:expanded="true"
+					@open="(fid: string) => openImagePreview({ id: fid, filename: panelFile?.name || '' })"
 				/>
 			</div>
 		</template>


### PR DESCRIPTION
Follow-up to #1028, targeting its branch: eight fixes for issues found in review, each verified against a live sandbox (real backend + scripted LLM driving `read_file` through the chat UI).

## Blockers

**1. PDFium is not thread-safe — all pypdfium2 use now takes a shared lock.**
Moving text extraction to PDFium routed every PDF read/search/grep through a native library documented as not thread-safe, on `asyncio.to_thread` workers, concurrently with the existing rasterization paths. Two simultaneous PDF reads were a native data race that can corrupt PDFium state or segfault the backend. `PDFIUM_LOCK` (module-level, in `_document_text.py`) now guards every open→read→close sequence: extraction, `render_pdf_pages_images`, and the PDF branch of `render_file_images`.

**2. Tool-generated page renders showed up as attachments on the next user message.**
`attach_drive_file_to_session` links renders to `report.files` with a NULL `completion_id`, and `_mark_images_with_completion` treats every unclaimed image in the report as a pending upload — so scanned-PDF page renders got stamped onto the *next* unrelated user message and rendered as attachments the user never sent. The sweep is now scoped to `source_kind="upload"` (non-null with a server default, so legacy uploads still match). Verified in the sandbox: `scanned_invoice.pdf.p1/p2.png` stay unclaimed across five later messages.

**3. Paged reads advertised the raw source PDF as `session_file_id`.**
The output schema tells the model to pass `session_file_id` to `inspect_data`/`read_excel_as_csv` — a guaranteed parse failure on a raw PDF. The viewer copy now reaches the UI via `preview.file_id` only; it is attached with `analysis=False` (kept off the live roster), and `#source` rows are excluded from `analysis_files` at agent init so they can't rejoin next turn.

## Fixes

**4. `_content_disposition` hardening.** `quote(name, safe='')` so `/` is percent-encoded in the RFC 5987 ext-value (connector names are often full paths; strict parsers drop the whole `filename*` otherwise); control characters (CR/LF) are stripped before either form is built (they survive an ascii encode and 500 at header send time); backslashes are removed so one can't escape the closing quote.

**5. Paged reads no longer rewrite the whole document per read.** The refresh-in-place path now compares sizes (free) and then bytes, and returns the existing row untouched when identical — skipping the full disk rewrite, the preview regeneration, and several commits per `page_range` read. Verified live: the second paged read of the same PDF logs `unchanged, reusing session file` instead of rewriting.

**6. Embed tokens re-mint before expiry.** A mounted iframe kept its original token URL forever (`visible` never flips back, so the watch never refired), so a tab open past the 1-hour TTL showed a dead 403 frame. `FilePreview` now schedules a refresh keyed to the cached token's age (`msUntilRefresh`) and the iframe src swaps reactively; the timer is cleared on unmount.

**7. TIFF is no longer offered as a browser-renderable image.** `is_picture_name` now tests against `_BROWSER_IMAGE_EXTS` (renderable minus tiff/tif), so a TIFF read falls back to its PNG renders instead of handing the UI a broken `<img>`. The vision path keeps decoding TIFF via PIL as before.

**8. Side-panel image click works.** The panel's `FilePreview` instance had no `@open` listener, so the advertised zoom click did nothing. It now opens `ImagePreviewModal`, same as the in-card instance. Verified interactively in the sandbox.

## Tests & verification

- Three tests in `test_read_file_source_document.py` updated to the new paged-read contract (doc reaches the UI via `preview.file_id`, not `session_file_id`; viewer copies attach with `analysis=False`); new cases for the header edge cases (path separators, CR/LF, trailing backslash) and the tiff split.
- Full backend unit suite on this branch: **3788 passed, 14 failed, 9 skipped** — and the same 14 tests fail identically on the unmodified PR head (`5d1ea14`, verified in a separate worktree), all in areas this diff does not touch (notification/email services, eval draft helpers, MCP tool registry, Sybase source, WhatsApp webhook, artifact relationship loading). No regressions introduced.
- Frontend production build clean.
- Live sandbox end-to-end on this branch: scanned/paged/RTL PDFs, CSV, XLSX, JSON, PNG, DOCX all preview correctly from both the live stream and the persisted `context_summary_json` projection; no attachment thumbnails on subsequent user messages; paged reads carry no `session_file_id` and reuse the stored document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZd1zWJdkvwU4yHQBv18CR