### PR TITLE
Stop instructions losing markdown when rendered and when saved

### DIFF
--- a/frontend/assets/css/instruction-prose.css
+++ b/frontend/assets/css/instruction-prose.css
@@ -1,0 +1,229 @@
+/*
+ * Rendered-markdown typography for instructions — ONE stylesheet driving both
+ * surfaces that display an instruction:
+ *
+ *   .instruction-prose            read-only  (InstructionText.vue, markdown-it → v-html)
+ *   .tiptap-prose                 editing    (InstructionEditor.vue, tiptap/ProseMirror)
+ *
+ * These used to be two near-identical copies inside each component's scoped
+ * <style>, and they drifted: the read-only copy never gained rules for the
+ * elements markdown-it emits beyond the handful someone remembered (tables,
+ * links, rules, h4-h6, images), so those rendered with nothing but Tailwind's
+ * preflight underneath them — borderless zero-padding table cells running
+ * together, links coloured exactly like body text, <hr> with no border at all,
+ * and h4+ at body size and weight. Keeping one stylesheet for both surfaces is
+ * what makes "the read-only view and the editor render identically" checkable
+ * rather than aspirational.
+ *
+ * Global (not scoped) on purpose: both class names are unique to instruction
+ * rendering, and `:deep()` from two components cannot share a declaration.
+ * Direction: every rule uses logical properties (padding-inline-start,
+ * border-inline-start) so a block whose own dir="rtl" flips without a second
+ * ruleset. Code and tabular data stay LTR — same policy as rtl.css.
+ */
+
+.instruction-prose,
+.tiptap-prose {
+  font-size: 13px;
+  line-height: 1.625;
+  color: #111827;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  /* `start` resolves against each block's own dir (set per block from its first
+   * strong character), so RTL blocks right-align. */
+  text-align: start;
+}
+
+.tiptap-prose { outline: none; }
+.tiptap-prose:focus { outline: none; }
+
+/* ── Headings ──────────────────────────────────────────────────────────────
+ * Preflight resets ALL six to `font-size: inherit; font-weight: inherit`, so
+ * any level left out here renders as plain body text. */
+.instruction-prose h1,
+.tiptap-prose h1 { font-size: 1.25em; font-weight: 600; margin: 0.75em 0 0.25em; color: #111827; }
+.instruction-prose h2,
+.tiptap-prose h2 { font-size: 1.1em; font-weight: 600; margin: 0.6em 0 0.2em; color: #111827; }
+.instruction-prose h3,
+.tiptap-prose h3 { font-size: 1em; font-weight: 600; margin: 0.5em 0 0.15em; color: #111827; }
+.instruction-prose h4,
+.tiptap-prose h4 { font-size: 0.95em; font-weight: 600; margin: 0.5em 0 0.15em; color: #374151; }
+.instruction-prose h5,
+.tiptap-prose h5 { font-size: 0.9em; font-weight: 600; margin: 0.5em 0 0.15em; color: #4b5563; }
+.instruction-prose h6,
+.tiptap-prose h6 { font-size: 0.85em; font-weight: 600; margin: 0.5em 0 0.15em; color: #6b7280; text-transform: uppercase; letter-spacing: 0.04em; }
+
+/* ── Paragraphs ─────────────────────────────────────────────────────────── */
+.instruction-prose p,
+.tiptap-prose p { margin-bottom: 0.5em; }
+.instruction-prose p:last-child,
+.tiptap-prose p:last-child { margin-bottom: 0; }
+
+/* ── Lists — logical padding puts markers on the start edge under RTL ───── */
+.instruction-prose ul,
+.tiptap-prose ul { padding-inline-start: 1.25em; list-style: disc; margin-bottom: 0.5em; }
+.instruction-prose ol,
+.tiptap-prose ol { padding-inline-start: 1.25em; list-style: decimal; margin-bottom: 0.5em; }
+.instruction-prose li,
+.tiptap-prose li { margin-bottom: 0.2em; }
+/* Nested lists sit inside their parent item, not as a second block after it. */
+.instruction-prose li > ul, .instruction-prose li > ol,
+.tiptap-prose li > ul, .tiptap-prose li > ol { margin-top: 0.2em; margin-bottom: 0; }
+
+/* ── Inline code ───────────────────────────────────────────────────────── */
+.instruction-prose code,
+.tiptap-prose code {
+  background: #f3f4f6;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.9em;
+  color: #374151;
+}
+
+/* ── Code blocks — always LTR (SQL / identifiers read left-to-right) ────── */
+.instruction-prose pre,
+.tiptap-prose pre {
+  background: #f9fafb;
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 0.5em;
+  overflow-x: auto;
+  direction: ltr;
+  unicode-bidi: isolate;
+  text-align: left;
+}
+.instruction-prose pre code,
+.tiptap-prose pre code {
+  background: none;
+  padding: 0;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+/* ── Blockquote — logical border so the bar sits on the start edge ─────── */
+.instruction-prose blockquote,
+.tiptap-prose blockquote {
+  border-inline-start: 3px solid #e5e7eb;
+  padding-inline-start: 1em;
+  margin: 0.5em 0;
+  color: #6b7280;
+}
+
+/* ── Links ─────────────────────────────────────────────────────────────────
+ * Preflight sets `a { color: inherit; text-decoration: inherit }`, which makes
+ * an unstyled link indistinguishable from the text around it. */
+.instruction-prose a,
+.tiptap-prose a {
+  color: #2563eb;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.instruction-prose a:hover,
+.tiptap-prose a:hover { color: #1d4ed8; }
+
+/* ── Thematic break ────────────────────────────────────────────────────────
+ * Preflight sets `border-width: 0` on every element, so an unstyled <hr>
+ * occupies space and paints nothing. */
+.instruction-prose hr,
+.tiptap-prose hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+  margin: 1em 0;
+  height: 0;
+}
+/* ProseMirror renders the rule as a selectable node wrapper. */
+.tiptap-prose hr.ProseMirror-selectednode { border-top-color: #93c5fd; }
+
+/* ── Images ───────────────────────────────────────────────────────────────
+ * Without a max-width an image overflows the instruction panel entirely. */
+.instruction-prose img,
+.tiptap-prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  margin: 0.4em 0;
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────
+ * Preflight collapses borders and zeroes cell padding, so a table with no
+ * rules of its own renders as a borderless, gutterless block whose cells run
+ * straight into one another and read as a wall of text.
+ *
+ * Both renderers put the table inside a scroll container: markdown-it via the
+ * table_open/table_close renderer overrides in InstructionText, tiptap via the
+ * Table extension's own `.tableWrapper`. Without one, a table wider than the
+ * panel is squeezed until every cell wraps character-by-character. */
+.instruction-prose .md-table-wrap,
+.tiptap-prose .tableWrapper {
+  overflow-x: auto;
+  margin: 0.6em 0;
+  max-width: 100%;
+}
+
+.instruction-prose table,
+.tiptap-prose table {
+  border-collapse: collapse;
+  font-size: 0.92em;
+  /* `auto` lets a column size to its content; the wrapper handles overflow. */
+  table-layout: auto;
+}
+
+.instruction-prose th,
+.tiptap-prose th {
+  border: 1px solid #e5e7eb;
+  padding: 5px 9px;
+  background: #f9fafb;
+  font-weight: 600;
+  color: #374151;
+  /* Browser default for <th> is `center`, which reads as a different column
+   * alignment from the body cells below it. */
+  text-align: start;
+  vertical-align: top;
+}
+
+.instruction-prose td,
+.tiptap-prose td {
+  border: 1px solid #e5e7eb;
+  padding: 5px 9px;
+  color: #111827;
+  text-align: start;
+  vertical-align: top;
+}
+
+/* Cell content is already block-level; drop the paragraph gap so a one-line
+ * cell is one line tall. */
+.instruction-prose th > p, .instruction-prose td > p,
+.tiptap-prose th > p, .tiptap-prose td > p { margin-bottom: 0; }
+
+/* Tiptap's cell-selection highlight. */
+.tiptap-prose .selectedCell::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(59, 130, 246, 0.12);
+  pointer-events: none;
+}
+.tiptap-prose th, .tiptap-prose td { position: relative; }
+
+/* ── Dark mode. `.dark` lives on <html> (Tailwind darkMode: 'class'). ───── */
+.dark .instruction-prose,
+.dark .tiptap-prose { color: #e5e7eb; }
+
+.dark .instruction-prose h1, .dark .tiptap-prose h1,
+.dark .instruction-prose h2, .dark .tiptap-prose h2,
+.dark .instruction-prose h3, .dark .tiptap-prose h3 { color: #f9fafb; }
+.dark .instruction-prose h4, .dark .tiptap-prose h4 { color: #d1d5db; }
+.dark .instruction-prose h5, .dark .tiptap-prose h5 { color: #9ca3af; }
+.dark .instruction-prose h6, .dark .tiptap-prose h6 { color: #9ca3af; }
+
+.dark .instruction-prose code, .dark .tiptap-prose code { background: #374151; color: #e5e7eb; }
+.dark .instruction-prose pre, .dark .tiptap-prose pre { background: #1f2937; }
+.dark .instruction-prose blockquote, .dark .tiptap-prose blockquote { border-inline-start-color: #374151; color: #9ca3af; }
+
+.dark .instruction-prose a, .dark .tiptap-prose a { color: #93c5fd; }
+.dark .instruction-prose a:hover, .dark .tiptap-prose a:hover { color: #bfdbfe; }
+
+.dark .instruction-prose hr, .dark .tiptap-prose hr { border-top-color: #374151; }
+
+.dark .instruction-prose th, .dark .tiptap-prose th { background: #1f2937; color: #d1d5db; border-color: #374151; }
+.dark .instruction-prose td, .dark .tiptap-prose td { color: #e5e7eb; border-color: #374151; }

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -893,8 +893,15 @@
                 <input v-if="editing" v-model="draft.description" dir="auto" :placeholder="$t('agentsPage.addDescriptionOptional')" class="w-full text-sm text-gray-600 dark:text-gray-300 bg-transparent outline-none placeholder:text-gray-300 dark:placeholder:text-gray-600 mb-4" />
                 <p v-else-if="detail?.description" dir="auto" class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ detail.description }}</p>
                 <div v-else class="mb-4"></div>
+                <!-- Editing uses the regular instruction editor; viewing uses the
+                     same read-only renderer as every other instruction surface.
+                     Viewing through a non-editable tiptap meant the markdown was
+                     parsed into the EDITOR's schema just to be displayed, so
+                     anything that schema lacked (a table, a link, a rule) was
+                     dropped before it could ever be painted. -->
                 <div class="prose-instruction">
-                  <InstructionEditor :key="(detail?.id || 'new') + (editing ? '-edit' : '-view')" v-model="draft.text" mode="wysiwyg" :editable="editing" :data-source-ids="draft.data_source_ids" :is-all-data-sources="draft.data_source_ids.length === 0" :placeholder="$t('agentsPage.instructionPlaceholder')" @mention-selected="onEditorMention" />
+                  <InstructionEditor v-if="editing" :key="(detail?.id || 'new') + '-edit'" v-model="draft.text" mode="wysiwyg" :editable="true" :data-source-ids="draft.data_source_ids" :is-all-data-sources="draft.data_source_ids.length === 0" :placeholder="$t('agentsPage.instructionPlaceholder')" @mention-selected="onEditorMention" />
+                  <InstructionText v-else :key="(detail?.id || 'new') + '-view'" :text="draft.text" :references="detailTextRefs" :prose="true" :markdown="true" />
                 </div>
               </div>
             </div>
@@ -1915,6 +1922,14 @@ const refIds = computed<string[]>({
     })
   },
 })
+// InstructionText takes flat references; draft rows are association rows.
+const detailTextRefs = computed(() => draft.references.map((r: any) => ({
+  id: String(r.object_id),
+  type: r.object_type,
+  name: r.display_text || null,
+  data_source_type: r.object?.data_source_type || r.object?.connection_type || null,
+})))
+
 // @-mentions in the editor must land in draft.references — the save body sends
 // only draft.references, so an unhandled mention would never become a row.
 const onEditorMention = (item: any) => {

--- a/frontend/components/instructions/InstructionEditor.vue
+++ b/frontend/components/instructions/InstructionEditor.vue
@@ -106,6 +106,12 @@
 import { Editor, EditorContent, BubbleMenu, Extension } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Mention from '@tiptap/extension-mention'
+import Link from '@tiptap/extension-link'
+import Image from '@tiptap/extension-image'
+import Table from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import MarkdownIt from 'markdown-it'
@@ -213,34 +219,119 @@ function serializeInlineMarks(text: string, marks: any[]): string {
   return text
 }
 
+const isListNode = (node: any): boolean =>
+  node?.type === 'bulletList' || node?.type === 'orderedList'
+
+const prefixLines = (text: string, prefix: string): string =>
+  text.split('\n').map((line) => (prefix + line).trimEnd()).join('\n')
+
+// Everything after an item's first line has to sit at the item's CONTENT
+// column, which is the width of its own marker — 2 for `- `, but 3 for `3. `
+// and 4 for `10. `. Indent a nested list by less than that and it is no longer
+// inside the item at all: the parser reads it as a new top-level list and
+// splits the parent list in two around it.
+const indentContinuation = (text: string, width: number): string => {
+  const pad = ' '.repeat(width)
+  return text
+    .split('\n')
+    .map((line, i) => (i === 0 ? line : (pad + line).trimEnd()))
+    .join('\n')
+}
+
+function serializeListWith(node: any, marker: (index: number) => string): string {
+  return (node.content || [])
+    .map((item: any, i: number) => {
+      const m = marker(i)
+      return m + indentContinuation(serializeListItem(item), m.length)
+    })
+    .join('\n')
+}
+
+// A table cell holds block content, but a GFM row is one line: flatten to a
+// single line and escape pipes so the cell boundary stays unambiguous.
+function serializeTableCell(cell: any): string {
+  return (cell?.content || [])
+    .map((n: any) => serializeNode(n))
+    .join(' ')
+    .replace(/\|/g, '\\|')
+    .replace(/\s*\n+\s*/g, ' ')
+    .trim()
+}
+
+function serializeTable(node: any): string {
+  const rows = (node.content || []).filter((r: any) => r?.type === 'tableRow')
+  if (!rows.length) return ''
+  const cellsOf = (row: any) => (row.content || []).map(serializeTableCell)
+  const grid = rows.map(cellsOf)
+  // Ragged rows are legal in ProseMirror but not in GFM — pad every row to the
+  // widest one so the delimiter row's column count always matches.
+  const width = Math.max(...grid.map((r: string[]) => r.length))
+  const line = (cells: string[]) =>
+    '| ' + Array.from({ length: width }, (_, i) => cells[i] ?? '').join(' | ') + ' |'
+  return [
+    line(grid[0]),
+    '| ' + Array.from({ length: width }, () => '---').join(' | ') + ' |',
+    ...grid.slice(1).map(line),
+  ].join('\n')
+}
+
 function serializeNode(node: any): string {
   if (!node) return ''
   switch (node.type) {
     case 'doc':
-      return (node.content || []).map(serializeNode).join('\n\n').trim()
+      return (node.content || []).map((n: any) => serializeNode(n)).join('\n\n').trim()
     case 'paragraph':
       if (!node.content?.length) return ''
-      return (node.content || []).map(serializeNode).join('')
+      return (node.content || []).map((n: any) => serializeNode(n)).join('')
     case 'heading': {
       const level = node.attrs?.level || 1
-      const inner = (node.content || []).map(serializeNode).join('')
+      const inner = (node.content || []).map((n: any) => serializeNode(n)).join('')
       return '#'.repeat(level) + ' ' + inner
     }
     case 'bulletList':
-      return (node.content || []).map((item: any) => '- ' + serializeListItem(item)).join('\n')
-    case 'orderedList':
-      return (node.content || []).map((item: any, i: number) => `${i + 1}. ` + serializeListItem(item)).join('\n')
+      return serializeListWith(node, () => '- ')
+    case 'orderedList': {
+      // A list authored as `5.` keeps its offset instead of being renumbered.
+      const start = Number(node.attrs?.start) || 1
+      return serializeListWith(node, (i) => `${start + i}. `)
+    }
     case 'listItem':
       return serializeListItem(node)
-    case 'blockquote':
-      return (node.content || []).map(serializeNode).map((s: string) => '> ' + s).join('\n')
+    case 'blockquote': {
+      // `>` belongs on every LINE, not every child node: a child that
+      // serializes to multiple lines (a list, a fence, two paragraphs) would
+      // otherwise leave the quote after its first line.
+      const inner = (node.content || []).map((n: any) => serializeNode(n)).join('\n\n')
+      return prefixLines(inner, '> ')
+    }
     case 'codeBlock': {
       const lang = node.attrs?.language || ''
-      const code = (node.content || []).map((n: any) => n.text || '').join('')
+      // The renderer emits a trailing newline inside <code>, so it comes back
+      // as part of the text node. Re-adding one on top of it would push a blank
+      // line into the fence — and another on every save after that.
+      const code = (node.content || []).map((n: any) => n.text || '').join('').replace(/\n$/, '')
       return '```' + lang + '\n' + code + '\n```'
     }
+    case 'horizontalRule':
+      return '---'
+    case 'image': {
+      const src = node.attrs?.src || ''
+      const alt = node.attrs?.alt || ''
+      const title = node.attrs?.title
+      return `![${alt}](${src}${title ? ` "${title}"` : ''})`
+    }
+    case 'table':
+      return serializeTable(node)
+    case 'tableRow':
+    case 'tableHeader':
+    case 'tableCell':
+      return serializeTableCell(node)
     case 'hardBreak':
-      return '\n'
+      // A bare newline re-parses as a soft break and gets folded away (the
+      // renderer runs with breaks:false). The backslash form survives the
+      // round-trip, and unlike two trailing spaces it also survives the
+      // per-line trimming that quoting and list indentation apply.
+      return '\\\n'
     case 'mention': {
       const label = node.attrs?.label || node.attrs?.id || ''
       // Quote names that a bare parse could not delimit, so the markdown stays
@@ -250,12 +341,22 @@ function serializeNode(node: any): string {
     case 'text':
       return serializeInlineMarks(node.text || '', node.marks || [])
     default:
-      return (node.content || []).map(serializeNode).join('')
+      return (node.content || []).map((n: any) => serializeNode(n)).join('')
   }
 }
 
+// A list item's children, unindented — the caller indents the whole block to
+// the item's content column. A nested list hangs directly off the line above it
+// (a tight list); any other following block needs the blank line that separates
+// two blocks, or the two would re-parse as one paragraph.
 function serializeListItem(node: any): string {
-  return (node.content || []).map(serializeNode).join('\n')
+  const children = node.content || []
+  let out = ''
+  children.forEach((child: any, i: number) => {
+    if (i > 0) out += isListNode(child) ? '\n' : '\n\n'
+    out += serializeNode(child)
+  })
+  return out
 }
 
 function docToMarkdown(doc: any): string {
@@ -269,15 +370,40 @@ function docToMarkdown(doc: any): string {
 let sourceMarkdown = props.modelValue || ''
 let lastEditorMarkdown: string | null = null
 
+// Constructs whose disappearance between two revisions means the editor could
+// not represent them, not that the user deleted them. Counted, not compared, so
+// an edit that legitimately removes one row still registers as a smaller count
+// on that probe alone.
+const STRUCTURE_PROBES: RegExp[] = [
+  /^[^\S\n]*\|.*\|[^\S\n]*$/gm,          // table row
+  /^[^\S\n]*(?:-{3,}|\*{3,}|_{3,})[^\S\n]*$/gm, // thematic break
+  /!\[[^\]]*\]\([^)]*\)/g,               // image
+  /\[[^\]]*\]\([^)]*\)/g,                // link (and image, counted by both)
+  /^[^\S\n]*(?:```|~~~)/gm,              // code fence
+]
+
+const countStructures = (text: string): number[] =>
+  STRUCTURE_PROBES.map((re) => (text.match(re) || []).length)
+
+// True when `candidate` holds fewer of some construct than `reference` does.
+function dropsStructure(candidate: string, reference: string): boolean {
+  const c = countStructures(candidate)
+  const r = countStructures(reference)
+  return c.some((n, i) => n < r[i])
+}
+
 function preserveSourceFormatting(previous: string, next: string): string {
   if (previous === next) return sourceMarkdown
   const dmp = new (DiffMatchPatch as any)()
   const patches = dmp.patch_make(previous, next)
   const [patched, applied] = dmp.patch_apply(patches, sourceMarkdown)
   if (applied.every(Boolean)) return patched
-  // A source that cannot accept the editor delta is already structurally
-  // different from what TipTap rendered. Fall back to its exact serialized
-  // document rather than applying a partial patch.
+  // Not every hunk landed. `next` is TipTap's serialization of the WHOLE
+  // document, so taking it wholesale also writes away anything the schema could
+  // not represent — which is how a single unsupported construct used to flatten
+  // an entire instruction. Prefer the partially patched source whenever it
+  // keeps at least as much structure as `next` would.
+  if (applied.some(Boolean) && !dropsStructure(patched, next)) return patched
   return next
 }
 
@@ -428,7 +554,14 @@ function scrollDropdownItem(index: number) {
 // is excluded) stay LTR. Applied as ProseMirror node decorations: the rendered
 // DOM gets a `dir` attribute but the document itself is untouched, so nothing
 // leaks into the serialized markdown.
-const AUTO_DIR_NODES = new Set(['paragraph', 'heading', 'bulletList', 'orderedList', 'listItem', 'blockquote'])
+// Mirrors InstructionText's DIR_OPEN_TOKENS — the two lists must agree, or the
+// editor and the read-only view disagree about which way a block reads. Tables
+// matter most: with no dir of its own a table inherits the document's LTR and
+// lays an RTL table's columns out backwards.
+const AUTO_DIR_NODES = new Set([
+  'paragraph', 'heading', 'bulletList', 'orderedList', 'listItem', 'blockquote',
+  'table', 'tableRow', 'tableHeader', 'tableCell',
+])
 
 const AutoDir = Extension.create({
   name: 'autoDir',
@@ -473,8 +606,29 @@ const editorFailed = ref(false)
 const editorOptions = () => ({
   extensions: [
     StarterKit.configure({
-      heading: { levels: [1, 2, 3] },
+      // All six levels: markdown allows `####`-`######`, and a level missing
+      // from the schema is parsed as a plain paragraph — which then serializes
+      // back without its `#` marks, demoting the heading permanently.
+      heading: { levels: [1, 2, 3, 4, 5, 6] },
     }),
+    // Every markdown construct md.render() can emit needs a matching schema
+    // node, or ProseMirror silently drops it on parse and docToMarkdown has
+    // nothing left to serialize — the construct is then deleted from the
+    // stored instruction on the next save. StarterKit covers paragraphs,
+    // headings, lists, code, quotes and rules; these cover the rest.
+    Link.configure({ openOnClick: false, autolink: false, HTMLAttributes: { rel: 'noopener noreferrer nofollow' } }),
+    // `inline` matches how the renderer emits images — always inside a
+    // paragraph, never as a sibling of one. As a block node the image forces
+    // ProseMirror to split the paragraph around it on parse, and the node can
+    // be dropped outright depending on what surrounds it.
+    Image.configure({ inline: true, allowBase64: true }),
+    // `resizable` is what installs tiptap's TableView, and with it the
+    // `.tableWrapper` scroll container — without it a table wider than the
+    // panel has nowhere to go and every cell wraps to breaking point.
+    Table.configure({ resizable: true }),
+    TableRow,
+    TableHeader,
+    TableCell,
     Mention.configure({
       HTMLAttributes: { class: 'mention-chip' },
       renderLabel: ({ node }: any) => `@${node.attrs.label ?? node.attrs.id}`,
@@ -637,73 +791,10 @@ function onRawInput() {
 }
 
 /* Tiptap editor content area */
-.wysiwyg-content :deep(.tiptap-prose) {
-  min-height: 210px;
-  padding: 8px 0;
-  font-size: 12px;
-  line-height: 1.625;
-  color: #111827;
-  outline: none;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  /* `start` resolves against each block's own dir (set by the auto-dir
-   * decorations), so RTL blocks right-align and LTR blocks left-align. */
-  text-align: start;
-}
-
-.wysiwyg-content :deep(.tiptap-prose:focus) {
-  outline: none;
-}
-
-/* Headings */
-.wysiwyg-content :deep(.tiptap-prose h1) { font-size: 1.25em; font-weight: 600; margin: 0.75em 0 0.25em; color: #111827; }
-.wysiwyg-content :deep(.tiptap-prose h2) { font-size: 1.1em; font-weight: 600; margin: 0.6em 0 0.2em; color: #111827; }
-.wysiwyg-content :deep(.tiptap-prose h3) { font-size: 1em; font-weight: 600; margin: 0.5em 0 0.15em; color: #111827; }
-
-/* Paragraphs */
-.wysiwyg-content :deep(.tiptap-prose p) { margin-bottom: 0.5em; }
-.wysiwyg-content :deep(.tiptap-prose p:last-child) { margin-bottom: 0; }
-
-/* Lists — logical padding so RTL lists get their markers on the right edge */
-.wysiwyg-content :deep(.tiptap-prose ul) { padding-inline-start: 1.25em; list-style: disc; margin-bottom: 0.5em; }
-.wysiwyg-content :deep(.tiptap-prose ol) { padding-inline-start: 1.25em; list-style: decimal; margin-bottom: 0.5em; }
-.wysiwyg-content :deep(.tiptap-prose li) { margin-bottom: 0.2em; }
-
-/* Inline code */
-.wysiwyg-content :deep(.tiptap-prose code) {
-  background: #f3f4f6;
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-family: ui-monospace, monospace;
-  font-size: 0.9em;
-  color: #374151;
-}
-
-/* Code blocks — always LTR regardless of the surrounding text direction
- * (same policy as rtl.css: SQL / identifiers read left-to-right). */
-.wysiwyg-content :deep(.tiptap-prose pre) {
-  background: #f9fafb;
-  padding: 10px 12px;
-  border-radius: 6px;
-  margin-bottom: 0.5em;
-  overflow-x: auto;
-  direction: ltr;
-  unicode-bidi: isolate;
-  text-align: left;
-}
-.wysiwyg-content :deep(.tiptap-prose pre code) {
-  background: none;
-  padding: 0;
-  font-size: 11px;
-  line-height: 1.5;
-}
-
-/* Blockquote — logical border/padding so the bar sits on the start edge */
-.wysiwyg-content :deep(.tiptap-prose blockquote) {
-  border-inline-start: 3px solid #e5e7eb;
-  padding-inline-start: 1em;
-  margin: 0.5em 0;
-  color: #6b7280;
-}
+/* Element typography for `.tiptap-prose` lives in
+ * assets/css/instruction-prose.css, shared with InstructionText's
+ * `.instruction-prose` so the editor and the read-only view cannot drift
+ * apart. Only editor-specific chrome stays here. */
 
 /* Mention chip */
 .wysiwyg-content :deep(.mention-chip) {
@@ -790,13 +881,6 @@ function onRawInput() {
    component's scope, so these are authored as :global and matched by the
    component-unique `.wysiwyg-content` / `.bubble-*` / `.raw-textarea` classes.
    Each pairs with an equal-specificity light rule above and wins by order. */
-:global(.dark .wysiwyg-content .tiptap-prose) { color: #e5e7eb; }
-:global(.dark .wysiwyg-content .tiptap-prose h1),
-:global(.dark .wysiwyg-content .tiptap-prose h2),
-:global(.dark .wysiwyg-content .tiptap-prose h3) { color: #f9fafb; }
-:global(.dark .wysiwyg-content .tiptap-prose code) { background: #374151; color: #e5e7eb; }
-:global(.dark .wysiwyg-content .tiptap-prose pre) { background: #1f2937; }
-:global(.dark .wysiwyg-content .tiptap-prose blockquote) { border-inline-start-color: #374151; color: #9ca3af; }
 :global(.dark .wysiwyg-content .mention-chip) {
   background-color: rgba(129, 140, 248, 0.18);
   color: #c7d2fe;

--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -45,6 +45,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import DocMermaid from '~/components/dashboard/DocMermaid.vue'
 import { firstStrongDir } from '~/utils/textDirection'
@@ -128,7 +129,20 @@ const md = new MarkdownIt({ html: true, breaks: false, linkify: false })
 // (via the logical CSS below). Code blocks are skipped — they stay LTR.
 const DIR_OPEN_TOKENS = new Set([
   'paragraph_open', 'heading_open', 'bullet_list_open', 'ordered_list_open', 'list_item_open', 'blockquote_open',
+  // Tables need it most: without a dir of their own an RTL table inherits the
+  // document's LTR and lays its columns out left-to-right, mirroring the order
+  // they were authored in. Cells carry their own dir as well, so a table mixing
+  // Hebrew labels with English identifiers aligns each cell by its own content.
+  'table_open', 'tr_open', 'th_open', 'td_open',
 ])
+
+// A table wider than the panel has nowhere to go: it is squeezed until every
+// cell wraps. Wrap each one in its own scroll container (the editor gets the
+// equivalent for free from the Table extension's `.tableWrapper`).
+md.renderer.rules.table_open = (tokens, idx, options, _env, self) =>
+  '<div class="md-table-wrap">' + self.renderToken(tokens, idx, options)
+md.renderer.rules.table_close = (tokens, idx, options, _env, self) =>
+  self.renderToken(tokens, idx, options) + '</div>'
 
 md.core.ruler.push('block_dir', (state) => {
   const tokens = state.tokens
@@ -159,9 +173,13 @@ function preprocessMentions(text: string, matcher: MentionMatcher | null): strin
   })
 }
 
+// Instruction text is not only hand-written: instructions are drafted by the
+// agent and learned from sessions, and the renderer runs with html:true so
+// authored HTML passes through. Straight into v-html that is a script-execution
+// path, so sanitize exactly as DocViewer does before rendering markdown.
 function renderProse(text: string, matcher: MentionMatcher | null): string {
   if (!text.trim()) return ''
-  return md.render(preprocessMentions(text, matcher))
+  return DOMPurify.sanitize(md.render(preprocessMentions(text, matcher)))
 }
 
 // Split the markdown into prose blocks and ```mermaid diagram blocks, so a
@@ -212,60 +230,10 @@ const blocks = computed<Block[]>(() => {
 </script>
 
 <style scoped>
-.instruction-prose {
-  font-size: 13px;
-  line-height: 1.625;
-  color: #111827;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  /* `start` resolves against each block's own dir (set per block from its
-   * first strong character), so RTL blocks right-align. */
-  text-align: start;
-}
-
-.instruction-prose :deep(h1) { font-size: 1.25em; font-weight: 600; margin: 0.75em 0 0.25em; color: #111827; }
-.instruction-prose :deep(h2) { font-size: 1.1em; font-weight: 600; margin: 0.6em 0 0.2em; color: #111827; }
-.instruction-prose :deep(h3) { font-size: 1em; font-weight: 600; margin: 0.5em 0 0.15em; color: #111827; }
-
-.instruction-prose :deep(p) { margin-bottom: 0.5em; }
-.instruction-prose :deep(p:last-child) { margin-bottom: 0; }
-
-.instruction-prose :deep(ul) { padding-inline-start: 1.25em; list-style: disc; margin-bottom: 0.5em; }
-.instruction-prose :deep(ol) { padding-inline-start: 1.25em; list-style: decimal; margin-bottom: 0.5em; }
-.instruction-prose :deep(li) { margin-bottom: 0.2em; }
-
-.instruction-prose :deep(code) {
-  background: #f3f4f6;
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-family: ui-monospace, monospace;
-  font-size: 0.9em;
-  color: #374151;
-}
-
-.instruction-prose :deep(pre) {
-  background: #f9fafb;
-  padding: 10px 12px;
-  border-radius: 6px;
-  margin-bottom: 0.5em;
-  overflow-x: auto;
-  /* Code always reads LTR (same policy as rtl.css). */
-  direction: ltr;
-  unicode-bidi: isolate;
-  text-align: left;
-}
-.instruction-prose :deep(pre code) {
-  background: none;
-  padding: 0;
-  font-size: 11px;
-  line-height: 1.5;
-}
-
-.instruction-prose :deep(blockquote) {
-  border-inline-start: 3px solid #e5e7eb;
-  padding-inline-start: 1em;
-  margin: 0.5em 0;
-  color: #6b7280;
-}
+/* Element typography for the rendered markdown lives in
+   assets/css/instruction-prose.css, shared with InstructionEditor's
+   `.tiptap-prose` so the read-only view and the editor cannot drift apart.
+   Only the mention chip — whose class differs between the two — stays here. */
 
 .instruction-prose :deep(.instruction-mention) {
   background-color: rgba(99, 102, 241, 0.12);
@@ -277,16 +245,9 @@ const blocks = computed<Block[]>(() => {
   white-space: nowrap;
 }
 
-/* Dark mode overrides. The `.dark` class lives on <html> (Tailwind darkMode:
-   'class'), outside this component's scope, so these rules are authored as
-   :global and matched by the unique `.instruction-prose` class. */
-:global(.dark .instruction-prose) { color: #e5e7eb; }
-:global(.dark .instruction-prose h1),
-:global(.dark .instruction-prose h2),
-:global(.dark .instruction-prose h3) { color: #f9fafb; }
-:global(.dark .instruction-prose code) { background: #374151; color: #e5e7eb; }
-:global(.dark .instruction-prose pre) { background: #1f2937; }
-:global(.dark .instruction-prose blockquote) { border-inline-start-color: #374151; color: #9ca3af; }
+/* The `.dark` class lives on <html> (Tailwind darkMode: 'class'), outside this
+   component's scope, so this is authored as :global and matched by the unique
+   `.instruction-prose` class. */
 :global(.dark .instruction-prose .instruction-mention) {
   background-color: rgba(129, 140, 248, 0.18);
   color: #c7d2fe;

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -69,6 +69,7 @@ export default defineNuxtConfig({
   ],
 
   css: [
+    '~/assets/css/instruction-prose.css',
     '~/assets/css/rtl.css',
     '~/assets/css/transitions.css',
     '~/assets/css/mobile.css',
@@ -223,6 +224,8 @@ export default defineNuxtConfig({
       exclude: [
         '@tiptap/extension-mention',
         '@tiptap/suggestion',
+        '@tiptap/extension-link',
+        '@tiptap/extension-image',
         '@tiptap/extension-table',
         '@tiptap/extension-table-row',
         '@tiptap/extension-table-cell',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "@nuxt-alt/proxy": "^2.5.8",
     "@nuxt/ui": "^2.16.0",
     "@nuxtjs/mdc": "^0.17.2",
+    "@tiptap/extension-image": "^2.27.2",
+    "@tiptap/extension-link": "^2.27.2",
     "@tiptap/extension-mention": "^2.27.2",
     "@tiptap/extension-table": "^2.27.2",
     "@tiptap/extension-table-cell": "^2.27.2",

--- a/frontend/tests/instructions/instruction-editor-renders.spec.ts
+++ b/frontend/tests/instructions/instruction-editor-renders.spec.ts
@@ -59,7 +59,14 @@ test('instruction detail renders its text in the editor', async ({ page }) => {
   await expect(page.getByText('Editor Render Regression Instruction').first())
     .toBeVisible({ timeout: 45000 });
 
-  // The actual regression: the tiptap editor must mount and show the body.
+  // Viewing renders through InstructionText, not the editor: parsing an
+  // instruction into the EDITOR's schema merely to display it dropped every
+  // construct that schema lacked before it could be painted.
+  await expect(page.locator('.instruction-prose').first())
+    .toContainText(marker, { timeout: 30000 });
+
+  // Editing mounts the regular instruction editor — the actual regression.
+  await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
   await expect(page.locator('.tiptap-prose').first())
     .toContainText(marker, { timeout: 30000 });
 

--- a/frontend/tests/instructions/instruction-markdown-fidelity.spec.ts
+++ b/frontend/tests/instructions/instruction-markdown-fidelity.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect } from '../fixtures/feature-test';
+
+// Regression: an instruction must survive being displayed AND being edited
+// without losing markdown constructs.
+//
+// Two separate failures used to compound here.
+//
+// 1. Display. InstructionText styled only h1-h3, p, lists, code and quotes, so
+//    every other element markdown-it emits met Tailwind's preflight bare:
+//    tables collapsed to borderless zero-padding cells that read as one run of
+//    text, links were coloured exactly like body copy, <hr> painted nothing,
+//    and h4-h6 rendered at body size and weight. RTL tables also inherited the
+//    document's LTR and laid their columns out backwards.
+//
+// 2. Storage. The editor registered only StarterKit + Mention, so tables,
+//    links, images and (via a missing serializer case) thematic rules had no
+//    schema node. ProseMirror dropped them on parse and docToMarkdown wrote
+//    the flattened document back — one unsupported construct could strip every
+//    table out of an instruction permanently on the next save.
+//
+// The fixture below is deliberately mundane; what matters is that it contains
+// one of each construct, in both text directions.
+const MD = [
+  '# Depot Handbook',
+  '',
+  'Covers **scheduling**, _billing_ and ~~retired~~ current routes.',
+  '',
+  '## Fact tables',
+  '',
+  '| Table | Grain | Measure |',
+  '| --- | --- | --- |',
+  '| `fct_trip` | one row per trip | `distance_km` |',
+  '| `fct_charge` | one row per charge | `amount_cents` |',
+  '',
+  '---',
+  '',
+  '### Rules',
+  '',
+  '1. Filter `fct_trip` on `is_void = false`.',
+  '2. Rollups run in three steps:',
+  '   - per-hour bucket',
+  '   - per-depot bucket',
+  '     - flag under 10%',
+  '     - flag over 90%',
+  '   - weekly summary',
+  '3. Never join two fact tables.',
+  '',
+  '#### Example',
+  '',
+  '```sql',
+  'SELECT depot_id, COUNT(*) FROM fct_trip GROUP BY 1',
+  '```',
+  '',
+  '##### Escalation',
+  '',
+  '> Ask the platform team first.',
+  '> They own the contract tests, which cover:',
+  '> - nightly reconciliation',
+  '> - depot alerting',
+  '',
+  '###### Retired',
+  '',
+  'See the [migration notes](https://example.com/depot/migration).',
+  '',
+  '## נהלים בעברית',
+  '',
+  '| מדד | טבלה |',
+  '| --- | --- |',
+  '| נסיעות | `fct_trip` |',
+  '| חיובים | `fct_charge` |',
+  '',
+  '![depot legend](https://example.com/depot/legend.png)',
+  '',
+].join('\n');
+
+// Counting constructs rather than diffing text: an edit legitimately changes
+// characters, but it must never reduce the number of tables, links or rules.
+const PROBES = {
+  tableRows: /^[^\S\n]*\|.*\|[^\S\n]*$/gm,
+  thematicBreaks: /^-{3}$/gm,
+  links: /\[[^\]]*\]\([^)]*\)/g,
+  images: /!\[[^\]]*\]\([^)]*\)/g,
+  codeFences: /^```/gm,
+  nestedListItems: /^ {2,}- /gm,
+  headings: /^#{1,6} /gm,
+  quotedLines: /^> /gm,
+};
+const profile = (text: string) =>
+  Object.fromEntries(Object.entries(PROBES).map(([k, re]) => [k, (text.match(re) || []).length]));
+
+test('an instruction renders, edits and saves without losing markdown', async ({ page }) => {
+  const cookies = await page.context().cookies();
+  const rawToken = cookies.find((c) => c.name === 'auth.token' || c.name === 'auth_token')?.value;
+  expect(rawToken, 'auth token cookie should exist in the admin storage state').toBeTruthy();
+  const bearer = decodeURIComponent(rawToken!);
+  const auth = bearer.startsWith('Bearer') ? bearer : `Bearer ${bearer}`;
+
+  const whoami = await page.request.get('/api/users/whoami', { headers: { Authorization: auth } });
+  expect(whoami.ok()).toBeTruthy();
+  const orgId = (await whoami.json()).organizations?.[0]?.id;
+  expect(orgId, 'admin user should belong to an organization').toBeTruthy();
+  const headers = { Authorization: auth, 'X-Organization-Id': orgId };
+
+  const created = await page.request.post('/api/instructions', {
+    headers,
+    data: {
+      title: 'Depot Handbook',
+      text: MD,
+      status: 'published',
+      category: 'general',
+      load_mode: 'always',
+      data_source_ids: [],
+    },
+  });
+  expect(created.ok(), `create instruction failed: ${created.status()}`).toBeTruthy();
+  const instruction = await created.json();
+
+  await page.goto(`/agents/instructions/${instruction.id}`, { waitUntil: 'commit' });
+  await expect(page.locator('.instruction-prose').first()).toBeVisible({ timeout: 45000 });
+  await expect(page.locator('.instruction-prose').first()).toContainText('Depot Handbook', { timeout: 30000 });
+
+  // ── 1. Everything markdown-it emits is rendered AND styled ────────────────
+  const view = await page.evaluate(() => {
+    const el = document.querySelector('.instruction-prose')!;
+    const px = (v: string | undefined) => parseFloat(v || '0');
+    const cell = el.querySelector('td');
+    const cellStyle = cell && getComputedStyle(cell);
+    const link = el.querySelector('a');
+    const body = el.querySelector('p');
+    const rule = el.querySelector('hr');
+    const h4 = el.querySelector('h4');
+    const rtlTable = [...el.querySelectorAll('table')].find((t) => t.getAttribute('dir') === 'rtl');
+    return {
+      tables: el.querySelectorAll('table').length,
+      tableScrollWrappers: el.querySelectorAll('.md-table-wrap').length,
+      cellBorderPx: px(cellStyle?.borderTopWidth),
+      cellPaddingPx: px(cellStyle?.paddingLeft),
+      linkColor: link && getComputedStyle(link).color,
+      bodyColor: body && getComputedStyle(body).color,
+      linkUnderlined: link ? getComputedStyle(link).textDecorationLine.includes('underline') : false,
+      ruleBorderPx: px(rule ? getComputedStyle(rule).borderTopWidth : '0'),
+      h4Px: px(h4 ? getComputedStyle(h4).fontSize : '0'),
+      h4Weight: h4 ? getComputedStyle(h4).fontWeight : '',
+      bodyPx: px(body ? getComputedStyle(body).fontSize : '0'),
+      headingTags: [...el.querySelectorAll('h1,h2,h3,h4,h5,h6')].map((h) => h.tagName).join(','),
+      nestedLists: el.querySelectorAll('li > ul, li > ol').length,
+      images: el.querySelectorAll('img').length,
+      rtlTableDirection: rtlTable ? getComputedStyle(rtlTable).direction : null,
+      scripts: el.querySelectorAll('script').length,
+    };
+  });
+
+  expect(view.tables, 'both tables render as real tables').toBe(2);
+  expect(view.tableScrollWrappers, 'each table gets its own scroll container').toBe(2);
+  expect(view.cellBorderPx, 'cells are separated by a visible border').toBeGreaterThan(0);
+  expect(view.cellPaddingPx, 'cells have a gutter so text does not run together').toBeGreaterThan(0);
+  expect(view.linkUnderlined, 'links are underlined').toBe(true);
+  expect(view.linkColor, 'links are not the same colour as body text').not.toBe(view.bodyColor);
+  expect(view.ruleBorderPx, 'a thematic break paints a line').toBeGreaterThan(0);
+  expect(view.h4Weight, 'h4 is bolder than body text').toBe('600');
+  expect(view.headingTags, 'all six heading levels survive').toBe('H1,H2,H3,H4,H5,H6,H2');
+  expect(view.nestedLists, 'nested lists stay nested').toBeGreaterThanOrEqual(2);
+  expect(view.images).toBe(1);
+  expect(view.rtlTableDirection, 'an RTL table lays its columns out right-to-left').toBe('rtl');
+  expect(view.scripts, 'rendered markdown is sanitized before v-html').toBe(0);
+
+  // ── 2. Editing mounts the regular editor, with the same content ───────────
+  await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+  await expect(page.locator('.tiptap-prose').first()).toBeVisible({ timeout: 30000 });
+
+  const editor = await page.evaluate(() => {
+    const el = document.querySelector('.tiptap-prose')!;
+    return {
+      tables: el.querySelectorAll('table').length,
+      links: el.querySelectorAll('a').length,
+      rules: el.querySelectorAll('hr').length,
+      // ProseMirror inserts its own <img class="ProseMirror-separator"> around
+      // inline nodes — count only images that carry a src.
+      images: el.querySelectorAll('img[src]:not(.ProseMirror-separator)').length,
+      nestedLists: el.querySelectorAll('li > ul, li > ol').length,
+      headingTags: [...el.querySelectorAll('h1,h2,h3,h4,h5,h6')].map((h) => h.tagName).join(','),
+      // The dir decoration lands on tiptap's table wrapper, so read the
+      // direction the browser resolves rather than the attribute.
+      tableDirections: [...el.querySelectorAll('table')].map((t) => getComputedStyle(t).direction),
+    };
+  });
+  expect(editor.tables, 'tables reach the editor schema').toBe(2);
+  expect(editor.links, 'links reach the editor schema').toBe(1);
+  expect(editor.rules, 'thematic breaks reach the editor schema').toBe(1);
+  expect(editor.images, 'images reach the editor schema').toBe(1);
+  expect(editor.nestedLists, 'nested lists reach the editor schema').toBeGreaterThanOrEqual(2);
+  expect(editor.headingTags, 'h4-h6 are in the editor schema, not demoted to paragraphs')
+    .toBe('H1,H2,H3,H4,H5,H6,H2');
+  // The editor and the read-only view must agree on direction per table, or an
+  // RTL table looks mirrored the moment you click Edit.
+  expect(editor.tableDirections, 'the editor resolves table direction the same way the reader does')
+    .toEqual(['ltr', 'rtl']);
+
+  // ── 3. Saving an edit keeps every construct in the STORED markdown ────────
+  const before = (await (await page.request.get(`/api/instructions/${instruction.id}`, { headers })).json()).text;
+
+  const marker = `reviewed-${Date.now()}`;
+  await page.locator('.tiptap-prose p').first().click();
+  await page.keyboard.press('End');
+  await page.keyboard.type(` Marker ${marker}.`);
+  await page.getByRole('button', { name: /^Save$/ }).first().click();
+  await expect(page.locator('.instruction-prose').first()).toBeVisible({ timeout: 30000 });
+
+  const after = (await (await page.request.get(`/api/instructions/${instruction.id}`, { headers })).json()).text;
+  expect(after, 'the typed edit reached storage').toContain(marker);
+  expect(profile(after), 'no markdown construct was dropped by the save').toEqual(profile(before));
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2292,6 +2292,11 @@
   resolved "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.27.2.tgz"
   integrity sha512-5zL/BY41FIt72azVrCrv3n+2YJ/JyO8wxCcA4Dk1eXIobcgVyIdo4rG39gCqIOiqziAsqnqoj12QHTBtHsJ6mQ==
 
+"@tiptap/extension-image@^2.27.2":
+  version "2.27.3"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-image/-/extension-image-2.27.3.tgz#c7ef556d68a4dec85e46dfe4ff17cb9d093ded67"
+  integrity sha512-YCOxC+UOFisHVpowPc3UmUtJDV9tjKJLeHKef3DZ6h1ixOnp2LStuhy2ohcSjISg1mZlYrx+/GoYottjwj7pww==
+
 "@tiptap/extension-italic@^2.27.2":
   version "2.27.2"
   resolved "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz"
@@ -2301,6 +2306,13 @@
   version "2.27.2"
   resolved "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.2.tgz"
   integrity sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==
+  dependencies:
+    linkifyjs "^4.3.2"
+
+"@tiptap/extension-link@^2.27.2":
+  version "2.27.3"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-link/-/extension-link-2.27.3.tgz#66bc28dddbb23bc211ae1d1b0633a3329e5c0108"
+  integrity sha512-0KF+iweOlegWjsRDJO7EZL1bmmcghNmjPbcSvvyeF19Lh7Nit44dYV0w1JCDvweRRAXECYFXpxZTcIvSf0fEng==
   dependencies:
     linkifyjs "^4.3.2"
 


### PR DESCRIPTION
Instructions render on two surfaces that were supposed to agree and did
not. Tables were the visible symptom; they were one case of a general gap.

Display (InstructionText). The component styled h1-h3, p, lists, code and
blockquotes, so everything else markdown-it emits met Tailwind's preflight
with nothing underneath it: tables collapsed to borderless zero-padding
cells that read as one run of text, links were coloured exactly like body
copy, <hr> painted nothing at all, and h4-h6 rendered at body size and
weight. Tables also had no scroll container, so one wider than the panel
was squeezed until every cell wrapped, and the per-block direction pass
skipped table tokens, so an RTL table inherited the document's LTR and laid
its columns out backwards.

Storage (InstructionEditor). The editor registered only StarterKit and
Mention, so tables, links and images had no schema node and ProseMirror
dropped them on parse; horizontal rules parsed but had no serializer case;
headings were capped at level 3, demoting h4-h6 to paragraphs; nested lists
were indented by a fixed two spaces, which is short of the content column of
an ordered marker like "3. " and split the parent list in two; blockquote
markers were applied per child node rather than per line; and code fences
gained a blank line on every save. docToMarkdown then wrote that flattened
document back, so a single unsupported construct could strip every table out
of an instruction permanently the next time someone edited it.

Changes:

- Register Link, Image (inline, matching how the renderer emits it), and the
  Table extensions already in package.json; allow heading levels 1-6.
- Serialize tables, images and thematic rules; indent list continuations to
  the item's own marker width; prefix blockquotes per line; keep ordered-list
  start offsets; make code fences idempotent.
- Guard preserveSourceFormatting: a failed patch no longer falls straight
  through to TipTap's whole-document serialization when that would drop
  structure the source still has.
- Move the shared prose typography into assets/css/instruction-prose.css,
  driving both .instruction-prose and .tiptap-prose from one stylesheet, and
  fill in tables, links, rules, images and h4-h6. Two near-identical copies
  in two scoped blocks are what let the surfaces drift apart.
- Give the read-only renderer a per-table scroll container, and teach both
  direction passes about table nodes.
- Sanitize the rendered HTML with DOMPurify before v-html. Instruction text is
  agent-drafted and learned from sessions, and the renderer runs with
  html:true, so this was a script-execution path (DocViewer already does this).
- Show the instruction detail read-only through InstructionText; the editor
  now mounts only for editing, on that route and for the primary instruction.

Verified end to end against a local sandbox: an instruction carrying every
construct in both text directions renders correctly, and four consecutive
edit-and-save rounds (in a table cell, a nested list item, a heading, and a
no-op save) leave the stored markdown byte-identical apart from the typed
text. Covered by a new regression test, and tests/instructions/
instruction-editor-renders.spec.ts is updated for the read/edit split.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HgmPDxds2C33QTgctz9pbr