### PR TITLE
security(snyk): document ignore for unfixable node-forge advisory

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,6 +6,26 @@
 # test suites, immutable migration history, vendored JS bundles, false-
 # positive sites in i18n keymaps, local dev helpers.
 version: v1.0.0
+# Open-source vulnerability ignores (client-side policy applied by `snyk test`).
+ignore:
+  # Improper Verification of Cryptographic Signature in node-forge (CVSS 8.7).
+  # Pulled in ONLY as a build/dev-tooling transitive:
+  #   nuxt > @nuxt/cli > listhen > node-forge
+  # listhen uses node-forge solely to mint a self-signed cert for the local
+  # `nuxt dev --https` server. node-forge is NOT part of the production runtime:
+  # `nuxt build` emits `.output/`, which the prod image runs directly, and the
+  # Nuxt CLI / listhen / node-forge never ship in that artifact. Every published
+  # node-forge version is flagged (semver: '*') and there is no upstream fix or
+  # patch available (fixedIn: []), so no upgrade can remediate it. Time-boxed so
+  # it is re-evaluated once an upstream fix lands or the dep chain drops it.
+  SNYK-JS-NODEFORGE-19635204:
+    - '*':
+        reason: >-
+          Dev/build-only transitive (nuxt dev CLI self-signed cert generation via
+          listhen); not present in the production .output runtime. No fixed
+          node-forge version exists (all versions affected, no patch). Re-review
+          on expiry.
+        expires: 2026-12-07T00:00:00.000Z
 exclude:
   code:
     - 'backend/tests'


### PR DESCRIPTION
Snyk scan (deps + Snyk Code SAST) found a single high/critical issue: SNYK-JS-NODEFORGE-19635204 — Improper Verification of Cryptographic Signature in node-forge@1.4.0 (CVSS 8.7).

It is a build/dev-tooling-only transitive:
  nuxt > @nuxt/cli > listhen > node-forge
listhen uses node-forge only to mint a self-signed cert for the local `nuxt dev --https` server. It is not part of the production runtime — `nuxt build` emits `.output/`, which the prod image runs directly, and the Nuxt CLI / listhen / node-forge never ship in that artifact.

Every published node-forge version is affected (semver '*') and there is no upstream fix or patch (fixedIn: []), so no upgrade remediates it. Added a documented, time-boxed `.snyk` ignore (expires 2026-12-07) so the scan gate passes while the risk stays tracked for re-review.

Backend deps (250) and Snyk Code: 0 high/critical. Backend boots and /health returns 200 after the change.


Claude-Session: https://claude.ai/code/session_01AXWvAMqdEm2C5DDB921eCD