### PR TITLE
Scope search_instructions to the session's agents and respect manual deactivation

### DIFF
--- a/backend/alembic/versions/deact01_add_instruction_deactivated_at.py
+++ b/backend/alembic/versions/deact01_add_instruction_deactivated_at.py
@@ -1,0 +1,32 @@
+"""add deactivated_at to instructions
+
+Revision ID: deact01
+Revises: ldapsecurity01
+Create Date: 2026-09-07 00:00:00.000000
+
+status='draft' is overloaded: a new suggestion awaiting review and a published
+instruction the user switched OFF both carry it. deactivated_at durably records
+the second meaning (set on a user-driven published→draft transition, cleared on
+re-publish) so session-scoped surfaces such as search_instructions' own-drafts
+widening can keep switched-off instructions out of the agent's view.
+
+No backfill: historical rows carry no record of *why* they are draft, so they
+are left NULL (treated as awaiting review — the safe, visible default).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'deact01'
+down_revision: Union[str, None] = 'ldapsecurity01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('instructions', sa.Column('deactivated_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('instructions', 'deactivated_at')

--- a/backend/app/ai/tools/implementations/search_instructions.py
+++ b/backend/app/ai/tools/implementations/search_instructions.py
@@ -391,6 +391,10 @@ class SearchInstructionsTool(Tool):
             # edit them within the same session.
             training_build_id = runtime_ctx.get("training_build_id")
             if training_build_id and not chat_mode:
+                # effective_ds_ids, not data.data_source_ids: the build is a
+                # snapshot of the whole org's instruction set (all agents), so
+                # trusting the model-supplied filter here reopens exactly the
+                # cross-agent widening the forced scope above exists to block.
                 draft_result = await service.get_instructions(
                     db=db,
                     organization=organization,
@@ -399,7 +403,7 @@ class SearchInstructionsTool(Tool):
                     limit=window,
                     status=None,
                     categories=categories,
-                    data_source_ids=data.data_source_ids,
+                    data_source_ids=effective_ds_ids,
                     search=None,
                     include_global=True,
                     build_id=training_build_id,
@@ -419,15 +423,30 @@ class SearchInstructionsTool(Tool):
             # which read as "the instruction disappeared" to the agent that had
             # just created it. Only the author's drafts: no org-wide widening.
             if not chat_mode:
-                from sqlalchemy import select as _select, and_ as _and
+                from sqlalchemy import select as _select, and_ as _and, or_ as _or
                 from app.models.instruction import Instruction as _Instruction
+                from app.models.data_source import DataSource as _DataSource
+                conditions = [
+                    _Instruction.organization_id == organization.id,
+                    _Instruction.user_id == str(user.id),
+                    _Instruction.status == "draft",
+                    _Instruction.deleted_at.is_(None),
+                ]
+                # Author-scoping alone is not enough: the same user works
+                # across agents, and without this an unrelated agent's drafts
+                # leak into every training session. Mirror the main query's
+                # scoping — attached to one of this session's data sources, or
+                # global (no associations). None means the scope itself is
+                # unresolved (e.g. knowledge mode with no ids) — leave as-is.
+                if effective_ds_ids is not None:
+                    conditions.append(_or(
+                        _Instruction.data_sources.any(
+                            _DataSource.id.in_([str(i) for i in effective_ds_ids])
+                        ),
+                        ~_Instruction.data_sources.any(),
+                    ))
                 own_drafts = (await db.execute(
-                    _select(_Instruction).where(_and(
-                        _Instruction.organization_id == organization.id,
-                        _Instruction.user_id == str(user.id),
-                        _Instruction.status == "draft",
-                        _Instruction.deleted_at.is_(None),
-                    )).limit(window)
+                    _select(_Instruction).where(_and(*conditions)).limit(window)
                 )).unique().scalars().all()
                 if own_drafts:
                     seen_ids = {str(getattr(c, "id", None)) for c in candidates}
@@ -435,6 +454,24 @@ class SearchInstructionsTool(Tool):
                         if str(row.id) not in seen_ids:
                             candidates.append(row)
                             candidate_total += 1
+
+            # Switched-off instructions: a user deactivating an instruction
+            # moves it published→draft, which the widening branches above then
+            # re-surface — the agent presents a rule the user explicitly turned
+            # OFF as live knowledge. deactivated_at is the only marker that
+            # separates "switched off" from "awaiting review" (both are
+            # status='draft'), so drop the former across every merge path
+            # (schema objects from the build query carry the field too).
+            if not chat_mode:
+                kept = [
+                    c for c in candidates
+                    if not (
+                        getattr(c, "status", None) == "draft"
+                        and getattr(c, "deactivated_at", None)
+                    )
+                ]
+                candidate_total -= len(candidates) - len(kept)
+                candidates = kept
 
             # Drafts the reviewer already decided on are gone from every
             # build-scoped surface, but their rows survive a reject — so the

--- a/backend/app/models/instruction.py
+++ b/backend/app/models/instruction.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, Integer, Boolean, ForeignKey, Table, JSON
+from sqlalchemy import Column, String, Text, Integer, Boolean, DateTime, ForeignKey, Table, JSON
 from sqlalchemy.orm import relationship
 
 from app.models.base import BaseSchema
@@ -23,6 +23,14 @@ class Instruction(BaseSchema):
     
     # Overall status for visibility/usability
     status = Column(String(50), nullable=False, default="draft")
+
+    # 'draft' is overloaded: a new suggestion awaiting review and a published
+    # instruction the user switched OFF both carry it. This timestamp is the
+    # only durable record of the second meaning — set when a user moves
+    # published→draft, cleared on re-publish. Session-scoped surfaces (e.g.
+    # search_instructions' own-drafts widening) use it to keep switched-off
+    # instructions out of the agent's view.
+    deactivated_at = Column(DateTime, nullable=True)
     
     # Categorization
     category = Column(String(50), nullable=False, default="general")

--- a/backend/app/schemas/instruction_schema.py
+++ b/backend/app/schemas/instruction_schema.py
@@ -173,6 +173,11 @@ class InstructionSchema(InstructionBase):
     agent_execution_id: Optional[str] = None
     trigger_reason: Optional[str] = None
 
+    # When a user switched this instruction OFF (published→draft). Distinguishes
+    # a deactivated instruction from a draft awaiting review — both share
+    # status='draft'. None for never-deactivated rows.
+    deactivated_at: Optional[UTCDatetime] = None
+
     # === Build System fields ===
     current_version_id: Optional[str] = None
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -1099,6 +1099,8 @@ class InstructionService:
             db, instruction, instruction_data, current_user, organization, user_permissions
         )
 
+        status_before_edit = instruction.status
+
         # Handle the update based on type
         if update_type == "admin_edit":
             await self._handle_admin_edit(instruction, instruction_data, current_user)
@@ -1118,6 +1120,8 @@ class InstructionService:
         # edit handlers run so a kind→skill change (or a skill whose load_mode
         # was passed as 'always'/'disabled') is normalized before versioning.
         self._enforce_skill_load_mode(instruction)
+
+        self._track_manual_deactivation(instruction, status_before_edit)
 
         # Handle data source associations
         if instruction_data.data_source_ids is not None:
@@ -3138,7 +3142,9 @@ class InstructionService:
                 
                 # Update status (simplified - no dual-status handling) - CONTENT CHANGE
                 if bulk_update.status:
+                    status_before_bulk = instruction.status
                     instruction.status = bulk_update.status
+                    self._track_manual_deactivation(instruction, status_before_bulk)
                     content_modified = True
                 
                 # Update load mode - CONTENT CHANGE
@@ -3708,6 +3714,24 @@ class InstructionService:
         if instruction.user_id == current_user.id:
             return "owner_edit"
         return "no_permission"
+
+    @staticmethod
+    def _track_manual_deactivation(instruction: Instruction, status_before: Optional[str]) -> None:
+        """Record user-driven on/off transitions on the row itself.
+
+        'draft' is overloaded: a new suggestion awaiting review and a published
+        instruction the user switched OFF both carry it, and only this
+        timestamp tells them apart. published→draft stamps it; any return to
+        published clears it. Same-status updates never touch it, so editing a
+        deactivated instruction's text keeps it deactivated.
+        """
+        status_after = instruction.status
+        if status_after == status_before:
+            return
+        if status_before == "published" and status_after == "draft":
+            instruction.deactivated_at = datetime.utcnow()
+        elif status_after == "published":
+            instruction.deactivated_at = None
 
     async def _handle_admin_edit(self, instruction: Instruction, instruction_data: InstructionUpdate, admin_user: User):
         """Handle admin editing any instruction (not review)"""

--- a/backend/tests/e2e/test_search_instructions_chat_mode.py
+++ b/backend/tests/e2e/test_search_instructions_chat_mode.py
@@ -140,6 +140,118 @@ async def test_chat_mode_forces_report_scope(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_training_mode_scopes_own_drafts_to_report_agents(
+    create_user, login_user, whoami, test_client, create_data_source
+):
+    """The own-drafts widening must respect the session's agent scope.
+
+    Author-scoping alone is not enough: the same user works across agents, and
+    an unfiltered drafts query leaks e.g. a hospital agent's draft into a music
+    store training session (where a keyword hit then presents it as an existing
+    instruction)."""
+    token, uid, org_id = _new_admin(create_user, login_user, whoami)
+    ds_a = create_data_source(
+        name="ds_a", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    ds_b = create_data_source(
+        name="ds_b", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    draft = _create(
+        test_client, token, org_id,
+        text="Draft margin rule for agent A.", title="A-margins",
+        load_mode="intelligent", status="draft", data_source_ids=[ds_a["id"]],
+    )
+
+    out_b = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds_b["id"]],
+    )
+    assert out_b["success"] is True, out_b
+    assert not any(i["id"] == draft["id"] for i in out_b["instructions"]), (
+        "another agent's draft must not surface in this session"
+    )
+
+    out_a = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds_a["id"]],
+    )
+    assert any(i["id"] == draft["id"] for i in out_a["instructions"]), out_a
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_training_mode_global_drafts_stay_visible(
+    create_user, login_user, whoami, test_client, create_data_source
+):
+    """A draft with no agent association is global and must keep surfacing in
+    a scoped session (mirrors the main query's include_global semantics)."""
+    token, uid, org_id = _new_admin(create_user, login_user, whoami)
+    ds = create_data_source(
+        name="ds_scope", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    draft = _create(
+        test_client, token, org_id,
+        text="Global draft rule about margins.", title="Global-margins",
+        load_mode="intelligent", status="draft",
+    )
+
+    out = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds["id"]],
+    )
+    assert out["success"] is True, out
+    assert any(i["id"] == draft["id"] for i in out["instructions"]), out
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_training_mode_hides_user_deactivated_instructions(
+    create_user, login_user, whoami, test_client
+):
+    """A user switching an instruction OFF (published→draft) must stick.
+
+    'draft' also means "awaiting review", which the own-drafts widening
+    deliberately surfaces — so without the deactivated_at marker a switched-off
+    rule reappears in training searches and the agent presents it as live
+    knowledge. Re-publishing clears the marker and restores visibility."""
+    token, uid, org_id = _new_admin(create_user, login_user, whoami)
+    inst = _create(
+        test_client, token, org_id,
+        text="Margin rule the user will switch off.", title="Off-margins",
+        load_mode="intelligent",
+    )
+
+    def _set_status(status):
+        resp = test_client.put(
+            f"/api/instructions/{inst['id']}",
+            json={"status": status},
+            headers=_auth(token, org_id),
+        )
+        assert resp.status_code == 200, resp.json()
+        return resp.json()
+
+    # Published → visible in training search.
+    out = await _run({"query": ["margin"]}, user_id=uid, org_id=org_id, mode="training")
+    assert any(i["id"] == inst["id"] for i in out["instructions"]), out
+
+    # User switches it off: published→draft must NOT resurface via own-drafts.
+    _set_status("draft")
+    out_off = await _run({"query": ["margin"]}, user_id=uid, org_id=org_id, mode="training")
+    assert not any(i["id"] == inst["id"] for i in out_off["instructions"]), (
+        "a switched-off instruction must not surface in training searches"
+    )
+
+    # Switching it back on clears the marker and restores visibility.
+    _set_status("published")
+    out_on = await _run({"query": ["margin"]}, user_id=uid, org_id=org_id, mode="training")
+    assert any(i["id"] == inst["id"] for i in out_on["instructions"]), out_on
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_training_mode_keeps_full_text(create_user, login_user, whoami, test_client):
     token, uid, org_id = _new_admin(create_user, login_user, whoami)
     long_body = "Margin rule. " + "More margin detail. " * 30


### PR DESCRIPTION
## Problem

`search_instructions` leaked out-of-scope instructions into training sessions, and ignored a user's decision to switch an instruction off. Observed live: a duplicates-review in a Music Store training session returned 5 instructions — including a rule the user had deliberately deactivated and a draft belonging to a different agent — and the agent presented both as live knowledge in its overlap analysis.

Three distinct causes:

1. **Current-build query trusted model input.** The training-build merge passed the model-supplied `data_source_ids` instead of the server-resolved `effective_ds_ids`. Since a build snapshots the whole org's instruction set (all agents, all statuses), omitting the field surfaced everything.
2. **Own-drafts widening had no agent filter at all.** It filtered by org + author + `status='draft'` only, so the author's drafts from unrelated agents (e.g. a hospital agent's dashboards) entered every training session. Running the exact query against a dev org returned 15 drafts spanning 4 agents for a single-agent session.
3. **`draft` is overloaded.** A new suggestion awaiting review and a published instruction the user switched OFF both carry `status='draft'` (the UI maps `draft` → "Inactive"), with no field distinguishing them — so the own-drafts widening resurfaced deliberately deactivated instructions.

## Fix

- Both side paths now filter by `effective_ds_ids` (attached to one of the session's data sources, or global), mirroring the main published query's `include_global` semantics. A `None` scope (e.g. knowledge mode with no ids) keeps today's behavior.
- New nullable `instructions.deactivated_at` column (migration `deact01`): stamped on a user-driven `published→draft` transition, cleared on re-publish, in both the single and bulk update paths. Same-status edits never touch it, so editing a deactivated instruction's text keeps it off.
- `search_instructions` drops `draft` candidates carrying `deactivated_at` after all merge paths (the field is also exposed on `InstructionSchema` so build-path schema objects carry it).
- No backfill: historical rows carry no record of *why* they are draft, so they stay NULL (visible — the safe default).

Deliberately **not** included (follow-ups): the equivalent scope bypass in `read_instruction`'s draft fallback, and any UI treatment of `deactivated_at`.

## Testing

- 3 new e2e tests: cross-agent drafts stay out of a scoped training search (while same-agent drafts still surface), global drafts stay visible, and the full deactivate → hidden → re-publish → visible lifecycle.
- All instruction suites pass: 50 tests across `test_search_instructions_chat_mode.py`, `test_search_instructions_pending.py`, `test_instruction.py`.
- Verified live against a dev environment: the same 6-keyword training search that previously returned 5 hits now returns exactly the 3 in-scope, active-or-pending instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)