### PR TITLE
Add sslmode support to Postgres connector

### DIFF
--- a/backend/app/data_sources/clients/postgresql_client.py
+++ b/backend/app/data_sources/clients/postgresql_client.py
@@ -21,12 +21,13 @@ class PostgresqlClient(DataSourceClient):
     # of literal dates that go stale when saved code is re-executed.
     relative_date_hint = "Relative dates (PostgreSQL): CURRENT_DATE, CURRENT_DATE - INTERVAL '7 days', date_trunc('month', CURRENT_DATE); the clock is the DB server's."
 
-    def __init__(self, host, port, database, user, password="", schema=None):
+    def __init__(self, host, port, database, user, password="", schema=None, sslmode="prefer"):
         self.host = host
         self.port = port
         self.database = database
         self.user = user
         self.password = password
+        self.sslmode = sslmode
         # Optional schema or comma-separated list of schemas
         self.schema = schema
         self._schemas = []
@@ -54,7 +55,7 @@ class PostgresqlClient(DataSourceClient):
         """Yield a connection to a Postgres db."""
         conn = None
         try:
-            engine = get_engine(self.pg_uri)
+            engine = get_engine(self.pg_uri, connect_args={"sslmode": self.sslmode})
             conn = engine.connect()
             # Set search_path if schemas are provided
             if self._schemas:

--- a/backend/app/schemas/data_sources/configs.py
+++ b/backend/app/schemas/data_sources/configs.py
@@ -296,6 +296,12 @@ class PostgreSQLConfig(BaseModel):
         description="Optional schema or comma-separated list of schemas",
         json_schema_extra={"ui:type": "string"}
     )
+    sslmode: str = Field(
+        "prefer",
+        title="SSL Mode",
+        description="libpq sslmode: disable, allow, prefer, require, verify-ca, verify-full. Use 'require' for IAM-authenticated connections (e.g. AWS RDS), which reject unencrypted logins.",
+        json_schema_extra={"ui:type": "select", "ui:options": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]}
+    )
 
 
 # SQLite (local file database)


### PR DESCRIPTION
The Postgres data source connector has no SSL/TLS config, unlike most other connectors (e.g. SAP HANA's `encrypt`/`verify_ssl`). This blocks connecting to providers like AWS RDS that reject unencrypted IAM-authenticated logins.

Adds an `sslmode` field to `PostgreSQLConfig`, passed through as `connect_args` to the existing engine pool (same mechanism the app's own internal DB connection already uses). Defaults to `prefer` (psycopg2's own default), so existing connections are unaffected.

Tested locally against a Postgres instance configured to reject unencrypted connections (`hostssl`-only in `pg_hba.conf`) — confirmed `sslmode=require` connects successfully where a plaintext attempt is rejected, and confirmed the default `prefer` still connects fine to a normal instance.