### PR TITLE
feat(llm): enable Astra as the OpenAI default

### DIFF
--- a/backend/app/ai/llm/clients/openai_responses_client.py
+++ b/backend/app/ai/llm/clients/openai_responses_client.py
@@ -135,7 +135,7 @@ class OpenAIResponsesClient(LLMClient):
         chat_completion = self.client.chat.completions.create(
             model=model_id,
             messages=[{"role": "user", "content": self._build_chat_content(prompt, images)}],
-            temperature=temperature,
+            **({"temperature": temperature} if not model_id.startswith("gpt-6") else {}),
         )
         content = chat_completion.choices[0].message.content or ""
         usage_raw = getattr(chat_completion, "usage", None)
@@ -152,7 +152,7 @@ class OpenAIResponsesClient(LLMClient):
         stream = await self.async_client.chat.completions.create(
             model=model_id,
             messages=[{"role": "user", "content": self._build_chat_content(prompt, images)}],
-            temperature=temperature,
+            **({"temperature": temperature} if not model_id.startswith("gpt-6") else {}),
             stream=True,
             stream_options={"include_usage": True},
         )
@@ -316,7 +316,7 @@ class OpenAIResponsesClient(LLMClient):
         # The Responses path historically sends no temperature (reasoning models
         # reject it); only an explicit admin-configured value is forwarded, and
         # not to reasoning models, which 400 on any sampling parameter.
-        if self.temperature is not None and not model_id.startswith(("o1", "o3", "o4", "gpt-5")):
+        if self.temperature is not None and not model_id.startswith(("o1", "o3", "o4", "gpt-5", "gpt-6")):
             request_kwargs["temperature"] = self.temperature
         if system:
             request_kwargs["instructions"] = system
@@ -343,7 +343,7 @@ class OpenAIResponsesClient(LLMClient):
             if tools and disable_parallel_tools:
                 request_kwargs["parallel_tool_calls"] = False
         is_reasoning_model = (
-            model_id.startswith(("o1", "o3", "o4", "gpt-5"))
+            model_id.startswith(("o1", "o3", "o4", "gpt-5", "gpt-6"))
             or model_id in {"o1", "o3"}
         )
         if thinking and is_reasoning_model:

--- a/backend/app/ai/llm/llm.py
+++ b/backend/app/ai/llm/llm.py
@@ -267,13 +267,15 @@ class LLM:
         custom_headers = build_provider_headers(additional_config) or None
         if self.provider == "openai":
             base_url = additional_config.get("base_url")
-            if base_url:
+            if base_url and not self.model_id.startswith("gpt-6"):
                 # Custom base URL on openai provider → use Chat Completions (compatible endpoint)
                 self.client = OpenAi(api_key=self.api_key, base_url=base_url, temperature=configured_temperature, default_headers=custom_headers)
             else:
-                # Default OpenAI → Responses API (supports reasoning content)
+                # Native OpenAI and GPT-6 (including gateways) use Responses;
+                # GPT-6 tool calling is not supported on Chat Completions.
                 self.client = OpenAIResponsesClient(
                     api_key=self.api_key,
+                    base_url=base_url,
                     enable_web_search=enable_web_search,
                     temperature=configured_temperature,
                     default_headers=custom_headers,

--- a/backend/app/models/llm_model.py
+++ b/backend/app/models/llm_model.py
@@ -15,6 +15,20 @@ DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW = 200_000
 
 LLM_MODEL_DETAILS = [
     {
+        # https://developers.openai.com/api/docs/models/gpt-6-astra
+        "name": "GPT-6 Astra",
+        "model_id": "gpt-6-astra",
+        "provider_type": "openai",
+        "is_preset": True,
+        "is_enabled": True,
+        "is_default": True,
+        "supports_vision": True,
+        "context_window_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "input_cost_per_million_tokens_usd": 10.00,
+        "output_cost_per_million_tokens_usd": 50.00
+    },
+    {
         "name": "GPT-5.6 Sol",
         "model_id": "gpt-5.6-sol",
         "provider_type": "openai",
@@ -33,7 +47,7 @@ LLM_MODEL_DETAILS = [
         "provider_type": "openai",
         "is_preset": True,
         "is_enabled": True,
-        "is_default": True,
+        "is_default": False,
         "supports_vision": True,
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000,

--- a/backend/tests/integrations/astra_smoke.py
+++ b/backend/tests/integrations/astra_smoke.py
@@ -1,0 +1,50 @@
+"""Run from backend: PYTHONPATH=. python tests/integrations/astra_smoke.py.
+
+Uses OPENAI_API_KEY from the environment, or a non-echoing terminal prompt.
+Only synthetic prompts are sent. Never prints credentials or raw API errors.
+"""
+import asyncio
+import getpass
+import os
+
+from app.ai.llm.clients.openai_responses_client import OpenAIResponsesClient
+from app.ai.llm.types import Message, TextDeltaEvent, ToolSpec, ToolUseCompleteEvent
+
+
+async def main():
+    key = os.environ.get('OPENAI_API_KEY') or getpass.getpass('OpenAI API key: ')
+    client = OpenAIResponsesClient(api_key=key, temperature=0.7)
+    client.client = client.client.with_options(timeout=60, max_retries=0)
+    client.async_client = client.async_client.with_options(timeout=60, max_retries=0)
+    model = 'gpt-6-astra'
+    try:
+        result = await asyncio.to_thread(client.inference, model, 'Reply with OK only.')
+        assert result.text.strip()
+        print('PASS plain inference', flush=True)
+        text = ''.join([chunk async for chunk in client.inference_stream(model, 'Reply with OK only.')])
+        assert text.strip()
+        print('PASS streaming inference (connection-test path)', flush=True)
+        messages = [Message(role='user', content='Call lookup_code to retrieve the code, then report it. Do not guess.')]
+        tools = [ToolSpec(name='lookup_code', description='Return the verification code.', input_schema={'type':'object','properties':{},'required':[], 'additionalProperties':False})]
+        events = [event async for event in client.inference_stream_v2(model, messages, tools=tools, thinking={'type':'adaptive'})]
+        calls = [event for event in events if isinstance(event, ToolUseCompleteEvent)]
+        assert calls, 'No tool call received'
+        call = calls[0]
+        messages.extend([
+            Message(role='assistant', content=[{'type':'tool_use','id':call.id,'name':call.name,'input':call.input}]),
+            Message(role='user', content=[{'type':'tool_result','tool_use_id':call.id,'content':'ASTRA-7391'}]),
+        ])
+        events = [event async for event in client.inference_stream_v2(model, messages, tools=tools, thinking={'type':'adaptive'})]
+        answer = ''.join(event.text for event in events if isinstance(event, TextDeltaEvent))
+        assert 'ASTRA-7391' in answer
+        print('PASS Responses reasoning + tool-result round trip', flush=True)
+    except Exception as exc:
+        print(f'FAIL {type(exc).__name__}; status={getattr(exc, "status_code", None)}; code={getattr(exc, "code", None)}', flush=True)
+        raise SystemExit(1) from None
+    finally:
+        await client.async_client.close()
+        client.client.close()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/backend/tests/unit/test_openai_reasoning_requests.py
+++ b/backend/tests/unit/test_openai_reasoning_requests.py
@@ -1,0 +1,60 @@
+"""Reasoning models must receive supported parameters on every inference path."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.ai.llm.clients.openai_responses_client import OpenAIResponsesClient
+from app.ai.llm.types import Message
+
+
+async def empty_stream():
+    if False:
+        yield
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('model_id', ['gpt-6-astra', 'gpt-6-astra-2026-09-05'])
+@pytest.mark.parametrize('temperature', [None, 0, 0.7])
+@pytest.mark.parametrize('path', ['sync', 'stream', 'tools'])
+async def test_reasoning_requests_omit_sampling_and_honor_thinking(model_id, temperature, path):
+    client = OpenAIResponsesClient(api_key='test-key', temperature=temperature)
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='ok'))])
+    sync_create = Mock(return_value=response)
+    async_create = AsyncMock(side_effect=lambda **kw: empty_stream())
+    client.client.chat.completions.create = sync_create
+    client.async_client.chat.completions.create = async_create
+    client.async_client.responses.create = async_create
+    if path == 'sync':
+        assert client.inference(model_id, 'hello').text
+        params = sync_create.call_args.kwargs
+    elif path == 'stream':
+        async for _ in client.inference_stream(model_id, 'hello'):
+            pass
+        params = async_create.call_args.kwargs
+    else:
+        async for _ in client.inference_stream_v2(
+            model_id, [Message(role='user', content='hello')],
+            thinking={'type': 'adaptive'},
+        ):
+            pass
+        params = async_create.call_args.kwargs
+        assert params['reasoning']['effort'] in {'low', 'medium', 'high', 'xhigh', 'max'}
+    assert 'temperature' not in params
+    await client.async_client.close()
+    client.client.close()
+
+
+@pytest.mark.parametrize('base_url', [None, 'https://gateway.example/v1'])
+def test_astra_openai_provider_uses_responses_with_configured_endpoint(base_url):
+    from app.ai.llm.llm import LLM
+
+    # Only the provider configuration is needed; no database operations occur.
+    provider = SimpleNamespace(
+        provider_type='openai', additional_config={'base_url': base_url},
+        decrypt_credentials=lambda: ('test-key', ''),
+    )
+    model = SimpleNamespace(model_id='gpt-6-astra', provider=provider, config={})
+    llm = LLM(model)
+    assert isinstance(llm.client, OpenAIResponsesClient)
+    assert str(llm.client.client.base_url).rstrip('/') == (base_url or 'https://api.openai.com/v1')

--- a/docs/feedback-loops/astra-model.md
+++ b/docs/feedback-loops/astra-model.md
@@ -1,0 +1,94 @@
+# Feedback Loop — Enable GPT-6 Astra
+
+Add Astra as the OpenAI default model and verify all three inference surfaces
+with the existing SDK. GPT-5.6 Luna remains the small-default model.
+
+## Root cause (validated)
+
+Before this change, `backend/app/ai/llm/clients/openai_responses_client.py:133`
+and `:148` always sent temperature on Chat Completions, including Astra, which
+rejects sampling parameters. The Responses checks at `:319` and `:345` only
+recognized GPT-5 and o-series, so configured temperature leaked into Astra
+requests and requested thinking settings were ignored.
+`backend/app/ai/llm/llm.py:270` routed every OpenAI base URL override to Chat
+Completions, although Astra tool calling requires Responses.
+
+## Loop A — deterministic reproduction
+
+From `backend`, with Python 3.12 and the backend dependencies installed:
+
+```sh
+BOW_DATABASE_URL=sqlite:///db/app.db TESTING=true PYTHONPATH=. python -m pytest \
+  --confcutdir=tests/unit tests/unit/test_openai_reasoning_requests.py -q
+```
+
+The original client failed all 18 request-parameter cases: unexpected temperature
+on sync/streaming requests and missing reasoning on Responses requests. After
+the fix, all 18 pass. Two additional routing cases verify native and overridden
+OpenAI endpoints select Responses and preserve the endpoint. The dated ID in the
+unit test is a synthetic compatibility case, not an advertised model snapshot.
+
+Broader focused verification:
+
+```sh
+BOW_DATABASE_URL=sqlite:///db/app.db TESTING=true PYTHONPATH=. python -m pytest \
+  --confcutdir=tests/unit \
+  tests/unit/test_openai_reasoning_requests.py \
+  tests/unit/test_openai_client_temperature.py \
+  tests/unit/test_llm_test_connection_schema.py \
+  tests/unit/test_openai_family_image_attach.py \
+  tests/unit/test_openai_tool_call_ids.py -q
+```
+
+Observed: **56 passed**, with existing deprecation warnings. SDK boundaries are
+stubbed; the tests call the public inference methods. No database is needed.
+Catalog validation also passed: 17 unique model IDs, positive prices, and no
+provider with multiple default or small-default flags.
+
+## Loop B — live confirmation
+
+```sh
+BOW_DATABASE_URL=sqlite:///db/app.db TESTING=true PYTHONPATH=. \
+  python tests/integrations/astra_smoke.py
+```
+
+Supply `OPENAI_API_KEY` through the environment, or use the script's non-echoing
+terminal prompt. Never put a key in this document or committed configuration.
+The script sends synthetic prompts and uses a configured temperature override
+to verify it is suppressed. Observed on 2026-09-05 against api.openai.com:
+
+```text
+PASS plain inference
+PASS streaming inference (connection-test path)
+PASS Responses reasoning + tool-result round trip
+```
+
+The tool loop retrieves a synthetic code through a function call, replays its
+result through the application's message translator, and verifies the final
+answer contains that code. Live gateway behavior was not tested.
+
+## The fix
+
+- Catalog: `gpt-6-astra`, text/image input, 1,050,000 context, 128,000 max output,
+  Standard base prices $10 input / $50 output per million tokens.
+- GPT-6 requests omit temperature on all three inference paths; Responses honors
+  the existing low/medium/high thinking mapping.
+- OpenAI providers using GPT-6 select Responses even with a base URL override.
+- `llm_service.py` already syncs catalog additions on model listing; no migration
+  or service change is required.
+
+Sources checked before implementation:
+[model specification and pricing](https://developers.openai.com/api/docs/models/gpt-6-astra),
+[migration requirements](https://developers.openai.com/api/docs/guides/latest-model).
+
+## Limits of verification
+
+The live calls verify the client and API access, not a full browser flow or a
+persisted console usage row. The full-stack boot was attempted but dependency
+installation failed on network/DNS access to files.pythonhosted.org. Tests used
+the existing local Python environment with the worktree on PYTHONPATH.
+
+Catalog costs remain base-rate estimates under the existing accounting model;
+this change does not implement Astra's cache-write pricing or the multipliers
+for prompts over 272K input tokens. Async tools and mid-turn steering are outside
+this enablement change.


### PR DESCRIPTION
Enable GPT-6 Astra and make it the OpenAI catalog default, retaining Luna as the small-model default.
The client previously sent unsupported temperature parameters to Astra and omitted its requested reasoning settings; OpenAI gateway overrides also selected Chat Completions for tool calls.

## Customer impact

OpenAI users can select Astra and run prompts and tool-assisted analysis. Managed OpenAI providers move from Terra to Astra through the existing catalog sync when that provider owns the default. Customer-managed providers retain their chosen default under the existing sync policy. Astra has higher base token prices ($10 input / $50 output per million), so this is an intentional quality/cost default change.

## Before / after

| Product journey | Before | After |
|---|---|---|
| OpenAI catalog default | Terra | Astra |
| Astra connection test | Unsupported temperature sent | Temperature omitted |
| Astra tool-assisted analysis | Reasoning settings ignored; gateway tool route incompatible | Thinking settings honored; Responses route selected |

```mermaid
flowchart LR
  A[OpenAI Astra request] --> B{Client behavior}
  B --> C[Before: temperature / Chat tool route]
  B --> D[After: omit temperature / Responses tools]
  C --> E[Rejected or ignored settings]
  D --> F[Text and tool-result round trip]
  style C fill:#ffdddd,stroke:#cc0000
  style E fill:#ffdddd,stroke:#cc0000
  style D fill:#ddffdd,stroke:#008800
  style F fill:#ddffdd,stroke:#008800
```

## Reviewer decision

| Item | Assessment |
|---|---|
| Risk | Intentional default and cost change; GPT-6 OpenAI gateway endpoints must support Responses |
| Blast radius | OpenAI catalog sync and GPT-6 inference paths; no schema migration |
| Intended behavior | Astra becomes the OpenAI default; Luna remains small-default |
| Verified | 56 focused tests, catalog invariants, three live API paths, diff whitespace check |
| Not verified | Full browser flow, persisted console usage row, real gateway endpoint; CI and automated review pending |
| Look first | `backend/app/models/llm_model.py`, `backend/app/ai/llm/clients/openai_responses_client.py`, `backend/app/ai/llm/llm.py` |

## Evidence

| Check | Observed result |
|---|---|
| Original-code reproduction | 18/18 request-parameter cases fail for temperature or missing reasoning |
| Focused unit suite after fixes | 56 passed, 0 failed |
| Catalog validation after default change | Exactly one OpenAI default (Astra), Luna small-default; provider default uniqueness passes |
| Live plain inference | PASS |
| Live streaming / connection-test client path | PASS |
| Live Responses thinking + function result replay | PASS |
| Full-stack boot | Blocked at dependency download by network/DNS failure; UI not tested |
| Failures attributable to final change | None observed in the checks above; broader application behavior not claimed verified |

Live calls used synthetic prompts and a non-echoing key prompt; credentials are absent from committed files. The smoke script intentionally configures temperature to confirm the client suppresses it.

## Context map

- Commit `0fbe0eb4`: catalog/default change, client compatibility, regression coverage and reproducible verification.
- `backend/app/models/llm_model.py`: catalog ID, vision/context/output metadata and base pricing.
- `backend/app/ai/llm/clients/openai_responses_client.py`: supported request parameters across sync, streaming and Responses inference.
- `backend/app/ai/llm/llm.py`: GPT-6 OpenAI providers keep Responses routing with custom base URLs.
- `backend/app/services/llm_service.py`: existing sync behavior; unchanged.
- `backend/tests/unit/test_openai_reasoning_requests.py`: request contract and endpoint selection coverage.
- `backend/tests/integrations/astra_smoke.py`: rerunnable live verification.
- `docs/feedback-loops/astra-model.md`: commands, observed before/after results and limitations.
- Related issue: none; requested directly by the maintainer.

## Scope and follow-ups

Provider-specific compatibility stays in the LLM client rather than planner code. Existing reasoning budget mapping remains low/medium/high; async tools and mid-turn steering are not introduced. Base catalog prices do not implement cache-write billing or the >272K input-token multipliers in the existing usage accounting model. No UI source files changed.

Sources: [official model specification/pricing](https://developers.openai.com/api/docs/models/gpt-6-astra), [official migration guide](https://developers.openai.com/api/docs/guides/latest-model).

Automated review: pending initial review; no review completion claimed.
