### PR TITLE
Enable artifact creation tools in training mode

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -700,8 +700,9 @@ Help the organization build and maintain high-quality instructions that document
 - Run real queries with create_data to validate your understanding of the data
 - Create and edit instructions based on verified findings
 - Answer questions and clarify requirements
+- Produce docs and dashboards (create_doc, create_artifact) when the user asks for one
 
-You CANNOT create artifacts (dashboards, reports) in Training mode. Your goal is always to produce instructions — use create_data as a verification tool to confirm your understanding before documenting it.
+Your primary goal is to produce instructions — use create_data as a verification tool to confirm your understanding before documenting it.
 
 - Constraints: EXACTLY one (or none) tool call per turn; output JSON only (strict schema below); never produce empty responses.
 - After EVERY tool execution, you MUST respond with valid JSON containing either another action OR analysis_complete=true with final_answer.

--- a/backend/app/ai/tools/implementations/create_artifact.py
+++ b/backend/app/ai/tools/implementations/create_artifact.py
@@ -80,7 +80,7 @@ class CreateArtifactTool(Tool):
             required_permissions=[],
             is_active=True,
             tags=["artifact",  "dashboard", "slides"],
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/app/ai/tools/implementations/create_doc.py
+++ b/backend/app/ai/tools/implementations/create_doc.py
@@ -142,7 +142,7 @@ class CreateDocTool(Tool):
             required_permissions=[],
             is_active=True,
             tags=["artifact", "doc"],
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/tests/training/test_connection_agent_tools.py
+++ b/backend/tests/training/test_connection_agent_tools.py
@@ -141,6 +141,17 @@ def test_registry_gates_tools_to_training_mode():
             assert not (new_tools & names), (mode, new_tools & names)
 
 
+def test_registry_offers_artifact_tools_in_training_mode():
+    from app.ai.registry import ToolRegistry
+    r = ToolRegistry()
+    artifact_tools = {"create_doc", "create_artifact"}
+    for mode in ("chat", "training"):
+        names = {t["name"] for t in r.get_catalog_for_plan_type("action", mode=mode)}
+        assert artifact_tools <= names, (mode, artifact_tools - names)
+    names = {t["name"] for t in r.get_catalog_for_plan_type("action", mode="knowledge")}
+    assert not (artifact_tools & names), artifact_tools & names
+
+
 @pytest.mark.asyncio
 async def test_list_connections_scoped_to_create_tier():
     ids = await _seed()


### PR DESCRIPTION
## Summary
Enable the `create_doc` and `create_artifact` tools to be available during training mode, allowing users to produce documentation and dashboards as part of their training workflow.

## Key Changes
- **Tool Registry**: Added test `test_registry_offers_artifact_tools_in_training_mode()` to verify that artifact tools are available in both "chat" and "training" modes, but not in "knowledge" mode
- **create_artifact.py**: Updated `allowed_modes` from `["chat"]` to `["chat", "training"]` to enable dashboard and slides creation during training
- **create_doc.py**: Updated `allowed_modes` from `["chat"]` to `["chat", "training"]` to enable document creation during training
- **Training Prompt**: Updated the training mode prompt to reflect that users can now produce docs and dashboards using `create_doc` and `create_artifact` tools, while clarifying that the primary goal remains producing instructions

## Implementation Details
The changes align the tool availability with the updated training workflow, where users can now create artifacts as part of their training process. The prompt guidance was updated to clarify that artifact creation is now permitted and encouraged when users request it, while maintaining the primary focus on instruction generation.

https://claude.ai/code/session_01BxhUS7kDSBvU4TrdyLxUKf