### PR TITLE
Show the open-in-new-tab button always, not only when published

### DIFF
--- a/frontend/components/dashboard/ArtifactFrame.vue
+++ b/frontend/components/dashboard/ArtifactFrame.vue
@@ -137,8 +137,9 @@
           </button>
         </UTooltip>
 
-        <!-- Open in new tab (if published) -->
-        <UTooltip :text="$t('artifactFrame.openInNewTab')" v-if="report?.status === 'published'">
+        <!-- Open in new tab. Always shown: /r/{id} itself enforces access —
+             an unshared report is still viewable there by its owner -->
+        <UTooltip :text="$t('artifactFrame.openInNewTab')" v-if="report">
           <a :href="`/r/${report.id}`" target="_blank" class="text-lg items-center flex gap-1 hover:bg-gray-100 dark:hover:bg-gray-700 px-2 py-1 rounded">
             <Icon name="heroicons:arrow-top-right-on-square" class="w-3.5 h-3.5 text-gray-500 dark:text-gray-400" />
           </a>


### PR DESCRIPTION
## What

The open-in-new-tab button in the artifact panel toolbar was only shown when `report.status === 'published'`. It is now always shown.

## Why it's safe

The `/r/{id}` page enforces access itself (`_check_visibility`): an unshared report (visibility `none`) is still viewable there by its **owner** — everyone else gets a 404. Since only people working on the report see the panel toolbar, the button always leads to a page that works for them; the frontend gate was stricter than the backend for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)