### PR TITLE
fix(files): find files by their folder, and calm the read_file PDF card

### DIFF
--- a/backend/app/ai/tools/implementations/list_files.py
+++ b/backend/app/ai/tools/implementations/list_files.py
@@ -50,7 +50,8 @@ class ListFilesTool(Tool):
                 "this reads the source directly (always current); otherwise it "
                 "reads the fast cached catalog. Returns up to 500 files. Only "
                 "files matching the connection's configured patterns are "
-                "visible. Filter by filename with name_pattern (glob: '*.xlsx')."
+                "visible. Filter with name_pattern (glob, matched against the filename "
+                "and the relative path: '*.xlsx', '*6044534*')."
             ),
             category="research",
             input_schema=ListFilesInput.model_json_schema(),
@@ -128,9 +129,16 @@ class ListFilesTool(Tool):
 
     def _apply(self, raw: List[dict], name_pattern) -> tuple:
         files = []
+        pat = (name_pattern or "").lower()
         for f in raw:
             name = f.get("name") or f.get("path") or f.get("id")
-            if name_pattern and not fnmatch.fnmatch(str(name).lower(), name_pattern.lower()):
+            # Match the bare filename OR the source-relative path, mirroring
+            # grep_files. A case folder named `6044534` holds files whose
+            # names carry no case number — `*6044534*` must still find them.
+            if pat and not (
+                fnmatch.fnmatch(str(name).lower(), pat)
+                or fnmatch.fnmatch(str(f.get("path") or name).lower(), pat)
+            ):
                 continue
             files.append({
                 "id": f.get("id") or f.get("file_id") or name,
@@ -229,8 +237,23 @@ class ListFilesTool(Tool):
             yield self._fail(data.connection_id, f"Failed to read cached catalog: {e}")
             return
 
+        # The catalog is flat (name == source-relative path), so scope
+        # folder_id / recursive here — the live path gets them from the client.
+        # Only when the id is a path the catalog knows: an opaque provider
+        # folder id (Graph/Drive) matches nothing, and blanking the listing
+        # for it would be worse than the unscoped list it always returned.
+        folder = (data.folder_id or "").strip().strip("/")
+        prefix = f"{folder}/" if folder else ""
+        if prefix and not any(str(t.name or "").startswith(prefix) for t in (tables or [])):
+            prefix = ""
         raw = []
         for t in (tables or []):
+            rel = str(t.name or "")
+            if prefix:
+                if not rel.startswith(prefix):
+                    continue
+                if not data.recursive and "/" in rel[len(prefix):]:
+                    continue
             meta_json = getattr(t, "metadata_json", None) or {}
             sub = next((meta_json.get(k) for k in _FILE_METADATA_KEYS if meta_json.get(k)), {}) or {}
             raw.append({

--- a/backend/app/ai/tools/implementations/search_files.py
+++ b/backend/app/ai/tools/implementations/search_files.py
@@ -29,7 +29,9 @@ from ._file_tool_common import resolve_file_client, resolve_file_data_source
 
 # Keys under a catalog row's metadata_json that may carry a keyword index.
 _FILE_METADATA_KEYS = ("network_dir", "graph", "google_drive", "s3")
-_WORD_RE = re.compile(r"[^\W\d_]{2,}", re.UNICODE)
+# Query tokens keep digit runs (case numbers, IDs) — unlike the indexer's
+# body tokenizer — so "6044534" scores against a name/path that carries it.
+_WORD_RE = re.compile(r"[^\W_]{2,}", re.UNICODE)
 
 
 def _index_search(tables, query: str, max_results: int) -> List[Dict[str, Any]]:

--- a/backend/app/data_sources/clients/_keywords.py
+++ b/backend/app/data_sources/clients/_keywords.py
@@ -15,6 +15,10 @@ from typing import List, Optional
 # Unicode "word" = 2+ letters (any script), no digits/punctuation. `\w` minus
 # digits/underscore via a negated class keeps Hebrew, accented Latin, etc.
 _WORD_RE = re.compile(r"[^\W\d_]{2,}", re.UNICODE)
+# Filename/path tokens additionally keep digit runs: an id-like name
+# (`6044534/appendix.pdf`) is exactly what people search for. Bodies
+# stay letters-only so numeric tables don't flood the keyword list.
+_NAME_RE = re.compile(r"[^\W_]{2,}", re.UNICODE)
 
 # Small, high-frequency stopword set. English + common Hebrew function words —
 # deliberately short (recall over precision; distinctive terms survive anyway).
@@ -51,7 +55,7 @@ def extract_keywords(
             keywords.append(tok)
 
     # Filename tokens first — always searchable.
-    for tok in _WORD_RE.findall((filename or "").lower()):
+    for tok in _NAME_RE.findall((filename or "").lower()):
         _add(tok)
         if len(keywords) >= max_keywords:
             return keywords[:max_keywords]

--- a/backend/app/data_sources/clients/network_dir_client.py
+++ b/backend/app/data_sources/clients/network_dir_client.py
@@ -822,7 +822,9 @@ class NetworkDirClient(DataSourceClient):
                     try:
                         path = root / f["id"]
                         text = self._file_text(path)
-                        meta["keywords"] = extract_keywords(text, f["name"], self.max_keywords)
+                        # Index the RELATIVE PATH, not just the basename: a case
+                        # folder (`6044534/…`) is how people find these files.
+                        meta["keywords"] = extract_keywords(text, name, self.max_keywords)
                         meta["content_hash"] = hashlib.sha1(
                             (text or "").encode("utf-8", "ignore")
                         ).hexdigest() if text else None

--- a/backend/tests/unit/test_attach_and_index.py
+++ b/backend/tests/unit/test_attach_and_index.py
@@ -59,6 +59,16 @@ class TestIndexSearch:
         hits = _index_search(rows, "acme", 10)
         assert hits[0]["path"] == "notes/acme.md"
 
+    def test_numeric_query_matches_path(self):
+        # A case number lives only in the folder segment of the path; the
+        # query tokenizer must keep digit runs so it scores against it.
+        rows = [
+            _row("6044534/appendix.pdf", ["appendix", "guarantee"]),
+            _row("7000001/appendix.pdf", ["appendix", "guarantee"]),
+        ]
+        hits = _index_search(rows, "case 6044534", 10)
+        assert [h["path"] for h in hits] == ["6044534/appendix.pdf"]
+
     def test_empty_when_not_indexed(self):
         # rows carry NO keywords -> not indexed -> [] (caller falls back to live)
         rows = [_row("a.csv"), _row("b.csv")]

--- a/backend/tests/unit/test_file_tools.py
+++ b/backend/tests/unit/test_file_tools.py
@@ -308,6 +308,63 @@ async def test_list_files_glob_filter():
 
 
 @pytest.mark.asyncio
+async def test_list_files_glob_matches_relative_path():
+    """Live listings carry name=basename and path=folder/basename. A glob
+    naming the FOLDER (a case number) must match through the path, as
+    grep_files already does — the files' own names carry no case number."""
+    client = MagicMock()
+    client.cheap_live_listing = True
+    client.alist_files = AsyncMock(return_value=[
+        {"id": "6044534/appendix.pdf", "name": "appendix.pdf", "path": "6044534/appendix.pdf"},
+        {"id": "6044534/deed.pdf", "name": "deed.pdf", "path": "6044534/deed.pdf"},
+        {"id": "7000001/appendix.pdf", "name": "appendix.pdf", "path": "7000001/appendix.pdf"},
+        {"id": "6044534", "name": "6044534", "path": "6044534", "is_folder": True},
+    ])
+    with patch("app.ai.tools.implementations.list_files.resolve_file_client",
+               new=AsyncMock(return_value=(client, None))):
+        tool = ListFilesTool()
+        events = await _collect(tool.run_stream(
+            {"connection_id": "C1", "name_pattern": "*6044534*", "recursive": True}, {}
+        ))
+    out = events[-1].payload["output"]
+    assert out["success"] is True
+    assert {f["id"] for f in out["files"]} == {"6044534/appendix.pdf", "6044534/deed.pdf"}
+    # Plain filename globs keep working.
+    with patch("app.ai.tools.implementations.list_files.resolve_file_client",
+               new=AsyncMock(return_value=(client, None))):
+        events = await _collect(ListFilesTool().run_stream(
+            {"connection_id": "C1", "name_pattern": "deed.*"}, {}
+        ))
+    assert [f["id"] for f in events[-1].payload["output"]["files"]] == ["6044534/deed.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_list_files_cache_scopes_folder_id():
+    """The cached catalog is flat; folder_id must still scope it (it was
+    silently ignored, returning the whole share)."""
+    ds = MagicMock(); ds.id = "DS1"
+    cached = _mock_cached_tables(
+        {"id": "1", "name": "6044534/appendix.pdf"},
+        {"id": "2", "name": "6044534/sub/deed.pdf"},
+        {"id": "3", "name": "7000001/appendix.pdf"},
+        {"id": "4", "name": "README.md"},
+    )
+    async def _run(inp):
+        with patch("app.ai.tools.implementations.list_files.resolve_file_data_source",
+                   new=AsyncMock(return_value=(ds, None))), \
+             patch("app.services.data_source_service.DataSourceService.get_data_source_schema",
+                   new=AsyncMock(return_value=cached)):
+            events = await _collect(ListFilesTool().run_stream({"connection_id": "DS1", **inp}, {}))
+        return {f["name"] for f in events[-1].payload["output"]["files"]}
+    assert await _run({"folder_id": "6044534", "recursive": True}) == {"6044534/appendix.pdf", "6044534/sub/deed.pdf"}
+    assert await _run({"folder_id": "6044534"}) == {"6044534/appendix.pdf"}
+    assert await _run({"folder_id": "/6044534/", "recursive": True, "name_pattern": "*deed*"}) == {"6044534/sub/deed.pdf"}
+    assert len(await _run({})) == 4
+    # Opaque (non-path) folder ids leave the listing unscoped rather than empty.
+    assert len(await _run({"folder_id": "01ABCDEF!123", "recursive": True})) == 4
+
+
+@pytest.mark.asyncio
 async def test_list_files_reads_from_cached_schema():
     """list_files no longer hits the upstream client — it reads cached
     DataSourceTable rows. metadata_json.graph carries the file_id."""

--- a/backend/tests/unit/test_keywords_numeric.py
+++ b/backend/tests/unit/test_keywords_numeric.py
@@ -1,0 +1,10 @@
+"""Keyword extraction keeps id-like tokens from the NAME only."""
+from app.data_sources.clients._keywords import extract_keywords
+
+
+def test_filename_digits_are_keywords_body_digits_are_not():
+    kws = extract_keywords("total 12345 and 6789 more", "6044534/appendix-2024.pdf")
+    assert "6044534" in kws
+    assert "2024" in kws
+    assert "appendix" in kws
+    assert "12345" not in kws and "6789" not in kws

--- a/frontend/components/FilePreview.vue
+++ b/frontend/components/FilePreview.vue
@@ -2,11 +2,13 @@
   <div ref="rootEl" class="w-full relative group/preview">
     <!-- Opens the same file in the side panel. Hidden where no panel exists
          (the share view), so the card never offers an action that does
-         nothing — `canExpand` is opt-in per host page. -->
+         nothing — `canExpand` is opt-in per host page. Always visible: the
+         inline frame hides the viewer's toolbar, so this is the one
+         affordance for reading the document at full size. -->
     <button
       v-if="canExpand && !expanded"
       type="button"
-      class="absolute top-2 end-2 z-10 p-1 rounded-md bg-white/90 dark:bg-gray-800/90 border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 opacity-0 group-hover/preview:opacity-100 focus:opacity-100 transition-opacity hover:text-gray-700 dark:hover:text-gray-200"
+      class="absolute top-2 end-2 z-10 p-1 rounded-md bg-white/90 dark:bg-gray-800/90 border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 shadow-sm transition-colors hover:text-gray-700 dark:hover:text-gray-200"
       :title="$t('filePreview.openInPanel')"
       :aria-label="$t('filePreview.openInPanel')"
       @click="$emit('expand')"
@@ -128,7 +130,9 @@ const images = computed<string[]>(() => props.imageFileIds || (props.fileId ? [p
 const activeIndex = ref(0)
 const activeImageId = computed(() => images.value[activeIndex.value] || images.value[0] || '')
 
-const frameHeight = computed(() => (props.expanded ? '70vh' : '260px'))
+// Inline (card) frames are a compact glance at the document; the side
+// panel (`expanded`) is where it is actually read.
+const frameHeight = computed(() => (props.expanded ? '70vh' : '200px'))
 // PDF Open Parameters, read by the browser's built-in viewer:
 //   page      open at the page the model actually read
 //   view=FitH fit the page WIDTH to the frame, not a zoomed-in corner
@@ -136,9 +140,13 @@ const frameHeight = computed(() => (props.expanded ? '70vh' : '260px'))
 //             half a panel-sized frame, squeezing the document into what is
 //             left. Useless for the single-page documents this mostly shows,
 //             and the toolbar already carries page navigation.
+//   toolbar=0 (inline only) the card is a glance, not a reader — the zoom /
+//             rotate / summarize bar dominates a 200px frame. The side panel
+//             keeps it. Chromium honors this; other viewers ignore it.
 const frameSrc = computed(() =>
   embedUrl.value
     ? `${embedUrl.value}#page=${props.targetPage || 1}&view=FitH&navpanes=0`
+      + (props.expanded ? '' : '&toolbar=0')
     : ''
 )
 

--- a/frontend/components/tools/ReadFileTool.vue
+++ b/frontend/components/tools/ReadFileTool.vue
@@ -29,9 +29,11 @@
     </Transition>
 
     <!-- Visual previews render on success without being asked, the way a
-         chart does in create_data; only plain text waits behind the chevron.
-         Exception: page-render galleries of a document (preview.derived) are
-         a lossy stand-in, so they wait behind an explicit click. -->
+         chart does in create_data — and the chevron opens by default to say
+         so, since everything below the title row is under it. Plain-text
+         reads stay collapsed. Exception: page-render galleries of a document
+         (preview.derived) are a lossy stand-in, so they wait behind an
+         explicit click. -->
     <button
       v-if="derivedGalleryCollapsed"
       type="button"
@@ -42,7 +44,8 @@
       {{ $t('tools.readFile.showPagePreviews', { n: (preview.image_file_ids || []).length }) }}
     </button>
     <Transition name="fade" appear>
-      <div v-if="showVisualPreview" class="mb-2">
+      <div v-if="showVisualPreview && expanded" class="mb-2">
+        <!-- Inline frame stays compact; the side panel is the full-size view. -->
         <FilePreview
           v-if="preview.kind === 'pdf' || preview.kind === 'image'"
           :kind="preview.kind"
@@ -52,7 +55,6 @@
           :pages-total="preview.pages_total"
           :truncated="preview.truncated"
           :name="rj.file_name"
-          :expanded="expanded"
           :can-expand="canExpand"
           @open="openImage"
           @expand="emitOpenPanel"
@@ -74,7 +76,8 @@
           <span class="text-gray-400 dark:text-gray-500">{{ $t('tools.readFile.pathLabel') }}</span>
           <code class="ms-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 break-all" dir="ltr">{{ filePath }}</code>
         </div>
-        <pre v-if="hasContent && preview.kind !== 'table'" class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
+        <!-- The document/picture IS the content — don't repeat it as a text dump. -->
+        <pre v-if="hasContent && !showVisualPreview" class="text-[11px] bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ previewText }}</pre>
         <div v-if="sessionFileId" class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
           <Icon name="heroicons-paper-clip" class="w-3 h-3 inline align-text-bottom me-0.5" />
           {{ $t('tools.readFile.attachedAsSessionFile') }}
@@ -242,7 +245,15 @@ function openImage(fileId: string) {
   imageModal.value?.open({ id: fileId, filename: rj.value.file_name || '' })
 }
 
-const expanded = ref(false)
+// Open by default when there is something visual to show (the preview lives
+// under the chevron, so a closed chevron over a visible document would lie);
+// closed for text-only reads, whose 4000-char dump is opt-in. The first click
+// takes over.
+const manualExpanded = ref<boolean | null>(null)
+const expanded = computed<boolean>({
+  get: () => (manualExpanded.value ?? showVisualPreview.value),
+  set: (v) => { manualExpanded.value = v },
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
list_files: `name_pattern` only matched the bare filename, so a glob naming
a case folder (`*6044534*`) found nothing while `folder_id=6044534` listed
the same files. Match the source-relative path too, as grep_files already
does. The cached-catalog path also ignored `folder_id`/`recursive`
entirely and returned the whole share; scope it by path prefix when the id
is a path the catalog knows (opaque provider ids stay unscoped).

search_files: the query tokenizer dropped digits, so an id-like query
("case 6044534") scored nothing from the number. Keep digit runs on the
query side, index digit tokens from the file's relative path (bodies stay
letters-only so numeric tables don't flood the keyword list), and have the
network_dir indexer feed the path rather than the basename.

read_file card: the PDF viewer rendered while the chevron read "collapsed",
because the visual preview never consulted the chevron. The chevron now
opens by default when there is something visual and gates the preview
too; the inline frame drops the viewer toolbar (Chromium `toolbar=0`) and
shrinks to a 200px glance with an always-visible "open in side panel"
button, and the extracted-text dump is no longer repeated under a document.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AM2W5x4BXSjNEkjtTf1DPa