### PR TITLE
Auto-scroll to selected turn in conversation trace modal

### DIFF
--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -61,6 +61,7 @@
                     </div>
                     <div v-else class="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 py-4 space-y-5">
                         <div v-for="(turn, i) in turns" :key="turn.completion_id || i"
+                             :data-completion-id="turn.completion_id || ''"
                              :class="['rounded-lg px-1.5 py-1.5 transition-colors', turn.completion_id === selectedCompletionId ? 'bg-blue-50/40 ring-1 ring-blue-100' : '']">
                             <!-- User bubble -->
                             <div class="flex justify-end mb-2">
@@ -874,6 +875,16 @@ const fetchConversation = async () => {
     } finally {
         isConvLoading.value = false
     }
+    // The conversation rail renders only after isConvLoading flips false, and it
+    // opens scrolled to the top — bring the preselected turn into view.
+    await scrollToSelectedTurn()
+}
+
+const scrollToSelectedTurn = async () => {
+    if (!selectedCompletionId.value) return
+    await nextTick()
+    const el = document.querySelector(`[data-completion-id="${selectedCompletionId.value}"]`)
+    el?.scrollIntoView({ block: 'center' })
 }
 
 const selectTurn = async (turn: ConversationTurn) => {


### PR DESCRIPTION
## Summary
Added automatic scrolling to the preselected conversation turn in the trace modal after the conversation data loads. This improves UX by ensuring the selected turn is visible without requiring manual scrolling.

## Key Changes
- Added `data-completion-id` attribute to turn elements for DOM querying
- Created new `scrollToSelectedTurn()` function that locates and scrolls to the selected turn using `scrollIntoView()`
- Integrated scroll behavior into `fetchConversation()` to trigger after conversation loads and the UI renders
- Used `nextTick()` to ensure DOM elements are available before attempting to scroll

## Implementation Details
- The scroll is triggered after `isConvLoading` flips to false, ensuring the conversation rail has rendered
- Uses `block: 'center'` positioning to center the selected turn in the viewport
- Gracefully handles cases where no turn is preselected by early returning

https://claude.ai/code/session_01PHRBo9kPfJr7HGgnhBXw2V