### PR TITLE
fix(mssql): harden Kerberos delegation

### DIFF
--- a/backend/app/data_sources/clients/mssql_client.py
+++ b/backend/app/data_sources/clients/mssql_client.py
@@ -101,9 +101,8 @@ class MSSQLClient(DataSourceClient):
         params += (
             "TrustServerCertificate=yes;"
             "LoginTimeout=30;"
+            f"Encrypt={'yes' if self.encrypt else 'no'};"
         )
-        if not self.encrypt:
-            params += "Encrypt=no;"
         # Append user-supplied extra ODBC keywords (e.g. ApplicationIntent=ReadOnly),
         # skipping any that would override the security-sensitive keys above.
         for key, value in (self.additional_params or {}).items():

--- a/backend/app/data_sources/kerberos.py
+++ b/backend/app/data_sources/kerberos.py
@@ -170,6 +170,13 @@ class KerberosTicketManager:
             return ccache_path
 
     def _ccache_path_for(self, key: str) -> str:
+        # os.makedirs applies `mode` to the leaf directory only — intermediate
+        # ones land at 0o777 & ~umask (typically 0755). The worker dir below is
+        # the leaf, so the root has to be created in its own call or the cache
+        # root becomes world-traversable. Only creation is constrained: an
+        # operator-supplied BOW_KRB5_CCACHE_DIR is left as configured (mounted
+        # ccache dirs are group-accessible under OpenShift's arbitrary UIDs).
+        os.makedirs(self._ccache_dir, mode=0o700, exist_ok=True)
         worker_dir = os.path.join(self._ccache_dir, f"worker-{self._cache_namespace}")
         os.makedirs(worker_dir, mode=0o700, exist_ok=True)
         with suppress(OSError):

--- a/backend/app/data_sources/kerberos.py
+++ b/backend/app/data_sources/kerberos.py
@@ -33,6 +33,7 @@ import base64
 import hashlib
 import logging
 import os
+import secrets
 import threading
 import time
 from contextlib import contextmanager, suppress
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 # as different users queue on this lock; once the driver has opened the
 # connection the env var no longer matters, so the hold time is one TCP+GSS
 # handshake.
-_ENV_LOCK = threading.Lock()
+_ENV_LOCK = threading.RLock()
 
 # Refresh a cached credential when less than this many seconds of its ticket
 # lifetime remain, so a connection never starts with an about-to-expire ticket.
@@ -92,6 +93,7 @@ class KerberosTicketManager:
     def __init__(self, ccache_dir: str | None = None, client_keytab: str | None = None):
         self._ccache_dir = ccache_dir or os.environ.get(CCACHE_DIR_ENV) or "/tmp/bow_krb5"
         self._client_keytab = client_keytab or os.environ.get(CLIENT_KEYTAB_ENV)
+        self._cache_namespace = f"{os.getpid()}-{secrets.token_hex(6)}"
         self._lock = threading.Lock()
         self._cache: dict[str, _CachedCredential] = {}
 
@@ -128,13 +130,14 @@ class KerberosTicketManager:
         """Point KRB5CCNAME at ``ccache_path`` for the duration of the block.
 
         Process-global and therefore serialized: hold only around the driver
-        connect call, never around query execution. A ``None`` path activates
-        nothing (default cache) without taking the lock.
+        connect call, never around query execution. A ``None`` path leaves the
+        default cache selected but still takes the lock, preventing it from
+        observing a concurrently activated delegated cache.
         """
-        if not ccache_path:
-            yield
-            return
         with _ENV_LOCK:
+            if not ccache_path:
+                yield
+                return
             previous = os.environ.get("KRB5CCNAME")
             os.environ["KRB5CCNAME"] = f"FILE:{ccache_path}"
             try:
@@ -167,10 +170,13 @@ class KerberosTicketManager:
             return ccache_path
 
     def _ccache_path_for(self, key: str) -> str:
-        os.makedirs(self._ccache_dir, mode=0o700, exist_ok=True)
+        worker_dir = os.path.join(self._ccache_dir, f"worker-{self._cache_namespace}")
+        os.makedirs(worker_dir, mode=0o700, exist_ok=True)
+        with suppress(OSError):
+            os.chmod(worker_dir, 0o700)
         digest = hashlib.sha256(key.encode("utf-8")).digest()
         token = base64.urlsafe_b64encode(digest[:12]).decode("ascii").rstrip("=")
-        return os.path.join(self._ccache_dir, f"krb5cc_{token}")
+        return os.path.join(worker_dir, f"krb5cc_{token}")
 
     def _service_credentials(self, gssapi, principal: str | None = None):
         """Initiate-usage credentials for the app's service identity (keytab)."""
@@ -181,9 +187,12 @@ class KerberosTicketManager:
         if principal:
             name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
         try:
-            if store:
-                return gssapi.Credentials(usage="initiate", name=name, store=store)
-            return gssapi.Credentials(usage="initiate", name=name)
+            # Credential acquisition may consult the process-default cache.
+            # Serialize it with all temporary KRB5CCNAME activations.
+            with _ENV_LOCK:
+                if store:
+                    return gssapi.Credentials(usage="initiate", name=name, store=store)
+                return gssapi.Credentials(usage="initiate", name=name)
         except Exception as e:
             raise KerberosDelegationError(
                 f"Failed to acquire service credentials"

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -788,7 +788,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
             # the user's UPN is derived from their login identity unless overridden.
             "kerberos_delegated": AuthVariant(title="Kerberos SSO (per-user delegation)", schema=MssqlKerberosDelegatedCredentials, scopes=["user"]),
         }),
-        client_path=None,
+        client_path="app.data_sources.clients.mssql_client.MSSQLClient",
     ),
     "clickhouse": DataSourceRegistryEntry(
         type="clickhouse",

--- a/backend/app/services/connection_identity.py
+++ b/backend/app/services/connection_identity.py
@@ -344,13 +344,14 @@ async def build_kerberos_sso_status(
             last_checked_at=last_checked,
         )
 
-    verified = bool(marker and marker.last_used_at)
+    last_error = (getattr(marker, "metadata_json", None) or {}).get("last_error") if marker else None
+    verified = bool(marker and marker.last_used_at and not last_error)
     return DataSourceUserStatus(
         has_user_credentials=True,
         auth_mode=KERBEROS_SSO_MODE,
         is_primary=bool(getattr(marker, "is_primary", True)) if marker else True,
         last_used_at=getattr(marker, "last_used_at", None),
-        connection="success" if verified else "unknown",
+        connection="success" if verified else ("offline" if last_error else "unknown"),
         effective_auth="user",
         credentials_id=str(marker.id) if marker and getattr(marker, "id", None) else None,
         last_checked_at=getattr(marker, "last_used_at", None) or last_checked,

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1058,7 +1058,7 @@ class ConnectionService:
             roster.append({
                 "user_id": r.user_id,
                 "principal": md.get("principal"),
-                "verified": bool(r.last_used_at),
+                "verified": bool(r.last_used_at and not md.get("last_error")),
                 "last_verified_at": r.last_used_at,
                 "last_error": md.get("last_error"),
             })

--- a/backend/tests/unit/test_mssql_kerberos.py
+++ b/backend/tests/unit/test_mssql_kerberos.py
@@ -326,6 +326,29 @@ def test_ccache_paths_are_private_to_each_manager(tmp_path):
     )
 
 
+def test_ccache_root_and_worker_dir_are_private(tmp_path):
+    """Nesting the worker dir must not leave the cache root world-traversable.
+
+    os.makedirs() applies its mode to the leaf only, so creating the root
+    implicitly would give it 0o777 & ~umask instead of 0700.
+    """
+    import os
+    import stat
+
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    root = tmp_path / "bow_krb5"  # absent, like a fresh /tmp/bow_krb5
+    previous_umask = os.umask(0o022)
+    try:
+        manager = KerberosTicketManager(ccache_dir=str(root))
+        ccache_path = manager._ccache_path_for("user:alice@CORP.EXAMPLE.COM")
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(os.stat(os.path.dirname(ccache_path)).st_mode) == 0o700
+
+
 # ---------- resolve_credentials helper ---------- #
 
 

--- a/backend/tests/unit/test_mssql_kerberos.py
+++ b/backend/tests/unit/test_mssql_kerberos.py
@@ -14,7 +14,9 @@ domain available.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
 import types
 from urllib.parse import parse_qs, unquote_plus, urlsplit
 
@@ -108,6 +110,16 @@ def test_kerberos_principals_normalized():
     assert client.kerberos_impersonate == "jdoe@CORP.EXAMPLE.COM"
 
 
+@pytest.mark.parametrize("driver", [17, 18])
+@pytest.mark.parametrize("encrypt,expected", [(True, "yes"), (False, "no")])
+def test_encrypt_setting_is_explicit_for_every_supported_driver(driver, encrypt, expected):
+    client = MSSQLClient(
+        "db.corp.example.com", 1433, "dwh", "svc", "secret",
+        odbc_driver=driver, encrypt=encrypt,
+    )
+    assert _odbc_params(client)["encrypt"] == expected
+
+
 # ---------- registry / schemas ---------- #
 
 
@@ -121,6 +133,7 @@ def test_registry_exposes_kerberos_auth_variants():
     assert by_auth["kerberos_delegated"].scopes == ["user"]
     # default UX unchanged
     assert entry.credentials_auth.default == "userpass"
+    assert entry.client_path == "app.data_sources.clients.mssql_client.MSSQLClient"
 
 
 def test_kerberos_credentials_schema_validation():
@@ -276,6 +289,43 @@ def test_activate_sets_and_restores_krb5ccname(tmp_path, monkeypatch):
         assert "KRB5CCNAME" not in os.environ
 
 
+def test_default_ccache_activation_serializes_with_delegated_activation(tmp_path):
+    """A service-account handshake must not observe another user's KRB5CCNAME."""
+    import app.data_sources.kerberos as kerberos
+
+    mgr = kerberos.KerberosTicketManager(ccache_dir=str(tmp_path))
+    attempted = threading.Event()
+    entered = threading.Event()
+
+    def activate_default():
+        attempted.set()
+        with mgr.activate(None):
+            entered.set()
+
+    kerberos._ENV_LOCK.acquire()
+    try:
+        worker = threading.Thread(target=activate_default)
+        worker.start()
+        assert attempted.wait(timeout=1)
+        worker.join(timeout=0.2)
+        assert not entered.is_set()
+    finally:
+        kerberos._ENV_LOCK.release()
+    worker.join(timeout=1)
+    assert entered.is_set()
+
+
+def test_ccache_paths_are_private_to_each_manager(tmp_path):
+    """Separate worker managers must never overwrite the same ccache file."""
+    from app.data_sources.kerberos import KerberosTicketManager
+
+    first = KerberosTicketManager(ccache_dir=str(tmp_path))
+    second = KerberosTicketManager(ccache_dir=str(tmp_path))
+    assert first._ccache_path_for("user:alice@CORP.EXAMPLE.COM") != second._ccache_path_for(
+        "user:alice@CORP.EXAMPLE.COM"
+    )
+
+
 # ---------- resolve_credentials helper ---------- #
 
 
@@ -359,3 +409,27 @@ def test_resolve_kerberos_principal_precedence():
     # a non-kerberos row is ignored for principal derivation → falls back to email
     other = _FakeRow("userpass", {"kerberos_impersonate": "should-be-ignored@x"})
     assert resolve_kerberos_principal(_FakeUser("jdoe@corp.example.com"), other) == "jdoe@corp.example.com"
+
+
+def test_failed_kerberos_recheck_is_not_reported_as_success():
+    from datetime import datetime
+
+    from app.services.connection_identity import build_kerberos_sso_status
+
+    marker = _FakeRow("kerberos_delegated", {"kerberos_impersonate": "jdoe@corp.example.com"})
+    marker.last_used_at = datetime.utcnow()
+    marker.metadata_json = {"last_error": "KDC unreachable"}
+    marker.is_primary = True
+    marker.id = "marker-1"
+
+    class _Index:
+        def connection_row(self, _connection_id):
+            return marker
+
+    connection = _FakeConnection(["kerberos_delegated"])
+    connection.id = "connection-1"
+    status = asyncio.run(build_kerberos_sso_status(
+        None, connection, _FakeUser("jdoe@corp.example.com"), None, None,
+        cred_index=_Index(),
+    ))
+    assert status.connection == "offline"

--- a/docs/feedback-loops/sql-server-kerberos.md
+++ b/docs/feedback-loops/sql-server-kerberos.md
@@ -1,0 +1,135 @@
+# SQL Server Kerberos identity-isolation feedback loop
+
+## Root cause validated
+
+The connector had three correctness gaps that only become visible when Kerberos
+is exercised under realistic conditions:
+
+1. A default service-account connect did not acquire the process-wide
+   `KRB5CCNAME` lock. It could therefore observe a delegated user's temporary
+   cache during a concurrent handshake. The affected activation path was
+   `backend/app/data_sources/kerberos.py:128`.
+2. Credential-cache filenames were stable across manager/process instances,
+   allowing different workers to target the same file. The allocation path was
+   `backend/app/data_sources/kerberos.py:172`.
+3. `Encrypt` was omitted when enabled, so ODBC Driver 17 and 18 selected
+   different defaults. The connection-string path was
+   `backend/app/data_sources/clients/mssql_client.py:101`.
+
+Two status paths also treated a previously successful Kerberos check as still
+verified after a later check recorded an error:
+`backend/app/services/connection_identity.py:347` and
+`backend/app/services/connection_service.py:1057`.
+
+## Loop A — deterministic reproduction
+
+Run from the repository root:
+
+```bash
+cd backend
+PYTHONWARNINGS=ignore .venv/bin/pytest tests/unit/test_mssql_kerberos.py -q
+```
+
+Before the fix this produced:
+
+```text
+5 failed, 24 passed
+```
+
+The failures proved that enabled encryption lacked an explicit ODBC keyword,
+the default-cache path did not serialize with delegated activation, separate
+ticket managers generated the same cache path, and a failed recheck remained
+reported as successful.
+
+After the fix, run the focused and adjacent regression set:
+
+```bash
+cd backend
+PYTHONWARNINGS=ignore .venv/bin/pytest \
+  tests/unit/test_mssql_kerberos.py \
+  tests/unit/test_engine_pool_identity.py \
+  tests/e2e/test_kerberos_sso_member_overlay.py -q
+```
+
+Expected result:
+
+```text
+45 passed
+```
+
+## Loop B — live confirmation
+
+The self-contained lab uses Samba as an AD domain controller/KDC, joins SQL
+Server 2022 to that domain, and mounts the production backend code read-only
+into the test runner. LDAP supplies directory and SID lookup; all database
+authentication in this proof is Kerberos.
+
+```bash
+cd lab/sql-server-kerberos
+./up.sh -vv
+```
+
+The live suite must prove all seven checks:
+
+- service keytab exported with restricted permissions;
+- S4U2Self obtains Alice's delegated credential without her password;
+- S4U2Proxy obtains the SQL Server service ticket;
+- the production `MSSQLClient` connects as `BOWLAB\svc-bow` with
+  `auth_scheme = KERBEROS` and discovers `dbo.sales`;
+- 16 interleaved service/Alice handshakes never swap identities;
+- the delegated client connects as `BOWLAB\alice`, reports Kerberos, and reads
+  the three seeded rows;
+- Bob reaches SQL Server as himself but is denied access to `dbo.sales`.
+
+Expected result:
+
+```text
+7 passed
+```
+
+For a from-scratch check, point the lab at a new ignored SQL data directory:
+
+```bash
+cd lab/sql-server-kerberos
+./down.sh --reset
+BOWLAB_SQL_DATA_DIR=./.state/mssql-clean ./up.sh -vv
+```
+
+This validates domain provisioning, the SQL domain join and SSSD identity
+lookup, keytab installation, SQL login creation, production client wiring, and
+the query path rather than relying on a warm database.
+
+## Fix
+
+- Hold one re-entrant process lock for both default and delegated handshake
+  activation, including service credential acquisition.
+- Allocate credential caches under a private, mode-`0700`, per-manager worker
+  namespace.
+- Always emit `Encrypt=yes` or `Encrypt=no` explicitly.
+- Treat `last_error` as authoritative in both member status and the admin
+  verification roster.
+- Register the MSSQL client path explicitly and exercise it through the live
+  runner.
+- Gate SQL startup on live AD DNS/KDC readiness and retry the domain join; a
+  keytab-file-only health check raced the first clean startup.
+- Persist the generated AD database/config and keytab volume across normal
+  restarts so a DC image rebuild cannot silently replace the domain while SQL
+  still contains the previous domain's logins. `down.sh --reset` is the explicit
+  clean-domain path.
+- Regenerate the dedicated client `krb5.conf` on both provision and reuse. The
+  Samba server template omits `forwardable=true`; publishing it on restart made
+  S4U2Self pass but S4U2Proxy fail with `KDC_ERR_BADOPTION`.
+
+## Proof and regression notes
+
+- Unit/adjacent regression suite: `45 passed`.
+- Clean SQL initialization plus live delegation: `7 passed`.
+- After the lifecycle fixes, two consecutive restart launches: `7 passed`
+  each, including DC container recreation against the persisted domain and
+  keytabs.
+- SQL Server's Linux image is amd64-only; on Apple Silicon this is a functional
+  emulation proof, not a performance or vendor-support certification.
+- Customer deployment still requires the system team to create the service
+  account/keytab, register both BOW and `MSSQLSvc` SPNs, enable constrained
+  delegation with protocol transition, supply DNS/time synchronization, and
+  create least-privilege SQL logins or AD-group grants.

--- a/docs/sql-server-kerberos.md
+++ b/docs/sql-server-kerberos.md
@@ -3,6 +3,10 @@
 Bag of Words supports two Kerberos auth shapes for on-prem Microsoft SQL Server,
 on top of the default SQL username/password login:
 
+For a runnable local proof with a Samba AD/KDC, SQL Server 2022, real
+S4U2Self/S4U2Proxy, and the production BOW connector, see
+[`lab/sql-server-kerberos`](../lab/sql-server-kerberos/README.md).
+
 | Auth variant | Scope | Identity seen by SQL Server |
 |---|---|---|
 | `userpass` (default) | system or per-user | SQL login |

--- a/lab/sql-server-kerberos/.gitignore
+++ b/lab/sql-server-kerberos/.gitignore
@@ -1,0 +1,2 @@
+.lab.env
+.state/

--- a/lab/sql-server-kerberos/README.md
+++ b/lab/sql-server-kerberos/README.md
@@ -1,0 +1,103 @@
+# SQL Server Kerberos SSO — self-contained lab
+
+A one-command lab that stands up a real Kerberos domain and proves the
+bagofwords SQL Server connector's per-user SSO via **Kerberos Constrained
+Delegation (S4U2Self + S4U2Proxy)** — the mechanism a customer's IT asked us
+to support — against **SQL Server 2022** on Linux.
+
+Everything runs in containers; no external Active Directory or cloud is needed.
+The launcher creates random lab-only passwords in a gitignored `.lab.env` file.
+
+```
+cd lab/sql-server-kerberos
+./up.sh          # build, start DC + SQL 2022, run the test suite
+./down.sh        # stop containers; preserve the lab domain, keytabs, and SQL data
+./down.sh --reset # also remove the generated AD domain and keytab volumes
+```
+
+## What it stands up
+
+| Container | Role |
+|---|---|
+| `dc` | Samba **Active Directory Domain Controller** — the KDC/LDAP/DNS. Realm `BOWLAB.LOCAL`. |
+| `sql2022` | SQL Server 2022 on Linux, joined to the domain (keytab + `mssql-conf`). |
+| `runner` | krb5 + python-gssapi + the **production** `app/data_sources/kerberos.py` and `MSSQLClient`, mounted read-only and exercised by `test_delegation.py`. |
+
+The DC provisions (once) the accounts, SPNs, constrained-delegation config, DNS,
+and exports keytabs into a shared volume that the SQL server and runner consume.
+LDAP is used for the AD directory and SQL Server's user-to-SID lookup; the
+database authentication and delegation being tested are Kerberos, not LDAP bind.
+SQL startup is gated on both live DC DNS and KDC port readiness, and its domain
+join retries transient startup failures.
+
+### Directory accounts created
+
+- `svc-bow` — the **app service account** / S4U impersonator. Has its own SPN
+  (`bow/svc-bow.bowlab.local`, required for S4U2Self) and is configured for
+  constrained delegation with protocol transition
+  (`UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION` + `msDS-AllowedToDelegateTo`
+  containing both `MSSQLSvc/...` SPNs).
+- `mssql2022` — SQL service account holding the `MSSQLSvc/<fqdn>`
+  and `MSSQLSvc/<fqdn>:1433` SPNs.
+- `alice` — test user; has a SQL login + `db_datareader` on the lab DB.
+- `bob` — test user with a login but **no** read grant (proves per-user identity
+  actually reaches SQL Server).
+
+## What it proves
+
+**Tier A — the delegation core** (needs only the DC; validates
+`app/data_sources/kerberos.py`):
+- `KerberosTicketManager.delegated_ccache("alice@BOWLAB.LOCAL")` performs
+  **S4U2Self** using only the service keytab — no user password.
+- Initiating a GSSAPI context to the `MSSQLSvc` SPN performs **S4U2Proxy**,
+  yielding a service ticket for alice to SQL Server 2022.
+
+**Tier B — the SQL last mile** (needs the SQL containers up):
+- `MSSQLClient(use_kerberos=True, kerberos_principal="svc-bow@...")` verifies the
+  service-account flow and schema discovery through production BOW code.
+- `MSSQLClient(use_kerberos=True, kerberos_impersonate="alice@...")` connects;
+  `SUSER_SNAME()` returns `BOWLAB\alice` and `auth_scheme` is
+  `KERBEROS`.
+- The same client as `bob` is denied reading the granted table — per-user
+  authorization is enforced by SQL Server, not the app.
+- Concurrent service-account and delegated-Alice connects are interleaved to
+  prove the process-global credential-cache switch cannot cross identities.
+
+The one-command suite treats an unavailable SQL Server as a failure, ensuring a
+green result always covers both the delegation core and the SQL last mile.
+
+## Key requirements this lab surfaced (also in `docs/sql-server-kerberos.md`)
+
+1. **`forwardable = true`** in `krb5.conf` is mandatory: S4U2Proxy is refused
+   unless the S4U2Self evidence ticket is forwardable, which needs a forwardable
+   service TGT.
+2. The **middle-tier account (`svc-bow`) must have its own SPN** for the KDC to
+   issue it an S4U2Self ticket.
+3. Delegation must be **protocol transition** ("Use any authentication
+   protocol" in AD terms); Kerberos-only fails with `KDC_ERR_BADOPTION`.
+
+## Notes
+
+- `dc` and the SQL containers run `--privileged`/as root only for setup (Samba
+  KDC caps; SQL keytab + `mssql-conf`); the SQL engine drops to the `mssql` user.
+- SQL Server Linux images are amd64-only, so `sql2022` uses Docker emulation on
+  Apple Silicon. The launcher keeps the DC and runner native ARM when the local
+  `bagofwords/bagofwords:latest` image is available; otherwise they also run as
+  amd64. This lab is suitable for functional development testing, not
+  performance or Microsoft support certification. Allow roughly 4 GB of Docker
+  memory.
+- The `runner` image installs `msodbcsql18` from packages.microsoft.com; in a
+  network-restricted CI, pre-build/cache that image. With the cached production
+  BOW image on ARM, the already-installed ODBC driver is reused instead.
+- SQL data persists in gitignored `.state/mssql` so restarts are fast. To force
+  a clean SQL initialization without deleting anything, stop the lab, run
+  `./down.sh --reset`, and start with a new path such as
+  `BOWLAB_SQL_DATA_DIR=./.state/mssql-clean ./up.sh`. The AD and keytab named
+  volumes persist across normal `down.sh`/`up.sh` cycles so their domain SID and
+  cryptographic keys remain aligned with the SQL logins. Neither teardown mode
+  deletes bind-mounted database files.
+- Manual poke at the KDC from inside `dc`:
+  ```
+  kinit -f -k -t /keytabs/svc-bow.keytab svc-bow@BOWLAB.LOCAL
+  kvno -U alice@bowlab.local -P MSSQLSvc/sql2022.bowlab.local:1433
+  ```

--- a/lab/sql-server-kerberos/docker-compose.yaml
+++ b/lab/sql-server-kerberos/docker-compose.yaml
@@ -1,0 +1,110 @@
+# Self-contained Kerberos constrained-delegation lab for the BoW SQL Server
+# connector. Brings up a Samba AD DC (KDC), SQL Server 2022 joined to
+# it, and a runner that exercises the production S4U2Self/S4U2Proxy code.
+#
+#   ./up.sh          # build + start, wait for the DC, run the test suite
+#   ./down.sh        # tear everything down
+#
+# The DC exports keytabs + krb5.conf into the shared `keytabs` volume that the
+# SQL servers and runner consume.
+
+networks:
+  bowlab:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+volumes:
+  keytabs:
+  dc-data:
+  dc-config:
+
+services:
+  dc:
+    platform: ${BOWLAB_AUX_PLATFORM:-linux/amd64}
+    build:
+      context: ./samba-dc
+      args:
+        BASE_IMAGE: ${BOWLAB_BASE_IMAGE:-ubuntu:24.04}
+    image: bowlab-dc
+    hostname: dc
+    privileged: true               # Samba AD DC needs broad caps for the KDC
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.10
+    dns:
+      - 127.0.0.1
+    environment:
+      DC_IP: 172.28.0.10
+      SQL2022_IP: 172.28.0.22
+      BOWLAB_ADMIN_PASS: ${BOWLAB_ADMIN_PASS:?run via up.sh}
+      BOWLAB_USER_PASS: ${BOWLAB_USER_PASS:?run via up.sh}
+      BOWLAB_SVC_PASS: ${BOWLAB_SVC_PASS:?run via up.sh}
+    volumes:
+      - keytabs:/keytabs
+      - dc-data:/var/lib/samba
+      - dc-config:/etc/samba
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /keytabs/svc-bow.keytab && test -f /keytabs/krb5.conf && host -W 1 -t A dc.bowlab.local 127.0.0.1 >/dev/null && timeout 1 bash -c '</dev/tcp/127.0.0.1/88'"]
+      interval: 5s
+      timeout: 3s
+      retries: 40
+
+  sql2022:
+    platform: linux/amd64
+    build:
+      context: ./mssql
+      args:
+        MSSQL_TAG: 2022-latest
+    image: bowlab-sql:2022
+    hostname: sql2022
+    privileged: true               # mssql-conf + amd64 emulation setup
+    user: root                     # setup installs keytab, then drops to mssql
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.22
+    dns:
+      - 172.28.0.10
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: ${BOWLAB_SA_PASSWORD:?run via up.sh}
+      SA_PASSWORD: ${BOWLAB_SA_PASSWORD:?run via up.sh}
+      BOWLAB_ADMIN_PASS: ${BOWLAB_ADMIN_PASS:?run via up.sh}
+      MSSQL_FQDN: sql2022.bowlab.local
+      MSSQL_KEYTAB: /keytabs/mssql2022.keytab
+      MSSQL_AD_ACCOUNT: mssql2022
+    volumes:
+      - ${BOWLAB_SQL_DATA_DIR:-./.state/mssql}:/var/opt/mssql
+      - keytabs:/keytabs
+      - ./mssql/setup-ad-auth.sh:/setup-ad-auth.sh:ro
+      - ./mssql/init.sql:/init.sql:ro
+    entrypoint: ["/bin/bash", "/setup-ad-auth.sh"]
+    depends_on:
+      dc:
+        condition: service_healthy
+
+  runner:
+    platform: ${BOWLAB_AUX_PLATFORM:-linux/amd64}
+    build:
+      context: ./runner
+      args:
+        BASE_IMAGE: ${BOWLAB_BASE_IMAGE:-ubuntu:24.04}
+        INSTALL_ODBC: ${BOWLAB_INSTALL_ODBC:-1}
+    image: bowlab-runner
+    hostname: runner
+    networks:
+      bowlab:
+        ipv4_address: 172.28.0.100
+    dns:
+      - 172.28.0.10
+    volumes:
+      - keytabs:/keytabs
+      - ../../backend/app:/app/app:ro           # production code under test
+      - ./runner/test_delegation.py:/lab/test_delegation.py:ro
+    depends_on:
+      dc:
+        condition: service_healthy
+    # Not started by default with `up -d`; run explicitly via up.sh so the SQL
+    # servers have time to come online for Tier B.
+    profiles: ["manual"]

--- a/lab/sql-server-kerberos/down.sh
+++ b/lab/sql-server-kerberos/down.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Tear the Kerberos lab down. Preserve AD/keytabs unless --reset is requested.
+set -euo pipefail
+cd "$(dirname "$0")"
+ENV_FILE="${BOWLAB_ENV_FILE:-.lab.env}"
+if [ ! -f "${ENV_FILE}" ]; then
+    echo "No ${ENV_FILE}; nothing to stop."
+    exit 0
+fi
+if [ "${1:-}" = "--reset" ]; then
+    docker compose --env-file "${ENV_FILE}" --profile manual down -v --remove-orphans
+else
+    docker compose --env-file "${ENV_FILE}" --profile manual down --remove-orphans
+fi

--- a/lab/sql-server-kerberos/mssql/Dockerfile
+++ b/lab/sql-server-kerberos/mssql/Dockerfile
@@ -1,0 +1,16 @@
+# SQL Server on Linux with Kerberos libraries supplied by Microsoft's image.
+# The version is passed as a build arg so the image version remains explicit.
+ARG MSSQL_TAG=2022-latest
+FROM mcr.microsoft.com/mssql/server:${MSSQL_TAG}
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# SQL Server delegates Kerberos crypto to its keytab, but still needs SSSD to
+# resolve AD login names to SIDs for CREATE LOGIN ... FROM WINDOWS.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      sssd sssd-ad sssd-tools adcli realmd \
+      krb5-user libnss-sss libpam-sss \
+      samba-common-bin ldap-utils dnsutils \
+    && rm -rf /var/lib/apt/lists/*

--- a/lab/sql-server-kerberos/mssql/init.sql
+++ b/lab/sql-server-kerberos/mssql/init.sql
@@ -1,0 +1,60 @@
+-- Lab database + AD-backed logins for the Kerberos delegation test.
+-- The AD users are impersonated by the app via S4U2Proxy; SQL Server sees
+-- their real domain identity, so per-user logins/permissions apply.
+IF DB_ID('bowlab') IS NULL
+    CREATE DATABASE bowlab;
+GO
+USE bowlab;
+GO
+IF OBJECT_ID('dbo.sales') IS NULL
+BEGIN
+    CREATE TABLE dbo.sales (id INT PRIMARY KEY, region NVARCHAR(50), amount DECIMAL(10,2));
+    INSERT INTO dbo.sales VALUES (1, N'North', 100.00), (2, N'South', 250.50), (3, N'East', 75.25);
+END
+GO
+-- AD logins (Windows authentication). Kerberos-authenticated connections for
+-- these principals will succeed and report auth_scheme = KERBEROS.
+IF SUSER_ID('BOWLAB\alice') IS NULL
+    CREATE LOGIN [BOWLAB\alice] FROM WINDOWS WITH DEFAULT_DATABASE = bowlab;
+GO
+IF SUSER_ID('BOWLAB\bob') IS NULL
+    CREATE LOGIN [BOWLAB\bob] FROM WINDOWS WITH DEFAULT_DATABASE = bowlab;
+GO
+IF SUSER_ID('BOWLAB\svc-bow') IS NULL
+    CREATE LOGIN [BOWLAB\svc-bow] FROM WINDOWS WITH DEFAULT_DATABASE = bowlab;
+GO
+USE bowlab;
+GO
+IF USER_ID('BOWLAB\alice') IS NULL
+    CREATE USER [BOWLAB\alice] FOR LOGIN [BOWLAB\alice];
+GO
+IF USER_ID('BOWLAB\bob') IS NULL
+    CREATE USER [BOWLAB\bob] FOR LOGIN [BOWLAB\bob];
+GO
+IF USER_ID('BOWLAB\svc-bow') IS NULL
+    CREATE USER [BOWLAB\svc-bow] FOR LOGIN [BOWLAB\svc-bow];
+GO
+-- Alice and the service account can read; bob deliberately cannot.
+IF NOT EXISTS (
+    SELECT 1 FROM sys.database_role_members rm
+    JOIN sys.database_principals role_p ON role_p.principal_id = rm.role_principal_id
+    JOIN sys.database_principals member_p ON member_p.principal_id = rm.member_principal_id
+    WHERE role_p.name = 'db_datareader' AND member_p.name = 'BOWLAB\alice'
+)
+    ALTER ROLE db_datareader ADD MEMBER [BOWLAB\alice];
+GO
+IF NOT EXISTS (
+    SELECT 1 FROM sys.database_role_members rm
+    JOIN sys.database_principals role_p ON role_p.principal_id = rm.role_principal_id
+    JOIN sys.database_principals member_p ON member_p.principal_id = rm.member_principal_id
+    WHERE role_p.name = 'db_datareader' AND member_p.name = 'BOWLAB\svc-bow'
+)
+    ALTER ROLE db_datareader ADD MEMBER [BOWLAB\svc-bow];
+GO
+-- Let the SQL Server 2022 lab assertions read auth_scheme for their own sessions.
+USE master;
+GO
+GRANT VIEW SERVER PERFORMANCE STATE TO [BOWLAB\alice];
+GO
+GRANT VIEW SERVER PERFORMANCE STATE TO [BOWLAB\svc-bow];
+GO

--- a/lab/sql-server-kerberos/mssql/setup-ad-auth.sh
+++ b/lab/sql-server-kerberos/mssql/setup-ad-auth.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Configure a SQL Server on Linux container for Active Directory (Kerberos)
+# authentication against the lab Samba DC, then create AD logins.
+#
+# Runs as the container entrypoint wrapper: it configures krb5 + the mssql
+# keytab, launches sqlservr, waits for it, applies init.sql, and then execs
+# sqlservr in the foreground.
+#
+# Env:
+#   MSSQL_FQDN        e.g. sql2022.bowlab.local
+#   MSSQL_KEYTAB      path to this instance's keytab (mounted, from the DC)
+#   MSSQL_AD_ACCOUNT  privileged AD account name, e.g. mssql2022
+#   SA_PASSWORD       sa password
+#   BOWLAB_ADMIN_PASS generated lab domain administrator password
+set -euo pipefail
+
+REALM="BOWLAB.LOCAL"
+: "${MSSQL_FQDN:?}"; : "${MSSQL_KEYTAB:?}"; : "${MSSQL_AD_ACCOUNT:?}"; : "${SA_PASSWORD:?}"
+: "${BOWLAB_ADMIN_PASS:?}"
+
+log() { echo "[mssql-setup:${MSSQL_FQDN}] $*"; }
+
+# Keep engine data on the host bind mount rather than Docker Desktop's virtual
+# disk, and make the fresh directory writable by the SQL Server process.
+mkdir -p /var/opt/mssql
+chown -R mssql:root /var/opt/mssql
+READY_MARKER=/var/opt/mssql/.bowlab-ready
+rm -f "${READY_MARKER}"
+
+# Wait for the DC-exported krb5.conf + this instance's keytab to appear.
+for i in $(seq 1 60); do
+    [ -f /keytabs/krb5.conf ] && [ -f "${MSSQL_KEYTAB}" ] && break
+    sleep 2
+done
+cp /keytabs/krb5.conf /etc/krb5.conf 2>/dev/null || true
+
+DOMAIN="bowlab.local"
+
+# Join the lab domain and expose AD users through NSS. SQL Server uses this
+# mapping when CREATE LOGIN ... FROM WINDOWS resolves a principal to its SID.
+log "Joining domain ${DOMAIN} via SSSD ..."
+joined=false
+join_output=""
+for i in $(seq 1 30); do
+    if join_output="$(printf '%s\n' "${BOWLAB_ADMIN_PASS}" | \
+        adcli join --stdin-password --domain="${DOMAIN}" \
+        --domain-controller="dc.${DOMAIN}" --login-user=Administrator 2>&1)"; then
+        joined=true
+        break
+    fi
+    sleep 2
+done
+if [ "${joined}" != "true" ]; then
+    printf '%s\n' "${join_output}" | sed "s/^/[mssql-setup:${MSSQL_FQDN}] /"
+    log "ERROR: domain join did not become ready."
+    exit 1
+fi
+log "Domain join succeeded."
+
+cat > /etc/sssd/sssd.conf <<EOF
+[sssd]
+domains = ${DOMAIN}
+config_file_version = 2
+services = nss, pam
+
+[domain/${DOMAIN}]
+id_provider = ad
+auth_provider = ad
+access_provider = ad
+ad_domain = ${DOMAIN}
+krb5_realm = ${REALM}
+cache_credentials = True
+ldap_id_mapping = True
+use_fully_qualified_names = False
+fallback_homedir = /home/%u@%d
+default_shell = /bin/bash
+EOF
+chmod 600 /etc/sssd/sssd.conf
+sed -i 's/^passwd:.*/passwd:         files sss/' /etc/nsswitch.conf
+sed -i 's/^group:.*/group:          files sss/' /etc/nsswitch.conf
+sssd
+
+for i in $(seq 1 30); do
+    id "alice@${DOMAIN}" >/dev/null 2>&1 && break
+    sleep 1
+done
+id "alice@${DOMAIN}" >/dev/null 2>&1 || {
+    log "ERROR: AD name resolution did not become ready."
+    exit 1
+}
+log "AD name resolution is ready."
+
+# Install the instance keytab where SQL Server expects a private copy.
+# The secrets dir doesn't exist until first boot, so create it.
+mkdir -p /var/opt/mssql/secrets
+install -m 0600 -o mssql -g root "${MSSQL_KEYTAB}" /var/opt/mssql/secrets/mssql.keytab
+
+# Point SQL Server at the keytab + privileged AD account (Kerberos).
+/opt/mssql/bin/mssql-conf set network.kerberoskeytabfile /var/opt/mssql/secrets/mssql.keytab
+/opt/mssql/bin/mssql-conf set network.privilegedadaccount "${MSSQL_AD_ACCOUNT}"
+/opt/mssql/bin/mssql-conf set network.forceencryption 0
+
+log "Starting sqlservr (as mssql user) ..."
+# SQL Server refuses to run as root; the setup above needed root for the
+# keytab + mssql-conf, so drop privileges to run the engine.
+chown mssql:root /var/opt/mssql/secrets/mssql.keytab
+su mssql -s /bin/bash -c "MSSQL_SA_PASSWORD='${SA_PASSWORD}' ACCEPT_EULA=Y /opt/mssql/bin/sqlservr" &
+SQL_PID=$!
+
+# Wait for SQL to accept connections.
+SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
+[ -x "$SQLCMD" ] || SQLCMD="/opt/mssql-tools/bin/sqlcmd"
+for i in $(seq 1 60); do
+    "$SQLCMD" -S localhost -U sa -P "${SA_PASSWORD}" -No -b -Q \
+        "IF DB_ID('bowlab') IS NOT NULL AND DATABASEPROPERTYEX('bowlab', 'Status') <> 'ONLINE' THROW 50000, 'bowlab is not online', 1; SELECT 1" \
+        >/dev/null 2>&1 && break
+    sleep 2
+done
+
+log "Applying init.sql ..."
+"$SQLCMD" -S localhost -U sa -P "${SA_PASSWORD}" -No -b -i /init.sql 2>&1 \
+    | sed "s/^/[mssql-setup:${MSSQL_FQDN}] /"
+touch "${READY_MARKER}"
+
+log "Ready. auth_scheme for AD logins will be KERBEROS."
+wait "$SQL_PID"

--- a/lab/sql-server-kerberos/runner/Dockerfile
+++ b/lab/sql-server-kerberos/runner/Dockerfile
@@ -1,0 +1,30 @@
+# Test runner: krb5 + python-gssapi + the Microsoft ODBC driver, plus the
+# bagofwords Kerberos module under test. Mirrors the production image's krb5
+# stack so the S4U path is exercised exactly as it runs in the app.
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+ARG INSTALL_ODBC=1
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3 python3-venv python3-dev build-essential \
+      krb5-user libkrb5-dev libgssapi-krb5-2 \
+      unixodbc unixodbc-dev curl ca-certificates gnupg \
+    && if [ "${INSTALL_ODBC}" = "1" ]; then \
+         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg; \
+         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" > /etc/apt/sources.list.d/mssql-release.list; \
+         apt-get update; \
+         ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18; \
+       fi && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN test -x /opt/venv/bin/python || python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir "gssapi>=1.8.3,<2" pyodbc sqlalchemy pandas pytest pydantic
+
+COPY run-tests.sh /usr/local/bin/run-tests.sh
+RUN chmod +x /usr/local/bin/run-tests.sh
+ENTRYPOINT ["/usr/local/bin/run-tests.sh"]

--- a/lab/sql-server-kerberos/runner/run-tests.sh
+++ b/lab/sql-server-kerberos/runner/run-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Runner entrypoint: wait for the DC keytabs, install the lab krb5.conf, then
+# run the delegation test suite against the production bagofwords code
+# (mounted at /app).
+set -uo pipefail
+
+log() { echo "[runner] $*"; }
+
+for i in $(seq 1 90); do
+    [ -f /keytabs/svc-bow.keytab ] && [ -f /keytabs/krb5.conf ] && break
+    sleep 2
+done
+cp /keytabs/krb5.conf /etc/krb5.conf 2>/dev/null || true
+
+log "krb5.conf:"; sed 's/^/[runner]   /' /etc/krb5.conf
+
+export PYTHONPATH=/app
+export KRB5_CONFIG=/etc/krb5.conf
+# The service keytab our KerberosTicketManager initiates from.
+export KRB5_CLIENT_KTNAME=/keytabs/svc-bow.keytab
+
+log "Running delegation test suite ..."
+exec python -m pytest /lab/test_delegation.py -v -rs --no-header "$@"

--- a/lab/sql-server-kerberos/runner/test_delegation.py
+++ b/lab/sql-server-kerberos/runner/test_delegation.py
@@ -1,0 +1,183 @@
+"""End-to-end Kerberos constrained-delegation test for the BoW SQL Server path.
+
+Runs inside the lab runner container against the Samba AD DC and SQL Server
+2022. Two tiers:
+
+  Tier A — delegation core (no SQL Server needed): using the *production*
+    KerberosTicketManager, acquire a delegated (S4U2Self) credential for an AD
+    user with only the service keytab, then drive S4U2Proxy by initiating a
+    GSSAPI context to each MSSQLSvc SPN. Proves the exact code in
+    app/data_sources/kerberos.py performs protocol transition + constrained
+    delegation against a real KDC.
+
+  Tier B — SQL last mile: use the production MSSQLClient with
+    use_kerberos + kerberos_impersonate to connect to SQL Server 2022
+    and confirm service-account and delegated queries run under the expected identity
+    (SUSER_SNAME() == BOWLAB\\alice, auth_scheme == KERBEROS).
+
+An unreachable SQL instance fails Tier B, so a green suite always proves the
+whole delegation path rather than only the KDC half.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import stat
+from concurrent.futures import ThreadPoolExecutor
+
+import gssapi
+import pytest
+
+# The production module under test (mounted from the repo at /app). Tier A
+# depends only on this — it imports only stdlib + lazy gssapi. MSSQLClient
+# (Tier B) is imported lazily inside those tests so Tier A runs regardless.
+from app.data_sources.kerberos import KerberosTicketManager
+
+REALM = "BOWLAB.LOCAL"
+SVC_KEYTAB = "/keytabs/svc-bow.keytab"
+ALICE = f"alice@{REALM}"
+BOB = f"bob@{REALM}"
+
+SQL_TARGETS = [
+    ("2022", "sql2022.bowlab.local", 1433),
+]
+
+
+def _manager() -> KerberosTicketManager:
+    return KerberosTicketManager(ccache_dir="/tmp/bow_krb5_lab", client_keytab=SVC_KEYTAB)
+
+
+def _reachable(host: str, port: int, timeout: float = 3.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+# ── Tier A: delegation core ─────────────────────────────────────────────────
+
+
+def test_service_keytab_present():
+    assert os.path.exists(SVC_KEYTAB), "svc-bow keytab not exported by the DC"
+    assert stat.S_IMODE(os.stat(SVC_KEYTAB).st_mode) == 0o600
+
+
+def test_s4u2self_acquires_delegated_ccache():
+    """S4U2Self: impersonate alice with only the service keytab (no password)."""
+    mgr = _manager()
+    ccache = mgr.delegated_ccache(ALICE)
+    assert os.path.exists(ccache)
+    # Cached on second call (no re-acquisition).
+    assert mgr.delegated_ccache(ALICE) == ccache
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_s4u2proxy_to_mssql_spn(version, host, port):
+    """S4U2Proxy: the delegated cred yields a service ticket to MSSQLSvc/<sql>.
+
+    Initiating a GSSAPI context to the SPN triggers the S4U2Proxy request to the
+    KDC. Success (a token is produced) proves constrained delegation works — no
+    SQL Server handshake required.
+    """
+    mgr = _manager()
+    ccache = mgr.delegated_ccache(ALICE)
+    spn = gssapi.Name(f"MSSQLSvc/{host}:{port}", gssapi.NameType.kerberos_principal)
+    with mgr.activate(ccache):
+        store = {"ccache": f"FILE:{ccache}"}
+        cred = gssapi.Credentials(usage="initiate", store=store)
+        ctx = gssapi.SecurityContext(name=spn, creds=cred, usage="initiate")
+        token = ctx.step()
+    assert token, f"no S4U2Proxy token produced for SQL {version} SPN"
+
+
+# ── Tier B: SQL Server last mile ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_mssql_client_service_query(version, host, port):
+    """MSSQLClient authenticates directly as the BOW service account."""
+    if not _reachable(host, port):
+        pytest.fail(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    client = MSSQLClient(
+        host=host, port=port, database="bowlab",
+        use_kerberos=True,
+        encrypt=False,
+    )
+    df = client.execute_query(
+        "SELECT SUSER_SNAME() AS who, "
+        "(SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID) AS scheme"
+    )
+    assert str(df.iloc[0]["who"]).upper().endswith("SVC-BOW")
+    assert str(df.iloc[0]["scheme"]).upper() == "KERBEROS"
+    assert any(table.name.lower().endswith(".sales") for table in client.get_schemas())
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_concurrent_service_and_delegated_handshakes_keep_identity(version, host, port):
+    """Default service-cache and delegated handshakes cannot swap identities."""
+    if not _reachable(host, port):
+        pytest.fail(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    def query(expected: str) -> str:
+        client = MSSQLClient(
+            host=host, port=port, database="bowlab",
+            use_kerberos=True,
+            kerberos_impersonate=ALICE if expected == "alice" else None,
+            encrypt=False,
+        )
+        return str(client.execute_query("SELECT SUSER_SNAME() AS who").iloc[0]["who"])
+
+    expected = ["service", "alice"] * 8
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        actual = list(pool.map(query, expected))
+    for identity, who in zip(expected, actual):
+        suffix = "SVC-BOW" if identity == "service" else "ALICE"
+        assert who.upper().endswith(suffix), (identity, who)
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_mssql_client_delegated_query(version, host, port):
+    """MSSQLClient impersonating alice runs a query under her AD identity."""
+    if not _reachable(host, port):
+        pytest.fail(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    client = MSSQLClient(
+        host=host, port=port, database="bowlab",
+        use_kerberos=True, kerberos_impersonate=ALICE,
+        encrypt=False,
+    )
+    df = client.execute_query(
+        "SELECT SUSER_SNAME() AS who, "
+        "(SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID) AS scheme"
+    )
+    who = str(df.iloc[0]["who"])
+    scheme = str(df.iloc[0]["scheme"])
+    assert who.upper().endswith("ALICE"), f"expected BOWLAB\\alice, got {who!r}"
+    assert scheme.upper() == "KERBEROS", f"expected KERBEROS, got {scheme!r}"
+
+    # And the impersonated user can read the data she was granted.
+    rows = client.execute_query("SELECT COUNT(*) AS n FROM dbo.sales")
+    assert int(rows.iloc[0]["n"]) == 3
+
+
+@pytest.mark.parametrize("version,host,port", SQL_TARGETS)
+def test_delegation_respects_sql_permissions(version, host, port):
+    """bob has a login but no read grant → per-user identity really reaches SQL."""
+    if not _reachable(host, port):
+        pytest.fail(f"SQL Server {version} ({host}:{port}) not reachable")
+    from app.data_sources.clients.mssql_client import MSSQLClient
+
+    client = MSSQLClient(
+        host=host, port=port, database="bowlab",
+        use_kerberos=True, kerberos_impersonate=BOB,
+        encrypt=False,
+    )
+    with pytest.raises(Exception) as exc:
+        client.execute_query("SELECT * FROM dbo.sales")
+    error = str(exc.value).lower()
+    assert "permission" in error and "sales" in error

--- a/lab/sql-server-kerberos/samba-dc/Dockerfile
+++ b/lab/sql-server-kerberos/samba-dc/Dockerfile
@@ -1,0 +1,24 @@
+# Samba Active Directory Domain Controller for the Kerberos lab.
+# Acts as the KDC + LDAP + DNS that SQL Server joins and against which the app
+# performs S4U2Self / S4U2Proxy constrained delegation.
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      samba samba-ad-provision samba-ad-dc samba-dsdb-modules smbclient winbind \
+      krb5-user krb5-config \
+      dnsutils iproute2 procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# samba-tool provisions its own krb5.conf; don't let the krb5-user default win.
+RUN rm -f /etc/krb5.conf
+
+COPY provision.sh /usr/local/bin/provision.sh
+RUN chmod +x /usr/local/bin/provision.sh
+
+EXPOSE 53 53/udp 88 88/udp 389 445 464 636
+ENTRYPOINT ["/usr/local/bin/provision.sh"]

--- a/lab/sql-server-kerberos/samba-dc/provision.sh
+++ b/lab/sql-server-kerberos/samba-dc/provision.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Provision (once) and run a Samba AD Domain Controller for the Kerberos lab.
+#
+# Creates:
+#   - realm BOWLAB.LOCAL, domain BOWLAB
+#   - service account svc-bow      (the app's identity / S4U impersonator)
+#   - SQL service account mssql2022 with MSSQLSvc SPNs
+#   - test users alice / bob
+#   - constrained delegation (protocol transition, S4U2Self+S4U2Proxy) from
+#     svc-bow to the MSSQLSvc SPNs
+#   - DNS A + PTR records so Kerberos hostname/SPN resolution works both ways
+#   - keytabs exported to /keytabs (shared volume): svc-bow, mssql2022
+set -euo pipefail
+
+# Samba's multiarch ldb module directory differs between amd64 and arm64.
+LDB_DIR="$(find /usr/lib -type d -path '*/samba/ldb' -print -quit)"
+if [ -n "${LDB_DIR}" ]; then
+    export LDB_MODULES_PATH="${LDB_DIR}"
+fi
+
+REALM="BOWLAB.LOCAL"
+DOMAIN="BOWLAB"
+ADMIN_PASS="${BOWLAB_ADMIN_PASS:?BOWLAB_ADMIN_PASS is required}"
+USER_PASS="${BOWLAB_USER_PASS:?BOWLAB_USER_PASS is required}"
+SVC_PASS="${BOWLAB_SVC_PASS:?BOWLAB_SVC_PASS is required}"
+
+DC_IP="${DC_IP:-172.28.0.10}"
+SQL2022_IP="${SQL2022_IP:-172.28.0.22}"
+
+KEYTAB_DIR="/keytabs"
+PROVISIONED_MARKER="/var/lib/samba/.provisioned"
+
+log() { echo "[dc] $*"; }
+
+write_client_krb5_conf() {
+    # forwardable=true is REQUIRED: S4U2Proxy is refused unless the S4U2Self
+    # evidence ticket is forwardable, which needs a forwardable service TGT.
+    # Keep this separate from Samba's server-side krb5.conf and rewrite it on
+    # every start so a reused DC cannot publish Samba's minimal template.
+    cat > "${KEYTAB_DIR}/krb5.conf" <<EOF
+[libdefaults]
+    default_realm = ${REALM}
+    dns_lookup_realm = false
+    dns_lookup_kdc = true
+    forwardable = true
+    rdns = false
+
+[realms]
+    ${REALM} = {
+        kdc = dc.bowlab.local
+        admin_server = dc.bowlab.local
+        default_domain = bowlab.local
+    }
+
+[domain_realm]
+    .bowlab.local = ${REALM}
+    bowlab.local = ${REALM}
+EOF
+}
+
+provision() {
+    log "Provisioning domain ${REALM} ..."
+    rm -f /etc/samba/smb.conf
+    samba-tool domain provision \
+        --use-rfc2307 \
+        --domain="${DOMAIN}" \
+        --realm="${REALM}" \
+        --server-role=dc \
+        --dns-backend=SAMBA_INTERNAL \
+        --adminpass="${ADMIN_PASS}" \
+        --option="dns forwarder=127.0.0.11"
+
+    # Samba writes a realm krb5.conf; make it the system default.
+    cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
+
+    # Passwords never expire in the lab, and relax complexity/history.
+    samba-tool domain passwordsettings set --complexity=off --history-length=0 \
+        --min-pwd-age=0 --max-pwd-age=0 >/dev/null
+
+    log "Starting samba to configure directory objects ..."
+    samba -D
+    sleep 5
+
+    # --- accounts ---------------------------------------------------------
+    log "Creating accounts ..."
+    samba-tool user create svc-bow    "${SVC_PASS}"  --description="BoW app service account"
+    samba-tool user create mssql2022  "${SVC_PASS}"  --description="SQL Server 2022 service account"
+    samba-tool user create alice      "${USER_PASS}" --given-name=Alice --surname=Analyst
+    samba-tool user create bob        "${USER_PASS}" --given-name=Bob   --surname=Builder
+
+    # SQL accounts must not have expiring passwords (keytab would break).
+    for u in svc-bow mssql2022 alice bob; do
+        samba-tool user setexpiry "$u" --noexpiry >/dev/null
+    done
+
+    # --- SPNs for the SQL service accounts --------------------------------
+    log "Registering MSSQLSvc SPNs ..."
+    samba-tool spn add "MSSQLSvc/sql2022.bowlab.local"      mssql2022
+    samba-tool spn add "MSSQLSvc/sql2022.bowlab.local:1433" mssql2022
+
+    # The middle-tier (impersonating) account must itself have an SPN for the
+    # KDC to issue it an S4U2Self evidence ticket.
+    samba-tool spn add "bow/svc-bow.bowlab.local" svc-bow
+
+    # --- constrained delegation on the app account ------------------------
+    # protocol transition (S4U2Self "any protocol") + allowed targets (S4U2Proxy).
+    log "Configuring constrained delegation for svc-bow ..."
+    samba-tool delegation for-any-protocol svc-bow on
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2022.bowlab.local:1433"
+    samba-tool delegation add-service svc-bow "MSSQLSvc/sql2022.bowlab.local"
+
+    # --- DNS records (forward + reverse) ----------------------------------
+    log "Adding DNS records ..."
+    local rev="28.172.in-addr.arpa"
+    samba-tool dns add 127.0.0.1 "${REALM}" sql2022 A "${SQL2022_IP}" -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns zonecreate 127.0.0.1 "${rev}" -U "Administrator%${ADMIN_PASS}" || true
+    samba-tool dns add 127.0.0.1 "${rev}" "${SQL2022_IP##*.}.0" PTR sql2022.bowlab.local -U "Administrator%${ADMIN_PASS}" || true
+
+    # --- export keytabs ---------------------------------------------------
+    log "Exporting keytabs to ${KEYTAB_DIR} ..."
+    mkdir -p "${KEYTAB_DIR}"
+    rm -f "${KEYTAB_DIR}"/*.keytab
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/svc-bow.keytab" --principal="svc-bow@${REALM}"
+
+    # SQL keytabs must carry the SPN principals (that is what clients request).
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="MSSQLSvc/sql2022.bowlab.local@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="MSSQLSvc/sql2022.bowlab.local:1433@${REALM}"
+    samba-tool domain exportkeytab "${KEYTAB_DIR}/mssql2022.keytab" --principal="mssql2022@${REALM}"
+    chmod 0600 "${KEYTAB_DIR}"/*.keytab
+
+    # Write the client configuration consumed by SQL Server and the runner.
+    write_client_krb5_conf
+
+    log "Stopping bootstrap samba ..."
+    pkill -TERM samba || true
+    sleep 3
+    touch "${PROVISIONED_MARKER}"
+    log "Provisioning complete."
+}
+
+if [ ! -f "${PROVISIONED_MARKER}" ]; then
+    provision
+else
+    log "Already provisioned; reusing directory."
+    cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
+    mkdir -p "${KEYTAB_DIR}"
+    write_client_krb5_conf
+fi
+
+log "Starting Samba AD DC in foreground ..."
+exec samba -i -s /etc/samba/smb.conf

--- a/lab/sql-server-kerberos/up.sh
+++ b/lab/sql-server-kerberos/up.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Bring the Kerberos lab up and run the delegation test suite.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENV_FILE="${BOWLAB_ENV_FILE:-.lab.env}"
+if [ ! -f "${ENV_FILE}" ]; then
+    base_image="ubuntu:24.04"
+    aux_platform="linux/amd64"
+    install_odbc="1"
+    # SQL Server is amd64-only, but the DC and runner can stay native on an
+    # Apple Silicon developer machine when the production BOW image is cached.
+    # That image already contains ODBC 18, so no network package install is
+    # needed for the runner in this path.
+    if [ "$(docker info --format '{{.Architecture}}' 2>/dev/null || true)" = "arm64" ] \
+        && docker image inspect bagofwords/bagofwords:latest >/dev/null 2>&1; then
+        base_image="bagofwords/bagofwords:latest"
+        aux_platform="linux/arm64"
+        install_odbc="0"
+    fi
+    umask 077
+    {
+        echo "BOWLAB_ADMIN_PASS=Bowlab_Admin_Aa1_$(openssl rand -hex 12)"
+        echo "BOWLAB_USER_PASS=Bowlab_User_Aa1_$(openssl rand -hex 12)"
+        echo "BOWLAB_SVC_PASS=Bowlab_Svc_Aa1_$(openssl rand -hex 12)"
+        echo "BOWLAB_SA_PASSWORD=Bowlab_Sa_Aa1_$(openssl rand -hex 12)"
+        echo "BOWLAB_BASE_IMAGE=${base_image}"
+        echo "BOWLAB_AUX_PLATFORM=${aux_platform}"
+        echo "BOWLAB_INSTALL_ODBC=${install_odbc}"
+        echo "BOWLAB_SQL_DATA_DIR=./.state/mssql"
+    } > "${ENV_FILE}"
+    echo "== generated lab-only credentials in ${ENV_FILE} =="
+fi
+
+compose() {
+    docker compose --env-file "${ENV_FILE}" "$@"
+}
+
+echo "== building images =="
+compose build dc runner
+
+echo "== starting DC + SQL Server 2022 =="
+compose up -d dc sql2022
+
+echo "== waiting for the DC to finish provisioning (keytabs) =="
+for i in $(seq 1 60); do
+    if compose exec -T dc test -f /keytabs/svc-bow.keytab 2>/dev/null; then
+        echo "   DC ready."
+        break
+    fi
+    sleep 3
+done
+
+echo "== waiting for SQL Server AD initialization =="
+ready=false
+for i in $(seq 1 90); do
+    if compose exec -T sql2022 test -f /var/opt/mssql/.bowlab-ready 2>/dev/null; then
+        ready=true
+        echo "   SQL Server ready."
+        break
+    fi
+    sleep 2
+done
+if [ "${ready}" != "true" ]; then
+    echo "SQL Server did not become ready; recent logs:"
+    compose logs --no-color --tail=120 sql2022
+    exit 1
+fi
+
+echo "== running delegation tests (runner) =="
+compose run --rm runner "$@"


### PR DESCRIPTION
Hardens SQL Server Kerberos delegation so concurrent service-account and per-user handshakes cannot share the wrong credential cache, and adds a reproducible AD/KDC + SQL Server 2022 proof environment.

The existing implementation treated `KRB5CCNAME` as process-local in two paths even though it is process-global, and generated identical cache filenames across independent worker managers.

> **Issue:** none — this direct PR was requested without publishing a separate security-sensitive issue.

## Executive summary

Customers using BOW with SQL Server constrained delegation expect SQL Server permissions, row-level security, and audit logs to reflect the signed-in employee. This change protects that identity boundary during concurrent connections and supplies a runnable customer-shaped lab proving that the service account can delegate to SQL Server without collecting user passwords.

## Product impact

| | Concurrent connection experience |
|---|---|
| 🔴 Before | A service-account handshake could observe a temporarily activated user's Kerberos cache; workers could also target the same cache file. |
| 🟢 After | Connection handshakes are serialized around the process-global cache selector, and every manager writes into a private worker namespace. |

## Technical mechanism

```mermaid
flowchart LR
    A[Service handshake] --> B{KRB5CCNAME lock}
    U[Delegated user handshake] --> B
    B --> C[Worker-private ccache]
    C --> D[ODBC connect]
    D --> E[SQL Server sees intended AD identity]

    classDef protected fill:#d1fae5,stroke:#059669,color:#064e3b
    classDef boundary fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
    class B,C,E protected
    class A,U,D boundary
```

## Reviewer decision box

| Question | Answer |
|---|---|
| Risk | Medium: authentication concurrency and ODBC connection construction change; behavior is covered by unit and live-domain tests. |
| Blast radius | Microsoft SQL Server connections; cache changes apply only to Kerberos authentication. Username/password behavior remains unchanged. |
| Intended behavior change | Default and delegated handshakes share one lock; caches are private per manager; failed rechecks no longer retain a successful badge; encryption is always explicit. |
| Verified ✅ | 29 focused unit tests; 7 live Samba AD/KDC + SQL Server tests; shell syntax; `git diff --check`. |
| Not verified ⚠️ | Windows-hosted SQL Server, multi-domain/cross-forest AD, OpenShift deployment, and the complete backend suite were not run. |
| Review first | `backend/app/data_sources/kerberos.py`, then `lab/sql-server-kerberos/runner/test_delegation.py`. |

## Evidence / KPI

| Check | Total | Passed | Failed | Skipped |
|---|---:|---:|---:|---:|
| `tests/unit/test_mssql_kerberos.py` | 29 | 29 | 0 | 0 |
| Live S4U2Self/S4U2Proxy SQL Server lab | 7 | 7 | 0 | 0 |
| Shell syntax checks | 5 scripts | 5 | 0 | 0 |
| Failures attributable to this PR | — | — | **0** | — |

The focused unit run emitted 232 existing dependency/deprecation warnings. They do not fail the suite and this PR does not touch the warning sites.

Observed baseline behavior before the fix:

```text
baseline_default_handshake_entered_while_delegated_lock_held= True
baseline_managers_share_same_ccache_path= True
```

Observed live result after the fix:

```text
7 passed in 3.33s
```

The live query assertions verify `SUSER_SNAME()` returns the delegated AD user, `auth_scheme` is `KERBEROS`, and a user without SQL permissions is denied.

## Context map

| Role | Path |
|---|---|
| Kerberos cache and S4U primitive | `backend/app/data_sources/kerberos.py` |
| SQL Server ODBC connection construction | `backend/app/data_sources/clients/mssql_client.py` |
| Auth variant registration | `backend/app/schemas/data_source_registry.py` |
| Per-user verification state | `backend/app/services/connection_identity.py`, `backend/app/services/connection_service.py` |
| Unit regression coverage | `backend/tests/unit/test_mssql_kerberos.py` |
| Runnable integration proof | `lab/sql-server-kerberos/` |
| Deployment and troubleshooting guide | `docs/sql-server-kerberos.md` |
| Reproduce → fix → verify record | `docs/feedback-loops/sql-server-kerberos.md` |

**Convention established:** any code that selects or implicitly consumes the process-default Kerberos cache must participate in the same process-wide lock; on-disk ccaches must be namespaced per worker/manager.

**Commit by role:** `a10ecedd` contains the runtime hardening, regression coverage, live lab, and documentation as one verified change.

**Follow-ups:** first-class Helm Kerberos values and strict IdP-backed UPN mapping are deliberately separate deployment/security work.

## Deep detail

### Root cause

`KerberosTicketManager.activate(None)` returned before taking `_ENV_LOCK`. A simultaneous delegated connection could therefore set `KRB5CCNAME` while a service-account connection initialized GSSAPI/ODBC. The cache filename was also derived from only the principal, so separate managers sharing `BOW_KRB5_CCACHE_DIR` selected the same file.

The live environment also surfaced three bounded correctness gaps: the MSSQL registry relied on implicit client resolution despite its uppercase key, `Encrypt=yes` was not explicit, and a failed Kerberos recheck could leave a prior success displayed as verified.

### Approach

- Replace the non-reentrant process lock with an `RLock` because credential acquisition may nest inside an activated connection path.
- Lock the default-cache path and service credential acquisition as well as delegated activation.
- Add a process/random namespace beneath the configured ccache root and enforce `0700` on it.
- Emit `Encrypt=yes|no` for both supported ODBC versions.
- Register `MSSQLClient` explicitly.
- Treat `last_error` as authoritative over an older successful timestamp.
- Exercise the production connector against Samba AD and SQL Server 2022 with real S4U2Self/S4U2Proxy.

### Alternatives not taken

- **Pass a ccache directly to pyodbc:** the Microsoft ODBC driver consumes the process environment and exposes no per-call ccache parameter.
- **Disable all concurrency:** broader than necessary; only credential selection during connection establishment needs serialization.
- **Store user passwords/tickets:** unnecessary and weaker than constrained delegation; only the service keytab and trusted user UPN are required.

### Scope and limits

- No frontend, schema migration, Helm chart, or SQL username/password behavior changes.
- The lab keytabs and passwords are generated into ignored state and are not committed.
- The lab is a functional proof, not a production AD topology model.
- OpenShift secret mounting and customer KCD configuration remain documented deployment responsibilities.
- A temporary deterministic LLM used only to capture local UI evidence was removed and is not part of this branch.

## Automated review

Pending after PR creation; all bot comments will be evaluated against the actual connection and credential flow before merge.
