### PR TITLE
Allow artifact edit/read tools in training mode

### DIFF
--- a/backend/app/ai/agents/planner/prompt_builder.py
+++ b/backend/app/ai/agents/planner/prompt_builder.py
@@ -700,7 +700,7 @@ Help the organization build and maintain high-quality instructions that document
 - Run real queries with create_data to validate your understanding of the data
 - Create and edit instructions based on verified findings
 - Answer questions and clarify requirements
-- Produce docs and dashboards (create_doc, create_artifact) when the user asks for one
+- Produce and iterate on docs and dashboards (create_doc/edit_doc, create_artifact/edit_artifact/read_artifact) when the user asks for one
 
 Your primary goal is to produce instructions — use create_data as a verification tool to confirm your understanding before documenting it.
 

--- a/backend/app/ai/tools/implementations/add_parameter.py
+++ b/backend/app/ai/tools/implementations/add_parameter.py
@@ -86,7 +86,7 @@ class AddParameterTool(Tool):
             required_permissions=[],
             is_active=True,
             tags=["data", "parameters", "filters"],
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/app/ai/tools/implementations/edit_artifact.py
+++ b/backend/app/ai/tools/implementations/edit_artifact.py
@@ -61,7 +61,7 @@ class EditArtifactTool(Tool):
             required_permissions=[],
             is_active=True,
             tags=["artifact", "dashboard", "edit"],
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/app/ai/tools/implementations/edit_doc.py
+++ b/backend/app/ai/tools/implementations/edit_doc.py
@@ -64,7 +64,7 @@ class EditDocTool(Tool):
             required_permissions=[],
             is_active=True,
             tags=["artifact", "doc"],
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/app/ai/tools/implementations/read_artifact.py
+++ b/backend/app/ai/tools/implementations/read_artifact.py
@@ -186,7 +186,7 @@ class ReadArtifactTool(Tool):
             required_permissions=[],
             tags=["artifact", "dashboard", "read"],
             observation_policy="on_trigger",
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/app/ai/tools/implementations/read_query.py
+++ b/backend/app/ai/tools/implementations/read_query.py
@@ -72,7 +72,7 @@ class ReadQueryTool(Tool):
             required_permissions=[],
             tags=["query", "visualization", "data", "read"],
             observation_policy="on_trigger",
-            allowed_modes=["chat"],
+            allowed_modes=["chat", "training"],
         )
 
     @property

--- a/backend/tests/training/test_connection_agent_tools.py
+++ b/backend/tests/training/test_connection_agent_tools.py
@@ -144,11 +144,22 @@ def test_registry_gates_tools_to_training_mode():
 def test_registry_offers_artifact_tools_in_training_mode():
     from app.ai.registry import ToolRegistry
     r = ToolRegistry()
-    artifact_tools = {"create_doc", "create_artifact"}
+    artifact_tools = {
+        "create_doc", "edit_doc",
+        "create_artifact", "edit_artifact", "read_artifact",
+        "read_query", "add_parameter",
+    }
+
+    def _names(mode):
+        names = set()
+        for pt in ("action", "research"):
+            names |= {t["name"] for t in r.get_catalog_for_plan_type(pt, mode=mode)}
+        return names
+
     for mode in ("chat", "training"):
-        names = {t["name"] for t in r.get_catalog_for_plan_type("action", mode=mode)}
+        names = _names(mode)
         assert artifact_tools <= names, (mode, artifact_tools - names)
-    names = {t["name"] for t in r.get_catalog_for_plan_type("action", mode="knowledge")}
+    names = _names("knowledge")
     assert not (artifact_tools & names), artifact_tools & names
 
 


### PR DESCRIPTION
create_doc and create_artifact were opened to training mode, but the tools needed to iterate on what they produce stayed chat-only. Open edit_doc, edit_artifact, read_artifact, read_query and add_parameter the same way so a training session can revise a doc or dashboard instead of recreating it, and extend the registry test to cover the full set.


Claude-Session: https://claude.ai/code/session_01BxhUS7kDSBvU4TrdyLxUKf