### PR TITLE
Route all system email through the org SMTP resolver; make the SMTP test send

### DIFF
--- a/.claude/skills/sandbox-feedback-loop/SKILL.md
+++ b/.claude/skills/sandbox-feedback-loop/SKILL.md
@@ -86,6 +86,48 @@ import main  # registers all SQLAlchemy mappers; safe, uvicorn only runs under _
 
 This is the highest-signal check for context changes: it shows exactly what the planner would see for that report.
 
+## 5b. Outbound email (SMTP)
+
+System email resolves per organization: **org SMTP** (`OrganizationSettings.config.smtp`,
+set on `/settings/smtp`) → **global bow-config SMTP** (`settings.email_client`).
+To prove *which* transport carried a message you need two local relays on
+different ports — with one sink the two are indistinguishable, which is how org
+SMTP came to be silently bypassed for invites and shares.
+
+```python
+# aiosmtpd is already a dev dependency; see backend/email_sandbox/relay.py
+org    = Controller(Recorder("org"),    hostname="127.0.0.1", port=2526,
+                    authenticator=auth("user", "pw"), auth_required=True,
+                    auth_require_tls=False)     # the org's own relay
+glob   = Controller(Recorder("global"), hostname="127.0.0.1", port=2527)
+```
+
+Point the **global** SMTP at port 2527 by copying `configs/bow-config.dev.yaml`,
+rewriting `smtp_settings` (`use_credentials: false`, `use_tls: false`), and
+booting with `BOW_CONFIG_PATH=/abs/path/to/your.yaml`. Configure the **org**
+relay (port 2526) through the real settings UI. Then every assertion is
+mechanical: *the invite landed in `org.jsonl` and `global.jsonl` is empty.*
+
+- **Never set `BOW_EMAIL_SMTP_OVERRIDE_HOST` for this.** It rewrites whatever
+  host is configured to a local sink, so a nonsense hostname "succeeds" and the
+  run proves nothing about the host the admin typed.
+- `MAIL_FROM` is validated by fastapi-mail: reserved TLDs (`.test`, `.invalid`)
+  make the app fail to boot. Use `.example.com`.
+- **Outbound SMTP is blocked in this container** (only HTTPS egress via the agent
+  proxy), so a real provider such as Resend times out at connect. To exercise the
+  STARTTLS + `AUTH LOGIN` path a hosted provider uses, run a third local relay
+  with a self-signed cert (`openssl req -x509 -newkey rsa:2048 -nodes -subj
+  /CN=localhost`), `auth_require_tls=True`, `require_starttls=True`, and turn
+  *Validate TLS certificates* off in the UI.
+- Paths worth asserting, all of which must reach the org relay: the settings
+  page's **Save & send test email**, member invites (`/settings/members`),
+  password reset (`/users/forgot-password`, signed *out* — a signed-in context
+  redirects away), report shares (`POST /api/reports/{id}/notify`), and the
+  welcome email sent at sign-up.
+- API calls from `page.evaluate` must use **relative** `/api/...` URLs (the Nuxt
+  dev server proxies; hitting `:8000` directly is blocked by CORS) and an
+  `Authorization: Bearer <auth.token cookie>` header.
+
 ## 6. Iterate
 
 Small numbered Playwright scripts (01_signup.js, 02_login.js, ...) beat one monolith: each failure is cheap to rerun, and `storageState` carries the session between them. When a selector fails: screenshot, read it, fix, rerun.

--- a/backend/app/ai/tools/mcp/send_email.py
+++ b/backend/app/ai/tools/mcp/send_email.py
@@ -51,10 +51,14 @@ class SendEmailMCPTool(MCPTool):
     async def is_available_for_org(self, db, organization) -> bool:
         """Whether outbound email resolves for this org (AI mailbox / org SMTP /
         global), mirroring the analyst send path."""
+        from app.services.email_client_resolver import (
+            global_smtp_configured,
+            is_outbound_available,
+        )
+
         org_id = getattr(organization, "id", None)
         if not db or not org_id:
-            return settings.email_client is not None
-        from app.services.email_client_resolver import is_outbound_available
+            return global_smtp_configured()
         return await is_outbound_available(db, str(org_id), purpose="analyst")
 
     @property

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -21,7 +21,8 @@ from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy import select, and_, func
 from httpx_oauth.oauth2 import BaseOAuth2
 
-from fastapi_mail import FastMail, MessageSchema, ConnectionConfig
+# fastapi-mail is no longer used here: account email goes through
+# notification_service so it honours the organization's own SMTP server.
 
 from app.schemas.user_schema import UserCreate
 from app.models.organization import Organization
@@ -716,28 +717,16 @@ class UserManager(BaseUserManager[User, str]):
             await bump_session_epoch(user.id)
 
     async def _send_reset_password_email(self, user: User, token: str, request: Optional[Request] = None):
-        import asyncio
-        
         base_url = settings.bow_config.base_url
-            
         reset_url = f"{base_url}/users/reset-password?token={token}"
-        
-        message = MessageSchema(
-            subject="Reset your password",
-            recipients=[user.email],
-            body=f"Hello {user.name},<br /><br />You have requested to reset your password for Bag of words. Click the link below to reset your password:<br /><br /> <a href='{reset_url}'>{reset_url}</a><br /><br />If you didn't request this, please ignore this email.<br /><br />Best regards,<br />Bag of words team",
-            subtype="html"
+        body = (
+            f"Hello {user.name},<br /><br />You have requested to reset your password for Bag of words. "
+            f"Click the link below to reset your password:<br /><br /> "
+            f"<a href='{reset_url}'>{reset_url}</a><br /><br />"
+            f"If you didn't request this, please ignore this email.<br /><br />"
+            f"Best regards,<br />Bag of words team"
         )
-        fm = settings.email_client
-        
-        async def send_email():
-            try:
-                await fm.send_message(message)
-            except Exception as e:
-                print(f"Error sending reset password email: {e}")
-        
-        # Create task without awaiting it
-        asyncio.create_task(send_email())
+        await self._send_account_email(user, "Reset your password", body, "reset password")
 
     async def on_after_request_verify(
         self, user: User, token: str, request: Optional[Request] = None
@@ -745,28 +734,65 @@ class UserManager(BaseUserManager[User, str]):
         await self._send_verification_email(user, token, request)
 
     async def _send_verification_email(self, user: User, token: str, request: Optional[Request] = None):
-        import asyncio
-        
         base_url = settings.bow_config.base_url
-            
         verification_url = f"{base_url}/users/verify?token={token}"
-        
-        message = MessageSchema(
-            subject="Verify your email",
-            recipients=[user.email],
-            body=f"Welcome to Bag of words! You are almost ready to start using our platform. Click to verify your email: <br /> {verification_url}",
-            subtype="html"
+        body = (
+            "Welcome to Bag of words! You are almost ready to start using our platform. "
+            f"Click to verify your email: <br /> {verification_url}"
         )
-        fm = settings.email_client
-        
-        async def send_email():
+        await self._send_account_email(user, "Verify your email", body, "verification")
+
+    async def _send_account_email(self, user: User, subject: str, body: str, kind: str) -> None:
+        """Send an account email (reset / verification) via the resolved transport.
+
+        Account mail has no organization in scope — fastapi-users knows the user,
+        not the tenant — so the org is derived from the user's membership when
+        that is unambiguous. Without this these two emails always left through
+        the global bow-config SMTP, ignoring whatever the organization had
+        configured, and simply vanished when no global SMTP existed.
+
+        Fire-and-forget by design (the caller is an auth flow that must not block
+        or leak whether an address exists), but the outcome is logged rather than
+        printed, and a missing transport no longer raises inside the task.
+        """
+        import asyncio
+
+        from app.services.email_client_resolver import sole_organization_id
+        from app.services.notification_service import notification_service
+
+        # Read the ORM instance now, while its session is still open. The task
+        # below outlives the request, and touching a detached User there raises
+        # DetachedInstanceError instead of sending the mail.
+        user_id = str(user.id)
+        recipient = user.email
+
+        async def _send() -> None:
             try:
-                await fm.send_message(message)
-            except Exception as e:
-                print(f"Error sending verification email: {e}")
-        
-        # Create task without awaiting it
-        asyncio.create_task(send_email())
+                from app.dependencies import async_session_maker
+
+                async with async_session_maker() as db:
+                    organization_id = await sole_organization_id(db, user_id)
+                    result = await notification_service.send_custom_email(
+                        recipients=[recipient],
+                        subject=subject,
+                        body=body,
+                        subtype="html",
+                        retries=2,
+                        timeout=15,
+                        db=db,
+                        organization_id=organization_id,
+                        purpose="system",
+                    )
+                if result.status == "sent":
+                    logger.info("Sent %s email to %s via %s", kind, recipient, result.source)
+                else:
+                    logger.error(
+                        "Failed to send %s email to %s: %s", kind, recipient, result.error
+                    )
+            except Exception as e:  # noqa: BLE001 — must never break the auth flow
+                logger.error("Error sending %s email to %s: %s", kind, recipient, e)
+
+        asyncio.create_task(_send())
 
     async def create(
         self,

--- a/backend/app/routes/bow_settings.py
+++ b/backend/app/routes/bow_settings.py
@@ -21,6 +21,14 @@ async def get_frontend_settings(db: AsyncSession = Depends(get_async_db)):
     # instead of a login form. This says the instance is unclaimed, which is
     # already discoverable by attempting to register.
     setup_required = not await any_user_exists(db)
+
+    # True when *any* transport exists — the global bow-config client or an
+    # organization's own SMTP server. This is a pre-auth page with no org in
+    # scope, so it cannot ask per-organization; asking only about the global
+    # client hid password reset from orgs that configure SMTP through the UI.
+    from app.services.email_client_resolver import any_smtp_configured
+
+    smtp_enabled = await any_smtp_configured(db)
     
     return JSONResponse({
         "google_oauth": {
@@ -57,7 +65,7 @@ async def get_frontend_settings(db: AsyncSession = Depends(get_async_db)):
         "telemetry": {
             "enabled": settings.bow_config.telemetry.enabled and not is_testing,
         },
-        "smtp_enabled": settings.bow_config.smtp_settings is not None,
+        "smtp_enabled": smtp_enabled,
         "setup_required": setup_required,
         "version": settings.PROJECT_VERSION,
         "environment": settings.ENVIRONMENT,

--- a/backend/app/routes/organization_settings.py
+++ b/backend/app/routes/organization_settings.py
@@ -11,6 +11,8 @@ from app.schemas.organization_settings_schema import (
     EntraProfileSyncConfig,
     GoogleProfileSyncConfig,
     OrgSmtpSchema,
+    OrgSmtpTestRequest,
+    OrgSmtpTestResult,
     OrgSmtpUpdate,
     OrganizationSettingsSchema,
     OrganizationSettingsUpdate,
@@ -268,14 +270,21 @@ async def update_org_smtp(
     return await settings_service.update_smtp(db, organization, current_user, data)
 
 
-@router.post("/organization/smtp/test", response_model=dict)
+@router.post("/organization/smtp/test", response_model=OrgSmtpTestResult)
 @requires_permission('manage_settings')
 async def test_org_smtp(
+    data: OrgSmtpTestRequest = OrgSmtpTestRequest(),
     current_user: User = Depends(current_user),
     db: AsyncSession = Depends(get_async_db),
     organization: Organization = Depends(get_current_organization),
 ):
-    return await settings_service.test_smtp(db, organization, current_user)
+    """Send a real test email through the org's configured transport.
+
+    Sends rather than probing: a connect-and-auth check cannot see a relay that
+    refuses the envelope sender or declines to relay, which is exactly what
+    silently breaks in production.
+    """
+    return await settings_service.test_smtp(db, organization, current_user, data)
 
 
 # --- PII protection (enterprise) ------------------------------------------

--- a/backend/app/routes/report.py
+++ b/backend/app/routes/report.py
@@ -398,9 +398,14 @@ async def notify_report(
     if payload.type in (NotificationType.SHARE_DASHBOARD, NotificationType.SHARE_CONVERSATION) and not payload.share_url:
         raise HTTPException(status_code=400, detail="share_url is required for share notifications")
 
-    # Guard: email channel requires SMTP
-    if NotificationChannel.EMAIL in payload.channels and not app_settings.email_client:
-        raise HTTPException(status_code=400, detail="Email notifications are not available (SMTP not configured)")
+    # Guard: email channel requires a transport. Asked per organization — an org
+    # with its own SMTP server can send even when the global bow-config SMTP is
+    # empty, so this must not key off the startup-global client alone.
+    if NotificationChannel.EMAIL in payload.channels:
+        from app.services.email_client_resolver import is_outbound_available
+
+        if not await is_outbound_available(db, str(organization.id), purpose="system"):
+            raise HTTPException(status_code=400, detail="Email notifications are not available (SMTP not configured)")
 
     # Build share_url for schedule type if not provided
     share_url = payload.share_url or f"{app_settings.bow_config.base_url}/r/{report.id}"
@@ -440,6 +445,10 @@ async def notify_report(
         message=payload.message,
         report_id=str(report.id),
         locale=_locale_from_org(organization),
+        # Without these the share mail bypasses the org's configured SMTP server
+        # and goes out via the global bow-config relay.
+        db=db,
+        organization_id=str(organization.id),
     )
 
     # Audit log

--- a/backend/app/schemas/notification_schema.py
+++ b/backend/app/schemas/notification_schema.py
@@ -42,6 +42,15 @@ class ChannelResult(BaseModel):
     status: str  # "sent" or "failed"
     recipients: List[str] = []
     error: Optional[str] = None
+    # Which transport actually carried the mail: "org_smtp" | "global" |
+    # "ai_mailbox" | "none". Recorded so a send that silently went out via the
+    # global bow-config SMTP instead of the org's configured relay is visible
+    # in logs and API responses rather than indistinguishable from success.
+    source: Optional[str] = None
+    # Which step of the SMTP conversation failed: "config" | "connect" | "tls" |
+    # "auth" | "sender" | "recipient" | "send". Lets the UI say what to fix
+    # instead of calling every failure a rejection.
+    stage: Optional[str] = None
 
 
 class NotifyResponse(BaseModel):

--- a/backend/app/schemas/organization_settings_schema.py
+++ b/backend/app/schemas/organization_settings_schema.py
@@ -416,6 +416,39 @@ class OrgSmtpSchema(BaseModel):
     # Advanced TLS: when False, skip certificate verification (self-signed /
     # internal CA relays). Mirrors bow-config's global SMTP ``validate_certs``.
     validate_certs: bool = True
+    # Which transport system mail is *actually* leaving through right now:
+    # "org_smtp" (this server), "global" (bow-config), or "none". Surfaced so an
+    # admin can see at a glance that their relay is or isn't in use, rather than
+    # discovering months later that invites went out via bow-config.
+    active_source: str = "none"
+    # Whether a global bow-config SMTP exists to fall back to when this server
+    # is disabled — i.e. whether turning it off means "use the global relay" or
+    # "stop sending system mail".
+    global_configured: bool = False
+
+
+class OrgSmtpTestRequest(BaseModel):
+    """Optional body for the SMTP test. ``to`` defaults to the caller's address.
+
+    Only the caller's own address is accepted — this endpoint sends real mail
+    through the organization's relay, so an arbitrary recipient would turn it
+    into a spam relay for anyone holding ``manage_settings``.
+    """
+    to: Optional[str] = None
+
+
+class OrgSmtpTestResult(BaseModel):
+    """Outcome of a real test send, including which transport carried it."""
+    success: bool
+    # "org_smtp" | "global" | "none" — the transport the message actually used.
+    source: Optional[str] = None
+    # Which step of the SMTP conversation failed, so the page can name the fix.
+    stage: Optional[str] = None
+    recipient: Optional[str] = None
+    from_address: Optional[str] = None
+    error: Optional[str] = None
+    # Flat string kept for older clients.
+    smtp: Optional[str] = None
 
 
 class OrgSmtpUpdate(BaseModel):

--- a/backend/app/services/data_source_member_email.py
+++ b/backend/app/services/data_source_member_email.py
@@ -94,8 +94,6 @@ async def send_member_added_email(
 
     from app.settings.config import settings
 
-    fm = settings.email_client
-
     from sqlalchemy import select
 
     from app.dependencies import async_session_maker
@@ -157,11 +155,14 @@ async def send_member_added_email(
         except Exception:
             logger.warning("agent-access in-app notification failed", exc_info=True)
 
-    # Email channel: only when SMTP is configured and the user has an email.
-    if fm is None or not recipient:
+    # Email channel: only when a transport resolves for this org and the user
+    # has an email. Availability is asked per organization so an org with its
+    # own SMTP server still gets mail when the global bow-config SMTP is empty.
+    if not recipient:
         return
 
-    from fastapi_mail import MessageSchema
+    from app.services.email_client_resolver import is_outbound_available
+    from app.services.notification_service import notification_service
 
     base_url = getattr(settings.bow_config, "base_url", None) or "http://localhost:3000"
     agent_url = f"{base_url.rstrip('/')}/agents/{data_source_id}"
@@ -182,14 +183,26 @@ async def send_member_added_email(
         f"text-decoration:none;border-radius:6px;font-weight:600;\">Open {ds_name}</a>"
     )
 
-    message = MessageSchema(
-        subject=subject,
-        recipients=[recipient],
-        body=body,
-        subtype="html",
-    )
-    try:
-        await fm.send_message(message)
-        logger.info("Member-added email sent to %s for data_source=%s", recipient, data_source_id)
-    except Exception as e:
-        logger.error("Failed to send member-added email to %s: %s", recipient, e)
+    async with async_session_maker() as send_db:
+        if not await is_outbound_available(send_db, str(organization_id), purpose="system"):
+            return
+        result = await notification_service.send_custom_email(
+            recipients=[recipient],
+            subject=subject,
+            body=body,
+            subtype="html",
+            retries=2,
+            timeout=15,
+            db=send_db,
+            organization_id=str(organization_id),
+            purpose="system",
+        )
+    if result.status == "sent":
+        logger.info(
+            "Member-added email sent to %s for data_source=%s via %s",
+            recipient, data_source_id, result.source,
+        )
+    else:
+        logger.error(
+            "Failed to send member-added email to %s: %s", recipient, result.error
+        )

--- a/backend/app/services/email/message_builder.py
+++ b/backend/app/services/email/message_builder.py
@@ -57,6 +57,12 @@ def build_email(
     root should be first. When ``in_reply_to`` is set the subject is prefixed
     with ``Re:`` if it isn't already.
     """
+    if not from_address:
+        # ``msg["From"] = None`` yields a message every relay rejects, and the
+        # failure surfaces far from its cause. An unset From address is a
+        # configuration error — name it here.
+        raise ValueError("from_address is required to build an email")
+
     msg = EmailMessage()
     msg["Message-ID"] = message_id or make_message_id()
     msg["Date"] = formatdate(localtime=True)

--- a/backend/app/services/email/sender.py
+++ b/backend/app/services/email/sender.py
@@ -16,13 +16,92 @@ import os
 import ssl
 from dataclasses import dataclass
 from email.message import EmailMessage
-from typing import Optional
+from typing import Optional, Tuple
 
 import aiosmtplib
 
 from app.services.email.oauth import OAuthSettings, get_xoauth2_string
 
 logger = logging.getLogger(__name__)
+
+
+# Which step of the SMTP conversation an error came from. Surfaced by the
+# settings "send test email" probe so an admin sees *what* the relay rejected
+# ("auth", "sender") instead of a bare transcript line.
+STAGE_CONFIG = "config"
+STAGE_CONNECT = "connect"
+STAGE_TLS = "tls"
+STAGE_AUTH = "auth"
+STAGE_SENDER = "sender"
+STAGE_RECIPIENT = "recipient"
+STAGE_SEND = "send"
+
+
+def _err(name: str):
+    """aiosmtplib error class by name, or a never-matching sentinel.
+
+    Looked up defensively so a rename across aiosmtplib majors degrades the
+    *classification* of a failure rather than raising inside the error handler.
+    """
+    return getattr(aiosmtplib, name, None) or getattr(
+        getattr(aiosmtplib, "errors", None), name, None
+    ) or type("_Missing", (Exception,), {})
+
+
+def _response_text(exc: BaseException) -> str:
+    """The server's human-readable response text, if the exception carries one."""
+    message = getattr(exc, "message", None)
+    if isinstance(message, bytes):
+        message = message.decode("utf-8", "replace")
+    return message if isinstance(message, str) else ""
+
+
+def classify_error(exc: BaseException) -> str:
+    """Map a transport exception to the stage of the SMTP conversation it hit.
+
+    The response *code* is consulted before the exception type, because a relay
+    reports "you have not authenticated" against whichever command it happened
+    to refuse. A server requiring AUTH answers ``MAIL FROM`` with
+    ``530 Authentication required``, which arrives as ``SMTPSenderRefused`` —
+    reading only the type would blame the From address for a password problem.
+    """
+    if isinstance(exc, _err("SMTPAuthenticationError")):
+        return STAGE_AUTH
+
+    code = getattr(exc, "code", None)
+    if code == 530:
+        # 530 is overloaded: "must issue a STARTTLS command first" and
+        # "authentication required" share it. The text is the only separator.
+        text = _response_text(exc).lower()
+        return STAGE_TLS if "tls" in text else STAGE_AUTH
+    if code in (534, 535, 538):
+        return STAGE_AUTH
+
+    if isinstance(exc, _err("SMTPSenderRefused")):
+        return STAGE_SENDER
+    if isinstance(exc, (_err("SMTPRecipientsRefused"), _err("SMTPRecipientRefused"))):
+        return STAGE_RECIPIENT
+    if isinstance(exc, ssl.SSLError):
+        return STAGE_TLS
+    if isinstance(exc, (_err("SMTPConnectError"), _err("SMTPConnectTimeoutError"))):
+        return STAGE_CONNECT
+    if isinstance(exc, _err("SMTPServerDisconnected")):
+        return STAGE_CONNECT
+    return STAGE_SEND
+
+
+def describe_error(exc: BaseException) -> str:
+    """A one-line, admin-readable rendering of a transport failure.
+
+    ``str(exc)`` on an aiosmtplib response error is a raw tuple
+    (``(530, '5.7.0 Authentication required', 'noreply@acme.com')``), which is
+    noise in a settings page. Prefer the code and the server's own words.
+    """
+    code = getattr(exc, "code", None)
+    text = _response_text(exc)
+    if code and text:
+        return f"{code} {text}"
+    return str(exc) or exc.__class__.__name__
 
 
 @dataclass
@@ -131,16 +210,29 @@ async def _send_xoauth2(cfg: SmtpConfig, msg: EmailMessage) -> bool:
             pass
 
 
-async def send_message(cfg: SmtpConfig, msg: EmailMessage) -> bool:
-    """Send ``msg`` via SMTP. Returns True on success, False on failure."""
+async def send_message_result(cfg: SmtpConfig, msg: EmailMessage) -> Tuple[bool, Optional[str], str]:
+    """Send ``msg``; return ``(ok, error, stage)``.
+
+    The error-preserving form of :func:`send_message`. Sending mail is the only
+    honest test of an SMTP config — a connect-and-auth probe cannot see a relay
+    that refuses the envelope sender or declines to relay to the recipient — so
+    the settings page drives this and reports the stage that failed.
+    """
     cfg = cfg.resolved()
     if not cfg.host:
         logger.warning("EMAIL_SENDER: no SMTP host configured")
-        return False
+        return False, "no SMTP host configured", STAGE_CONFIG
+    if not msg.get("From"):
+        # build_email refuses to construct this, but a caller assembling its own
+        # EmailMessage can still get here; every relay rejects a missing sender.
+        return False, "no From address configured", STAGE_CONFIG
 
     try:
         if cfg.oauth is not None:
-            return await _send_xoauth2(cfg, msg)
+            ok = await _send_xoauth2(cfg, msg)
+            return ok, (None if ok else "XOAUTH2 authentication failed"), (
+                STAGE_SEND if ok else STAGE_AUTH
+            )
 
         use_tls = cfg.security == "ssl"
         start_tls = cfg.security == "starttls"
@@ -158,7 +250,22 @@ async def send_message(cfg: SmtpConfig, msg: EmailMessage) -> bool:
             kwargs["username"] = cfg.username
             kwargs["password"] = cfg.password
         await aiosmtplib.send(msg, **kwargs)
-        return True
+        return True, None, STAGE_SEND
     except Exception as e:  # noqa: BLE001 — transport errors must not crash the agent
-        logger.warning("EMAIL_SENDER: failed to send to %s: %s", msg.get("To"), e)
-        return False
+        stage = classify_error(e)
+        detail = describe_error(e)
+        logger.warning(
+            "EMAIL_SENDER: failed to send to %s via %s:%s at stage=%s: %s",
+            msg.get("To"), cfg.host, cfg.port, stage, detail,
+        )
+        return False, detail, stage
+
+
+async def send_message(cfg: SmtpConfig, msg: EmailMessage) -> bool:
+    """Send ``msg`` via SMTP. Returns True on success, False on failure.
+
+    Bool-returning wrapper kept for the fire-and-forget senders; callers that
+    need to report *why* a send failed use :func:`send_message_result`.
+    """
+    ok, _error, _stage = await send_message_result(cfg, msg)
+    return ok

--- a/backend/app/services/email_client_resolver.py
+++ b/backend/app/services/email_client_resolver.py
@@ -112,6 +112,19 @@ def choose_outbound(
     return ResolvedOutbound(source="global" if global_present else "none")
 
 
+def global_smtp_configured() -> bool:
+    """Whether the global bow-config SMTP client exists.
+
+    The last-resort answer for code with no organization in scope. Prefer
+    :func:`is_outbound_available`, which also sees an organization's own relay;
+    keying on the global client alone is what made orgs that configured SMTP
+    through the UI look like they had no email at all.
+    """
+    from app.settings.config import settings
+
+    return settings.email_client is not None
+
+
 async def get_org_smtp(db, organization_id: str) -> Optional[dict]:
     """Load + decrypt the org's SMTP settings from OrganizationSettings.config.smtp."""
     if not organization_id:
@@ -133,6 +146,60 @@ async def get_org_smtp(db, organization_id: str) -> Optional[dict]:
     out = dict(smtp)
     out["password"] = decrypt_secret(smtp.get("password_enc"))
     return out
+
+
+async def any_smtp_configured(db) -> bool:
+    """Whether *any* outbound transport exists on this deployment.
+
+    The pre-authentication answer, for pages such as password reset that have no
+    organization in scope and must still know whether mail can be sent at all.
+    Keying this on the global bow-config client alone told organizations that
+    configured SMTP through the UI that password reset was unavailable, while
+    the reset mail would in fact have been delivered by their own relay.
+    """
+    if global_smtp_configured():
+        return True
+    try:
+        from sqlalchemy import select
+        from app.models.organization_settings import OrganizationSettings
+
+        rows = (await db.execute(select(OrganizationSettings.config))).scalars().all()
+    except Exception:  # noqa: BLE001 — a pre-auth flag must never 500 the page
+        logger.warning("any_smtp_configured: lookup failed", exc_info=True)
+        return False
+    for config in rows:
+        smtp = (config or {}).get("smtp") if isinstance(config, dict) else None
+        if isinstance(smtp, dict) and smtp.get("enabled") and smtp.get("host"):
+            return True
+    return False
+
+
+async def sole_organization_id(db, user_id: str) -> Optional[str]:
+    """The organization to send a user's account mail from, or ``None``.
+
+    Password resets and email verifications happen outside any organization
+    context — fastapi-users knows the user, not the tenant — yet they are system
+    mail and should leave via the organization's own relay when there is one.
+
+    A user with exactly one membership has an unambiguous answer, which covers
+    every self-hosted and single-tenant deployment. With several memberships
+    there is no principled choice (whose relay should carry a password reset?),
+    so we return ``None`` and the caller falls back to the global bow-config
+    SMTP rather than leaking the user's presence in one org to another org's
+    mail server.
+    """
+    if not user_id:
+        return None
+    from sqlalchemy import select
+    from app.models.membership import Membership
+
+    rows = (await db.execute(
+        select(Membership.organization_id).where(Membership.user_id == str(user_id))
+    )).scalars().all()
+    unique = {str(r) for r in rows if r}
+    if len(unique) == 1:
+        return unique.pop()
+    return None
 
 
 async def resolve_outbound(db, organization_id: str, purpose: str = "system") -> ResolvedOutbound:

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from dataclasses import dataclass
 from typing import List, Optional
 from logging import getLogger
 
@@ -18,6 +19,23 @@ from app.services.email_renderer import (
 )
 
 logger = getLogger(__name__)
+
+
+@dataclass
+class SendOutcome:
+    """Result of one outbound send, including *which* transport carried it.
+
+    ``source`` is the deciding piece of information: "org_smtp" means the
+    organization's own relay took the message, "global" means it went out via
+    the bow-config SMTP, "none" means no transport was configured at all.
+    Without it, mail leaving through the wrong server is indistinguishable from
+    success.
+    """
+
+    ok: bool
+    source: str
+    error: Optional[str] = None
+    stage: Optional[str] = None
 
 
 def _default_locale() -> str:
@@ -108,7 +126,7 @@ class NotificationService:
         }
         return handlers.get(channel)
 
-    # ---- outbound resolution (org mailbox overrides global SMTP) ----
+    # ---- outbound resolution (org SMTP overrides global bow-config SMTP) ----
 
     async def _resolved_send(
         self,
@@ -124,13 +142,23 @@ class NotificationService:
         message_id: Optional[str] = None,
         in_reply_to: Optional[str] = None,
         references: Optional[list] = None,
-    ) -> bool:
+        retries: int = 0,
+        retry_delay: float = 1.5,
+        timeout: Optional[float] = None,
+    ) -> "SendOutcome":
         """Send mail via the purpose-resolved transport.
 
         ``purpose="analyst"`` → the AI mailbox; ``purpose="system"`` → org SMTP
         (``OrganizationSettings.config.smtp``) → global ``settings.email_client``.
         Backward compatible: no org SMTP → global; org SMTP set → used even when
         the global client is empty.
+
+        **An org that has configured and enabled its own SMTP is authoritative.**
+        When that relay refuses the mail we report the failure; we do not quietly
+        re-send through the global bow-config SMTP. Falling back would deliver
+        the message from a From identity the admin never chose and would leave a
+        broken relay looking like it worked — which is precisely how org SMTP
+        came to be silently bypassed for invites and shares.
 
         ``message_id`` / ``in_reply_to`` / ``references`` thread the message so a
         reply can be re-attached to a report (SMTP-config path only).
@@ -142,17 +170,39 @@ class NotificationService:
 
                 resolved = await resolve_outbound(db, organization_id, purpose=purpose)
             except Exception as e:  # noqa: BLE001
-                logger.warning("Email resolution failed, using global client: %s", e)
+                # Infrastructure failure (DB down), not a configuration verdict —
+                # we cannot tell whether this org has its own relay, so the
+                # global client is the only option left. Logged loudly because it
+                # may mean mail left from the wrong identity.
+                logger.warning(
+                    "Email resolution failed for org %s, using global client: %s",
+                    organization_id, e,
+                )
                 resolved = None
 
         if resolved and resolved.uses_smtp_config:
-            import os
-            import re as _re
-            from app.services.email.message_builder import build_email
-            from app.services.email.sender import send_message
+            return await self._send_via_smtp_config(
+                resolved, recipients, subject, body,
+                subtype=subtype, attachments=attachments,
+                message_id=message_id, in_reply_to=in_reply_to, references=references,
+                retries=retries, retry_delay=retry_delay, timeout=timeout,
+            )
 
-            def _to_tuple(att: dict):
-                """Normalize either attachment dict shape to (filename, bytes, mime)."""
+        return await self._send_via_global(
+            recipients, subject, body,
+            subtype=subtype, attachments=attachments,
+            retries=retries, retry_delay=retry_delay, timeout=timeout,
+        )
+
+    @staticmethod
+    def _attachment_tuples(attachments: Optional[list]) -> list:
+        """Normalize fastapi-mail attachment dicts to (filename, bytes, mime)."""
+        import os
+        import re as _re
+
+        out = []
+        for att in attachments or []:
+            try:
                 path = att.get("file")
                 with open(path, "rb") as f:
                     content = f.read()
@@ -165,17 +215,50 @@ class NotificationService:
                     mime = f"{att.get('mime_type')}/{att.get('mime_subtype', 'octet-stream')}"
                 else:
                     mime = f"{att.get('type', 'application')}/{att.get('subtype', 'octet-stream')}"
-                return (filename, content, mime)
+                out.append((filename, content, mime))
+            except Exception:  # noqa: BLE001
+                continue
+        return out
 
-            built_attachments = []
-            for att in attachments or []:
-                try:
-                    built_attachments.append(_to_tuple(att))
-                except Exception:  # noqa: BLE001
-                    continue
+    async def _send_via_smtp_config(
+        self,
+        resolved,
+        recipients: List[str],
+        subject: str,
+        body: str,
+        *,
+        subtype: str,
+        attachments: Optional[list],
+        message_id: Optional[str],
+        in_reply_to: Optional[str],
+        references: Optional[list],
+        retries: int,
+        retry_delay: float,
+        timeout: Optional[float],
+    ) -> "SendOutcome":
+        from app.services.email.message_builder import build_email
+        from app.services.email.sender import STAGE_CONFIG, send_message_result
 
-            all_ok = True
-            for rcpt in recipients:
+        if not resolved.from_address:
+            # Every relay rejects a message with no envelope sender, and
+            # build_email refuses to construct one — fail with the fix, not a
+            # transport stack trace.
+            return SendOutcome(
+                ok=False, source=resolved.source, stage=STAGE_CONFIG,
+                error="no From address configured for this SMTP server",
+            )
+
+        built_attachments = self._attachment_tuples(attachments)
+
+        # Retry only the recipients that have not been accepted yet, so a
+        # partial failure across a multi-recipient send cannot double-deliver.
+        pending = list(recipients)
+        last_error: Optional[str] = None
+        last_stage: Optional[str] = None
+
+        for attempt in range(retries + 1):
+            still_pending = []
+            for rcpt in pending:
                 msg = build_email(
                     from_address=resolved.from_address,
                     from_name=resolved.from_name,
@@ -188,35 +271,104 @@ class NotificationService:
                     references=references,
                     attachments=built_attachments or None,
                 )
-                ok = await send_message(resolved.smtp_config, msg)
-                all_ok = all_ok and ok
-            return all_ok
+                try:
+                    coro = send_message_result(resolved.smtp_config, msg)
+                    if timeout is not None:
+                        ok, error, stage = await asyncio.wait_for(coro, timeout=timeout)
+                    else:
+                        ok, error, stage = await coro
+                except asyncio.TimeoutError:
+                    ok, error, stage = False, f"timed out after {timeout}s", "connect"
+                except Exception as e:  # noqa: BLE001
+                    ok, error, stage = False, str(e) or e.__class__.__name__, "send"
+                if not ok:
+                    still_pending.append(rcpt)
+                    last_error, last_stage = error, stage
 
-        # Fallback: global fastapi-mail client.
+            pending = still_pending
+            if not pending:
+                return SendOutcome(ok=True, source=resolved.source)
+            if attempt < retries:
+                await asyncio.sleep(retry_delay * (attempt + 1))
+
+        logger.error(
+            "Email via %s failed for %s at stage=%s: %s",
+            resolved.source, pending, last_stage, last_error,
+        )
+        return SendOutcome(
+            ok=False, source=resolved.source, error=last_error, stage=last_stage,
+        )
+
+    async def _send_via_global(
+        self,
+        recipients: List[str],
+        subject: str,
+        body: str,
+        *,
+        subtype: str,
+        attachments: Optional[list],
+        retries: int,
+        retry_delay: float,
+        timeout: Optional[float],
+    ) -> "SendOutcome":
+        """Send via the global bow-config fastapi-mail client."""
         fm = settings.email_client
         if not fm:
-            return False
-        message = MessageSchema(
+            return SendOutcome(
+                ok=False, source="none", stage="config",
+                error="SMTP is not configured",
+            )
+
+        message_kwargs = dict(
             subject=subject,
             recipients=recipients,
             body=body,
             subtype=subtype,
-            attachments=attachments or [],
         )
-        await fm.send_message(message)
-        return True
+        if attachments:
+            message_kwargs["attachments"] = attachments
+        message = MessageSchema(**message_kwargs)
+
+        last_error: Optional[str] = None
+        for attempt in range(retries + 1):
+            try:
+                if timeout is not None:
+                    await asyncio.wait_for(fm.send_message(message), timeout=timeout)
+                else:
+                    await fm.send_message(message)
+                return SendOutcome(ok=True, source="global")
+            except Exception as e:  # noqa: BLE001
+                last_error = str(e) or e.__class__.__name__
+                logger.error(
+                    "Failed to send email via global SMTP (attempt %d/%d): %s",
+                    attempt + 1, retries + 1, last_error,
+                )
+                if attempt < retries:
+                    await asyncio.sleep(retry_delay * (attempt + 1))
+
+        return SendOutcome(ok=False, source="global", error=last_error, stage="send")
 
     # ---- email channel ----
 
     async def _send_email(self, recipients: List[str], context: dict) -> ChannelResult:
         db = context.get("db")
         organization_id = context.get("organization_id")
-        if settings.email_client is None and not (db is not None and organization_id):
+        # Availability is a per-org question: an org that configured its own
+        # SMTP can send even when the global bow-config client is empty.
+        if db is not None and organization_id:
+            from app.services.email_client_resolver import is_outbound_available
+
+            available = await is_outbound_available(db, organization_id, purpose="system")
+        else:
+            available = settings.email_client is not None  # no org in scope
+        if not available:
             return ChannelResult(
                 channel="email",
                 status="failed",
                 recipients=recipients,
                 error="SMTP is not configured",
+                source="none",
+                stage="config",
             )
 
         subject, html = render_notification_email(
@@ -228,71 +380,91 @@ class NotificationService:
             message=context.get("message"),
         )
 
-        async def _do_send():
-            try:
-                # Generate PDF attachment for dashboard shares (in background).
-                # Withheld in viewer-identity mode on user-scoped connections:
-                # the PDF renders the creator's snapshot, which those viewers
-                # must not receive (see viewer_data_policy) — email ships with
-                # the link only.
-                attachments = []
-                report_id = context.get("report_id")
-                if context["notification_type"] == NotificationType.SHARE_DASHBOARD and report_id:
-                    try:
-                        from app.services.report_pdf_service import ReportPdfService
-                        from app.services.viewer_data_policy import report_snapshot_withheld
-                        from app.dependencies import async_session_maker as _asm
-                        from pathlib import Path
+        async def _build_attachments() -> list:
+            # Generate the PDF attachment for dashboard shares.
+            # Withheld in viewer-identity mode on user-scoped connections:
+            # the PDF renders the creator's snapshot, which those viewers
+            # must not receive (see viewer_data_policy) — email ships with
+            # the link only.
+            attachments = []
+            report_id = context.get("report_id")
+            if context["notification_type"] == NotificationType.SHARE_DASHBOARD and report_id:
+                try:
+                    from app.services.report_pdf_service import ReportPdfService
+                    from app.services.viewer_data_policy import report_snapshot_withheld
+                    from app.dependencies import async_session_maker as _asm
+                    from pathlib import Path
 
-                        async with _asm() as policy_db:
-                            withheld = await report_snapshot_withheld(policy_db, report_id)
-                        if withheld:
-                            logger.info(
-                                "Skipping PDF attachment for shared dashboard %s: "
-                                "viewer-identity mode on user-scoped connections", report_id,
-                            )
-                        else:
-                            pdf_service = ReportPdfService()
-                            pdf_path = await pdf_service.generate_for_report(report_id)
-                            if pdf_path:
-                                pdf_file = Path(pdf_path)
-                                if pdf_file.exists():
-                                    attachments.append({
-                                        "file": str(pdf_file),
-                                        "filename": f"{context['report_title'] or 'report'}.pdf",
-                                        "type": "application",
-                                        "subtype": "pdf",
-                                    })
-                    except Exception as e:
-                        logger.warning("PDF generation failed for shared dashboard %s: %s", report_id, e)
-
-                # System mail → Org SMTP → global (never the AI mailbox). This
-                # runs as a background task, so the request db may be closed —
-                # open a fresh session for the org-SMTP lookup.
-                if organization_id:
-                    from app.dependencies import async_session_maker
-                    async with async_session_maker() as send_db:
-                        await self._resolved_send(
-                            recipients, subject, html,
-                            subtype="html", attachments=attachments or None,
-                            db=send_db, organization_id=organization_id, purpose="system",
+                    async with _asm() as policy_db:
+                        withheld = await report_snapshot_withheld(policy_db, report_id)
+                    if withheld:
+                        logger.info(
+                            "Skipping PDF attachment for shared dashboard %s: "
+                            "viewer-identity mode on user-scoped connections", report_id,
                         )
-                else:
-                    await self._resolved_send(
-                        recipients, subject, html,
-                        subtype="html", attachments=attachments or None,
-                        purpose="system",
-                    )
-                logger.info("Notification email sent to %s", recipients)
-            except Exception as e:
-                logger.error("Failed to send notification email: %s", e)
+                    else:
+                        pdf_service = ReportPdfService()
+                        pdf_path = await pdf_service.generate_for_report(report_id)
+                        if pdf_path:
+                            pdf_file = Path(pdf_path)
+                            if pdf_file.exists():
+                                attachments.append({
+                                    "file": str(pdf_file),
+                                    "filename": f"{context['report_title'] or 'report'}.pdf",
+                                    "type": "application",
+                                    "subtype": "pdf",
+                                })
+                except Exception as e:
+                    logger.warning("PDF generation failed for shared dashboard %s: %s", report_id, e)
+            return attachments
 
-        asyncio.create_task(_do_send())
+        # Awaited, not fire-and-forget: this used to spawn a background task and
+        # return "sent" immediately, so a share that never left the building
+        # reported success to the admin. The caller's modal already shows a
+        # spinner; a few honest seconds beat an instant lie. Bounded by a
+        # timeout so a hung relay cannot hold the request open.
+        attachments = await _build_attachments()
 
+        # System mail → Org SMTP → global (never the AI mailbox). The request db
+        # may be mid-transaction, so open a fresh session for the org lookup.
+        if organization_id:
+            from app.dependencies import async_session_maker
+            async with async_session_maker() as send_db:
+                outcome = await self._resolved_send(
+                    recipients, subject, html,
+                    subtype="html", attachments=attachments or None,
+                    db=send_db, organization_id=organization_id, purpose="system",
+                    retries=1, timeout=20,
+                )
+        else:
+            outcome = await self._resolved_send(
+                recipients, subject, html,
+                subtype="html", attachments=attachments or None,
+                purpose="system", retries=1, timeout=20,
+            )
+
+        if outcome.ok:
+            logger.info(
+                "Notification email sent to %s via %s", recipients, outcome.source
+            )
+            return ChannelResult(
+                channel="email",
+                status="sent",
+                recipients=recipients,
+                source=outcome.source,
+            )
+
+        logger.error(
+            "Notification email to %s failed via %s: %s",
+            recipients, outcome.source, outcome.error,
+        )
         return ChannelResult(
             channel="email",
-            status="sent",
+            status="failed",
             recipients=recipients,
+            error=outcome.error or "send failed",
+            source=outcome.source,
+            stage=outcome.stage,
         )
 
     # ---- free-form email ----
@@ -320,8 +492,13 @@ class NotificationService:
         and body provided. The send is awaited so the returned status reflects
         actual delivery to the SMTP server, not just enqueueing.
 
-        When ``db`` + ``organization_id`` are supplied and the org has an Email
-        integration, that mailbox is used (overriding the global SMTP client).
+        When ``db`` + ``organization_id`` are supplied, the transport is resolved
+        per organization: ``purpose="analyst"`` uses the AI mailbox,
+        ``purpose="system"`` uses the org's own SMTP and falls back to the global
+        bow-config client only when the org has not configured one. Callers that
+        omit the org context get the global client and therefore ignore whatever
+        the organization configured — always pass ``db`` and ``organization_id``
+        for organization-scoped mail.
 
         Reliability knobs (all opt-in, defaults preserve old behaviour):
         - ``retries``: extra attempts on failure (total tries = retries + 1),
@@ -335,80 +512,39 @@ class NotificationService:
         if subtype not in ("plain", "html"):
             subtype = "plain"
 
-        # Prefer the org's Email integration mailbox when org context is given.
-        if db is not None and organization_id:
-            try:
-                ok = await self._resolved_send(
-                    recipients,
-                    subject,
-                    body,
-                    subtype=subtype,
-                    attachments=attachments,
-                    db=db,
-                    organization_id=organization_id,
-                    purpose=purpose,
-                    message_id=message_id,
-                    in_reply_to=in_reply_to,
-                    references=references,
-                )
-                if ok:
-                    logger.info("Custom email sent to %s", recipients)
-                    return ChannelResult(
-                        channel="email",
-                        status="sent",
-                        recipients=recipients,
-                    )
-                # Not sent via the resolver — fall through to the global path.
-            except Exception as e:
-                logger.error("Org-mailbox send failed, falling back to global: %s", e)
+        outcome = await self._resolved_send(
+            recipients,
+            subject,
+            body,
+            subtype=subtype,
+            attachments=attachments,
+            db=db,
+            organization_id=organization_id,
+            purpose=purpose,
+            message_id=message_id,
+            in_reply_to=in_reply_to,
+            references=references,
+            retries=retries,
+            retry_delay=retry_delay,
+            timeout=timeout,
+        )
 
-        # Global fastapi-mail path with retries/timeout/attachments.
-        fm = settings.email_client
-        if not fm:
+        if outcome.ok:
+            logger.info("Custom email sent to %s via %s", recipients, outcome.source)
             return ChannelResult(
                 channel="email",
-                status="failed",
+                status="sent",
                 recipients=recipients,
-                error="SMTP is not configured",
+                source=outcome.source,
             )
-
-        message_kwargs = dict(
-            subject=subject,
-            recipients=recipients,
-            body=body,
-            subtype=subtype,
-        )
-        if attachments:
-            message_kwargs["attachments"] = attachments
-        message = MessageSchema(**message_kwargs)
-
-        last_error: Optional[str] = None
-        for attempt in range(retries + 1):
-            try:
-                if timeout is not None:
-                    await asyncio.wait_for(fm.send_message(message), timeout=timeout)
-                else:
-                    await fm.send_message(message)
-                logger.info("Custom email sent to %s", recipients)
-                return ChannelResult(
-                    channel="email",
-                    status="sent",
-                    recipients=recipients,
-                )
-            except Exception as e:
-                last_error = str(e) or e.__class__.__name__
-                logger.error(
-                    "Failed to send custom email (attempt %d/%d): %s",
-                    attempt + 1, retries + 1, last_error,
-                )
-                if attempt < retries:
-                    await asyncio.sleep(retry_delay * (attempt + 1))
 
         return ChannelResult(
             channel="email",
             status="failed",
             recipients=recipients,
-            error=last_error,
+            error=outcome.error or "send failed",
+            source=outcome.source,
+            stage=outcome.stage,
         )
 
     # ---- scheduled report results ----

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -411,12 +411,12 @@ class OrganizationService:
         # be verified at registration time.
         invite_email_status: Optional[str] = None
         if invitation_email and membership_with_user.user_id is None:
-            if not (hasattr(settings, 'email_client') and settings.email_client):
-                invite_email_status = "skipped_no_smtp"
-            else:
-                invite_email_status = await self._send_invitation_email(
-                    invitation_email, membership_with_user.invite_token
-                )
+            invite_email_status = await self._send_invitation_email(
+                db,
+                str(membership_with_user.organization_id),
+                invitation_email,
+                membership_with_user.invite_token,
+            )
 
         # Create RBAC role_assignment if user_id is set
         if membership_with_user.user_id and membership_data.role:
@@ -687,11 +687,9 @@ class OrganizationService:
         await db.commit()
         await db.refresh(membership)
 
-        status = None
-        if hasattr(settings, 'email_client') and settings.email_client:
-            status = await self._send_invitation_email(membership.email, membership.invite_token)
-        else:
-            status = "skipped_no_smtp"
+        status = await self._send_invitation_email(
+            db, str(membership.organization_id), membership.email, membership.invite_token
+        )
 
         result = await db.execute(
             select(Membership).options(selectinload(Membership.user)).where(Membership.id == membership.id)
@@ -781,17 +779,32 @@ class OrganizationService:
                 count += 1
         return count
     
-    async def _send_invitation_email(self, email: str, token: Optional[str] = None) -> str:
-        """Send the invite email now, reliably. Returns "sent" or "failed".
+    async def _send_invitation_email(
+        self,
+        db: AsyncSession,
+        organization_id: str,
+        email: str,
+        token: Optional[str] = None,
+    ) -> str:
+        """Send the invite email now, reliably. Returns "sent", "failed" or
+        "skipped_no_smtp".
 
         Awaited (not fire-and-forget) so the caller knows the real outcome,
         with a couple of retries for transient SMTP blips and a per-attempt
         timeout so a hung relay can't stall the invite request. The link carries
         the invite token (proof of inbox ownership at registration).
+
+        ``db`` + ``organization_id`` are required, not optional: without them the
+        notification service cannot see the organization's own SMTP server and
+        every invite silently leaves through the global bow-config relay.
         """
         from urllib.parse import quote
         from app.services.notification_service import notification_service
+        from app.services.email_client_resolver import is_outbound_available
         from app.services.email_copy import invite_email
+
+        if not await is_outbound_available(db, organization_id, purpose="system"):
+            return "skipped_no_smtp"
 
         params = f"email={quote(email)}"
         if token:
@@ -805,9 +818,14 @@ class OrganizationService:
             subtype="plain",
             retries=2,
             timeout=15,
+            db=db,
+            organization_id=organization_id,
+            purpose="system",
         )
         if result.status != "sent":
             logger.error("Invitation email to %s failed: %s", email, result.error)
+        else:
+            logger.info("Invitation email to %s sent via %s", email, result.source)
         return result.status
 
 

--- a/backend/app/services/organization_settings_service.py
+++ b/backend/app/services/organization_settings_service.py
@@ -945,10 +945,26 @@ class OrganizationSettingsService:
         return result
 
     async def get_smtp(self, db: AsyncSession, organization: Organization, current_user: User):
-        """Return the org's SMTP server config (password redacted)."""
+        """Return the org's SMTP server config (password redacted).
+
+        Includes ``active_source`` — the transport system mail is *actually*
+        using — resolved through the same code path that sends it, so the page
+        cannot claim one thing while the mailer does another.
+        """
         from app.schemas.organization_settings_schema import OrgSmtpSchema
+        from app.services.email_client_resolver import (
+            global_smtp_configured,
+            resolve_outbound,
+        )
+
         settings = await self.get_settings(db, organization, current_user)
         raw = (settings.config or {}).get("smtp") or {}
+        try:
+            active_source = (
+                await resolve_outbound(db, str(organization.id), purpose="system")
+            ).source
+        except Exception:  # noqa: BLE001 — a readout must never break the page
+            active_source = "none"
         return OrgSmtpSchema(
             enabled=bool(raw.get("enabled", False)),
             host=raw.get("host"),
@@ -959,6 +975,8 @@ class OrganizationSettingsService:
             from_address=raw.get("from_address"),
             from_name=raw.get("from_name"),
             validate_certs=bool(raw.get("validate_certs", True)),
+            active_source=active_source,
+            global_configured=global_smtp_configured(),
         )
 
     async def update_smtp(self, db: AsyncSession, organization: Organization, current_user: User, data):
@@ -987,8 +1005,18 @@ class OrganizationSettingsService:
         if data.password:
             smtp["password_enc"] = encrypt_secret(data.password)
 
-        if smtp["enabled"] and not smtp["host"]:
-            raise HTTPException(status_code=400, detail="SMTP host is required when enabled")
+        if smtp["enabled"]:
+            if not smtp["host"]:
+                raise HTTPException(status_code=400, detail="SMTP host is required when enabled")
+            # Every relay rejects a message with no envelope sender, and
+            # build_email refuses to construct one — so an enabled server with
+            # no From address is guaranteed to fail at send time. Catch it here
+            # instead of at 3am in a scheduled report.
+            if not (smtp["from_address"] or smtp["username"]):
+                raise HTTPException(
+                    status_code=400,
+                    detail="A From address is required when a custom SMTP server is enabled",
+                )
 
         current_config["smtp"] = smtp
         settings.config = current_config
@@ -1010,38 +1038,125 @@ class OrganizationSettingsService:
 
         return await self.get_smtp(db, organization, current_user)
 
-    async def test_smtp(self, db: AsyncSession, organization: Organization, current_user: User) -> dict:
-        """Probe the org's saved SMTP server (connect + auth, no send)."""
-        from app.services.email_client_resolver import get_org_smtp
-        from app.services.email.sender import SmtpConfig, _tls_context
-        import aiosmtplib
+    # A *delivered* test costs the org a message and lands in someone's inbox, so
+    # successful sends are throttled. A rejected one delivers nothing, and an
+    # admin fixing a password should not be made to wait between attempts — so
+    # only success starts the clock. Keyed per org, in-process: a courtesy
+    # throttle against inbox spam, not a security control.
+    _SMTP_TEST_COOLDOWN_SECONDS = 10
+    _smtp_test_last_send: dict = {}
 
-        smtp = await get_org_smtp(db, organization.id)
-        if not (smtp and smtp.get("host")):
-            return {"success": False, "smtp": "no SMTP host configured"}
-        cfg = SmtpConfig(
-            host=smtp["host"], port=int(smtp.get("port") or 587),
-            username=smtp.get("username"), password=smtp.get("password"),
-            security=smtp.get("security") or "starttls",
-            validate_certs=bool(smtp.get("validate_certs", True)),
-        ).resolved()
-        try:
-            kwargs = dict(
-                hostname=cfg.host, port=cfg.port,
-                use_tls=(cfg.security == "ssl"),
-                start_tls=(cfg.security == "starttls"), timeout=15,
+    async def test_smtp(
+        self,
+        db: AsyncSession,
+        organization: Organization,
+        current_user: User,
+        data=None,
+    ) -> dict:
+        """Send a real test email through the org's configured transport.
+
+        This deliberately *sends* rather than probing connect+auth. A probe
+        cannot see the failures that actually bite — a relay that refuses the
+        envelope sender, one that declines to relay to the recipient, a missing
+        From address — so a connect-only check reports "Connection OK" for
+        configurations that never deliver a single message.
+
+        It runs the production path (``resolve_outbound`` → ``build_email`` →
+        ``send_message``), not a parallel implementation, so whatever it proves
+        is true of real mail. It also reports *which* transport carried the
+        message, which is the only way to notice that mail an admin believes is
+        going through their relay is really going out via bow-config.
+        """
+        import time
+
+        from app.services.email.sender import STAGE_CONFIG
+        from app.services.email_client_resolver import resolve_outbound
+        from app.services.notification_service import notification_service
+
+        own_address = (current_user.email or "").strip()
+        recipient = (getattr(data, "to", None) or "").strip() or own_address
+        if not recipient:
+            return {
+                "success": False, "source": "none", "stage": STAGE_CONFIG,
+                "error": "your account has no email address to send the test to",
+            }
+        # Only the caller's own address: this endpoint sends real mail through
+        # the org's relay, and an arbitrary recipient would make it a spam relay
+        # for anyone holding manage_settings.
+        if recipient.lower() != own_address.lower():
+            raise HTTPException(
+                status_code=400,
+                detail="The test email can only be sent to your own address",
             )
-            tls_context = _tls_context(cfg)
-            if tls_context is not None:
-                kwargs["tls_context"] = tls_context
-            client = aiosmtplib.SMTP(**kwargs)
-            await client.connect()
-            if cfg.username and cfg.password:
-                await client.login(cfg.username, cfg.password)
-            await client.quit()
-            return {"success": True, "smtp": "ok"}
-        except Exception as e:
-            return {"success": False, "smtp": f"failed: {e}"}
+
+        org_key = str(organization.id)
+        last = self._smtp_test_last_send.get(org_key)
+        if last is not None:
+            elapsed = time.monotonic() - last
+            if elapsed < self._SMTP_TEST_COOLDOWN_SECONDS:
+                wait = int(self._SMTP_TEST_COOLDOWN_SECONDS - elapsed) + 1
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"Please wait {wait}s before sending another test email",
+                )
+
+        resolved = await resolve_outbound(db, org_key, purpose="system")
+        if resolved.source == "none":
+            return {
+                "success": False, "source": "none", "stage": STAGE_CONFIG,
+                "error": "no SMTP server is configured for this organization",
+            }
+
+        subject = "Bag of words — SMTP test"
+        body = (
+            f"This is a test message from Bag of words, sent to confirm that "
+            f"{organization.name or 'your organization'}'s system email is working.\n\n"
+            f"Transport: {resolved.source}\n"
+            f"From: {resolved.from_address}\n\n"
+            f"If you received this, invites, report shares and scheduled report "
+            f"results will be delivered the same way."
+        )
+
+        result = await notification_service.send_custom_email(
+            recipients=[recipient],
+            subject=subject,
+            body=body,
+            subtype="plain",
+            timeout=25,
+            db=db,
+            organization_id=org_key,
+            purpose="system",
+        )
+
+        if result.status == "sent":
+            now = time.monotonic()
+            # Drop expired entries as we go, so a long-lived process serving many
+            # organizations does not accumulate one dict entry per org forever.
+            for key, stamp in list(self._smtp_test_last_send.items()):
+                if now - stamp >= self._SMTP_TEST_COOLDOWN_SECONDS:
+                    self._smtp_test_last_send.pop(key, None)
+            self._smtp_test_last_send[org_key] = now
+
+        try:
+            await audit_service.log(
+                db=db, organization_id=org_key,
+                action="settings.org_smtp_tested", user_id=str(current_user.id),
+                resource_type="organization_settings", resource_id=org_key,
+                details={"source": result.source, "status": result.status},
+            )
+        except Exception:
+            pass
+
+        return {
+            "success": result.status == "sent",
+            "source": result.source,
+            "stage": result.stage,
+            "recipient": recipient,
+            "from_address": resolved.from_address,
+            "error": result.error,
+            # Kept for older clients that read the flat "smtp" string.
+            "smtp": "ok" if result.status == "sent" else (result.error or "failed"),
+        }
 
     async def get_locale(
         self,

--- a/backend/app/services/organization_settings_service.py
+++ b/backend/app/services/organization_settings_service.py
@@ -1107,11 +1107,15 @@ class OrganizationSettingsService:
                 "error": "no SMTP server is configured for this organization",
             }
 
+        transport = {
+            "org_smtp": "this organization's own SMTP server",
+            "global": "the globally configured SMTP server",
+        }.get(resolved.source, resolved.source)
         subject = "Bag of words — SMTP test"
         body = (
             f"This is a test message from Bag of words, sent to confirm that "
             f"{organization.name or 'your organization'}'s system email is working.\n\n"
-            f"Transport: {resolved.source}\n"
+            f"Sent via: {transport}\n"
             f"From: {resolved.from_address}\n\n"
             f"If you received this, invites, report shares and scheduled report "
             f"results will be delivered the same way."

--- a/backend/app/services/welcome_email.py
+++ b/backend/app/services/welcome_email.py
@@ -37,14 +37,13 @@ async def send_welcome_email(user_id: str) -> None:
     """Send the welcome email. Safe to call fire-and-forget; swallows errors."""
     try:
         from app.settings.config import settings
-        if settings.email_client is None:
-            return
 
         from sqlalchemy import select
         from app.dependencies import async_session_maker
         from app.models.user import User
         from app.models.membership import Membership
         from app.services.notification_service import notification_service
+        from app.services.email_client_resolver import is_outbound_available
         from app.services.email_copy import welcome_email as build_welcome_email
 
         async with async_session_maker() as db:
@@ -61,18 +60,29 @@ async def send_welcome_email(user_id: str) -> None:
             recipient = user.email
             name = getattr(user, "name", None)
 
-        base_url = (settings.bow_config.base_url or "http://localhost:3000").rstrip("/")
-        subject, body = build_welcome_email(name, agent_names, base_url)
+            base_url = (settings.bow_config.base_url or "http://localhost:3000").rstrip("/")
+            subject, body = build_welcome_email(name, agent_names, base_url)
 
-        result = await notification_service.send_custom_email(
-            recipients=[recipient],
-            subject=subject,
-            body=body,
-            subtype="plain",
-            retries=2,
-            timeout=15,
-        )
+            # The org context is what lets this reach the organization's own SMTP
+            # server; without it the welcome mail always leaves via the global
+            # bow-config relay, and orgs with no global SMTP get nothing.
+            if org_id and not await is_outbound_available(db, str(org_id), purpose="system"):
+                return
+
+            result = await notification_service.send_custom_email(
+                recipients=[recipient],
+                subject=subject,
+                body=body,
+                subtype="plain",
+                retries=2,
+                timeout=15,
+                db=db,
+                organization_id=str(org_id) if org_id else None,
+                purpose="system",
+            )
         if result.status != "sent":
             logger.error("Welcome email to %s failed: %s", recipient, result.error)
+        else:
+            logger.info("Welcome email to %s sent via %s", recipient, result.source)
     except Exception as e:
         logger.warning("Failed to send welcome email for user %s: %s", user_id, e)

--- a/backend/email_sandbox/README.md
+++ b/backend/email_sandbox/README.md
@@ -19,7 +19,7 @@ cd backend/email_sandbox
 python -m pytest            # asyncio_mode=auto via pytest.ini
 ```
 
-Expected: **48 passed**.
+Expected: **65 passed**.
 
 ## What each file proves
 
@@ -31,6 +31,8 @@ Expected: **48 passed**.
 | `test_email_adapter.py` | Inbound parse; new-thread vs reply (`References` root); quoted-history + signature stripping; sender-as-identity. |
 | `test_email_oauth.py` | XOAUTH2 SASL formatting; Microsoft client-credentials token (mocked HTTP); Google service-account dispatch (mocked); `SmtpConfig`/`ImapConfig` carry the OAuth settings; provider dispatch. |
 | `test_email_sandbox_loop.py` | **End-to-end against a live SMTP server:** (1) SMTP-only sends + overrides global; (2) full integration: inbound → poller → adapter → threaded reply chained via `In-Reply-To`/`References`; (3) agent-initiated email → user reply re-attaches to the same report via the thread root; (4) spoofed reply blocked at the boundary. |
+| `test_smtp_probe_honesty.py` | **Every configuration that the old connect-and-auth probe called "Connection OK" while being unable to deliver:** wrong password, missing password (a rotated Fernet key), an unauthorised envelope sender, relay-denied recipient, a STARTTLS-required relay, a missing From address, an unreachable host. Each must now come back as a failure, tagged with the stage that explains it. |
+| `relay.py` | The rejecting relay these tests run against (not a test itself). |
 
 ## How it maps to the requirements
 
@@ -50,6 +52,42 @@ Expected: **48 passed**.
 The SMTP sink (`smtp_sink` fixture) captures raw bytes of everything sent, so
 new outbound assertions just parse `handler.messages[-1]`. Inbound scenarios use
 `FakeMailboxReader.deliver(raw_bytes)` then drive `EmailPoller.poll_once()`.
+
+### A relay that can say no
+
+`smtp_sink` accepts everything, which is fine for "did we build the right MIME"
+and useless for "does this configuration actually deliver". `relay.run_relay()`
+is the sink that refuses:
+
+```python
+from relay import run_relay
+
+with run_relay(require_auth=("user", "pw"),
+               allowed_senders=["noreply@acme.com"],
+               allowed_rcpts=["admin@acme.com"],
+               require_tls=True) as relay:
+    ...                      # relay.host, relay.port, relay.count, relay.handler
+```
+
+Each knob models a refusal real servers hand out — `535` on bad credentials,
+`550` on an unowned sender or a recipient it will not relay to, `530` while the
+session is in plaintext. A relay that cannot reject cannot distinguish a fixed
+test from a broken one, which is exactly how the old settings probe shipped.
+
+### Two sinks, not one
+
+To prove *which* transport carried a message, run two relays on different ports:
+one standing in for the organization's own SMTP server and one for the global
+bow-config client. "The invite went to the org relay" is then a mechanical
+assertion (`org.count == 1 and global.count == 0`) rather than a guess — with a
+single sink the two are indistinguishable, which is how org SMTP came to be
+silently bypassed for invites and shares.
+
+> **Do not set `BOW_EMAIL_SMTP_OVERRIDE_HOST` in an end-to-end run.** It rewrites
+> whatever host is configured to a local sink, so the run proves nothing about
+> the host the admin actually typed — a nonsense hostname "succeeds". See
+> `test_sandbox_override_is_not_silently_applied`, which asserts that effect
+> explicitly so nobody relies on it by accident.
 
 ## Full-stack validation (optional)
 

--- a/backend/email_sandbox/relay.py
+++ b/backend/email_sandbox/relay.py
@@ -1,0 +1,184 @@
+"""A local SMTP relay that can say **no**.
+
+The existing ``smtp_sink`` fixture accepts everything, which makes it useless
+for the failure mode that actually bites: a configuration that connects and
+authenticates fine and still never delivers a message. A relay that cannot
+reject cannot tell a fixed test from a broken one.
+
+This relay models the four refusals real servers hand out:
+
+===================  ===========================================
+``require_auth``     ``535`` unless the exact username/password
+                     is offered — catches a password that failed
+                     to decrypt, or a username saved with no
+                     password, both of which a connect-and-auth
+                     probe silently skips.
+``allowed_senders``  ``550`` on ``MAIL FROM`` for an envelope
+                     sender the relay will not vouch for.
+``allowed_rcpts``    ``550`` on ``RCPT TO`` — "relay denied".
+``require_tls``      ``530 5.7.0 Must issue a STARTTLS command
+                     first`` while the session is in plaintext.
+===================  ===========================================
+
+Usage::
+
+    with run_relay(require_auth=("user", "pw")) as relay:
+        ...                      # relay.host, relay.port
+        assert relay.messages     # raw bytes of everything accepted
+"""
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from email import message_from_bytes
+from email.message import Message
+
+
+def free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _Authenticator:
+    """aiosmtpd authenticator accepting exactly one username/password pair."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+
+    def __call__(self, server, session, envelope, mechanism, auth_data):
+        from aiosmtpd.smtp import AuthResult, LoginPassword
+
+        fail = AuthResult(success=False, handled=False)
+        if not isinstance(auth_data, LoginPassword):
+            return fail
+        username = auth_data.login.decode("utf-8", "replace")
+        password = auth_data.password.decode("utf-8", "replace")
+        if username == self._username and password == self._password:
+            return AuthResult(success=True)
+        return fail
+
+
+@dataclass
+class RelayHandler:
+    """Records accepted mail and enforces the configured refusals."""
+
+    allowed_senders: Sequence[str] | None = None
+    allowed_rcpts: Sequence[str] | None = None
+    require_tls: bool = False
+
+    messages: list[bytes] = field(default_factory=list)
+    senders: list[str] = field(default_factory=list)
+    rcpts: list[list[str]] = field(default_factory=list)
+
+    # -- aiosmtpd hooks -------------------------------------------------
+    async def handle_MAIL(self, server, session, envelope, address, mail_options):  # noqa: N802
+        if self.require_tls and not getattr(session, "ssl", None):
+            return "530 5.7.0 Must issue a STARTTLS command first"
+        if self.allowed_senders is not None and address not in self.allowed_senders:
+            return f"550 5.7.1 Sender address {address} not owned by user"
+        envelope.mail_from = address
+        envelope.mail_options.extend(mail_options)
+        return "250 OK"
+
+    async def handle_RCPT(self, server, session, envelope, address, rcpt_options):  # noqa: N802
+        if self.allowed_rcpts is not None and address not in self.allowed_rcpts:
+            return f"550 5.7.1 Relay access denied for {address}"
+        envelope.rcpt_tos.append(address)
+        return "250 OK"
+
+    async def handle_DATA(self, server, session, envelope):  # noqa: N802
+        self.messages.append(envelope.content)
+        self.senders.append(envelope.mail_from)
+        self.rcpts.append(list(envelope.rcpt_tos))
+        return "250 Message accepted"
+
+    # -- assertions helpers ---------------------------------------------
+    @property
+    def count(self) -> int:
+        return len(self.messages)
+
+    def parsed(self, index: int = -1) -> Message:
+        return message_from_bytes(self.messages[index])
+
+    def subjects(self) -> list[str]:
+        return [message_from_bytes(m).get("Subject", "") for m in self.messages]
+
+    def body(self, index: int = -1) -> str:
+        msg = self.parsed(index)
+        if msg.is_multipart():
+            parts = [
+                p.get_payload(decode=True) or b""
+                for p in msg.walk()
+                if p.get_content_maintype() == "text"
+            ]
+            return b"\n".join(parts).decode("utf-8", "replace")
+        return (msg.get_payload(decode=True) or b"").decode("utf-8", "replace")
+
+    def find(self, needle: str) -> list[Message]:
+        """Every accepted message whose subject or body contains ``needle``."""
+        out = []
+        for i in range(len(self.messages)):
+            if needle in self.parsed(i).get("Subject", "") or needle in self.body(i):
+                out.append(self.parsed(i))
+        return out
+
+    def clear(self) -> None:
+        self.messages.clear()
+        self.senders.clear()
+        self.rcpts.clear()
+
+
+@dataclass
+class Relay:
+    host: str
+    port: int
+    handler: RelayHandler
+
+    @property
+    def messages(self) -> list[bytes]:
+        return self.handler.messages
+
+    @property
+    def count(self) -> int:
+        return self.handler.count
+
+
+@contextmanager
+def run_relay(
+    *,
+    require_auth: tuple[str, str] | None = None,
+    allowed_senders: Sequence[str] | None = None,
+    allowed_rcpts: Sequence[str] | None = None,
+    require_tls: bool = False,
+    port: int | None = None,
+) -> Iterator[Relay]:
+    """Run a rejecting SMTP relay on localhost for the duration of the block."""
+    from aiosmtpd.controller import Controller
+
+    handler = RelayHandler(
+        allowed_senders=allowed_senders,
+        allowed_rcpts=allowed_rcpts,
+        require_tls=require_tls,
+    )
+    kwargs = {}
+    if require_auth is not None:
+        kwargs.update(
+            authenticator=_Authenticator(*require_auth),
+            auth_required=True,
+            # The sandbox speaks plaintext; without this aiosmtpd refuses AUTH
+            # outside TLS, which would mask the auth assertions under a 538.
+            auth_require_tls=False,
+        )
+    chosen = port or free_port()
+    controller = Controller(handler, hostname="127.0.0.1", port=chosen, **kwargs)
+    controller.start()
+    try:
+        yield Relay(host="127.0.0.1", port=chosen, handler=handler)
+    finally:
+        controller.stop()

--- a/backend/email_sandbox/test_smtp_probe_honesty.py
+++ b/backend/email_sandbox/test_smtp_probe_honesty.py
@@ -1,0 +1,182 @@
+"""The SMTP test must fail whenever a real send would fail.
+
+Every case here passed the old connect-and-auth probe — it reported
+"Connection OK" — while the configuration could not deliver a single message.
+The probe is now a real send through the production path, so each of these
+must come back as a failure, with the stage that explains it.
+
+These run against a live local relay (``relay.run_relay``) with only
+``aiosmtplib``/``aiosmtpd``, no app stack.
+"""
+from __future__ import annotations
+
+import pytest
+from relay import run_relay
+
+from app.services.email.message_builder import build_email
+from app.services.email.sender import (
+    STAGE_AUTH,
+    STAGE_CONFIG,
+    STAGE_CONNECT,
+    STAGE_RECIPIENT,
+    STAGE_SENDER,
+    SmtpConfig,
+    send_message_result,
+)
+
+SENDER = "noreply@acme.com"
+RCPT = "admin@acme.com"
+
+
+def _cfg(relay, **over) -> SmtpConfig:
+    base = {
+        "host": relay.host, "port": relay.port, "security": "none",
+        "username": None, "password": None, "validate_certs": False,
+    }
+    base.update(over)
+    return SmtpConfig(**base)
+
+
+def _msg(to=RCPT, frm=SENDER):
+    return build_email(
+        from_address=frm, from_name="Acme", to_address=to,
+        subject="probe", body="hello", body_subtype="plain",
+    )
+
+
+async def test_happy_path_delivers():
+    with run_relay() as relay:
+        ok, error, stage = await send_message_result(_cfg(relay), _msg())
+        assert ok, error
+        assert relay.count == 1
+        assert relay.handler.senders[-1] == SENDER
+        assert relay.handler.rcpts[-1] == [RCPT]
+
+
+async def test_wrong_password_fails_at_auth():
+    """The old probe skipped AUTH whenever the password was falsy or wrong."""
+    with run_relay(require_auth=("relay-user", "correct-horse")) as relay:
+        ok, error, stage = await send_message_result(
+            _cfg(relay, username="relay-user", password="wrong"), _msg()
+        )
+        assert not ok
+        assert stage == STAGE_AUTH, f"expected auth failure, got {stage}: {error}"
+        assert relay.count == 0
+
+
+async def test_missing_password_fails_at_auth():
+    """A username saved with no password — e.g. a password that would not decrypt.
+
+    This is the exact shape of a Fernet key rotation: ``decrypt_secret`` returns
+    ``None``, the sender offers no credentials, and the relay refuses. The old
+    probe's ``if username and password`` guard skipped AUTH entirely here and
+    reported success.
+    """
+    with run_relay(require_auth=("relay-user", "correct-horse")) as relay:
+        ok, error, stage = await send_message_result(
+            _cfg(relay, username="relay-user", password=None), _msg()
+        )
+        assert not ok
+        assert stage == STAGE_AUTH, f"expected auth failure, got {stage}: {error}"
+        assert relay.count == 0
+
+
+async def test_correct_password_authenticates():
+    with run_relay(require_auth=("relay-user", "correct-horse")) as relay:
+        ok, error, stage = await send_message_result(
+            _cfg(relay, username="relay-user", password="correct-horse"), _msg()
+        )
+        assert ok, f"{stage}: {error}"
+        assert relay.count == 1
+
+
+async def test_unauthorized_sender_is_refused():
+    """A relay that will not vouch for the From address — invisible to a probe."""
+    with run_relay(allowed_senders=[SENDER]) as relay:
+        ok, error, stage = await send_message_result(
+            _cfg(relay), _msg(frm="spoofed@elsewhere.test")
+        )
+        assert not ok
+        assert stage == STAGE_SENDER, f"expected sender refusal, got {stage}: {error}"
+        assert relay.count == 0
+
+
+async def test_relay_denied_for_recipient():
+    with run_relay(allowed_rcpts=[RCPT]) as relay:
+        ok, error, stage = await send_message_result(
+            _cfg(relay), _msg(to="outsider@elsewhere.test")
+        )
+        assert not ok
+        assert stage == STAGE_RECIPIENT, f"expected relay denial, got {stage}: {error}"
+        assert relay.count == 0
+
+
+async def test_missing_from_address_is_caught_before_the_wire():
+    """No From address is a guaranteed rejection; say so, don't emit a stack trace."""
+    with run_relay() as relay:
+        with pytest.raises(ValueError):
+            build_email(
+                from_address=None, from_name=None, to_address=RCPT,
+                subject="probe", body="hello",
+            )
+        # And a hand-rolled message with no From is refused before connecting.
+        from email.message import EmailMessage
+
+        bare = EmailMessage()
+        bare["To"] = RCPT
+        bare.set_content("hello")
+        ok, error, stage = await send_message_result(_cfg(relay), bare)
+        assert not ok
+        assert stage == STAGE_CONFIG
+        assert relay.count == 0
+
+
+async def test_unreachable_host_fails_at_connect():
+    from relay import free_port
+
+    dead = free_port()  # nothing is listening here
+    cfg = SmtpConfig(host="127.0.0.1", port=dead, security="none", validate_certs=False)
+    ok, error, stage = await send_message_result(cfg, _msg())
+    assert not ok
+    assert stage == STAGE_CONNECT, f"expected connect failure, got {stage}: {error}"
+
+
+async def test_starttls_required_relay_rejects_plaintext():
+    """``security: none`` against a relay that demands STARTTLS must fail loudly."""
+    from app.services.email.sender import STAGE_TLS
+
+    with run_relay(require_tls=True) as relay:
+        ok, error, stage = await send_message_result(_cfg(relay), _msg())
+        assert not ok
+        assert relay.count == 0
+        assert stage == STAGE_TLS, f"expected tls failure, got {stage}: {error}"
+
+
+async def test_error_text_is_readable():
+    """Admins see the server's own words, not a Python tuple repr."""
+    with run_relay(require_auth=("relay-user", "correct-horse")) as relay:
+        ok, error, _stage = await send_message_result(
+            _cfg(relay, username="relay-user", password="wrong"), _msg()
+        )
+        assert not ok
+        assert not error.startswith("("), f"raw tuple leaked to the UI: {error}"
+        assert "535" in error or "Authentication" in error
+
+
+async def test_sandbox_override_is_not_silently_applied(monkeypatch):
+    """``BOW_EMAIL_SMTP_OVERRIDE_HOST`` must not make a bad config look healthy.
+
+    The override exists for sandboxes, but it rewrites *whatever* host is
+    configured. A test run that leaves it set proves nothing about the host the
+    admin actually typed — so the sandbox suite asserts the override's effect
+    explicitly instead of relying on it.
+    """
+    with run_relay() as sink:
+        monkeypatch.setenv("BOW_EMAIL_SMTP_OVERRIDE_HOST", sink.host)
+        monkeypatch.setenv("BOW_EMAIL_SMTP_OVERRIDE_PORT", str(sink.port))
+        bogus = SmtpConfig(host="nonexistent.invalid", port=25, security="none")
+        ok, error, stage = await send_message_result(bogus, _msg())
+        # With the override set, a nonsense host "succeeds" — which is exactly
+        # why the e2e run must not set it.
+        assert ok, f"{stage}: {error}"
+        assert sink.count == 1

--- a/backend/tests/e2e/test_org_smtp.py
+++ b/backend/tests/e2e/test_org_smtp.py
@@ -143,3 +143,121 @@ def test_password_enc_not_plaintext_in_config(create_user, login_user, whoami):
     assert "password" not in smtp  # no plaintext key
     assert smtp.get("password_enc")
     assert "PLAINTEXT_SECRET" not in str(smtp)  # not anywhere in the stored blob
+
+
+@pytest.mark.e2e
+def test_enabled_smtp_requires_a_from_address(create_user, login_user, whoami):
+    """An enabled relay with no sender is a guaranteed send-time failure.
+
+    ``build_email`` refuses to construct a message with no From address and every
+    relay rejects one, so this must be caught when the admin saves rather than at
+    3am in a scheduled report.
+    """
+    email = _unique_email()
+    create_user(email=email)
+    token = login_user(email, "test123")
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    from main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    H = {"Authorization": f"Bearer {token}", "X-Organization-Id": org_id}
+
+    r = client.put("/api/organization/smtp", json={
+        "enabled": True, "host": "relay.acme.com", "port": 587,
+        "security": "starttls",  # no username, no from_address
+    }, headers=H)
+    assert r.status_code == 400, r.text
+    assert "From address" in r.json()["detail"]
+
+    # A From address alone is enough (open relay, no auth).
+    r = client.put("/api/organization/smtp", json={
+        "enabled": True, "host": "relay.acme.com", "port": 25,
+        "security": "none", "from_address": "noreply@acme.com",
+    }, headers=H)
+    assert r.status_code == 200, r.text
+
+    # Disabling never requires it — the config is kept as-is.
+    r = client.put("/api/organization/smtp", json={
+        "enabled": False, "host": "relay.acme.com",
+    }, headers=H)
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.e2e
+def test_smtp_get_reports_the_active_transport(create_user, login_user, whoami):
+    """The page must be able to show which transport system mail really uses."""
+    email = _unique_email()
+    create_user(email=email)
+    token = login_user(email, "test123")
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    from main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    H = {"Authorization": f"Bearer {token}", "X-Organization-Id": org_id}
+
+    before = client.get("/api/organization/smtp", headers=H).json()
+    assert before["active_source"] in ("global", "none")
+    assert before["enabled"] is False
+
+    client.put("/api/organization/smtp", json={
+        "enabled": True, "host": "relay.acme.com", "port": 587, "security": "starttls",
+        "username": "noreply@acme.com", "password": "s3cret",
+        "from_address": "noreply@acme.com",
+    }, headers=H)
+    after = client.get("/api/organization/smtp", headers=H).json()
+    assert after["active_source"] == "org_smtp"
+
+    # Toggling off flips the readout back without discarding the settings.
+    client.put("/api/organization/smtp", json={
+        "enabled": False, "host": "relay.acme.com", "port": 587, "security": "starttls",
+        "username": "noreply@acme.com", "from_address": "noreply@acme.com",
+    }, headers=H)
+    off = client.get("/api/organization/smtp", headers=H).json()
+    assert off["active_source"] in ("global", "none")
+    assert off["host"] == "relay.acme.com"   # configuration survived
+    assert off["password_set"] is True       # password survived
+
+
+@pytest.mark.e2e
+def test_smtp_test_only_sends_to_the_caller(create_user, login_user, whoami):
+    """The test endpoint sends real mail through the org's relay.
+
+    An arbitrary recipient would make it a spam relay for anyone holding
+    ``manage_settings``, so it only ever sends to the caller's own address.
+    """
+    email = _unique_email()
+    create_user(email=email)
+    token = login_user(email, "test123")
+    org_id = whoami(token)["organizations"][0]["id"]
+
+    from main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    H = {"Authorization": f"Bearer {token}", "X-Organization-Id": org_id}
+
+    client.put("/api/organization/smtp", json={
+        "enabled": True, "host": "127.0.0.1", "port": 1,  # nothing listening
+        "security": "none", "from_address": "noreply@acme.com",
+    }, headers=H)
+
+    r = client.post("/api/organization/smtp/test",
+                    json={"to": "someone-else@elsewhere.test"}, headers=H)
+    assert r.status_code == 400, r.text
+    assert "your own address" in r.json()["detail"]
+
+    # Defaulting to the caller is allowed and reaches the transport (and fails
+    # there, because nothing is listening on port 1 — which is the point: the
+    # test reports a real transport failure instead of "Connection OK").
+    r = client.post("/api/organization/smtp/test", json={}, headers=H)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is False
+    assert body["source"] == "org_smtp"
+    assert body["recipient"] == email
+    assert body["stage"] in ("connect", "send")
+    assert body["error"]

--- a/backend/tests/unit/test_data_source_member_email.py
+++ b/backend/tests/unit/test_data_source_member_email.py
@@ -105,45 +105,53 @@ def _user(email="member@example.com", name="Member"):
 
 
 class TestSendMemberAddedEmail:
-    def test_sends_when_membership_present(self):
-        fm = MagicMock()
-        fm.send_message = AsyncMock()
+    def test_sends_with_org_context_so_org_smtp_is_used(self):
+        """The send must carry db + organization_id.
+
+        Without them the notification service cannot see the organization's own
+        SMTP server and the mail silently leaves via the global bow-config
+        relay — which is what this notification used to do.
+        """
         db = _make_db(membership=object(), data_source=_ds(), user=_user(),
                       added_by=_user("admin@example.com", "Admin"))
 
         with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
              patch("app.settings.config.settings") as settings, \
-             patch("app.dependencies.async_session_maker", _session_maker(db)):
-            settings.email_client = fm
+             patch("app.dependencies.async_session_maker", _session_maker(db)), \
+             patch("app.services.email_client_resolver.is_outbound_available",
+                   AsyncMock(return_value=True)), \
+             patch("app.services.notification_service.notification_service") as ns:
+            ns.send_custom_email = AsyncMock(
+                return_value=MagicMock(status="sent", source="org_smtp", error=None)
+            )
             settings.bow_config = MagicMock(base_url="http://localhost:3000")
             asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
 
-        fm.send_message.assert_awaited_once()
-        message = fm.send_message.call_args.args[0]
-        # fastapi-mail >= 1.6 parses recipients into NameEmail objects.
-        assert [str(getattr(r, "email", r)) for r in message.recipients] == ["member@example.com"]
+        ns.send_custom_email.assert_awaited_once()
+        kwargs = ns.send_custom_email.call_args.kwargs
+        assert kwargs["recipients"] == ["member@example.com"]
+        assert kwargs["organization_id"] == "org1"
+        assert kwargs["db"] is db
+        assert kwargs["purpose"] == "system"
 
     def test_skips_when_membership_removed(self):
         """The mistake-undo path: membership gone before the delay elapsed."""
-        fm = MagicMock()
-        fm.send_message = AsyncMock()
         db = _make_db(membership=None, data_source=_ds(), user=_user(),
                       added_by=_user("admin@example.com", "Admin"))
 
         with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
              patch("app.settings.config.settings") as settings, \
-             patch("app.dependencies.async_session_maker", _session_maker(db)):
-            settings.email_client = fm
+             patch("app.dependencies.async_session_maker", _session_maker(db)), \
+             patch("app.services.notification_service.notification_service") as ns:
+            ns.send_custom_email = AsyncMock()
             settings.bow_config = MagicMock(base_url="http://localhost:3000")
             asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
 
-        fm.send_message.assert_not_called()
+        ns.send_custom_email.assert_not_called()
 
-    def test_creates_inapp_but_no_email_without_smtp(self):
-        """Notify-first: without SMTP the session is still opened to create the
-        in-app notification, but no email is sent."""
-        fm = MagicMock()
-        fm.send_message = AsyncMock()
+    def test_creates_inapp_but_no_email_without_any_transport(self):
+        """Notify-first: with no transport for this org the in-app notification
+        is still created, but no email is sent."""
         db = _make_db(membership=object(), data_source=_ds(), user=_user(),
                       added_by=_user("admin@example.com", "Admin"))
         maker = _session_maker(db)
@@ -151,15 +159,17 @@ class TestSendMemberAddedEmail:
         with patch("app.core.scheduler.claim_scheduled_run", return_value=True), \
              patch("app.settings.config.settings") as settings, \
              patch("app.dependencies.async_session_maker", maker), \
+             patch("app.services.email_client_resolver.is_outbound_available",
+                   AsyncMock(return_value=False)), \
+             patch("app.services.notification_service.notification_service") as ns, \
              patch("app.services.inbox_service.inbox_service") as inbox:
+            ns.send_custom_email = AsyncMock()
             inbox.notify_users = AsyncMock()
-            settings.email_client = None  # SMTP not configured
             settings.bow_config = MagicMock(base_url="http://localhost:3000")
             asyncio.run(mod.send_member_added_email("ds1", "user1", "admin1", "org1"))
 
-        maker.assert_called_once()                 # session opened for the in-app notification
         inbox.notify_users.assert_awaited_once()   # in-app notification created
-        fm.send_message.assert_not_called()        # no email without SMTP
+        ns.send_custom_email.assert_not_called()   # no email without a transport
 
     def test_skips_when_not_claim_winner(self):
         with patch("app.core.scheduler.claim_scheduled_run", return_value=False), \

--- a/backend/tests/unit/test_email_transport_routing.py
+++ b/backend/tests/unit/test_email_transport_routing.py
@@ -1,0 +1,238 @@
+"""System email must leave through the organization's own SMTP server.
+
+Two properties are locked down here:
+
+1. **No silent fallback.** An organization that configured and enabled its own
+   relay is authoritative. When that relay refuses the message we report the
+   failure; re-sending through the global bow-config SMTP would deliver the mail
+   from an identity the admin never chose and make a broken relay look healthy.
+
+2. **Nothing sends via the global client behind the resolver's back.** The bug
+   this suite exists to prevent was six senders reading ``settings.email_client``
+   directly, so invites, shares, welcome mail and account mail ignored the org's
+   configuration entirely. The guard test fails if that pattern reappears.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from app.services.email.sender import SmtpConfig
+from app.services.email_client_resolver import ResolvedOutbound, choose_outbound
+from app.services.notification_service import NotificationService
+
+BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[2]
+APP_ROOT = BACKEND_ROOT / "app"
+
+# The only modules allowed to touch the global fastapi-mail client: the one that
+# builds it, the one that decides which transport to use, and the one that owns
+# the global send path.
+GLOBAL_CLIENT_OWNERS = {
+    "app/settings/config.py",
+    "app/services/email_client_resolver.py",
+    "app/services/notification_service.py",
+}
+
+
+def _org_smtp(**over) -> dict:
+    base = {
+        "enabled": True, "host": "relay.acme.com", "port": 587,
+        "security": "starttls", "username": "noreply@acme.com",
+        "password": "s3cret", "from_address": "noreply@acme.com",
+        "from_name": "Acme", "validate_certs": True,
+    }
+    base.update(over)
+    return base
+
+
+class TestNoSilentFallback:
+    """A failing org relay must not be papered over by the global client."""
+
+    @pytest.mark.asyncio
+    async def test_org_smtp_failure_does_not_reach_global_client(self, monkeypatch):
+        service = NotificationService()
+        resolved = ResolvedOutbound(
+            source="org_smtp",
+            smtp_config=SmtpConfig(host="relay.acme.com"),
+            from_address="noreply@acme.com",
+            from_name="Acme",
+        )
+
+        async def _fail(cfg, msg):
+            return False, "535 5.7.8 Authentication credentials invalid", "auth"
+
+        global_calls = []
+
+        async def _global(*args, **kwargs):
+            global_calls.append(kwargs)
+            raise AssertionError("must not fall back to the global SMTP client")
+
+        monkeypatch.setattr(
+            "app.services.email.sender.send_message_result", _fail, raising=True
+        )
+        monkeypatch.setattr(service, "_send_via_global", _global, raising=True)
+
+        outcome = await service._send_via_smtp_config(
+            resolved, ["admin@acme.com"], "subject", "body",
+            subtype="plain", attachments=None,
+            message_id=None, in_reply_to=None, references=None,
+            retries=0, retry_delay=0, timeout=None,
+        )
+
+        assert outcome.ok is False
+        assert outcome.source == "org_smtp"
+        assert outcome.stage == "auth"
+        assert "535" in (outcome.error or "")
+        assert global_calls == []
+
+    @pytest.mark.asyncio
+    async def test_missing_from_address_fails_with_the_fix_not_a_stack_trace(self):
+        service = NotificationService()
+        resolved = ResolvedOutbound(
+            source="org_smtp",
+            smtp_config=SmtpConfig(host="relay.acme.com"),
+            from_address=None,
+            from_name=None,
+        )
+        outcome = await service._send_via_smtp_config(
+            resolved, ["admin@acme.com"], "subject", "body",
+            subtype="plain", attachments=None,
+            message_id=None, in_reply_to=None, references=None,
+            retries=0, retry_delay=0, timeout=None,
+        )
+        assert outcome.ok is False
+        assert outcome.stage == "config"
+        assert "From address" in (outcome.error or "")
+
+    @pytest.mark.asyncio
+    async def test_retry_does_not_redeliver_to_accepted_recipients(self, monkeypatch):
+        """A partial failure must retry only the recipients that were refused."""
+        service = NotificationService()
+        resolved = ResolvedOutbound(
+            source="org_smtp",
+            smtp_config=SmtpConfig(host="relay.acme.com"),
+            from_address="noreply@acme.com",
+        )
+        attempts: list[str] = []
+
+        async def _selective(cfg, msg):
+            rcpt = msg["To"]
+            attempts.append(rcpt)
+            if rcpt == "flaky@acme.com" and attempts.count(rcpt) == 1:
+                return False, "451 temporary failure", "send"
+            return True, None, "send"
+
+        monkeypatch.setattr(
+            "app.services.email.sender.send_message_result", _selective, raising=True
+        )
+
+        outcome = await service._send_via_smtp_config(
+            resolved, ["ok@acme.com", "flaky@acme.com"], "subject", "body",
+            subtype="plain", attachments=None,
+            message_id=None, in_reply_to=None, references=None,
+            retries=1, retry_delay=0, timeout=None,
+        )
+
+        assert outcome.ok is True
+        assert attempts.count("ok@acme.com") == 1, "accepted recipient was re-sent"
+        assert attempts.count("flaky@acme.com") == 2
+
+
+class TestResolutionPrecedence:
+    def test_enabled_org_smtp_wins_over_global(self):
+        resolved = choose_outbound(
+            "system", None, None, _org_smtp(), global_present=True
+        )
+        assert resolved.source == "org_smtp"
+        assert resolved.smtp_config.host == "relay.acme.com"
+
+    def test_org_smtp_used_even_without_a_global_client(self):
+        resolved = choose_outbound(
+            "system", None, None, _org_smtp(), global_present=False
+        )
+        assert resolved.source == "org_smtp"
+
+    def test_disabled_org_smtp_falls_back_to_global(self):
+        resolved = choose_outbound(
+            "system", None, None, _org_smtp(enabled=False), global_present=True
+        )
+        assert resolved.source == "global"
+
+    def test_disabled_org_smtp_without_global_is_none(self):
+        resolved = choose_outbound(
+            "system", None, None, _org_smtp(enabled=False), global_present=False
+        )
+        assert resolved.source == "none"
+
+    def test_system_mail_never_uses_the_ai_mailbox(self):
+        ai_creds = {"smtp_host": "smtp.office365.com", "smtp_username": "ai@acme.com"}
+        resolved = choose_outbound(
+            "system", {}, ai_creds, _org_smtp(), global_present=True
+        )
+        assert resolved.source == "org_smtp"
+
+    def test_from_address_falls_back_to_username(self):
+        resolved = choose_outbound(
+            "system", None, None, _org_smtp(from_address=None), global_present=True
+        )
+        assert resolved.from_address == "noreply@acme.com"
+
+
+class TestNoDirectGlobalClientUse:
+    """Nothing may send via ``settings.email_client`` behind the resolver."""
+
+    def test_no_module_reads_the_global_client_directly(self):
+        pattern = re.compile(r"^(?!\s*#).*\bemail_client\b", re.MULTILINE)
+        offenders = []
+        for path in APP_ROOT.rglob("*.py"):
+            rel = path.relative_to(BACKEND_ROOT).as_posix()
+            if rel in GLOBAL_CLIENT_OWNERS:
+                continue
+            for match in pattern.finditer(path.read_text()):
+                line = match.group(0).strip()
+                # Docstrings and prose may name it; only code counts.
+                if "settings.email_client" in line or "email_client" in line.split("#")[0]:
+                    if line.startswith(('"', "'", "*", "-")) or line.endswith('"""'):
+                        continue
+                    offenders.append(f"{rel}: {line}")
+        assert not offenders, (
+            "These modules bypass the org-SMTP resolver and will silently send "
+            "via the global bow-config SMTP:\n  " + "\n  ".join(offenders)
+            + "\n\nUse notification_service.send_custom_email(db=..., "
+              "organization_id=...) or email_client_resolver.is_outbound_available()."
+        )
+
+    def test_no_module_builds_its_own_fastapi_mail_message(self):
+        """``MessageSchema`` outside the notification service means a bypass."""
+        allowed = {"app/services/notification_service.py"}
+        offenders = []
+        for path in APP_ROOT.rglob("*.py"):
+            rel = path.relative_to(BACKEND_ROOT).as_posix()
+            if rel in allowed:
+                continue
+            text = path.read_text()
+            if re.search(r"^\s*from fastapi_mail import.*MessageSchema", text, re.MULTILINE):
+                offenders.append(rel)
+        assert not offenders, (
+            "These modules construct fastapi-mail messages directly, which can "
+            "only reach the global SMTP client:\n  " + "\n  ".join(offenders)
+        )
+
+
+class TestInviteSenderRequiresOrgContext:
+    """The invite sender must demand the org context it needs to resolve SMTP."""
+
+    def test_send_invitation_email_takes_db_and_organization_id(self):
+        import inspect
+
+        from app.services.organization_service import OrganizationService
+
+        params = list(
+            inspect.signature(OrganizationService._send_invitation_email).parameters
+        )
+        assert params[:3] == ["self", "db", "organization_id"], (
+            "invites resolved SMTP from no organization context and always used "
+            f"the global relay; signature is now {params}"
+        )

--- a/frontend/components/NotifyRecipientPicker.vue
+++ b/frontend/components/NotifyRecipientPicker.vue
@@ -178,6 +178,15 @@ const send = async () => {
             },
         })
         if (res.error.value) throw res.error.value
+        // The API reports per-channel outcomes; a 200 means the request was
+        // understood, not that the mail was accepted by a relay. Reporting
+        // "sent" regardless is how a share that never left the building looked
+        // like a success.
+        const failures = ((res.data.value as any)?.errors || []) as any[]
+        if (failures.length) {
+            throw new Error(failures.map((f: any) => f.error).filter(Boolean).join('; ')
+                || 'The mail server rejected the message')
+        }
         sendStatus.value = 'sent'
         toast.add({ title: 'Notifications sent', color: 'green' })
         emit('sent')
@@ -187,9 +196,13 @@ const send = async () => {
             message.value = ''
             sendStatus.value = null
         }, 2000)
-    } catch {
+    } catch (e: any) {
         sendStatus.value = 'failed'
-        toast.add({ title: 'Failed to send notifications', color: 'red' })
+        toast.add({
+            title: 'Failed to send notifications',
+            description: e?.data?.detail || e?.message || undefined,
+            color: 'red',
+        })
     } finally {
         isSending.value = false
     }

--- a/frontend/pages/settings/smtp.vue
+++ b/frontend/pages/settings/smtp.vue
@@ -46,17 +46,22 @@
         </div>
       </div>
 
+      <!-- The whole block dims when the server is off: the settings are kept,
+           but editing them has no effect until it is switched back on. -->
+      <fieldset :disabled="!form.enabled"
+        class="min-w-0 border-0 p-0 m-0"
+        :class="form.enabled ? '' : 'opacity-60'">
       <div class="grid grid-cols-2 gap-3 mb-3">
         <div>
           <label class="block text-sm font-medium mb-1">From name</label>
-          <input v-model="form.from_name" type="text" data-testid="smtp-from-name" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="Acme" />
+          <input v-model="form.from_name" type="text" data-testid="smtp-from-name" :disabled="!form.enabled" :class="fieldClass" placeholder="Acme" />
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">
             From address
             <span v-if="form.enabled" class="text-red-500">*</span>
           </label>
-          <input v-model="form.from_address" type="email" data-testid="smtp-from-address" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="noreply@acme.com" />
+          <input v-model="form.from_address" type="email" data-testid="smtp-from-address" :disabled="!form.enabled" :class="fieldClass" placeholder="noreply@acme.com" />
         </div>
       </div>
       <div class="grid grid-cols-2 gap-3 mb-3">
@@ -65,21 +70,21 @@
             Host
             <span v-if="form.enabled" class="text-red-500">*</span>
           </label>
-          <input v-model="form.host" type="text" data-testid="smtp-host" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="smtp.acme.com" />
+          <input v-model="form.host" type="text" data-testid="smtp-host" :disabled="!form.enabled" :class="fieldClass" placeholder="smtp.acme.com" />
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Port</label>
-          <input v-model.number="form.port" type="number" data-testid="smtp-port" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
+          <input v-model.number="form.port" type="number" data-testid="smtp-port" :disabled="!form.enabled" :class="fieldClass" />
         </div>
       </div>
       <div class="grid grid-cols-2 gap-3 mb-1">
         <div>
           <label class="block text-sm font-medium mb-1">Username <span class="text-gray-400 font-normal">(optional)</span></label>
-          <input v-model="form.username" type="text" data-testid="smtp-username" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
+          <input v-model="form.username" type="text" data-testid="smtp-username" :disabled="!form.enabled" :class="fieldClass" />
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Password <span class="text-gray-400 font-normal">(optional)</span></label>
-          <input v-model="form.password" type="password" data-testid="smtp-password" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+          <input v-model="form.password" type="password" data-testid="smtp-password" :disabled="!form.enabled" :class="fieldClass"
             :placeholder="passwordSet ? '•••••••• (unchanged)' : ''" />
           <p v-if="passwordSet" class="text-xs text-gray-500 dark:text-gray-400 mt-1">Leave blank to keep the saved password.</p>
         </div>
@@ -87,17 +92,19 @@
       <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">Leave username &amp; password empty for an open relay that doesn't require authentication.</p>
       <div class="mb-3">
         <label class="block text-sm font-medium mb-1">Security</label>
-        <select v-model="form.security" data-testid="smtp-security" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+        <select v-model="form.security" data-testid="smtp-security" :disabled="!form.enabled" :class="fieldClass">
           <option value="starttls">STARTTLS (587)</option>
           <option value="ssl">SSL/TLS (465)</option>
           <option value="none">None</option>
         </select>
       </div>
-      <label v-if="form.security !== 'none'" class="flex items-center gap-2 mb-4 cursor-pointer">
-        <UToggle v-model="form.validate_certs" />
+      <label v-if="form.security !== 'none'" class="flex items-center gap-2 mb-4"
+        :class="form.enabled ? 'cursor-pointer' : 'cursor-default'">
+        <UToggle v-model="form.validate_certs" :disabled="!form.enabled" />
         <span class="text-sm text-gray-700 dark:text-gray-300">Validate TLS certificates</span>
         <span class="text-xs text-gray-400 dark:text-gray-600">— turn off for self-signed / internal-CA relays</span>
       </label>
+      </fieldset>
 
       <div class="flex items-center gap-2">
         <button type="submit" :disabled="busy" data-testid="smtp-save"
@@ -172,6 +179,15 @@ async function showResult(result: { ok: boolean; text: string; detail?: string }
   testResult.value = result
   testedSignature.value = result ? formSignature.value : null
 }
+
+/** Inputs read as off — greyed and not editable — while the server is disabled. */
+const fieldClass = computed(() => [
+  'w-full border rounded px-2 py-1',
+  form.enabled
+    ? 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white'
+    : 'border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800'
+      + ' text-gray-500 dark:text-gray-400 cursor-not-allowed',
+])
 
 const activeBanner = computed(() => {
   if (serverState.active_source === 'org_smtp') {

--- a/frontend/pages/settings/smtp.vue
+++ b/frontend/pages/settings/smtp.vue
@@ -4,10 +4,17 @@
       SMTP Server
       <p class="text-sm text-gray-500 dark:text-gray-400 font-normal mb-6">
         The server used to send your organization's <strong>system emails</strong> —
-        report shares, scheduled‑report results, and invites. When set, it overrides
-        the global SMTP configured in <code>bow-config</code>.
+        report shares, scheduled‑report results, invites, welcome and account emails.
+        When enabled, it overrides the global SMTP configured in <code>bow-config</code>.
       </p>
     </h2>
+
+    <!-- Which transport system mail is actually leaving through right now. -->
+    <div v-if="loaded" class="md:w-2/3 mb-4 rounded-lg border px-3 py-2.5 flex items-start gap-2 text-xs"
+      :class="activeBanner.class">
+      <UIcon :name="activeBanner.icon" class="w-4 h-4 shrink-0 mt-px" />
+      <span data-testid="smtp-active-source"><strong>{{ activeBanner.title }}</strong> {{ activeBanner.detail }}</span>
+    </div>
 
     <div class="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-3 my-3 text-xs text-blue-800 dark:text-blue-200 md:w-2/3">
       <strong>SMTP Server vs AI Mailbox.</strong> This SMTP server only sends
@@ -17,38 +24,62 @@
     </div>
 
     <form class="md:w-2/3 mt-4" @submit.prevent="save">
-      <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
-        Fill in a host to use a custom SMTP server. Leave the host blank to fall back to the global SMTP from <code>bow-config</code>.
-      </p>
+      <!-- Enable/disable is its own switch: blanking the host to "turn it off"
+           used to throw the whole configuration away. -->
+      <div class="flex items-start gap-3 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2.5 mb-4">
+        <UToggle v-model="form.enabled" data-testid="smtp-enabled-toggle" class="mt-0.5" />
+        <div class="text-sm">
+          <div class="font-medium text-gray-900 dark:text-white">Use a custom SMTP server</div>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            <template v-if="form.enabled">
+              System email is sent through the server below.
+            </template>
+            <template v-else-if="serverState.global_configured">
+              Off — system email falls back to the global SMTP from <code>bow-config</code>.
+              Your settings below are kept.
+            </template>
+            <template v-else>
+              Off — and no global SMTP is configured, so <strong>no system email will be
+              sent at all</strong>. Your settings below are kept.
+            </template>
+          </p>
+        </div>
+      </div>
 
       <div class="grid grid-cols-2 gap-3 mb-3">
         <div>
           <label class="block text-sm font-medium mb-1">From name</label>
-          <input v-model="form.from_name" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="Acme" />
+          <input v-model="form.from_name" type="text" data-testid="smtp-from-name" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="Acme" />
         </div>
         <div>
-          <label class="block text-sm font-medium mb-1">From address</label>
-          <input v-model="form.from_address" type="email" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="noreply@acme.com" />
+          <label class="block text-sm font-medium mb-1">
+            From address
+            <span v-if="form.enabled" class="text-red-500">*</span>
+          </label>
+          <input v-model="form.from_address" type="email" data-testid="smtp-from-address" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="noreply@acme.com" />
         </div>
       </div>
       <div class="grid grid-cols-2 gap-3 mb-3">
         <div>
-          <label class="block text-sm font-medium mb-1">Host</label>
-          <input v-model="form.host" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="smtp.acme.com" />
+          <label class="block text-sm font-medium mb-1">
+            Host
+            <span v-if="form.enabled" class="text-red-500">*</span>
+          </label>
+          <input v-model="form.host" type="text" data-testid="smtp-host" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" placeholder="smtp.acme.com" />
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Port</label>
-          <input v-model.number="form.port" type="number" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
+          <input v-model.number="form.port" type="number" data-testid="smtp-port" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
         </div>
       </div>
       <div class="grid grid-cols-2 gap-3 mb-1">
         <div>
           <label class="block text-sm font-medium mb-1">Username <span class="text-gray-400 font-normal">(optional)</span></label>
-          <input v-model="form.username" type="text" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
+          <input v-model="form.username" type="text" data-testid="smtp-username" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white" />
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Password <span class="text-gray-400 font-normal">(optional)</span></label>
-          <input v-model="form.password" type="password" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+          <input v-model="form.password" type="password" data-testid="smtp-password" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
             :placeholder="passwordSet ? '•••••••• (unchanged)' : ''" />
           <p v-if="passwordSet" class="text-xs text-gray-500 dark:text-gray-400 mt-1">Leave blank to keep the saved password.</p>
         </div>
@@ -56,7 +87,7 @@
       <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">Leave username &amp; password empty for an open relay that doesn't require authentication.</p>
       <div class="mb-3">
         <label class="block text-sm font-medium mb-1">Security</label>
-        <select v-model="form.security" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+        <select v-model="form.security" data-testid="smtp-security" class="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
           <option value="starttls">STARTTLS (587)</option>
           <option value="ssl">SSL/TLS (465)</option>
           <option value="none">None</option>
@@ -69,59 +100,133 @@
       </label>
 
       <div class="flex items-center gap-2">
-        <button type="button" v-if="form.host" :disabled="testing" @click="test"
-          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm px-3 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50">
-          {{ testing ? 'Testing…' : 'Test connection' }}
-        </button>
-        <button type="submit" :disabled="saving" class="bg-blue-500 text-white text-sm px-3 py-1.5 rounded-md disabled:opacity-50">
+        <button type="submit" :disabled="busy" data-testid="smtp-save"
+          class="bg-blue-500 text-white text-sm px-3 py-1.5 rounded-md disabled:opacity-50">
           {{ saving ? 'Saving…' : 'Save' }}
         </button>
+        <button type="button" v-if="form.enabled" :disabled="busy" @click="test" data-testid="smtp-test"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm px-3 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50">
+          {{ testing ? 'Sending…' : 'Save & send test email' }}
+        </button>
+        <span v-if="form.enabled && currentUserEmail" class="text-xs text-gray-400 dark:text-gray-500">
+          sends to {{ currentUserEmail }}
+        </span>
       </div>
-      <p v-if="testResult" :class="testResult.ok ? 'text-green-600' : 'text-red-600'" class="text-sm mt-2 flex items-start gap-1">
-        <UIcon :name="testResult.ok ? 'i-heroicons-check-circle' : 'i-heroicons-x-circle'" class="w-4 h-4 shrink-0 mt-0.5" />
-        <span>{{ testResult.text }}</span>
-      </p>
+
+      <div v-if="visibleTestResult" data-testid="smtp-test-result"
+        class="text-sm mt-3 rounded-md border px-3 py-2 flex items-start gap-2"
+        :class="visibleTestResult.ok
+          ? 'border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200'
+          : 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-200'">
+        <UIcon :name="visibleTestResult.ok ? 'i-heroicons-check-circle' : 'i-heroicons-x-circle'" class="w-4 h-4 shrink-0 mt-0.5" />
+        <div>
+          <div class="font-medium">{{ visibleTestResult.text }}</div>
+          <div v-if="visibleTestResult.detail" class="text-xs mt-0.5 opacity-90 break-words">{{ visibleTestResult.detail }}</div>
+        </div>
+      </div>
     </form>
   </div>
 </template>
 
 <script setup lang="ts">
-import { reactive, ref, onMounted } from 'vue'
+import { reactive, ref, computed, nextTick, onMounted } from 'vue'
 
 definePageMeta({ auth: true, permissions: ['manage_settings'], layout: 'settings' })
 
 const toast = useToast()
+const { data: authData } = useAuth()
+const currentUserEmail = computed(() => (authData.value as any)?.email || '')
 
 const form = reactive({
+  enabled: false,
   host: '', port: 587, security: 'starttls',
   username: '', password: '', from_address: '', from_name: '', validate_certs: true,
 })
+const serverState = reactive({ active_source: 'none', global_configured: false, host: '' })
+const loaded = ref(false)
 const passwordSet = ref(false)
 const saving = ref(false)
 const testing = ref(false)
-const testResult = ref<{ ok: boolean; text: string } | null>(null)
+const busy = computed(() => saving.value || testing.value)
+const testResult = ref<{ ok: boolean; text: string; detail?: string } | null>(null)
+
+// A green "delivered" line sitting next to fields the admin has since edited is
+// the stale-success problem in miniature. Rather than watching the form (which
+// races with the state refresh a successful save performs), stamp the result
+// with the configuration it describes and show it only while that still matches.
+const formSignature = computed(() => JSON.stringify([
+  form.enabled, form.host.trim(), form.port, form.security,
+  form.username, form.from_address, form.from_name, form.validate_certs,
+  !!form.password,
+]))
+const testedSignature = ref<string | null>(null)
+const visibleTestResult = computed(
+  () => (testedSignature.value === formSignature.value ? testResult.value : null),
+)
+
+/** Show ``result`` against the configuration currently in the form. */
+async function showResult(result: { ok: boolean; text: string; detail?: string } | null) {
+  // Let any pending reactive updates (e.g. the post-save state refresh) settle
+  // first, so the signature we stamp is the one the admin is looking at.
+  await nextTick()
+  testResult.value = result
+  testedSignature.value = result ? formSignature.value : null
+}
+
+const activeBanner = computed(() => {
+  if (serverState.active_source === 'org_smtp') {
+    return {
+      class: 'border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200',
+      icon: 'i-heroicons-check-circle',
+      title: 'System email uses this SMTP server.',
+      detail: `Sending via ${serverState.host || 'your relay'}.`,
+    }
+  }
+  if (serverState.active_source === 'global') {
+    return {
+      class: 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 text-amber-800 dark:text-amber-200',
+      icon: 'i-heroicons-information-circle',
+      title: 'System email uses the global bow-config SMTP.',
+      detail: 'Enable a custom SMTP server below to send from your own relay instead.',
+    }
+  }
+  return {
+    class: 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-200',
+    icon: 'i-heroicons-exclamation-triangle',
+    title: 'No SMTP server is configured.',
+    detail: 'Invites, report shares and scheduled-report emails are not being sent.',
+  }
+})
+
+function applyServerState(s: any) {
+  form.enabled = !!s.enabled
+  form.host = s.host || ''
+  form.port = s.port || 587
+  form.security = s.security || 'starttls'
+  form.username = s.username || ''
+  form.from_address = s.from_address || ''
+  form.from_name = s.from_name || ''
+  form.validate_certs = s.validate_certs !== false
+  passwordSet.value = !!s.password_set
+  serverState.active_source = s.active_source || 'none'
+  serverState.global_configured = !!s.global_configured
+  serverState.host = s.host || ''
+}
+
+async function load() {
+  const res = await useMyFetch('/api/organization/smtp')
+  const s = res.data.value as any
+  if (s) applyServerState(s)
+  loaded.value = true
+}
 
 onMounted(async () => {
-  try {
-    const res = await useMyFetch('/api/organization/smtp')
-    const s = res.data.value as any
-    if (s) {
-      form.host = s.host || ''
-      form.port = s.port || 587
-      form.security = s.security || 'starttls'
-      form.username = s.username || ''
-      form.from_address = s.from_address || ''
-      form.from_name = s.from_name || ''
-      form.validate_certs = s.validate_certs !== false
-      passwordSet.value = !!s.password_set
-    }
-  } catch (e) { /* ignore */ }
+  try { await load() } catch { loaded.value = true }
 })
 
 function payload() {
   const p: any = {
-    // Enabled is derived from the host: filled in → used, blank → falls back to global SMTP.
-    enabled: !!form.host.trim(), host: form.host.trim(), port: form.port, security: form.security,
+    enabled: form.enabled, host: form.host.trim(), port: form.port, security: form.security,
     username: form.username, from_address: form.from_address, from_name: form.from_name,
     validate_certs: form.validate_certs,
   }
@@ -129,16 +234,26 @@ function payload() {
   return p
 }
 
+/** Persist the form. Returns true only when the server actually accepted it. */
+async function persist(): Promise<boolean> {
+  const res = await useMyFetch('/api/organization/smtp', { method: 'PUT', body: payload() })
+  if (res.status.value !== 'success') {
+    const detail = (res.error.value as any)?.data?.detail || 'Could not save the SMTP settings'
+    toast.add({ title: 'Failed to save SMTP', description: detail, color: 'red' })
+    await showResult({ ok: false, text: 'Not saved', detail })
+    return false
+  }
+  const s = res.data.value as any
+  if (s) applyServerState(s)
+  form.password = ''
+  return true
+}
+
 async function save() {
   saving.value = true
-  testResult.value = null
+  await showResult(null)
   try {
-    const res = await useMyFetch('/api/organization/smtp', { method: 'PUT', body: payload() })
-    if (res.status.value === 'success') {
-      toast.add({ title: 'SMTP saved', color: 'green' })
-    } else {
-      toast.add({ title: 'Failed to save SMTP', description: (res.error.value as any)?.data?.detail || 'Error', color: 'red' })
-    }
+    if (await persist()) toast.add({ title: 'SMTP saved', color: 'green' })
   } finally {
     saving.value = false
   }
@@ -147,22 +262,90 @@ async function save() {
 async function test() {
   saving.value = true
   testing.value = true
-  testResult.value = null
+  await showResult(null)
   try {
-    // Save first so the test probes the stored config.
-    await useMyFetch('/api/organization/smtp', { method: 'PUT', body: payload() })
-    passwordSet.value = passwordSet.value || !!form.password
-    form.password = ''
-    const res = await useMyFetch('/api/organization/smtp/test', { method: 'POST' })
+    // Save first, and *stop* if the save failed — otherwise the test probes
+    // whatever was stored before and reports success for settings that were
+    // never persisted.
+    if (!await persist()) return
+
+    const res = await useMyFetch('/api/organization/smtp/test', { method: 'POST', body: {} })
+    if (res.status.value !== 'success') {
+      const detail = (res.error.value as any)?.data?.detail || 'The test request failed'
+      await showResult({ ok: false, text: 'Test failed', detail })
+      return
+    }
     const data = res.data.value as any
-    if (res.status.value === 'success' && data?.success) {
-      testResult.value = { ok: true, text: 'Connection OK' }
+    // The send just proved which transport is live; refresh the banner with it
+    // before stamping the result so both describe the same state.
+    await load()
+    if (data?.success) {
+      await showResult({
+        ok: true,
+        text: `Test email delivered to ${data.recipient}`,
+        detail: `Sent via ${sourceLabel(data.source)}${data.from_address ? ` as ${data.from_address}` : ''}. `
+          + 'Check your inbox to confirm it arrived.',
+      })
     } else {
-      testResult.value = { ok: false, text: data?.smtp || 'Connection failed — check the settings' }
+      const { text, hint } = failureCopy(data?.stage)
+      await showResult({
+        ok: false,
+        text,
+        detail: `${data?.error || 'Unknown error'} — ${hint} (transport: ${sourceLabel(data?.source)})`,
+      })
     }
   } finally {
     saving.value = false
     testing.value = false
   }
+}
+
+/** Name the step that failed, and what to look at. "Rejected" is wrong for a
+ * server that never answered — the stage is what tells an admin where to look. */
+function failureCopy(stage?: string): { text: string; hint: string } {
+  switch (stage) {
+    case 'connect':
+      return {
+        text: 'Could not reach the mail server',
+        hint: 'check the host and port, and that outbound SMTP is not blocked by a firewall',
+      }
+    case 'tls':
+      return {
+        text: 'TLS negotiation failed',
+        hint: 'try a different Security setting, or turn off certificate validation for an internal relay',
+      }
+    case 'auth':
+      return {
+        text: 'The mail server rejected the credentials',
+        hint: 'check the username and password',
+      }
+    case 'sender':
+      return {
+        text: 'The mail server refused the From address',
+        hint: 'the relay will not send as this address — use one it is authorised for',
+      }
+    case 'recipient':
+      return {
+        text: 'The mail server refused to relay to that address',
+        hint: 'the relay does not accept mail for this recipient',
+      }
+    case 'config':
+      return {
+        text: 'The SMTP settings are incomplete',
+        hint: 'fill in the missing field and try again',
+      }
+    default:
+      return {
+        text: 'The mail server rejected the message',
+        hint: 'see the server response above',
+      }
+  }
+}
+
+function sourceLabel(source?: string) {
+  if (source === 'org_smtp') return 'this SMTP server'
+  if (source === 'global') return 'the global bow-config SMTP'
+  if (source === 'ai_mailbox') return 'the AI mailbox'
+  return 'no transport'
 }
 </script>

--- a/frontend/pages/settings/smtp.vue
+++ b/frontend/pages/settings/smtp.vue
@@ -5,7 +5,7 @@
       <p class="text-sm text-gray-500 dark:text-gray-400 font-normal mb-6">
         The server used to send your organization's <strong>system emails</strong> —
         report shares, scheduled‑report results, invites, welcome and account emails.
-        When enabled, it overrides the global SMTP configured in <code>bow-config</code>.
+        When enabled, it overrides the SMTP server configured globally.
       </p>
     </h2>
 
@@ -35,12 +35,12 @@
               System email is sent through the server below.
             </template>
             <template v-else-if="serverState.global_configured">
-              Off — system email falls back to the global SMTP from <code>bow-config</code>.
+              Off — system email falls back to the globally configured SMTP server.
               Your settings below are kept.
             </template>
             <template v-else>
-              Off — and no global SMTP is configured, so <strong>no system email will be
-              sent at all</strong>. Your settings below are kept.
+              Off — and no SMTP server is configured globally, so <strong>no system email
+              will be sent at all</strong>. Your settings below are kept.
             </template>
           </p>
         </div>
@@ -186,7 +186,7 @@ const activeBanner = computed(() => {
     return {
       class: 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 text-amber-800 dark:text-amber-200',
       icon: 'i-heroicons-information-circle',
-      title: 'System email uses the global bow-config SMTP.',
+      title: 'System email uses the globally configured SMTP server.',
       detail: 'Enable a custom SMTP server below to send from your own relay instead.',
     }
   }
@@ -344,7 +344,7 @@ function failureCopy(stage?: string): { text: string; hint: string } {
 
 function sourceLabel(source?: string) {
   if (source === 'org_smtp') return 'this SMTP server'
-  if (source === 'global') return 'the global bow-config SMTP'
+  if (source === 'global') return 'the globally configured SMTP server'
   if (source === 'ai_mailbox') return 'the AI mailbox'
   return 'no transport'
 }


### PR DESCRIPTION
The SMTP settings page reported success for configurations that could not
deliver a single message, and most system mail ignored the page entirely.

**Test connection was a connect-and-auth probe.** It skipped AUTH whenever the
password was falsy — including when `decrypt_secret` silently returns None after
an encryption-key change — so a wrong or undecryptable password read as
"Connection OK". It never spoke MAIL FROM or RCPT TO, so an unauthorised sender,
a relay that declines to relay, and a missing From address were all invisible.
It also negotiated TLS differently from the real sender (explicit `start_tls=
False` vs the sender's opportunistic `None`), so it could pass where a send
would fail.

It now sends a real message through the production path (`resolve_outbound` →
`build_email` → `send_message`) rather than a parallel implementation, and
reports which transport carried it plus the stage that failed (connect / tls /
auth / sender / recipient), so the page names the fix instead of calling every
failure a rejection. It sends only to the caller's own address — an arbitrary
recipient would make it a spam relay for anyone holding manage_settings — and
throttles successful sends so it cannot be used to flood an inbox.

**Six senders read `settings.email_client` directly**, bypassing the resolver, so
invites, resends, report shares, welcome mail, the "added to agent" notification,
password resets and email verifications all left via the global bow-config relay
whatever the organization had configured — and were skipped outright when no
global SMTP existed. Each now passes db + organization_id, and availability is
asked per organization via `is_outbound_available`. Account mail (reset/verify)
has no organization in scope, so it resolves the user's sole membership and
falls back to global when that is ambiguous. The pre-auth `smtp_enabled` flag now
also sees org SMTP, so password reset stops claiming to be unavailable.

**The silent fallback is gone.** An org whose relay refused a message had it
quietly re-sent through bow-config, delivering from an identity the admin never
chose and making a broken relay look healthy. A configured, enabled org relay is
now authoritative: failures are reported, with the source recorded on every
ChannelResult. Report-share dispatch is awaited rather than fire-and-forget, so
"sent" means sent.

UI: enable/disable is its own toggle (blanking the host to turn it off used to
discard the whole configuration), the page shows which transport system mail is
actually using, saving is verified before a test runs, and a stale success line
can no longer sit next to edited fields.

Also: `build_email` rejects a missing From address instead of producing a message
every relay refuses; saving an enabled server without one is a 400; retries no
longer re-deliver to recipients a partial failure already accepted.

Tests: a local relay that can actually reject (auth 535, sender/recipient 550,
STARTTLS 530) plus a case for every configuration the old probe called healthy;
a guard test that fails if anything outside the resolver touches the global
client again; and e2e coverage of the active-transport readout, the From-address
rule and the test endpoint's recipient rule.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BV2HV1kynTUNGYrvNFsmcc