### PR TITLE
Scope the tables selector per connection, not per data source

### DIFF
--- a/backend/alembic/versions/overlayconn01_per_connection_user_overlay.py
+++ b/backend/alembic/versions/overlayconn01_per_connection_user_overlay.py
@@ -1,0 +1,124 @@
+"""Make the per-user table overlay connection-aware.
+
+``user_data_source_tables`` recorded which tables a given user may see on a
+given DATA SOURCE. An agent, however, can hold several connections, and the
+per-user catalog is a property of a connection (its auth policy, its token),
+not of the agent. Two consequences, both user-visible:
+
+* the unique key ``(data_source_id, user_id, table_name)`` collided whenever
+  two connections on one agent exposed the same table name, so the second
+  connection's accessibility overwrote the first's;
+* readers could not tell which connection an overlay row described, so the
+  tables selector filtered the WHOLE catalog through an overlay that only ever
+  described one connection and every other connection's tables disappeared.
+
+This adds ``connection_id`` and swaps the unique constraint. The backfill
+resolves the connection through ``datasource_tables -> connection_tables``;
+rows whose canonical table is unlinked (a delegated user's own discovery) stay
+NULL and are treated by readers as "this user, any connection" — safe, because
+every overlay read is already filtered by ``user_id``.
+
+Revision ID: overlayconn01
+Revises: diagrollup01
+Create Date: 2026-09-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "overlayconn01"
+down_revision: Union[str, None] = "diagrollup01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "user_data_source_tables"
+_OLD_UQ = "uq_user_ds_table"
+_NEW_UQ = "uq_user_ds_conn_table"
+_IX = "ix_udst_ds_user_conn"
+_IX_CONN = "ix_user_data_source_tables_connection_id"
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    return column in {c["name"] for c in sa.inspect(bind).get_columns(table)}
+
+
+def _constraint_names(bind, table: str) -> set:
+    insp = sa.inspect(bind)
+    names = {c.get("name") for c in insp.get_unique_constraints(table)}
+    names |= {i.get("name") for i in insp.get_indexes(table)}
+    return {n for n in names if n}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_TABLE):
+        return
+
+    # SQLite cannot ALTER a constraint in place; batch_alter_table rebuilds the
+    # table. On PostgreSQL the same operations run as plain DDL.
+    with op.batch_alter_table(_TABLE) as batch:
+        if not _has_column(bind, _TABLE, "connection_id"):
+            batch.add_column(sa.Column(
+                "connection_id",
+                sa.String(36),
+                sa.ForeignKey(
+                    "connections.id",
+                    ondelete="CASCADE",
+                    # SQLite rebuilds the table in batch mode and refuses to copy
+                    # an unnamed constraint, so name it explicitly.
+                    name="fk_user_data_source_tables_connection_id_connections",
+                ),
+                nullable=True,
+            ))
+
+    # Backfill before swapping the constraint so the new key is already correct.
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {_TABLE}
+               SET connection_id = (
+                   SELECT ct.connection_id
+                     FROM datasource_tables dst
+                     JOIN connection_tables ct ON ct.id = dst.connection_table_id
+                    WHERE dst.id = {_TABLE}.data_source_table_id
+               )
+             WHERE connection_id IS NULL
+               AND data_source_table_id IS NOT NULL
+            """
+        )
+    )
+
+    existing = _constraint_names(bind, _TABLE)
+    with op.batch_alter_table(_TABLE) as batch:
+        if _OLD_UQ in existing:
+            batch.drop_constraint(_OLD_UQ, type_="unique")
+        if _NEW_UQ not in existing:
+            batch.create_unique_constraint(
+                _NEW_UQ, ["data_source_id", "user_id", "connection_id", "table_name"]
+            )
+        if _IX not in existing:
+            batch.create_index(_IX, ["data_source_id", "user_id", "connection_id"])
+        if _IX_CONN not in existing:
+            batch.create_index(_IX_CONN, ["connection_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_TABLE):
+        return
+    existing = _constraint_names(bind, _TABLE)
+    with op.batch_alter_table(_TABLE) as batch:
+        if _IX_CONN in existing:
+            batch.drop_index(_IX_CONN)
+        if _IX in existing:
+            batch.drop_index(_IX)
+        if _NEW_UQ in existing:
+            batch.drop_constraint(_NEW_UQ, type_="unique")
+        if _OLD_UQ not in existing:
+            batch.create_unique_constraint(
+                _OLD_UQ, ["data_source_id", "user_id", "table_name"]
+            )
+        if _has_column(bind, _TABLE, "connection_id"):
+            batch.drop_column("connection_id")

--- a/backend/alembic/versions/overlayconn01_per_connection_user_overlay.py
+++ b/backend/alembic/versions/overlayconn01_per_connection_user_overlay.py
@@ -18,6 +18,10 @@ rows whose canonical table is unlinked (a delegated user's own discovery) stay
 NULL and are treated by readers as "this user, any connection" — safe, because
 every overlay read is already filtered by ``user_id``.
 
+The downgrade has to put the narrower key back over rows the new key made
+legal, so it reconciles cross-connection duplicates first — see
+``_collapse_cross_connection_duplicates``.
+
 Revision ID: overlayconn01
 Revises: diagrollup01
 Create Date: 2026-09-12
@@ -104,10 +108,85 @@ def upgrade() -> None:
             batch.create_index(_IX_CONN, ["connection_id"])
 
 
+def _udst_tables():
+    """Lightweight table clauses for the reconciliation DML.
+
+    Expressed in Core rather than raw SQL so booleans render correctly on both
+    PostgreSQL (``true``) and SQLite (``1``).
+    """
+    udst = sa.table(
+        _TABLE,
+        sa.column("id", sa.String),
+        sa.column("data_source_id", sa.String),
+        sa.column("user_id", sa.String),
+        sa.column("table_name", sa.String),
+        sa.column("is_accessible", sa.Boolean),
+    )
+    udsc = sa.table(
+        "user_data_source_columns",
+        sa.column("id", sa.String),
+        sa.column("user_data_source_table_id", sa.String),
+    )
+    return udst, udsc
+
+
+def _delete_overlay_rows(udst, udsc, where_clause) -> None:
+    """Delete overlay rows and their columns.
+
+    The columns' FK cascades on PostgreSQL, but SQLite does not enforce foreign
+    keys unless the connection asked it to, so the children go first explicitly.
+    """
+    doomed = sa.select(udst.c.id).where(where_clause)
+    op.execute(udsc.delete().where(udsc.c.user_data_source_table_id.in_(doomed)))
+    op.execute(udst.delete().where(udst.c.id.in_(doomed)))
+
+
+def _collapse_cross_connection_duplicates() -> None:
+    """Reduce each (data source, user, table name) to ONE row.
+
+    Per-connection overlays make ``(data_source_id, user_id, table_name)``
+    legitimately non-unique: two connections on one agent can each expose an
+    ``orders``. The old constraint cannot be recreated over those rows — the
+    downgrade failed outright with a unique violation on any agent that had
+    started using the feature — so the rows are reconciled first.
+
+    The downgrade is lossy by nature (the old schema has nowhere to record which
+    connection a row described). The policy keeps the most permissive answer,
+    which is the one the pre-connection readers assumed: an accessible row wins
+    over an inaccessible one for the same name, and among equals the lowest id
+    wins so the outcome is deterministic and repeatable.
+    """
+    udst, udsc = _udst_tables()
+
+    # 1. Drop inaccessible rows whose name is accessible on another connection.
+    v = udst.alias("v")
+    _delete_overlay_rows(
+        udst, udsc,
+        sa.and_(
+            udst.c.is_accessible.is_(False),
+            sa.exists(
+                sa.select(sa.literal(1)).select_from(v).where(
+                    v.c.data_source_id == udst.c.data_source_id,
+                    v.c.user_id == udst.c.user_id,
+                    v.c.table_name == udst.c.table_name,
+                    v.c.is_accessible.is_(True),
+                )
+            ),
+        ),
+    )
+
+    # 2. Collapse whatever duplicates remain (same accessibility) to one row.
+    keep = sa.select(sa.func.min(udst.c.id)).group_by(
+        udst.c.data_source_id, udst.c.user_id, udst.c.table_name
+    )
+    _delete_overlay_rows(udst, udsc, udst.c.id.notin_(keep))
+
+
 def downgrade() -> None:
     bind = op.get_bind()
     if not sa.inspect(bind).has_table(_TABLE):
         return
+    _collapse_cross_connection_duplicates()
     existing = _constraint_names(bind, _TABLE)
     with op.batch_alter_table(_TABLE) as batch:
         if _IX_CONN in existing:

--- a/backend/app/ai/context/builders/instruction_context_builder.py
+++ b/backend/app/ai/context/builders/instruction_context_builder.py
@@ -1421,25 +1421,68 @@ class InstructionContextBuilder:
             usage_count=usage_count,
         )
     
-    async def _get_user_inaccessible_table_ids(self) -> Set[str]:
-        """Return datasource_table IDs the current user explicitly cannot access.
+    async def _get_user_inaccessible_table_ids(self, candidate_ids: Set[str]) -> Set[str]:
+        """Of `candidate_ids`, the datasource_table IDs this user may NOT see.
 
-        Only applies when user_data_source_tables rows exist (i.e. the connection
-        uses auth_policy='user_required' and an overlay sync has run).  If there
-        are no overlay rows for the user, returns an empty set (= no filtering).
+        An ALLOW-list, evaluated per connection. This used to be a deny-list —
+        it collected only the rows a per-user overlay had explicitly marked
+        `is_accessible=False`, so a table the user had no overlay row for at
+        all counted as accessible. On a delegated connection that is precisely
+        the table they cannot reach: one user's Power BI models are absent from
+        another user's overlay rather than present-and-denied. Instructions
+        written against them therefore leaked into the other user's prompt.
+
+        Scoped through DataSourceService._resolve_catalog_scope, the same
+        predicate the tables selector and the schema context use, so an
+        instruction can only ride on a table the agent itself would show.
+        Bounded by the tables actually referenced, so it costs one query per
+        data source those references span (typically one).
         """
-        if not self.current_user:
+        if not self.current_user or not candidate_ids:
             return set()
 
-        result = await self.db.execute(
-            select(UserDataSourceTable.data_source_table_id)
-            .where(
-                UserDataSourceTable.user_id == str(self.current_user.id),
-                UserDataSourceTable.is_accessible == False,
-                UserDataSourceTable.data_source_table_id.isnot(None),
-            )
-        )
-        return {row[0] for row in result.all()}
+        from app.models.datasource_table import DataSourceTable
+        from app.models.data_source import DataSource
+        from app.services.data_source_service import DataSourceService
+        from sqlalchemy.orm import selectinload
+
+        ids = list(candidate_ids)
+        rows = (await self.db.execute(
+            select(DataSourceTable.id, DataSourceTable.datasource_id)
+            .where(DataSourceTable.id.in_(ids))
+        )).all()
+        by_ds: Dict[str, Set[str]] = {}
+        for tid, ds_id in rows:
+            by_ds.setdefault(str(ds_id), set()).add(str(tid))
+
+        # A reference whose table no longer exists is NOT treated as
+        # inaccessible. "Deleted" is not a per-user access fact, and counting it
+        # as one would newly hide instructions whose only reference happens to
+        # point at a pruned table — a behaviour change unrelated to the leak
+        # this closes. Unknown ids simply drop out of the calculation, exactly
+        # as they did under the deny-list.
+        inaccessible: Set[str] = set()
+
+        svc = DataSourceService()
+        for ds_id, table_ids in by_ds.items():
+            ds = (await self.db.execute(
+                select(DataSource)
+                .options(selectinload(DataSource.connections))
+                .where(DataSource.id == ds_id)
+            )).scalar_one_or_none()
+            if ds is None:
+                inaccessible |= table_ids
+                continue
+            scope = await svc._resolve_catalog_scope(self.db, ds, self.current_user)
+            visible = {
+                str(r) for r in (await self.db.execute(
+                    scope(select(DataSourceTable.id).where(
+                        DataSourceTable.id.in_(list(table_ids))
+                    ))
+                )).scalars().all()
+            }
+            inaccessible |= (table_ids - visible)
+        return inaccessible
 
     async def _filter_instructions_by_table_accessibility(
         self,
@@ -1453,8 +1496,7 @@ class InstructionContextBuilder:
         - At least one referenced table accessible → keep
         - No current_user → keep all (system/admin context)
         """
-        inaccessible = await self._get_user_inaccessible_table_ids()
-        if not inaccessible:
+        if not self.current_user:
             return instructions
 
         # Batch-load table references for all candidate instructions
@@ -1473,7 +1515,15 @@ class InstructionContextBuilder:
         # Build map: instruction_id -> set of referenced table IDs
         refs_by_instruction: Dict[str, Set[str]] = {}
         for inst_id, table_id in ref_result.all():
-            refs_by_instruction.setdefault(inst_id, set()).add(table_id)
+            refs_by_instruction.setdefault(inst_id, set()).add(str(table_id))
+
+        # Evaluate access over exactly the tables referenced. The allow-list
+        # needs the candidates up front, so this runs AFTER the references are
+        # loaded rather than before.
+        candidates = {t for refs in refs_by_instruction.values() for t in refs}
+        inaccessible = await self._get_user_inaccessible_table_ids(candidates)
+        if not inaccessible:
+            return instructions
 
         filtered = []
         for inst in instructions:
@@ -1500,8 +1550,7 @@ class InstructionContextBuilder:
 
         Used in build-based loading where we have InstructionItem (not ORM Instruction).
         """
-        inaccessible = await self._get_user_inaccessible_table_ids()
-        if not inaccessible:
+        if not self.current_user:
             return items
 
         item_ids = [item.id for item in items]
@@ -1518,7 +1567,14 @@ class InstructionContextBuilder:
 
         refs_by_instruction: Dict[str, Set[str]] = {}
         for inst_id, table_id in ref_result.all():
-            refs_by_instruction.setdefault(inst_id, set()).add(table_id)
+            refs_by_instruction.setdefault(inst_id, set()).add(str(table_id))
+
+        # Allow-list over exactly the referenced tables (see
+        # _get_user_inaccessible_table_ids).
+        candidates = {t for refs in refs_by_instruction.values() for t in refs}
+        inaccessible = await self._get_user_inaccessible_table_ids(candidates)
+        if not inaccessible:
+            return items
 
         filtered = []
         for item in items:

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -275,16 +275,56 @@ class SchemaContextBuilder:
             ds_tables = ds_tables_result.scalars().all()
             canonical_by_name: Dict[str, DataSourceTable] = {getattr(t, 'name', ''): t for t in ds_tables}
 
-            # Choose source based on the user's CURRENT access to this data source.
-            # auth_policy lives on the Connection (not the DataSource), so resolve
-            # it from the linked connection — reading it off `ds` would always
-            # default to 'system_only' and silently serve the full catalog.
-            #   'user'   → this user's per-user overlay (their visible subset)
-            #   'system' → owner/admin via service account → full canonical catalog
-            #   'none'   → no proven access → no tables (don't leak the catalog)
-            effective_auth = await self._resolve_user_access(ds)
-            use_overlay = (effective_auth == "user")
-            access_denied = (effective_auth == "none")
+            # Choose the source PER CONNECTION. auth_policy, the token and the
+            # catalog all belong to a connection, not to the agent, so one
+            # verdict for the whole data source is wrong on any agent with more
+            # than one connection — and `connections[0]` decided which way it
+            # was wrong. A delegated connection sorting first replaced the whole
+            # catalog with an overlay that describes only that connection, so
+            # the agent lost every other connection's tables and told users it
+            # had one connection when it had three. A delegated connection
+            # sorting second skipped scoping altogether, putting another user's
+            # delegated tables into this user's prompt.
+            #
+            #   overlay → this user's own token on that connection: their
+            #             per-user overlay rows (which also carry column masking)
+            #   open    → system_only, or service-account/admin: canonical rows
+            #   denied  → delegated with no proven access: nothing
+            #
+            # The classification is DataSourceService.classify_connection_access,
+            # the same one the tables selector scopes with, so the agent reasons
+            # over exactly the tables the user can see in the UI.
+            from app.services.data_source_service import DataSourceService as _DSS
+            open_conn_ids, overlay_conn_ids, denied_conn_ids = (
+                await _DSS().classify_connection_access(self.db, ds, self.user)
+            )
+            if connection_ids:
+                _requested = set(str(x) for x in connection_ids)
+                open_conn_ids = [c for c in open_conn_ids if c in _requested]
+                overlay_conn_ids = [c for c in overlay_conn_ids if c in _requested]
+                denied_conn_ids = [c for c in denied_conn_ids if c in _requested]
+            use_overlay = bool(overlay_conn_ids)
+            # Unlinked canonical rows have no connection to classify. Keep the
+            # historical allowance (they are legacy name-keyed rows) only while
+            # nothing is restricted; once a delegated connection is in play they
+            # are served through the overlay branch instead, so one user's
+            # discovered tables stop reaching another user's prompt.
+            _restricted = bool(overlay_conn_ids or denied_conn_ids)
+
+            def _row_is_open(t, _open=frozenset(open_conn_ids), _restricted=_restricted):
+                """Does this canonical row belong to a connection served
+                canonically (rather than through this user's overlay)?"""
+                ct = getattr(t, 'connection_table', None)
+                cid = str(ct.connection_id) if ct is not None and getattr(ct, 'connection_id', None) else None
+                if cid is not None:
+                    return cid in _open
+                meta = getattr(t, 'metadata_json', None)
+                discovered = meta.get('discovered_connection_id') if isinstance(meta, dict) else None
+                if discovered:
+                    # A delegated user's own discovery: served by the overlay
+                    # branch for that user, and withheld from everyone else.
+                    return str(discovered) in _open
+                return not _restricted
 
             # Normalize into a common shape for downstream rendering
             # Each entry: { name, columns: [{name,dtype}], pks: [{name,dtype}], fks: [fk], metadata_json, metrics, is_active }
@@ -295,16 +335,19 @@ class SchemaContextBuilder:
             # source silently vanishing when one of several connections is down.
             unhealthy_conns: Dict[str, Dict[str, Any]] = {}
 
-            if access_denied:
-                # User has no current access — emit the data source with no tables
-                # rather than the canonical catalog they can't actually query.
-                pass
-            elif use_overlay:
+            if use_overlay:
                 overlays_q = await self.db.execute(
                     select(UserDataSourceTable).where(
                         UserDataSourceTable.data_source_id == str(ds.id),
                         UserDataSourceTable.user_id == str(self.user.id),
                         UserDataSourceTable.is_accessible == True,
+                        # Only the connections this user actually runs delegated
+                        # on. NULL predates connection-aware overlays and is
+                        # this user's own row either way, so it is admitted.
+                        or_(
+                            UserDataSourceTable.connection_id.is_(None),
+                            UserDataSourceTable.connection_id.in_(overlay_conn_ids),
+                        ),
                     )
                 )
                 overlay_tables = overlays_q.scalars().all()
@@ -556,8 +599,13 @@ class SchemaContextBuilder:
                         "cached_next_refresh": cached_next_refresh,
                         "description": cached_description,
                     })
-            else:
-                for t in ds_tables:
+            # Canonical rows for the OPEN connections. This runs ALONGSIDE the
+            # overlay branch above rather than instead of it — that either/or is
+            # exactly what dropped a mixed agent's warehouse tables the moment
+            # the caller had their own token on its Power BI connection.
+            _canonical_rows = [t for t in ds_tables if _row_is_open(t)]
+            if _canonical_rows:
+                for t in _canonical_rows:
                     table_is_active = bool(getattr(t, 'is_active', False))
                     # Skip inactive tables when active_only is True
                     if active_only and not table_is_active:
@@ -871,31 +919,6 @@ class SchemaContextBuilder:
         for s in ds_sections:
             s.native_mcp = native_on
         return native_on
-
-    async def _resolve_user_access(self, ds) -> str:
-        """Classify self.user's CURRENT access to data source `ds`.
-
-        Returns 'user' (own creds → overlay), 'system' (owner/admin via service
-        account → full catalog), or 'none' (no proven access → no tables).
-
-        For non-user_required connections, or when there is no user in context,
-        returns 'system' (the canonical catalog is the right thing to serve).
-        Fails closed to 'none' for user_required so a stale overlay can't keep
-        leaking tables after a user loses access.
-        """
-        conns = list(getattr(ds, 'connections', None) or [])
-        conn = conns[0] if conns else None
-        auth_policy = (getattr(conn, 'auth_policy', None) or 'system_only') if conn else 'system_only'
-        if auth_policy != 'user_required' or self.user is None or conn is None:
-            return 'system'
-        try:
-            from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
-            status = await UserDataSourceCredentialsService().build_user_status_for_connection(
-                self.db, conn, self.user, data_source=ds, live_test=False
-            )
-            return status.effective_auth or 'none'
-        except Exception:
-            return 'none'
 
     # File-source connectors and which of them have a native search API.
     _FILE_SOURCE_TYPES = {

--- a/backend/app/ai/context/builders/schema_context_builder.py
+++ b/backend/app/ai/context/builders/schema_context_builder.py
@@ -342,11 +342,15 @@ class SchemaContextBuilder:
                         UserDataSourceTable.user_id == str(self.user.id),
                         UserDataSourceTable.is_accessible == True,
                         # Only the connections this user actually runs delegated
-                        # on. NULL predates connection-aware overlays and is
-                        # this user's own row either way, so it is admitted.
-                        or_(
-                            UserDataSourceTable.connection_id.is_(None),
-                            UserDataSourceTable.connection_id.in_(overlay_conn_ids),
+                        # on. A NULL connection_id predates connection-aware
+                        # overlays (or the migration could not attribute it):
+                        # unknown provenance, which is not permission. While a
+                        # connection on this agent is DENIED, such a row may be
+                        # that connection's, so being authorized on a different
+                        # one does not justify it — same rule as the tables
+                        # selector (`_overlay_connection_predicate`).
+                        _DSS._overlay_connection_predicate(
+                            overlay_conn_ids, denied_conn_ids
                         ),
                     )
                 )

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -976,18 +976,30 @@ class TablesSchemaContext(ContextSection):
                 return xml_tag("tables", "\n".join(tables_xml))
 
         @staticmethod
-        def _connection_key(t) -> str | None:
-            """Identity of the connection a table came from.
+        def _connection_key(t):
+            """Identity of the connection a table came from: (id, name).
 
-            The id when there is one, the name only as a fallback. Keying on the
-            name alone merged two connections that happen to share a display
-            name into one roster entry — and an agent cannot tell apart, or
-            scope a discovery call to, connections it sees as one.
+            BOTH halves are load-bearing, for opposite reasons:
+
+            * the id, because two connections can share a display name, and an
+              agent cannot tell apart — or scope describe_tables to — connections
+              it sees as one;
+            * the name, because one physical connection can expose two client
+              identities, the live source and its ``::fast`` sibling serving
+              materialized custom queries. They share a connection_id on
+              purpose, so keying on the id alone merges them under whichever
+              name comes first and points half the tables at a client that
+              cannot serve them.
+
+            Same key as `_group_tables_by_connection`, whose docstring covers
+            the second case; the two must agree or the roster names connections
+            the <connection> blocks do not.
             """
             cid = getattr(t, 'connection_id', None)
-            if cid:
-                return str(cid)
-            return getattr(t, 'connection_name', None) or None
+            name = getattr(t, 'connection_name', None) or None
+            if not cid and not name:
+                return None
+            return (str(cid) if cid else "", name or "")
 
         def _connection_roster(self) -> list:
             """(id, name, type, table_count) per connection, in first-seen order.

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -982,11 +982,26 @@ class TablesSchemaContext(ContextSection):
             # Build nested <item> elements with minimal metrics
             items_xml: List[str] = []
             cap = max(0, index_limit)
+            # Only the top-K tables get rendered inside a <connection> block, so
+            # on a multi-connection agent everything past the cap lands here with
+            # no way to tell which connection it came from. Asked to name its
+            # connections, the agent could only report the ones that made the
+            # cut and said the rest "do not have a corresponding <connection>
+            # element" — true, and exactly the gap this closes. One short
+            # attribute, and only when there is more than one connection to
+            # disambiguate.
+            distinct_conns = {
+                getattr(t, 'connection_name', None) for t in tables
+                if getattr(t, 'connection_name', None)
+            }
+            name_connections = len(distinct_conns) > 1
             for t in tables[:cap if cap > 0 else len(tables)]:
                 attrs = {
                     "name": t.name,
                     "cols": str(len(getattr(t, 'columns', []) or [])),
                 }
+                if name_connections and getattr(t, 'connection_name', None):
+                    attrs["connection"] = str(t.connection_name)
                 try:
                     if getattr(t, 'score', None) is not None:
                         attrs["score"] = str(round(float(getattr(t, 'score')), 2))

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -975,6 +975,72 @@ class TablesSchemaContext(ContextSection):
                 tables_xml = [render_table(t) for t in top_tables]
                 return xml_tag("tables", "\n".join(tables_xml))
 
+        def _connection_roster(self) -> list:
+            """(name, type, table_count) per connection, in first-seen order.
+
+            Derived from `self.tables` — the SCOPED table set — and never from
+            the data source's connection list. A connection this caller is
+            denied contributes no tables, so it contributes no roster entry
+            either; reading the agent's connections directly would name it and
+            undo the per-user scoping the builder just applied.
+            """
+            seen: dict = {}
+            for t in (self.tables or []):
+                name = getattr(t, 'connection_name', None)
+                if not name:
+                    continue
+                entry = seen.get(name)
+                if entry is None:
+                    seen[name] = {"name": name,
+                                  "type": getattr(t, 'connection_type', None) or "",
+                                  "count": 1,
+                                  "alias": str(len(seen) + 1)}
+                else:
+                    entry["count"] += 1
+            return list(seen.values())
+
+        def _render_connections_roster_xml(self, full_cap: int = 200) -> str:
+            """Every connection this caller can see, named, with its table count.
+
+            Only the top-K tables render inside a <connection> block and the
+            index is capped, so on a large agent both are a SAMPLE: at 100
+            connections x 100 tables the agent saw 10 connections and had no
+            way to learn the other 90 existed — it answered "1 connection" for
+            a three-connection agent and would answer "10" for a hundred. The
+            roster is the complete list, and it is what makes describe_tables
+            (which already takes connection_ids) reachable for the tail.
+
+            Mirrors <available_agents>/<more_agents>, which solves the same
+            problem one level up for agents.
+            """
+            roster = self._connection_roster()
+            if len(roster) < 2:
+                return ""   # single-connection agents already read unambiguously
+            head = roster[:full_cap]
+            lines = [f'<connections count="{len(roster)}">']
+            for c in head:
+                lines.append(
+                    f'  <connection c="{c["alias"]}" name="{xml_escape(c["name"])}" '
+                    f'type="{xml_escape(c["type"])}" tables="{c["count"]}"/>'
+                )
+            tail = roster[full_cap:]
+            if tail:
+                # Names only past the cap — a name is what describe_tables needs
+                # to be callable, so an unnamed connection is an unreachable one.
+                # Same trade <more_agents> makes.
+                names = ", ".join(xml_escape(c["name"]) for c in tail)
+                lines.append(
+                    f'  <more_connections count="{len(tail)}">{names}</more_connections>'
+                )
+            lines.append(
+                '  ALL connections on this agent are listed above; the sample and '
+                'index below are a subset. Index items carry c="N" matching the c '
+                'attribute here. Reach any connection\'s tables with '
+                'describe_tables(connection_ids=[...]).'
+            )
+            lines.append("</connections>")
+            return "\n".join(lines)
+
         def _render_names_index(self, index_limit: int = 200) -> str:
             tables = list(self.tables or [])
             if not tables:
@@ -982,26 +1048,40 @@ class TablesSchemaContext(ContextSection):
             # Build nested <item> elements with minimal metrics
             items_xml: List[str] = []
             cap = max(0, index_limit)
-            # Only the top-K tables get rendered inside a <connection> block, so
-            # on a multi-connection agent everything past the cap lands here with
-            # no way to tell which connection it came from. Asked to name its
-            # connections, the agent could only report the ones that made the
-            # cut and said the rest "do not have a corresponding <connection>
-            # element" — true, and exactly the gap this closes. One short
-            # attribute, and only when there is more than one connection to
-            # disambiguate.
-            distinct_conns = {
-                getattr(t, 'connection_name', None) for t in tables
-                if getattr(t, 'connection_name', None)
-            }
-            name_connections = len(distinct_conns) > 1
+            # An ALIAS, not the name. Spelling the connection out on every item
+            # cost 30-52 bytes each — at the 1000-item cap that was 30-52 KB,
+            # around a third of the whole rendered context, to repeat a handful
+            # of strings a thousand times. The roster above maps c="N" back to
+            # the name once.
+            alias_by_name = {c["name"]: c["alias"] for c in self._connection_roster()}
+            name_connections = len(alias_by_name) > 1
+            if cap and len(tables) > cap and len(alias_by_name) > 1:
+                # Round-robin the cap across connections instead of taking the
+                # global top N. Rank-ordered truncation clusters: at 100
+                # connections x 100 tables the first 1000 rows all came from the
+                # same handful of connections, so ninety connections had every
+                # one of their tables cut and vanished from the agent's view
+                # entirely. Interleaving gives each connection an equal share,
+                # so a connection loses depth rather than existence. Order
+                # WITHIN each connection is preserved, so the best tables of
+                # each still come first.
+                from itertools import zip_longest
+                buckets: dict = {}
+                for t in tables:
+                    buckets.setdefault(getattr(t, 'connection_name', None) or "", []).append(t)
+                tables = [
+                    t for row in zip_longest(*buckets.values())
+                    for t in row if t is not None
+                ]
             for t in tables[:cap if cap > 0 else len(tables)]:
                 attrs = {
                     "name": t.name,
                     "cols": str(len(getattr(t, 'columns', []) or [])),
                 }
-                if name_connections and getattr(t, 'connection_name', None):
-                    attrs["connection"] = str(t.connection_name)
+                if name_connections:
+                    alias = alias_by_name.get(getattr(t, 'connection_name', None))
+                    if alias:
+                        attrs["c"] = alias
                 try:
                     if getattr(t, 'score', None) is not None:
                         attrs["score"] = str(round(float(getattr(t, 'score')), 2))
@@ -1067,6 +1147,13 @@ class TablesSchemaContext(ContextSection):
             status_xml = ds._render_status_xml()
             if status_xml:
                 inner_parts.append(status_xml)
+            # Before the sample: the sample and index are both capped, so the
+            # roster is the only complete statement of what this agent connects
+            # to, and the model should read it before drawing conclusions from
+            # a truncated list.
+            roster_xml = ds._render_connections_roster_xml()
+            if roster_xml:
+                inner_parts.append(roster_xml)
             if getattr(ds.info, 'context', None):
                 inner_parts.append(xml_tag("description", xml_escape(ds.info.context)))
             if sample_xml:

--- a/backend/app/ai/context/sections/tables_schema_section.py
+++ b/backend/app/ai/context/sections/tables_schema_section.py
@@ -975,8 +975,22 @@ class TablesSchemaContext(ContextSection):
                 tables_xml = [render_table(t) for t in top_tables]
                 return xml_tag("tables", "\n".join(tables_xml))
 
+        @staticmethod
+        def _connection_key(t) -> str | None:
+            """Identity of the connection a table came from.
+
+            The id when there is one, the name only as a fallback. Keying on the
+            name alone merged two connections that happen to share a display
+            name into one roster entry — and an agent cannot tell apart, or
+            scope a discovery call to, connections it sees as one.
+            """
+            cid = getattr(t, 'connection_id', None)
+            if cid:
+                return str(cid)
+            return getattr(t, 'connection_name', None) or None
+
         def _connection_roster(self) -> list:
-            """(name, type, table_count) per connection, in first-seen order.
+            """(id, name, type, table_count) per connection, in first-seen order.
 
             Derived from `self.tables` — the SCOPED table set — and never from
             the data source's connection list. A connection this caller is
@@ -986,15 +1000,18 @@ class TablesSchemaContext(ContextSection):
             """
             seen: dict = {}
             for t in (self.tables or []):
-                name = getattr(t, 'connection_name', None)
-                if not name:
+                key = self._connection_key(t)
+                if not key:
                     continue
-                entry = seen.get(name)
+                entry = seen.get(key)
                 if entry is None:
-                    seen[name] = {"name": name,
-                                  "type": getattr(t, 'connection_type', None) or "",
-                                  "count": 1,
-                                  "alias": str(len(seen) + 1)}
+                    cid = getattr(t, 'connection_id', None)
+                    seen[key] = {"key": key,
+                                 "id": str(cid) if cid else "",
+                                 "name": getattr(t, 'connection_name', None) or "",
+                                 "type": getattr(t, 'connection_type', None) or "",
+                                 "count": 1,
+                                 "alias": str(len(seen) + 1)}
                 else:
                     entry["count"] += 1
             return list(seen.values())
@@ -1020,23 +1037,29 @@ class TablesSchemaContext(ContextSection):
             lines = [f'<connections count="{len(roster)}">']
             for c in head:
                 lines.append(
-                    f'  <connection c="{c["alias"]}" name="{xml_escape(c["name"])}" '
+                    f'  <connection c="{c["alias"]}" id="{xml_escape(c["id"])}" '
+                    f'name="{xml_escape(c["name"])}" '
                     f'type="{xml_escape(c["type"])}" tables="{c["count"]}"/>'
                 )
             tail = roster[full_cap:]
             if tail:
-                # Names only past the cap — a name is what describe_tables needs
-                # to be callable, so an unnamed connection is an unreachable one.
-                # Same trade <more_agents> makes.
-                names = ", ".join(xml_escape(c["name"]) for c in tail)
-                lines.append(
-                    f'  <more_connections count="{len(tail)}">{names}</more_connections>'
-                )
+                # Past the cap: id and name only, no type or table count. The id
+                # is the half that cannot be dropped — describe_tables takes
+                # connection_ids, so a connection listed by name alone is one the
+                # agent can see but not query, which is worse than not listing
+                # it. Same trade <more_agents> makes, with the id kept.
+                lines.append(f'  <more_connections count="{len(tail)}">')
+                for c in tail:
+                    lines.append(
+                        f'    <connection c="{c["alias"]}" id="{xml_escape(c["id"])}" '
+                        f'name="{xml_escape(c["name"])}"/>'
+                    )
+                lines.append('  </more_connections>')
             lines.append(
                 '  ALL connections on this agent are listed above; the sample and '
                 'index below are a subset. Index items carry c="N" matching the c '
                 'attribute here. Reach any connection\'s tables with '
-                'describe_tables(connection_ids=[...]).'
+                'describe_tables(connection_ids=[...]) using the id attribute.'
             )
             lines.append("</connections>")
             return "\n".join(lines)
@@ -1053,9 +1076,9 @@ class TablesSchemaContext(ContextSection):
             # around a third of the whole rendered context, to repeat a handful
             # of strings a thousand times. The roster above maps c="N" back to
             # the name once.
-            alias_by_name = {c["name"]: c["alias"] for c in self._connection_roster()}
-            name_connections = len(alias_by_name) > 1
-            if cap and len(tables) > cap and len(alias_by_name) > 1:
+            alias_by_key = {c["key"]: c["alias"] for c in self._connection_roster()}
+            name_connections = len(alias_by_key) > 1
+            if cap and len(tables) > cap and len(alias_by_key) > 1:
                 # Round-robin the cap across connections instead of taking the
                 # global top N. Rank-ordered truncation clusters: at 100
                 # connections x 100 tables the first 1000 rows all came from the
@@ -1068,7 +1091,7 @@ class TablesSchemaContext(ContextSection):
                 from itertools import zip_longest
                 buckets: dict = {}
                 for t in tables:
-                    buckets.setdefault(getattr(t, 'connection_name', None) or "", []).append(t)
+                    buckets.setdefault(self._connection_key(t) or "", []).append(t)
                 tables = [
                     t for row in zip_longest(*buckets.values())
                     for t in row if t is not None
@@ -1079,7 +1102,7 @@ class TablesSchemaContext(ContextSection):
                     "cols": str(len(getattr(t, 'columns', []) or [])),
                 }
                 if name_connections:
-                    alias = alias_by_name.get(getattr(t, 'connection_name', None))
+                    alias = alias_by_key.get(self._connection_key(t))
                     if alias:
                         attrs["c"] = alias
                 try:

--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -187,7 +187,14 @@ class DataSource(BaseSchema):
         "Connection",
         secondary=domain_connection,
         back_populates="data_sources",
-        lazy="selectin"
+        lazy="selectin",
+        # Deterministic. Several call sites still reduce a multi-connection
+        # agent to `connections[0]`, and with no ORDER BY the database was free
+        # to return a different "first" connection between two requests — the
+        # same agent would show one connection's tables on one render and
+        # another's on the next. Ordering doesn't make those call sites correct,
+        # but it makes them reproducible, which is what a regression test needs.
+        order_by="Connection.created_at, Connection.id",
     )
 
     # M:N relationship to File. Files attached here are auto-snapshotted
@@ -253,10 +260,15 @@ class DataSource(BaseSchema):
         # Default to first connection for backward compatibility
         return self.connections[0]
 
-    async def get_schemas(self, db: AsyncSession = None, include_inactive: bool = False, with_stats: bool = False, organization: Organization | None = None, top_k: int | None = None) -> List[Table]:
+    async def get_schemas(self, db: AsyncSession = None, include_inactive: bool = False, with_stats: bool = False, organization: Organization | None = None, top_k: int | None = None, visible_table_ids: set[str] | None = None) -> List[Table]:
         """
         Get the database schema information from associated DataSourceTable records.
         Returns a list of Table objects containing table structure information.
+
+        `visible_table_ids`, when not None, restricts the result to those
+        canonical row ids. Callers on a multi-connection agent use it to apply
+        per-connection identity scoping (DataSourceService._resolve_catalog_scope)
+        without this model method having to know anything about auth policies.
         """
         # Use provided session or try to get from object
         session = db or object_session(self)
@@ -291,6 +303,8 @@ class DataSource(BaseSchema):
         scored: list[tuple[float, Table]] = []
         for table in data_source.tables:
             if not include_inactive and not table.is_active:
+                continue
+            if visible_table_ids is not None and str(table.id) not in visible_table_ids:
                 continue
                 
             columns = [

--- a/backend/app/models/user_data_source_overlay.py
+++ b/backend/app/models/user_data_source_overlay.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, JSON, UniqueConstraint
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, JSON, UniqueConstraint, Index
 from sqlalchemy.orm import relationship
 
 from app.models.base import BaseSchema
@@ -7,11 +7,23 @@ from app.models.base import BaseSchema
 class UserDataSourceTable(BaseSchema):
     __tablename__ = "user_data_source_tables"
     __table_args__ = (
-        UniqueConstraint('data_source_id', 'user_id', 'table_name', name='uq_user_ds_table'),
+        # Scoped by CONNECTION, not just by data source. An agent can hold two
+        # delegated connections that both expose an `orders`; keyed on
+        # (data_source, user, table_name) alone they collided into one row, so
+        # the second connection's table silently overwrote the first's
+        # accessibility. The old constraint name is kept free for the migration
+        # that swaps them.
+        UniqueConstraint('data_source_id', 'user_id', 'connection_id', 'table_name', name='uq_user_ds_conn_table'),
+        Index('ix_udst_ds_user_conn', 'data_source_id', 'user_id', 'connection_id'),
     )
 
     data_source_id = Column(String(36), ForeignKey('data_sources.id', ondelete='CASCADE'), nullable=False, index=True)
     user_id = Column(String(36), ForeignKey('users.id'), nullable=False, index=True)
+    # Which connection this row describes. Nullable for rows written before
+    # overlays were connection-aware (and backfilled where the canonical row is
+    # linked); readers treat NULL as "applies to this user on any connection",
+    # which is safe because every read is already filtered by user_id.
+    connection_id = Column(String(36), ForeignKey('connections.id', ondelete='CASCADE'), nullable=True, index=True)
     table_name = Column(String, nullable=False)
     # SET NULL (not CASCADE): a schema re-sync that drops a canonical table should
     # keep this per-user row (re-linked by name next sync; preserves audit history).

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1582,7 +1582,7 @@ class ConnectionService:
                         # visibility is recorded in their overlay
                         # (user_connection_tables / user_data_source_tables),
                         # which is refreshed right after this by
-                        # DataSourceService._refresh_shared_user_overlay.
+                        # DataSourceService._reloaded_schema_for.
                         skipped_count += 1
                         continue
                     # Update existing

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3155,6 +3155,23 @@ class DataSourceService:
         if not visible_ids:
             return []
 
+        # The overlay speaks ONLY for the connections the caller currently runs
+        # delegated on. An overlay row survives a connection moving to a service
+        # account (query identity switched to `service_account`, so the
+        # classifier now calls it open), and keeping that stale personal row
+        # suppressed the canonical schema through `covered` below — the agent
+        # kept serving one user's narrowed column set for a connection everyone
+        # now shares. Same NULL-provenance rule as the row predicate.
+        open_ids, overlay_ids, denied_ids = buckets
+        allowed_conn_ids = set(overlay_ids)
+        allow_unattributed = bool(overlay_ids) and not denied_ids
+
+        def _overlay_row_allowed(t) -> bool:
+            cid = getattr(t, "connection_id", None)
+            if not cid:
+                return allow_unattributed
+            return str(cid) in allowed_conn_ids
+
         overlay_tables = []
         try:
             overlay_tables = [
@@ -3162,7 +3179,7 @@ class DataSourceService:
                     db=db, data_source=data_source, user=current_user,
                     active_only=not include_inactive,
                 )
-                if str(getattr(t, "id", "")) in visible_ids
+                if str(getattr(t, "id", "")) in visible_ids and _overlay_row_allowed(t)
             ]
         except Exception:
             logger.warning(
@@ -3178,7 +3195,7 @@ class DataSourceService:
         # raised, where falling back to canonical would turn a transient failure
         # into a masking bypass.
         canonical_eligible = await self._open_catalog_table_ids(
-            db, data_source, open_ids=buckets[0], candidate_ids=visible_ids
+            db, data_source, open_ids=open_ids, candidate_ids=visible_ids
         )
         covered = {str(getattr(t, "id", "")) for t in overlay_tables}
         canonical_tables = await data_source.get_schemas(
@@ -3459,6 +3476,35 @@ class DataSourceService:
                 open_ids.append(str(conn.id))
         return open_ids, overlay_ids, denied_ids
 
+    @staticmethod
+    def _overlay_connection_predicate(overlay_ids: list[str], denied_ids: list[str]):
+        """Which of a caller's overlay rows their CURRENT access still justifies.
+
+        A row names the connection it describes, except for rows written before
+        overlays were connection-aware (and rows the migration could not
+        attribute, because the canonical table was never linked). Those keep
+        connection_id NULL, which is unknown provenance, not permission — and
+        the rule for unknown provenance is what this decides:
+
+          * no delegated connection authorized  -> nothing. The rows only record
+            what the caller COULD see before access was revoked.
+          * some connection denied              -> named rows on authorized
+            connections only. A NULL row may well BE the denied connection's,
+            and admitting it on the strength of a different connection the
+            caller happens to still hold is exactly the leak: deactivate A's
+            credentials while B stays valid and A's legacy models stayed
+            visible. They come back when a proven identity rediscovers them.
+          * nothing denied                      -> NULL rows too. There is no
+            revoked connection for them to have come from, and excluding them
+            would drop a legacy single-connection agent's whole catalog.
+        """
+        if not overlay_ids:
+            return sa_false()
+        named = UserOverlayTable.connection_id.in_(overlay_ids)
+        if denied_ids:
+            return named
+        return or_(UserOverlayTable.connection_id.is_(None), named)
+
     async def _resolve_catalog_scope(
         self,
         db: AsyncSession,
@@ -3522,24 +3568,9 @@ class DataSourceService:
             UserOverlayTable.is_accessible == True,  # noqa: E712
             UserOverlayTable.data_source_table_id.isnot(None),
         )
-        if overlay_ids:
-            # Rows written before overlays carried a connection (and rows for a
-            # canonical table the SP never linked) keep connection_id NULL; they
-            # stay admitted because they are already this user's own rows.
-            overlay_rows = overlay_rows.where(
-                or_(
-                    UserOverlayTable.connection_id.is_(None),
-                    UserOverlayTable.connection_id.in_(overlay_ids),
-                )
-            )
-        else:
-            # No connection on this agent is currently authorized for the
-            # caller's own token. Their overlay rows are then only a record of
-            # what they COULD see before access was revoked or credentials
-            # deactivated, so nothing may be admitted on their strength —
-            # leaving this unrestricted kept previously discovered semantic
-            # models visible through the unlinked-row branch below.
-            overlay_rows = overlay_rows.where(sa_false())
+        overlay_rows = overlay_rows.where(
+            self._overlay_connection_predicate(overlay_ids, denied_ids)
+        )
 
         branches = []
         if open_ids:

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3217,6 +3217,7 @@ class DataSourceService:
         data_source: DataSource,
         current_user: User,
         connection=None,
+        cred_index=None,
     ) -> str:
         """Classify a user's CURRENT access to a (user_required) CONNECTION.
 
@@ -3241,7 +3242,8 @@ class DataSourceService:
                 return "none"
             from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
             status = await UserDataSourceCredentialsService().build_user_status_for_connection(
-                db, conn, current_user, data_source=data_source, live_test=False
+                db, conn, current_user, data_source=data_source, live_test=False,
+                cred_index=cred_index,
             )
             return status.effective_auth or "none"
         except Exception:
@@ -3280,10 +3282,37 @@ class DataSourceService:
         sorting second skipped scoping entirely. One classifier means a third
         call site cannot drift into a third variant of the same bug.
         """
+        conns = list(getattr(data_source, "connections", None) or [])
+        delegated = [
+            c for c in conns
+            if (getattr(c, "auth_policy", None) or "system_only") == "user_required"
+        ]
+
+        # Load this user's credential rows for EVERY delegated connection up
+        # front. Resolving them one connection at a time cost 9 statements per
+        # connection (one credential lookup plus the relationship loads it
+        # drags behind it), serialized — measured dead linear, so an agent with
+        # 100 delegated connections spent ~900 round trips on a question this
+        # answers in two. `UserCredentialIndex` is the same prefetch the
+        # agent-list endpoints already use for exactly this reason.
+        cred_index = None
+        if delegated and current_user is not None:
+            from app.services.connection_identity import UserCredentialIndex
+            cred_index = await UserCredentialIndex.build(
+                db, current_user,
+                connection_ids=[str(c.id) for c in delegated],
+                data_source_ids=[str(data_source.id)],
+            )
+
+        # The owner/admin display fallback is a property of the CALLER and the
+        # agent, not of any one connection, so resolve it at most once instead
+        # of per denied connection (it resolves the full permission set).
+        admin_fallback: bool | None = None
+
         open_ids: list[str] = []
         overlay_ids: list[str] = []
         denied_ids: list[str] = []
-        for conn in list(getattr(data_source, "connections", None) or []):
+        for conn in conns:
             if (getattr(conn, "auth_policy", None) or "system_only") != "user_required":
                 open_ids.append(str(conn.id))
                 continue
@@ -3293,12 +3322,16 @@ class DataSourceService:
                 open_ids.append(str(conn.id))
                 continue
             eff_auth = await self._resolve_effective_auth(
-                db, data_source, current_user, connection=conn
+                db, data_source, current_user, connection=conn, cred_index=cred_index,
             )
             if eff_auth == "user":
                 overlay_ids.append(str(conn.id))
             elif eff_auth == "none":
-                if await self._admin_catalog_access(db, data_source, current_user):
+                if admin_fallback is None:
+                    admin_fallback = await self._admin_catalog_access(
+                        db, data_source, current_user
+                    )
+                if admin_fallback:
                     open_ids.append(str(conn.id))
                 else:
                     denied_ids.append(str(conn.id))
@@ -3967,7 +4000,22 @@ class DataSourceService:
             )
         )
         total_selected = selected_count_result.scalar() or 0
-        
+
+        # Loud when an agent crosses the point where its context stops listing
+        # every table. Not an error and not a cap: the roster keeps every
+        # connection named and describe_tables still reaches any of them. But
+        # this is the line past which "the agent didn't see my table" becomes
+        # possible, and it should be visible in the logs when it is crossed
+        # rather than inferred later from a confused answer.
+        if new_status and total_selected > self.CONTEXT_TABLE_SOFT_LIMIT:
+            logger.warning(
+                "data source %s now has %d active tables, over the %d the schema "
+                "context lists individually; past this the agent sees a "
+                "round-robin sample per connection plus the <connections> roster, "
+                "and reaches the rest through describe_tables",
+                data_source_id, total_selected, self.CONTEXT_TABLE_SOFT_LIMIT,
+            )
+
         return DeltaUpdateTablesResponse(
             activated_count=affected_count if new_status else 0,
             deactivated_count=affected_count if not new_status else 0,
@@ -4775,8 +4823,19 @@ class DataSourceService:
         
         return data_source
     
-    # Maximum tables to set as active when auto-selecting
-    MAX_ACTIVE_TABLES = 500
+    # How many of an agent's active tables the LLM context can actually carry.
+    # Mirrors agent_v2.INDEX_LIMIT: beyond this the schema context lists a
+    # round-robin sample across connections rather than every table. Every
+    # connection stays named in the <connections> roster and remains reachable
+    # with describe_tables, so nothing disappears — but the agent no longer has
+    # every table name in front of it.
+    #
+    # This replaces a `MAX_ACTIVE_TABLES = 500` that was declared here and
+    # referenced nowhere: it read like an enforced cap on activation and was
+    # not one. Activation is deliberately NOT capped — "Select all" means what
+    # it says, and silently activating 500 of 5,000 would be worse than
+    # activating them all — so this is a threshold to report, not to enforce.
+    CONTEXT_TABLE_SOFT_LIMIT = 1000
     
     # Onboarding: auto-select a focused set of tables
     ONBOARDING_MAX_TABLES = 0
@@ -5449,22 +5508,44 @@ class DataSourceService:
         return [DataSourceMembershipSchema.from_orm(m) for m in data_source_memberships]
 
     async def _get_prompt_schema(self, db: AsyncSession, data_source: DataSource, organization: Organization, current_user: User | None) -> str:
-        """Resolve a prompt-ready schema string for this data source.
-        - For system_only: use canonical via DataSource.prompt_schema
-        - For user_required with user: use per-user overlay tables and TableFormatter
+        """Resolve a prompt-ready schema string for this data source, scoped to
+        what `current_user` may actually see on each of its connections.
+
+        This gated on `data_source.auth_policy` — a field that moved to
+        `Connection`, so `getattr(..., "system_only")` always returned the
+        default and the per-user branch was unreachable. Dead code that reads
+        as live: the delegated path looked handled and never ran, so agent
+        summaries, conversation starters, descriptions and the onboarding
+        instruction draft were all written from the canonical catalog, ignoring
+        per-user access entirely.
+
+        `get_data_source_schema` already merges overlay tables (with their
+        per-user column masking) for delegated connections and canonical tables
+        for open ones, so route through it rather than re-deriving the rule a
+        third time.
         """
-        # User-required path uses per-user overlays — cache-first read, no
-        # live walk on every prompt build.
-        if getattr(data_source, "auth_policy", "system_only") == "user_required" and current_user is not None:
-            tables = await self.read_user_data_source_schema(db=db, data_source=data_source, user=current_user, active_only=True)
-            try:
-                from app.ai.prompt_formatters import TableFormatter
-                return TableFormatter(tables).table_str
-            except Exception:
-                # Fallback to no-stats canonical prompt schema
-                return await data_source.prompt_schema(db=db, with_stats=False)
-        # System path: canonical tables
-        return await data_source.prompt_schema(db=db, with_stats=False)
+        from app.ai.prompt_formatters import TableFormatter
+
+        delegated = [
+            c for c in (getattr(data_source, "connections", None) or [])
+            if (getattr(c, "auth_policy", None) or "system_only") == "user_required"
+        ]
+        if not delegated or current_user is None:
+            return await data_source.prompt_schema(db=db, with_stats=False)
+
+        try:
+            tables = await self.get_data_source_schema(
+                db=db, data_source_id=str(data_source.id), include_inactive=False,
+                organization=organization, current_user=current_user,
+            )
+            return TableFormatter(tables).table_str
+        except Exception:
+            logger.warning(
+                "Scoped prompt schema failed for data source %s / user %s; "
+                "falling back to the canonical catalog",
+                data_source.id, getattr(current_user, "id", None), exc_info=True,
+            )
+            return await data_source.prompt_schema(db=db, with_stats=False)
 
     # ==================== Domain-Connection Architecture Methods ====================
 

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -1794,12 +1794,29 @@ class DataSourceService:
             # Channel availability gating (external channels only).
             if not d.is_available_in(channel):
                 continue
-            conn = d.connections[0] if d.connections else None
-            # Only include data sources with system_only auth policy
-            # Skip user_required data sources since channel mentions can't use individual user credentials
-            auth_policy = conn.auth_policy if conn else "system_only"
-            if auth_policy == "user_required":
+            # Only include data sources every channel member can actually
+            # query. A channel mention is public and cannot stand in for an
+            # individual's credentials, so ANY delegated connection disqualifies
+            # the agent — not just the first one.
+            #
+            # This asked `connections[0]`, so a MIXED agent (system_only
+            # warehouse first, delegated Power BI second) reported
+            # "system_only" and was offered in the channel anyway — precisely
+            # what this filter exists to prevent. Channel members who have not
+            # connected their own account then get "Connect required" from an
+            # agent the channel advertised, and an owner or admin mentioning it
+            # reaches the system-credentials fallback in a public channel.
+            if any(
+                (getattr(c, "auth_policy", None) or "system_only") == "user_required"
+                for c in (d.connections or [])
+            ):
                 continue
+            # Legacy response fields only: the schema still carries a single
+            # `type` and `auth_policy`, so they report the first connection's.
+            # Everything that decides BEHAVIOUR above is per connection; these
+            # two are display shape the API has always had.
+            conn = d.connections[0] if d.connections else None
+            auth_policy = (getattr(conn, "auth_policy", None) or "system_only") if conn else "system_only"
 
             connections_list = await self._build_connections_list(
                 db=db,

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -132,6 +132,16 @@ def normalize_overlay_fks(fks) -> list:
     return out
 
 
+# First-read overlay warming is per (data source, user, connection), and a
+# connection the user legitimately sees nothing on writes no rows — so "has no
+# rows" can never mean "already warmed". These remember the attempt instead, so
+# such a connection is re-crawled once per window rather than on every read.
+# Process-local and best-effort: a restart or a second worker just re-attempts.
+_WARM_ATTEMPTS: dict[tuple, float] = {}
+_WARM_RETRY_S = 300.0
+_WARM_ATTEMPTS_MAX = 10000
+
+
 class DataSourceService:
 
     def __init__(self):
@@ -3131,7 +3141,10 @@ class DataSourceService:
         # connecting isn't empty. A no-op once warm.
         await self._warm_user_overlay_if_empty(db, data_source, current_user, delegated_conns)
 
-        scope = await self._resolve_catalog_scope(db, data_source, current_user)
+        buckets = await self.classify_connection_access(db, data_source, current_user)
+        scope = await self._resolve_catalog_scope(
+            db, data_source, current_user, buckets=buckets
+        )
         visible_ids = {
             str(row) for row in (await db.execute(
                 scope(select(DataSourceTable.id).where(
@@ -3157,15 +3170,66 @@ class DataSourceService:
                 data_source.id, getattr(current_user, "id", None), exc_info=True,
             )
 
-        # Canonical rows for everything the overlay did not already describe —
-        # i.e. the open (system_only / service-account) connections.
+        # Canonical rows for the OPEN connections only. Canonical rows carry the
+        # full column set as the service account discovered it, so serving one
+        # for a delegated connection hands the caller columns their own token
+        # cannot see. Anything a delegated connection owns therefore comes from
+        # the overlay list or not at all — including when the overlay read above
+        # raised, where falling back to canonical would turn a transient failure
+        # into a masking bypass.
+        canonical_eligible = await self._open_catalog_table_ids(
+            db, data_source, open_ids=buckets[0], candidate_ids=visible_ids
+        )
         covered = {str(getattr(t, "id", "")) for t in overlay_tables}
         canonical_tables = await data_source.get_schemas(
             db=db, include_inactive=include_inactive, with_stats=with_stats,
-            visible_table_ids={i for i in visible_ids if i not in covered},
+            visible_table_ids={i for i in canonical_eligible if i not in covered},
         )
 
         return overlay_tables + canonical_tables
+
+    async def _open_catalog_table_ids(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        open_ids: list[str],
+        candidate_ids: set[str],
+    ) -> set[str]:
+        """Of `candidate_ids`, the rows canonical (unmasked) schema may serve.
+
+        That is: rows belonging to an open connection, plus unlinked legacy rows
+        that no delegated user's own sync contributed (`discovered_by != "user"`
+        — the shared catalog of a pre-connection agent). A row a delegated user
+        discovered under their own token is theirs, has per-user columns, and
+        must come from the overlay.
+        """
+        from app.models.connection_table import ConnectionTable
+
+        if not candidate_ids:
+            return set()
+
+        discovered_by = self._json_text(db, DataSourceTable.metadata_json, "discovered_by")
+        branches = [
+            and_(
+                DataSourceTable.connection_table_id.is_(None),
+                or_(discovered_by.is_(None), discovered_by != "user"),
+            )
+        ]
+        if open_ids:
+            branches.append(DataSourceTable.connection_table_id.in_(
+                select(ConnectionTable.id).where(ConnectionTable.connection_id.in_(open_ids))
+            ))
+
+        # Filtered by data source rather than by the candidate id list: that
+        # list is one bind parameter per table and a delegated catalog runs to
+        # tens of thousands, past PostgreSQL's 32767 ceiling. Intersect locally.
+        rows = (await db.execute(
+            select(DataSourceTable.id).where(
+                DataSourceTable.datasource_id == str(data_source.id),
+                or_(*branches),
+            )
+        )).scalars().all()
+        return {str(r) for r in rows} & candidate_ids
 
     async def _warm_user_overlay_if_empty(
         self,
@@ -3174,32 +3238,71 @@ class DataSourceService:
         current_user: User,
         delegated_conns: list,
     ) -> None:
-        """Populate this caller's overlay on first read, if they run delegated
-        and have no rows yet. Cheap no-op once warm; failures are non-fatal
-        (the caller falls back to whatever the scope predicate admits)."""
+        """Populate this caller's overlay on first read, PER CONNECTION.
+
+        Warming used to short-circuit on the first overlay row found anywhere on
+        the agent, so a delegated connection attached after the user's first
+        read stayed permanently un-warmed: its catalog was missing until someone
+        hit an explicit refresh. Each connection is now warmed on its own.
+
+        Cheap no-op once warm; failures are non-fatal (the caller falls back to
+        whatever the scope predicate admits).
+        """
         try:
-            existing = (await db.execute(
-                select(UserOverlayTable.id).where(
+            rows = (await db.execute(
+                select(UserOverlayTable.connection_id).where(
                     UserOverlayTable.data_source_id == str(data_source.id),
                     UserOverlayTable.user_id == str(current_user.id),
-                ).limit(1)
-            )).first()
-            if existing:
-                return
+                ).distinct()
+            )).scalars().all()
+            warm_conn_ids = {str(r) for r in rows if r}
+            has_legacy_rows = any(r is None for r in rows)
+
             for conn in delegated_conns:
+                conn_id = str(conn.id)
+                if conn_id in warm_conn_ids:
+                    continue
+                # Rows written before overlays were connection-aware carry no
+                # connection; on a single-connection agent they ARE that
+                # connection's catalog, so warming again would re-crawl a source
+                # that is already warm.
+                if has_legacy_rows and len(delegated_conns) == 1:
+                    continue
+                if self._warm_attempted(data_source, current_user, conn_id):
+                    # A connection the user legitimately sees nothing on writes
+                    # no rows, so "no rows" can never mean "warm". Without this
+                    # the read path would re-crawl the source on every request.
+                    continue
                 eff = await self._resolve_effective_auth(
                     db, data_source, current_user, connection=conn
                 )
-                if eff == "user":
-                    await self.get_user_data_source_schema(
-                        db=db, data_source=data_source, user=current_user
-                    )
-                    return
+                if eff != "user":
+                    continue
+                self._mark_warm_attempted(data_source, current_user, conn_id)
+                await self._sync_user_overlay_for_connection(
+                    db=db, data_source=data_source, user=current_user, connection=conn
+                )
         except Exception:
             logger.warning(
                 "Overlay warm failed for data source %s / user %s",
                 data_source.id, getattr(current_user, "id", None), exc_info=True,
             )
+
+    def _warm_key(self, data_source: DataSource, user: User, connection_id: str) -> tuple:
+        return (str(data_source.id), str(getattr(user, "id", "")), connection_id)
+
+    def _warm_attempted(self, data_source: DataSource, user: User, connection_id: str) -> bool:
+        import time
+
+        at = _WARM_ATTEMPTS.get(self._warm_key(data_source, user, connection_id))
+        return at is not None and (time.monotonic() - at) < _WARM_RETRY_S
+
+    def _mark_warm_attempted(self, data_source: DataSource, user: User, connection_id: str) -> None:
+        import time
+
+        if len(_WARM_ATTEMPTS) > _WARM_ATTEMPTS_MAX:
+            _WARM_ATTEMPTS.clear()
+        _WARM_ATTEMPTS[self._warm_key(data_source, user, connection_id)] = time.monotonic()
 
     async def _admin_catalog_access(self, db: AsyncSession, data_source: DataSource, current_user: User) -> bool:
         """May this not-yet-connected caller see the CANONICAL catalog for
@@ -3361,9 +3464,13 @@ class DataSourceService:
         db: AsyncSession,
         data_source: DataSource,
         current_user: User,
+        buckets: tuple[list[str], list[str], list[str]] | None = None,
     ):
         """Build the row predicate for "which of this agent's tables may this
         caller see", resolved per connection.
+
+        `buckets` lets a caller that already ran `classify_connection_access`
+        hand the result in rather than pay for it twice.
 
         Returns a callable that takes a query selecting over DataSourceTable and
         returns it narrowed. Every count, total, page and filter dropdown in the
@@ -3386,7 +3493,7 @@ class DataSourceService:
         if current_user is None or not conns:
             return lambda q: q
 
-        open_ids, overlay_ids, denied_ids = await self.classify_connection_access(
+        open_ids, overlay_ids, denied_ids = buckets or await self.classify_connection_access(
             db, data_source, current_user
         )
 
@@ -3425,6 +3532,14 @@ class DataSourceService:
                     UserOverlayTable.connection_id.in_(overlay_ids),
                 )
             )
+        else:
+            # No connection on this agent is currently authorized for the
+            # caller's own token. Their overlay rows are then only a record of
+            # what they COULD see before access was revoked or credentials
+            # deactivated, so nothing may be admitted on their strength —
+            # leaving this unrestricted kept previously discovered semantic
+            # models visible through the unlinked-row branch below.
+            overlay_rows = overlay_rows.where(sa_false())
 
         branches = []
         if open_ids:
@@ -4227,6 +4342,12 @@ class DataSourceService:
         tables: list[Table] = []
         for row in overlay_rows:
             tables.append(Table(
+                # The CANONICAL DataSourceTable id, not the overlay row's own.
+                # Callers that merge this list with canonical rows key off it to
+                # tell which tables the overlay already describes; without it
+                # every overlay table looked unidentifiable, the merge dropped
+                # them all and served the canonical (unmasked) columns instead.
+                id=str(row.data_source_table_id) if row.data_source_table_id else None,
                 name=row.table_name,
                 columns=[
                     TableColumn(name=c.column_name, dtype=c.data_type)
@@ -4234,6 +4355,7 @@ class DataSourceService:
                 ],
                 pks=[],
                 fks=[],
+                connection_id=str(row.connection_id) if row.connection_id else None,
                 metadata_json=row.metadata_json,
             ))
         return tables
@@ -4580,11 +4702,27 @@ class DataSourceService:
                 pass
             return None
 
-        canonical_by_dataset_table = {}
+        # Connection-scoped on the SAME rule as canonical_by_name, and for the
+        # same reason: this index is consulted FIRST, so indexing every row here
+        # put both connections' overlays on one canonical row whenever the same
+        # semantic model was reachable through two delegated connections —
+        # undoing the per-connection attribution, activation and filtering the
+        # name index had just established.
+        canonical_by_dataset_table: dict = {}
         for row in existing_canonical:
             k = _dataset_table_key(getattr(row, "metadata_json", None))
-            if k is not None:
-                canonical_by_dataset_table.setdefault(k, row)
+            if k is None:
+                continue
+            row_conn = _canonical_connection_id(row)
+            if conn_id is not None and row_conn is not None and row_conn != conn_id:
+                continue
+            prev = canonical_by_dataset_table.get(k)
+            if prev is None or (
+                conn_id is not None
+                and row_conn == conn_id
+                and _canonical_connection_id(prev) is None
+            ):
+                canonical_by_dataset_table[k] = row
 
         # Decide whether this connection's catalog should be UNIONED with the
         # user's own discovery (create canonical rows on demand from the user's

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3256,6 +3256,56 @@ class DataSourceService:
             return column.op('->>')(key)
         return func.json_extract(column, f'$.{key}')
 
+    async def classify_connection_access(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        current_user: User,
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Sort an agent's connections into (open, overlay, denied) for a caller.
+
+          open    — system_only, or delegated-but-effective-auth is 'system'
+                    (service account), or an owner/admin viewing a connection
+                    they have not personally connected (display fallback; query
+                    execution still fails closed in resolve_credentials).
+          overlay — delegated and the caller runs with their OWN token: only the
+                    tables their per-user overlay marks accessible.
+          denied  — delegated, no proven access, not an owner/admin: nothing.
+
+        THE authority on "what may this user see on this agent", shared by the
+        tables selector (`_resolve_catalog_scope`) and the agent's schema
+        context (`SchemaContextBuilder`). Both used to answer it independently
+        from `connections[0]`, and both got it wrong in the same two ways: a
+        delegated connection sorting first hid every other connection, and one
+        sorting second skipped scoping entirely. One classifier means a third
+        call site cannot drift into a third variant of the same bug.
+        """
+        open_ids: list[str] = []
+        overlay_ids: list[str] = []
+        denied_ids: list[str] = []
+        for conn in list(getattr(data_source, "connections", None) or []):
+            if (getattr(conn, "auth_policy", None) or "system_only") != "user_required":
+                open_ids.append(str(conn.id))
+                continue
+            if current_user is None:
+                # No user in context (background job, system caller): the
+                # canonical catalog is the right thing to serve.
+                open_ids.append(str(conn.id))
+                continue
+            eff_auth = await self._resolve_effective_auth(
+                db, data_source, current_user, connection=conn
+            )
+            if eff_auth == "user":
+                overlay_ids.append(str(conn.id))
+            elif eff_auth == "none":
+                if await self._admin_catalog_access(db, data_source, current_user):
+                    open_ids.append(str(conn.id))
+                else:
+                    denied_ids.append(str(conn.id))
+            else:  # 'system' — service account / admin SP sees the full catalog
+                open_ids.append(str(conn.id))
+        return open_ids, overlay_ids, denied_ids
+
     async def _resolve_catalog_scope(
         self,
         db: AsyncSession,
@@ -3286,25 +3336,9 @@ class DataSourceService:
         if current_user is None or not conns:
             return lambda q: q
 
-        open_ids: list[str] = []
-        overlay_ids: list[str] = []
-        denied_ids: list[str] = []
-        for conn in conns:
-            if (getattr(conn, "auth_policy", None) or "system_only") != "user_required":
-                open_ids.append(str(conn.id))
-                continue
-            eff_auth = await self._resolve_effective_auth(
-                db, data_source, current_user, connection=conn
-            )
-            if eff_auth == "user":
-                overlay_ids.append(str(conn.id))
-            elif eff_auth == "none":
-                if await self._admin_catalog_access(db, data_source, current_user):
-                    open_ids.append(str(conn.id))
-                else:
-                    denied_ids.append(str(conn.id))
-            else:  # 'system' — service account / admin SP sees the full catalog
-                open_ids.append(str(conn.id))
+        open_ids, overlay_ids, denied_ids = await self.classify_connection_access(
+            db, data_source, current_user
+        )
 
         # Nothing delegated in play: the whole catalog is visible, and no extra
         # predicate is added at all (identical SQL to a single system_only agent).

--- a/backend/app/services/data_source_service.py
+++ b/backend/app/services/data_source_service.py
@@ -3088,66 +3088,101 @@ class DataSourceService:
         if not data_source:
             raise HTTPException(status_code=404, detail="Data source not found")
         
-        # Get auth_policy from the first connection (auth_policy is now on Connection, not DataSource)
-        auth_policy = "system_only"
-        if data_source.connections:
-            auth_policy = data_source.connections[0].auth_policy or "system_only"
-            
-        # For user_required policy, read from the persisted user overlay first.
-        # Cache-first keeps page renders fast and avoids hammering Drive APIs on
-        # every UI navigation.
+        # Per-connection identity scoping. This used to read auth_policy off
+        # `connections[0]` and then return EITHER the caller's overlay OR the
+        # canonical catalog for the whole agent. On a mixed agent (delegated
+        # Power BI + system_only warehouse) that either/or dropped every table
+        # belonging to the other connections.
         #
-        # On a cache miss (no overlay rows yet) fall back to the live per-user
-        # fetch, which resolves credentials with the owner/admin system-creds
-        # fallback and persists the overlay (warming the cache for next time).
-        # This is the populate-on-first-read path; it also restores the owner
-        # fallback on shared-catalog user_required sources (e.g. SQLite), where
-        # an owner refresh stores tables as inactive canonical rows that a
-        # cache-only read would miss. If the live fetch can't run (no creds yet,
-        # e.g. OneDrive before OAuth) it raises and we drop to the canonical
-        # schema below — typically empty for per-user catalogs.
-        if auth_policy == "user_required" and current_user is not None:
-            # Gate on the user's CURRENT access, not just the (possibly stale)
-            # overlay. The overlay's is_accessible flag tracks the last sync, not
-            # live credential validity — a disconnected user's rows can linger as
-            # accessible. Classify access fresh and serve accordingly.
-            effective_auth = await self._resolve_effective_auth(db, data_source, current_user)
-            if effective_auth == "user":
-                # User has their own creds → their overlay/live catalog only.
-                # Never fall through to the canonical (admin) catalog: for shared
-                # user_required sources (e.g. Fabric) that would leak tables the
-                # user can't actually query.
-                try:
-                    _active_only = not include_inactive
-                    overlay = await self.read_user_data_source_schema(
-                        db=db, data_source=data_source, user=current_user, active_only=_active_only,
+        # The two halves are not interchangeable and must be merged, not chosen
+        # between: overlay rows carry per-user COLUMN masking, canonical rows do
+        # not, so serving canonical rows for a delegated connection would widen
+        # what that user sees. So: overlay tables for the connections the caller
+        # runs delegated on, canonical tables for the open ones.
+        delegated_conns = [
+            c for c in (data_source.connections or [])
+            if (getattr(c, "auth_policy", None) or "system_only") == "user_required"
+        ]
+
+        if not delegated_conns or current_user is None:
+            return await data_source.get_schemas(
+                db=db, include_inactive=include_inactive, with_stats=with_stats
+            )
+
+        # Populate-on-first-read: warm the overlay when the caller runs with
+        # their own token and has no rows yet, so the first render after
+        # connecting isn't empty. A no-op once warm.
+        await self._warm_user_overlay_if_empty(db, data_source, current_user, delegated_conns)
+
+        scope = await self._resolve_catalog_scope(db, data_source, current_user)
+        visible_ids = {
+            str(row) for row in (await db.execute(
+                scope(select(DataSourceTable.id).where(
+                    DataSourceTable.datasource_id == str(data_source.id)
+                ))
+            )).scalars().all()
+        }
+        if not visible_ids:
+            return []
+
+        overlay_tables = []
+        try:
+            overlay_tables = [
+                t for t in await self.read_user_data_source_schema(
+                    db=db, data_source=data_source, user=current_user,
+                    active_only=not include_inactive,
+                )
+                if str(getattr(t, "id", "")) in visible_ids
+            ]
+        except Exception:
+            logger.warning(
+                "Overlay read failed for data source %s / user %s; serving open connections only",
+                data_source.id, getattr(current_user, "id", None), exc_info=True,
+            )
+
+        # Canonical rows for everything the overlay did not already describe —
+        # i.e. the open (system_only / service-account) connections.
+        covered = {str(getattr(t, "id", "")) for t in overlay_tables}
+        canonical_tables = await data_source.get_schemas(
+            db=db, include_inactive=include_inactive, with_stats=with_stats,
+            visible_table_ids={i for i in visible_ids if i not in covered},
+        )
+
+        return overlay_tables + canonical_tables
+
+    async def _warm_user_overlay_if_empty(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        current_user: User,
+        delegated_conns: list,
+    ) -> None:
+        """Populate this caller's overlay on first read, if they run delegated
+        and have no rows yet. Cheap no-op once warm; failures are non-fatal
+        (the caller falls back to whatever the scope predicate admits)."""
+        try:
+            existing = (await db.execute(
+                select(UserOverlayTable.id).where(
+                    UserOverlayTable.data_source_id == str(data_source.id),
+                    UserOverlayTable.user_id == str(current_user.id),
+                ).limit(1)
+            )).first()
+            if existing:
+                return
+            for conn in delegated_conns:
+                eff = await self._resolve_effective_auth(
+                    db, data_source, current_user, connection=conn
+                )
+                if eff == "user":
+                    await self.get_user_data_source_schema(
+                        db=db, data_source=data_source, user=current_user
                     )
-                    if overlay:
-                        return overlay
-                    live = await self.get_user_data_source_schema(db=db, data_source=data_source, user=current_user)
-                    if live and _active_only:
-                        # The live sync returns the user's whole upstream
-                        # catalog; re-read through the activation gate.
-                        return await self.read_user_data_source_schema(
-                            db=db, data_source=data_source, user=current_user, active_only=True,
-                        )
-                    return live or []
-                except Exception:
-                    return []
-            elif effective_auth == "none":
-                # No proven access (disconnected, expired, revoked) → no tables
-                # for a plain member; do NOT leak the canonical catalog to them.
-                # Owner/admin fall through to the canonical catalog below — they
-                # already see it via connection management endpoints, and hiding
-                # it here only breaks agent configuration before first sign-in.
-                if not await self._admin_catalog_access(db, data_source, current_user):
-                    return []
-            # effective_auth == "system" → owner/admin via service account:
-            # fall through to the canonical full catalog below.
-
-        schemas = await data_source.get_schemas(db=db, include_inactive=include_inactive, with_stats=with_stats)
-
-        return schemas
+                    return
+        except Exception:
+            logger.warning(
+                "Overlay warm failed for data source %s / user %s",
+                data_source.id, getattr(current_user, "id", None), exc_info=True,
+            )
 
     async def _admin_catalog_access(self, db: AsyncSession, data_source: DataSource, current_user: User) -> bool:
         """May this not-yet-connected caller see the CANONICAL catalog for
@@ -3176,8 +3211,14 @@ class DataSourceService:
         except Exception:
             return False
 
-    async def _resolve_effective_auth(self, db: AsyncSession, data_source: DataSource, current_user: User) -> str:
-        """Classify a user's CURRENT access to a (user_required) data source.
+    async def _resolve_effective_auth(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        current_user: User,
+        connection=None,
+    ) -> str:
+        """Classify a user's CURRENT access to a (user_required) CONNECTION.
 
         Returns one of:
           'user'   — the user has their own active credentials (use their overlay)
@@ -3189,7 +3230,13 @@ class DataSourceService:
         default never hides the canonical catalog from them.
         """
         try:
-            conn = data_source.connections[0] if getattr(data_source, "connections", None) else None
+            # `connection` is the connection being classified. It defaults to the
+            # first one only for legacy single-connection callers; anything that
+            # scopes a multi-connection agent MUST pass the connection explicitly,
+            # because auth_policy and credentials are per connection.
+            conn = connection
+            if conn is None:
+                conn = data_source.connections[0] if getattr(data_source, "connections", None) else None
             if conn is None:
                 return "none"
             from app.services.user_data_source_credentials_service import UserDataSourceCredentialsService
@@ -3199,6 +3246,132 @@ class DataSourceService:
             return status.effective_auth or "none"
         except Exception:
             return "none"
+
+    @staticmethod
+    def _json_text(db: AsyncSession, column, key: str):
+        """Cross-dialect JSON text extraction (PostgreSQL ->> vs SQLite json_extract)."""
+        bind = db.get_bind()
+        dialect_name = bind.dialect.name if bind else "sqlite"
+        if dialect_name == "postgresql":
+            return column.op('->>')(key)
+        return func.json_extract(column, f'$.{key}')
+
+    async def _resolve_catalog_scope(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        current_user: User,
+    ):
+        """Build the row predicate for "which of this agent's tables may this
+        caller see", resolved per connection.
+
+        Returns a callable that takes a query selecting over DataSourceTable and
+        returns it narrowed. Every count, total, page and filter dropdown in the
+        tables view runs through the SAME callable, so a row can never be hidden
+        from the grid while still being counted in "Showing 1-20 of N" or named
+        in the schema dropdown.
+
+        Each connection lands in exactly one bucket:
+          open    — system_only, or delegated-but-effective-auth is 'system'
+                    (service account), or an owner/admin viewing a connection
+                    they have not personally connected (display fallback; query
+                    execution still fails closed in resolve_credentials).
+          overlay — delegated and the caller runs with their OWN token: only the
+                    tables their per-user overlay marks accessible.
+          denied  — delegated, no proven access, not an owner/admin: nothing.
+        """
+        from app.models.connection_table import ConnectionTable
+
+        conns = list(getattr(data_source, "connections", None) or [])
+        if current_user is None or not conns:
+            return lambda q: q
+
+        open_ids: list[str] = []
+        overlay_ids: list[str] = []
+        denied_ids: list[str] = []
+        for conn in conns:
+            if (getattr(conn, "auth_policy", None) or "system_only") != "user_required":
+                open_ids.append(str(conn.id))
+                continue
+            eff_auth = await self._resolve_effective_auth(
+                db, data_source, current_user, connection=conn
+            )
+            if eff_auth == "user":
+                overlay_ids.append(str(conn.id))
+            elif eff_auth == "none":
+                if await self._admin_catalog_access(db, data_source, current_user):
+                    open_ids.append(str(conn.id))
+                else:
+                    denied_ids.append(str(conn.id))
+            else:  # 'system' — service account / admin SP sees the full catalog
+                open_ids.append(str(conn.id))
+
+        # Nothing delegated in play: the whole catalog is visible, and no extra
+        # predicate is added at all (identical SQL to a single system_only agent).
+        if not overlay_ids and not denied_ids:
+            return lambda q: q
+
+        def _tables_of(conn_ids: list[str]):
+            # Connection ids are per agent (a handful), so a bound IN list here
+            # costs a handful of parameters — unlike a per-table id list.
+            return select(ConnectionTable.id).where(
+                ConnectionTable.connection_id.in_(conn_ids)
+            )
+
+        # The caller's own accessible overlay rows. A SUBQUERY, not a
+        # materialized id list: a delegated source can overlay tens of thousands
+        # of tables for one user and `id.in_([...])` spends one bind parameter
+        # per row — past PostgreSQL's 32767-parameter ceiling that is a hard
+        # InterfaceError, so the entire Tables view would 500 rather than merely
+        # slow down. Always filtered by user_id, so anything it admits is the
+        # caller's own permitted set.
+        overlay_rows = select(UserOverlayTable.data_source_table_id).where(
+            UserOverlayTable.data_source_id == str(data_source.id),
+            UserOverlayTable.user_id == str(current_user.id),
+            UserOverlayTable.is_accessible == True,  # noqa: E712
+            UserOverlayTable.data_source_table_id.isnot(None),
+        )
+        if overlay_ids:
+            # Rows written before overlays carried a connection (and rows for a
+            # canonical table the SP never linked) keep connection_id NULL; they
+            # stay admitted because they are already this user's own rows.
+            overlay_rows = overlay_rows.where(
+                or_(
+                    UserOverlayTable.connection_id.is_(None),
+                    UserOverlayTable.connection_id.in_(overlay_ids),
+                )
+            )
+
+        branches = []
+        if open_ids:
+            branches.append(DataSourceTable.connection_table_id.in_(_tables_of(open_ids)))
+        if overlay_ids:
+            branches.append(and_(
+                DataSourceTable.connection_table_id.in_(_tables_of(overlay_ids)),
+                DataSourceTable.id.in_(overlay_rows),
+            ))
+        # Rows with no connection link at all fall into two very different
+        # groups, and telling them apart matters for both halves of this bug:
+        #   * legacy name-keyed rows from the old save_or_update_tables path —
+        #     genuine tables, no per-user meaning; keep them visible, exactly as
+        #     before, or a mixed agent would lose its legacy catalog.
+        #   * rows a delegated user's own sync contributed (tagged
+        #     discovered_by="user" in _upsert_user_overlay) — these are ONE
+        #     user's Power BI/Fabric models living on a shared agent. Admitting
+        #     them unconditionally is how a second user saw the first user's
+        #     semantic models whenever the delegated connection was not first.
+        discovered_by = self._json_text(db, DataSourceTable.metadata_json, "discovered_by")
+        branches.append(and_(
+            DataSourceTable.connection_table_id.is_(None),
+            or_(
+                discovered_by.is_(None),
+                discovered_by != "user",
+                DataSourceTable.id.in_(overlay_rows),
+            ),
+        ))
+
+        predicate = or_(*branches) if branches else sa_false()
+        return lambda q: q.where(predicate)
 
     async def get_data_source_schema_paginated(
         self,
@@ -3256,50 +3429,25 @@ class DataSourceService:
         def _active(q):
             return q.where(DataSourceTable.is_active == True) if restrict_to_active else q
 
-        # Identity-aware scoping: for a user_required (delegated) source, the tables
-        # selector must show what the CURRENT effective identity can see — the same
-        # rule the agent's schema context and query execution follow:
+        # Identity-aware scoping, resolved PER CONNECTION. For a user_required
+        # (delegated) connection the tables selector must show what the CURRENT
+        # effective identity can see on THAT connection — the same rule the
+        # agent's schema context and query execution follow:
         #   'user'   (toggle = Me, has token) → only the user's overlay tables
         #   'none'   (Me, not connected)      → nothing
         #   'system' (toggle = Service account / admin SP) → full catalog
-        # `overlay_scope is None` means "no restriction" (full catalog);
-        # `overlay_deny_all` means "restrict to nothing".
-        overlay_scope = None
-        overlay_deny_all = False
-        conn0 = data_source.connections[0] if getattr(data_source, "connections", None) else None
-        if current_user is not None and conn0 is not None and (conn0.auth_policy or "system_only") == "user_required":
-            eff_auth = await self._resolve_effective_auth(db, data_source, current_user)
-            if eff_auth == "user":
-                # A SUBQUERY, not a materialized id list. A delegated source can
-                # overlay tens of thousands of tables for a single user, and
-                # `id.in_([...])` spends one bind parameter per row — past
-                # PostgreSQL's 32767-parameter ceiling that is a hard
-                # InterfaceError, so the entire Tables view would 500 rather
-                # than merely slow down. The subquery costs zero parameters at
-                # any catalog size.
-                overlay_scope = (
-                    select(UserOverlayTable.data_source_table_id).where(
-                        UserOverlayTable.data_source_id == str(data_source_id),
-                        UserOverlayTable.user_id == str(current_user.id),
-                        UserOverlayTable.is_accessible == True,  # noqa: E712
-                        UserOverlayTable.data_source_table_id.isnot(None),
-                    )
-                )
-            elif eff_auth == "none":
-                # Not connected yet. For a plain member this fails closed
-                # (nothing). An owner/admin, however, already sees the canonical
-                # catalog through connection management (the Add Connection
-                # modal's "Discovered N tables", GET /connections/{id}/tables) —
-                # hiding the same names here only breaks agent configuration, so
-                # show them the full catalog. Query time stays fail-closed via
-                # resolve_credentials.
-                if not await self._admin_catalog_access(db, data_source, current_user):
-                    overlay_deny_all = True
-
-        def _scope(q):
-            if overlay_deny_all:
-                return q.where(sa_false())
-            return q if overlay_scope is None else q.where(DataSourceTable.id.in_(overlay_scope))
+        #
+        # Per connection, not per data source. An agent can hold a delegated
+        # Power BI connection AND a system_only warehouse at once. Deciding once
+        # from `connections[0]` (as this did) filtered the WHOLE catalog through
+        # an overlay that only ever describes ONE connection, so every other
+        # connection's tables silently vanished from the rows, the counts and
+        # the filter dropdowns — and because `DataSource.connections` has no
+        # deterministic order, which connection survived could flip between
+        # requests. The reverse ordering leaked instead of hid: with the
+        # system_only connection first no scoping was applied at all, so one
+        # user saw another user's delegated-catalog tables.
+        _scope = await self._resolve_catalog_scope(db, data_source, current_user)
 
         # Exclude file-source catalog rows from the Tables view: a file connection
         # (network_dir / s3 / SharePoint / OneDrive / Drive) is surfaced as Files,
@@ -3428,15 +3576,30 @@ class DataSourceService:
                 base_query = base_query.where(or_(*schema_conditions))
                 count_query = count_query.where(or_(*schema_conditions))
 
-        # Apply connection filter (via connection_table -> connection relationship)
+        # Apply connection filter. A subquery on connection_table_id rather than
+        # a JOIN: the JOIN dropped every unlinked row before the filter could
+        # consider it, so a delegated user filtering to their Power BI
+        # connection lost exactly the models only they can see. The provenance
+        # tag carries those rows.
         if connection_filter and len(connection_filter) > 0:
-            # Join with ConnectionTable to filter by connection_id
-            base_query = base_query.join(
-                ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id
-            ).where(ConnectionTable.connection_id.in_(connection_filter))
-            count_query = count_query.join(
-                ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id
-            ).where(ConnectionTable.connection_id.in_(connection_filter))
+            _ct_ids = select(ConnectionTable.id).where(
+                ConnectionTable.connection_id.in_(connection_filter)
+            )
+            _discovered = self._json_text(db, DataSourceTable.metadata_json, "discovered_connection_id")
+            # Local binds: the conditional `from sqlalchemy import or_` in the
+            # schema-filter branch above makes `or_` a function-local name for
+            # this whole method, so referencing it here would raise
+            # UnboundLocalError whenever no schema filter was supplied.
+            from sqlalchemy import or_ as _or_cf, and_ as _and_cf
+            _conn_pred = _or_cf(
+                DataSourceTable.connection_table_id.in_(_ct_ids),
+                _and_cf(
+                    DataSourceTable.connection_table_id.is_(None),
+                    _discovered.in_(list(connection_filter)),
+                ),
+            )
+            base_query = base_query.where(_conn_pred)
+            count_query = count_query.where(_conn_pred)
 
         # Apply search filter
         if search and search.strip():
@@ -3470,7 +3633,10 @@ class DataSourceService:
             .where(DataSourceTable.datasource_id == data_source_id)
             .distinct()
         )
-        connections_query = _active(connections_query)
+        # Scoped identically to the rows. Unscoped, this dropdown listed every
+        # connection on the agent while the grid showed one connection's tables —
+        # the visible symptom users reported as "it only shows one source".
+        connections_query = _active(_scope(connections_query))
         if exclude_file_source_types:
             connections_query = connections_query.where(Connection.type.notin_(_FILE_SOURCE_TYPES))
         connections_result = await db.execute(connections_query)
@@ -3485,7 +3651,7 @@ class DataSourceService:
         schema_expr = get_schema_expr()
         if has_multi_connection:
             schemas_result = await db.execute(
-                _active(
+                _active(_scope(
                     select(schema_expr, Connection.name)
                     .select_from(DataSourceTable)
                     .join(ConnectionTable, DataSourceTable.connection_table_id == ConnectionTable.id)
@@ -3493,18 +3659,18 @@ class DataSourceService:
                     .where(DataSourceTable.datasource_id == data_source_id)
                     .where(schema_expr.isnot(None))
                     .distinct()
-                )
+                ))
             )
             distinct_schemas = [
                 f"{row[1]}:{row[0]}" for row in schemas_result.fetchall() if row[0]
             ]
         else:
             schemas_result = await db.execute(
-                _active(
+                _active(_scope(
                     select(func.distinct(schema_expr))
                     .where(DataSourceTable.datasource_id == data_source_id)
                     .where(schema_expr.isnot(None))
-                )
+                ))
             )
             distinct_schemas = [row[0] for row in schemas_result.fetchall() if row[0]]
 
@@ -3542,6 +3708,7 @@ class DataSourceService:
         # `Album` are different relations that collided into one bucket, so the
         # new relation displayed the other one's usage count. The same applies
         # to two connections on one agent that both have an `orders`.
+        _conn_by_id = {str(c.id): c for c in (data_source.connections or [])}
         stats_by_id = {}
         stats_by_name = {}
         if with_stats:
@@ -3571,7 +3738,13 @@ class DataSourceService:
                     # better exists for this relation.
                     stats = stats_by_name.get((table.name or '').lower())
 
-            # Extract connection info from relationship
+            # Extract connection info from relationship, falling back to the
+            # provenance tag. A table a delegated user discovered with their own
+            # token has NO ConnectionTable to link to (the service principal
+            # cannot see it), so without this fallback it rendered with a blank
+            # connection: unattributable in the grid's connection column and
+            # unmatchable by the connection filter, on the very connection the
+            # user came to configure.
             conn_id = None
             conn_name = None
             conn_type = None
@@ -3580,6 +3753,14 @@ class DataSourceService:
                 conn_id = str(conn.id)
                 conn_name = conn.name
                 conn_type = conn.type
+            else:
+                meta = table.metadata_json if isinstance(table.metadata_json, dict) else {}
+                discovered = meta.get("discovered_connection_id")
+                if discovered and str(discovered) in _conn_by_id:
+                    conn = _conn_by_id[str(discovered)]
+                    conn_id = str(conn.id)
+                    conn_name = conn.name
+                    conn_type = conn.type
 
             table_schema = DataSourceTableSchema(
                 id=str(table.id),
@@ -3958,11 +4139,132 @@ class DataSourceService:
             ))
         return tables
 
+    def _per_user_catalog_connections(self, data_source: DataSource) -> list:
+        """The connections whose catalog is per user: delegated (user_required,
+        e.g. Power BI / Fabric OBO) and per_user-owned (OneDrive, personal
+        Drive). A system_only warehouse on the same agent has one shared
+        catalog and is not synced per user."""
+        from app.schemas.data_source_registry import get_entry
+
+        out = []
+        for conn in (getattr(data_source, "connections", None) or []):
+            if (getattr(conn, "auth_policy", None) or "system_only") == "user_required":
+                out.append(conn)
+                continue
+            try:
+                if get_entry(conn.type).catalog_ownership == "per_user":
+                    out.append(conn)
+            except Exception:
+                continue
+        return out
+
+    async def _construct_user_catalog_client(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        connection,
+        user: User,
+    ):
+        """Build a discovery client for ONE connection with that connection's
+        own credentials resolved for `user`.
+
+        `construct_client` cannot be used here: it always builds the FIRST
+        connection's client, which is why the per-user overlay only ever
+        described one connection no matter how many an agent had."""
+        import inspect
+
+        ClientClass = resolve_client_class(connection.type)
+        config = json.loads(connection.config) if isinstance(connection.config, str) else (connection.config or {})
+        creds = await self.resolve_credentials_for_connection(
+            db=db, connection=connection, data_source=data_source, current_user=user
+        )
+        params = {**(config or {}), **(creds or {})}
+        meta_keys = {"auth_type", "auth_policy", "allowed_user_auth_modes"}
+        params = {
+            k: v for k, v in (params or {}).items()
+            if v is not None and k not in meta_keys and not k.startswith("oauth_")
+        }
+        try:
+            sig = inspect.signature(ClientClass.__init__)
+            accepts_var_kwargs = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+            allowed = params if accepts_var_kwargs else {
+                k: v for k, v in params.items() if k in sig.parameters and k != "self"
+            }
+        except Exception:
+            allowed = params
+        return ClientClass(**allowed)
+
     async def get_user_data_source_schema(
         self,
         db: AsyncSession,
         data_source: DataSource,
         user: User,
+        prefetched_tables=None,
+        progress_callback=None,
+    ):
+        """Sync + return this user's catalog across EVERY per-user connection.
+
+        One agent can hold more than one delegated connection, and each has its
+        own token, its own catalog and its own overlay rows. This fans out over
+        them and concatenates; per-connection reconciliation lives in
+        `_upsert_user_overlay`.
+
+        `prefetched_tables` may be a dict keyed by connection id (what
+        `refresh_data_source_schema` collects when it has already crawled with
+        this user's credentials) or, for legacy single-connection callers, a
+        plain list — which is only reused when there is exactly one per-user
+        connection to attribute it to.
+        """
+        conns = self._per_user_catalog_connections(data_source)
+        if not conns:
+            return []
+
+        if isinstance(prefetched_tables, dict):
+            prefetched_by_conn = {str(k): v for k, v in prefetched_tables.items()}
+        elif prefetched_tables is not None and len(conns) == 1:
+            prefetched_by_conn = {str(conns[0].id): prefetched_tables}
+        else:
+            # A merged list across connections cannot be attributed safely: it
+            # would hand one connection's tables to another connection's
+            # overlay, which is how they leak. Re-fetch instead.
+            prefetched_by_conn = {}
+
+        tables: list = []
+        last_error: Exception | None = None
+        failed = 0
+        for conn in conns:
+            try:
+                tables.extend(await self._sync_user_overlay_for_connection(
+                    db=db, data_source=data_source, user=user, connection=conn,
+                    prefetched_tables=prefetched_by_conn.get(str(conn.id)),
+                    progress_callback=progress_callback,
+                ))
+            except Exception as e:
+                # One unreachable connection must not cost the user the catalogs
+                # of the others.
+                failed += 1
+                last_error = e
+                logger.warning(
+                    "Per-user overlay sync failed for connection %s (data source %s, user %s)",
+                    getattr(conn, "id", None), data_source.id, getattr(user, "id", None),
+                    exc_info=True,
+                )
+        if failed == len(conns) and last_error is not None:
+            # Nothing synced at all. Callers distinguish "this user legitimately
+            # sees no tables" from "the fetch could not run" by the exception —
+            # returning [] here would silently look like revoked access and let
+            # a reconciliation revoke a live overlay.
+            raise last_error
+        return tables
+
+    async def _sync_user_overlay_for_connection(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        user: User,
+        connection,
         prefetched_tables: Optional[list] = None,
         progress_callback=None,
     ):
@@ -4000,8 +4302,18 @@ class DataSourceService:
             prior_tables = None
             try:
                 rows = (await db.execute(
-                    select(DataSourceTable).where(DataSourceTable.datasource_id == data_source.id)
+                    select(DataSourceTable)
+                    .options(selectinload(DataSourceTable.connection_table))
+                    .where(DataSourceTable.datasource_id == data_source.id)
                 )).scalars().all()
+                # Only this connection's known tables are a valid "already
+                # indexed" hint for this connection's crawl.
+                _cid = str(connection.id)
+                rows = [
+                    r for r in rows
+                    if getattr(r, "connection_table", None) is None
+                    or str(r.connection_table.connection_id) == _cid
+                ]
                 prior_tables = {
                     r.name: {
                         "columns": r.columns or [],
@@ -4013,7 +4325,9 @@ class DataSourceService:
                 } or None
             except Exception:
                 prior_tables = None
-            client = await self.construct_client(db=db, data_source=data_source, current_user=user)
+            client = await self._construct_user_catalog_client(
+                db=db, data_source=data_source, connection=connection, user=user
+            )
             from app.data_sources.clients.base import _accepts_kwarg
             # Only pass what the client actually accepts, and only when there is
             # something to pass: a bare `aget_schemas(self)` — every stub client
@@ -4062,7 +4376,10 @@ class DataSourceService:
                 }
 
         # Persist overlays
-        await self._upsert_user_overlay(db=db, data_source=data_source, user=user, normalized=normalized)
+        await self._upsert_user_overlay(
+            db=db, data_source=data_source, user=user, normalized=normalized,
+            connection=connection,
+        )
 
         # Build Table models compatible with prompt formatters
         from app.ai.prompt_formatters import Table, TableColumn, ForeignKey as PromptForeignKey
@@ -4086,7 +4403,14 @@ class DataSourceService:
 
         return tables
 
-    async def _upsert_user_overlay(self, db: AsyncSession, data_source: DataSource, user: User, normalized: dict[str, dict]):
+    async def _upsert_user_overlay(
+        self,
+        db: AsyncSession,
+        data_source: DataSource,
+        user: User,
+        normalized: dict[str, dict],
+        connection=None,
+    ):
         """Upsert per-user table/column overlay based on normalized schema.
 
         Tables/columns present in `normalized` are marked accessible. Any rows
@@ -4094,12 +4418,56 @@ class DataSourceService:
         `is_accessible=False, status='revoked'` so consumers (LLM schema context,
         UI) stop surfacing them when the user loses permissions upstream. Rows
         are kept (not hard-deleted) so audit history survives across syncs.
+
+        `connection` is the connection this snapshot came from, and scopes BOTH
+        halves of that reconciliation. Without it, syncing one connection
+        revoked every other connection's rows for this user — one agent with two
+        delegated connections would flip-flop, each sync revoking the other's
+        tables — and the rows it wrote could not be attributed to a connection
+        at read time.
         """
+        from app.models.connection_table import ConnectionTable
+
         now = datetime.now(timezone.utc)
-        # Load canonical mapping to link if present
-        existing_q = await db.execute(select(DataSourceTable).where(DataSourceTable.datasource_id == data_source.id))
+        conn_id = str(connection.id) if connection is not None else None
+
+        # Load canonical mapping to link if present.
+        existing_q = await db.execute(
+            select(DataSourceTable)
+            .options(selectinload(DataSourceTable.connection_table))
+            .where(DataSourceTable.datasource_id == data_source.id)
+        )
         existing_canonical = list(existing_q.scalars().all())
-        canonical_by_name = {row.name: row for row in existing_canonical}
+
+        def _canonical_connection_id(row) -> str | None:
+            """Which connection a canonical row belongs to, linked or not."""
+            ct = getattr(row, "connection_table", None)
+            if ct is not None and getattr(ct, "connection_id", None):
+                return str(ct.connection_id)
+            meta = getattr(row, "metadata_json", None)
+            if isinstance(meta, dict) and meta.get("discovered_connection_id"):
+                return str(meta["discovered_connection_id"])
+            return None
+
+        # Name alone is not an identity on a multi-connection agent: two
+        # connections can each have an `orders`. Linking this user's overlay to
+        # whichever row happened to sort first pointed their per-user
+        # accessibility at ANOTHER connection's table — so the table they can
+        # really query disappeared and one they cannot appeared in its place.
+        # Prefer this connection's own row, never adopt another connection's,
+        # and fall back to an unattributed (legacy) row.
+        canonical_by_name: dict = {}
+        for row in existing_canonical:
+            row_conn = _canonical_connection_id(row)
+            if conn_id is not None and row_conn is not None and row_conn != conn_id:
+                continue
+            prev = canonical_by_name.get(row.name)
+            if prev is None or (
+                conn_id is not None
+                and row_conn == conn_id
+                and _canonical_connection_id(prev) is None
+            ):
+                canonical_by_name[row.name] = row
 
         def _dataset_table_key(meta) -> tuple | None:
             """Stable identity for a Power BI table independent of display name:
@@ -4138,7 +4506,9 @@ class DataSourceService:
         is_per_user_catalog = False
         try:
             from app.schemas.data_source_registry import get_entry
-            conn = (data_source.connections or [None])[0]
+            # The connection this snapshot came from. Falls back to the first
+            # only for legacy single-connection callers that pass none.
+            conn = connection or (data_source.connections or [None])[0]
             if conn is not None:
                 is_per_user_catalog = get_entry(conn.type).catalog_ownership == "per_user"
                 is_delegated = (conn.auth_policy or "system_only") == "user_required"
@@ -4180,6 +4550,12 @@ class DataSourceService:
                 # row alone; it survives until no user can access it.
                 row_meta = dict(meta) if isinstance(meta, dict) else {}
                 row_meta.setdefault("discovered_by", "user")
+                if connection is not None:
+                    # Which connection contributed this unlinked row. The row has
+                    # no ConnectionTable to link to (the service principal cannot
+                    # see it), so this tag is the only provenance the read path
+                    # has for grouping and scoping it.
+                    row_meta.setdefault("discovered_connection_id", str(connection.id))
                 row = DataSourceTable(
                     # Client-side id: the overlay rows below reference it, so
                     # generating it here avoids a flush() per contributed table
@@ -4208,7 +4584,22 @@ class DataSourceService:
                 UserOverlayTable.deleted_at.is_(None),
             )
         )
-        prior_by_name = {row.table_name: row for row in all_prior_q.scalars().all()}
+        # Scope the reconciliation to THIS connection. Rows belonging to the
+        # agent's other connections are not part of this snapshot and must not
+        # be revoked by it. NULL connection_id rows predate connection-aware
+        # overlays (or point at a canonical row the service principal never
+        # linked, so the migration could not backfill them); the first
+        # connection to sync adopts them by stamping its own id, which heals
+        # them permanently.
+        prior_by_name = {}
+        for row in all_prior_q.scalars().all():
+            row_conn = str(row.connection_id) if row.connection_id else None
+            if conn_id is not None and row_conn is not None and row_conn != conn_id:
+                continue
+            prior_by_name[row.table_name] = row
+            if conn_id is not None and row_conn is None:
+                row.connection_id = conn_id
+                db.add(row)
         new_table_names = set(normalized.keys())
 
         # Batch-load every prior column overlay in ONE pass instead of querying
@@ -4249,6 +4640,7 @@ class DataSourceService:
                     id=str(uuid.uuid4()),
                     data_source_id=str(data_source.id),
                     user_id=str(user.id),
+                    connection_id=conn_id,
                     table_name=table_name,
                     data_source_table_id=str(canonical_by_name.get(table_name).id) if canonical_by_name.get(table_name) else None,
                     is_accessible=True,
@@ -4656,8 +5048,11 @@ class DataSourceService:
                 # second time in the same request (on Power BI/Fabric OBO each
                 # crawl is a full tenant walk; the duplicate doubled Reload time).
                 caller_id = str(current_user.id) if current_user is not None else None
-                caller_fetched_tables: list = []
-                all_fetched_as_caller = caller_id is not None
+                # Keyed BY CONNECTION. Merging every connection's crawl into one
+                # list threw away the only thing that made it reusable — which
+                # connection each table came from — so it could not be handed to
+                # a per-connection overlay sync without cross-contaminating them.
+                prefetched_by_conn: dict[str, list] = {}
 
                 for conn in shared_conns:
                     # Wait for any active indexing run before refreshing synchronously.
@@ -4677,11 +5072,9 @@ class DataSourceService:
                     fetched = getattr(connection_service, "last_refresh_fresh_tables", None)
                     fetched_as = getattr(connection_service, "last_refresh_identity_user_id", None)
                     if fetched is not None and fetched_as is not None and fetched_as == caller_id:
-                        caller_fetched_tables.extend(fetched)
-                    else:
-                        all_fetched_as_caller = False
+                        prefetched_by_conn[str(conn.id)] = fetched
 
-                prefetched = caller_fetched_tables if all_fetched_as_caller else None
+                prefetched = prefetched_by_conn or None
 
                 # Sync ConnectionTable -> DataSourceTable (linked). Reconciles/heals
                 # any legacy unlinked orphan rows; keep existing is_active state.
@@ -4690,88 +5083,66 @@ class DataSourceService:
                         db, data_source, conn, max_auto_select=None
                     )
                 if not per_user_conns:
-                    user_scoped = await self._refresh_shared_user_overlay(
-                        db, data_source, current_user, prefetched_tables=prefetched
+                    return await self._reloaded_schema_for(
+                        db, data_source, organization, current_user, prefetched
                     )
-                    if user_scoped is not None:
-                        return user_scoped
-                    schemas = await data_source.get_schemas(db=db, include_inactive=True)
-                    return schemas
 
-            # Per-user catalogs: fetch the caller's own catalog against their creds.
-            if per_user_conns and current_user is not None:
-                schemas = await self.get_user_data_source_schema(db=db, data_source=data_source, user=current_user)
-                return schemas or []
-
-            # Mixed (shared + per-user) already refreshed the shared side above.
-            if shared_conns:
-                user_scoped = await self._refresh_shared_user_overlay(
-                    db, data_source, current_user, prefetched_tables=prefetched
+            # Per-user catalogs (and mixed agents, whose shared side refreshed
+            # above): one merged, identity-scoped answer either way.
+            if per_user_conns or shared_conns:
+                return await self._reloaded_schema_for(
+                    db, data_source, organization, current_user,
+                    prefetched if shared_conns else None,
                 )
-                if user_scoped is not None:
-                    return user_scoped
-                schemas = await data_source.get_schemas(db=db, include_inactive=True)
-                return schemas
 
         # No connections at all: legacy direct fetch (nothing to link against).
         schemas = await self.save_or_update_tables(db=db, data_source=data_source, organization=organization, should_set_active=False, current_user=current_user)
         return schemas or []
 
-    async def _refresh_shared_user_overlay(
+    async def _reloaded_schema_for(
         self,
         db: AsyncSession,
         data_source: DataSource,
+        organization: Organization,
         current_user: User,
-        prefetched_tables: Optional[list] = None,
+        prefetched_tables=None,
     ):
-        """On an explicit reload of a SHARED-catalog, user_required (delegated/OBO,
-        e.g. Fabric/PowerBI) source, also refresh the CALLER's per-user overlay.
+        """The answer a Reload returns: every connection this caller may see.
 
-        The shared-catalog refresh above only updates the canonical catalog
-        (ConnectionTable -> DataSourceTable). But the tables selector is
-        overlay-scoped for a caller running with their own delegated token
-        (effective_auth == "user"), so without this the caller sees ZERO tables
-        right after reloading and only sees them later, once an unrelated path
-        (sign-in, OAuth connect, credential upsert) lazily warms the overlay.
+        Warms the caller's per-user overlay for the delegated / per-user
+        connections (without this, a caller running on their own token saw ZERO
+        tables straight after a reload and only recovered when some unrelated
+        path lazily warmed the overlay), then returns ONE merged catalog —
+        overlay tables for delegated connections, canonical tables for the open
+        ones.
 
-        Returns the caller's user-scoped schema list when the overlay applies, or
-        None to signal the caller should get the full canonical catalog (admin via
-        service account, or a non-delegated source).
+        Returning just one of those two is what made a multi-connection agent
+        come back from a Reload looking single-connection.
         """
-        conns = getattr(data_source, "connections", None) or []
-        auth_policy = (conns[0].auth_policy if conns else "system_only") or "system_only"
-        if auth_policy != "user_required" or current_user is None:
-            return None
-        effective_auth = await self._resolve_effective_auth(db, data_source, current_user)
-        if effective_auth == "user":
-            # Caller runs with their own token: populate + return their overlay so
-            # the reload reflects exactly the tables they can query.
+        if current_user is not None and self._per_user_catalog_connections(data_source):
             try:
-                schemas = await self.get_user_data_source_schema(
+                await self.get_user_data_source_schema(
                     db=db, data_source=data_source, user=current_user,
                     prefetched_tables=prefetched_tables,
                 )
-                return schemas or []
-            except Exception as e:
-                # Degrading to "no tables" is deliberate (a live fetch against the
-                # user's token can fail for reasons we can't fix here), but stay
-                # loud about it: a swallowed DB error here reads downstream as an
-                # empty overlay, which is indistinguishable from "user sees
-                # nothing" and cost real debugging time once already.
+            except Exception:
+                # Degrading here is deliberate (a live fetch against the user's
+                # token can fail for reasons we can't fix), but stay loud: a
+                # swallowed error reads downstream as an empty overlay, which is
+                # indistinguishable from "user sees nothing".
                 logger.warning(
-                    "Per-user overlay refresh failed for data source %s / user %s: %s",
-                    data_source.id, getattr(current_user, "id", None), e, exc_info=True,
+                    "Per-user overlay refresh failed for data source %s / user %s",
+                    data_source.id, getattr(current_user, "id", None), exc_info=True,
                 )
-                return []
-        if effective_auth == "none":
-            # No proven access (disconnected/expired) → nothing to show for a
-            # plain member. Owner/admin get the canonical catalog (display
-            # fallback, same rule as get_data_source_schema_paginated).
-            if await self._admin_catalog_access(db, data_source, current_user):
-                return None
-            return []
-        # effective_auth == "system": admin via service account → full catalog.
-        return None
+
+        return await self.get_data_source_schema(
+            db=db,
+            data_source_id=str(data_source.id),
+            include_inactive=True,
+            organization=organization,
+            current_user=current_user,
+        )
+
 
     async def get_metadata_resources(self, db: AsyncSession, data_source_id: str, organization: Organization, current_user: User = None):
         result = await db.execute(select(DataSource).filter(DataSource.id == data_source_id, DataSource.organization_id == organization.id))

--- a/backend/app/services/user_data_source_credentials_service.py
+++ b/backend/app/services/user_data_source_credentials_service.py
@@ -84,9 +84,8 @@ class UserDataSourceCredentialsService:
             last_checked = None
             if live_test:
                 try:
-                    from app.services.data_source_service import DataSourceService
-                    ds_service = DataSourceService()
-                    client = await ds_service.construct_client(db=db, data_source=data_source, current_user=user)
+                    from app.services.connection_service import ConnectionService
+                    client = await ConnectionService().construct_client(db, connection, user)
                     ok = await client.atest_connection()
                     success = bool(ok.get("success")) if isinstance(ok, dict) else bool(ok)
                     conn_status = "success" if success else "not_connected"
@@ -139,9 +138,11 @@ class UserDataSourceCredentialsService:
                 if live_test:
                     try:
                         # Attempt live test using system credentials
-                        from app.services.data_source_service import DataSourceService
-                        ds_service = DataSourceService()
-                        client = await ds_service.construct_client(db=db, data_source=data_source, current_user=user)
+                        from app.services.connection_service import ConnectionService
+                        # THIS connection, not the data source's first one: a
+                        # multi-connection agent was reporting connection A's
+                        # reachability as connection B's status.
+                        client = await ConnectionService().construct_client(db, connection, user)
                         ok = await client.atest_connection()
                         success = bool(ok.get("success")) if isinstance(ok, dict) else bool(ok)
                         conn = "success" if success else "not_connected"
@@ -165,9 +166,8 @@ class UserDataSourceCredentialsService:
         if live_test:
             try:
                 # Local import to avoid circular
-                from app.services.data_source_service import DataSourceService
-                ds_service = DataSourceService()
-                client = await ds_service.construct_client(db=db, data_source=data_source, current_user=user)
+                from app.services.connection_service import ConnectionService
+                client = await ConnectionService().construct_client(db, connection, user)
                 ok = await client.atest_connection()
                 success = bool(ok.get("success")) if isinstance(ok, dict) else bool(ok)
                 conn = "success" if success else "not_connected"

--- a/backend/tests/e2e/test_channel_mixed_agent_gate.py
+++ b/backend/tests/e2e/test_channel_mixed_agent_gate.py
@@ -1,0 +1,129 @@
+"""A mixed agent must not be offered for Slack channel mentions.
+
+`get_public_data_sources` serves the agents a CHANNEL mention may use. Its own
+docstring states the rule — "only ... system_only auth ... where we can't rely
+on individual user credentials" — but it read the policy off
+`data_source.connections[0]`:
+
+    conn = d.connections[0] if d.connections else None
+    auth_policy = conn.auth_policy if conn else "system_only"
+    if auth_policy == "user_required":
+        continue
+
+So a MIXED agent (system_only warehouse first, delegated Power BI second)
+answered "system_only" and was offered in the channel anyway. Channel members
+who have not connected their own account get "Connect required" from an agent
+the channel advertised, and an owner or admin mentioning it reaches the
+system-credentials fallback in a public channel.
+
+Same `connections[0]` root cause as the tables-selector bug, in the gate that
+decides what a public channel may reach.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_channel_mixed_agent_gate.py -v -s
+"""
+import uuid
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.domain_connection import domain_connection
+from app.services.data_source_service import DataSourceService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _agent(org_id, name, policies, base):
+    """One public agent whose connections carry `policies`, in that order."""
+    suffix = uuid.uuid4().hex[:6]
+    async with async_session_maker() as db:
+        ds = DataSource(name=f"{name} {suffix}", organization_id=org_id,
+                        is_active=True, is_public=True)
+        db.add(ds)
+        await db.flush()
+        for i, policy in enumerate(policies):
+            c = Connection(
+                organization_id=org_id, name=f"{name}-{i}-{suffix}",
+                type="postgresql" if policy == "system_only" else "powerbi",
+                config={}, auth_policy=policy,
+                allowed_user_auth_modes=None if policy == "system_only" else ["oauth"],
+                created_at=base + timedelta(minutes=i),
+            )
+            c.encrypt_credentials({"user": "u", "password": "p"})
+            db.add(c)
+            await db.flush()
+            await db.execute(domain_connection.insert().values(
+                data_source_id=ds.id, connection_id=c.id))
+        await db.commit()
+        return str(ds.id), ds.name
+
+
+async def _seed():
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with async_session_maker() as db:
+        org = Organization(name=f"Channel Org {uuid.uuid4().hex[:8]}")
+        db.add(org)
+        await db.commit()
+        org_id = org.id
+    out = {}
+    # The delegated connection sorts SECOND — the ordering under which the old
+    # gate read "system_only" and let the agent through.
+    out["mixed"] = await _agent(org_id, "Mixed", ["system_only", "user_required"], base)
+    # ...and FIRST, which the old gate happened to catch. Both must be skipped.
+    out["mixed_delegated_first"] = await _agent(
+        org_id, "MixedDelegatedFirst", ["user_required", "system_only"], base)
+    out["open"] = await _agent(org_id, "OpenOnly", ["system_only", "system_only"], base)
+    out["delegated"] = await _agent(org_id, "DelegatedOnly", ["user_required"], base)
+    return org_id, out
+
+
+async def _channel_agents(org_id):
+    async with async_session_maker() as db:
+        org = await db.get(Organization, org_id)
+        items = await DataSourceService().get_public_data_sources(
+            db, org, channel="slack")
+        return {i.name for i in items}
+
+
+@pytest.mark.e2e
+def test_channel_mentions_skip_any_agent_with_a_delegated_connection():
+    org_id, agents = _run(_seed())
+    offered = _run(_channel_agents(org_id))
+    print(f"\noffered to a Slack channel: {sorted(offered)}")
+
+    open_name = agents["open"][1]
+    assert open_name in offered, "a fully system_only agent must still be offered"
+
+    for key in ("mixed", "mixed_delegated_first", "delegated"):
+        name = agents[key][1]
+        assert name not in offered, (
+            f"{name} has a user_required connection and must not be offered for "
+            f"channel mentions — a channel cannot supply individual credentials"
+        )
+
+
+@pytest.mark.e2e
+def test_the_legacy_type_field_still_renders():
+    """The gate rebinds `conn` for the response's legacy single `type` field;
+    dropping that binding would NameError the whole endpoint."""
+    org_id, agents = _run(_seed())
+
+    async def _items():
+        async with async_session_maker() as db:
+            org = await db.get(Organization, org_id)
+            return await DataSourceService().get_public_data_sources(
+                db, org, channel="slack")
+
+    items = _run(_items())
+    assert items, "expected the open agent to be listed"
+    assert all(getattr(i, "type", None) == "postgresql" for i in items)

--- a/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
+++ b/backend/tests/e2e/test_fabric_second_admin_overlay_repro.py
@@ -266,11 +266,11 @@ def test_reload_populates_second_admin_overlay(monkeypatch):
     async def _noop_refresh_schema(self, db, connection, current_user=None, **kwargs):
         return []
 
-    async def _fake_construct_client(self, db, data_source, current_user):
+    async def _fake_construct_client(self, db, data_source, connection=None, user=None, **kw):
         return _FakeFabricClient()
 
     monkeypatch.setattr(ConnectionService, "refresh_schema", _noop_refresh_schema)
-    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
+    monkeypatch.setattr(DataSourceService, "_construct_user_catalog_client", _fake_construct_client)
 
     async def _reload_as_admin2():
         svc = DataSourceService()

--- a/backend/tests/e2e/test_multi_connection_tables_selector.py
+++ b/backend/tests/e2e/test_multi_connection_tables_selector.py
@@ -1,0 +1,364 @@
+"""A multi-connection agent must show EVERY connection's tables — and only the
+tables the caller may actually see on each of them.
+
+Reported symptom: "an agent with 2+ connections often shows only 1 source of
+tables". The tables selector (`get_data_source_schema_paginated`) decided ONCE
+per data source, from `data_source.connections[0]`, whether to scope rows to
+the caller's per-user overlay:
+
+    conn0 = data_source.connections[0]
+    if (conn0.auth_policy or "system_only") == "user_required": ...
+
+Two failures fell out of that, and which one you got depended on the order the
+database happened to return the connections in (the relationship had no
+ORDER BY, so it could differ between two requests on the same agent):
+
+  * delegated connection FIRST — the whole catalog was filtered through an
+    overlay that only ever described that one connection (the sync built its
+    client with `construct_client`, documented as "first connection only"), so
+    every OTHER connection's tables vanished from the rows, the counts, and the
+    filter dropdowns. This is the reported bug.
+
+  * delegated connection SECOND — no scoping was applied at all, so one user
+    saw another user's delegated Power BI models. This is the security half,
+    and it is the one a "shows all the tables now" fix can easily leave open.
+
+The fix resolves the scope PER CONNECTION (`_resolve_catalog_scope`) and syncs
+the overlay per connection (`_sync_user_overlay_for_connection`), so each
+connection contributes exactly what its own auth policy and this user's own
+access allow.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_multi_connection_tables_selector.py -v -s
+"""
+import uuid
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+from app.models.user_connection_credentials import UserConnectionCredentials
+from app.models.user_data_source_overlay import UserDataSourceTable as UserOverlayTable
+from app.services.data_source_service import DataSourceService
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# Warehouse (system_only) catalog — one shared catalog, same for every user.
+WAREHOUSE_TABLES = ["public.customers", "public.orders", "shared_name"]
+
+# What each user's OWN Power BI token can see. Both see ModelA (which the
+# service principal also indexed) and a `shared_name` that collides with a
+# warehouse table; each also sees one model the other cannot.
+PBI_BY_USER = {
+    "analyst1": ["ModelA/T1", "ModelU1/T9", "shared_name"],
+    "analyst2": ["ModelA/T1", "ModelU2/T8", "shared_name"],
+}
+
+
+def _pbi_payload(name):
+    return {
+        "name": name,
+        "columns": [{"name": "id", "dtype": "int"}],
+        "pks": [], "fks": [],
+        "metadata_json": {"powerbi": {"datasetId": f"ds-{name}", "tableName": name}},
+    }
+
+
+class _FakeDelegatedPBIClient:
+    def __init__(self, table_names):
+        self._names = table_names
+
+    async def aget_schemas(self, progress_callback=None, prior_tables=None):
+        return [_pbi_payload(n) for n in self._names]
+
+
+async def _seed(delegated_first: bool):
+    """One agent, two connections: a system_only warehouse and a delegated
+    (OBO) Power BI. `delegated_first` controls which one the ordered
+    relationship yields as `connections[0]`, which is the whole point."""
+    suffix = uuid.uuid4().hex[:8]
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with async_session_maker() as db:
+        org = Organization(name=f"MultiConn Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        users = {}
+        for uname in ("analyst1", "analyst2"):
+            u = User(
+                name=uname,
+                email=f"{uname}-{suffix}@example.com",
+                hashed_password="x",
+                is_active=True, is_superuser=False, is_verified=True,
+            )
+            db.add(u)
+            users[uname] = u
+        await db.flush()
+
+        wh = Connection(
+            organization_id=org.id,
+            name=f"Warehouse {suffix}",
+            type="postgresql",
+            config={"host": "localhost", "port": 5432, "database": "demo_db"},
+            auth_policy="system_only",
+            created_at=base if not delegated_first else base + timedelta(hours=1),
+        )
+        wh.encrypt_credentials({"user": "u", "password": "p"})
+        pbi = Connection(
+            organization_id=org.id,
+            name=f"PowerBI {suffix}",
+            type="powerbi",
+            config={},
+            auth_policy="user_required",
+            allowed_user_auth_modes=["oauth"],
+            created_at=base if delegated_first else base + timedelta(hours=1),
+        )
+        pbi.encrypt_credentials({"tenant_id": "t", "client_id": "c", "client_secret": "s"})
+        db.add_all([wh, pbi])
+        await db.flush()
+
+        ds = DataSource(name=f"Mixed Agent {suffix}", organization_id=org.id, is_active=True)
+        db.add(ds)
+        await db.flush()
+        for conn in (wh, pbi):
+            await db.execute(domain_connection.insert().values(
+                data_source_id=ds.id, connection_id=conn.id,
+            ))
+
+        # Canonical catalog. The warehouse's whole catalog is shared; the SP's
+        # Power BI crawl only reached ModelA and the colliding `shared_name`.
+        for conn, names in ((wh, WAREHOUSE_TABLES), (pbi, ["ModelA/T1", "shared_name"])):
+            for name in names:
+                ct = ConnectionTable(
+                    name=name, connection_id=conn.id,
+                    columns=[{"name": "id", "dtype": "int"}],
+                    pks=[], fks=[], no_rows=0,
+                    metadata_json={"schema": "public"},
+                )
+                db.add(ct)
+                await db.flush()
+                db.add(DataSourceTable(
+                    name=name, datasource_id=ds.id, connection_table_id=ct.id,
+                    is_active=True, metadata_json={"schema": "public"},
+                    columns=[{"name": "id", "dtype": "int"}],
+                    pks=[], fks=[], no_rows=0,
+                ))
+
+        # Both analysts have signed in to Power BI: real delegated tokens exist.
+        for u in users.values():
+            cred = UserConnectionCredentials(
+                connection_id=str(pbi.id),
+                user_id=str(u.id),
+                organization_id=str(org.id),
+                auth_mode="oauth",
+                is_active=True, is_primary=True,
+                last_used_at=datetime.now(timezone.utc),
+            )
+            cred.encrypt_credentials({"access_token": "delegated-token"})
+            db.add(cred)
+
+        await db.commit()
+        return {
+            "org_id": org.id, "ds_id": ds.id,
+            "wh_id": str(wh.id), "pbi_id": str(pbi.id),
+            "users": {k: v.id for k, v in users.items()},
+            "names": {v.id: k for k, v in users.items()},
+        }
+
+
+async def _load_ds(db, ds_id):
+    return (await db.execute(
+        select(DataSource)
+        .options(selectinload(DataSource.connections))
+        .where(DataSource.id == ds_id)
+    )).scalar_one()
+
+
+async def _sync(ids, user_id):
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        user = await db.get(User, user_id)
+        ds = await _load_ds(db, ids["ds_id"])
+        return sorted(t.name for t in await svc.get_user_data_source_schema(
+            db=db, data_source=ds, user=user))
+
+
+async def _selector(ids, user_id):
+    """Exactly what the TablesSelector grid renders for this user."""
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, user_id)
+        resp = await svc.get_data_source_schema_paginated(
+            db=db, data_source_id=ids["ds_id"], organization=org,
+            page=1, page_size=500, include_inactive=True, current_user=user,
+        )
+        return {
+            "names": sorted(t.name for t in resp.tables),
+            "by_connection": sorted(
+                (t.connection_name or "?", t.name) for t in resp.tables
+            ),
+            "connection_ids": sorted({str(c.id) for c in resp.connections}),
+            "total": resp.total,
+        }
+
+
+def _install_fake_pbi(monkeypatch, ids, calls):
+    async def _fake(self, db, data_source, connection=None, user=None, **kw):
+        assert connection is not None, "the overlay sync must name its connection"
+        assert str(connection.id) == ids["pbi_id"], (
+            "only the delegated connection has a per-user catalog; the "
+            "system_only warehouse must never be crawled per user"
+        )
+        calls.append((str(connection.id), user.name))
+        return _FakeDelegatedPBIClient(PBI_BY_USER[user.name])
+    monkeypatch.setattr(DataSourceService, "_construct_user_catalog_client", _fake)
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("delegated_first", [True, False], ids=["delegated-first", "delegated-second"])
+def test_mixed_agent_shows_every_connection_scoped_per_user(monkeypatch, delegated_first):
+    calls = []
+    ids = _run(_seed(delegated_first))
+    _install_fake_pbi(monkeypatch, ids, calls)
+
+    u1 = ids["users"]["analyst1"]
+    u2 = ids["users"]["analyst2"]
+
+    fetched1 = _run(_sync(ids, u1))
+    fetched2 = _run(_sync(ids, u2))
+    assert fetched1 == sorted(PBI_BY_USER["analyst1"])
+    assert fetched2 == sorted(PBI_BY_USER["analyst2"])
+    assert {c[0] for c in calls} == {ids["pbi_id"]}
+
+    view1 = _run(_selector(ids, u1))
+    view2 = _run(_selector(ids, u2))
+    print(f"\n[delegated_first={delegated_first}] analyst1 sees: {view1['names']}")
+    print(f"[delegated_first={delegated_first}] analyst2 sees: {view2['names']}")
+
+    # 1. THE REPORTED BUG: the warehouse's tables are present no matter which
+    #    connection sorts first.
+    for name in WAREHOUSE_TABLES:
+        assert name in view1["names"], f"warehouse table {name} missing for analyst1"
+        assert name in view2["names"], f"warehouse table {name} missing for analyst2"
+
+    # 2. Both connections are represented in the rows AND in the filter
+    #    dropdown, so the grid can't claim a connection it shows nothing for.
+    assert view1["connection_ids"] == sorted([ids["wh_id"], ids["pbi_id"]])
+    conns_with_rows = {c for c, _ in view1["by_connection"]}
+    assert len(conns_with_rows) == 2, f"only one connection produced rows: {conns_with_rows}"
+
+    # 3. THE SECURITY HALF: each analyst sees their OWN delegated models and
+    #    never the other's — including when the delegated connection is not
+    #    first, which used to skip overlay scoping entirely.
+    assert "ModelU1/T9" in view1["names"]
+    assert "ModelU2/T8" not in view1["names"], "analyst1 sees analyst2's Power BI model"
+    assert "ModelU2/T8" in view2["names"]
+    assert "ModelU1/T9" not in view2["names"], "analyst2 sees analyst1's Power BI model"
+
+    # 4. A name shared across two connections stays two distinct rows — one per
+    #    connection — rather than collapsing into one.
+    shared = [c for c in view1["by_connection"] if c[1] == "shared_name"]
+    assert len(shared) == 2, f"expected shared_name on both connections, got {shared}"
+
+    # 5. The header count agrees with the rows actually rendered.
+    assert view1["total"] == len(view1["names"])
+
+
+@pytest.mark.e2e
+def test_overlay_rows_are_attributed_to_their_connection(monkeypatch):
+    """Every overlay row a sync writes names the connection it came from, so a
+    second connection's sync can reconcile its own rows without revoking these."""
+    calls = []
+    ids = _run(_seed(delegated_first=True))
+    _install_fake_pbi(monkeypatch, ids, calls)
+    u1 = ids["users"]["analyst1"]
+    _run(_sync(ids, u1))
+
+    async def _rows():
+        async with async_session_maker() as db:
+            return (await db.execute(
+                select(UserOverlayTable).where(
+                    UserOverlayTable.data_source_id == ids["ds_id"],
+                    UserOverlayTable.user_id == u1,
+                )
+            )).scalars().all()
+
+    rows = _run(_rows())
+    assert rows, "the sync wrote no overlay rows"
+    assert all(str(r.connection_id) == ids["pbi_id"] for r in rows), (
+        f"overlay rows not attributed to their connection: "
+        f"{[(r.table_name, r.connection_id) for r in rows]}"
+    )
+
+
+@pytest.mark.e2e
+def test_second_sync_does_not_revoke_the_other_connections_rows(monkeypatch):
+    """Re-syncing is idempotent per connection: it must not mark another
+    connection's rows revoked just because they're absent from this snapshot."""
+    calls = []
+    ids = _run(_seed(delegated_first=True))
+    _install_fake_pbi(monkeypatch, ids, calls)
+    u1 = ids["users"]["analyst1"]
+
+    _run(_sync(ids, u1))
+    first = _run(_selector(ids, u1))
+    _run(_sync(ids, u1))
+    second = _run(_selector(ids, u1))
+
+    assert first["names"] == second["names"], (
+        f"re-syncing changed what the user sees:\n  before={first['names']}\n  after={second['names']}"
+    )
+
+
+@pytest.mark.e2e
+def test_connection_filter_reaches_user_discovered_rows(monkeypatch):
+    """Filtering to the delegated connection must keep the models only this
+    user can see. Those rows have no ConnectionTable to join through, so the
+    old JOIN-based filter dropped them — the user filtered to their Power BI
+    connection and lost exactly the tables that were theirs."""
+    calls = []
+    ids = _run(_seed(delegated_first=True))
+    _install_fake_pbi(monkeypatch, ids, calls)
+    u1 = ids["users"]["analyst1"]
+    _run(_sync(ids, u1))
+
+    async def _filtered(connection_ids):
+        svc = DataSourceService()
+        async with async_session_maker() as db:
+            org = await db.get(Organization, ids["org_id"])
+            user = await db.get(User, u1)
+            resp = await svc.get_data_source_schema_paginated(
+                db=db, data_source_id=ids["ds_id"], organization=org,
+                page=1, page_size=500, include_inactive=True, current_user=user,
+                connection_filter=connection_ids,
+            )
+            return sorted(t.name for t in resp.tables), resp.total
+
+    pbi_names, pbi_total = _run(_filtered([ids["pbi_id"]]))
+    wh_names, wh_total = _run(_filtered([ids["wh_id"]]))
+    print(f"\nfiltered to PowerBI:   {pbi_names}")
+    print(f"filtered to Warehouse: {wh_names}")
+
+    assert "ModelU1/T9" in pbi_names, "the user's own discovered model was filtered away"
+    assert sorted(pbi_names) == sorted(PBI_BY_USER["analyst1"])
+    assert pbi_total == len(pbi_names), "count disagrees with the filtered rows"
+
+    assert sorted(wh_names) == sorted(WAREHOUSE_TABLES)
+    assert "ModelU1/T9" not in wh_names
+    assert wh_total == len(wh_names)

--- a/backend/tests/e2e/test_multi_connection_tables_selector.py
+++ b/backend/tests/e2e/test_multi_connection_tables_selector.py
@@ -362,3 +362,78 @@ def test_connection_filter_reaches_user_discovered_rows(monkeypatch):
     assert sorted(wh_names) == sorted(WAREHOUSE_TABLES)
     assert "ModelU1/T9" not in wh_names
     assert wh_total == len(wh_names)
+
+
+@pytest.mark.e2e
+def test_classification_cost_is_flat_in_connection_count(monkeypatch):
+    """Classifying access must not cost a round trip per connection.
+
+    It did: `_resolve_effective_auth` per delegated connection, each dragging
+    its relationship loads behind it — measured at exactly 9.0 SQL statements
+    per connection, dead linear, so a 100-connection agent spent ~900
+    serialized round trips. The tables selector runs this on every page, sort,
+    filter and search, uncached. `UserCredentialIndex` answers all of them in
+    two queries, which is what the agent-list endpoints already do.
+    """
+    from sqlalchemy import event
+    from sqlalchemy.engine import Engine
+    from app.models.connection import Connection
+    from app.models.user_connection_credentials import UserConnectionCredentials
+
+    counter = {"n": 0, "on": False}
+
+    @event.listens_for(Engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, params, context, executemany):
+        if counter["on"]:
+            counter["n"] += 1
+
+    async def _agent_with(n_delegated, org_id, user_id):
+        suffix = uuid.uuid4().hex[:6]
+        async with async_session_maker() as db:
+            ds = DataSource(name=f"Flat {n_delegated} {suffix}",
+                            organization_id=org_id, is_active=True)
+            db.add(ds)
+            await db.flush()
+            for i in range(n_delegated):
+                c = Connection(organization_id=org_id, name=f"d-{i}-{suffix}",
+                               type="powerbi", config={}, auth_policy="user_required",
+                               allowed_user_auth_modes=["oauth"])
+                c.encrypt_credentials({"tenant_id": "t", "client_id": "c", "client_secret": "s"})
+                db.add(c)
+                await db.flush()
+                await db.execute(domain_connection.insert().values(
+                    data_source_id=ds.id, connection_id=c.id))
+                cred = UserConnectionCredentials(
+                    connection_id=str(c.id), user_id=str(user_id),
+                    organization_id=str(org_id), auth_mode="oauth",
+                    is_active=True, is_primary=True,
+                    last_used_at=datetime.now(timezone.utc))
+                cred.encrypt_credentials({"access_token": "tok"})
+                db.add(cred)
+            await db.commit()
+            return str(ds.id)
+
+    async def _cost(ds_id, user_id):
+        svc = DataSourceService()
+        async with async_session_maker() as db:
+            ds = await _load_ds(db, ds_id)
+            user = await db.get(User, user_id)
+            await svc.classify_connection_access(db, ds, user)  # warm
+            counter["n"], counter["on"] = 0, True
+            await svc.classify_connection_access(db, ds, user)
+            counter["on"] = False
+            return counter["n"]
+
+    ids = _run(_seed(delegated_first=True))
+    org_id, user_id = ids["org_id"], ids["users"]["analyst1"]
+
+    costs = {}
+    for n in (1, 20):
+        ds_id = _run(_agent_with(n, org_id, user_id))
+        costs[n] = _run(_cost(ds_id, user_id))
+    print(f"\nclassification cost: 1 conn={costs[1]} stmts, 20 conns={costs[20]} stmts")
+
+    assert costs[20] == costs[1], (
+        f"cost grows with connection count: {costs[1]} -> {costs[20]} "
+        f"({(costs[20] - costs[1]) / 19:.1f} statements per extra connection)"
+    )

--- a/backend/tests/e2e/test_overlay_review_regressions.py
+++ b/backend/tests/e2e/test_overlay_review_regressions.py
@@ -361,3 +361,77 @@ def test_newly_attached_connection_is_warmed(monkeypatch):
     by_name = _run(_full_schema(ids))
     assert "FromA" in by_name
     assert "FromB" in by_name, "the later-attached connection was never warmed"
+
+
+# ---------------------------------------------------------------------------
+# Second review round
+# ---------------------------------------------------------------------------
+
+def test_denied_connection_legacy_overlay_is_not_saved_by_another_connection(monkeypatch):
+    """A denied connection's UNATTRIBUTED overlay row must not ride in on a
+    different connection the caller still holds.
+
+    The first fix only closed the case where NO connection was authorized. With
+    A denied and B still authorized, the NULL-connection allowance admitted A's
+    legacy rows anyway — and a NULL connection_id is unknown provenance, not
+    permission.
+    """
+    ids = _run(_seed(n_delegated=2))
+    a, b = ids["pbi_ids"]
+    _install_catalog(monkeypatch, {a: {"PrivateA": ["id"]}, b: {"FromB": ["id"]}})
+
+    assert "PrivateA" in _run(_full_schema(ids))
+
+    async def _make_legacy_and_revoke_a():
+        """A's row loses its connection (what the migration leaves behind for a
+        row whose canonical table was never linked), then A is deactivated."""
+        async with async_session_maker() as db:
+            await db.execute(
+                update(UserOverlayTable)
+                .where(UserOverlayTable.connection_id == a)
+                .values(connection_id=None)
+            )
+            await db.execute(
+                update(UserConnectionCredentials)
+                .where(UserConnectionCredentials.connection_id == a)
+                .values(is_active=False)
+            )
+            await db.commit()
+    _run(_make_legacy_and_revoke_a())
+    _WARM_ATTEMPTS.clear()
+
+    after = _run(_full_schema(ids))
+    assert "FromB" in after, "the still-authorized connection is unaffected"
+    assert "public.customers" in after, "the open connection is unaffected"
+    assert "PrivateA" not in after, (
+        "a denied connection's unattributed overlay row stayed visible because "
+        "another connection was authorized"
+    )
+
+
+def test_service_account_switch_serves_the_canonical_schema(monkeypatch):
+    """When a connection moves to a service account the classifier calls it
+    open — and a leftover personal overlay must stop speaking for it, or the
+    agent keeps serving one user's narrowed columns to everyone."""
+    ids = _run(_seed())
+    pbi_id = ids["pbi_ids"][0]
+    _install_catalog(monkeypatch, {pbi_id: {"Secrets": ["id"]}})
+    _run(_seed_wide_canonical(ids["ds_id"], pbi_id))
+
+    before = _run(_full_schema(ids))
+    assert before["Secrets"] == ["id"], "delegated: the user's own masked columns"
+
+    # The connection is now classified OPEN for this caller (service account).
+    real = DataSourceService.classify_connection_access
+
+    async def _all_open(self, db, data_source, current_user):
+        open_ids, overlay_ids, denied_ids = await real(self, db, data_source, current_user)
+        return (open_ids + overlay_ids, [], denied_ids)
+    monkeypatch.setattr(DataSourceService, "classify_connection_access", _all_open)
+
+    after = _run(_full_schema(ids))
+    assert "Secrets" in after
+    assert after["Secrets"] == ["id", "salary"], (
+        f"a stale personal overlay suppressed the service account's schema: "
+        f"{after['Secrets']}"
+    )

--- a/backend/tests/e2e/test_overlay_review_regressions.py
+++ b/backend/tests/e2e/test_overlay_review_regressions.py
@@ -1,0 +1,363 @@
+"""Regressions found reviewing the per-connection overlay change.
+
+Four defects, two of them access-control:
+
+1. COLUMN MASKING. `get_data_source_schema` merges the caller's overlay with
+   the canonical catalog, keyed on the table id. `read_user_data_source_schema`
+   built its `Table` DTOs without setting `id`, so every overlay table failed
+   the merge filter and the canonical row — carrying the FULL column set the
+   service principal discovered — was served in its place. The per-user column
+   masking the overlay exists to apply was silently off on that path.
+
+2. CANONICAL FALLBACK. The same merge fell back to canonical rows for
+   delegated connections whenever the overlay read raised, turning a transient
+   failure into the same masking bypass.
+
+3. REVOKED ACCESS. `_resolve_catalog_scope` left the overlay subquery
+   unrestricted whenever the caller had no currently-authorized connection, so
+   the unlinked-row branch kept admitting semantic models they discovered
+   before their credentials were deactivated.
+
+4. IDENTITY MATCHING. `_upsert_user_overlay` scoped the name index to the
+   connection being synced but left the (datasetId, tableName) index — which is
+   consulted FIRST — indexing every canonical row, so the same Power BI dataset
+   reached through two delegated connections collapsed onto one canonical row.
+
+5. WARMING. First-read warming short-circuited on the first overlay row found
+   anywhere on the agent, so a connection attached after the user's first read
+   never got a catalog.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_overlay_review_regressions.py -v -s
+"""
+import uuid
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.orm import selectinload
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.data_source import DataSource
+from app.models.connection_table import ConnectionTable
+from app.models.datasource_table import DataSourceTable
+from app.models.domain_connection import domain_connection
+from app.models.user_connection_credentials import UserConnectionCredentials
+from app.models.user_data_source_overlay import (
+    UserDataSourceTable as UserOverlayTable,
+    UserDataSourceColumn as UserOverlayColumn,
+)
+from app.services.data_source_service import DataSourceService, _WARM_ATTEMPTS
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _clear_warm_cache():
+    """Warming is guarded by a process-local attempt cache; tests must not
+    inherit another test's attempts."""
+    _WARM_ATTEMPTS.clear()
+    yield
+    _WARM_ATTEMPTS.clear()
+
+
+def _payload(name, columns):
+    return {
+        "name": name,
+        "columns": [{"name": c, "dtype": "text"} for c in columns],
+        "pks": [], "fks": [],
+        "metadata_json": {"powerbi": {"datasetId": f"ds-{name}", "tableName": name}},
+    }
+
+
+class _FakeClient:
+    """A delegated catalog: what THIS user's own token sees, columns included."""
+
+    def __init__(self, tables):
+        self._tables = tables
+
+    async def aget_schemas(self, progress_callback=None, prior_tables=None):
+        return [_payload(n, cols) for n, cols in self._tables.items()]
+
+
+async def _seed(n_delegated=1):
+    """One agent: a system_only warehouse plus `n_delegated` OBO Power BI
+    connections, one signed-in user."""
+    suffix = uuid.uuid4().hex[:8]
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with async_session_maker() as db:
+        org = Organization(name=f"Review Org {suffix}")
+        db.add(org)
+        await db.flush()
+
+        user = User(
+            name="member", email=f"member-{suffix}@example.com",
+            hashed_password="x", is_active=True, is_superuser=False, is_verified=True,
+        )
+        db.add(user)
+        await db.flush()
+
+        wh = Connection(
+            organization_id=org.id, name=f"Warehouse {suffix}", type="postgresql",
+            config={"host": "localhost", "port": 5432, "database": "demo_db"},
+            auth_policy="system_only", created_at=base,
+        )
+        wh.encrypt_credentials({"user": "u", "password": "p"})
+        db.add(wh)
+
+        pbis = []
+        for i in range(n_delegated):
+            pbi = Connection(
+                organization_id=org.id, name=f"PowerBI {i} {suffix}", type="powerbi",
+                config={}, auth_policy="user_required", allowed_user_auth_modes=["oauth"],
+                created_at=base + timedelta(hours=i + 1),
+            )
+            pbi.encrypt_credentials({"tenant_id": "t", "client_id": "c", "client_secret": "s"})
+            db.add(pbi)
+            pbis.append(pbi)
+        await db.flush()
+
+        ds = DataSource(name=f"Review Agent {suffix}", organization_id=org.id, is_active=True)
+        db.add(ds)
+        await db.flush()
+        for conn in [wh, *pbis]:
+            await db.execute(domain_connection.insert().values(
+                data_source_id=ds.id, connection_id=conn.id,
+            ))
+
+        # Warehouse canonical catalog.
+        ct = ConnectionTable(
+            name="public.customers", connection_id=wh.id,
+            columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0,
+            metadata_json={"schema": "public"},
+        )
+        db.add(ct)
+        await db.flush()
+        db.add(DataSourceTable(
+            name="public.customers", datasource_id=ds.id, connection_table_id=ct.id,
+            is_active=True, metadata_json={"schema": "public"},
+            columns=[{"name": "id", "dtype": "int"}], pks=[], fks=[], no_rows=0,
+        ))
+
+        for u in (user,):
+            for pbi in pbis:
+                cred = UserConnectionCredentials(
+                    connection_id=str(pbi.id), user_id=str(u.id),
+                    organization_id=str(org.id), auth_mode="oauth",
+                    is_active=True, is_primary=True,
+                    last_used_at=datetime.now(timezone.utc),
+                )
+                cred.encrypt_credentials({"access_token": "delegated-token"})
+                db.add(cred)
+
+        await db.commit()
+        return {
+            "org_id": org.id, "ds_id": ds.id, "user_id": user.id,
+            "wh_id": str(wh.id), "pbi_ids": [str(p.id) for p in pbis],
+        }
+
+
+async def _load_ds(db, ds_id):
+    return (await db.execute(
+        select(DataSource)
+        .options(selectinload(DataSource.connections))
+        .where(DataSource.id == ds_id)
+    )).scalar_one()
+
+
+def _install_catalog(monkeypatch, by_conn_id):
+    """by_conn_id: {connection_id: {table_name: [column, ...]}}"""
+    async def _fake(self, db, data_source, connection=None, user=None, **kw):
+        return _FakeClient(by_conn_id[str(connection.id)])
+    monkeypatch.setattr(DataSourceService, "_construct_user_catalog_client", _fake)
+
+
+async def _seed_wide_canonical(ds_id, conn_id):
+    """The service principal's crawl of `Secrets` found a column this user's
+    own token cannot see."""
+    meta = {"powerbi": {"datasetId": "ds-Secrets", "tableName": "Secrets"}}
+    cols = [{"name": "id", "dtype": "int"}, {"name": "salary", "dtype": "int"}]
+    async with async_session_maker() as db:
+        ct = ConnectionTable(
+            name="Secrets", connection_id=conn_id, columns=cols,
+            pks=[], fks=[], no_rows=0, metadata_json=meta,
+        )
+        db.add(ct)
+        await db.flush()
+        db.add(DataSourceTable(
+            name="Secrets", datasource_id=ds_id, connection_table_id=ct.id,
+            is_active=True, metadata_json=meta, columns=cols,
+            pks=[], fks=[], no_rows=0,
+        ))
+        await db.commit()
+
+
+async def _full_schema(ids):
+    svc = DataSourceService()
+    async with async_session_maker() as db:
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, ids["user_id"])
+        tables = await svc.get_data_source_schema(
+            db=db, data_source_id=ids["ds_id"], organization=org,
+            include_inactive=True, current_user=user,
+        )
+        return {t.name: sorted(c.name for c in (t.columns or [])) for t in tables}
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2: column masking on the merged full-schema path
+# ---------------------------------------------------------------------------
+
+def test_full_schema_serves_the_users_masked_columns(monkeypatch):
+    """The canonical row for `Secrets` carries `salary`; this user's own token
+    does not see it. The merged schema must show the overlay's column set."""
+    ids = _run(_seed())
+    pbi_id = ids["pbi_ids"][0]
+    _install_catalog(monkeypatch, {pbi_id: {"Secrets": ["id"]}})
+
+    _run(_seed_wide_canonical(ids["ds_id"], pbi_id))
+
+    by_name = _run(_full_schema(ids))
+    assert "Secrets" in by_name, "the delegated table vanished from the schema"
+    assert by_name["Secrets"] == ["id"], (
+        f"canonical columns leaked through the merge: {by_name['Secrets']}"
+    )
+    # The open connection still contributes its canonical row.
+    assert "public.customers" in by_name
+
+
+def test_overlay_read_failure_does_not_fall_back_to_canonical(monkeypatch):
+    """A failed overlay read must cost the delegated tables, not unmask them."""
+    ids = _run(_seed())
+    pbi_id = ids["pbi_ids"][0]
+    _install_catalog(monkeypatch, {pbi_id: {"Secrets": ["id"]}})
+
+    _run(_seed_wide_canonical(ids["ds_id"], pbi_id))
+
+    _run(_full_schema(ids))   # warm the overlay first
+
+    async def _boom(self, *a, **kw):
+        raise RuntimeError("overlay store unavailable")
+    monkeypatch.setattr(DataSourceService, "read_user_data_source_schema", _boom)
+
+    by_name = _run(_full_schema(ids))
+    assert "public.customers" in by_name, "the open connection must still serve"
+    assert "Secrets" not in by_name, (
+        "a failed overlay read served the canonical (unmasked) delegated row"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3: revoked access must not leave stale models visible
+# ---------------------------------------------------------------------------
+
+def test_deactivated_credentials_hide_previously_discovered_models(monkeypatch):
+    ids = _run(_seed())
+    pbi_id = ids["pbi_ids"][0]
+    _install_catalog(monkeypatch, {pbi_id: {"Private/T9": ["id"]}})
+
+    before = _run(_full_schema(ids))
+    assert "Private/T9" in before, "the user's own model should be visible while connected"
+
+    async def _revoke():
+        async with async_session_maker() as db:
+            await db.execute(
+                update(UserConnectionCredentials)
+                .where(UserConnectionCredentials.connection_id == pbi_id)
+                .values(is_active=False)
+            )
+            await db.commit()
+    _run(_revoke())
+    _WARM_ATTEMPTS.clear()
+
+    after = _run(_full_schema(ids))
+    assert "public.customers" in after, "the open connection is unaffected"
+    assert "Private/T9" not in after, (
+        "a model discovered under revoked credentials stayed visible"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4: two connections must not share one canonical row
+# ---------------------------------------------------------------------------
+
+def test_same_dataset_through_two_connections_keeps_separate_rows(monkeypatch):
+    """Both connections expose dataset `ds-Shared` / table `Shared`. Matching on
+    (datasetId, tableName) across the whole agent pointed both overlays at one
+    canonical row, losing per-connection attribution and activation."""
+    ids = _run(_seed(n_delegated=2))
+    a, b = ids["pbi_ids"]
+    _install_catalog(monkeypatch, {
+        a: {"Shared": ["id"]},
+        b: {"Shared": ["id"]},
+    })
+
+    async def _sync():
+        svc = DataSourceService()
+        async with async_session_maker() as db:
+            user = await db.get(User, ids["user_id"])
+            ds = await _load_ds(db, ids["ds_id"])
+            await svc.get_user_data_source_schema(db=db, data_source=ds, user=user)
+    _run(_sync())
+
+    async def _inspect():
+        async with async_session_maker() as db:
+            rows = (await db.execute(
+                select(UserOverlayTable).where(
+                    UserOverlayTable.data_source_id == str(ids["ds_id"]),
+                    UserOverlayTable.table_name == "Shared",
+                )
+            )).scalars().all()
+            return [(str(r.connection_id), str(r.data_source_table_id)) for r in rows]
+
+    rows = _run(_inspect())
+    assert len(rows) == 2, f"expected one overlay row per connection, got {rows}"
+    assert {c for c, _ in rows} == {a, b}
+    canonical_ids = {t for _, t in rows}
+    assert len(canonical_ids) == 2, (
+        f"both connections' overlays point at the same canonical row: {rows}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5: a connection attached later still gets warmed
+# ---------------------------------------------------------------------------
+
+def test_newly_attached_connection_is_warmed(monkeypatch):
+    ids = _run(_seed(n_delegated=2))
+    a, b = ids["pbi_ids"]
+    _install_catalog(monkeypatch, {a: {"FromA": ["id"]}, b: {"FromB": ["id"]}})
+
+    # Simulate "B attached after the first read": drop B's overlay rows, so
+    # only A is warm — exactly the state the short-circuit never recovered from.
+    _run(_full_schema(ids))
+
+    async def _forget_b():
+        async with async_session_maker() as db:
+            ids_b = (await db.execute(
+                select(UserOverlayTable.id).where(UserOverlayTable.connection_id == b)
+            )).scalars().all()
+            for row_id in ids_b:
+                await db.execute(
+                    UserOverlayColumn.__table__.delete().where(
+                        UserOverlayColumn.user_data_source_table_id == row_id
+                    )
+                )
+            await db.execute(
+                UserOverlayTable.__table__.delete().where(UserOverlayTable.connection_id == b)
+            )
+            await db.commit()
+    _run(_forget_b())
+    _WARM_ATTEMPTS.clear()
+
+    by_name = _run(_full_schema(ids))
+    assert "FromA" in by_name
+    assert "FromB" in by_name, "the later-attached connection was never warmed"

--- a/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
+++ b/backend/tests/e2e/test_powerbi_overlay_intersection_repro.py
@@ -225,11 +225,12 @@ async def _canonical_snapshot(ids):
 
 @pytest.mark.e2e
 def test_user_visible_model_missing_from_sp_catalog_is_selectable(monkeypatch):
-    async def _fake_construct_client(self, db, data_source, current_user=None, **kw):
-        assert current_user is not None, "overlay sync must run with the user's identity"
+    async def _fake_construct_client(self, db, data_source, connection=None, user=None, **kw):
+        assert user is not None, "overlay sync must run with the user's identity"
+        assert connection is not None, "overlay sync must name the connection it crawls"
         return _FakeDelegatedPBIClient()
 
-    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
+    monkeypatch.setattr(DataSourceService, "_construct_user_catalog_client", _fake_construct_client)
 
     ids = _run(_seed())
     u1, u2 = ids["user_ids"]
@@ -279,10 +280,10 @@ def test_user_discovered_model_rename_updates_canonical_name(monkeypatch):
     remaining ONE row (matched by identity, no duplicate)."""
     clients = {"impl": _FakeDelegatedPBIClient()}
 
-    async def _fake_construct_client(self, db, data_source, current_user=None, **kw):
+    async def _fake_construct_client(self, db, data_source, connection=None, user=None, **kw):
         return clients["impl"]
 
-    monkeypatch.setattr(DataSourceService, "construct_client", _fake_construct_client)
+    monkeypatch.setattr(DataSourceService, "_construct_user_catalog_client", _fake_construct_client)
 
     ids = _run(_seed())
     u1 = ids["user_ids"][0]

--- a/backend/tests/e2e/test_schema_context_multi_connection.py
+++ b/backend/tests/e2e/test_schema_context_multi_connection.py
@@ -1,0 +1,147 @@
+"""The AGENT's schema context must cover every connection, scoped per user.
+
+Companion to test_multi_connection_tables_selector.py. That one covers what the
+tables selector renders; this one covers what the model actually reasons over —
+and the two used to disagree, because `SchemaContextBuilder` answered "what may
+this user see" independently, from `data_source.connections[0]`:
+
+    conns = list(getattr(ds, 'connections', None) or [])
+    conn = conns[0] if conns else None
+
+Same two failures as the selector bug, decided by connection order:
+
+  * delegated connection first  -> the whole data source was served from the
+    per-user overlay, which only describes delegated connections, so every
+    system_only connection's tables vanished from the prompt. Asked "what are
+    your connections?", a three-connection agent answered "1 PowerBI
+    connection ... 18 tables total" (reproduced live against Claude Haiku).
+  * delegated connection second -> no scoping at all, so one user's prompt
+    carried another user's delegated tables.
+
+Both call sites now share DataSourceService.classify_connection_access, and the
+builder unions the two sources instead of choosing between them: overlay rows
+(which carry per-user column masking) for delegated connections, canonical rows
+for open ones.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/e2e/test_schema_context_multi_connection.py -v -s
+"""
+import asyncio
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.dependencies import async_session_maker
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.data_source import DataSource
+from app.models.datasource_table import DataSourceTable
+from app.ai.context.builders.schema_context_builder import SchemaContextBuilder
+
+# Reuse the three-connection fixture and the delegated-client fake.
+from tests.e2e.test_multi_connection_tables_selector import (  # noqa: E402
+    _seed, _sync, _install_fake_pbi, WAREHOUSE_TABLES, PBI_BY_USER,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _activate_all(ids):
+    """Activate every canonical row, as an agent manager would in the tables
+    wizard. A table a delegated user discovered themselves is created INACTIVE
+    on purpose (their upstream access must not widen the agent past what its
+    manager selected), and the agent context is activation-gated — so without
+    this the user-specific models are correctly absent and the per-user
+    assertions below would be testing the activation gate, not the scoping."""
+    async with async_session_maker() as db:
+        rows = (await db.execute(
+            select(DataSourceTable).where(DataSourceTable.datasource_id == ids["ds_id"])
+        )).scalars().all()
+        for r in rows:
+            r.is_active = True
+            db.add(r)
+        await db.commit()
+        return len(rows)
+
+
+async def _context_for(ids, user_id):
+    """Exactly what the planner is handed for this user on this agent."""
+    async with async_session_maker() as db:
+        ds = (await db.execute(
+            select(DataSource).options(selectinload(DataSource.connections))
+            .where(DataSource.id == ids["ds_id"])
+        )).scalar_one()
+        org = await db.get(Organization, ids["org_id"])
+        user = await db.get(User, user_id)
+        ctx = await SchemaContextBuilder(
+            db=db, data_sources=[ds], organization=org, report=None, user=user
+        ).build(with_stats=False)
+        return ctx.render() if ctx else ""
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("delegated_first", [True, False],
+                         ids=["delegated-first", "delegated-second"])
+def test_agent_context_covers_every_connection(monkeypatch, delegated_first):
+    ids = _run(_seed(delegated_first))
+    _install_fake_pbi(monkeypatch, ids, [])
+    u1 = ids["users"]["analyst1"]
+    u2 = ids["users"]["analyst2"]
+    _run(_sync(ids, u1))
+    _run(_sync(ids, u2))
+    _run(_activate_all(ids))
+
+    ctx1 = _run(_context_for(ids, u1))
+    ctx2 = _run(_context_for(ids, u2))
+
+    # 1. THE BUG: the warehouse tables must be in the prompt whichever
+    #    connection sorts first. Without the fix, `delegated-first` served the
+    #    overlay alone and none of these appeared.
+    for name in WAREHOUSE_TABLES:
+        assert name in ctx1, f"{name} missing from analyst1's agent context"
+        assert name in ctx2, f"{name} missing from analyst2's agent context"
+
+    # 2. Each analyst's OWN delegated tables are there...
+    assert "ModelU1/T9" in ctx1
+    assert "ModelU2/T8" in ctx2
+
+    # 3. ...and the other's are not. `delegated-second` used to skip scoping
+    #    entirely and put both users' models in both prompts.
+    assert "ModelU2/T8" not in ctx1, "analyst1's prompt carries analyst2's model"
+    assert "ModelU1/T9" not in ctx2, "analyst2's prompt carries analyst1's model"
+
+
+@pytest.mark.e2e
+def test_agent_context_is_independent_of_connection_order(monkeypatch):
+    """The same user on the same agent must get the same context regardless of
+    the order the relationship happens to yield connections in — the
+    nondeterminism that made this bug intermittent in production."""
+    contexts = {}
+    for delegated_first in (True, False):
+        ids = _run(_seed(delegated_first))
+        _install_fake_pbi(monkeypatch, ids, [])
+        u1 = ids["users"]["analyst1"]
+        # Sync BOTH analysts so analyst2's model genuinely exists in the
+        # catalog — otherwise the "analyst1 must not see it" assertion below
+        # passes for the wrong reason (there is nothing to see).
+        _run(_sync(ids, u1))
+        _run(_sync(ids, ids["users"]["analyst2"]))
+        _run(_activate_all(ids))
+        ctx = _run(_context_for(ids, u1))
+        # Table names only: ids and generated names differ between seeds.
+        names = sorted({
+            n for n in (WAREHOUSE_TABLES + PBI_BY_USER["analyst1"] + ["ModelU2/T8"])
+            if n in ctx
+        })
+        contexts[delegated_first] = names
+
+    assert contexts[True] == contexts[False], (
+        f"context depends on connection order:\n"
+        f"  delegated-first={contexts[True]}\n  delegated-second={contexts[False]}"
+    )
+    assert "ModelU2/T8" not in contexts[True]

--- a/backend/tests/unit/test_connection_roster_and_scale.py
+++ b/backend/tests/unit/test_connection_roster_and_scale.py
@@ -31,12 +31,13 @@ from app.ai.prompt_formatters import Table as PromptTable, TableColumn
 from app.schemas.data_source_schema import DataSourceSummarySchema
 
 
-def _table(name, conn_name, conn_type="postgresql"):
+def _table(name, conn_name, conn_type="postgresql", conn_id=None):
     return PromptTable(
         name=name,
         columns=[TableColumn(name="a", dtype="text"),
                  TableColumn(name="b", dtype="text")],
         pks=[], fks=[],
+        connection_id=conn_id or f"id-{conn_name}",
         connection_name=conn_name,
         connection_type=conn_type,
         is_active=True,
@@ -53,11 +54,18 @@ def _ds(n_conns, n_tables_each):
     )
 
 
+def _roster_entries(xml):
+    """(id, name) per <connection> element, head and tail alike, in order."""
+    out = []
+    for el in re.findall(r'<connection\b[^>]*/>', xml):
+        cid = re.search(r'\bid="([^"]*)"', el)
+        name = re.search(r'\bname="([^"]*)"', el)
+        out.append((cid.group(1) if cid else None, name.group(1) if name else None))
+    return out
+
+
 def _roster_names(xml):
-    named = re.findall(r'<connection c="[^"]*" name="([^"]+)"', xml)
-    for blob in re.findall(r'<more_connections count="\d+">([^<]*)</more_connections>', xml):
-        named += [n.strip() for n in blob.split(",") if n.strip()]
-    return named
+    return [n for _, n in _roster_entries(xml)]
 
 
 @pytest.mark.parametrize("n_conns,n_each", [(3, 5), (12, 100), (100, 100)])
@@ -126,3 +134,35 @@ def test_roster_is_built_from_the_scoped_tables_not_the_agents_connections():
     names = _roster_names(ds._render_connections_roster_xml())
     assert names == ["warehouse_000", "warehouse_002"]
     assert "warehouse_001" not in ds._render_connections_roster_xml()
+
+
+@pytest.mark.parametrize("n_conns", [3, 100, 260])
+def test_every_roster_entry_carries_its_uuid(n_conns):
+    """describe_tables takes connection_ids, not names or c= aliases. A roster
+    entry without an id names a connection the agent can see but cannot scope a
+    discovery call to — so the tail past the cap needs the id most of all."""
+    ds = _ds(n_conns, 2)
+    entries = _roster_entries(ds._render_connections_roster_xml())
+    assert len(entries) == n_conns
+    assert all(cid for cid, _ in entries), "some connections rendered without an id"
+    assert entries[0] == ("id-warehouse_000", "warehouse_000")
+    assert entries[-1] == (
+        f"id-warehouse_{n_conns - 1:03d}", f"warehouse_{n_conns - 1:03d}"
+    )
+
+
+def test_duplicate_connection_names_stay_separate():
+    """Two connections may share a display name. Keyed on the name they merged
+    into one roster entry with one table count, and the agent had no way to ask
+    for either of them specifically."""
+    ds = TablesSchemaContext.DataSource(
+        info=DataSourceSummarySchema(id="ds-1", name="Dup Agent", type="postgresql"),
+        tables=(
+            [_table(f"a.t{i}", "Warehouse", conn_id="conn-a") for i in range(3)]
+            + [_table(f"b.t{i}", "Warehouse", conn_id="conn-b") for i in range(2)]
+        ),
+    )
+    xml = ds._render_connections_roster_xml()
+    assert '<connections count="2">' in xml
+    assert _roster_entries(xml) == [("conn-a", "Warehouse"), ("conn-b", "Warehouse")]
+    assert 'tables="3"' in xml and 'tables="2"' in xml

--- a/backend/tests/unit/test_connection_roster_and_scale.py
+++ b/backend/tests/unit/test_connection_roster_and_scale.py
@@ -166,3 +166,33 @@ def test_duplicate_connection_names_stay_separate():
     assert '<connections count="2">' in xml
     assert _roster_entries(xml) == [("conn-a", "Warehouse"), ("conn-b", "Warehouse")]
     assert 'tables="3"' in xml and 'tables="2"' in xml
+
+
+def test_fast_sibling_stays_a_separate_identity():
+    """One physical connection can expose two client identities: the live
+    source and its `::fast` sibling serving materialized custom queries. They
+    share a connection_id ON PURPOSE, so keying the roster on the id alone
+    merged them under whichever name came first — and the coder maps that name
+    onto a client_key, so half the tables pointed at a client that cannot serve
+    them. Same key as _group_tables_by_connection."""
+    ds = TablesSchemaContext.DataSource(
+        info=DataSourceSummarySchema(id="ds-1", name="Fast Agent", type="postgresql"),
+        tables=[
+            _table("cached.q1", "warehouse::fast", conn_type="duckdb", conn_id="conn-w"),
+            _table("public.live_orders", "warehouse", conn_id="conn-w"),
+            _table("public.other", "warehouse2", conn_id="conn-x"),
+        ],
+    )
+    xml = ds._render_connections_roster_xml()
+    assert '<connections count="3">' in xml
+    assert _roster_entries(xml) == [
+        ("conn-w", "warehouse::fast"),
+        ("conn-w", "warehouse"),
+        ("conn-x", "warehouse2"),
+    ]
+    # And the index must alias each table to its OWN identity, not the sibling's.
+    index = ds._render_names_index(index_limit=200)
+    aliases = dict(re.findall(r'<item name="([^"]+)"[^>]*\bc="([^"]+)"', index))
+    assert aliases["cached.q1"] != aliases["public.live_orders"], (
+        f"the ::fast sibling and the live source share an alias: {aliases}"
+    )

--- a/backend/tests/unit/test_connection_roster_and_scale.py
+++ b/backend/tests/unit/test_connection_roster_and_scale.py
@@ -1,0 +1,128 @@
+"""The context must name every connection an agent has, and stay flat in cost.
+
+Three properties, all of which failed before:
+
+1. ROSTER. Only the top-K tables render inside a <connection> block and the
+   index is capped (agent_v2.INDEX_LIMIT), so on a large agent both are a
+   sample. At 100 connections x 100 tables the agent saw 10 connections and
+   had no way to learn the other 90 existed — it answered "1 PowerBI
+   connection ... 18 tables total" for a three-connection agent, and would
+   answer "10" for a hundred. <connections> is the complete list.
+
+2. ROUND-ROBIN. Rank-ordered truncation clusters: the first 1000 rows all came
+   from a handful of connections, so ninety connections had every table cut.
+   Interleaving costs each connection depth, never existence.
+
+3. ALIAS. Spelling the connection name onto every index item cost 30-52 bytes
+   each — at the 1000-item cap, a third of the whole rendered context to
+   repeat a handful of strings a thousand times.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/unit/test_connection_roster_and_scale.py -v
+"""
+import re
+
+import pytest
+
+from app.ai.context.sections.tables_schema_section import TablesSchemaContext
+from app.ai.prompt_formatters import Table as PromptTable, TableColumn
+from app.schemas.data_source_schema import DataSourceSummarySchema
+
+
+def _table(name, conn_name, conn_type="postgresql"):
+    return PromptTable(
+        name=name,
+        columns=[TableColumn(name="a", dtype="text"),
+                 TableColumn(name="b", dtype="text")],
+        pks=[], fks=[],
+        connection_name=conn_name,
+        connection_type=conn_type,
+        is_active=True,
+    )
+
+
+def _ds(n_conns, n_tables_each):
+    return TablesSchemaContext.DataSource(
+        info=DataSourceSummarySchema(id="ds-1", name="Big Agent", type="postgresql"),
+        tables=[
+            _table(f"schema_{c:03d}.table_{t:03d}", f"warehouse_{c:03d}")
+            for c in range(n_conns) for t in range(n_tables_each)
+        ],
+    )
+
+
+def _roster_names(xml):
+    named = re.findall(r'<connection c="[^"]*" name="([^"]+)"', xml)
+    for blob in re.findall(r'<more_connections count="\d+">([^<]*)</more_connections>', xml):
+        named += [n.strip() for n in blob.split(",") if n.strip()]
+    return named
+
+
+@pytest.mark.parametrize("n_conns,n_each", [(3, 5), (12, 100), (100, 100)])
+def test_every_connection_is_named_in_the_roster(n_conns, n_each):
+    ds = _ds(n_conns, n_each)
+    xml = ds._render_connections_roster_xml()
+    assert f'<connections count="{n_conns}">' in xml
+    names = _roster_names(xml)
+    assert len(names) == n_conns, f"{n_conns - len(names)} connections unnamed"
+    assert names[0] == "warehouse_000" and names[-1] == f"warehouse_{n_conns - 1:03d}"
+    # The tool that reaches the truncated tail must be named for the model.
+    assert "describe_tables" in xml
+
+
+def test_single_connection_agent_pays_nothing():
+    """No roster and no per-item alias when there is nothing to disambiguate."""
+    ds = _ds(1, 20)
+    assert ds._render_connections_roster_xml() == ""
+    index = ds._render_names_index(200)
+    assert ' c="' not in index
+
+
+def test_index_truncation_keeps_every_connection_present():
+    """1000-item cap over 100x100: each connection keeps a share rather than
+    ninety of them being cut entirely."""
+    ds = _ds(100, 100)
+    index = ds._render_names_index(1000)
+    assert 'truncated="true"' in index and 'count="10000"' in index
+    items = re.findall(r"<item [^>]*/>", index)
+    assert len(items) == 1000
+    aliases = {re.search(r'\sc="([^"]+)"', i).group(1) for i in items}
+    assert len(aliases) == 100, f"only {len(aliases)} of 100 connections survived truncation"
+
+
+def test_alias_is_cheaper_than_the_name_it_replaces():
+    ds = _ds(100, 100)
+    index = ds._render_names_index(1000)
+    alias_bytes = sum(len(m) for m in re.findall(r'\sc="[^"]*"', index))
+    # What spelling the name out on every item would have cost.
+    name_bytes = sum(
+        len(' connection="%s"' % t.connection_name) for t in ds.tables[:1000]
+    )
+    # Measured 6,920B vs 27,000B here — a 74% cut, and this is the WORST case:
+    # these fixture names are 13 characters. A real name like "Production
+    # Snowflake EU-West Analytics" widens the gap, because the alias stays
+    # 1-3 digits however long the name is.
+    assert alias_bytes < name_bytes * 0.35, (
+        f"alias {alias_bytes}B vs names {name_bytes}B — saving is only "
+        f"{100 * (1 - alias_bytes / name_bytes):.0f}%"
+    )
+    # And the saving must grow, not shrink, with realistic names.
+    long_names = sum(
+        len(' connection="Production Snowflake EU-West Analytics"')
+        for _ in ds.tables[:1000]
+    )
+    assert alias_bytes < long_names * 0.15
+
+
+def test_roster_is_built_from_the_scoped_tables_not_the_agents_connections():
+    """A connection the caller cannot see contributes no tables, so it must
+    contribute no roster entry — otherwise the roster re-leaks exactly what the
+    per-connection scoping withholds."""
+    ds = _ds(3, 4)
+    # Simulate scoping having dropped connection 001 entirely.
+    ds.tables = [t for t in ds.tables if t.connection_name != "warehouse_001"]
+    names = _roster_names(ds._render_connections_roster_xml())
+    assert names == ["warehouse_000", "warehouse_002"]
+    assert "warehouse_001" not in ds._render_connections_roster_xml()

--- a/backend/tests/unit/test_overlay_connection_migration.py
+++ b/backend/tests/unit/test_overlay_connection_migration.py
@@ -1,0 +1,258 @@
+"""overlayconn01 must round-trip, including over rows the new key legalizes.
+
+`user_data_source_tables` was keyed on (data_source_id, user_id, table_name).
+Per-connection overlays add connection_id to that key, which makes two rows
+with the same table name legal — one per connection. Recreating the old, narrow
+constraint on the way down then failed outright:
+
+    sqlite3.IntegrityError: UNIQUE constraint failed:
+      user_data_source_tables.data_source_id, ..., table_name
+
+so any deployment that had actually used the feature could not be rolled back.
+The downgrade reconciles those duplicates first: accessible beats inaccessible
+for a name, lowest id breaks remaining ties.
+
+Run:
+    cd backend
+    BOW_DATABASE_URL=sqlite:///db/app.db \
+      python -m pytest tests/unit/test_overlay_connection_migration.py -v
+"""
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic import op  # noqa: F401  (imported for its side effects on context)
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+import importlib.util
+
+
+REV = Path(__file__).resolve().parents[2] / "alembic" / "versions" / \
+    "overlayconn01_per_connection_user_overlay.py"
+
+
+def _load_revision():
+    spec = importlib.util.spec_from_file_location("overlayconn01_rev", REV)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# The pre-migration schema, only as far as this migration touches it. Built
+# from metadata rather than raw DDL so it is correct on both dialects (a
+# `BOOLEAN DEFAULT 1` is fine in SQLite and a type error in PostgreSQL).
+def _pre_metadata() -> sa.MetaData:
+    md = sa.MetaData()
+    sa.Table("connections", md, sa.Column("id", sa.String(36), primary_key=True))
+    sa.Table(
+        "connection_tables", md,
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("connection_id", sa.String(36)),
+    )
+    sa.Table(
+        "datasource_tables", md,
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("connection_table_id", sa.String(36)),
+    )
+    sa.Table(
+        "user_data_source_tables", md,
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("data_source_id", sa.String(36), nullable=False),
+        sa.Column("user_id", sa.String(36), nullable=False),
+        sa.Column("table_name", sa.String, nullable=False),
+        sa.Column("data_source_table_id", sa.String(36)),
+        sa.Column("is_accessible", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("status", sa.String, nullable=False, server_default="accessible"),
+        sa.Column("metadata_json", sa.JSON),
+        sa.UniqueConstraint(
+            "data_source_id", "user_id", "table_name", name="uq_user_ds_table"
+        ),
+    )
+    sa.Table(
+        "user_data_source_columns", md,
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("user_data_source_table_id", sa.String(36), nullable=False),
+        sa.Column("column_name", sa.String, nullable=False),
+        sa.Column("is_accessible", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("is_masked", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("data_type", sa.String),
+    )
+    return md
+
+
+def _pg_url():
+    """A PostgreSQL to also run against, when one is offered.
+
+    SQLite rebuilds the table for every constraint change and PostgreSQL alters
+    it in place, so the two exercise genuinely different code in
+    batch_alter_table — a downgrade that passes on one can still fail on the
+    other."""
+    return os.environ.get("BOW_TEST_PG_URL")
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def engine(request, tmp_path):
+    if request.param == "postgres":
+        url = _pg_url()
+        if not url:
+            pytest.skip("set BOW_TEST_PG_URL to also run against PostgreSQL")
+        eng = sa.create_engine(url)
+        schema = f"mig_{uuid.uuid4().hex[:8]}"
+        with eng.begin() as conn:
+            conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        eng = sa.create_engine(
+            url, connect_args={"options": f"-csearch_path={schema}"}
+        )
+    else:
+        eng = sa.create_engine(f"sqlite:///{tmp_path/'mig.db'}")
+    _pre_metadata().create_all(eng)
+    return eng
+
+
+def _run(engine, fn):
+    """Run one migration function against a live connection, the way alembic
+    does — `op` is a module-level proxy bound to the current context."""
+    mod = _load_revision()
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            getattr(mod, fn)()
+
+
+def _seed_shared_dataset(engine, ds="ds-1", user="u-1"):
+    """One user, one agent, the same table name on two connections."""
+    rows = []
+    with engine.begin() as conn:
+        for i, cname in enumerate(("conn-a", "conn-b")):
+            conn.execute(sa.text(
+                "INSERT INTO connections (id) VALUES (:i)"), {"i": cname})
+            ct = f"ct-{i}"
+            dst = f"dst-{i}"
+            conn.execute(sa.text(
+                "INSERT INTO connection_tables (id, connection_id) VALUES (:i, :c)"),
+                {"i": ct, "c": cname})
+            conn.execute(sa.text(
+                "INSERT INTO datasource_tables (id, connection_table_id) VALUES (:i, :c)"),
+                {"i": dst, "c": ct})
+            rows.append((f"row-{i}", dst, cname))
+    return rows
+
+
+def _insert_overlay(engine, row_id, ds, user, name, dst=None, accessible=True):
+    with engine.begin() as conn:
+        conn.execute(sa.text(
+            """INSERT INTO user_data_source_tables
+               (id, data_source_id, user_id, table_name, data_source_table_id,
+                is_accessible, status)
+               VALUES (:id, :ds, :u, :n, :dst, :acc, 'accessible')"""),
+            {"id": row_id, "ds": ds, "u": user, "n": name, "dst": dst,
+             "acc": accessible})
+        conn.execute(sa.text(
+            """INSERT INTO user_data_source_columns
+               (id, user_data_source_table_id, column_name)
+               VALUES (:id, :t, 'id')"""),
+            {"id": f"col-{row_id}", "t": row_id})
+
+
+def _overlay_rows(engine):
+    """(id, table_name, is_accessible) — the shape both schemas share.
+
+    is_accessible is normalized to bool: SQLite hands back 1/0."""
+    with engine.connect() as conn:
+        return [(r[0], r[1], bool(r[2])) for r in conn.execute(sa.text(
+            "SELECT id, table_name, is_accessible "
+            "FROM user_data_source_tables ORDER BY id"
+        ))]
+
+
+def _connection_ids(engine):
+    with engine.connect() as conn:
+        return {r[0]: r[1] for r in conn.execute(sa.text(
+            "SELECT id, connection_id FROM user_data_source_tables"))}
+
+
+def _columns(engine):
+    with engine.connect() as conn:
+        return {c["name"] for c in sa.inspect(conn).get_columns("user_data_source_tables")}
+
+
+def _constraints(engine):
+    with engine.connect() as conn:
+        insp = sa.inspect(conn)
+        return {c["name"] for c in insp.get_unique_constraints("user_data_source_tables")} | \
+               {i["name"] for i in insp.get_indexes("user_data_source_tables")}
+
+
+def test_upgrade_backfills_connection_id(engine):
+    rows = _seed_shared_dataset(engine)
+    for i, (row_id, dst, _conn) in enumerate(rows[:1]):
+        _insert_overlay(engine, row_id, "ds-1", "u-1", "orders", dst=dst)
+
+    _run(engine, "upgrade")
+
+    assert "connection_id" in _columns(engine)
+    assert "uq_user_ds_conn_table" in _constraints(engine)
+    assert _overlay_rows(engine) == [("row-0", "orders", True)]
+    assert _connection_ids(engine) == {"row-0": "conn-a"}
+
+
+def test_upgrade_is_repeatable(engine):
+    _seed_shared_dataset(engine)
+    _run(engine, "upgrade")
+    _run(engine, "upgrade")
+    assert "uq_user_ds_conn_table" in _constraints(engine)
+
+
+def test_downgrade_reconciles_cross_connection_duplicates(engine):
+    """The row the new key legalizes: same name, same user, two connections."""
+    rows = _seed_shared_dataset(engine)
+    _insert_overlay(engine, "row-0", "ds-1", "u-1", "orders", dst=rows[0][1])
+    _run(engine, "upgrade")
+    # Only legal AFTER the upgrade — this is the row that broke the downgrade.
+    _insert_overlay(engine, "row-1", "ds-1", "u-1", "orders", dst=rows[1][1])
+    with engine.begin() as conn:
+        conn.execute(sa.text(
+            "UPDATE user_data_source_tables SET connection_id='conn-b' WHERE id='row-1'"))
+
+    _run(engine, "downgrade")
+
+    assert "connection_id" not in _columns(engine)
+    assert "uq_user_ds_table" in _constraints(engine)
+    assert _overlay_rows(engine) == [("row-0", "orders", True)]
+    # Orphaned columns went with the row they belonged to.
+    with engine.connect() as conn:
+        kept = [r[0] for r in conn.execute(sa.text(
+            "SELECT user_data_source_table_id FROM user_data_source_columns"))]
+    assert kept == ["row-0"]
+
+
+def test_downgrade_prefers_the_accessible_row(engine):
+    """Losing the connection dimension must not silently revoke access: the
+    accessible answer wins even when it sorts second."""
+    rows = _seed_shared_dataset(engine)
+    _insert_overlay(engine, "row-0", "ds-1", "u-1", "orders",
+                    dst=rows[0][1], accessible=False)
+    _run(engine, "upgrade")
+    _insert_overlay(engine, "row-1", "ds-1", "u-1", "orders",
+                    dst=rows[1][1], accessible=True)
+    with engine.begin() as conn:
+        conn.execute(sa.text(
+            "UPDATE user_data_source_tables SET connection_id='conn-b' WHERE id='row-1'"))
+
+    _run(engine, "downgrade")
+
+    assert _overlay_rows(engine) == [("row-1", "orders", True)]
+
+
+def test_downgrade_keeps_distinct_names(engine):
+    rows = _seed_shared_dataset(engine)
+    _insert_overlay(engine, "row-0", "ds-1", "u-1", "orders", dst=rows[0][1])
+    _run(engine, "upgrade")
+    _insert_overlay(engine, "row-1", "ds-1", "u-1", "customers", dst=rows[1][1])
+
+    _run(engine, "downgrade")
+
+    assert sorted(r[1] for r in _overlay_rows(engine)) == ["customers", "orders"]

--- a/backend/tests/unit/test_overlay_connection_migration.py
+++ b/backend/tests/unit/test_overlay_connection_migration.py
@@ -101,8 +101,13 @@ def engine(request, tmp_path):
             pytest.skip("set BOW_TEST_PG_URL to also run against PostgreSQL")
         eng = sa.create_engine(url)
         schema = f"mig_{uuid.uuid4().hex[:8]}"
-        with eng.begin() as conn:
-            conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        try:
+            with eng.begin() as conn:
+                conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        except sa.exc.OperationalError as e:
+            # A configured-but-unreachable PostgreSQL is an environment
+            # problem, not a failure of the migration under test.
+            pytest.skip(f"PostgreSQL at BOW_TEST_PG_URL is unreachable: {e}")
         eng = sa.create_engine(
             url, connect_args={"options": f"-csearch_path={schema}"}
         )

--- a/backend/tests/unit/test_overlay_inactive_canonical_context.py
+++ b/backend/tests/unit/test_overlay_inactive_canonical_context.py
@@ -84,12 +84,28 @@ async def _user_with_overlay(db, ds, email, table_names):
     return user
 
 
+def _force_delegated(monkeypatch):
+    """Treat every connection on the agent as one this user runs delegated on.
+
+    The fixture seeds a `user_required` connection but no credentials, so the
+    real classifier resolves 'none'. Patch the SHARED classifier rather than a
+    builder-private method: it is the seam the builder actually consults (and
+    the one the tables selector consults too), so this test keeps testing the
+    production path instead of a stub that has drifted away from it.
+    """
+    from app.services.data_source_service import DataSourceService
+
+    async def _classify(self, db, data_source, current_user):
+        conns = getattr(data_source, "connections", None) or []
+        return [], [str(c.id) for c in conns], []
+
+    monkeypatch.setattr(DataSourceService, "classify_connection_access", _classify)
+
+
 async def _agent_tables(db, org, ds, user, monkeypatch, **build_kwargs):
     builder = SchemaContextBuilder(db, [ds], org, None, user=user)
 
-    async def _user_access(_ds):
-        return "user"
-    monkeypatch.setattr(builder, "_resolve_user_access", _user_access)
+    _force_delegated(monkeypatch)
     ctx = await builder.build(with_stats=False, **build_kwargs)
     return {getattr(t, "name", None)
             for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])}
@@ -113,9 +129,7 @@ async def test_activating_canonical_row_surfaces_overlay_table_with_user_columns
 
     builder = SchemaContextBuilder(db, [ds], org, None, user=user)
 
-    async def _user_access(_ds):
-        return "user"
-    monkeypatch.setattr(builder, "_resolve_user_access", _user_access)
+    _force_delegated(monkeypatch)
     ctx = await builder.build(with_stats=False)
     tables = {getattr(t, "name", None)
               for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])}
@@ -194,9 +208,7 @@ async def test_relationship_targets_restricted_to_activated_tables(db, monkeypat
 
     builder = SchemaContextBuilder(db, [ds], org, None, user=user)
 
-    async def _user_access(_ds):
-        return "user"
-    monkeypatch.setattr(builder, "_resolve_user_access", _user_access)
+    _force_delegated(monkeypatch)
     ctx = await builder.build(with_stats=False)
     a_tables = [t for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])
                 if getattr(t, "name", None) == "m/A"]
@@ -214,9 +226,7 @@ async def test_active_only_false_still_emits_inactive_overlay_table_flagged(db, 
 
     builder = SchemaContextBuilder(db, [ds], org, None, user=user)
 
-    async def _user_access(_ds):
-        return "user"
-    monkeypatch.setattr(builder, "_resolve_user_access", _user_access)
+    _force_delegated(monkeypatch)
     ctx = await builder.build(with_stats=False, active_only=False)
     rows = [t for dss in ctx.data_sources for t in (getattr(dss, "tables", []) or [])]
     assert [getattr(t, "name", None) for t in rows] == ["m/A"]

--- a/backend/tests/unit/test_refresh_overlay_prefetch.py
+++ b/backend/tests/unit/test_refresh_overlay_prefetch.py
@@ -2,6 +2,10 @@
 just fetched with the SAME user's credentials, instead of re-crawling the
 source. On tabular OBO sources (Power BI / Fabric) each crawl is a full
 tenant walk — the duplicate fetch doubled every "Reload tables" click.
+
+The sync fans out over every per-user connection on the agent, so these
+exercise the per-connection catalog seam (`_construct_user_catalog_client`)
+rather than the old single-client `construct_client`.
 """
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,15 +24,25 @@ def _table(name="SalesModel/Customers"):
     )
 
 
+def _delegated_ds(conn_id="conn-uuid", ds_id="ds-uuid"):
+    """An agent with exactly one delegated connection — the shape that makes
+    a legacy plain-list `prefetched_tables` attributable."""
+    conn = MagicMock(id=conn_id, type="powerbi", auth_policy="user_required")
+    return MagicMock(id=ds_id, connections=[conn]), conn
+
+
 @pytest.mark.asyncio
 async def test_prefetched_tables_skip_live_fetch():
     """With prefetched_tables provided, no client is constructed and no live
     aget_schemas call happens — the overlay is built from the handed-in list."""
     svc = DataSourceService()
+    svc._construct_user_catalog_client = AsyncMock(
+        side_effect=AssertionError("must not re-crawl the source")
+    )
     svc.construct_client = AsyncMock(side_effect=AssertionError("must not re-crawl the source"))
     svc._upsert_user_overlay = AsyncMock()
 
-    ds = MagicMock(id="ds-uuid")
+    ds, _conn = _delegated_ds()
     user = MagicMock(id="user-uuid")
 
     out = await svc.get_user_data_source_schema(
@@ -43,18 +57,40 @@ async def test_prefetched_tables_skip_live_fetch():
 
 
 @pytest.mark.asyncio
+async def test_prefetch_keyed_by_connection_skips_live_fetch():
+    """The fan-out form: a dict keyed by connection id is reused for that
+    connection without re-crawling."""
+    svc = DataSourceService()
+    svc._construct_user_catalog_client = AsyncMock(
+        side_effect=AssertionError("must not re-crawl the source")
+    )
+    svc._upsert_user_overlay = AsyncMock()
+
+    ds, conn = _delegated_ds()
+
+    out = await svc.get_user_data_source_schema(
+        db=MagicMock(), data_source=ds, user=MagicMock(id="u"),
+        prefetched_tables={conn.id: [_table("Keyed/Table")]},
+    )
+
+    assert [t.name for t in out] == ["Keyed/Table"]
+
+
+@pytest.mark.asyncio
 async def test_no_prefetch_falls_back_to_live_fetch():
     svc = DataSourceService()
     client = MagicMock()
     client.aget_schemas = AsyncMock(return_value=[_table("Live/Table")])
-    svc.construct_client = AsyncMock(return_value=client)
+    svc._construct_user_catalog_client = AsyncMock(return_value=client)
     svc._upsert_user_overlay = AsyncMock()
 
+    ds, _conn = _delegated_ds()
+
     out = await svc.get_user_data_source_schema(
-        db=MagicMock(), data_source=MagicMock(id="ds"), user=MagicMock(id="u"),
+        db=MagicMock(), data_source=ds, user=MagicMock(id="u"),
     )
 
-    svc.construct_client.assert_awaited_once()
+    svc._construct_user_catalog_client.assert_awaited_once()
     assert [t.name for t in out] == ["Live/Table"]
 
 
@@ -63,11 +99,30 @@ async def test_empty_prefetch_returns_empty_without_live_fetch():
     """An empty prefetched list means the user's own crawl saw nothing —
     same handling as a live fetch returning nothing (no fallback re-crawl)."""
     svc = DataSourceService()
-    svc.construct_client = AsyncMock(side_effect=AssertionError("must not re-crawl the source"))
+    svc._construct_user_catalog_client = AsyncMock(
+        side_effect=AssertionError("must not re-crawl the source")
+    )
     svc._upsert_user_overlay = AsyncMock()
 
+    ds, _conn = _delegated_ds()
+
     out = await svc.get_user_data_source_schema(
-        db=MagicMock(), data_source=MagicMock(id="ds"), user=MagicMock(id="u"),
+        db=MagicMock(), data_source=ds, user=MagicMock(id="u"),
         prefetched_tables=[],
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_no_per_user_connections_returns_empty():
+    """A system_only agent has one shared catalog — nothing to sync per user."""
+    svc = DataSourceService()
+    svc._construct_user_catalog_client = AsyncMock(
+        side_effect=AssertionError("must not re-crawl the source")
+    )
+    ds = MagicMock(id="ds", connections=[MagicMock(id="c", type="postgresql", auth_policy="system_only")])
+
+    out = await svc.get_user_data_source_schema(
+        db=MagicMock(), data_source=ds, user=MagicMock(id="u"),
     )
     assert out == []


### PR DESCRIPTION
An agent with 2+ connections often showed only one connection's tables.

`get_data_source_schema_paginated` decided ONCE per data source, from
`data_source.connections[0]`, whether to scope rows to the caller's
per-user overlay. Two failures fell out of that, and which one you got
depended on the order the database happened to return the connections in
— the relationship had no ORDER BY, so it could differ between requests
on the same agent:

  * delegated connection first — the whole catalog was filtered through
    an overlay that only ever described that one connection (the sync
    built its client with `construct_client`, documented as "first
    connection only"), so every other connection's tables vanished from
    the rows, the counts and the filter dropdowns. This is the reported
    bug.

  * delegated connection second — no scoping was applied at all, so one
    user saw another user's delegated Power BI models.

Resolve the scope per connection instead (`_resolve_catalog_scope`):
each connection lands in open / overlay-scoped / denied on its own auth
policy and this caller's own access, and every count, page, total and
filter dropdown runs through the same predicate, so a row can no longer
be hidden from the grid while still being counted in "Showing 1-20 of N"
or named in the schema dropdown.

The overlay itself is now connection-aware end to end:

- `user_data_source_tables` gains `connection_id` (backfilled through
  connection_tables; unique key widened to include it, so two
  connections exposing the same table name no longer collide).
- `get_user_data_source_schema` fans out over every per-user connection
  instead of building one client for `connections[0]`, and
  `_upsert_user_overlay` reconciles per connection — syncing one
  connection no longer revokes another's rows.
- Canonical-row lookup is connection-scoped, so an `orders` on one
  connection can't link to an `orders` on another.
- Rows a delegated user discovered themselves (no ConnectionTable to
  link to) carry their connection as provenance, so they render with the
  right connection and the connection filter reaches them.

The legacy non-paginated `get_data_source_schema` returned EITHER the
overlay OR the canonical catalog; on a mixed agent that dropped the
other connections. It now merges them — overlay tables (which carry
per-user column masking) for delegated connections, canonical tables for
the open ones.

Also: per-connection live connection tests in
`build_user_status_for_connection` (it was reporting connection A's
reachability as connection B's status), and a deterministic `order_by`
on `DataSource.connections` so the remaining `connections[0]` callers are
at least reproducible.

Verified end to end against a real Postgres, a real SQLite and a real
delegated Power BI/Entra connection on one agent, with two signed-in
users: before, a member saw 18 tables (Power BI only); after, 27 (5
Postgres + 4 SQLite + 18 Power BI), with each user seeing only their own
Power BI models.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ks6uuXjodLpo8TFCFfQMJm