### PR TITLE
fix(entities): describe_entity gives the planner the same budgeted preview and history digest as create_data

### DIFF
--- a/backend/app/ai/context/builders/message_context_builder.py
+++ b/backend/app/ai/context/builders/message_context_builder.py
@@ -96,6 +96,63 @@ def _is_postgres_session(db: AsyncSession) -> bool:
         return False
 
 
+def _digest_data_result(rj: dict, allow_llm_see_data: bool, *, applied_params: dict | None = None) -> str:
+    """One history digest for every tool whose result carries a
+    ``data_preview`` (create_data, describe_entity): shape, column names,
+    chart type, viz id, the top row when data may be shown, and — for
+    parameterized results — the values it ran with, so a later turn can reuse
+    the result instead of reading or rebuilding it."""
+    if not isinstance(rj, dict):
+        return ""
+    preview = rj.get('data_preview') or {}
+    stats = rj.get('stats') or {}
+    data_obj = rj.get('data') or {}
+    columns = preview.get('columns') or data_obj.get('columns', []) or []
+    rows = data_obj.get('rows', []) or []
+    preview_rows = preview.get('rows') or []
+    col_names = [
+        (c.get('field') or c.get('headerName'))
+        for c in columns
+        if isinstance(c, dict) and (c.get('field') or c.get('headerName'))
+    ]
+    row_count = (
+        stats.get('total_rows')
+        or preview.get('row_count')
+        or len(rows)
+        or len(preview_rows)
+    )
+    parts = [f"{row_count} rows × {len(col_names)} cols"]
+    if col_names:
+        head_cols = ", ".join(col_names[:10])
+        parts.append(f"cols: {head_cols}{'…' if len(col_names) > 10 else ''}")
+    if applied_params:
+        try:
+            parts.append("params: " + ", ".join(f"{k}={v!r}" for k, v in applied_params.items()))
+        except Exception:
+            pass
+    try:
+        dm = rj.get('data_model') or {}
+        dm_type = str(dm.get('type') or '').strip()
+        if dm_type and dm_type != 'table':
+            parts.append(f"chart: {dm_type}")
+    except Exception:
+        pass
+    try:
+        viz_ids = rj.get('created_visualization_ids') or []
+        if viz_ids:
+            parts.append(f"viz_id: {viz_ids[0]}")
+    except Exception:
+        pass
+    if allow_llm_see_data:
+        sample_row = preview_rows[0] if preview_rows else (rows[0] if rows else None)
+        if sample_row:
+            try:
+                parts.append(f"top row: {json.dumps(sample_row)}")
+            except Exception:
+                pass
+    return "; ".join(parts)
+
+
 def _digest_read_query(tool_execution) -> str:
     """Render referenceable read_query metadata without its full data rows.
 
@@ -1539,69 +1596,19 @@ class MessageContextBuilder:
                                     tool_info += " - " + "; ".join(digest_parts)
                                 # Digest for create_data results (same style as create_widget)
                                 elif tool_execution.tool_name == 'create_data' and tool_execution.result_json:
-                                    rj = tool_execution.result_json or {}
-                                    preview = rj.get('data_preview') or {}
-                                    stats = rj.get('stats') or {}
-                                    data_obj = rj.get('data') or {}
-                                    columns = preview.get('columns') or data_obj.get('columns', []) or []
-                                    rows = data_obj.get('rows', []) or []
-                                    preview_rows = preview.get('rows') or []
-                                    col_names = [
-                                        (c.get('field') or c.get('headerName'))
-                                        for c in columns
-                                        if isinstance(c, dict) and (c.get('field') or c.get('headerName'))
-                                    ]
-                                    row_count = (
-                                        stats.get('total_rows')
-                                        or preview.get('row_count')
-                                        or len(rows)
-                                        or len(preview_rows)
-                                    )
-                                    sample_row = None
-                                    if allow_llm_see_data:
-                                        if preview_rows:
-                                            sample_row = preview_rows[0]
-                                        elif rows:
-                                            sample_row = rows[0]
-                                    digest_parts = [f"{row_count} rows × {len(col_names)} cols"]
-                                    if col_names:
-                                        head_cols = ", ".join(col_names[:10])
-                                        digest_parts.append(f"cols: {head_cols}{'…' if len(col_names) > 10 else ''}")
-                                    # If a non-table viz was inferred, surface it concisely
-                                    try:
-                                        dm = rj.get('data_model') or {}
-                                        dm_type = str(dm.get('type') or '').strip()
-                                        if dm_type and dm_type != 'table':
-                                            digest_parts.append(f"chart: {dm_type}")
-                                    except Exception:
-                                        pass
-                                    # Surface visualization_id if available (added by orchestrator)
-                                    try:
-                                        viz_ids = rj.get('created_visualization_ids') or []
-                                        if viz_ids:
-                                            digest_parts.append(f"viz_id: {viz_ids[0]}")
-                                    except Exception:
-                                        pass
-                                    if sample_row:
-                                        try:
-                                            digest_parts.append(f"top row: {json.dumps(sample_row)}")
-                                        except Exception:
-                                            pass
-                                    tool_info += " - " + "; ".join(digest_parts)
-                                # Digest for describe_entity results
+                                    digest = _digest_data_result(tool_execution.result_json or {}, allow_llm_see_data)
+                                    if digest:
+                                        tool_info += " - " + digest
+                                # Digest for describe_entity results: the entity plus the
+                                # same shape/values digest create_data gets.
                                 elif tool_execution.tool_name == 'describe_entity' and tool_execution.result_json:
                                     rj = tool_execution.result_json or {}
                                     digest_parts = []
-                                    entity_title = rj.get('title')
-                                    if entity_title:
-                                        digest_parts.append(f"entity: {entity_title}")
-                                    # Surface visualization_id if created
-                                    try:
-                                        viz_ids = rj.get('created_visualization_ids') or []
-                                        if viz_ids:
-                                            digest_parts.append(f"viz_id: {viz_ids[0]}")
-                                    except Exception:
-                                        pass
+                                    if rj.get('title'):
+                                        digest_parts.append(f"entity: {rj.get('title')}")
+                                    digest = _digest_data_result(rj, allow_llm_see_data, applied_params=rj.get('applied_params') or None)
+                                    if digest:
+                                        digest_parts.append(digest)
                                     if digest_parts:
                                         tool_info += " - " + "; ".join(digest_parts)
                                 elif tool_execution.tool_name == 'read_query' and tool_execution.result_json:
@@ -2344,65 +2351,19 @@ class MessageContextBuilder:
                                             pass
                                 tool_info += " - " + "; ".join(digest_parts)
                             elif tool_execution.status == 'success' and tool_execution.tool_name == 'create_data' and tool_execution.result_json:
-                                rj = tool_execution.result_json or {}
-                                preview = rj.get('data_preview') or {}
-                                stats = rj.get('stats') or {}
-                                data_obj = rj.get('data') or {}
-                                columns = preview.get('columns') or data_obj.get('columns', []) or []
-                                rows = data_obj.get('rows', []) or []
-                                preview_rows = preview.get('rows') or []
-                                col_names = [
-                                    (c.get('field') or c.get('headerName'))
-                                    for c in columns
-                                    if isinstance(c, dict) and (c.get('field') or c.get('headerName'))
-                                ]
-                                row_count = (
-                                    stats.get('total_rows')
-                                    or preview.get('row_count')
-                                    or len(rows)
-                                    or len(preview_rows)
-                                )
-                                digest_parts = [f"{row_count} rows × {len(col_names)} cols"]
-                                if col_names:
-                                    head_cols = ", ".join(col_names[:10])
-                                    digest_parts.append(f"cols: {head_cols}{'…' if len(col_names) > 10 else ''}")
-                                if allow_llm_see_data:
-                                    sample_row = preview_rows[0] if preview_rows else (rows[0] if rows else None)
-                                    if sample_row:
-                                        try:
-                                            digest_parts.append(f"top row: {json.dumps(sample_row)}")
-                                        except Exception:
-                                            pass
-                                # If a non-table viz was inferred, surface it concisely
-                                try:
-                                    dm = rj.get('data_model') or {}
-                                    dm_type = str(dm.get('type') or '').strip()
-                                    if dm_type and dm_type != 'table':
-                                        digest_parts.append(f"chart: {dm_type}")
-                                except Exception:
-                                    pass
-                                # Surface visualization_id if available (added by orchestrator)
-                                try:
-                                    viz_ids = rj.get('created_visualization_ids') or []
-                                    if viz_ids:
-                                        digest_parts.append(f"viz_id: {viz_ids[0]}")
-                                except Exception:
-                                    pass
-                                tool_info += " - " + "; ".join(digest_parts)
+                                digest = _digest_data_result(tool_execution.result_json or {}, allow_llm_see_data)
+                                if digest:
+                                    tool_info += " - " + digest
                             elif tool_execution.status == 'success' and tool_execution.tool_name == 'describe_entity' and tool_execution.result_json:
-                                # Digest for describe_entity results
+                                # Digest for describe_entity results: the entity plus the
+                                # same shape/values digest create_data gets.
                                 rj = tool_execution.result_json or {}
                                 digest_parts = []
-                                entity_title = rj.get('title')
-                                if entity_title:
-                                    digest_parts.append(f"entity: {entity_title}")
-                                # Surface visualization_id if created
-                                try:
-                                    viz_ids = rj.get('created_visualization_ids') or []
-                                    if viz_ids:
-                                        digest_parts.append(f"viz_id: {viz_ids[0]}")
-                                except Exception:
-                                    pass
+                                if rj.get('title'):
+                                    digest_parts.append(f"entity: {rj.get('title')}")
+                                digest = _digest_data_result(rj, allow_llm_see_data, applied_params=rj.get('applied_params') or None)
+                                if digest:
+                                    digest_parts.append(digest)
                                 if digest_parts:
                                     tool_info += " - " + "; ".join(digest_parts)
                             elif tool_execution.status == 'success' and tool_execution.tool_name == 'read_query' and tool_execution.result_json:

--- a/backend/app/ai/tools/implementations/describe_entity.py
+++ b/backend/app/ai/tools/implementations/describe_entity.py
@@ -337,7 +337,15 @@ class DescribeEntityTool(Tool):
             except Exception:
                 pass
 
+        # UI card keeps the compact column profile; the PLANNER gets the same
+        # budgeted preview create_data/read_query emit — small results (an
+        # options list, a lookup) come through whole instead of 5 head rows,
+        # so the planner never needs a second read_query to see them.
         data_profile = self._build_data_profile(entity_data, allow_llm_see_data)
+        from app.ai.data_preview import build_data_preview, clamp_stats, gate_stats_for_privacy
+        data_preview = build_data_preview(entity_data or {}, allow_llm_see_data=allow_llm_see_data)
+        _info = (entity_data or {}).get("info", {}) or {}
+        stats = clamp_stats(_info) if allow_llm_see_data else clamp_stats(gate_stats_for_privacy(_info))
 
         # If should_create, create step and visualization
         step_id = None
@@ -407,6 +415,8 @@ class DescribeEntityTool(Tool):
             description=entity.description,
             code=entity.code if allow_llm_see_data else "[code hidden]",
             data_profile=data_profile,
+            data_preview=data_preview,
+            stats=stats,
             step_id=step_id,
             data_model=data_model,
             view=view,
@@ -440,7 +450,8 @@ class DescribeEntityTool(Tool):
             "entity_type": entity.type,
             "title": entity.title,
             "description": entity.description[:200] if entity.description else None,
-            "data_profile": data_profile,
+            "data_preview": data_preview,
+            "stats": stats,
             "analysis_complete": False,
             "final_answer": None,
         }

--- a/backend/app/ai/tools/schemas/describe_entity.py
+++ b/backend/app/ai/tools/schemas/describe_entity.py
@@ -52,6 +52,11 @@ class DescribeEntityOutput(BaseModel):
         default=None,
         description="Data profile with row_count, column_count, columns stats, and optional sample rows",
     )
+    # The budgeted preview the planner reads — the same shape create_data and
+    # read_query produce (build_data_preview), so history digests, result
+    # projections and observation compaction treat all three alike.
+    data_preview: Optional[Dict[str, Any]] = Field(default=None, description="Budgeted, self-describing preview of the entity rows")
+    stats: Optional[Dict[str, Any]] = Field(default=None, description="Per-column stats of the entity rows")
     
     # Created artifact info (when should_create=True)
     step_id: Optional[str] = Field(default=None, description="Created step ID if should_create=True")

--- a/backend/tests/e2e/test_describe_entity_params.py
+++ b/backend/tests/e2e/test_describe_entity_params.py
@@ -80,6 +80,12 @@ def test_values_run_materializes_the_entity_for_those_values(test_client, admin)
     out, obs = payload["output"], payload["observation"]
     assert out["success"], out["errors"]
     assert [r["year"] for r in out["data"]["rows"]] == [year]
+    # The planner reads the same budgeted preview create_data emits: a small
+    # result comes through whole, with stats — no second read_query needed.
+    assert obs["data_preview"]["rows"] == out["data"]["rows"]
+    assert obs["data_preview"]["row_count"] == 1 and obs["data_preview"]["truncated"] is False
+    assert "stats" in obs and "data_profile" not in obs
+    assert out["data_preview"]["rows"] == out["data"]["rows"]
     # What the orchestrator persists onto the created query/step.
     assert out["code"].strip() == CODE.strip()
     assert [p["name"] for p in out["parameters"]] == ["year"]

--- a/backend/tests/unit/test_data_result_digest.py
+++ b/backend/tests/unit/test_data_result_digest.py
@@ -1,0 +1,40 @@
+"""History digest shared by create_data and describe_entity results: shape,
+columns, chart, viz id, the top row when data may be shown, and the values a
+parameterized result ran with — so a later turn can reuse the result rather
+than read or rebuild it."""
+from app.ai.context.builders.message_context_builder import _digest_data_result
+
+RESULT = {
+    "data_preview": {
+        "columns": [{"field": "GenreId"}, {"field": "Name"}],
+        "rows": [{"GenreId": 1, "Name": "Rock"}, {"GenreId": 2, "Name": "Jazz"}],
+        "row_count": 25,
+    },
+    "data_model": {"type": "bar_chart"},
+    "created_visualization_ids": ["viz-1"],
+}
+
+
+def test_digest_carries_shape_columns_chart_viz_and_top_row():
+    d = _digest_data_result(RESULT, True)
+    assert d.startswith("25 rows × 2 cols")
+    for needle in ("cols: GenreId, Name", "chart: bar_chart", "viz_id: viz-1", '"Name": "Rock"'):
+        assert needle in d
+
+
+def test_digest_hides_rows_when_data_may_not_be_shown():
+    d = _digest_data_result(RESULT, False)
+    assert "25 rows × 2 cols" in d
+    assert "top row" not in d and "Rock" not in d
+
+
+def test_digest_records_the_values_a_parameterized_result_ran_with():
+    d = _digest_data_result(RESULT, True, applied_params={"genre": "Rock", "year": None})
+    assert "params: genre='Rock', year=None" in d
+
+
+def test_digest_falls_back_to_legacy_full_data_shape():
+    legacy = {"data": {"columns": [{"field": "a"}], "rows": [{"a": 1}, {"a": 2}]}}
+    assert _digest_data_result(legacy, True).startswith("2 rows × 1 cols")
+    assert _digest_data_result({}, True) == "0 rows × 0 cols"
+    assert _digest_data_result(None, True) == ""


### PR DESCRIPTION
**What:** `describe_entity` now hands the planner a `data_preview` + `stats` built by `build_data_preview` (the create_data/read_query preview), and the history digest for entity results matches the create_data digest (shape, columns, chart, viz id, top row) plus the parameter values it ran with.
**Why:** the planner got only 5 head rows from an entity while create_data gives it every row that fits the 48 KB preview budget, so loading a small saved query (an options list) always cost a second `read_query`; and prior-turn entity results were digested as title-only, so later turns could not reuse them.

## Executive summary

A saved "Genre options" entity with 25 rows was loaded via `describe_entity`, and the agent then called `read_query` on the query it had just created to see the genres it had asked for. Every saved-query load paid an extra tool round-trip and the planner call behind it. With one preview contract across the data tools, small results arrive whole, and on later turns the agent can reference a loaded entity (its shape, top row, and the values it was run with) instead of re-reading or rebuilding it.

## Before / after

| | Before | After |
|---|---|---|
| Planner sees, latest turn | `data_profile`: columns + 5 head rows | `data_preview` (all rows within budget, truncation note) + `stats`, same as create_data |
| History digest, later turns | `entity: Genre options; viz_id: …` | `entity: Genre options; 25 rows × 2 cols; cols: GenreId, GenreName; params: genre='Rock'; top row: {…}` |
| Result projection / observation compaction | not applicable (different key) | keyed on `data_preview`, so entity results get the cheap projection and sampling for free |
| Live: "what genres are available in the store?" (25-row entity, Haiku 4.5) | `describe_entity` → `read_query` → answer | `describe_entity` → answer (one tool call) |

```mermaid
flowchart LR
  subgraph Before
    A1[describe_entity] --> B1[data_profile: 5 head rows]:::bad --> C1[planner: not enough] --> D1[read_query on its own query]:::bad
  end
  subgraph After
    A2[describe_entity] --> B2[build_data_preview: whole small result + stats]:::good --> C2[planner answers]:::good
    B2 --> H2[_digest_data_result: shared with create_data]:::good
  end
  classDef bad fill:#fde2e2,stroke:#c0392b
  classDef good fill:#e3f7e3,stroke:#27ae60
```

## Reviewer decision box

| | |
|---|---|
| **Risk** | Low–medium. The create_data history digest is re-expressed through a shared helper (same fields, same gating); describe_entity observations change shape. |
| **Blast radius** | Planner observation for `describe_entity`; history digests for `create_data` and `describe_entity` (two call sites each, now one helper). The tool card keeps `data_profile`, so the UI is untouched. |
| **Behavior change (intended)** | Larger observations for entity loads (bounded by the existing 48 KB budget); entity digests carry shape, top row and `params`. |
| **Verified ✅** | 4 new unit tests for the shared digest; describe_entity e2e asserts the preview carries the whole small result and `stats`; message-context projection, transcript and history-summary tests re-run green (33). Live sandbox turn above: one `describe_entity`, no `read_query`. |
| **NOT verified ⚠️** | Postgres not run locally (CI runs it). |
| **Where to look first** | `backend/app/ai/context/builders/message_context_builder.py` (`_digest_data_result` and its four call sites), `backend/app/ai/tools/implementations/describe_entity.py` (observation block). |

## Evidence / KPI

| Check | Result |
|---|---|
| New tests | 4 unit (digest) + 1 extended e2e assertion — pass |
| Neighbouring tests | describe_entity params 3, multi-agent 3, tool-result projection, history summary, transcript bridge — 33 pass |
| Failures attributable to this PR | 0 |
| Live tool calls for a 25-row options entity | before 2 (`describe_entity`, `read_query`) → after 1 (`describe_entity`) |

## Context map

- `backend/app/ai/data_preview.py` — `build_data_preview` is the single source of truth for data previews; any tool that returns rows should emit `data_preview` + `stats` through it.
- `backend/app/ai/context/builders/message_context_builder.py` — `_digest_data_result`; add new data tools to it rather than writing another inline digest.
- Follow-ups: the tool card could render from `data_preview` and `data_profile` could then be dropped; parameter option sources pointing at entities, and loadables in entity runs (entity-to-entity dependencies), are tracked separately.

## Deep detail

Root cause was an asymmetry, not a bug: `describe_entity` predates the budgeted previews (`data_preview.py` says it "replaces scattered `rows[:5]` slices") and kept its own profile. The create_data digest existed twice, byte-similar, in the history builder; unifying it was the cheapest way to give entities the same treatment without a third copy. `data_profile` stays on the tool output only for the Vue card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JedQ59VpKZePTTJ21aHaqe