### PR TITLE
Improve Power BI connection test with better 404 handling

### DIFF
--- a/backend/app/data_sources/clients/powerbi_client.py
+++ b/backend/app/data_sources/clients/powerbi_client.py
@@ -73,10 +73,12 @@ class PowerBIClient(DataSourceClient):
     AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     SCOPE = "https://analysis.windows.net/powerbi/api/.default"
 
-    # Connection-test probe budget: enough to skip a few empty/system models
-    # without hammering large tenants.
-    MAX_PROBE_WORKSPACES = 5
-    MAX_PROBE_DATASETS = 5
+    # Connection-test probe budget: enough to walk past a run of models the
+    # caller cannot query (Viewer-only workspaces, live-connection or usage
+    # metrics models answer 404) without hammering large tenants. Each probe
+    # is one cheap DAX call, and the walk stops at the first success.
+    MAX_PROBE_WORKSPACES = 10
+    MAX_PROBE_DATASETS = 20
 
     def __init__(
         self,
@@ -423,6 +425,7 @@ class PowerBIClient(DataSourceClient):
         probed = 0
         datasets_seen = 0
         engine_details: List[str] = []   # engine answered, model unqueryable (empty, RLS, ...)
+        skipped: List[str] = []          # 404 on executeQueries: no Build, or not a queryable model
         permission_error: Optional[str] = None
         last_error: Optional[str] = None
 
@@ -464,7 +467,15 @@ class PowerBIClient(DataSourceClient):
                     permission_error = f"dataset '{ds_name}' in workspace '{ws_name}': {detail}"
                 elif outcome == "error":
                     last_error = f"dataset '{ds_name}' in workspace '{ws_name}': {detail}"
-                # outcome == "skip" (404/stale) → try the next dataset
+                elif outcome == "skip":
+                    # 404 from executeQueries on a dataset the listing just
+                    # returned. Power BI hides a model behind 404 (not 403)
+                    # when a personal sign-in has no Build permission on it,
+                    # and answers 404 for models that endpoint cannot serve
+                    # (live connections, usage metrics, push datasets). Keep
+                    # the name: if nothing else is queryable it is the only
+                    # clue the user gets.
+                    skipped.append(f"'{ds_name}' ({ws_name})")
 
         if engine_details:
             # Query access verified — every probed model just had nothing to query.
@@ -512,9 +523,39 @@ class PowerBIClient(DataSourceClient):
                 "connectivity": True,
             }
 
+        if last_error:
+            return {
+                "success": False,
+                "message": f"Connected but could not verify query access: {last_error}",
+                "connectivity": True,
+            }
+
+        # Every probed model answered 404. The identity can SEE workspaces
+        # (a Viewer role is enough for that) but cannot query anything it
+        # walked past. That says nothing about the models this connection is
+        # actually indexed on — a user holding Build on those alone is the
+        # normal delegated shape — so check the catalog before failing, the
+        # same way the no-workspace and forbidden branches do.
+        ok, detail = self._probe_known_catalog()
+        if ok:
+            return {
+                "success": True,
+                "message": f"Connected to Power BI. Verified query access on {detail}.",
+                "workspaces": len(workspaces),
+                "datasets": datasets_seen,
+            }
+        shown = "; ".join(skipped[:5])
+        more = f" and {len(skipped) - 5} more" if len(skipped) > 5 else ""
         return {
             "success": False,
-            "message": f"Connected but could not verify query access: {last_error or 'no dataset could be probed'}",
+            "message": (
+                f"Connected to {len(workspaces)} workspace(s), but none of the {len(skipped)} probed "
+                f"semantic model(s) could be queried with this identity (Power BI answered 404 for "
+                f"{shown}{more}). For a personal sign-in this usually means no Build permission: ask "
+                "an admin for Build on the semantic models this connection uses, or a Member/Contributor "
+                "role on their workspace (Viewer is not enough). Live-connection, usage-metrics and "
+                "push datasets cannot be queried through the REST API at all."
+            ),
             "connectivity": True,
         }
 

--- a/backend/tests/unit/test_powerbi_client.py
+++ b/backend/tests/unit/test_powerbi_client.py
@@ -192,11 +192,56 @@ class TestTestConnection:
 
     def test_probe_budget_respected(self):
         c = _mk_client()
-        many = {"ws1": [{"id": f"d{i}", "name": f"M{i}"} for i in range(20)]}
-        _wire_probe(c, WS, many, [_resp(404)] * 20)
+        many = {"ws1": [{"id": f"d{i}", "name": f"M{i}"} for i in range(c.MAX_PROBE_DATASETS + 10)]}
+        _wire_probe(c, WS, many, [_resp(404)] * (c.MAX_PROBE_DATASETS + 10))
         out = c.test_connection()
+        # No catalog attached, so nothing beyond the workspace walk is probed.
         assert c._request.call_count == c.MAX_PROBE_DATASETS
         assert out["success"] is False
+
+    def test_probe_budget_walks_past_a_run_of_unqueryable_models(self):
+        """A Viewer-only workspace answers 404 for every model in it. The
+        budget must be wide enough to reach a queryable model further down
+        instead of giving up after a handful."""
+        c = _mk_client()
+        many = {"ws1": [{"id": f"d{i}", "name": f"M{i}"} for i in range(12)]}
+        _wire_probe(c, WS, many, [_resp(404)] * 11 + [_resp(200, {"results": []})])
+        out = c.test_connection()
+        assert out["success"] is True
+        assert "M11" in out["message"]
+
+    def test_all_404_names_the_skipped_models(self):
+        """The old fallback printed 'no dataset could be probed' — no model
+        names, no hint. A user who can list a workspace but has no Build on
+        its models needs to know which models answered 404 and what to ask for."""
+        c = _mk_client()
+        _wire_probe(c, WS, DS, [_resp(404), _resp(404)])
+        out = c.test_connection()
+        assert out["success"] is False
+        assert out["connectivity"] is True
+        assert "no dataset could be probed" not in out["message"]
+        assert "Model1" in out["message"]
+        assert "Model2" in out["message"]
+        assert "Build" in out["message"]
+
+    def test_all_404_still_checks_the_known_catalog(self):
+        """Viewer somewhere + Build on the connection's own model is the normal
+        delegated shape. The workspace walk sees only the Viewer models (404);
+        the catalog probe must be consulted before failing the user."""
+        c = _mk_client()
+        c.attach_table_metadata([{
+            "name": "Shared/Orders",
+            "metadata_json": {"powerbi": {
+                "datasetId": "ds-shared", "workspaceId": "ws-x",
+                "workspaceName": "Elsewhere", "datasetName": "Shared", "tableName": "Orders",
+            }},
+        }])
+        _wire_probe(c, WS, DS, [_resp(404), _resp(404), _resp(200, {"results": []})])
+        out = c.test_connection()
+        assert out["success"] is True
+        assert "Shared" in out["message"]
+        # The third call is the tenant-level catalog probe, not a workspace one.
+        assert "/datasets/ds-shared/executeQueries" in c._request.call_args_list[2].args[1]
 
 
 # ---------- _request retry ---------- #


### PR DESCRIPTION
## Summary
Enhanced the Power BI connection test to better handle 404 responses from the API, which occur when users lack Build permissions or when querying non-queryable models (live connections, usage metrics, push datasets). The probe budget was increased and the error messaging was significantly improved to guide users toward resolution.

## Key Changes

- **Increased probe budgets**: `MAX_PROBE_WORKSPACES` increased from 5 to 10, and `MAX_PROBE_DATASETS` increased from 5 to 20, allowing the connection test to walk past runs of unqueryable models and reach queryable ones
- **Improved 404 handling**: Added explicit tracking of skipped models (those returning 404) with detailed comments explaining why Power BI returns 404 for permission-denied and non-queryable models
- **Enhanced error messages**: When all probed models return 404, the error message now:
  - Lists the specific model names that answered 404 (up to 5, with count of additional ones)
  - Explains the likely cause (missing Build permission for personal sign-ins)
  - Provides actionable guidance (request Build permission or Member/Contributor role)
  - Notes that certain model types (live connections, usage metrics, push datasets) cannot be queried via REST API
- **Catalog fallback**: Added fallback to probe the known catalog when all workspace models return 404, supporting the common delegated access pattern where users have Build on specific models but only Viewer access to workspaces
- **Better error precedence**: Separated handling of `last_error` cases from the all-404 case, providing more specific error messages

## Notable Implementation Details

- The connection test now distinguishes between three failure modes: permission errors (403), query errors (500+), and not-found errors (404)
- The `skipped` list tracks models that returned 404, preserving model names for user feedback
- When all probed models are unqueryable, the test checks the attached catalog metadata before failing, allowing connections with Build access to specific models to succeed even if the workspace walk only encounters Viewer-accessible models
- Updated test coverage includes scenarios for budget respect, walking past runs of unqueryable models, and catalog fallback behavior

https://claude.ai/code/session_01R6a1s9PpSweAqStWraNUfJ