### PR TITLE
Add file capabilities to ServiceNow connector for record attachments

### DIFF
--- a/backend/app/ai/tools/implementations/_file_tool_common.py
+++ b/backend/app/ai/tools/implementations/_file_tool_common.py
@@ -35,6 +35,12 @@ logger = logging.getLogger(__name__)
 FILE_SOURCE_TYPES = {
     "sharepoint", "onedrive", "google_drive", "outlook_mail", "gmail_mail",
     "network_dir", "s3", "onenote",
+    # Hybrid connectors (QUERY + file capabilities). ServiceNow serves record
+    # attachments (KB files by default) live via its Attachment API; its
+    # tabular catalog is untouched, so it must NOT be added to the type sets
+    # that strip file rows from Tables views (schema_context_builder,
+    # data_source_service) — it has no file catalog rows to strip.
+    "servicenow",
 }
 
 

--- a/backend/app/data_sources/clients/servicenow_client.py
+++ b/backend/app/data_sources/clients/servicenow_client.py
@@ -42,6 +42,11 @@ DEFAULT_TABLES = [
     "sys_user_group",
     "cmdb_ci",
     "kb_knowledge",
+    # Attachment metadata for every record's files (file_name, content_type,
+    # size, and the table_name/table_sys_id it hangs off). Exposed so the agent
+    # can go from any record to its files: query here for the attachment's
+    # sys_id, then read_file(sys_id) for the bytes — no per-table wiring needed.
+    "sys_attachment",
 ]
 
 # Roots whose descendants count as "business" tables in discover_all mode.
@@ -905,6 +910,12 @@ class ServiceNowClient(DataSourceClient):
                 "        - search_files(query) matches attachment file names.\n"
                 "        The article BODY is the kb_knowledge.text column (HTML) via execute_query;\n"
                 "        the attachments are separate files on the article.\n"
+                "        To read a file on ANY record (incident, alert, ...) — not just the\n"
+                "        attachment tables above — you need the attachment's sys_id, then call\n"
+                "        read_file(sys_id). Get the id by querying the `sys_attachment` table,\n"
+                "        filtered by table_name + table_sys_id (never query it unfiltered):\n"
+                '        execute_query(\'{"table": "sys_attachment", "query": "table_name=incident^table_sys_id=<record sys_id>", "fields": ["sys_id", "file_name", "content_type", "size_bytes"]}\')\n'
+                "        then read_file(<sys_id from that result>).\n"
             )
         return text
 

--- a/backend/app/data_sources/clients/servicenow_client.py
+++ b/backend/app/data_sources/clients/servicenow_client.py
@@ -9,15 +9,22 @@ Schema discovery reads ServiceNow's own metadata tables in bulk
 full snapshot — custom `u_*`/`x_*` tables included — is a handful of requests,
 not one per table. Reference-type fields become foreign keys.
 """
+import io
 import json
 import re
 from contextlib import contextmanager
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Tuple
 
 import pandas as pd
 import requests
 
-from app.data_sources.clients.base import DataSourceClient
+from app.data_sources.clients._document_text import (
+    DOC_EXTS,
+    doc_text_is_usable,
+    extract_document_text_from_bytes,
+)
+from app.data_sources.clients._file_source_common import DocumentText, NamedBytes
+from app.data_sources.clients.base import Capability, DataSourceClient
 from app.ai.prompt_formatters import ForeignKey, Table, TableColumn, ServiceFormatter
 
 
@@ -160,7 +167,43 @@ def _reconcile_dtype(dtypes: List[str]) -> str:
     return "str"
 
 
+# Attachment API base path. Metadata queries and binary downloads both live
+# here — the raw sys_attachment_doc chunk table is never touched (the binary
+# is stored gzipped in base64 chunks; the API reassembles it server-side).
+ATTACHMENT_API = "/api/now/attachment"
+
+# Default table whose attachments are exposed via the file tools.
+DEFAULT_ATTACHMENT_TABLES = "kb_knowledge"
+
+# Max attachments returned by one list_files/search_files call.
+ATTACHMENT_LIST_LIMIT = 500
+
+_RE_SYS_ID = re.compile(r"^[0-9a-f]{32}$")
+
+# Extensions parsed as tabular / plain text in read_file. Anything else that
+# isn't a DOC_EXTS document comes back as NamedBytes for the vision fallback.
+_TABULAR_EXTS = {"csv", "tsv", "xlsx", "xls"}
+_TEXT_EXTS = {"txt", "md", "html", "htm", "log", "yaml", "yml", "xml"}
+
+
 class ServiceNowClient(DataSourceClient):
+    # Hybrid connector: tabular Table API queries plus record attachments as
+    # files (KB articles by default). The class advertises the file
+    # capabilities so the tools appear in the agent catalog; an instance with
+    # enable_attachments=False narrows itself back to QUERY-only below, so
+    # runtime resolution rejects file calls (the network_dir WRITE_FILE
+    # pattern).
+    capabilities = {
+        Capability.QUERY,
+        Capability.LIST_FILES,
+        Capability.READ_FILE,
+        Capability.SEARCH_FILES,
+    }
+
+    # Listing attachments is one Attachment API call — cheap enough to serve
+    # list_files live from this connection instead of the shared catalog cache
+    # (attachments are deliberately never indexed into the catalog).
+    cheap_live_listing = True
 
     def __init__(
         self,
@@ -173,6 +216,8 @@ class ServiceNowClient(DataSourceClient):
         display_values: bool = True,
         verify_ssl: bool = True,
         infer_schema_from_data: bool = False,
+        enable_attachments: bool = True,
+        attachment_tables: Optional[str] = None,
     ):
         self.instance_url = (instance_url or "").rstrip("/")
         self.username = username
@@ -190,6 +235,13 @@ class ServiceNowClient(DataSourceClient):
         # For users granted read on the business tables but not on ServiceNow's
         # metadata tables (a common ACL posture for scoped integration accounts).
         self.infer_schema_from_data = bool(infer_schema_from_data)
+        self.enable_attachments = bool(enable_attachments)
+        self.attachment_tables = [
+            t.strip() for t in (attachment_tables or DEFAULT_ATTACHMENT_TABLES).split(",")
+            if t.strip()
+        ]
+        if not self.enable_attachments:
+            self.capabilities = {Capability.QUERY}
 
     # ── connection ──────────────────────────────────────────────────────────
 
@@ -600,6 +652,201 @@ class ServiceNowClient(DataSourceClient):
             raise ValueError('ServiceNow query spec must include a "table" key.')
         return spec
 
+    # ── attachments (file capabilities) ─────────────────────────────────────
+    #
+    # Record attachments exposed as files. Metadata lives in sys_attachment
+    # (file_name, content_type, size_bytes, table_name + table_sys_id pointing
+    # at the owning record); binaries are served reassembled by the Attachment
+    # API. Inline images embedded in article HTML are stored under a
+    # "ZZ_YY"-prefixed table_name, so filtering by the real table names also
+    # keeps that noise out of listings.
+
+    def _require_attachments(self):
+        if not self.enable_attachments:
+            raise RuntimeError(
+                "Attachments are disabled on this ServiceNow connection "
+                "(enable_attachments=false)."
+            )
+
+    def _attachment_scope_query(self, folder_id: Optional[str]) -> str:
+        """Encoded query for a listing scope.
+
+        Folder conventions (mirrors the path-shaped ids the entries carry):
+          None                      → all configured attachment tables
+          "kb_knowledge"            → one table
+          "kb_knowledge/<sys_id>"   → one record's attachments
+        """
+        if folder_id:
+            scope = str(folder_id).strip().strip("/")
+            if "/" in scope:
+                table, record = scope.split("/", 1)
+                return f"table_name={table}^table_sys_id={record.split('/', 1)[0]}"
+            return f"table_name={scope}"
+        return "table_nameIN" + ",".join(self.attachment_tables)
+
+    def _attachment_entry(self, row: dict) -> dict:
+        table = _scalar(row.get("table_name")) or ""
+        record = _scalar(row.get("table_sys_id")) or ""
+        name = _scalar(row.get("file_name")) or _scalar(row.get("sys_id"))
+        size = _scalar(row.get("size_bytes"))
+        try:
+            size = int(size)
+        except (TypeError, ValueError):
+            size = None
+        return {
+            "id": _scalar(row.get("sys_id")),
+            "name": name,
+            "path": f"{table}/{record}/{name}",
+            "mime_type": _scalar(row.get("content_type")),
+            "size": size,
+            "modified_at": _scalar(row.get("sys_updated_on")),
+            "is_folder": False,
+            "web_url": f"{self.instance_url}/sys_attachment.do?sys_id={_scalar(row.get('sys_id'))}",
+        }
+
+    _ATTACHMENT_FIELDS = "sys_id,file_name,content_type,size_bytes,table_name,table_sys_id,sys_updated_on"
+
+    def _list_attachments(self, session: requests.Session, query: str, limit: int) -> List[dict]:
+        page = self._get(
+            session,
+            ATTACHMENT_API,
+            {
+                "sysparm_query": query,
+                "sysparm_limit": min(int(limit or ATTACHMENT_LIST_LIMIT), ATTACHMENT_LIST_LIMIT),
+                "sysparm_fields": self._ATTACHMENT_FIELDS,
+            },
+        )
+        return [self._attachment_entry(r) for r in page.get("result", [])]
+
+    def list_files(self, folder_id: Optional[str] = None, recursive: bool = False,
+                   limit: Optional[int] = None) -> List[dict]:
+        self._require_attachments()
+        with self.connect() as session:
+            return self._list_attachments(
+                session, self._attachment_scope_query(folder_id), limit or ATTACHMENT_LIST_LIMIT
+            )
+
+    def search_files(self, query: str, **_) -> List[dict]:
+        self._require_attachments()
+        safe = str(query or "").strip()
+        if not safe:
+            return []
+        scope = "table_nameIN" + ",".join(self.attachment_tables)
+        with self.connect() as session:
+            return self._list_attachments(
+                session, f"file_nameLIKE{safe}^{scope}", ATTACHMENT_LIST_LIMIT
+            )
+
+    def _attachment_meta(self, session: requests.Session, file_id: str) -> dict:
+        """Resolve a file id to its sys_attachment metadata row.
+
+        Accepts the attachment sys_id (the canonical id), the path-shaped id
+        the listings hand out (table/record_sys_id/file_name), or a bare file
+        name searched across the configured attachment tables — the model
+        frequently passes the readable name it saw.
+        """
+        fid = str(file_id or "").strip().strip("/")
+        if _RE_SYS_ID.match(fid):
+            data = self._get(session, f"{ATTACHMENT_API}/{fid}", {})
+            meta = data.get("result")
+            if meta:
+                return meta
+            raise ValueError(f"ServiceNow attachment '{fid}' not found.")
+        if "/" in fid:
+            table, rest = fid.split("/", 1)
+            record, _, name = rest.partition("/")
+            query = f"table_name={table}^table_sys_id={record}"
+            if name:
+                query += f"^file_name={name}"
+        else:
+            scope = "table_nameIN" + ",".join(self.attachment_tables)
+            query = f"file_name={fid}^{scope}"
+        page = self._get(
+            session, ATTACHMENT_API,
+            {"sysparm_query": query, "sysparm_limit": 1},
+        )
+        rows = page.get("result", [])
+        if not rows:
+            raise ValueError(
+                f"ServiceNow attachment '{file_id}' not found — pass the attachment "
+                "sys_id or the table/record/file_name path from list_files."
+            )
+        return rows[0]
+
+    def _download_attachment(self, session: requests.Session, sys_id: str) -> bytes:
+        response = session.get(
+            f"{self.instance_url}{ATTACHMENT_API}/{sys_id}/file",
+            headers={"Accept": "*/*"},
+            timeout=120,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"ServiceNow attachment download failed ({response.status_code}) for {sys_id}."
+            )
+        return response.content
+
+    def read_file(self, file_id: str, max_bytes: Optional[int] = None, **_ignored):
+        """Read one attachment. Same contract as the drive clients:
+        tabular → DataFrame, text → str, documents → extracted text
+        (DocumentText carrying the original bytes), everything else →
+        NamedBytes so the tool layer keeps its vision/preview fallbacks
+        (attachment sys_ids are opaque — the payload must carry the name)."""
+        self._require_attachments()
+        with self.connect() as session:
+            meta = self._attachment_meta(session, file_id)
+            name = _scalar(meta.get("file_name")) or str(file_id)
+            mime = _scalar(meta.get("content_type")) or ""
+            content = self._download_attachment(session, _scalar(meta.get("sys_id")))
+        if max_bytes and len(content) > int(max_bytes):
+            content = content[: int(max_bytes)]
+
+        ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+        if ext in DOC_EXTS:
+            text = extract_document_text_from_bytes(content, name)
+            if doc_text_is_usable(text, ext):
+                return DocumentText(text, raw=content, name=name, mime=mime)
+            return NamedBytes(content, name=name, mime=mime)
+        if ext in _TABULAR_EXTS:
+            try:
+                if ext == "csv":
+                    return pd.read_csv(io.BytesIO(content))
+                if ext == "tsv":
+                    return pd.read_csv(io.BytesIO(content), sep="\t")
+                return pd.read_excel(io.BytesIO(content))
+            except Exception:
+                return NamedBytes(content, name=name, mime=mime)
+        if ext == "json":
+            try:
+                return json.loads(content.decode("utf-8", errors="replace"))
+            except Exception:
+                return content.decode("utf-8", errors="replace")
+        if ext in _TEXT_EXTS or mime.startswith("text/"):
+            return content.decode("utf-8", errors="replace")
+        return NamedBytes(content, name=name, mime=mime)
+
+    def read_raw_bytes(self, file_id: str) -> Tuple[bytes, str, Optional[str]]:
+        """Original bytes + name + mime, unparsed — for the viewer/attach paths."""
+        self._require_attachments()
+        with self.connect() as session:
+            meta = self._attachment_meta(session, file_id)
+            content = self._download_attachment(session, _scalar(meta.get("sys_id")))
+            return (
+                content,
+                _scalar(meta.get("file_name")) or str(file_id),
+                _scalar(meta.get("content_type")) or None,
+            )
+
+    def file_version(self, file_id: str) -> Optional[str]:
+        """Cheap staleness token (metadata only, no download): updated_on + size."""
+        if not self.enable_attachments:
+            return None
+        try:
+            with self.connect() as session:
+                meta = self._attachment_meta(session, file_id)
+            return f"{_scalar(meta.get('sys_updated_on'))}|{_scalar(meta.get('size_bytes'))}"
+        except Exception:
+            return None
+
     # ── prompts ─────────────────────────────────────────────────────────────
 
     def prompt_schema(self):
@@ -646,6 +893,19 @@ class ServiceNowClient(DataSourceClient):
         df = client.execute_query('{"table": "sys_user", "query": "active=true", "fields": ["name", "email", "department"], "limit": 500}')
         ```
         """
+        if self.enable_attachments:
+            text += (
+                "\n        ### Attachments (Knowledge Base files etc.)\n"
+                "        Record attachments are FILES — use the file tools, not execute_query:\n"
+                f"        - list_files(folder_id=None) lists attachments on: {', '.join(self.attachment_tables)}.\n"
+                "          folder_id can scope to a table ('kb_knowledge') or one record\n"
+                "          ('kb_knowledge/<sys_id>' — take sys_id from a query result).\n"
+                "        - read_file(file_id=<attachment id from list_files>) downloads and reads it\n"
+                "          (documents return extracted text; images/PDFs render for viewing).\n"
+                "        - search_files(query) matches attachment file names.\n"
+                "        The article BODY is the kb_knowledge.text column (HTML) via execute_query;\n"
+                "        the attachments are separate files on the article.\n"
+            )
         return text
 
     @property

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -636,6 +636,27 @@ class ServiceNowConfig(BaseModel):
         ),
         json_schema_extra={"ui:type": "boolean"}
     )
+    enable_attachments: bool = Field(
+        True,
+        title="Enable Attachments",
+        description=(
+            "Expose record attachments (e.g. Knowledge Base article files) through the "
+            "file tools (list/read/search). Downloads go through the Attachment API "
+            "(/api/now/attachment) and respect the instance's ACLs for the "
+            "authenticated identity."
+        ),
+        json_schema_extra={"ui:type": "boolean"}
+    )
+    attachment_tables: Optional[str] = Field(
+        "kb_knowledge",
+        title="Attachment Tables",
+        description=(
+            "Comma-separated list of tables whose attachments are exposed. Defaults to "
+            "kb_knowledge (Knowledge Base articles). Add e.g. incident,change_request "
+            "to expose those records' attachments too."
+        ),
+        json_schema_extra={"ui:type": "string"}
+    )
 
 
 # Priority ERP (Priority Software) — OData v4 REST API, cloud and on-premise.

--- a/backend/tests/unit/test_servicenow_client.py
+++ b/backend/tests/unit/test_servicenow_client.py
@@ -329,3 +329,237 @@ def test_http_errors_surface_with_status(client):
     c, _ = client(lambda path, params: FakeResponse({}, status_code=403))
     with pytest.raises(RuntimeError, match="403"):
         c.execute_query('{"table": "incident"}')
+
+
+# ── attachments (file capabilities) ──────────────────────────────────────────
+#
+# Metadata lives in sys_attachment (served via the Attachment API); the binary
+# comes back from /api/now/attachment/{sys_id}/file. The fake session here
+# accepts the `headers` kwarg the binary download passes, which the metadata-
+# only FakeSession above does not.
+
+import pytest as _pytest  # noqa: E402  (kept local to this section)
+
+
+class AttachmentSession:
+    """Serves Attachment API metadata + binary, records requests."""
+
+    def __init__(self, meta_rows, binary=b"%PDF-1.4 fake"):
+        self.meta_rows = meta_rows
+        self.binary = binary
+        self.requests = []
+        self.auth = None
+        self.headers = {}
+
+    def get(self, url, params=None, timeout=None, headers=None):
+        path = urlparse(url).path
+        self.requests.append((path, params or {}))
+
+        class _Resp:
+            def __init__(self, payload=None, content=None, status_code=200):
+                self._payload = payload
+                self.content = content if content is not None else b""
+                self.status_code = status_code
+                self.text = json.dumps(payload) if payload is not None else ""
+
+            def json(self):
+                return self._payload
+
+        if path.endswith("/file"):
+            return _Resp(content=self.binary)
+        # /api/now/attachment/{sys_id}  (single) vs  /api/now/attachment (list)
+        tail = path.rsplit("/api/now/attachment", 1)[-1].strip("/")
+        if tail and "/" not in tail:
+            match = next((r for r in self.meta_rows if r["sys_id"] == tail), None)
+            return _Resp({"result": match})
+        # list/query
+        q = (params or {}).get("sysparm_query", "")
+        rows = self.meta_rows
+        if "file_nameLIKE" in q:
+            needle = q.split("file_nameLIKE", 1)[1].split("^", 1)[0]
+            rows = [r for r in rows if needle.lower() in r["file_name"].lower()]
+        if "table_sys_id=" in q:
+            rec = q.split("table_sys_id=", 1)[1].split("^", 1)[0]
+            rows = [r for r in rows if r["table_sys_id"] == rec]
+        if "file_name=" in q and "file_nameLIKE" not in q:
+            fn = q.split("file_name=", 1)[1].split("^", 1)[0]
+            rows = [r for r in rows if r["file_name"] == fn]
+        return _Resp({"result": rows})
+
+    def close(self):
+        pass
+
+
+PDF_ROW = {
+    "sys_id": "a" * 32,
+    "file_name": "vpn_setup_guide.pdf",
+    "content_type": "application/pdf",
+    "size_bytes": "973",
+    "table_name": "kb_knowledge",
+    "table_sys_id": "rec123",
+    "sys_updated_on": "2026-09-03 18:00:00",
+}
+TXT_ROW = {
+    "sys_id": "b" * 32,
+    "file_name": "notes.txt",
+    "content_type": "text/plain",
+    "size_bytes": "12",
+    "table_name": "kb_knowledge",
+    "table_sys_id": "rec123",
+    "sys_updated_on": "2026-09-03 18:05:00",
+}
+
+
+@_pytest.fixture
+def attach_client(monkeypatch):
+    def make(meta_rows, binary=b"%PDF-1.4 fake", **kwargs):
+        c = ServiceNowClient(
+            instance_url="https://example.service-now.com",
+            username="u", password="p", **kwargs,
+        )
+        session = AttachmentSession(meta_rows, binary=binary)
+        monkeypatch.setattr(
+            "app.data_sources.clients.servicenow_client.requests.Session",
+            lambda: session,
+        )
+        return c, session
+    return make
+
+
+def test_capabilities_include_file_tools_when_enabled():
+    from app.data_sources.clients.base import Capability
+    c = ServiceNowClient(instance_url="https://x", username="u", password="p")
+    assert Capability.LIST_FILES in c.capabilities
+    assert Capability.READ_FILE in c.capabilities
+    assert Capability.SEARCH_FILES in c.capabilities
+    assert c.cheap_live_listing is True
+
+
+def test_capabilities_query_only_when_attachments_disabled():
+    from app.data_sources.clients.base import Capability
+    c = ServiceNowClient(instance_url="https://x", username="u", password="p",
+                         enable_attachments=False)
+    assert c.capabilities == {Capability.QUERY}
+
+
+def test_list_files_returns_attachment_entries(attach_client):
+    c, _ = attach_client([PDF_ROW, TXT_ROW])
+    files = c.list_files()
+    names = {f["name"] for f in files}
+    assert names == {"vpn_setup_guide.pdf", "notes.txt"}
+    pdf = next(f for f in files if f["name"] == "vpn_setup_guide.pdf")
+    assert pdf["id"] == "a" * 32
+    assert pdf["mime_type"] == "application/pdf"
+    assert pdf["size"] == 973
+    assert pdf["path"] == "kb_knowledge/rec123/vpn_setup_guide.pdf"
+    assert pdf["is_folder"] is False
+
+
+def test_list_files_scopes_to_configured_tables(attach_client):
+    c, session = attach_client([PDF_ROW])
+    c.list_files()
+    _, params = session.requests[-1]
+    assert params["sysparm_query"] == "table_nameINkb_knowledge"
+
+
+def test_list_files_record_scope(attach_client):
+    c, session = attach_client([PDF_ROW])
+    c.list_files(folder_id="kb_knowledge/rec123")
+    _, params = session.requests[-1]
+    assert "table_name=kb_knowledge" in params["sysparm_query"]
+    assert "table_sys_id=rec123" in params["sysparm_query"]
+
+
+def test_list_files_disabled_raises(attach_client):
+    c, _ = attach_client([PDF_ROW], enable_attachments=False)
+    with pytest.raises(RuntimeError, match="disabled"):
+        c.list_files()
+
+
+def test_read_file_pdf_returns_extracted_text(attach_client, monkeypatch):
+    # Stub the document extractor so the test doesn't depend on a real PDF.
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.extract_document_text_from_bytes",
+        lambda content, name: "Corporate VPN Setup Guide\nInstall the client.",
+    )
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.doc_text_is_usable",
+        lambda text, ext: True,
+    )
+    c, _ = attach_client([PDF_ROW], binary=b"%PDF-1.4 realbytes")
+    payload = c.read_file("a" * 32)
+    assert isinstance(payload, str)
+    assert "Corporate VPN Setup Guide" in payload
+    # DocumentText carries the original name + bytes for the viewer/vision path.
+    assert payload.name == "vpn_setup_guide.pdf"
+    assert payload.raw == b"%PDF-1.4 realbytes"
+
+
+def test_read_file_scanned_pdf_falls_back_to_named_bytes(attach_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.extract_document_text_from_bytes",
+        lambda content, name: "",
+    )
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.doc_text_is_usable",
+        lambda text, ext: False,
+    )
+    c, _ = attach_client([PDF_ROW], binary=b"%PDF-1.4 scan")
+    payload = c.read_file("a" * 32)
+    assert isinstance(payload, bytes)
+    assert payload.name == "vpn_setup_guide.pdf"
+    assert payload.mime == "application/pdf"
+
+
+def test_read_file_text(attach_client):
+    c, _ = attach_client([TXT_ROW], binary=b"hello ticket")
+    payload = c.read_file("b" * 32)
+    assert payload == "hello ticket"
+
+
+def test_read_file_resolves_bare_name(attach_client):
+    c, _ = attach_client([TXT_ROW], binary=b"hello ticket")
+    payload = c.read_file("notes.txt")
+    assert payload == "hello ticket"
+
+
+def test_read_file_resolves_path_id(attach_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.extract_document_text_from_bytes",
+        lambda content, name: "text",
+    )
+    monkeypatch.setattr(
+        "app.data_sources.clients.servicenow_client.doc_text_is_usable",
+        lambda text, ext: True,
+    )
+    c, _ = attach_client([PDF_ROW], binary=b"x")
+    payload = c.read_file("kb_knowledge/rec123/vpn_setup_guide.pdf")
+    assert payload.name == "vpn_setup_guide.pdf"
+
+
+def test_read_raw_bytes(attach_client):
+    c, _ = attach_client([PDF_ROW], binary=b"%PDF-1.4 raw")
+    content, name, mime = c.read_raw_bytes("a" * 32)
+    assert content == b"%PDF-1.4 raw"
+    assert name == "vpn_setup_guide.pdf"
+    assert mime == "application/pdf"
+
+
+def test_search_files_matches_filename(attach_client):
+    c, session = attach_client([PDF_ROW, TXT_ROW])
+    hits = c.search_files("vpn")
+    assert [h["name"] for h in hits] == ["vpn_setup_guide.pdf"]
+    _, params = session.requests[-1]
+    assert "file_nameLIKEvpn" in params["sysparm_query"]
+    assert "table_nameINkb_knowledge" in params["sysparm_query"]
+
+
+def test_file_version_from_metadata(attach_client):
+    c, _ = attach_client([PDF_ROW])
+    assert c.file_version("a" * 32) == "2026-09-03 18:00:00|973"
+
+
+def test_missing_attachment_raises(attach_client):
+    c, _ = attach_client([PDF_ROW])
+    with pytest.raises(ValueError, match="not found"):
+        c.read_file("c" * 32)


### PR DESCRIPTION
## Summary
Extends the ServiceNow connector with file tool capabilities to expose record attachments (Knowledge Base articles, incidents, etc.) as readable files through the standard file interface (list_files, read_file, search_files).

## Key Changes

- **File capabilities integration**: Added `LIST_FILES`, `READ_FILE`, and `SEARCH_FILES` capabilities to ServiceNowClient, with `cheap_live_listing=True` since attachment metadata queries are lightweight
- **Attachment API support**: Implemented methods to query and download attachments via ServiceNow's `/api/now/attachment` endpoint:
  - `_list_attachments()` - queries attachment metadata with filtering
  - `_attachment_meta()` - resolves file IDs (sys_id, path-shaped IDs, or bare filenames)
  - `_download_attachment()` - fetches binary content
- **Smart file parsing**: `read_file()` intelligently handles different file types:
  - Documents (PDF, Word, etc.) → extracted text via DocumentText wrapper
  - Tabular formats (CSV, TSV, Excel) → pandas DataFrames
  - JSON → parsed objects
  - Plain text → strings
  - Everything else → NamedBytes for vision/preview fallbacks
- **Configurable scope**: New config options:
  - `enable_attachments` (default: True) - toggle file capabilities on/off
  - `attachment_tables` (default: "kb_knowledge") - comma-separated list of tables to expose
- **Capability gating**: When `enable_attachments=False`, capabilities are narrowed to `{QUERY}` only, allowing runtime rejection of file calls
- **Enhanced system prompt**: Added documentation section explaining attachment access patterns, including how to query `sys_attachment` directly for files on arbitrary records
- **Comprehensive test coverage**: Added 14 tests covering metadata queries, file resolution, parsing, scoping, and error cases

## Implementation Details

- Attachment metadata is never indexed into the catalog; listings are served live from the connection
- Inline images embedded in KB article HTML (stored with "ZZ_YY"-prefixed table names) are automatically filtered out
- File IDs support three formats: canonical sys_id (32 hex chars), path-shaped IDs from listings (table/record/name), or bare filenames searched across configured tables
- The `file_version()` method returns a staleness token combining `sys_updated_on` and `size_bytes` for caching
- Respects instance ACLs for the authenticated identity on all attachment operations

https://claude.ai/code/session_01HJhCCN4BSx1HNYvDM6K9Gt