### PR TITLE
Scope the single-provider SSO auto-start to the embedded /authorize flow

### DIFF
--- a/docs/feedback-loops/sso-auto-start-logout-loop.md
+++ b/docs/feedback-loops/sso-auto-start-logout-loop.md
@@ -1,0 +1,60 @@
+# Feedback Loop — "logout on an Entra sso_only instance signs the user straight back in"
+
+On an `auth.mode: sso_only` instance with a single enabled OIDC provider
+(Entra), signing out was pointless: the user landed back inside the app with a
+fresh session and no prompt. Same for session expiry.
+
+## Root cause (validated)
+
+PR #1064 added a single-provider auto-start to `frontend/pages/users/sign-in.vue`:
+when the mode is `sso_only` and exactly one provider is enabled, `onMounted`
+presses the provider button for the user. It was built for the embedded flow
+(an app sends the browser to `/authorize`, the auth middleware bounces it to
+sign-in, and the user should get a zero-click SSO hop), but it fired on every
+visit to the sign-in page.
+
+Sign-out lands on `/`, which requires auth, so the middleware bounces to
+`/users/sign-in?redirect=/`. The auto-start ran, BOW's authorize URL carries no
+`prompt=` parameter, BOW's logout never touches the provider, and the user's
+Microsoft session was still alive — so Entra returned a code silently and the
+callback signed them in again.
+
+The existing guards (`?error`, `?local=true`) only stop the loop on a *failed*
+round trip. A successful one, which is what logout produces, had nothing.
+
+## Fix
+
+Scope the auto-start to the flow it was written for. `embeddedAuthorizeFlow`
+is true only when the sign-in page's `redirect` target has the path
+`/authorize` (the OAuth consent page) or a `login_hint` is present; the
+auto-start now requires it. A plain visit, a post-logout landing, and an
+expired-session bounce all render the provider button instead.
+
+No config, no backend change. The embedded flow is byte-for-byte unchanged.
+
+## Verification (sandbox)
+
+Backend on `configs/bow-config.dev.entra.yaml` semantics (`sso_only`, Entra the
+only enabled provider, real discovery document, dummy client secret); first
+user seeded in hybrid mode, then the backend restarted in `sso_only`.
+Playwright routes every `login.microsoftonline.com` request to `abort()` and
+counts the attempts, so "left for the provider" is observed without a real
+tenant round trip.
+
+| Scenario | Before | After |
+|---|---|---|
+| Sign out (`POST /api/auth/jwt/logout` 204, land on `/`) → `/users/sign-in?redirect=/` | 1 navigation to Entra, page never rendered | 0 navigations, "Sign in with Microsoft" button rendered |
+| Direct visit to `/users/sign-in` | (same as above) | 0 navigations, button rendered |
+| Unauthenticated `/authorize?client_id=…&login_hint=someone@example.com` → bounced to sign-in with the consent URL as `redirect` | 1 navigation to Entra | 1 navigation to Entra, `login_hint=someone@example.com` on the authorize URL |
+
+The "before" row was reproduced by running the same scripts against the
+unpatched file (`git stash`), then re-running after `git stash pop`.
+
+## Not covered
+
+- The post-sign-in redirect stash (`bow:postSignInRedirect`) could not be read
+  in the embedded scenario because the tab had already left for the aborted
+  provider URL. That code path is untouched by this change.
+- An embedding app that opens BOW's root URL directly, rather than through
+  `/authorize`, now sees the button instead of a zero-click hop. #1064 was
+  written for the `/authorize` path, so this is believed to be nobody's flow.

--- a/frontend/pages/users/sign-in.vue
+++ b/frontend/pages/users/sign-in.vue
@@ -125,6 +125,20 @@
     if (!target || !target.includes('?') || !query) return ''
     return new URLSearchParams(query).get('login_hint') || ''
   })
+  // True only when this page was reached from the OAuth consent page: an
+  // embedding app sent the browser to /authorize, the global auth middleware
+  // bounced it here, and the consent URL rides along as `redirect`. That is
+  // the one flow that wants a zero-click SSO hop. Every other arrival — a
+  // logout landing here, an expired session, a typed URL — has no such
+  // redirect and must show the button, or a signed-out user is quietly
+  // signed straight back in while their provider session is still alive.
+  const embeddedAuthorizeFlow = computed(() => {
+    if (loginHint.value) return true
+    const target = safeRedirectTarget(route.query.redirect)
+    if (!target) return false
+    const path = target.split('?')[0].split('#')[0].replace(/\/+$/, '')
+    return path === '/authorize'
+  })
 
   // `?local=true` is the escape hatch that lets an admin reach the password
   // form on an sso_only instance.
@@ -274,16 +288,23 @@
       return
     }
 
-    // Single-provider SSO: the button would be the only thing on the page, so
-    // press it. This is what lets an embedding app open BOW with no visible
-    // sign-in step when the user already has a live session at the provider.
+    // Single-provider SSO on the embedded flow: the button would be the only
+    // thing on the page, so press it. This is what lets an embedding app open
+    // BOW with no visible sign-in step when the user already has a live
+    // session at the provider.
     //
-    // The guards are what keep it from becoming a redirect loop: a failed
-    // round trip comes back with ?error and must be able to show it, and
-    // ?local=true stays an escape hatch to the password form when the
+    // It is scoped to that flow on purpose (`embeddedAuthorizeFlow`). Left
+    // unscoped it fired on every visit, so signing out bounced the user here
+    // and straight back into the provider, which — still holding its own
+    // session — signed them in again without a prompt.
+    //
+    // The remaining guards are what keep it from becoming a redirect loop: a
+    // failed round trip comes back with ?error and must be able to show it,
+    // and ?local=true stays an escape hatch to the password form when the
     // provider is unreachable.
     if (
       authMode.value === 'sso_only'
+      && embeddedAuthorizeFlow.value
       && !localOverride.value
       && !ldapEnabled.value
       && !inviteError


### PR DESCRIPTION
## Problem

On an `auth.mode: sso_only` instance with a single enabled provider (Entra), signing out did nothing useful: the user landed straight back inside the app with a fresh session and no prompt. Session expiry looped the same way.

#1064 added a single-provider auto-start to `frontend/pages/users/sign-in.vue` for the embedded flow (an app sends the browser to `/authorize`, the auth middleware bounces it to sign-in, the user gets a zero-click SSO hop). It fired on **every** visit to the sign-in page. Sign-out lands on `/`, the middleware bounces to `/users/sign-in?redirect=/`, the auto-start ran, and Entra, still holding its own session, with no `prompt=` on our authorize URL and no end-session call from our logout, returned a code silently. The existing `?error` / `?local=true` guards only cover a *failed* round trip.

## Fix

Gate the auto-start on the flow it was written for. A new `embeddedAuthorizeFlow` computed is true only when the sign-in page's `redirect` target has the path `/authorize` (the OAuth consent page) or a `login_hint` is present. A plain visit, a post-logout landing, and an expired-session bounce all render the provider button instead.

No config, no backend change. The embedded flow is unchanged.

## Verification (sandbox, real UI)

Backend booted with `configs/bow-config.dev.entra.yaml` semantics (`sso_only`, Entra the only enabled provider, real discovery doc, dummy client secret). Playwright intercepts every `login.microsoftonline.com` request, aborts it, and counts the attempts.

| Scenario | Before | After |
|---|---|---|
| Sign out (logout POST 204, land on `/`) → `/users/sign-in?redirect=/` | 1 navigation to Entra, page never rendered | 0 navigations, "Sign in with Microsoft" rendered |
| Direct visit to `/users/sign-in` | same | 0 navigations, button rendered |
| Unauthenticated `/authorize?client_id=…&login_hint=someone@example.com` → bounced to sign-in with the consent URL as `redirect` | 1 navigation to Entra | 1 navigation to Entra, `login_hint=someone@example.com` on the authorize URL |

The "before" column was reproduced by running the same scripts against the unpatched file. Full write-up in `docs/feedback-loops/sso-auto-start-logout-loop.md`.

## Trade-off

An embedding app that opens BOW's root URL directly, rather than through `/authorize`, now sees the button instead of a zero-click hop. #1064 was written for the `/authorize` path, so this is believed to be nobody's flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CVafibN7j7CcnTARFkYt4

---
_Generated by [Claude Code](https://claude.ai/code/session_017CVafibN7j7CcnTARFkYt4)_