### PR TITLE
fix(skills): correct two rule-out statements in the infrastructure RCA skill

### DIFF
--- a/backend/app/ai/skills/library/infrastructure-rca.md
+++ b/backend/app/ai/skills/library/infrastructure-rca.md
@@ -3,7 +3,7 @@ key: infrastructure-rca
 title: Infrastructure root cause analysis
 description: Use when something broke or degraded in the infrastructure — find the event, build a timeline from logs, metrics and alerts, then separate cause from symptom.
 category: general
-version: "1.0"
+version: "1.1"
 modes: [chat]
 tags: [observability, diagnostics]
 ---
@@ -93,8 +93,10 @@ sawtooth is a restart loop.
 Narrow to the smallest set of hosts, nodes, tiers or services that shows the
 problem, and check what they share — a rack, an availability zone, a version, a
 config, an upstream dependency. **What is unaffected is as informative as what
-is affected**: if only one tier degraded, everything shared by all tiers is
-ruled out.
+is affected**: if only one tier degraded, anything shared by all tiers needs
+an explanation for why it hit only one. It is not ruled out (a shared database
+can hurt one tier through a query, a lock or a pool the others never touch),
+but it is no longer sufficient on its own.
 
 Use topology rather than inference where you have it: Aria `relationships`,
 AppDynamics `service_flows`, Jaeger `dependencies`. Follow the call graph
@@ -107,9 +109,12 @@ Most infrastructure incidents are caused by a change. Look for deploys, config
 pushes, feature flags, scaling actions, certificate expiries, scheduled jobs,
 and ServiceNow change records in the window.
 
-Then rule out. A change is not the cause if it **predates the first deviation**,
-or if it landed on hosts that did **not** degrade. State the ruled-out changes —
-half the value of an RCA is the list of things it is safely not.
+Then rule out. A change is not the cause if it landed **after the first
+deviation** (allow a few minutes of slack for scrape intervals, alert
+evaluation delay and clock skew — the observed first deviation lags the real
+one), or if it landed only on hosts that did **not** degrade. State the
+ruled-out changes — half the value of an RCA is the list of things it is
+safely not.
 
 ## 6. Separate cause from symptom
 


### PR DESCRIPTION
## Summary

Two sentences in the bundled `infrastructure-rca` skill (`backend/app/ai/skills/library/infrastructure-rca.md`) stated the wrong rule. Both were reported in feedback on the playbook wording; neither is a code change.

- **Timing rule was backwards (section 5).** It said a change is not the cause if it *predates* the first deviation. A cause has to predate its effect, and the skill's own timing test in section 6 already says so. It now rules out changes that landed *after* the first deviation, with a few minutes of slack for scrape intervals, alert evaluation delay and clock skew, since the observed first deviation lags the real one.
- **Exclusion rule was too absolute (section 4).** It said that if only one tier degraded, everything shared by all tiers is ruled out. A shared database can hurt one tier through a query, a lock or a pool the others never touch. It now says a shared dependency needs an explanation for the uneven impact and is no longer sufficient on its own, matching the counter-example test in section 6.

The skill version is bumped from 1.0 to 1.1 so organizations that already installed it are offered the update in the catalog.

## Verification

- Parsed the edited file through `_parse_skill_file` from `app/ai/skills/catalog.py`: it loads, keeps key `infrastructure-rca`, category `general`, mode `chat`, and the description stays within `MAX_DESCRIPTION_LEN`. The catalog still lists all 12 library skills.
- The full `tests/unit/test_skill_catalog_library.py` suite could not run in this container because backend dependencies are not installed; CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4QndpEfkAZYFKhZfw2JS3

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4QndpEfkAZYFKhZfw2JS3)_