### PR TITLE
Fix wizard table step layout to fill parent height

### DIFF
--- a/docs/feedback-loops/wizard-visual-expansion.md
+++ b/docs/feedback-loops/wizard-visual-expansion.md
@@ -12,7 +12,7 @@ The reported wizard expansion put the diagram behind the modal overlay. Table an
 
 ## Fix
 
-The wizard grows to 1152px on the table step and nearly the viewport width when expanded. Its selector stays inside the same modal. The wizard keeps its own Save & Continue and Cancel controls and reserves space for them below the canvas. Dropdown Escape closes the dropdown first; a subsequent Escape inside the selector exits expansion.
+The wizard keeps one width (768px) on every step and grows to nearly the viewport width only when expanded; a per-step width made the table step read as a different dialog, and its header, stepper and hint were laid out for the narrow width. The table step is a fixed-height flex column (`fill` on `AgentKnowledgeTabs`, `TablesSelector` and `TablesCanvas`), so the list or diagram grows into the remaining height and the Save & Continue and Cancel controls stay at the bottom. The canvas no longer measures the window in that mode: inside a centered modal a taller canvas re-centered the modal, moved the canvas up, and measured taller again until the title scrolled out of view. The modal's vertical margin is also reduced to `sm:my-4` so the viewport-capped body fits without an outer scroll. Its selector stays inside the same modal. Dropdown Escape closes the dropdown first; a subsequent Escape inside the selector exits expansion.
 
 Cards use shared 360×224 geometry for rendering, layout and viewport fitting. The initial minimum zoom is reduced to keep wider neighboring cards in view. Table and source names each allow two lines; the full table name remains available in its title. Selected connection chips also allow longer names. Primary actions precede Cancel on the physical left, including Hebrew.
 

--- a/frontend/components/NewAgentWizardModal.vue
+++ b/frontend/components/NewAgentWizardModal.vue
@@ -1,6 +1,10 @@
 <template>
-  <UModal v-model="isOpen" :transition="false" :ui="{ width: expanded ? 'sm:max-w-[calc(100vw-2rem)]' : step === 'schema' ? 'sm:max-w-6xl' : 'sm:max-w-3xl' }" :prevent-close="step !== 'connect'">
-    <div class="p-5 max-h-[calc(100dvh-2rem)] overflow-y-auto" data-testid="new-agent-wizard">
+  <!-- One width for every step; the table step gets room through the canvas's
+       own expand control, which widens the whole modal in place. The table
+       step is a fixed-height column so the list or diagram fills it instead
+       of pushing the header off screen. -->
+  <UModal v-model="isOpen" :transition="false" :ui="{ width: expanded ? 'sm:max-w-[calc(100vw-2rem)]' : 'sm:max-w-3xl', margin: 'sm:my-4' }" :prevent-close="step !== 'connect'">
+    <div class="p-5 overflow-y-auto" :class="step === 'schema' ? 'h-[calc(100dvh-2rem)] flex flex-col' : 'max-h-[calc(100dvh-2rem)]'" data-testid="new-agent-wizard">
       <!-- Header -->
       <div v-show="!expanded" class="flex items-center justify-between mb-1">
         <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Create Data Agent</h3>
@@ -137,10 +141,9 @@
       </div>
 
       <!-- ── Step 2: Configure knowledge (tables / files / tools) ──── -->
-      <div v-else-if="step === 'schema'">
-        <p v-show="!expanded" class="text-sm text-gray-500 dark:text-gray-400 text-center mb-4">Pick tables for databases, review the file scope for directories — each source its own way.</p>
-        <div class="bg-white dark:bg-gray-900 rounded-lg">
-          <AgentKnowledgeTabs :ds-id="dsId" fullscreen-in-place continue-label="Save & Continue" @fullscreen-change="expanded = $event" @saved="expanded = false; step = 'context'">
+      <div v-else-if="step === 'schema'" class="flex-1 min-h-0 flex flex-col">
+        <div class="flex-1 min-h-0 flex flex-col bg-white dark:bg-gray-900 rounded-lg">
+          <AgentKnowledgeTabs :ds-id="dsId" fill fullscreen-in-place continue-label="Save & Continue" @fullscreen-change="expanded = $event" @saved="expanded = false; step = 'context'">
             <template #continue-actions><button type="button" class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400" @click="isOpen = false">{{ $t('common.cancel') }}</button></template>
           </AgentKnowledgeTabs>
         </div>

--- a/frontend/components/datasources/AgentKnowledgeTabs.vue
+++ b/frontend/components/datasources/AgentKnowledgeTabs.vue
@@ -1,27 +1,27 @@
 <template>
-  <div>
+  <div :class="fill ? 'flex-1 min-h-0 flex flex-col' : ''">
     <div v-if="!ready" class="py-10 text-center text-gray-400 text-sm">Loading…</div>
-    <div v-else>
+    <div v-else :class="fill ? 'flex-1 min-h-0 flex flex-col' : ''">
       <!-- Category tabs — only the ones this agent has (Files always available). -->
-      <div v-if="tabs.length > 1" class="flex gap-1 border-b border-gray-200 dark:border-gray-700 mb-4">
+      <div v-if="tabs.length > 1" class="shrink-0 flex gap-1 border-b border-gray-200 dark:border-gray-700 mb-4">
         <button v-for="tab in tabs" :key="tab.key" type="button"
           class="px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors"
           :class="active === tab.key ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'"
           @click="active = tab.key">{{ tab.label }}</button>
       </div>
 
-      <div v-show="active === 'tables'" class="bg-white dark:bg-gray-900 rounded-lg">
+      <div v-show="active === 'tables'" class="bg-white dark:bg-gray-900 rounded-lg" :class="fill ? 'flex-1 min-h-0 flex flex-col' : ''">
         <TablesSelector ref="tablesRef" :ds-id="dsId" schema="full" :connection-filter="tableConnectionIds"
-          :fullscreen-in-place="fullscreenInPlace" @fullscreen-change="$emit('fullscreen-change', $event)" :can-update="true" :show-refresh="true" :show-save="false" :show-header="true"
+          :fill="fill" :fullscreen-in-place="fullscreenInPlace" @fullscreen-change="$emit('fullscreen-change', $event)" :can-update="true" :show-refresh="true" :show-save="false" :show-header="true"
           header-title="Select tables" header-subtitle="Choose which tables to enable. Start focused, you can always add more later."
           :show-stats="true" :skip-refresh-on-save="true" />
       </div>
 
-      <div v-show="active === 'files'" class="bg-white dark:bg-gray-900 rounded-lg px-1">
+      <div v-show="active === 'files'" class="bg-white dark:bg-gray-900 rounded-lg px-1" :class="fill ? 'flex-1 min-h-0 overflow-y-auto' : ''">
         <AgentFilesPanel :ds-id="dsId" :can-update="true" @edit-connection="(c) => $emit('edit-connection', c)" />
       </div>
 
-      <div v-show="active === 'tools'" class="bg-white dark:bg-gray-900 rounded-lg">
+      <div v-show="active === 'tools'" class="bg-white dark:bg-gray-900 rounded-lg" :class="fill ? 'flex-1 min-h-0 overflow-y-auto' : ''">
         <ToolsSelector
           :ds-id="dsId" :connections="toolConns" :can-update="true"
           @edit-connection="(c) => $emit('edit-connection', c)"
@@ -31,7 +31,7 @@
         />
       </div>
 
-      <div v-if="showContinue" class="mt-4 flex items-center gap-3 justify-start rtl:flex-row-reverse">
+      <div v-if="showContinue" class="shrink-0 mt-4 flex items-center gap-3 justify-start rtl:flex-row-reverse">
         <button type="button" :disabled="saving" @click="saveAndContinue"
           class="px-4 py-2 text-sm font-medium text-white rounded-lg bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400">
           {{ saving ? 'Saving…' : continueLabel }}
@@ -47,7 +47,9 @@ import TablesSelector from '@/components/datasources/TablesSelector.vue'
 import AgentFilesPanel from '@/components/datasources/AgentFilesPanel.vue'
 import ToolsSelector from '@/components/datasources/ToolsSelector.vue'
 
-const props = withDefaults(defineProps<{ dsId: string; fullscreenInPlace?: boolean; showContinue?: boolean; continueLabel?: string }>(), {
+// `fill`: stretch to the parent's height (a bounded flex column) and let the
+// active panel scroll or grow inside it, instead of sizing to content.
+const props = withDefaults(defineProps<{ dsId: string; fill?: boolean; fullscreenInPlace?: boolean; showContinue?: boolean; continueLabel?: string }>(), {
   showContinue: true, continueLabel: 'Save & Continue',
 })
 const emit = defineEmits(['saved', 'fullscreen-change', 'edit-connection', 'add-mcp', 'add-custom-api', 'delete-connection'])

--- a/frontend/components/datasources/TablesCanvas.vue
+++ b/frontend/components/datasources/TablesCanvas.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="canvasElement" class="relative overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-950/30" :style="{ height: `${canvasHeight}px` }" data-testid="tables-erd">
+  <div ref="canvasElement" class="relative overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-950/30" :style="fill ? undefined : { height: `${canvasHeight}px` }" data-testid="tables-erd">
     <div class="absolute top-3 start-3 end-3 z-10 flex items-start justify-between gap-2 pointer-events-none">
       <div class="flex flex-wrap items-center gap-1 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-1 shadow-sm pointer-events-auto">
         <USelectMenu v-if="canUpdate" v-model="menuSelection" :options="menuOptions" multiple searchable value-attribute="id" option-attribute="name"
@@ -83,7 +83,7 @@ import { TABLE_NODE_WIDTH, TABLE_NODE_HEIGHT, tableGraph, tableId, visibleTableI
 import TableCanvasNode from './TableCanvasNode.vue'
 import TableRecentPrompts from './TableRecentPrompts.vue'
 import DataSourceIcon from '@/components/DataSourceIcon.vue'
-const props = defineProps<{ agentId?: string; canViewPrompts?: boolean; tables: GraphTable[]; activeIds: Set<string>; matchIds: Set<string>; filtering: boolean; canUpdate: boolean; showStats: boolean; editableQueryIds?: Set<string>; fullscreen?: boolean; bottomInset?: number }>()
+const props = defineProps<{ agentId?: string; canViewPrompts?: boolean; tables: GraphTable[]; activeIds: Set<string>; matchIds: Set<string>; filtering: boolean; canUpdate: boolean; showStats: boolean; editableQueryIds?: Set<string>; fullscreen?: boolean; bottomInset?: number; fill?: boolean }>()
 const emit = defineEmits<{ toggle: [id: string, value: boolean]; editQuery: [id: string]; toggleFullscreen: []; ready: [] }>()
 const { t, locale } = useI18n()
 const flowId = `table-erd-${useId()}`
@@ -93,6 +93,11 @@ const canvasHeight = ref(460)
 const { width: canvasWidth } = useElementSize(canvasElement)
 function resizeCanvas() {
   if (!canvasElement.value) return
+  // In `fill` mode the parent's flex column decides the height. Measuring the
+  // window instead would feed back on itself inside a centered modal: a taller
+  // canvas re-centers the modal, which moves the canvas up, which measures
+  // taller again, until the modal's header scrolls out of view.
+  if (props.fill) { canvasHeight.value = canvasElement.value.clientHeight; return }
   canvasHeight.value = Math.max(320, window.innerHeight - Math.max(0, canvasElement.value.getBoundingClientRect().top) - (props.bottomInset || 72))
 }
 onMounted(() => nextTick(resizeCanvas))

--- a/frontend/components/datasources/TablesSelector.vue
+++ b/frontend/components/datasources/TablesSelector.vue
@@ -1,11 +1,11 @@
 <template>
   <Teleport to="body" :disabled="!fullscreen || fullscreenInPlace">
-  <div @keydown.esc.capture="onEmbeddedEscape" ref="selectorElement" :role="fullscreen && !fullscreenInPlace ? 'dialog' : undefined" :aria-modal="(fullscreen && !fullscreenInPlace) || undefined" :aria-label="fullscreen ? t('tableErd.erd') : undefined" tabindex="-1" class="w-full" :class="fullscreen && !fullscreenInPlace ? 'fixed inset-0 z-40 overflow-auto bg-white dark:bg-gray-900 p-4' : ''">
-    <div v-if="showHeader" class="mb-3">
+  <div @keydown.esc.capture="onEmbeddedEscape" ref="selectorElement" :role="fullscreen && !fullscreenInPlace ? 'dialog' : undefined" :aria-modal="(fullscreen && !fullscreenInPlace) || undefined" :aria-label="fullscreen ? t('tableErd.erd') : undefined" tabindex="-1" class="w-full" :class="[fullscreen && !fullscreenInPlace ? 'fixed inset-0 z-40 overflow-auto bg-white dark:bg-gray-900 p-4' : '', fill ? 'flex-1 min-h-0 flex flex-col' : '']">
+    <div v-if="showHeader" class="shrink-0 mb-3">
       <h1 class="text-lg font-semibold dark:text-white">{{ headerTitle }}</h1>
       <p class="text-gray-500 dark:text-gray-400 text-sm">{{ headerSubtitle }}</p>
     </div>
-    <div class="mb-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2" data-testid="table-view-toolbar">
+    <div class="shrink-0 mb-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2" data-testid="table-view-toolbar">
       <div class="flex items-center gap-4">
         <slot name="reload-left" />
         <div class="flex items-center gap-4" :aria-label="t('tableErd.view')" role="group">
@@ -53,7 +53,7 @@
     />
 
     <!-- Search and filters row -->
-    <div>
+    <div class="shrink-0">
       <div class="relative flex items-center gap-1.5">
         <input 
           v-model="searchInput" 
@@ -270,18 +270,18 @@
       </div>
     </div>
 
-    <div v-if="erdOpened" v-show="tableView === 'erd'" class="relative isolate" :aria-busy="!diagramReady && !catalogError">
-      <div v-if="!catalogLoaded && !catalogError" class="h-[460px]" />
+    <div v-if="erdOpened" v-show="tableView === 'erd'" class="relative isolate" :class="fill ? 'flex-1 min-h-0 flex flex-col' : ''" :aria-busy="!diagramReady && !catalogError">
+      <div v-if="!catalogLoaded && !catalogError" :class="fill ? 'flex-1 min-h-[240px]' : 'h-[460px]'" />
       <div v-if="!diagramReady && !catalogError" class="absolute inset-0 z-20 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950" role="status" :aria-label="t('tableErd.loading')" data-testid="erd-loading">
         <Spinner class="w-6 h-6 text-gray-400" aria-hidden="true" />
       </div>
       <div v-if="catalogError" class="py-4 text-xs text-gray-500" role="alert">{{ t('tableErd.loadError') }} <button class="text-blue-600 underline" @click="loadCatalog()">{{ t('tableErd.retry') }}</button></div>
-      <TablesCanvas v-if="catalogLoaded" :class="{ 'opacity-0 pointer-events-none': !diagramReady }" @ready="diagramReady = true" :agent-id="dsId" :can-view-prompts="canUpdate" :tables="catalog" :active-ids="canvasActiveIds" :match-ids="canvasMatchIds"
+      <TablesCanvas v-if="catalogLoaded" :class="[{ 'opacity-0 pointer-events-none': !diagramReady }, fill ? 'flex-1 min-h-[240px]' : '']" :fill="fill" @ready="diagramReady = true" :agent-id="dsId" :can-view-prompts="canUpdate" :tables="catalog" :active-ids="canvasActiveIds" :match-ids="canvasMatchIds"
         :filtering="hasActiveFilters" :can-update="canUpdate && !saving" :show-stats="showStats"
         :bottom-inset="fullscreenInPlace ? 120 : 72" :fullscreen="fullscreen" @toggle-fullscreen="toggleFullscreen" :editable-query-ids="editableQueryIds" @toggle="onTableToggle" @edit-query="editQueryTable" />
     </div>
 
-    <div v-show="tableView === 'table'">
+    <div v-show="tableView === 'table'" :class="fill ? 'flex-1 min-h-0 flex flex-col' : ''">
     <!-- Loading state -->
     <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400 py-10 flex items-center justify-center">
       <Spinner class="w-4 h-4 me-2" />
@@ -289,7 +289,7 @@
     </div>
 
     <!-- Tables list -->
-    <div v-else class="flex-1 flex flex-col h-full">
+    <div v-else class="flex-1 flex flex-col" :class="fill ? 'min-h-0' : 'h-full'">
       <!-- Delegated (OBO) connection, caller not signed in yet: explain instead
            of an unexplained empty list, and offer the sign-in right here. -->
       <div v-if="tables.length === 0 && connectRequiredConn" class="py-8 flex flex-col items-center gap-1.5 text-center">
@@ -318,7 +318,7 @@
         </p>
       </div>
       <div v-else-if="tables.length === 0" class="text-sm text-gray-500 dark:text-gray-400 py-4">No {{ props.itemNoun.plural }} found.</div>
-      <div v-else class="flex-1 flex flex-col min-h-full">
+      <div v-else class="flex-1 flex flex-col" :class="fill ? 'min-h-0' : 'min-h-full'">
         <!-- Admin/owner viewing the canonical catalog without a personal token:
              selection works, but queries need their own sign-in. -->
         <div v-if="connectRequiredConn" class="mt-2 flex items-center justify-between gap-3 rounded-md bg-blue-50 dark:bg-blue-500/10 px-3 py-2">
@@ -336,7 +336,7 @@
             Connect
           </button>
         </div>
-        <div class="flex-1 overflow-y-auto min-h-0 mt-2" :style="{ maxHeight }">
+        <div class="flex-1 overflow-y-auto min-h-0 mt-2" :style="fill ? undefined : { maxHeight }">
           <ul class="divide-y divide-gray-100 dark:divide-gray-800">
             <li v-for="table in tables" :key="tableKey(table)" class="py-2 px-2" :data-testid="table.custom_query_id ? `cq-row-${table.name}` : undefined">
               <div class="flex items-center">
@@ -674,6 +674,10 @@ type PaginatedResponse = {
 const props = withDefaults(defineProps<{
   dsId: string;
   fullscreenInPlace?: boolean;
+  // Fill the parent's height (a bounded flex column): the list and the
+  // diagram grow into the remaining space instead of a fixed `maxHeight`
+  // or a window-measured canvas height.
+  fill?: boolean;
   schema: 'full' | 'user';
   canUpdate?: boolean;
   showRefresh?: boolean;


### PR DESCRIPTION
## Summary
Fixes the New Agent Wizard's table/schema configuration step to properly fill the modal's available height, preventing layout issues where the diagram or table list would push the header off-screen or cause unexpected scrolling behavior.

## Key Changes

- **NewAgentWizardModal.vue**: 
  - Changed modal width strategy: uses consistent `sm:max-w-3xl` width for all steps (except when expanded), removing the per-step width that made the table step appear as a different dialog
  - Made the schema step a fixed-height flex column (`h-[calc(100dvh-2rem)] flex flex-col`) so child components can fill the available space
  - Reduced modal vertical margin to `sm:my-4` to prevent outer scrolling when content fills the viewport
  - Removed the separate max-width constraint on the modal body for the schema step

- **AgentKnowledgeTabs.vue**:
  - Added `fill` prop to enable height-filling behavior in bounded flex columns
  - Applied flex layout classes to root and tab content divs when `fill` is true
  - Added `shrink-0` to tab bar and continue button to prevent them from shrinking
  - Made tab panels (`tables`, `files`, `tools`) flex containers that fill available height with appropriate overflow handling

- **TablesSelector.vue**:
  - Added `fill` prop to enable height-filling behavior
  - Applied flex layout classes to root container and table list sections when `fill` is true
  - Added `shrink-0` to header, toolbar, and search sections to prevent them from shrinking
  - Made the ERD and table view containers flex columns that fill available height
  - Removed fixed `maxHeight` style when `fill` is true, allowing the list to grow into available space

- **TablesCanvas.vue**:
  - Added `fill` prop to skip fixed height styling
  - Modified `resizeCanvas()` to measure `clientHeight` when in `fill` mode instead of calculating from window position
  - This prevents feedback loops where a taller canvas re-centers the modal, moving the canvas up, causing it to measure taller again

## Implementation Details

The fix introduces a `fill` prop pattern across multiple components that enables them to act as flex children in bounded containers. When enabled:
- Components use `flex-1 min-h-0` to fill available height while preventing flex overflow
- Fixed-height calculations and `maxHeight` styles are replaced with flex-based sizing
- Non-scrollable sections use `shrink-0` to maintain their natural height
- The canvas measurement logic adapts to avoid window-based calculations that cause layout thrashing in centered modals

https://claude.ai/code/session_01FpitMKtZFUUSyKvCqARC9J