### PR TITLE
Improve connection linking UX with error handling and existing connection support

### DIFF
--- a/frontend/components/AddCustomAPIModal.vue
+++ b/frontend/components/AddCustomAPIModal.vue
@@ -21,15 +21,21 @@ const props = defineProps<{
   editConnection?: any
   existingConnections?: any[]
 }>()
-const emit = defineEmits(['created'])
+const emit = defineEmits<{
+  (e: 'created', connection: any, meta?: { existing?: boolean }): void
+}>()
 
 const toast = useToast()
 const { t } = useI18n()
 const isEditMode = computed(() => !!props.editConnection)
 
-function handleSaved(connection: any) {
-  toast.add({ title: isEditMode.value ? t('data.connectionUpdated') : t('data.capiConnected'), color: 'green' })
+function handleSaved(connection: any, meta?: { existing?: boolean }) {
+  // "Use existing connection" saves nothing here — the parent links it to the
+  // agent and toasts the real outcome, so a success toast now would be a lie.
+  if (!meta?.existing) {
+    toast.add({ title: isEditMode.value ? t('data.connectionUpdated') : t('data.capiConnected'), color: 'green' })
+  }
   isOpen.value = false
-  emit('created', connection)
+  emit('created', connection, meta)
 }
 </script>

--- a/frontend/components/AddMCPModal.vue
+++ b/frontend/components/AddMCPModal.vue
@@ -22,14 +22,20 @@ const props = defineProps<{
   editConnection?: any
   existingConnections?: any[]
 }>()
-const emit = defineEmits(['created'])
+const emit = defineEmits<{
+  (e: 'created', connection: any, meta?: { existing?: boolean }): void
+}>()
 
 const toast = useToast()
 const isEditMode = computed(() => !!props.editConnection)
 
-function handleSaved(connection: any) {
-  toast.add({ title: isEditMode.value ? t('settings.mcpModal.updated') : t('settings.mcpModal.connected'), color: 'green' })
+function handleSaved(connection: any, meta?: { existing?: boolean }) {
+  // "Use existing connection" saves nothing here — the parent links it to the
+  // agent and toasts the real outcome, so a success toast now would be a lie.
+  if (!meta?.existing) {
+    toast.add({ title: isEditMode.value ? t('settings.mcpModal.updated') : t('settings.mcpModal.connected'), color: 'green' })
+  }
   isOpen.value = false
-  emit('created', connection)
+  emit('created', connection, meta)
 }
 </script>

--- a/frontend/components/CustomAPIConnectionForm.vue
+++ b/frontend/components/CustomAPIConnectionForm.vue
@@ -359,7 +359,10 @@ const props = defineProps<{
   } | null
 }>()
 const emit = defineEmits<{
-  (e: 'saved', connection: any): void
+  // meta.existing marks the "use existing connection" path: nothing was created
+  // or updated here — the parent still has to link the connection and owns the
+  // outcome feedback.
+  (e: 'saved', connection: any, meta?: { existing?: boolean }): void
   (e: 'cancel'): void
 }>()
 
@@ -825,7 +828,7 @@ async function testConnection() {
 async function handleSubmit() {
   if (selectedExisting.value) {
     const conn = existingConnections.value.find((c: any) => c.id === selectedExisting.value.id)
-    if (conn) emit('saved', conn)
+    if (conn) emit('saved', conn, { existing: true })
     return
   }
 

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -2452,14 +2452,30 @@ const toolsRefreshKey = ref(0)
 const connTargetAgentId = ref<string | null>(null)
 const openAddMcp = (agentId: string) => { connTargetAgentId.value = agentId; showAddMCP.value = true }
 const openAddCustomApi = (agentId: string) => { connTargetAgentId.value = agentId; showAddCustomAPI.value = true }
-const mcpExistingConnections = computed(() => connections.value.filter((c: any) => c.type === 'mcp'))
-const customApiExistingConnections = computed(() => connections.value.filter((c: any) => c.type === 'custom_api'))
-// New connection created: link it to the target agent (if any) and refresh its tools.
-const onConnCreated = async (conn?: any) => {
+// Offer only connections not already linked to the target agent — picking a
+// linked one would be a guaranteed "already linked" error.
+const linkedConnIds = computed(() => new Set(
+  (((agents.value.find(a => a.id === connTargetAgentId.value) as any)?.connections) || []).map((c: any) => String(c.id))
+))
+const mcpExistingConnections = computed(() => connections.value.filter((c: any) => c.type === 'mcp' && !linkedConnIds.value.has(String(c.id))))
+const customApiExistingConnections = computed(() => connections.value.filter((c: any) => c.type === 'custom_api' && !linkedConnIds.value.has(String(c.id))))
+// New or existing connection picked: link it to the target agent (if any) and
+// refresh its tools. useMyFetch resolves (never throws) on HTTP errors, so the
+// link outcome must be read from response.error — a 403 here (e.g. the caller
+// lacks `create_data_sources` on the connection) would otherwise vanish.
+const onConnCreated = async (conn?: any, meta?: { existing?: boolean }) => {
   const aid = connTargetAgentId.value
   if (aid && conn?.id) {
-    try { await useMyFetch(`/data_sources/${aid}/connections/${conn.id}`, { method: 'POST' }) } catch {}
-    try { await useMyFetch(`/connections/${conn.id}/refresh-tools`, { method: 'POST' }) } catch {}
+    const link = await useMyFetch(`/data_sources/${aid}/connections/${conn.id}`, { method: 'POST' })
+    if (link.error?.value) {
+      const err: any = link.error.value
+      toast.add({ title: t('agentsPage.connectionLinkFailed'), description: err?.data?.detail || err?.message, color: 'red' })
+    } else {
+      // The modal only toasts when it actually created/updated a connection;
+      // for the "use existing" path the link IS the action — report it.
+      if (meta?.existing) toast.add({ title: t('agentsPage.connectionLinked'), color: 'green' })
+      await useMyFetch(`/connections/${conn.id}/refresh-tools`, { method: 'POST' })
+    }
   }
   showAddMCP.value = false; showAddCustomAPI.value = false; showAddConnection.value = false
   if (aid) { agentLoaded.value.delete(aid); await loadAgentMeta(aid); if (agentView.value?.agentId === aid) await refreshAgentDetail() }

--- a/frontend/components/MCPConnectionForm.vue
+++ b/frontend/components/MCPConnectionForm.vue
@@ -269,7 +269,10 @@ const props = defineProps<{
   } | null
 }>()
 const emit = defineEmits<{
-  (e: 'saved', connection: any): void
+  // meta.existing marks the "use existing connection" path: nothing was created
+  // or updated here — the parent still has to link the connection and owns the
+  // outcome feedback.
+  (e: 'saved', connection: any, meta?: { existing?: boolean }): void
   (e: 'cancel'): void
 }>()
 
@@ -547,7 +550,7 @@ async function testConnection() {
 async function handleSubmit() {
   if (selectedExisting.value) {
     const conn = existingConnections.value.find((c: any) => c.id === selectedExisting.value.id)
-    if (conn) emit('saved', conn)
+    if (conn) emit('saved', conn, { existing: true })
     return
   }
 

--- a/frontend/pages/agents/new/[id]/schema.vue
+++ b/frontend/pages/agents/new/[id]/schema.vue
@@ -45,6 +45,8 @@ import AddMCPModal from '~/components/AddMCPModal.vue'
 import AddCustomAPIModal from '~/components/AddCustomAPIModal.vue'
 const route = useRoute()
 const router = useRouter()
+const toast = useToast()
+const { t } = useI18n()
 const id = computed(() => String(route.params.id || ''))
 function onSaved() { router.replace(`/agents/new/${id.value}/context`) }
 
@@ -62,9 +64,24 @@ function openAddModal(type: 'mcp' | 'custom_api') {
   modalType.value = type
   showModal.value = true
 }
-function onConnectionChanged() {
+async function onConnectionChanged(conn?: any) {
   showModal.value = false
+  const wasEdit = !!editingConnection.value
   editingConnection.value = null
+  // A connection added from this page's Tools tab is created org-level by the
+  // modal — it still has to be linked to THIS agent, or it never shows up here.
+  // (Edits are already linked; re-linking would 400.)
+  if (!wasEdit && conn?.id) {
+    const link = await useMyFetch(`/data_sources/${id.value}/connections/${conn.id}`, { method: 'POST' })
+    if (link.error?.value) {
+      // useMyFetch resolves (never throws) on HTTP errors — surface the backend
+      // detail and skip the reload so the toast is actually seen.
+      const err: any = link.error.value
+      toast.add({ title: t('agentsPage.connectionLinkFailed'), description: err?.data?.detail || err?.message, color: 'red' })
+      return
+    }
+    await useMyFetch(`/connections/${conn.id}/refresh-tools`, { method: 'POST' })
+  }
   // Full route refresh: the tools list, counts and policies all changed.
   router.go(0)
 }

--- a/frontend/pages/old_agents/[id]/tools.vue
+++ b/frontend/pages/old_agents/[id]/tools.vue
@@ -97,13 +97,18 @@ const availableCustomApiConnections = computed(() => {
     return allOrgToolConnections.value.filter((c: any) => c.type === 'custom_api' && !linkedIds.has(String(c.id)))
 })
 
-async function onConnectionCreated(conn: any) {
-    try {
-        await useMyFetch(`/data_sources/${id.value}/connections/${conn.id}`, { method: 'POST' })
-    } catch { /* link endpoint may not exist yet */ }
-    try {
+// useMyFetch resolves (never throws) on HTTP errors, so the link outcome must
+// be read from response.error — a 403 (e.g. missing `create_data_sources` on
+// the connection) would otherwise vanish behind the modal's success toast.
+async function onConnectionCreated(conn: any, meta?: { existing?: boolean }) {
+    const link = await useMyFetch(`/data_sources/${id.value}/connections/${conn.id}`, { method: 'POST' })
+    if (link.error?.value) {
+        const err: any = link.error.value
+        toast.add({ title: 'Failed to add connection to agent', description: err?.data?.detail || err?.message, color: 'red' })
+    } else {
+        if (meta?.existing) toast.add({ title: 'Connection added to agent', color: 'green' })
         await useMyFetch(`/connections/${conn.id}/refresh-tools`, { method: 'POST' })
-    } catch {}
+    }
     await fetchIntegration()
     await fetchOrgToolConnections()
 }

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "تعذّر حفظ الوصف",
     "toastTablesReloaded": "تمت إعادة تحميل الجداول",
     "toastToolsReloaded": "تمت إعادة تحميل الأدوات",
+    "connectionLinked": "تمت إضافة الاتصال إلى الوكيل",
+    "connectionLinkFailed": "فشلت إضافة الاتصال إلى الوكيل",
     "toastUploaded": "تم رفع {n} ملف",
     "toastUploadFailed": "فشل الرفع",
     "uploadTooLarge": "الملف أكبر من حد الرفع المسموح به في الخادم",

--- a/locales/de.json
+++ b/locales/de.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Beschreibung konnte nicht gespeichert werden",
     "toastTablesReloaded": "Tabellen neu geladen",
     "toastToolsReloaded": "Werkzeuge neu geladen",
+    "connectionLinked": "Verbindung zum Agenten hinzugefügt",
+    "connectionLinkFailed": "Verbindung konnte dem Agenten nicht hinzugefügt werden",
     "toastUploaded": "{n} Datei(en) hochgeladen",
     "toastUploadFailed": "Hochladen fehlgeschlagen",
     "uploadTooLarge": "Die Datei überschreitet das Upload-Limit des Servers",

--- a/locales/en.json
+++ b/locales/en.json
@@ -243,6 +243,8 @@
     "toastSaveDescFailed": "Failed to save description",
     "toastTablesReloaded": "Tables reloaded",
     "toastToolsReloaded": "Tools reloaded",
+    "connectionLinked": "Connection added to agent",
+    "connectionLinkFailed": "Failed to add connection to agent",
     "toastUploaded": "Uploaded {n} file(s)",
     "toastUploadFailed": "Upload failed",
     "uploadTooLarge": "File is too large for the server's upload limit",

--- a/locales/es.json
+++ b/locales/es.json
@@ -242,6 +242,8 @@
     "toastSaveDescFailed": "No se pudo guardar la descripción",
     "toastTablesReloaded": "Tablas recargadas",
     "toastToolsReloaded": "Herramientas recargadas",
+    "connectionLinked": "Conexión añadida al agente",
+    "connectionLinkFailed": "No se pudo añadir la conexión al agente",
     "toastUploaded": "{n} archivo(s) subido(s)",
     "toastUploadFailed": "Error al subir",
     "uploadTooLarge": "El archivo supera el límite de subida del servidor",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Échec de l’enregistrement de la description",
     "toastTablesReloaded": "Tables rechargées",
     "toastToolsReloaded": "Outils rechargés",
+    "connectionLinked": "Connexion ajoutée à l'agent",
+    "connectionLinkFailed": "Échec de l'ajout de la connexion à l'agent",
     "toastUploaded": "{n} fichier(s) téléversé(s)",
     "toastUploadFailed": "Échec du téléversement",
     "uploadTooLarge": "Le fichier dépasse la limite de téléversement du serveur",

--- a/locales/he.json
+++ b/locales/he.json
@@ -242,6 +242,8 @@
     "toastSaveDescFailed": "שמירת התיאור נכשלה",
     "toastTablesReloaded": "הטבלאות נטענו מחדש",
     "toastToolsReloaded": "הכלים נטענו מחדש",
+    "connectionLinked": "החיבור נוסף לסוכן",
+    "connectionLinkFailed": "הוספת החיבור לסוכן נכשלה",
     "toastUploaded": "הועלו {n} קבצים",
     "toastUploadFailed": "ההעלאה נכשלה",
     "uploadTooLarge": "הקובץ גדול ממגבלת ההעלאה של השרת",

--- a/locales/it.json
+++ b/locales/it.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Impossibile salvare la descrizione",
     "toastTablesReloaded": "Tabelle ricaricate",
     "toastToolsReloaded": "Strumenti ricaricati",
+    "connectionLinked": "Connessione aggiunta all'agente",
+    "connectionLinkFailed": "Impossibile aggiungere la connessione all'agente",
     "toastUploaded": "Caricato/i {n} file",
     "toastUploadFailed": "Caricamento non riuscito",
     "uploadTooLarge": "Il file supera il limite di caricamento del server",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Falha ao salvar descrição",
     "toastTablesReloaded": "Tabelas recarregadas",
     "toastToolsReloaded": "Ferramentas recarregadas",
+    "connectionLinked": "Conexão adicionada ao agente",
+    "connectionLinkFailed": "Falha ao adicionar a conexão ao agente",
     "toastUploaded": "{n} arquivo(s) enviado(s)",
     "toastUploadFailed": "Falha no envio",
     "uploadTooLarge": "O arquivo excede o limite de upload do servidor",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Не удалось сохранить описание",
     "toastTablesReloaded": "Таблицы перезагружены",
     "toastToolsReloaded": "Инструменты перезагружены",
+    "connectionLinked": "Подключение добавлено к агенту",
+    "connectionLinkFailed": "Не удалось добавить подключение к агенту",
     "toastUploaded": "Загружено файлов: {n}",
     "toastUploadFailed": "Не удалось загрузить",
     "uploadTooLarge": "Файл превышает лимит загрузки на сервере",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -230,6 +230,8 @@
     "toastSaveDescFailed": "Kunde inte spara beskrivning",
     "toastTablesReloaded": "Tabeller omladdade",
     "toastToolsReloaded": "Verktyg omladdade",
+    "connectionLinked": "Anslutningen lades till agenten",
+    "connectionLinkFailed": "Det gick inte att lägga till anslutningen till agenten",
     "toastUploaded": "Laddade upp {n} fil(er)",
     "toastUploadFailed": "Uppladdning misslyckades",
     "uploadTooLarge": "Filen överskrider serverns uppladdningsgräns",


### PR DESCRIPTION
## Summary
This PR enhances the connection linking workflow by adding proper error handling for failed link operations and supporting the "use existing connection" path with appropriate user feedback. Previously, link failures were silently swallowed, and existing connections were treated the same as newly created ones in toast notifications.

## Key Changes

- **Error handling for connection linking**: Modified `onConnCreated` handlers in KnowledgeExplorer, agents schema, and old_agents tools pages to check `useMyFetch` response errors and display user-friendly error messages with backend details when linking fails.

- **Distinguish new vs. existing connections**: Added `meta?.existing` flag to track whether a connection was newly created or selected from existing connections. This prevents misleading success toasts when using existing connections (the actual action is the linking, not the creation).

- **Filter already-linked connections**: Updated `mcpExistingConnections` and `customApiExistingConnections` computed properties in KnowledgeExplorer to exclude connections already linked to the target agent, preventing "already linked" errors.

- **Updated modal emit signatures**: Modified AddMCPModal and AddCustomAPIModal to pass the `meta` object through the event chain, and updated form components (MCPConnectionForm, CustomAPIConnectionForm) to emit the `existing` flag when the "use existing connection" path is taken.

- **Conditional toast notifications**: Forms now only show success toasts for actual create/update operations, not for the "use existing" path where the parent component owns the outcome feedback.

- **Internationalization**: Added two new translation keys (`connectionLinked` and `connectionLinkFailed`) across all supported languages (en, ar, de, es, fr, he, it, pt, ru, sv).

## Implementation Details

- The `useMyFetch` composable resolves (never throws) on HTTP errors, so error checking must read from `response.error?.value` rather than catching exceptions.
- Connection linking is now properly surfaced to users with specific error messages from the backend (e.g., missing `create_data_sources` permission).
- The existing connection filtering prevents unnecessary API errors by not offering already-linked options to users.

https://claude.ai/code/session_018EeRSHhpati1UcVH3C4Utn