### PR TITLE
Scope search_instructions' training side paths to the session's agents

### DIFF
--- a/backend/app/ai/tools/implementations/search_instructions.py
+++ b/backend/app/ai/tools/implementations/search_instructions.py
@@ -391,6 +391,10 @@ class SearchInstructionsTool(Tool):
             # edit them within the same session.
             training_build_id = runtime_ctx.get("training_build_id")
             if training_build_id and not chat_mode:
+                # effective_ds_ids, not data.data_source_ids: the build is a
+                # snapshot of the whole org's instruction set (all agents), so
+                # trusting the model-supplied filter here reopens exactly the
+                # cross-agent widening the forced scope above exists to block.
                 draft_result = await service.get_instructions(
                     db=db,
                     organization=organization,
@@ -399,7 +403,7 @@ class SearchInstructionsTool(Tool):
                     limit=window,
                     status=None,
                     categories=categories,
-                    data_source_ids=data.data_source_ids,
+                    data_source_ids=effective_ds_ids,
                     search=None,
                     include_global=True,
                     build_id=training_build_id,
@@ -419,15 +423,30 @@ class SearchInstructionsTool(Tool):
             # which read as "the instruction disappeared" to the agent that had
             # just created it. Only the author's drafts: no org-wide widening.
             if not chat_mode:
-                from sqlalchemy import select as _select, and_ as _and
+                from sqlalchemy import select as _select, and_ as _and, or_ as _or
                 from app.models.instruction import Instruction as _Instruction
+                from app.models.data_source import DataSource as _DataSource
+                conditions = [
+                    _Instruction.organization_id == organization.id,
+                    _Instruction.user_id == str(user.id),
+                    _Instruction.status == "draft",
+                    _Instruction.deleted_at.is_(None),
+                ]
+                # Author-scoping alone is not enough: the same user works
+                # across agents, and without this an unrelated agent's drafts
+                # leak into every training session. Mirror the main query's
+                # scoping — attached to one of this session's data sources, or
+                # global (no associations). None means the scope itself is
+                # unresolved (e.g. knowledge mode with no ids) — leave as-is.
+                if effective_ds_ids is not None:
+                    conditions.append(_or(
+                        _Instruction.data_sources.any(
+                            _DataSource.id.in_([str(i) for i in effective_ds_ids])
+                        ),
+                        ~_Instruction.data_sources.any(),
+                    ))
                 own_drafts = (await db.execute(
-                    _select(_Instruction).where(_and(
-                        _Instruction.organization_id == organization.id,
-                        _Instruction.user_id == str(user.id),
-                        _Instruction.status == "draft",
-                        _Instruction.deleted_at.is_(None),
-                    )).limit(window)
+                    _select(_Instruction).where(_and(*conditions)).limit(window)
                 )).unique().scalars().all()
                 if own_drafts:
                     seen_ids = {str(getattr(c, "id", None)) for c in candidates}

--- a/backend/tests/e2e/test_search_instructions_chat_mode.py
+++ b/backend/tests/e2e/test_search_instructions_chat_mode.py
@@ -140,6 +140,74 @@ async def test_chat_mode_forces_report_scope(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_training_mode_scopes_own_drafts_to_report_agents(
+    create_user, login_user, whoami, test_client, create_data_source
+):
+    """The own-drafts widening must respect the session's agent scope.
+
+    Author-scoping alone is not enough: the same user works across agents, and
+    an unfiltered drafts query leaks e.g. a hospital agent's draft into a music
+    store training session (where a keyword hit then presents it as an existing
+    instruction)."""
+    token, uid, org_id = _new_admin(create_user, login_user, whoami)
+    ds_a = create_data_source(
+        name="ds_a", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    ds_b = create_data_source(
+        name="ds_b", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    draft = _create(
+        test_client, token, org_id,
+        text="Draft margin rule for agent A.", title="A-margins",
+        load_mode="intelligent", status="draft", data_source_ids=[ds_a["id"]],
+    )
+
+    out_b = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds_b["id"]],
+    )
+    assert out_b["success"] is True, out_b
+    assert not any(i["id"] == draft["id"] for i in out_b["instructions"]), (
+        "another agent's draft must not surface in this session"
+    )
+
+    out_a = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds_a["id"]],
+    )
+    assert any(i["id"] == draft["id"] for i in out_a["instructions"]), out_a
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_training_mode_global_drafts_stay_visible(
+    create_user, login_user, whoami, test_client, create_data_source
+):
+    """A draft with no agent association is global and must keep surfacing in
+    a scoped session (mirrors the main query's include_global semantics)."""
+    token, uid, org_id = _new_admin(create_user, login_user, whoami)
+    ds = create_data_source(
+        name="ds_scope", type="sqlite", config={"database": str(_SQLITE_DB)},
+        credentials={}, user_token=token, org_id=org_id,
+    )
+    draft = _create(
+        test_client, token, org_id,
+        text="Global draft rule about margins.", title="Global-margins",
+        load_mode="intelligent", status="draft",
+    )
+
+    out = await _run(
+        {"query": ["margin"]}, user_id=uid, org_id=org_id,
+        mode="training", scope_ds_ids=[ds["id"]],
+    )
+    assert out["success"] is True, out
+    assert any(i["id"] == draft["id"] for i in out["instructions"]), out
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_training_mode_keeps_full_text(create_user, login_user, whoami, test_client):
     token, uid, org_id = _new_admin(create_user, login_user, whoami)
     long_body = "Margin rule. " + "More margin detail. " * 30


### PR DESCRIPTION
## Summary

`search_instructions` leaked out-of-scope instructions into training sessions through two side paths that bypassed the forced report scope:

- **Current-build query** passed the model-supplied `data_source_ids` instead of the server-resolved effective scope. The build is a snapshot of the whole org's instruction set, so whenever the model omitted the field, every agent's instructions (any status) surfaced.
- **Own-drafts widening** filtered by org + author only, so the author's drafts from unrelated agents surfaced in every training session.

Both paths now filter by `effective_ds_ids` (attached to one of the session's data sources, or global with no associations), mirroring the main published query's scoping. When the scope is unresolved (`None`) the drafts query stays unfiltered, as before.

Deliberately out of scope for this PR: the separate issue where a user-deactivated instruction (published→draft) resurfaces via the own-drafts widening. That needs a schema change and will come in its own PR.

## Test plan

- [x] New e2e: `test_training_mode_scopes_own_drafts_to_report_agents` — agent A's draft does not surface in agent B's training session, and does surface in agent A's.
- [x] New e2e: `test_training_mode_global_drafts_stay_visible` — a draft with no agent association keeps surfacing in a scoped session.
- [x] `pytest tests/e2e/test_search_instructions_chat_mode.py` — 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)