### PR TITLE
Gate training mode entry on report creation from home prompt

### DIFF
--- a/backend/app/schemas/report_schema.py
+++ b/backend/app/schemas/report_schema.py
@@ -18,6 +18,9 @@ class ReportCreate(ReportBase):
     # Create the report directly inside a project (folder). Validated against
     # the creator's project access at create time.
     project_id: Optional[str] = None
+    # Start the report in a mode (the home prompt box's Chat/Training picker).
+    # Omit for chat. Training is gated exactly like ReportUpdate.mode.
+    mode: Optional[Literal["chat", "training"]] = None
 
 class ReportUpdate(BaseModel):
     title: Optional[str] = None

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -795,6 +795,63 @@ class ReportService:
         await self._enrich_fork_lineage(db, report, report_schema)
         return report_schema
 
+    async def _assert_can_enter_training_mode(
+        self,
+        db: AsyncSession,
+        current_user: User,
+        organization: Organization,
+        training_ds_ids: list[str],
+    ) -> None:
+        """Gate for putting a report into training mode.
+
+        Shared by create (mode picked on the home prompt box) and update (mode
+        picked inside a report) so both entry points enforce the same contract:
+
+        - The org flag ``enable_training_mode`` must be on (400 otherwise).
+        - Per-agent authorization: entering training mode is the agent-admin
+          capability, not an org-wide one. The actor must be able to manage
+          instructions on EVERY agent (data source) the report is attached to —
+          via full_admin / org-level manage_instructions, or a per-data_source
+          ``manage`` grant (which implies manage_instructions). A plain member
+          (view only) on the agent is denied, even if they manage some other
+          agent (403).
+        """
+        # Reuse the settings already eager-loaded on the request-scoped
+        # organization instead of issuing another query.
+        org_settings = organization.settings
+        if org_settings:
+            enable_training_mode = org_settings.get_config("enable_training_mode")
+            training_mode_disabled = False
+            if enable_training_mode is not None:
+                if hasattr(enable_training_mode, 'value'):
+                    training_mode_disabled = enable_training_mode.value is False
+                elif isinstance(enable_training_mode, dict):
+                    training_mode_disabled = enable_training_mode.get('value') is False
+            else:
+                # Default to disabled if not set
+                training_mode_disabled = True
+            if training_mode_disabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Training mode is not enabled for this organization"
+                )
+        from app.core.permission_resolver import resolve_permissions
+        resolved = await resolve_permissions(
+            db, str(current_user.id), str(organization.id)
+        )
+        can_train = resolved.has_org_permission('manage_instructions') or (
+            bool(training_ds_ids)
+            and all(
+                resolved.has_resource_permission('data_source', ds, 'manage_instructions')
+                for ds in training_ds_ids
+            )
+        )
+        if not can_train:
+            raise HTTPException(
+                status_code=403,
+                detail="You need manage access on this agent to enter training mode",
+            )
+
     async def create_report(self, db: AsyncSession, report_data: ReportCreate, current_user: User, organization: Organization) -> ReportSchema:
         file_uuids = report_data.files or []
         del report_data.files
@@ -802,6 +859,11 @@ class ReportService:
         del report_data.data_sources
         project_id = report_data.project_id
         del report_data.project_id
+        # Mode is optional on create; None must not reach the ORM (it would
+        # write NULL past the column default). Gated below once the effective
+        # agent list is known (project defaults may fill it in).
+        requested_mode = report_data.mode or 'chat'
+        del report_data.mode
 
         # Create the report object
         report = Report(**report_data.dict())
@@ -825,6 +887,15 @@ class ReportService:
             # context-build time (FilesContextBuilder / file tools), so
             # adding or removing a file on the project applies to every
             # report in it, including ones created before the change.
+        # Training mode straight from the home prompt box: same gate as
+        # switching an existing report (org flag + manage_instructions on every
+        # attached agent). Checked before anything is written so a denied
+        # request leaves no half-created chat report behind.
+        if requested_mode == 'training':
+            await self._assert_can_enter_training_mode(
+                db, current_user, organization, [str(x) for x in data_source_ids]
+            )
+        report.mode = requested_mode
         # Ensure a default theme is set for new reports
         if getattr(report, 'theme_name', None) in (None, ''):
             report.theme_name = 'default'
@@ -947,55 +1018,14 @@ class ReportService:
             report.theme_overrides = report_data.theme_overrides
         # Persist mode update if present in payload
         if hasattr(report_data, 'mode') and report_data.mode is not None:
-            # Block training mode if enable_training_mode or allow_llm_see_data is disabled
             if report_data.mode == 'training':
-                # Reuse the settings already eager-loaded on the request-scoped
-                # organization instead of issuing another query.
-                org_settings = organization.settings
-                if org_settings:
-                    # Check enable_training_mode flag
-                    enable_training_mode = org_settings.get_config("enable_training_mode")
-                    training_mode_disabled = False
-                    if enable_training_mode is not None:
-                        if hasattr(enable_training_mode, 'value'):
-                            training_mode_disabled = enable_training_mode.value is False
-                        elif isinstance(enable_training_mode, dict):
-                            training_mode_disabled = enable_training_mode.get('value') is False
-                    else:
-                        # Default to disabled if not set
-                        training_mode_disabled = True
-                    if training_mode_disabled:
-                        raise HTTPException(
-                            status_code=400,
-                            detail="Training mode is not enabled for this organization"
-                        )
-                # Per-agent authorization: entering training mode is the
-                # agent-admin capability, not an org-wide one. The actor must be
-                # able to manage instructions on EVERY agent (data source) the
-                # report is attached to — via full_admin / org-level
-                # manage_instructions, or a per-data_source `manage` grant (which
-                # implies manage_instructions). A plain member (view only) on the
-                # agent is denied, even if they manage some other agent.
-                from app.core.permission_resolver import resolve_permissions
                 if report_data.data_sources is not None:
                     training_ds_ids = [str(x) for x in report_data.data_sources]
                 else:
                     training_ds_ids = [str(ds.id) for ds in (report.data_sources or [])]
-                resolved = await resolve_permissions(
-                    db, str(current_user.id), str(organization.id)
+                await self._assert_can_enter_training_mode(
+                    db, current_user, organization, training_ds_ids
                 )
-                can_train = resolved.has_org_permission('manage_instructions') or (
-                    bool(training_ds_ids)
-                    and all(
-                        resolved.has_resource_permission('data_source', ds, 'manage_instructions')
-                        for ds in training_ds_ids
-                    )
-                )
-                if not can_train:
-                    raise HTTPException(
-                        status_code=403,
-                        detail="You need manage access on this agent to enter training mode",
-                    )
             report.mode = report_data.mode
         # Persist report-level LLM override if present in payload.
         #   None          -> field omitted, leave the current value untouched

--- a/backend/tests/e2e/rbac/test_rbac_training_mode.py
+++ b/backend/tests/e2e/rbac/test_rbac_training_mode.py
@@ -284,3 +284,111 @@ def test_agent_admin_eval_writes_are_scoped(test_client, training_world):
     assert _case(u["token"], [agent1]).status_code == 403
     # Control: full admin can still create a global eval.
     assert _case(admin["token"], []).status_code == 200
+
+
+# ── Entry gate on CREATE (home prompt box picks Training before a report exists) ──
+#
+# The home page creates the report and hands off to it; the mode picked there
+# must land on the report row itself (otherwise the report opens as chat and
+# every message after the first runs as chat). Same gate as the PUT path.
+
+def _create_report(test_client, token, org_id, ds_ids, mode=None):
+    body = {"title": "from home", "data_sources": ds_ids}
+    if mode is not None:
+        body["mode"] = mode
+    return test_client.post("/api/reports", json=body, headers=_hdr(token, org_id))
+
+
+def _get_report(test_client, token, org_id, report_id):
+    r = test_client.get(f"/api/reports/{report_id}", headers=_hdr(token, org_id))
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+@pytest.mark.e2e
+def test_create_report_defaults_to_chat_mode(test_client, training_world):
+    """Omitting mode on create yields a chat report (unchanged default)."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    r = _create_report(test_client, u["token"], org, [training_world["agent1"]["id"]])
+    assert r.status_code in (200, 201), r.text
+    assert r.json()["mode"] == "chat"
+    assert _get_report(test_client, u["token"], org, r.json()["id"])["mode"] == "chat"
+
+
+@pytest.mark.e2e
+def test_agent_admin_can_create_report_in_training_mode(test_client, training_world):
+    """An agent admin who picks Training on the home prompt box gets a report
+    that IS in training mode — on the create response and when re-fetched."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    r = _create_report(test_client, u["token"], org, [training_world["agent2"]["id"]], mode="training")
+    assert r.status_code in (200, 201), r.text
+    assert r.json()["mode"] == "training"
+    assert _get_report(test_client, u["token"], org, r.json()["id"])["mode"] == "training"
+
+
+@pytest.mark.e2e
+def test_member_cannot_create_report_in_training_mode(test_client, training_world):
+    """A plain member is denied a training report on that agent (403), and no
+    report is left behind — but a chat report on the same agent still works."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    before = test_client.get("/api/reports", headers=_hdr(u["token"], org))
+    assert before.status_code == 200, before.text
+    before_total = before.json().get("total", len(before.json().get("items", [])))
+
+    denied = _create_report(test_client, u["token"], org, [training_world["agent1"]["id"]], mode="training")
+    assert denied.status_code == 403, denied.text
+
+    after = test_client.get("/api/reports", headers=_hdr(u["token"], org))
+    after_total = after.json().get("total", len(after.json().get("items", [])))
+    assert after_total == before_total
+
+    ok = _create_report(test_client, u["token"], org, [training_world["agent1"]["id"]], mode="chat")
+    assert ok.status_code in (200, 201), ok.text
+    assert ok.json()["mode"] == "chat"
+
+
+@pytest.mark.e2e
+def test_create_training_report_requires_manage_on_every_agent(test_client, training_world):
+    """Cross-agent: a user who manages agent2 but only views agent1 can create a
+    training report on agent2, not on agent1, and not on both together."""
+    org = training_world["org_id"]
+    u = training_world["u"]
+    a1, a2 = training_world["agent1"]["id"], training_world["agent2"]["id"]
+
+    assert _create_report(test_client, u["token"], org, [a2], mode="training").status_code in (200, 201)
+    assert _create_report(test_client, u["token"], org, [a1], mode="training").status_code == 403
+    assert _create_report(test_client, u["token"], org, [a1, a2], mode="training").status_code == 403
+
+
+@pytest.mark.e2e
+def test_full_admin_can_create_training_report_on_any_agent(test_client, training_world):
+    org = training_world["org_id"]
+    admin = training_world["admin"]
+    for agent in ("agent1", "agent2"):
+        r = _create_report(test_client, admin["token"], org, [training_world[agent]["id"]], mode="training")
+        assert r.status_code in (200, 201), f"{agent}: {r.text}"
+        assert r.json()["mode"] == "training"
+
+
+@pytest.mark.e2e
+def test_create_training_report_blocked_when_org_flag_disabled(
+    test_client, training_world, update_organization_settings
+):
+    """With enable_training_mode off, nobody can create a training report —
+    not the agent admin, not the full admin."""
+    org = training_world["org_id"]
+    admin = training_world["admin"]
+    u = training_world["u"]
+    update_organization_settings(
+        config={"enable_training_mode": {"value": False}},
+        user_token=admin["token"],
+        org_id=org,
+    )
+    a2 = training_world["agent2"]["id"]
+    assert _create_report(test_client, u["token"], org, [a2], mode="training").status_code == 400
+    assert _create_report(test_client, admin["token"], org, [a2], mode="training").status_code == 400
+    # Chat creation is unaffected by the flag.
+    assert _create_report(test_client, u["token"], org, [a2], mode="chat").status_code in (200, 201)

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -1732,7 +1732,11 @@ async function createReport() {
                 title: 'untitled report',
                 files: successfullyUploadedFiles.value?.map((file: any) => file.id) || [],
                 new_message: text.value,
-                data_sources: selectedDataSources.value?.map((ds: any) => ds.id) || []
+                data_sources: selectedDataSources.value?.map((ds: any) => ds.id) || [],
+                // Persist the picker's mode on the report itself. The query
+                // param below only shapes the FIRST completion; without this
+                // the report loads as chat and the picker snaps back.
+                mode: mode.value
             })
         })
         if ((response as any)?.error?.value) {


### PR DESCRIPTION
## Summary
Extends training mode authorization to the report creation flow on the home prompt box, ensuring the same access controls apply whether training mode is entered at creation time or via report update. Previously, training mode could only be set when updating an existing report; now it can be selected during creation with identical permission enforcement.

## Key Changes
- **New authorization method** (`_assert_can_enter_training_mode`): Extracted shared validation logic for training mode entry that checks:
  - Organization flag `enable_training_mode` is enabled (400 if disabled)
  - User has `manage_instructions` permission on every attached data source (403 if not)
  - Supports both org-level and per-data-source permission grants
  
- **Report creation flow**: 
  - Added optional `mode` field to `ReportCreate` schema (defaults to `chat`)
  - Validates training mode authorization before persisting the report
  - Ensures no half-created reports are left behind on permission denial
  
- **Report update refactoring**: Replaced 40+ lines of duplicated authorization logic with call to shared `_assert_can_enter_training_mode` method

- **Frontend integration**: Updated home prompt box to persist the mode picker selection (`Chat`/`Training`) to the report's `mode` field on creation, ensuring the report opens in the selected mode rather than defaulting to chat

## Implementation Details
- Authorization check happens after data source list is finalized (project defaults may fill in sources) but before any database writes
- Reuses organization settings already eager-loaded on the request scope to avoid redundant queries
- Maintains backward compatibility: omitting `mode` on create defaults to `chat` mode
- Comprehensive test coverage for all permission scenarios (agent admin, member, full admin, org flag disabled)

https://claude.ai/code/session_01HCzfrBQ7dqa5SenGeh6G7P