### PR TITLE
Make session tokens revocable and keep them out of SSO redirect URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+- Session tokens are now revocable: logging out, changing or resetting a password, and the new admin force-signout all invalidate every session token already issued to that user. Previously logout only cleared the browser's copy, so a token taken from a session stayed valid for its full 7-day lifetime even after the user logged out and back in. **Upgrading signs every user out once** — existing tokens predate the check and are rejected.
+- SSO sign-in no longer returns the session token in the redirect URL. The callback now redirects with a single-use code (60s) that the app trades for the token over POST, keeping the credential out of browser history, `Referer` headers, and reverse-proxy access logs.
+
 ## Version 0.0.554 (September 3, 2026)
 - Added a side panel view for query results with a full-width preview (#1054)
 - Added scikit-learn support with ML training constraints (#1055)

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -72,6 +72,7 @@ from app.models.user_connection_tool import UserConnectionTool
 from app.models.user_connection_tool_preference import UserConnectionToolPreference
 from app.models.tool_confirmation import ToolConfirmation
 from app.models.officejs_pending_result import OfficeJsPendingResult
+from app.models.login_exchange_code import LoginExchangeCode
 from app.models.data_source_connection_tool import DataSourceConnectionTool
 from app.models.domain_connection import domain_connection
 from app.models.user_connection_credentials import UserConnectionCredentials

--- a/backend/alembic/versions/sessepoch01_session_revocation.py
+++ b/backend/alembic/versions/sessepoch01_session_revocation.py
@@ -1,0 +1,64 @@
+"""session revocation: user.session_epoch + login_exchange_codes
+
+Two halves of the same fix for un-revokable session tokens:
+
+* ``users.session_epoch`` — stamped into every session JWT and compared on each
+  request, so logout / password change / admin force-signout actually revoke
+  tokens that were already issued. Existing tokens carry no claim (read as 0)
+  and so are rejected against the seeded value of 1: every user is signed out
+  once on upgrade, which is intended for a credential-revocation fix.
+
+* ``login_exchange_codes`` — lets the SSO callback stop putting the JWT in the
+  redirect URL, handing back a single-use short-lived code instead.
+
+Revision ID: sessepoch01
+Revises: officejs01
+Create Date: 2026-09-04
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "sessepoch01"
+down_revision: Union[str, None] = "officejs01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("session_epoch", sa.Integer(), nullable=False, server_default="1"),
+    )
+
+    op.create_table(
+        "login_exchange_codes",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.Column("code_hash", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("access_token", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_login_exchange_codes_code_hash",
+        "login_exchange_codes",
+        ["code_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_login_exchange_codes_user_id", "login_exchange_codes", ["user_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_login_exchange_codes_user_id", table_name="login_exchange_codes")
+    op.drop_index("ix_login_exchange_codes_code_hash", table_name="login_exchange_codes")
+    op.drop_table("login_exchange_codes")
+    op.drop_column("users", "session_epoch")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -39,6 +39,8 @@ from app.core.telemetry import telemetry
 
 SECRET = settings.bow_config.encryption_key
 
+logger = logging.getLogger(__name__)
+
 
 DEFAULT_ORG_NAME = "Main Org"
 DEFAULT_ORG_DESCRIPTION = ""
@@ -209,7 +211,14 @@ class UserManager(BaseUserManager[User, str]):
                 response_data = {}
             token = response_data.get('access_token')
             if token:
-                redirect_url = f"{settings.bow_config.base_url}/users/sign-in?access_token={token}&email={user.email}"
+                # Hand back a single-use code, never the token itself: a URL
+                # ends up in browser history, Referer headers and proxy logs.
+                from app.services.login_exchange_service import issue_login_code
+
+                login_code = await issue_login_code(str(user.id), token)
+                redirect_url = (
+                    f"{settings.bow_config.base_url}/users/sign-in?login_code={login_code}"
+                )
                 raise HTTPException(status_code=303, headers={"Location": redirect_url})
 
     async def _attach_open_memberships(self, user: User, session: AsyncSession):
@@ -664,6 +673,22 @@ class UserManager(BaseUserManager[User, str]):
     ):
         await self._send_reset_password_email(user, token, request)
 
+    async def on_after_reset_password(self, user: User, request: Optional[Request] = None):
+        # A password reset is the one moment where the old sessions are most
+        # likely the attacker's, so they must not survive it.
+        await bump_session_epoch(user.id)
+
+    async def on_after_update(
+        self,
+        user: User,
+        update_dict: dict,
+        request: Optional[Request] = None,
+    ):
+        # Same reasoning for a self-service password change. Other profile
+        # edits (name, avatar) leave sessions alone.
+        if "password" in update_dict or "hashed_password" in update_dict:
+            await bump_session_epoch(user.id)
+
     async def _send_reset_password_email(self, user: User, token: str, request: Optional[Request] = None):
         import asyncio
         
@@ -934,13 +959,102 @@ async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db
 
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
 
+# Claim carrying the user's `session_epoch` at the moment the token was minted.
+# Tokens issued before this claim existed decode to 0, which never matches the
+# seeded epoch of 1 — so upgrading signs everyone out once, on purpose.
+SESSION_EPOCH_CLAIM = "session_epoch"
 
-def get_jwt_strategy() -> JWTStrategy:
+
+def _session_epoch_of(user: User) -> int:
+    return int(getattr(user, "session_epoch", 0) or 0)
+
+
+async def bump_session_epoch(user_id: str) -> None:
+    """Invalidate every session token already issued to a user.
+
+    The increment runs in SQL so concurrent bumps can't clobber each other. Used
+    by logout, password change/reset, and the admin force-signout endpoint.
+    """
+    from app.dependencies import async_session_maker
+
+    async with async_session_maker() as db:
+        await db.execute(
+            update(User)
+            .where(User.id == str(user_id))
+            .values(session_epoch=User.session_epoch + 1)
+        )
+        await db.commit()
+
+
+class SessionEpochJWTStrategy(JWTStrategy):
+    """JWTStrategy that makes its tokens revocable.
+
+    Plain `JWTStrategy` is stateless: once minted, a token is valid until it
+    expires, and `destroy_token` raises `StrategyDestroyNotSupportedError` — so
+    fastapi-users' logout route silently does nothing and a stolen bearer token
+    survives any number of logout/login cycles for its full lifetime.
+
+    Stamping the user's `session_epoch` into the token and re-checking it on
+    every request turns that into a real revocation: bumping the column rejects
+    every token minted before the bump. The user row is already loaded to
+    authenticate the request, so this costs a comparison, not a query.
+    """
+
+    async def write_token(self, user: User) -> str:
+        from fastapi_users.jwt import generate_jwt
+
+        data = {
+            "sub": str(user.id),
+            "aud": self.token_audience,
+            SESSION_EPOCH_CLAIM: _session_epoch_of(user),
+        }
+        return generate_jwt(
+            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm
+        )
+
+    async def read_token(self, token: Optional[str], user_manager) -> Optional[User]:
+        from fastapi_users.jwt import decode_jwt
+
+        user = await super().read_token(token, user_manager)
+        if user is None:
+            return None
+
+        try:
+            claims = decode_jwt(
+                token, self.decode_key, self.token_audience, algorithms=[self.algorithm]
+            )
+        except Exception:
+            return None
+
+        if int(claims.get(SESSION_EPOCH_CLAIM, 0) or 0) != _session_epoch_of(user):
+            logger.info(
+                "Rejected session token for user %s: revoked (stale session_epoch)",
+                user.id,
+            )
+            return None
+
+        return user
+
+
+def get_jwt_strategy() -> SessionEpochJWTStrategy:
     # Align JWT lifetime with frontend cookie (7 days) to avoid desync logout
-    return JWTStrategy(secret=SECRET, lifetime_seconds=60 * 60 * 24 * 7)
+    return SessionEpochJWTStrategy(secret=SECRET, lifetime_seconds=60 * 60 * 24 * 7)
 
 
-auth_backend = AuthenticationBackend(
+class RevocableAuthenticationBackend(AuthenticationBackend):
+    """Authentication backend whose logout actually invalidates the token.
+
+    The stock backend calls `strategy.destroy_token`, swallows the
+    "not supported" error a stateless JWT raises, and returns 204 — leaving the
+    token usable. Bumping the session epoch first makes the 204 honest.
+    """
+
+    async def logout(self, strategy, user, token):
+        await bump_session_epoch(user.id)
+        return await super().logout(strategy, user, token)
+
+
+auth_backend = RevocableAuthenticationBackend(
     name="jwt",
     transport=bearer_transport,
     get_strategy=get_jwt_strategy,

--- a/backend/app/models/login_exchange_code.py
+++ b/backend/app/models/login_exchange_code.py
@@ -1,0 +1,34 @@
+"""One-time code that exchanges an SSO redirect for a session token.
+
+The SSO callback used to hand the session JWT back to the browser in the
+redirect URL (``/users/sign-in?access_token=<jwt>``). That put a credential
+with a 7-day lifetime into browser history, ``Referer`` headers and every
+reverse-proxy access log in front of the app — the most likely way a bearer
+token gets lifted off a self-hosted install.
+
+Now the callback stores the minted token here, keyed by a short-lived
+single-use code, and redirects with only that code. The SPA POSTs it to
+``/api/auth/exchange`` once and gets the JWT in the response body. A code that
+leaks into a log is worthless: it expires in seconds and dies on first use.
+"""
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import relationship
+
+from app.models.base import BaseSchema
+
+
+class LoginExchangeCode(BaseSchema):
+    __tablename__ = "login_exchange_codes"
+
+    # SHA-256 of the code — the plaintext only ever exists in the redirect URL
+    # and the exchange request, never at rest.
+    code_hash = Column(String(64), nullable=False, unique=True, index=True)
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
+    # The session JWT itself. Short-lived at rest: the row is consumed on first
+    # exchange and swept once expired.
+    access_token = Column(Text, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    consumed_at = Column(DateTime, nullable=True)
+
+    user = relationship("User")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Boolean
+from sqlalchemy import Column, String, DateTime, Boolean, Integer
 from typing import List
 from sqlalchemy.orm import relationship
 from fastapi_users.db import SQLAlchemyBaseUserTable
@@ -19,6 +19,14 @@ class User(SQLAlchemyBaseUserTable[str], Base):
     last_seen = Column(DateTime, nullable=True)
     scim_external_id = Column(String(255), nullable=True, index=True)  # IdP external identifier for SCIM provisioning
     ldap_dn = Column(String(512), nullable=True, index=True)  # LDAP distinguished name
+    # Monotonic counter stamped into every session JWT as the `session_epoch`
+    # claim. A token is only accepted while its claim matches this column, so
+    # incrementing it revokes every session token already issued to the user.
+    # Bumped on logout, on password change/reset, and by an admin forcing a
+    # sign-out. Without it the JWTs are stateless and unrevokable: logging out
+    # only drops the browser's copy while the token stays valid for its full
+    # 7-day lifetime.
+    session_epoch = Column(Integer, nullable=False, default=1, server_default="1")
     # True for the backing row of a ServiceAccount (a non-human API principal).
     # Such rows cannot log in interactively (is_active=False) and are filtered
     # out of human-facing surfaces (member lists, people pickers, seat counts).

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,11 +1,16 @@
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi import Depends
+from pydantic import BaseModel
 
 from app.services.auth_providers import build_authorize_url, handle_callback
 from app.core.auth import get_user_manager
 
 router = APIRouter()
+
+
+class LoginCodeExchange(BaseModel):
+    login_code: str
 
 
 @router.get("/auth/{provider}/authorize")
@@ -29,3 +34,20 @@ async def callback(
     )
 
 
+
+
+@router.post("/auth/exchange")
+async def exchange_login_code(payload: LoginCodeExchange) -> JSONResponse:
+    """Trade a single-use SSO login code for the session token.
+
+    The second half of keeping the JWT out of the redirect URL: the callback
+    redirects with a short-lived code and the SPA POSTs it here, so the token
+    itself only ever travels in a request/response body.
+    """
+    from app.services.login_exchange_service import redeem_login_code
+
+    access_token = await redeem_login_code(payload.login_code)
+    if not access_token:
+        raise HTTPException(status_code=400, detail="Invalid or expired login code")
+
+    return JSONResponse({"access_token": access_token, "token_type": "bearer"})

--- a/backend/app/routes/organization.py
+++ b/backend/app/routes/organization.py
@@ -72,6 +72,49 @@ async def remove_member(
     )
     return await organization_service.remove_member(db, organization_id, membership_id, current_user, organization)
 
+@router.post("/organizations/{organization_id}/members/{membership_id}/sign-out", status_code=204, dependencies=[Depends(forbid_service_account_principal)])
+@requires_permission('manage_members')
+async def force_member_sign_out(
+    organization_id: str,
+    membership_id: str,
+    request: Request,
+    current_user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_async_db),
+    organization: Organization = Depends(get_current_organization)
+):
+    """Revoke every session token held by a member.
+
+    The break-glass control for a leaked bearer token: session JWTs are only
+    accepted while they carry the user's current `session_epoch`, so bumping it
+    invalidates all of them at once, on every device. Before this existed the
+    only lever was deactivating the account.
+    """
+    from app.core.auth import bump_session_epoch
+
+    # Scope the lookup to the org the caller was actually authorized against
+    # (the resolved `organization`), not the org id in the path — those are
+    # separate inputs, and only the former has been checked for membership and
+    # manage_members.
+    membership = await organization_service.get_member(
+        db, membership_id, str(organization.id), current_user
+    )
+    if membership is None or not membership.user_id:
+        raise HTTPException(status_code=404, detail="Member not found")
+
+    await bump_session_epoch(membership.user_id)
+
+    await audit_service.log(
+        db=db,
+        organization_id=organization_id,
+        action="member.sessions_revoked",
+        user_id=current_user.id,
+        resource_type="membership",
+        resource_id=membership_id,
+        request=request,
+    )
+    return None
+
+
 @router.put("/organizations/{organization_id}/members/{membership_id}", response_model=MembershipSchema, dependencies=[Depends(forbid_service_account_principal)])
 @requires_permission('manage_members')
 async def update_member(

--- a/backend/app/services/auth_providers.py
+++ b/backend/app/services/auth_providers.py
@@ -326,9 +326,7 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
 
         await _record_login(user)
 
-        strategy = get_jwt_strategy()
-        jwt_token = await strategy.write_token(user)
-        return RedirectResponse(f"/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
+        return await _login_redirect(user)
 
     # OIDC providers
     cfg = _get_oidc_config(provider)
@@ -488,9 +486,24 @@ async def _handle_callback(provider: str, request: Request, code: Optional[str],
 
     await _record_login(user)
 
+    return await _login_redirect(user)
+
+
+async def _login_redirect(user) -> RedirectResponse:
+    """Finish an SSO login by redirecting the SPA to a one-time exchange code.
+
+    The session JWT deliberately does not travel in this URL — it would be
+    written to browser history, leak via Referer, and land in the access logs of
+    every proxy in front of a self-hosted install, where it stays valid for its
+    full 7-day lifetime. The code here is single-use and expires in 60s; the SPA
+    trades it for the token over POST /api/auth/exchange.
+    """
+    from app.services.login_exchange_service import issue_login_code
+
     strategy = get_jwt_strategy()
     jwt_token = await strategy.write_token(user)
-    return RedirectResponse(f"/users/sign-in?access_token={jwt_token}&email={user.email}", status_code=303)
+    login_code = await issue_login_code(str(user.id), jwt_token)
+    return RedirectResponse(f"/users/sign-in?login_code={login_code}", status_code=303)
 
 
 async def _record_login(user) -> None:

--- a/backend/app/services/login_exchange_service.py
+++ b/backend/app/services/login_exchange_service.py
@@ -1,0 +1,111 @@
+"""Single-use codes that hand an SSO-minted session token to the browser.
+
+Replaces `redirect to /users/sign-in?access_token=<jwt>`. See
+``app.models.login_exchange_code`` for why the JWT must not travel in a URL.
+"""
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta
+
+from sqlalchemy import select, update
+
+from app.models.login_exchange_code import LoginExchangeCode
+
+logger = logging.getLogger(__name__)
+
+# The browser redeems the code on the very next request, so this only has to
+# cover the redirect hop. Short by design: it caps how long a code scraped from
+# a proxy log or browser history is worth anything.
+CODE_LIFETIME = timedelta(seconds=60)
+
+
+def _hash(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+async def issue_login_code(user_id: str, access_token: str) -> str:
+    """Persist ``access_token`` behind a fresh one-time code and return the code."""
+    from app.dependencies import async_session_maker
+
+    # Opportunistic housekeeping: the table only ever holds codes from the last
+    # 60 seconds, so sweeping on issue keeps it from accumulating spent rows
+    # without needing a scheduled job.
+    await purge_expired_login_codes()
+
+    code = secrets.token_urlsafe(32)
+    async with async_session_maker() as db:
+        db.add(
+            LoginExchangeCode(
+                code_hash=_hash(code),
+                user_id=str(user_id),
+                access_token=access_token,
+                expires_at=datetime.utcnow() + CODE_LIFETIME,
+            )
+        )
+        await db.commit()
+    return code
+
+
+async def redeem_login_code(code: str) -> str | None:
+    """Consume ``code`` and return the session token, or None if it is not valid.
+
+    Consumption is a conditional UPDATE, so two racing redemptions of the same
+    code can never both come back with a token.
+    """
+    from app.dependencies import async_session_maker
+
+    if not code:
+        return None
+
+    async with async_session_maker() as db:
+        now = datetime.utcnow()
+        result = await db.execute(
+            update(LoginExchangeCode)
+            .where(
+                LoginExchangeCode.code_hash == _hash(code),
+                LoginExchangeCode.consumed_at.is_(None),
+                LoginExchangeCode.expires_at > now,
+            )
+            .values(consumed_at=now)
+        )
+        if result.rowcount != 1:
+            await db.rollback()
+            return None
+
+        row = (
+            await db.execute(
+                select(LoginExchangeCode).where(
+                    LoginExchangeCode.code_hash == _hash(code)
+                )
+            )
+        ).scalar_one_or_none()
+        await db.commit()
+
+        if row is None:
+            return None
+        return row.access_token
+
+
+async def purge_expired_login_codes() -> int:
+    """Delete spent/expired rows. Best-effort housekeeping; never raises."""
+    from sqlalchemy import delete, or_
+
+    from app.dependencies import async_session_maker
+
+    try:
+        async with async_session_maker() as db:
+            result = await db.execute(
+                delete(LoginExchangeCode).where(
+                    or_(
+                        LoginExchangeCode.expires_at < datetime.utcnow(),
+                        LoginExchangeCode.consumed_at.isnot(None),
+                    )
+                )
+            )
+            await db.commit()
+            return result.rowcount or 0
+    except Exception:
+        logger.debug("purge_expired_login_codes failed", exc_info=True)
+        return 0

--- a/backend/tests/e2e/test_login_exchange_code.py
+++ b/backend/tests/e2e/test_login_exchange_code.py
@@ -1,0 +1,125 @@
+"""e2e: SSO hands the browser a one-time code, never the session token.
+
+The SSO callback used to redirect to ``/users/sign-in?access_token=<jwt>``,
+putting a 7-day credential into browser history, Referer headers and the access
+log of every proxy in front of a self-hosted install. It now redirects with a
+single-use code that the SPA trades for the token over POST.
+
+The exchange route lives on the SSO router, which the test config (auth mode
+``local_only``) does not mount — so these tests mount that router on their own
+app. The token it returns is still checked against the real application, which
+is what makes the round trip meaningful.
+"""
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from sqlalchemy import select
+from starlette.testclient import TestClient
+
+from app.models.user import User
+from app.routes import auth as auth_routes
+from app.services.login_exchange_service import issue_login_code
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def sso_client():
+    """A minimal app exposing the SSO auth router (incl. /auth/exchange)."""
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix="/api")
+    return TestClient(app)
+
+
+async def _load_user(email: str) -> User:
+    from app.dependencies import async_session_maker
+
+    async with async_session_maker() as db:
+        return (
+            await db.execute(select(User).where(User.email == email))
+        ).scalar_one()
+
+
+def _register(create_user):
+    email = f"exch_{uuid.uuid4().hex[:10]}@test.com"
+    create_user(email=email, password="Test1234!")
+    return email
+
+
+@pytest.mark.asyncio
+async def test_sso_redirect_carries_a_code_and_not_the_token(create_user):
+    """The regression that matters: no session JWT anywhere in the redirect."""
+    from app.services.auth_providers import _login_redirect
+
+    user = await _load_user(_register(create_user))
+    location = (await _login_redirect(user)).headers["location"]
+
+    assert "login_code=" in location
+    assert "access_token" not in location
+    # A JWT is three base64 segments joined by dots — nothing like it may appear
+    # in a URL, under any parameter name.
+    assert location.count(".") == 0 or "eyJ" not in location
+
+
+@pytest.mark.asyncio
+async def test_exchanged_code_yields_a_working_session(create_user, sso_client, test_client):
+    """The other half of the contract: the browser really can trade the code for
+    a token, and that token authenticates against the real API."""
+    from app.services.auth_providers import _login_redirect
+
+    email = _register(create_user)
+    user = await _load_user(email)
+    location = (await _login_redirect(user)).headers["location"]
+    code = location.split("login_code=")[1].split("&")[0]
+
+    resp = sso_client.post("/api/auth/exchange", json={"login_code": code})
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+
+    me = test_client.get("/api/users/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert me.status_code == 200, me.text
+    assert me.json()["email"] == email
+
+
+@pytest.mark.asyncio
+async def test_a_code_can_only_be_exchanged_once(create_user, sso_client):
+    """A code scraped from a log after the browser used it is worthless."""
+    user = await _load_user(_register(create_user))
+    code = await issue_login_code(str(user.id), "a-token")
+
+    assert sso_client.post("/api/auth/exchange", json={"login_code": code}).status_code == 200
+    replay = sso_client.post("/api/auth/exchange", json={"login_code": code})
+    assert replay.status_code == 400
+    assert "access_token" not in replay.text
+
+
+@pytest.mark.asyncio
+async def test_expired_code_is_refused(create_user, sso_client):
+    from sqlalchemy import update
+
+    from app.dependencies import async_session_maker
+    from app.models.login_exchange_code import LoginExchangeCode
+
+    user = await _load_user(_register(create_user))
+    code = await issue_login_code(str(user.id), "a-token")
+
+    # Age the row past its lifetime. Done in SQL because the service deliberately
+    # exposes no way to mint a code with a caller-chosen expiry.
+    async with async_session_maker() as db:
+        await db.execute(
+            update(LoginExchangeCode).values(
+                expires_at=datetime.utcnow() - timedelta(seconds=1)
+            )
+        )
+        await db.commit()
+
+    assert sso_client.post("/api/auth/exchange", json={"login_code": code}).status_code == 400
+
+
+@pytest.mark.parametrize("bogus", ["", "not-a-real-code", "x" * 64])
+def test_unknown_codes_are_refused(sso_client, bogus):
+    resp = sso_client.post("/api/auth/exchange", json={"login_code": bogus})
+    assert resp.status_code == 400
+    assert "access_token" not in resp.text

--- a/backend/tests/e2e/test_session_revocation.py
+++ b/backend/tests/e2e/test_session_revocation.py
@@ -1,0 +1,196 @@
+"""e2e: session tokens are revocable.
+
+Session JWTs used to be stateless with a 7-day lifetime and a logout route that
+did nothing server-side, so a bearer token lifted off a user (out of a proxy
+log, browser history, or the browser itself) stayed valid for a week no matter
+how many times its owner logged out and back in.
+
+Every test here asserts the same invariant from a different angle: once a
+session has been revoked, *any* token issued before that point is refused on the
+whole authenticated API — while tokens minted afterwards keep working.
+"""
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _auth(token, org_id=None):
+    headers = {"Authorization": f"Bearer {token}"}
+    if org_id:
+        headers["X-Organization-Id"] = str(org_id)
+    return headers
+
+
+def _new_account(create_user, login_user):
+    email = f"revoke_{uuid.uuid4().hex[:10]}@test.com"
+    password = "Test1234!"
+    create_user(email=email, password=password)
+    return {"email": email, "password": password, "token": login_user(email, password)}
+
+
+def _org_id(whoami, token):
+    """The org registration already put this user in (they land in Main Org)."""
+    orgs = whoami(token)["organizations"]
+    assert orgs, "expected the registered user to belong to an organization"
+    return orgs[0]["id"]
+
+
+def _token_works(test_client, token) -> bool:
+    """Probe an authenticated route; True iff the token still authenticates."""
+    resp = test_client.get("/api/users/whoami", headers=_auth(token))
+    assert resp.status_code in (200, 401), resp.status_code
+    return resp.status_code == 200
+
+
+def test_logout_revokes_the_token_it_was_called_with(test_client, create_user, login_user):
+    acct = _new_account(create_user, login_user)
+    assert _token_works(test_client, acct["token"])
+
+    logout = test_client.post("/api/auth/jwt/logout", headers=_auth(acct["token"]))
+    assert logout.status_code in (200, 204), logout.status_code
+
+    assert not _token_works(test_client, acct["token"])
+
+
+def test_logging_back_in_does_not_revive_the_old_token(test_client, create_user, login_user):
+    """The reported behavior: log out, log back in, and the old bearer token
+    was still accepted. A fresh login must not resurrect a revoked session."""
+    acct = _new_account(create_user, login_user)
+    stolen = acct["token"]
+
+    test_client.post("/api/auth/jwt/logout", headers=_auth(stolen))
+    fresh = login_user(acct["email"], acct["password"])
+
+    assert not _token_works(test_client, stolen)
+    assert _token_works(test_client, fresh)
+
+
+def test_logout_revokes_every_outstanding_session_not_just_the_caller(
+    test_client, create_user, login_user
+):
+    """Sessions on other devices die too — the point of the control is that one
+    logout ends every session, including one an attacker holds."""
+    acct = _new_account(create_user, login_user)
+    other_device = login_user(acct["email"], acct["password"])
+    assert _token_works(test_client, other_device)
+
+    test_client.post("/api/auth/jwt/logout", headers=_auth(acct["token"]))
+
+    assert not _token_works(test_client, other_device)
+
+
+def test_revoked_token_is_refused_across_the_authenticated_api(
+    test_client, create_user, login_user, whoami
+):
+    """Revocation is enforced in the auth dependency, so it holds for every
+    authenticated route — not just the one whoami probe the other tests use."""
+    acct = _new_account(create_user, login_user)
+    org_id = _org_id(whoami, acct["token"])
+
+    routes = [
+        "/api/users/whoami",
+        "/api/organizations",
+        f"/api/organizations/{org_id}/members",
+    ]
+    for route in routes:
+        assert test_client.get(route, headers=_auth(acct["token"], org_id)).status_code == 200, route
+
+    test_client.post("/api/auth/jwt/logout", headers=_auth(acct["token"]))
+
+    for route in routes:
+        resp = test_client.get(route, headers=_auth(acct["token"], org_id))
+        assert resp.status_code == 401, f"{route} still accepted a revoked token"
+
+
+def test_password_change_revokes_existing_sessions(test_client, create_user, login_user):
+    acct = _new_account(create_user, login_user)
+    old_session = login_user(acct["email"], acct["password"])
+
+    resp = test_client.patch(
+        "/api/users/me",
+        json={"password": "Changed1234!"},
+        headers=_auth(acct["token"]),
+    )
+    assert resp.status_code == 200, resp.json()
+
+    assert not _token_works(test_client, old_session)
+    assert not _token_works(test_client, acct["token"])
+    assert _token_works(test_client, login_user(acct["email"], "Changed1234!"))
+
+
+def test_profile_edit_that_is_not_a_password_change_keeps_sessions_alive(
+    test_client, create_user, login_user
+):
+    """Guard against over-revoking: renaming yourself must not sign you out."""
+    acct = _new_account(create_user, login_user)
+
+    resp = test_client.patch(
+        "/api/users/me",
+        json={"name": f"renamed_{uuid.uuid4().hex[:6]}"},
+        headers=_auth(acct["token"]),
+    )
+    assert resp.status_code == 200, resp.json()
+
+    assert _token_works(test_client, acct["token"])
+
+
+def test_admin_can_force_sign_out_a_member(test_client, create_user, login_user, whoami):
+    """The break-glass control for a leaked token: an admin revokes a member's
+    sessions without having to deactivate the account."""
+    admin = _new_account(create_user, login_user)
+    org_id = _org_id(whoami, admin["token"])
+
+    member_email = f"revoke_{uuid.uuid4().hex[:10]}@test.com"
+    invite = test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": member_email, "role": "member"},
+        headers=_auth(admin["token"], org_id),
+    )
+    assert invite.status_code == 200, invite.json()
+    membership_id = invite.json()["id"]
+
+    create_user(email=member_email, password="Test1234!")
+    member_token = login_user(member_email, "Test1234!")
+    assert _token_works(test_client, member_token)
+
+    resp = test_client.post(
+        f"/api/organizations/{org_id}/members/{membership_id}/sign-out",
+        headers=_auth(admin["token"], org_id),
+    )
+    assert resp.status_code == 204, resp.status_code
+
+    assert not _token_works(test_client, member_token)
+    # The admin's own session is untouched, and the member can sign back in.
+    assert _token_works(test_client, admin["token"])
+    assert _token_works(test_client, login_user(member_email, "Test1234!"))
+
+
+def test_member_cannot_force_sign_out_another_member(
+    test_client, create_user, login_user, whoami
+):
+    """Force-signout is a manage_members action — a regular member must not be
+    able to boot anyone, including the admin."""
+    admin = _new_account(create_user, login_user)
+    org_id = _org_id(whoami, admin["token"])
+
+    admin_membership = test_client.get(
+        f"/api/organizations/{org_id}/members", headers=_auth(admin["token"], org_id)
+    ).json()[0]["id"]
+
+    member_email = f"revoke_{uuid.uuid4().hex[:10]}@test.com"
+    test_client.post(
+        f"/api/organizations/{org_id}/members",
+        json={"organization_id": org_id, "email": member_email, "role": "member"},
+        headers=_auth(admin["token"], org_id),
+    )
+    create_user(email=member_email, password="Test1234!")
+    member_token = login_user(member_email, "Test1234!")
+
+    resp = test_client.post(
+        f"/api/organizations/{org_id}/members/{admin_membership}/sign-out",
+        headers=_auth(member_token, org_id),
+    )
+    assert resp.status_code in (401, 403), resp.status_code
+    assert _token_works(test_client, admin["token"])

--- a/frontend/pages/users/sign-in.vue
+++ b/frontend/pages/users/sign-in.vue
@@ -184,9 +184,27 @@
     if (inviteError) {
       error_message.value = inviteError
     }
-    const access_token = route.query.access_token as string
-    const userEmail = route.query.email as string
-    if (access_token) {
+    // SSO hands back a single-use code, not the token — see
+    // app/models/login_exchange_code.py for why the JWT must not ride in a URL.
+    const login_code = route.query.login_code as string
+    if (login_code) {
+      let access_token = ''
+      try {
+        const exchanged = await $fetch<{ access_token: string }>('/api/auth/exchange', {
+          method: 'POST',
+          body: { login_code },
+        })
+        access_token = exchanged?.access_token ?? ''
+      } catch (e) {
+        error_message.value = t('auth.signInFailed')
+        pageLoaded.value = true
+        return
+      }
+      if (!access_token) {
+        error_message.value = t('auth.signInFailed')
+        pageLoaded.value = true
+        return
+      }
       rawToken.value = access_token
       await getSession({ force: true })
       // Check if the user has an organization (same as credentials login)

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "تسجيل الدخول باستخدام {provider}",
     "continueWithProvider": "المتابعة باستخدام {provider}",
     "invalidCredentials": "بيانات الاعتماد غير صحيحة",
+    "signInFailed": "فشل تسجيل الدخول. يرجى المحاولة مرة أخرى.",
     "registrationError": "حدث خطأ أثناء التسجيل.",
     "googleInitError": "تعذّر بدء تسجيل الدخول باستخدام Google",
     "providerInitError": "تعذّر بدء تسجيل الدخول باستخدام {provider}",

--- a/locales/de.json
+++ b/locales/de.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Mit {provider} anmelden",
     "continueWithProvider": "Mit {provider} fortfahren",
     "invalidCredentials": "Ungültige Anmeldedaten",
+    "signInFailed": "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "registrationError": "Bei der Registrierung ist ein Fehler aufgetreten.",
     "googleInitError": "Google-Anmeldung konnte nicht initialisiert werden",
     "providerInitError": "{provider}-Anmeldung konnte nicht initialisiert werden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -481,6 +481,7 @@
     "signInWithProvider": "Sign in with {provider}",
     "continueWithProvider": "Continue with {provider}",
     "invalidCredentials": "Invalid credentials",
+    "signInFailed": "Sign-in failed. Please try again.",
     "registrationError": "An error occurred during registration.",
     "googleInitError": "Failed to initialize Google sign-in",
     "providerInitError": "Failed to initialize {provider} sign-in",

--- a/locales/es.json
+++ b/locales/es.json
@@ -464,6 +464,7 @@
     "signInWithProvider": "Iniciar sesión con {provider}",
     "continueWithProvider": "Continuar con {provider}",
     "invalidCredentials": "Credenciales no válidas",
+    "signInFailed": "Error al iniciar sesión. Inténtalo de nuevo.",
     "registrationError": "Ha ocurrido un error durante el registro.",
     "googleInitError": "No se pudo iniciar el inicio de sesión con Google",
     "providerInitError": "No se pudo iniciar el inicio de sesión con {provider}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Se connecter avec {provider}",
     "continueWithProvider": "Continuer avec {provider}",
     "invalidCredentials": "Identifiants invalides",
+    "signInFailed": "Échec de la connexion. Veuillez réessayer.",
     "registrationError": "Une erreur s'est produite lors de l'inscription.",
     "googleInitError": "Échec de l'initialisation de la connexion Google",
     "providerInitError": "Échec de l'initialisation de la connexion {provider}",

--- a/locales/he.json
+++ b/locales/he.json
@@ -464,6 +464,7 @@
     "signInWithProvider": "התחברות עם {provider}",
     "continueWithProvider": "המשך עם {provider}",
     "invalidCredentials": "פרטי התחברות לא תקינים",
+    "signInFailed": "ההתחברות נכשלה. אנא נסה שוב.",
     "registrationError": "אירעה שגיאה במהלך ההרשמה.",
     "googleInitError": "לא ניתן להפעיל התחברות עם Google",
     "providerInitError": "לא ניתן להפעיל התחברות עם {provider}",

--- a/locales/it.json
+++ b/locales/it.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Accedi con {provider}",
     "continueWithProvider": "Continua con {provider}",
     "invalidCredentials": "Credenziali non valide",
+    "signInFailed": "Accesso non riuscito. Riprova.",
     "registrationError": "Si è verificato un errore durante la registrazione.",
     "googleInitError": "Impossibile inizializzare l'accesso con Google",
     "providerInitError": "Impossibile inizializzare l'accesso con {provider}",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Entrar com {provider}",
     "continueWithProvider": "Continuar com {provider}",
     "invalidCredentials": "Credenciais inválidas",
+    "signInFailed": "Falha ao iniciar sessão. Tente novamente.",
     "registrationError": "Ocorreu um erro durante o cadastro.",
     "googleInitError": "Falha ao inicializar o login com Google",
     "providerInitError": "Falha ao inicializar o login com {provider}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Войти через {provider}",
     "continueWithProvider": "Продолжить через {provider}",
     "invalidCredentials": "Неверные учётные данные",
+    "signInFailed": "Не удалось войти. Пожалуйста, попробуйте снова.",
     "registrationError": "При регистрации произошла ошибка.",
     "googleInitError": "Не удалось инициализировать вход через Google",
     "providerInitError": "Не удалось инициализировать вход через {provider}",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -452,6 +452,7 @@
     "signInWithProvider": "Logga in med {provider}",
     "continueWithProvider": "Fortsätt med {provider}",
     "invalidCredentials": "Ogiltiga inloggningsuppgifter",
+    "signInFailed": "Inloggningen misslyckades. Försök igen.",
     "registrationError": "Ett fel uppstod under registreringen.",
     "googleInitError": "Det gick inte att initiera Google-inloggning",
     "providerInitError": "Det gick inte att initiera {provider}-inloggning",


### PR DESCRIPTION
Session JWTs were stateless with a 7-day lifetime, and the logout route was a
no-op: fastapi-users' backend calls `JWTStrategy.destroy_token`, which raises
`StrategyDestroyNotSupportedError`, swallows it, and returns 204. A bearer token
taken from a session therefore stayed valid for a week no matter how many times
its owner logged out and back in — the behavior a self-hosted customer reported.
The SSO callback made such a token easy to obtain in the first place by
redirecting to `/users/sign-in?access_token=<jwt>`, writing the credential into
browser history, Referer headers, and every reverse-proxy access log.

Revocation: `users.session_epoch` is stamped into each token and compared on
every request. Incrementing it rejects every token minted before the bump.
Logout, password change, and password reset now bump it, and admins get
POST /organizations/{id}/members/{membership_id}/sign-out as a break-glass
control for a leaked token — previously the only lever was deactivating the
account. The user row is already loaded to authenticate the request, so the
check costs a comparison, not a query. Revocation is per user, not per device:
one logout ends every session, which is the point when one of them is an
attacker's.

Token in the URL: the callback now redirects with a single-use 60-second code
that the SPA trades for the token over POST /api/auth/exchange, so the JWT only
ever travels in a request/response body. A code scraped from a log is worthless.

Upgrading signs every user out once: existing tokens carry no session_epoch
claim (read as 0) and are rejected against the seeded value of 1. That is
intended for a credential-revocation fix — any already-stolen token dies on
deploy — but it is a visible one-time cost for every install.

Verified in a local sandbox (backend + Nuxt + Playwright): with the epoch check
disabled the reported bug reproduces exactly (logout 204, token still 200 after
logout and re-login); with it, the same script against the same user returns 401
after logout. Driving the real UI, a token copied out of the browser goes
200 -> 401 across a logout/re-login cycle, and the SSO redirect carries only a
login_code that the SPA exchanges once (replay returns 400).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C4n8uWmAcpLmtEmhb1J2TA