### PR TITLE
feat(auth): auto-start single-provider SSO and pass login_hint through

### DIFF
--- a/backend/app/routes/oauth_server.py
+++ b/backend/app/routes/oauth_server.py
@@ -96,6 +96,7 @@ async def authorize_redirect(
     scope: Optional[str] = None,
     code_challenge: Optional[str] = None,
     code_challenge_method: Optional[str] = None,
+    login_hint: Optional[str] = None,
     db: AsyncSession = Depends(get_async_db),
 ):
     """OAuth authorize endpoint.
@@ -141,6 +142,11 @@ async def authorize_redirect(
         params["code_challenge"] = code_challenge
     if code_challenge_method:
         params["code_challenge_method"] = code_challenge_method
+    # Carried so the consent page can hand it to the SSO round trip: the app
+    # embedding BOW knows who it is opening the session for, and naming that
+    # user is what keeps the provider from showing an account picker.
+    if login_hint:
+        params["login_hint"] = login_hint
 
     consent_url = f"/authorize?{urlencode(params)}"
     return RedirectResponse(url=consent_url, status_code=302)

--- a/backend/app/services/auth_providers.py
+++ b/backend/app/services/auth_providers.py
@@ -104,6 +104,24 @@ def _read_pkce_cookie(provider: str, request: Request) -> Optional[str]:
     return request.cookies.get(f"oidc_{provider}_verifier")
 
 
+def _read_login_hint(request: Request) -> Optional[str]:
+    """Read an optional ``login_hint`` off the authorize request.
+
+    An embedded app already knows which user it is opening BOW for, so it can
+    name them here and skip the provider's account picker — the difference
+    between a silent SSO round trip and a chooser screen for anyone signed in
+    to more than one account. Only this one parameter is honoured; the rest of
+    the authorize URL is ours to build.
+    """
+    value = (request.query_params.get("login_hint") or "").strip()
+    # Entra echoes the hint into a redirect; a CR/LF would let a caller graft
+    # extra header lines onto it, and the length cap keeps a hostile value from
+    # blowing past the provider's URL limit.
+    if not value or len(value) > 320 or any(c in value for c in "\r\n"):
+        return None
+    return value
+
+
 def _generate_pkce_pair() -> Tuple[str, str]:
     # verifier (43-128 chars) and S256 challenge
     verifier_bytes = os.urandom(64)
@@ -177,12 +195,17 @@ async def build_authorize_url(provider: str, request: Request) -> JSONResponse:
     state = uuid.uuid4().hex
     redirect_uri = _get_redirect_uri(provider, request, getattr(cfg, "redirect_path", None))
 
+    login_hint = _read_login_hint(request)
+
     authorization_url = await client.get_authorization_url(
         redirect_uri=redirect_uri,
         state=state,
         scope=_get_scopes(getattr(cfg, "scopes", None)),
         extras_params={
             **(getattr(cfg, "extra_authorize_params", {}) or {}),
+            # A per-request hint names the actual user, so it beats the static
+            # config default rather than the other way round.
+            **({"login_hint": login_hint} if login_hint else {}),
             **({"code_challenge": code_challenge, "code_challenge_method": "S256"} if getattr(cfg, "pkce", True) else {}),
         },
     )

--- a/backend/tests/unit/test_sso_login_hint.py
+++ b/backend/tests/unit/test_sso_login_hint.py
@@ -1,0 +1,150 @@
+"""Unit tests for the `login_hint` pass-through on the SSO authorize URL.
+
+An app embedding BOW already knows which user it is opening the session for.
+Naming that user on the authorize request is what keeps the provider from
+stopping on an account picker, which is the difference between a silent SSO
+round trip and a visible one.
+"""
+from unittest.mock import patch
+
+import pytest
+from starlette.requests import Request
+
+from app.services.auth_providers import _read_login_hint, build_authorize_url
+
+
+def _FakeRequest(query: str = "") -> Request:
+    """A real Request so base-URL derivation behaves as it does in production."""
+    return Request({
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/api/auth/entra/authorize",
+        "raw_path": b"/api/auth/entra/authorize",
+        "query_string": query.encode(),
+        "root_path": "",
+        "headers": [(b"host", b"bow.example.com")],
+        "server": ("bow.example.com", 443),
+        "client": ("10.0.0.1", 1234),
+    })
+
+
+# ── _read_login_hint ──
+
+
+def test_reads_a_plain_hint():
+    assert _read_login_hint(_FakeRequest("login_hint=alice@example.com")) == (
+        "alice@example.com"
+    )
+
+
+def test_absent_hint_is_none():
+    assert _read_login_hint(_FakeRequest("")) is None
+
+
+def test_blank_hint_is_none():
+    assert _read_login_hint(_FakeRequest("login_hint=%20%20")) is None
+
+
+def test_hint_is_trimmed():
+    assert _read_login_hint(_FakeRequest("login_hint=%20alice@example.com%20")) == (
+        "alice@example.com"
+    )
+
+
+@pytest.mark.parametrize("injected", ["a@b.com%0aSet-Cookie:%20x", "a@b.com%0d%0aX:%20y"])
+def test_crlf_bearing_hint_is_rejected(injected):
+    """The hint is echoed into a redirect; a bare CR/LF must not survive."""
+    assert _read_login_hint(_FakeRequest(f"login_hint={injected}")) is None
+
+
+def test_overlong_hint_is_rejected():
+    assert _read_login_hint(_FakeRequest(f"login_hint={'a' * 400}@b.com")) is None
+
+
+def test_hint_at_the_length_cap_is_kept():
+    hint = "a" * 320
+    assert _read_login_hint(_FakeRequest(f"login_hint={hint}")) == hint
+
+
+# ── build_authorize_url ──
+
+
+class _StubOIDCConfig:
+    name = "entra"
+    enabled = True
+    issuer = "https://login.microsoftonline.com/tenant-id/v2.0"
+    client_id = "client-id"
+    client_secret = "client-secret"
+    scopes = ["openid", "profile", "email"]
+    pkce = True
+    redirect_path = None
+    extra_authorize_params: dict = {}
+
+
+async def _authorize_extras(query: str, cfg=None):
+    """Run build_authorize_url and return the extras_params it passed through."""
+    captured = {}
+
+    class _StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def get_authorization_url(self, **kwargs):
+            captured.update(kwargs)
+            return "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/authorize?x=1"
+
+    with patch("app.services.auth_providers._get_oidc_config", return_value=cfg or _StubOIDCConfig()), \
+         patch("app.services.auth_providers.OpenID", _StubClient):
+        await build_authorize_url("entra", _FakeRequest(query))
+
+    return captured["extras_params"]
+
+
+@pytest.mark.asyncio
+async def test_hint_reaches_the_provider_authorize_url():
+    extras = await _authorize_extras("login_hint=alice@example.com")
+    assert extras["login_hint"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_no_hint_sends_no_login_hint_param():
+    """Without a hint the URL must look exactly as it did before this feature."""
+    extras = await _authorize_extras("")
+    assert "login_hint" not in extras
+
+
+@pytest.mark.asyncio
+async def test_pkce_is_still_applied_alongside_a_hint():
+    extras = await _authorize_extras("login_hint=alice@example.com")
+    assert extras["code_challenge_method"] == "S256"
+    assert extras["code_challenge"]
+
+
+@pytest.mark.asyncio
+async def test_request_hint_beats_the_static_config_default():
+    """A per-request hint names the real user, so it wins over config."""
+
+    class _WithDefaultHint(_StubOIDCConfig):
+        extra_authorize_params = {"login_hint": "shared@example.com", "domain_hint": "example"}
+
+    extras = await _authorize_extras("login_hint=bob@example.com", cfg=_WithDefaultHint())
+    assert extras["login_hint"] == "bob@example.com"
+    # Unrelated configured params are untouched.
+    assert extras["domain_hint"] == "example"
+
+
+@pytest.mark.asyncio
+async def test_configured_hint_survives_when_the_request_carries_none():
+    class _WithDefaultHint(_StubOIDCConfig):
+        extra_authorize_params = {"login_hint": "shared@example.com"}
+
+    extras = await _authorize_extras("", cfg=_WithDefaultHint())
+    assert extras["login_hint"] == "shared@example.com"
+
+
+@pytest.mark.asyncio
+async def test_rejected_hint_does_not_reach_the_provider():
+    extras = await _authorize_extras("login_hint=a@b.com%0aSet-Cookie:%20x")
+    assert "login_hint" not in extras

--- a/frontend/pages/authorize.vue
+++ b/frontend/pages/authorize.vue
@@ -93,6 +93,7 @@ const scope = (route.query.scope as string) || 'mcp'
 const codeChallenge = route.query.code_challenge as string
 const codeChallengeMethod = (route.query.code_challenge_method as string) || 'S256'
 const responseType = (route.query.response_type as string) || 'code'
+const loginHint = route.query.login_hint as string | undefined
 
 const clientInitials = computed(() => clientName.value.split(/\s+/).filter(Boolean).slice(0, 2).map(part => part[0]?.toUpperCase()).join('') || 'OA')
 
@@ -112,7 +113,11 @@ onMounted(async () => {
   await getSession()
   if (status.value !== 'authenticated') {
     const returnTo = window.location.pathname + window.location.search
-    await navigateTo(`/users/sign-in?redirect=${encodeURIComponent(returnTo)}`)
+    // login_hint rides alongside `redirect` rather than only inside it: the
+    // sign-in page reads its own query to build the SSO URL, and would never
+    // see a hint buried in the encoded return path.
+    const signIn = `/users/sign-in?redirect=${encodeURIComponent(returnTo)}`
+    await navigateTo(loginHint ? `${signIn}&login_hint=${encodeURIComponent(loginHint)}` : signIn)
     return
   }
 

--- a/frontend/pages/users/sign-in.vue
+++ b/frontend/pages/users/sign-in.vue
@@ -122,6 +122,24 @@
   const smtpEnabled = ref(false)
   const isSubmitting = ref(false)
   const localOverride = computed(() => route.query.local === 'true')
+  // How many ways there are to sign in. When there is exactly one there is
+  // nothing for the user to choose, so we can start it for them.
+  const ssoProviderCount = computed(() => oidcProviders.value.length + (googleSignIn.value ? 1 : 0))
+  // Set by an embedding app that already knows whose session it is opening.
+  // Forwarded to the provider so a browser holding several accounts doesn't
+  // stop on a chooser.
+  const loginHint = computed(() => {
+    const direct = (route.query.login_hint as string) || ''
+    if (direct) return direct
+    // The global auth middleware bounces an unauthenticated /authorize here
+    // before that page's own code can run, and it forwards only the original
+    // path — so on the flow that matters the hint arrives nested inside
+    // `redirect` rather than beside it.
+    const target = safeRedirectTarget(route.query.redirect)
+    const query = target?.slice(target.indexOf('?') + 1)
+    if (!target || !target.includes('?') || !query) return ''
+    return new URLSearchParams(query).get('login_hint') || ''
+  })
 
   definePageMeta({
   auth: {
@@ -203,6 +221,32 @@
       }
       return
     }
+
+    // Single-provider SSO: the button would be the only thing on the page, so
+    // press it. This is what lets an embedding app open BOW with no visible
+    // sign-in step when the user already has a live session at the provider.
+    //
+    // The guards are what keep it from becoming a redirect loop: a failed
+    // round trip comes back with ?error and must be able to show it, and
+    // ?local=true stays an escape hatch to the password form when the
+    // provider is unreachable.
+    if (
+      authMode.value === 'sso_only'
+      && !localOverride.value
+      && !inviteError
+      && ssoProviderCount.value === 1
+    ) {
+      const provider = oidcProviders.value[0]
+      await (provider ? signInWithProvider(provider.name) : signInWithGoogle())
+      // Both helpers swallow their own errors and clear loadingProvider when
+      // the authorize call failed; on success the browser is already leaving,
+      // so staying unloaded keeps the form from flashing up mid-redirect.
+      if (loadingProvider.value === null) {
+        pageLoaded.value = true
+      }
+      return
+    }
+
     pageLoaded.value = true
   })
 
@@ -287,7 +331,10 @@
     try {
       loadingProvider.value = name
       persistRedirectForOAuth()
-      const response = await $fetch(`/api/auth/${name}/authorize`, { method: 'GET' })
+      const response = await $fetch(`/api/auth/${name}/authorize`, {
+        method: 'GET',
+        query: loginHint.value ? { login_hint: loginHint.value } : undefined,
+      })
       if ((response as any)?.authorization_url) {
         window.location.href = (response as any).authorization_url
       }


### PR DESCRIPTION
An app embedding BOW over the OAuth `app` scope could already reach a token
without a consent screen, but not without a click: even in `sso_only` mode
the sign-in page rendered a lone "Sign in with <provider>" button and waited.
For a user already signed in to the provider that button is the only thing
standing between them and a session, so press it for them.

Two changes:

- sign-in auto-starts the round trip when auth.mode is `sso_only` and exactly
  one provider is enabled. Guarded so it cannot loop: a failed round trip
  comes back with ?error and must be able to show it, and ?local=true stays
  an escape hatch to the password form when the provider is unreachable. The
  page stays unrendered while redirecting so no form flashes up mid-flight.

- `login_hint` is carried from the embedding app through
  /api/oauth/authorize, the consent page and sign-in to the provider's
  authorize URL. Without it a browser holding more than one account stops on
  a chooser, which is the difference between a silent SSO hop and a visible
  one. Only this one parameter is honoured, and it is rejected if it carries
  CR/LF or runs past 320 chars, since the provider echoes it into a redirect.
  A per-request hint beats the static extra_authorize_params default.

The hint is recovered from the `redirect` target as well as from its own
query param: the global auth middleware bounces an unauthenticated
/authorize to sign-in before that page's own code runs, so on the flow that
actually matters the hint arrives nested inside `redirect`.

Verified against the real Entra tenant in a sandbox: the authorize URL is
accepted with no AADSTS error and the hinted user is pre-filled on the live
Microsoft sign-in page; the sign-in page leaves for Entra with zero clicks;
both guards hold; and with a session established from a real Entra id_token
the embedded flow runs authorize -> code -> access token -> BOW API call as
that user, then refreshes with rotation, without any interaction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TtCSJJH89i3TKwuQofdpfw