### PR TITLE
Promote the Prometheus connector out of dev_only, as beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+- **Prometheus connector promoted out of `dev_only`** — now in the connector catalog for every environment, shipping as `beta`.
+- **Histogram/summary metrics are typed correctly** — `_bucket`/`_sum`/`_count` series resolve their metadata from the base metric, so `_bucket` is typed `histogram (use histogram_quantile)` and `_sum`/`_count` as counters. Previously ~20% of a stock instance's metrics indexed as `unknown` and nothing was ever typed `histogram`, silently dropping the rate()/histogram_quantile hints the agent plans from.
+- **Bounded Prometheus schema discovery** — `/api/v1/series` is queried over a recent window (default 1h, configurable) with a result limit, instead of scanning the full retention period and materialising every series ever seen.
+- **Prometheus request timeout and discovery lookback are configurable** on the connection; blank numeric fields fall back to defaults instead of failing schema indexing.
+
 ## Version 0.0.554 (September 3, 2026)
 - Added a side panel view for query results with a full-width preview (#1054)
 - Added scikit-learn support with ML training constraints (#1055)

--- a/backend/app/data_sources/clients/prometheus_client.py
+++ b/backend/app/data_sources/clients/prometheus_client.py
@@ -3,6 +3,7 @@ from app.ai.prompt_formatters import Table, TableColumn, ServiceFormatter
 
 import pandas as pd
 import requests
+import time
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
 
@@ -22,6 +23,21 @@ _TYPE_HINT = {
     "summary": "summary",
     "untyped": "untyped",
     "unknown": "unknown",
+}
+
+# A histogram/summary is exposed as three *suffixed* series — `_bucket`, `_sum`
+# and `_count` — but `/api/v1/metadata` only carries an entry under the BASE
+# name (`http_request_duration_seconds`), which is itself never a series and so
+# never appears in `/api/v1/label/__name__/values`. Looking metadata up by the
+# exact series name therefore misses every component: on a stock Prometheus
+# ~20% of metrics come back `unknown` and NOTHING is ever typed `histogram`.
+# The suffix decides the component's own type: `_bucket` is the histogram body
+# (needs histogram_quantile), while `_sum`/`_count` are plain counters (need
+# rate/increase) — querying those raw returns meaningless monotonic totals.
+_COMPONENT_SUFFIX_TYPE = {
+    "_bucket": "histogram",
+    "_sum": "counter",
+    "_count": "counter",
 }
 
 
@@ -47,10 +63,36 @@ class PrometheusClient(DataSourceClient):
     Mimir).
     """
 
+    # PromQL's own relative windows are the range selectors inside the query;
+    # the instant/range boundary lives in execute_query's start/end args, which
+    # are Python-side and so must be computed from `now` rather than frozen as
+    # literals that go stale on the next dashboard refresh.
+    relative_date_hint = (
+        "Relative dates (PromQL): windows inside the query are relative already "
+        "— rate(m[5m]), m offset 1h, avg_over_time(m[24h]). For a range query, "
+        "compute execute_query's start/end from datetime.now(timezone.utc) "
+        "(e.g. end - timedelta(hours=1)); never hard-code a date literal."
+    )
+
     # Discovering label sets series-by-series is the slow part on large
     # instances, so metric names are matched in batches of this size per
     # /api/v1/series request.
     _SERIES_BATCH = 40
+
+    # `/api/v1/series` with no start/end scans the FULL retention window and
+    # returns one JSON object per matching series — on a churning instance
+    # (pods, jobs, build ids) that is every series ever seen, not the live ones,
+    # so the response can be orders of magnitude larger than the live label set
+    # it is being read for. We only need which label KEYS a metric currently
+    # carries, so discovery is bounded to a recent window. Overridable per
+    # connection for an instance scraped less often than this.
+    _DISCOVERY_LOOKBACK_S = 3600
+
+    # Hard ceiling on series returned per discovery request, so one
+    # high-cardinality metric cannot pin the response size. Prometheus caps
+    # server-side (2.45+/3.x); older servers ignore it and stay bounded by the
+    # lookback window alone.
+    _SERIES_LIMIT = 5000
 
     def __init__(
         self,
@@ -61,6 +103,7 @@ class PrometheusClient(DataSourceClient):
         verify_ssl: bool = True,
         org_id: Optional[str] = None,
         metric_prefix: Optional[str] = None,
+        discovery_lookback_hours: Optional[float] = None,
         timeout: int = 30,
     ):
         self.base_url = (base_url or "").rstrip("/")
@@ -70,7 +113,29 @@ class PrometheusClient(DataSourceClient):
         self.verify_ssl = verify_ssl
         self.org_id = org_id
         self.metric_prefix = (metric_prefix or "").strip() or None
-        self.timeout = timeout
+        # Optional numeric config arrives from the connect form as a STRING —
+        # and as "" when the admin leaves the field blank, which `requests`
+        # rejects with "Timeout value connect was , but it must be an int,
+        # float or None". Coerce both here so a blank field means "default".
+        self.timeout = self._as_number(timeout, int, 30)
+        hours = self._as_number(discovery_lookback_hours, float, 0)
+        self.discovery_lookback_s = (
+            int(hours * 3600) if hours and hours > 0 else self._DISCOVERY_LOOKBACK_S
+        )
+
+    @staticmethod
+    def _as_number(value, cast, default):
+        """Cast an optional config value, falling back on blank/garbage input."""
+        if value is None:
+            return default
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return default
+        try:
+            return cast(value)
+        except (TypeError, ValueError):
+            return default
 
     # ── HTTP plumbing ────────────────────────────────────────────────────────
 
@@ -154,19 +219,58 @@ class PrometheusClient(DataSourceClient):
                     out[name] = entries[0]
         return out
 
+    @staticmethod
+    def _metadata_for(metadata: Dict[str, dict], name: str) -> dict:
+        """Metadata for one series name, resolving histogram/summary components.
+
+        Exact name first. Failing that, a `_bucket`/`_sum`/`_count` series is
+        looked up under its base name and re-typed for what that component
+        actually is (see _COMPONENT_SUFFIX_TYPE) — the base entry says
+        `histogram`, but only `_bucket` is the histogram body; `_sum`/`_count`
+        are counters. `help` and `unit` carry over from the base metric, which
+        is exactly what they describe.
+        """
+        meta = metadata.get(name)
+        if meta:
+            return meta
+        for suffix, component_type in _COMPONENT_SUFFIX_TYPE.items():
+            if not name.endswith(suffix):
+                continue
+            base = metadata.get(name[: -len(suffix)])
+            if not base:
+                continue
+            base_type = (base.get("type") or "").lower()
+            # Only re-type when the base really is a histogram/summary; a plain
+            # counter that happens to end in `_count` keeps its own type.
+            if base_type not in ("histogram", "summary"):
+                return base
+            return {**base, "type": component_type}
+        return {}
+
     def _labels_for(self, session: requests.Session, names: List[str]) -> Dict[str, set]:
         """Map each metric name to the set of label keys seen on its series.
 
         Uses ``/api/v1/series`` with one ``match[]=<metric>`` selector per name,
         batched to keep each request bounded. ``__name__`` is dropped from the
         label set (it is the metric/table name itself).
+
+        Every request is bounded by ``start``/``end`` (a recent window) and a
+        ``limit`` — without them Prometheus scans the whole retention period and
+        materialises one object per series ever seen, which on a churning
+        instance dwarfs the live label set this is actually reading.
         """
         labels: Dict[str, set] = {n: set() for n in names}
+        now = int(time.time())
+        window = [
+            ("start", str(now - self.discovery_lookback_s)),
+            ("end", str(now)),
+            ("limit", str(self._SERIES_LIMIT)),
+        ]
         for i in range(0, len(names), self._SERIES_BATCH):
             batch = names[i : i + self._SERIES_BATCH]
             series = self._api(
                 session, "/api/v1/series",
-                params=[("match[]", n) for n in batch], method="POST",
+                params=[("match[]", n) for n in batch] + window, method="POST",
             ) or []
             for s in series:
                 name = s.get("__name__")
@@ -201,7 +305,7 @@ class PrometheusClient(DataSourceClient):
 
             tables: List[Table] = []
             for name in names:
-                meta = metadata.get(name, {})
+                meta = self._metadata_for(metadata, name)
                 mtype = (meta.get("type") or "unknown").lower()
                 help_text = meta.get("help") or None
                 unit = meta.get("unit") or None
@@ -371,10 +475,16 @@ df = client.execute_query('sum by (job) (rate(prometheus_http_requests_total[5m]
 # Histograms: use histogram_quantile over the _bucket series
 df = client.execute_query('histogram_quantile(0.95, sum by (le) (rate(prometheus_http_request_duration_seconds_bucket[5m])))')
 
-# Range query — a time series over a window (returns one row per sample)
+# Range query — a time series over a window (returns one row per sample).
+# Compute start/end RELATIVE to now: this code is re-executed on dashboard
+# refreshes and scheduled runs, and a hard-coded date would pin every future
+# run to the same stale window.
+from datetime import datetime, timedelta, timezone
+end = datetime.now(timezone.utc)
+start = end - timedelta(hours=1)
 df = client.execute_query(
     'sum(rate(prometheus_http_requests_total[5m]))',
-    start='2024-01-01T00:00:00Z', end='2024-01-01T01:00:00Z', step='60s')
+    start=start.isoformat(), end=end.isoformat(), step='60s')
 ```
 
 ### Alerts

--- a/backend/app/schemas/data_source_registry.py
+++ b/backend/app/schemas/data_source_registry.py
@@ -1004,7 +1004,7 @@ REGISTRY: Dict[str, DataSourceRegistryEntry] = {
             },
         ),
         client_path="app.data_sources.clients.prometheus_client.PrometheusClient",
-        dev_only=True,
+        version="beta",
     ),
     "jaeger": DataSourceRegistryEntry(
         type="jaeger",

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -1630,6 +1630,18 @@ class PrometheusConfig(BaseModel):
         description="Optional prefix to bound metric discovery on large instances (e.g. 'node_' or 'http_'). Leave blank to index all metrics.",
         json_schema_extra={"ui:type": "string"},
     )
+    discovery_lookback_hours: Optional[float] = Field(
+        None,
+        title="Discovery Lookback (hours)",
+        description="How far back schema discovery looks for a metric's labels. Defaults to 1 hour, which keeps indexing cheap on high-churn instances. Raise it only if a metric is scraped less often than that and its labels are being missed.",
+        json_schema_extra={"ui:type": "number"},
+    )
+    timeout: Optional[int] = Field(
+        None,
+        title="Request Timeout (seconds)",
+        description="Per-request timeout for the Prometheus HTTP API. Defaults to 30. Raise it for a slow or heavily loaded instance.",
+        json_schema_extra={"ui:type": "number"},
+    )
 
 
 # Jaeger (distributed tracing via the Query JSON HTTP API)

--- a/backend/tests/unit/test_prometheus_client.py
+++ b/backend/tests/unit/test_prometheus_client.py
@@ -275,3 +275,160 @@ def test_registry_resolves_prometheus_client():
     from app.schemas.data_source_registry import resolve_client_class
 
     assert resolve_client_class("prometheus") is PrometheusClient
+
+
+# ---------- histogram / summary component metadata ---------- #
+
+
+def _histogram_routes():
+    """A stock Prometheus exposure: the histogram and summary appear ONLY as
+    their suffixed component series, while /api/v1/metadata carries a single
+    entry under each base name (which is itself never a series)."""
+    return {
+        "/api/v1/label/__name__/values": _ok(
+            [
+                "http_request_duration_seconds_bucket",
+                "http_request_duration_seconds_sum",
+                "http_request_duration_seconds_count",
+                "gc_pause_seconds_sum",
+                "gc_pause_seconds_count",
+                "items_count",
+            ]
+        ),
+        "/api/v1/metadata": _ok(
+            {
+                "http_request_duration_seconds": [
+                    {"type": "histogram", "help": "Latency of HTTP requests.", "unit": "seconds"}
+                ],
+                "gc_pause_seconds": [{"type": "summary", "help": "GC pauses.", "unit": ""}],
+                # A plain gauge that merely ends in `_count` — it must keep its
+                # own type rather than being re-typed as a histogram component.
+                "items_count": [{"type": "gauge", "help": "Items in queue.", "unit": ""}],
+            }
+        ),
+        "/api/v1/series": _ok(
+            [
+                {"__name__": "http_request_duration_seconds_bucket", "handler": "/", "le": "0.1"},
+                {"__name__": "http_request_duration_seconds_sum", "handler": "/"},
+                {"__name__": "http_request_duration_seconds_count", "handler": "/"},
+                {"__name__": "gc_pause_seconds_sum", "job": "app"},
+                {"__name__": "gc_pause_seconds_count", "job": "app"},
+                {"__name__": "items_count", "queue": "inbox"},
+            ]
+        ),
+    }
+
+
+def test_histogram_components_resolve_type_from_the_base_metric(monkeypatch):
+    """`_bucket` is the histogram body; `_sum`/`_count` are counters.
+
+    /api/v1/metadata only has the base name, so an exact-name lookup leaves
+    every component `unknown` — losing the histogram_quantile hint on `_bucket`
+    and, worse, the rate() hint on `_sum`/`_count`, which are counters that
+    return meaningless monotonic totals when queried raw.
+    """
+    _install(monkeypatch, _histogram_routes())
+    by_name = {t.name: t for t in PrometheusClient(base_url="http://h:9090").get_schemas()}
+
+    bucket = by_name["http_request_duration_seconds_bucket"]
+    assert bucket.metadata_json["metric_type"] == "histogram"
+    assert bucket.columns[-1].dtype == "histogram (use histogram_quantile)"
+    # help/unit carry over from the base metric, which is what they describe.
+    assert bucket.description == "Latency of HTTP requests."
+    assert bucket.metadata_json["unit"] == "seconds"
+
+    for suffix in ("sum", "count"):
+        comp = by_name[f"http_request_duration_seconds_{suffix}"]
+        assert comp.metadata_json["metric_type"] == "counter"
+        assert comp.columns[-1].dtype == "counter (use rate/increase)"
+
+
+def test_summary_components_are_counters(monkeypatch):
+    _install(monkeypatch, _histogram_routes())
+    by_name = {t.name: t for t in PrometheusClient(base_url="http://h:9090").get_schemas()}
+    for suffix in ("sum", "count"):
+        assert by_name[f"gc_pause_seconds_{suffix}"].metadata_json["metric_type"] == "counter"
+
+
+def test_metric_whose_own_name_ends_in_count_keeps_its_type(monkeypatch):
+    """`items_count` has its own metadata entry — the suffix fallback must not
+    fire and re-type a real gauge as a histogram component."""
+    _install(monkeypatch, _histogram_routes())
+    by_name = {t.name: t for t in PrometheusClient(base_url="http://h:9090").get_schemas()}
+    assert by_name["items_count"].metadata_json["metric_type"] == "gauge"
+
+
+def test_unknown_component_without_base_metadata_stays_unknown(monkeypatch):
+    routes = _histogram_routes()
+    routes["/api/v1/metadata"] = _ok({})
+    _install(monkeypatch, routes)
+    by_name = {t.name: t for t in PrometheusClient(base_url="http://h:9090").get_schemas()}
+    assert by_name["http_request_duration_seconds_bucket"].metadata_json["metric_type"] == "unknown"
+
+
+# ---------- bounded discovery ---------- #
+
+
+def test_series_discovery_is_bounded_by_window_and_limit(monkeypatch):
+    """An unbounded /api/v1/series scans the whole retention window and returns
+    one object per series ever seen. Discovery only needs the live label keys,
+    so every request carries start/end and a limit."""
+    session = _install(monkeypatch, _schema_routes())
+    PrometheusClient(base_url="http://h:9090").get_schemas()
+
+    series_calls = [c for c in session.calls if "/api/v1/series" in c[1]]
+    assert series_calls, "expected at least one /series call"
+    for _method, _url, data in series_calls:
+        keys = dict(data)
+        assert "start" in keys and "end" in keys, "series discovery must be time-bounded"
+        assert int(keys["end"]) - int(keys["start"]) == 3600
+        assert keys["limit"] == "5000"
+
+
+def test_discovery_lookback_is_configurable(monkeypatch):
+    session = _install(monkeypatch, _schema_routes())
+    PrometheusClient(base_url="http://h:9090", discovery_lookback_hours=6).get_schemas()
+    data = dict([c for c in session.calls if "/api/v1/series" in c[1]][0][2])
+    assert int(data["end"]) - int(data["start"]) == 6 * 3600
+
+
+def test_blank_lookback_falls_back_to_the_default(monkeypatch):
+    session = _install(monkeypatch, _schema_routes())
+    PrometheusClient(base_url="http://h:9090", discovery_lookback_hours=None).get_schemas()
+    data = dict([c for c in session.calls if "/api/v1/series" in c[1]][0][2])
+    assert int(data["end"]) - int(data["start"]) == 3600
+
+
+def test_prometheus_is_no_longer_dev_only():
+    """The connector is catalog-visible outside dev environments."""
+    from app.schemas.data_source_registry import REGISTRY
+
+    entry = REGISTRY["prometheus"]
+    assert entry.dev_only is False
+    assert entry.version == "beta"
+
+
+# ---------- optional numeric config from the connect form ---------- #
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None])
+def test_blank_numeric_config_falls_back_to_defaults(blank):
+    """The connect form submits optional number fields as strings, and as ""
+    when left blank — which `requests` rejects with "Timeout value connect was
+    , but it must be an int, float or None", failing schema indexing with a 500
+    even though Test-connection passed."""
+    c = PrometheusClient(base_url="http://h:9090", timeout=blank, discovery_lookback_hours=blank)
+    assert c.timeout == 30
+    assert c.discovery_lookback_s == 3600
+
+
+def test_numeric_config_accepts_form_strings():
+    c = PrometheusClient(base_url="http://h:9090", timeout="45", discovery_lookback_hours="2.5")
+    assert c.timeout == 45
+    assert c.discovery_lookback_s == 9000
+
+
+def test_garbage_numeric_config_does_not_break_the_client():
+    c = PrometheusClient(base_url="http://h:9090", timeout="soon", discovery_lookback_hours="lots")
+    assert c.timeout == 30
+    assert c.discovery_lookback_s == 3600

--- a/docs/feedback-loops/prometheus-connector.md
+++ b/docs/feedback-loops/prometheus-connector.md
@@ -4,7 +4,8 @@ Adds a **Prometheus** data source connector: a `DataSourceClient` subclass that
 speaks the Prometheus HTTP API (`/api/v1/query`, `/api/v1/query_range`,
 `/api/v1/label/__name__/values`, `/api/v1/metadata`, `/api/v1/series`) using
 plain `requests`, with Pydantic config/credentials schemas and a `REGISTRY`
-entry (beta, `dev_only` while incubating). Prometheus is queried with **PromQL**,
+entry (beta, catalog-visible in every environment since the promotion below).
+Prometheus is queried with **PromQL**,
 not SQL — the closest existing reference is `posthog_client.py` (HTTP API + a
 non-SQL query language + a discovered catalog), *not* `postgresql_client.py`.
 
@@ -14,11 +15,44 @@ non-SQL query language + a discovered catalog), *not* `postgresql_client.py`.
 |-------|------|--------|
 | Client | `backend/app/data_sources/clients/prometheus_client.py` | New `PrometheusClient(DataSourceClient)` |
 | Config | `backend/app/schemas/data_sources/configs.py` | `PrometheusConfig`, `PrometheusNoAuthCredentials`, `PrometheusBasicCredentials`, `PrometheusBearerCredentials` |
-| Registry | `backend/app/schemas/data_source_registry.py` | `"prometheus"` entry: explicit `client_path`, `data_shape="tables"`, `version="beta"`, `dev_only=True` |
+| Registry | `backend/app/schemas/data_source_registry.py` | `"prometheus"` entry: explicit `client_path`, `data_shape="tables"`, `version="beta"` |
 | Driver | — | none: plain `requests` (already a dependency), no Dockerfile change |
 | Icon | `frontend/public/data_sources_icons/prometheus.png` | Prometheus flame mark |
 | Unit tests | `backend/tests/unit/test_prometheus_client.py` | 12 tests, `requests` boundary faked |
 | Demo stack | `docs/feedback-loops/assets/prometheus-stack/` | compose: Prometheus + Alertmanager + node-exporter + alert/recording rules |
+
+## Promotion out of `dev_only` (validated against a live stack)
+
+The connector shipped behind `dev_only=True` while incubating, which hid it from
+the connector catalog outside dev. It was promoted after a full sandbox re-run
+against a live Prometheus 3.14.0 (673 metrics, 2156 series, 9 firing alerts),
+which also surfaced three defects worth fixing first:
+
+- **Histogram/summary components were never typed.** `/api/v1/metadata` only
+  carries an entry under a histogram's BASE name, which is itself never a series
+  and so never appears in `/api/v1/label/__name__/values`. Looking metadata up by
+  the exact series name left every `_bucket`/`_sum`/`_count` as `unknown` —
+  **177 of 673 metrics (26%) on this stock instance, with `histogram` never
+  assigned to anything**. `_metadata_for()` now falls back to the base name and
+  re-types per suffix: `_bucket` → `histogram`, `_sum`/`_count` → `counter`
+  (they are counters; queried raw they return meaningless monotonic totals). A
+  metric with its own metadata that merely ends in `_count` keeps its own type.
+  After the fix: **unknown 177 → 48, histogram 0 → 31, counter 220 → 318**. The
+  48 that remain are genuinely untyped at the source — synthetic series
+  (`ALERTS`, recording rules) plus node_exporter metrics that declare
+  `"type": "unknown"` themselves.
+- **Schema discovery was unbounded.** `/api/v1/series` with no `start`/`end`
+  scans the whole retention window and returns one object per series *ever*
+  seen. Measured on this stack after 400 short-lived targets were removed:
+  **406 series / 39.1 KiB unbounded vs 6 series / 0.7 KiB over a live window —
+  58x the payload, for label keys that a bounded query answers exactly.**
+  Discovery now carries `start`/`end` (default 1h, `discovery_lookback_hours`)
+  and a `limit`.
+- **Blank optional number fields broke indexing.** The connect form submits
+  unset numeric fields as `""`, which `requests` rejects with *"Timeout value
+  connect was , but it must be an int, float or None"* — Test-connection passed
+  while schema indexing failed with a 500. Numeric config is now coerced, with
+  blank/garbage falling back to the default.
 
 ## Design decisions
 


### PR DESCRIPTION
The connector shipped behind `dev_only=True` while incubating, which hid it
from the connector catalog in every non-dev environment. Validated end to end
against a live Prometheus 3.14.0 (673 metrics, 2156 series, 9 firing alerts)
driven through the real UI, which surfaced three defects fixed here first.

Histogram and summary components were never typed. /api/v1/metadata only
carries an entry under a histogram's BASE name, which is itself never a series
and so never appears in /api/v1/label/__name__/values — so an exact-name lookup
left every _bucket/_sum/_count as `unknown`: 177 of 673 metrics (26%) on a
stock instance, with `histogram` never assigned to anything. That silently
drops the two hints the planner relies on, since a counter queried without
rate() returns meaningless monotonic totals. Metadata now falls back to the
base name and re-types per suffix (_bucket -> histogram, _sum/_count ->
counter), while a metric with its own metadata that merely ends in `_count`
keeps its own type. Measured after: unknown 177 -> 48, histogram 0 -> 31,
counter 220 -> 318; the remaining 48 are untyped at the source.

Schema discovery was unbounded. /api/v1/series with no start/end scans the
whole retention window and materialises one object per series ever seen, not
the live ones it is being read for. Measured on the same stack after 400
short-lived targets were removed: 406 series / 39.1 KiB unbounded vs 6 series
/ 0.7 KiB over a live window. Discovery now carries start/end (default 1h, set
per connection with discovery_lookback_hours) and a result limit.

Blank optional number fields broke indexing. The connect form submits unset
numeric fields as "", which requests rejects with "Timeout value connect was ,
but it must be an int, float or None" — Test-connection passed while schema
indexing failed with a 500. Numeric config is coerced, blank means default.

Also adds a relative_date_hint so range queries compute start/end from now
rather than freezing a date literal that goes stale on the next dashboard
refresh, and exposes the request timeout on the connection.

13 new unit tests (25 total, all passing), plus the data-source, connection
and source-metadata-context suites (22 passing).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AgDofWQ8Y7VoguMzuc1MYk