### PR TITLE
Refactor agent expansion to not auto-open Instructions group

### DIFF
--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -3292,7 +3292,9 @@ const expand = (key: string, force?: boolean) => {
   if (force) expanded.value.add(key)
   else if (expanded.value.has(key)) expanded.value.delete(key)
   else expanded.value.add(key)
-  if (key.startsWith('agent:') && expanded.value.has(key)) { const id = key.slice('agent:'.length); expanded.value.add('instr:' + id); loadAgentMeta(id) }
+  // Opening an agent loads its meta but leaves the Instructions group collapsed;
+  // it opens only on an explicit click (or openAgentSection / a fresh create).
+  if (key.startsWith('agent:') && expanded.value.has(key)) loadAgentMeta(key.slice('agent:'.length))
   // Lazy-load instruction rows on first expand of a group (rows arrive from the
   // backend; counts/badges were already loaded on mount).
   if (expanded.value.has(key)) {


### PR DESCRIPTION
## Summary
Modified the agent expansion logic in KnowledgeExplorer to prevent automatically opening the Instructions group when an agent is expanded. The Instructions group now only opens on explicit user interaction.

## Key Changes
- Removed automatic expansion of the Instructions group (`'instr:' + id`) when an agent is opened
- Simplified the expansion condition to only call `loadAgentMeta()` without side effects on the Instructions group state
- Added clarifying comments explaining the new behavior: agent meta loads on expansion, but Instructions group remains collapsed until explicitly clicked or opened via `openAgentSection` or fresh create operations

## Implementation Details
The change preserves the agent metadata loading functionality while giving users more control over the UI state. The Instructions group will now only expand through:
- Explicit user clicks on the group
- Programmatic calls to `openAgentSection`
- Fresh agent creation flows

https://claude.ai/code/session_01984wzQmKv928fP1fiZ1dvE