### PR TITLE
Stop the agent losing context to a session race, and let the DB pool drain

### DIFF
--- a/backend/app/ai/agent_v2.py
+++ b/backend/app/ai/agent_v2.py
@@ -1041,6 +1041,33 @@ class AgentV2:
         except Exception:
             return ()
 
+    def _mlog(self, label: str) -> None:
+        """Run-progress log line, timestamped against the start of the run.
+
+        This used to be a closure defined inside ``main_execution``, but two
+        call sites outside that frame referenced it — ``_persist_focus_on_use``
+        and ``_ensure_clients_for_attached`` — where the name does not resolve.
+        Both sit inside ``except Exception`` blocks, so the resulting
+        ``NameError: name '_mlog' is not defined`` was caught and relabelled as
+        the failure of whatever the block was guarding, on the *success* path:
+
+          - focus-on-use logged ``focus-on-use: commit failed`` after the commit
+            had already succeeded (8 times across a 10-agent run here), then ran
+            a no-op rollback;
+          - building a client for a mid-run attached agent logged
+            ``mid-run client construction failed`` for a client that was built
+            and registered fine.
+
+        Both messages point an operator at the opposite of what happened, and
+        they masked genuine failures of the same paths. Being a method keeps it
+        in scope everywhere.
+        """
+        import time as _time
+        t0 = getattr(self, "_run_t0", None)
+        rid = str(self.report_id)[:8] if self.report else "?"
+        elapsed = f" +{(_time.monotonic() - t0) * 1000:.0f}ms" if t0 else ""
+        logger.info(f"[agent:{rid}] {label}{elapsed}")
+
     async def _ensure_clients_for_attached(self) -> None:
         """Build query clients for agents attached AFTER run start (approved
         set_report_agents expansion) — without this create_data against the new
@@ -1060,7 +1087,7 @@ class AgentV2:
                     if built:
                         self.clients.update(built)
                         self.data_sources.append(ds)
-                        _mlog(f"mid-run client built for {ds.name}")
+                        self._mlog(f"mid-run client built for {ds.name}")
                 except Exception:
                     logger.exception("mid-run client construction failed for %s", getattr(ds, "name", "?"))
         except Exception:
@@ -1120,13 +1147,18 @@ class AgentV2:
             self.db.add(self.report)
             await self.db.commit()
             self._focus_set_by_use = True
-            _mlog(f"focus_on_use persisted={merged} via {tool_name}")
         except Exception:
             logger.exception("focus-on-use: commit failed")
             try:
                 await self.db.rollback()
             except Exception:
                 pass
+            return
+        # Outside the try on purpose: this block guards the commit, and anything
+        # raised by the success log would otherwise be reported as the commit
+        # having failed — which is exactly what happened while `_mlog` was an
+        # out-of-scope name here.
+        self._mlog(f"focus_on_use persisted={merged} via {tool_name}")
 
     def _resolve_instruction_scope_ids(self) -> Optional[List[str]]:
         """Data-source scope for the standing <instructions> block.
@@ -3983,10 +4015,9 @@ class AgentV2:
                 logger.warning("[headers] failed to rebuild planner LLM with membership identity", exc_info=True)
         try:
             import time as _time
-            _t0 = _time.monotonic()
-            _rid = str(self.report_id)[:8] if self.report else "?"
-            def _mlog(label):
-                logger.info(f"[agent:{_rid}] {label} +{(_time.monotonic()-_t0)*1000:.0f}ms")
+            # Anchor the run clock that self._mlog() reports elapsed against.
+            self._run_t0 = _time.monotonic()
+            _mlog = self._mlog
 
             # Start agent execution tracking
             self.current_execution = await self.project_manager.start_agent_execution(

--- a/backend/app/ai/context/context_hub.py
+++ b/backend/app/ai/context/context_hub.py
@@ -827,8 +827,14 @@ class ContextHub:
         previous answer ("now break that down by month") got an agent that had
         forgotten the thing it was refining.
 
-        Serializing costs nothing because there was no parallelism to lose, and
-        anything that still fails is logged at WARNING with the section named
+        Serializing costs nothing because there was no parallelism to lose:
+        benchmarked over three interleaved repetitions of 40 refreshes on a warm
+        session, p50 was 14.34 ms gathered versus 14.19 ms serialized. (On a
+        session that has just committed, the gathered version *is* a few ms
+        faster — because a builder that loses the race returns an empty section
+        without running its query at all.)
+
+        Anything that still fails is logged at WARNING with the section named
         instead of vanishing into a ``return_exceptions`` tuple. Returns results
         positionally, exceptions included, so callers keep their existing shape.
         """

--- a/backend/app/ai/context/context_hub.py
+++ b/backend/app/ai/context/context_hub.py
@@ -1,6 +1,7 @@
 """
 ContextHub - Main orchestrator for all agent context.
 """
+import asyncio
 import json
 import logging
 import time
@@ -290,6 +291,10 @@ class ContextHub:
         mode: Optional[str] = None,
     ):
         self.db = db
+        # Guards `self.db` across the context builders. Every builder here is
+        # constructed with this one AsyncSession, and an AsyncSession is not
+        # safe for concurrent use — see `_run_builders`.
+        self._db_lock = asyncio.Lock()
         self.organization = organization
         self.organization_settings = organization_settings
         self.data_sources = data_sources
@@ -699,7 +704,6 @@ class ContextHub:
             The user's query/prompt. If provided, enables intelligent instruction
             search to find relevant instructions beyond just 'always' load mode.
         """
-        import asyncio
         _t0 = time.monotonic()
 
         async def _timed(name, coro):
@@ -777,15 +781,16 @@ class ContextHub:
             _INSTRUCTIONS_CACHE[instr_key] = (time.monotonic(), built)
             return built
 
-        # Run static builders in parallel; schemas/instructions come from
-        # the cache when warm.
-        schemas, instructions, resources, files = await asyncio.gather(
-            _build_or_get_schemas(),
-            _build_or_get_instructions(),
-            _timed("resources", self.resource_builder.build()),
-            _timed("files", self.files_builder.build()),
-            return_exceptions=True,
-        )
+        # Static builders share self.db too, so they run serially for the same
+        # reason as the warm ones — see _run_builders. The stakes are higher
+        # here: a lost section is the schema or the instructions, and the agent
+        # would go on to plan against a connection it thinks has no tables.
+        schemas, instructions, resources, files = await self._run_builders("prime_static", [
+            ("schemas", _build_or_get_schemas()),
+            ("instructions", _build_or_get_instructions()),
+            ("resources", _timed("resources", self.resource_builder.build())),
+            ("files", _timed("files", self.files_builder.build())),
+        ])
         _hub_logger.info(f"[context_hub:prime_static] all_done +{(time.monotonic()-_t0)*1000:.0f}ms")
 
         # Store results (handle exceptions gracefully)
@@ -795,12 +800,58 @@ class ContextHub:
         self._static_cache["resources"] = resources if not isinstance(resources, Exception) else None
         self._static_cache["files"] = files if not isinstance(files, Exception) else None
 
+    async def _run_builders(self, phase: str, builders):
+        """Run context builders that share ``self.db``, one at a time.
+
+        These used to go through ``asyncio.gather(..., return_exceptions=True)``,
+        which was wrong twice over.
+
+        It was never parallel. Every builder is constructed with the *same*
+        AsyncSession, which owns exactly one DBAPI connection, so their queries
+        could not have overlapped on the wire even in principle. What overlapped
+        was the bookkeeping around them — and an AsyncSession rejects that:
+        whichever builder called ``execute()`` while another was still
+        provisioning the connection got ``This session is provisioning a new
+        connection; concurrent operations are not permitted``. The window is
+        widest when the session holds no connection yet, which is precisely the
+        state ``agent_v2._release_db_between_steps()`` leaves it in before each
+        loop iteration's refresh — so this fired on ordinary turns, not just
+        under load. Measured against Postgres: every one of 20 refreshes
+        following a commit lost at least one section, and a 10-agent concurrent
+        run logged 26 swallowed occurrences across 98 refreshes.
+
+        And the damage was silent. Each builder catches its own failure and
+        returns an empty section, so the planner was handed
+        ``<queries>``-with-no-items — the agent's record of what it had already
+        queried — as though the report genuinely had none. A user refining a
+        previous answer ("now break that down by month") got an agent that had
+        forgotten the thing it was refining.
+
+        Serializing costs nothing because there was no parallelism to lose, and
+        anything that still fails is logged at WARNING with the section named
+        instead of vanishing into a ``return_exceptions`` tuple. Returns results
+        positionally, exceptions included, so callers keep their existing shape.
+        """
+        results = []
+        async with self._db_lock:
+            for name, coro in builders:
+                try:
+                    results.append(await coro)
+                except Exception as exc:
+                    _hub_logger.warning(
+                        "[context_hub:%s] %s builder failed — that section will be "
+                        "missing from the planner's context: %r",
+                        phase, name, exc, exc_info=True,
+                    )
+                    results.append(exc)
+        return results
+
     async def refresh_warm(self) -> None:
         """Rebuild warm sections each loop (messages, queries, observations, entities).
 
-        Runs builders in parallel where possible for faster refresh.
+        Builders run one at a time — see `_run_builders` for why gathering them
+        was never actually parallel.
         """
-        import asyncio
         _t0 = time.monotonic()
 
         async def _timed(name, coro):
@@ -828,20 +879,20 @@ class ContextHub:
         except Exception:
             user_text = ""
 
-        # Run all warm builders in parallel
-        messages, queries, mentions, entities = await asyncio.gather(
-            _timed("messages", self.message_builder.build(max_messages=DEFAULT_CONTEXT_LIMITS["messages_max"])),
-            _timed("queries", self.query_builder.build(max_queries=5, include_data_preview=allow_llm_see_data)),
-            _timed("mentions", self.mention_builder.build()),
-            _timed("entities", self.entity_builder.build_for_turn(
+        # Warm builders all share self.db, so they run serially — see
+        # _run_builders.
+        messages, queries, mentions, entities = await self._run_builders("refresh_warm", [
+            ("messages", _timed("messages", self.message_builder.build(max_messages=DEFAULT_CONTEXT_LIMITS["messages_max"]))),
+            ("queries", _timed("queries", self.query_builder.build(max_queries=5, include_data_preview=allow_llm_see_data))),
+            ("mentions", _timed("mentions", self.mention_builder.build())),
+            ("entities", _timed("entities", self.entity_builder.build_for_turn(
                 top_k=5,
                 require_source_assoc=True,
                 user_text=user_text,
                 allow_llm_see_data=allow_llm_see_data,
                 data_source_ids=self._run_agent_ids(),
-            )),
-            return_exceptions=True,
-        )
+            ))),
+        ])
         _hub_logger.info(f"[context_hub:refresh_warm] all_done +{(time.monotonic()-_t0)*1000:.0f}ms")
         
         # Build observations synchronously (it's fast, no DB calls)

--- a/backend/app/ai/context/context_hub.py
+++ b/backend/app/ai/context/context_hub.py
@@ -696,7 +696,10 @@ class ContextHub:
     async def prime_static(self, query: str | None = None) -> None:
         """Build and cache static sections once (schemas, instructions, code, resources).
 
-        Runs all builders in parallel for faster startup.
+        Holds ``self._db_lock`` for its whole body — see ``_run_builders``.
+        ``agent_v2`` gathers this with ``refresh_warm()`` on the same hub and the
+        same session at startup, so every touch of ``self.db`` here, including
+        ``_instruction_query()``, has to be inside the guard.
 
         Parameters
         ----------
@@ -704,6 +707,11 @@ class ContextHub:
             The user's query/prompt. If provided, enables intelligent instruction
             search to find relevant instructions beyond just 'always' load mode.
         """
+        async with self._db_lock:
+            await self._prime_static_locked(query)
+
+    async def _prime_static_locked(self, query: str | None = None) -> None:
+        """Body of ``prime_static``; runs with ``self._db_lock`` held."""
         _t0 = time.monotonic()
 
         async def _timed(name, coro):
@@ -786,10 +794,10 @@ class ContextHub:
         # here: a lost section is the schema or the instructions, and the agent
         # would go on to plan against a connection it thinks has no tables.
         schemas, instructions, resources, files = await self._run_builders("prime_static", [
-            ("schemas", _build_or_get_schemas()),
-            ("instructions", _build_or_get_instructions()),
-            ("resources", _timed("resources", self.resource_builder.build())),
-            ("files", _timed("files", self.files_builder.build())),
+            ("schemas", _build_or_get_schemas),
+            ("instructions", _build_or_get_instructions),
+            ("resources", lambda: _timed("resources", self.resource_builder.build())),
+            ("files", lambda: _timed("files", self.files_builder.build())),
         ])
         _hub_logger.info(f"[context_hub:prime_static] all_done +{(time.monotonic()-_t0)*1000:.0f}ms")
 
@@ -802,6 +810,14 @@ class ContextHub:
 
     async def _run_builders(self, phase: str, builders):
         """Run context builders that share ``self.db``, one at a time.
+
+        **The caller must already hold ``self._db_lock``.** The lock lives at the
+        public entry points (``prime_static`` / ``refresh_warm``) rather than
+        here, because those methods touch the session outside the builder list
+        too — ``_instruction_query()``, the org-settings read, the scheduled-tasks
+        read — and ``agent_v2`` gathers both methods concurrently on one hub at
+        startup. Guarding only this loop left those reads racing, which is the
+        same failure one layer up.
 
         These used to go through ``asyncio.gather(..., return_exceptions=True)``,
         which was wrong twice over.
@@ -837,27 +853,46 @@ class ContextHub:
         Anything that still fails is logged at WARNING with the section named
         instead of vanishing into a ``return_exceptions`` tuple. Returns results
         positionally, exceptions included, so callers keep their existing shape.
+
+        ``builders`` is a list of ``(name, factory)`` where ``factory`` is a
+        zero-argument callable returning the coroutine. Building each coroutine
+        only when its turn comes means a cancellation part-way through leaves no
+        never-awaited coroutine objects behind to surface as ``RuntimeWarning``
+        during loop teardown.
         """
+        if not self._db_lock.locked():
+            raise RuntimeError(
+                "_run_builders requires self._db_lock to be held by the caller "
+                "(see its docstring — the lock must span the whole of "
+                "prime_static/refresh_warm, not just the builder list)"
+            )
         results = []
-        async with self._db_lock:
-            for name, coro in builders:
-                try:
-                    results.append(await coro)
-                except Exception as exc:
-                    _hub_logger.warning(
-                        "[context_hub:%s] %s builder failed — that section will be "
-                        "missing from the planner's context: %r",
-                        phase, name, exc, exc_info=True,
-                    )
-                    results.append(exc)
+        for name, factory in builders:
+            try:
+                results.append(await factory())
+            except Exception as exc:
+                _hub_logger.warning(
+                    "[context_hub:%s] %s builder failed — that section will be "
+                    "missing from the planner's context: %r",
+                    phase, name, exc, exc_info=True,
+                )
+                results.append(exc)
         return results
 
     async def refresh_warm(self) -> None:
         """Rebuild warm sections each loop (messages, queries, observations, entities).
 
         Builders run one at a time — see `_run_builders` for why gathering them
-        was never actually parallel.
+        was never actually parallel. The lock spans the whole body, not just the
+        builder list: the org-settings read below and the scheduled-tasks read at
+        the end touch the same session, and ``agent_v2`` gathers this with
+        ``prime_static()`` at startup.
         """
+        async with self._db_lock:
+            await self._refresh_warm_locked()
+
+    async def _refresh_warm_locked(self) -> None:
+        """Body of ``refresh_warm``; runs with ``self._db_lock`` held."""
         _t0 = time.monotonic()
 
         async def _timed(name, coro):
@@ -888,10 +923,10 @@ class ContextHub:
         # Warm builders all share self.db, so they run serially — see
         # _run_builders.
         messages, queries, mentions, entities = await self._run_builders("refresh_warm", [
-            ("messages", _timed("messages", self.message_builder.build(max_messages=DEFAULT_CONTEXT_LIMITS["messages_max"]))),
-            ("queries", _timed("queries", self.query_builder.build(max_queries=5, include_data_preview=allow_llm_see_data))),
-            ("mentions", _timed("mentions", self.mention_builder.build())),
-            ("entities", _timed("entities", self.entity_builder.build_for_turn(
+            ("messages", lambda: _timed("messages", self.message_builder.build(max_messages=DEFAULT_CONTEXT_LIMITS["messages_max"]))),
+            ("queries", lambda: _timed("queries", self.query_builder.build(max_queries=5, include_data_preview=allow_llm_see_data))),
+            ("mentions", lambda: _timed("mentions", self.mention_builder.build())),
+            ("entities", lambda: _timed("entities", self.entity_builder.build_for_turn(
                 top_k=5,
                 require_source_assoc=True,
                 user_text=user_text,

--- a/backend/app/settings/database.py
+++ b/backend/app/settings/database.py
@@ -33,6 +33,75 @@ def _get_test_database_url() -> str:
     return os.environ.get("TEST_DATABASE_URL", settings.TEST_DATABASE_URL)
 
 
+# Default pool geometry for the production async engine, per uvicorn worker.
+# The effective ceiling against the database is
+# ``(pool_size + max_overflow) * workers * replicas`` — size it under the
+# server's ``max_connections - superuser_reserved_connections`` (stock Postgres
+# is 100 - 3 = 97). Exceeding it does NOT surface as a QueuePool timeout: the
+# server refuses the connect outright with "remaining connection slots are
+# reserved for roles with the SUPERUSER attribute", which then surfaces to
+# users as a failed agent run.
+DEFAULT_DB_POOL_SIZE = 20
+DEFAULT_DB_MAX_OVERFLOW = 20
+
+
+def _env_pool_int(name: str, default: int) -> int:
+    """Read a pool-geometry override from the environment.
+
+    These were hardcoded, so an operator hitting connection-slot exhaustion had
+    no lever short of editing the image. Invalid or negative values fall back to
+    the default rather than failing startup.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not an integer; using %d", name, raw, default)
+        return default
+    if value < 0:
+        logger.warning("%s=%d is negative; using %d", name, value, default)
+        return default
+    return value
+
+
+def _pool_size() -> int:
+    return _env_pool_int("BOW_DB_POOL_SIZE", DEFAULT_DB_POOL_SIZE)
+
+
+def _max_overflow() -> int:
+    return _env_pool_int("BOW_DB_MAX_OVERFLOW", DEFAULT_DB_MAX_OVERFLOW)
+
+
+def _idle_session_timeout_ms() -> int:
+    """Server-side idle-session reaping, in ms. 0 (the default) disables it.
+
+    A QueuePool never shrinks on its own: `pool_recycle` is applied lazily at
+    checkout and *replaces* a stale connection rather than closing it, and
+    SQLAlchemy has no idle-pool reaper. So once a burst has grown the pool to
+    `pool_size`, that many Postgres backends stay open for the life of the
+    worker. Measured here against a local PG16: after a 40-way burst the pool
+    sat at 20 open backends indefinitely under light traffic, with or without
+    `pool_use_lifo`.
+
+    Letting the *server* close sessions idle past this timeout is what actually
+    drains it; `pool_pre_ping` (enabled below) then detects the closed socket at
+    next checkout and reconnects transparently. With the timeout at 5s and one
+    query/second of traffic, the same pool settled at 4 open backends under FIFO
+    checkout and 1 under LIFO.
+
+    OFF BY DEFAULT because `idle_session_timeout` is PostgreSQL 14+, and an
+    unrecognised GUC passed as a startup parameter makes *every* connection fail
+    with `UndefinedObjectError` — so enabling it blindly would hard-break
+    deployments on older servers. Operators on 14+ opt in with
+    BOW_DB_IDLE_SESSION_TIMEOUT_MS (the Helm chart, which bundles PG 17, sets
+    it). Keep it far longer than any gap between queries on a busy worker —
+    minutes, not seconds — or the pool churns reconnects instead of draining.
+    """
+    return _env_pool_int("BOW_DB_IDLE_SESSION_TIMEOUT_MS", 0)
+
+
 def _get_database_url() -> str:
     """Resolve the database URL from config, supporting IAM auth providers."""
     db = settings.bow_config.database
@@ -243,6 +312,14 @@ def _build_async_database_engine():
             server_settings = connect_args.setdefault("server_settings", {})
             server_settings.setdefault("lock_timeout", "30000")
             server_settings.setdefault("idle_in_transaction_session_timeout", "300000")
+            #   - idle_session_timeout: lets the server close sessions the pool
+            #     is holding but not using, so a quiet worker's backends drain
+            #     instead of pinning `pool_size` slots forever. Off unless the
+            #     operator opts in — see `_idle_session_timeout_ms` for why
+            #     (PG 14+ only; an unknown GUC here fails every connect).
+            _idle_ms = _idle_session_timeout_ms()
+            if _idle_ms > 0:
+                server_settings.setdefault("idle_session_timeout", str(_idle_ms))
             # PostgreSQL: use connection pooling for production
             # Pool sizing assumes one uvicorn worker. Each in-flight SSE
             # completion holds the agent's primary session for its entire
@@ -253,11 +330,22 @@ def _build_async_database_engine():
             engine = create_async_engine(
                 database_url,
                 echo=False,
-                pool_size=20,          # connections per worker
-                max_overflow=20,       # extra under load
+                pool_size=_pool_size(),          # connections per worker
+                max_overflow=_max_overflow(),    # extra under load
                 pool_timeout=30,       # wait time for connection
                 pool_recycle=1800,     # recycle every 30min (avoids stale connections)
                 pool_pre_ping=True,    # check connection health before use
+                # LIFO checkout: hand back the most recently used connection
+                # instead of round-robining through the whole pool, so steady
+                # light traffic concentrates on a few connections and the tail
+                # goes genuinely idle. On its own this does NOT reduce open
+                # backends (nothing closes a pooled connection) — it multiplies
+                # what `idle_session_timeout` above can reclaim: measured on a
+                # 20-connection pool under one query/second, FIFO settled at 4
+                # open backends and LIFO at 1. Mirrors the data-source pool,
+                # which sets it for the same reason
+                # (data_sources/engine_pool.py).
+                pool_use_lifo=True,
                 connect_args=connect_args,
             )
             if db_config.uses_iam_auth:

--- a/backend/tests/unit/test_context_hub_session_serialization.py
+++ b/backend/tests/unit/test_context_hub_session_serialization.py
@@ -9,17 +9,19 @@ concurrent operations are not permitted``.
 
 The window is widest when the session holds no connection yet — exactly the
 state ``agent_v2._release_db_between_steps()`` leaves it in before each loop
-iteration's refresh. Measured: 100% of refreshes that followed a commit lost at
-least one section, and 27% across a 10-agent concurrent run.
+iteration's refresh. Measured: every one of 20 refreshes that followed a commit
+lost at least one section.
 
 The damage was silent. Each builder catches its own failure and returns an empty
 section, so the planner was handed a ``<queries>`` section with no items — the
 agent's record of what it had already queried — as though the report genuinely
 had none.
 
-These tests pin the two properties that fix depends on: the builders are
-entered one at a time, and a builder that does fail is reported rather than
-swallowed.
+Guarding only the builder list was not enough, which is what these tests now
+pin. Both public methods touch the session *outside* their builder list
+(``_instruction_query()``, the org-settings read, the scheduled-tasks read), and
+``agent_v2`` gathers the two methods concurrently on one hub at startup — so the
+same race survived one layer up until the lock moved to the public entry points.
 """
 import asyncio
 import logging
@@ -30,7 +32,7 @@ from app.ai.context.context_hub import ContextHub
 
 
 def _bare_hub():
-    """A ContextHub with only what ``_run_builders`` touches.
+    """A ContextHub with only what the locking machinery touches.
 
     The real constructor wires a dozen builders against live ORM objects; this
     exercises the serialization contract without that apparatus.
@@ -38,6 +40,22 @@ def _bare_hub():
     hub = object.__new__(ContextHub)
     hub._db_lock = asyncio.Lock()
     return hub
+
+
+class _ConcurrencyTracker:
+    """Records the peak number of overlapping sections."""
+
+    def __init__(self):
+        self._active = 0
+        self.max_concurrency = 0
+
+    async def section(self, hold=0.01):
+        self._active += 1
+        self.max_concurrency = max(self.max_concurrency, self._active)
+        try:
+            await asyncio.sleep(hold)
+        finally:
+            self._active -= 1
 
 
 class _SharedSessionBuilder:
@@ -50,10 +68,8 @@ class _SharedSessionBuilder:
     def __init__(self):
         self._active = 0
         self.max_concurrency = 0
-        self.calls = 0
 
     async def build(self, value):
-        self.calls += 1
         self._active += 1
         self.max_concurrency = max(self.max_concurrency, self._active)
         try:
@@ -68,18 +84,75 @@ class _SharedSessionBuilder:
             self._active -= 1
 
 
+# --------------------------------------------------------------------------
+# The public lifecycle: what agent_v2 actually does at startup
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prime_static_and_refresh_warm_serialize_against_each_other():
+    """``agent_v2`` gathers these two on one hub and one session:
+
+        await asyncio.gather(
+            self.context_hub.prime_static(query=prompt_text),
+            self.context_hub.refresh_warm(),
+        )
+
+    So the guard has to sit at the public entry points. Stubbing the locked
+    bodies keeps this pinned to lock *placement* rather than to the shape of the
+    builder graph underneath.
+    """
+    hub = _bare_hub()
+    tracker = _ConcurrencyTracker()
+
+    async def fake_prime(query=None):
+        await tracker.section()
+
+    async def fake_warm():
+        await tracker.section()
+
+    hub._prime_static_locked = fake_prime
+    hub._refresh_warm_locked = fake_warm
+
+    await asyncio.gather(hub.prime_static(query="q"), hub.refresh_warm())
+
+    assert tracker.max_concurrency == 1, (
+        "prime_static and refresh_warm overlapped on the shared session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_builders_refuses_to_run_without_the_lock():
+    """The lock moved to the callers, so a direct call must not silently skip it.
+
+    Without this, re-introducing the original gap — guarding only the builder
+    list while the surrounding session reads run free — would pass unnoticed.
+    """
+    hub = _bare_hub()
+
+    async def ok():
+        return "fine"
+
+    with pytest.raises(RuntimeError, match="_db_lock"):
+        await hub._run_builders("refresh_warm", [("messages", ok)])
+
+
+# --------------------------------------------------------------------------
+# Inside one phase
+# --------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_builders_sharing_a_session_are_serialized():
-    """The whole point: one builder in flight at a time, every section returned."""
+    """One builder in flight at a time, every section returned."""
     shared = _SharedSessionBuilder()
     hub = _bare_hub()
 
-    results = await hub._run_builders("refresh_warm", [
-        ("messages", shared.build("messages")),
-        ("queries", shared.build("queries")),
-        ("mentions", shared.build("mentions")),
-        ("entities", shared.build("entities")),
-    ])
+    async with hub._db_lock:
+        results = await hub._run_builders("refresh_warm", [
+            ("messages", lambda: shared.build("messages")),
+            ("queries", lambda: shared.build("queries")),
+            ("mentions", lambda: shared.build("mentions")),
+            ("entities", lambda: shared.build("entities")),
+        ])
 
     assert shared.max_concurrency == 1, "builders overlapped on the shared session"
     assert results == ["messages", "queries", "mentions", "entities"]
@@ -91,7 +164,7 @@ async def test_gathering_the_same_builders_would_race():
     """Guards that the serialization above is actually load-bearing.
 
     If this ever stops racing, the fake no longer models the hazard and the
-    test above proves nothing.
+    tests above prove nothing.
     """
     shared = _SharedSessionBuilder()
 
@@ -141,10 +214,11 @@ async def test_failing_builder_is_reported_not_swallowed():
     hub_logger.addHandler(handler)
     try:
         hub = _bare_hub()
-        results = await hub._run_builders("prime_static", [
-            ("schemas", ok()),
-            ("instructions", boom()),
-        ])
+        async with hub._db_lock:
+            results = await hub._run_builders("prime_static", [
+                ("schemas", ok),
+                ("instructions", boom),
+            ])
     finally:
         hub_logger.removeHandler(handler)
         hub_logger.disabled = was_disabled
@@ -166,10 +240,55 @@ async def test_lock_is_released_when_a_builder_raises():
         return "second refresh ran"
 
     hub = _bare_hub()
-    await hub._run_builders("refresh_warm", [("messages", boom())])
+    async with hub._db_lock:
+        await hub._run_builders("refresh_warm", [("messages", boom)])
     assert not hub._db_lock.locked()
 
-    results = await asyncio.wait_for(
-        hub._run_builders("refresh_warm", [("messages", ok())]), timeout=1.0
+    async def second():
+        async with hub._db_lock:
+            return await hub._run_builders("refresh_warm", [("messages", ok)])
+
+    assert await asyncio.wait_for(second(), timeout=1.0) == ["second refresh ran"]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_leaves_no_unstarted_coroutines():
+    """Builders are built on demand, so a cancelled phase orphans nothing.
+
+    When every coroutine was constructed up front, cancelling during the first
+    await left the rest never-awaited, surfacing as ``RuntimeWarning: coroutine
+    ... was never awaited`` during later event-loop cleanup. Asserting that the
+    later factory is never *called* is the deterministic form of that check —
+    the warning itself only fires at garbage-collection time.
+    """
+    hub = _bare_hub()
+    built_later = []
+
+    async def slow():
+        await asyncio.sleep(10)
+
+    def first_factory():
+        return slow()
+
+    def second_factory():
+        built_later.append("second")
+        return slow()
+
+    async def runner():
+        async with hub._db_lock:
+            await hub._run_builders("refresh_warm", [
+                ("messages", first_factory),
+                ("queries", second_factory),
+            ])
+
+    task = asyncio.create_task(runner())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert built_later == [], (
+        "a later builder's coroutine was constructed before its turn, so "
+        "cancellation orphaned it"
     )
-    assert results == ["second refresh ran"]
+    assert not hub._db_lock.locked(), "cancellation stranded the session lock"

--- a/backend/tests/unit/test_context_hub_session_serialization.py
+++ b/backend/tests/unit/test_context_hub_session_serialization.py
@@ -1,0 +1,175 @@
+"""Regression: context builders must not collide on the hub's shared session.
+
+Production failure class (reproduced against Postgres in a live sandbox):
+``ContextHub.refresh_warm`` and ``prime_static`` ran their builders under
+``asyncio.gather(..., return_exceptions=True)``. Every builder is constructed
+with the *same* ``AsyncSession``, which is not safe for concurrent use, so the
+overlapping calls raised ``This session is provisioning a new connection;
+concurrent operations are not permitted``.
+
+The window is widest when the session holds no connection yet — exactly the
+state ``agent_v2._release_db_between_steps()`` leaves it in before each loop
+iteration's refresh. Measured: 100% of refreshes that followed a commit lost at
+least one section, and 27% across a 10-agent concurrent run.
+
+The damage was silent. Each builder catches its own failure and returns an empty
+section, so the planner was handed a ``<queries>`` section with no items — the
+agent's record of what it had already queried — as though the report genuinely
+had none.
+
+These tests pin the two properties that fix depends on: the builders are
+entered one at a time, and a builder that does fail is reported rather than
+swallowed.
+"""
+import asyncio
+import logging
+
+import pytest
+
+from app.ai.context.context_hub import ContextHub
+
+
+def _bare_hub():
+    """A ContextHub with only what ``_run_builders`` touches.
+
+    The real constructor wires a dozen builders against live ORM objects; this
+    exercises the serialization contract without that apparatus.
+    """
+    hub = object.__new__(ContextHub)
+    hub._db_lock = asyncio.Lock()
+    return hub
+
+
+class _SharedSessionBuilder:
+    """Mimics a builder bound to one AsyncSession.
+
+    Overlapping calls raise the way SQLAlchemy does for concurrent operations
+    on a single session; serialized callers never collide.
+    """
+
+    def __init__(self):
+        self._active = 0
+        self.max_concurrency = 0
+        self.calls = 0
+
+    async def build(self, value):
+        self.calls += 1
+        self._active += 1
+        self.max_concurrency = max(self.max_concurrency, self._active)
+        try:
+            if self._active > 1:
+                raise RuntimeError(
+                    "This session is provisioning a new connection; "
+                    "concurrent operations are not permitted"
+                )
+            await asyncio.sleep(0.005)  # widen the overlap window
+            return value
+        finally:
+            self._active -= 1
+
+
+@pytest.mark.asyncio
+async def test_builders_sharing_a_session_are_serialized():
+    """The whole point: one builder in flight at a time, every section returned."""
+    shared = _SharedSessionBuilder()
+    hub = _bare_hub()
+
+    results = await hub._run_builders("refresh_warm", [
+        ("messages", shared.build("messages")),
+        ("queries", shared.build("queries")),
+        ("mentions", shared.build("mentions")),
+        ("entities", shared.build("entities")),
+    ])
+
+    assert shared.max_concurrency == 1, "builders overlapped on the shared session"
+    assert results == ["messages", "queries", "mentions", "entities"]
+    assert not any(isinstance(r, Exception) for r in results)
+
+
+@pytest.mark.asyncio
+async def test_gathering_the_same_builders_would_race():
+    """Guards that the serialization above is actually load-bearing.
+
+    If this ever stops racing, the fake no longer models the hazard and the
+    test above proves nothing.
+    """
+    shared = _SharedSessionBuilder()
+
+    results = await asyncio.gather(
+        shared.build("messages"),
+        shared.build("queries"),
+        shared.build("mentions"),
+        shared.build("entities"),
+        return_exceptions=True,
+    )
+
+    assert shared.max_concurrency > 1, "expected the builders to overlap"
+    assert any(isinstance(r, Exception) for r in results), (
+        "expected at least one section to be lost to the race"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failing_builder_is_reported_not_swallowed():
+    """A failure names its section in the log and comes back positionally.
+
+    The old ``return_exceptions=True`` tuple was unpacked straight into
+    ``x if not isinstance(x, Exception) else None``, so a lost section left no
+    trace anywhere.
+
+    Captures via an explicit handler rather than ``caplog``, and re-enables the
+    logger for the duration: the test configuration leaves the app's loggers
+    with ``disabled = True``, so neither ``caplog`` nor a plain handler sees
+    anything until that is lifted.
+    """
+    async def ok():
+        return "fine"
+
+    async def boom():
+        raise RuntimeError("builder exploded")
+
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture(level=logging.WARNING)
+    hub_logger = logging.getLogger("app.ai.context.context_hub")
+    was_disabled = hub_logger.disabled
+    hub_logger.disabled = False
+    hub_logger.addHandler(handler)
+    try:
+        hub = _bare_hub()
+        results = await hub._run_builders("prime_static", [
+            ("schemas", ok()),
+            ("instructions", boom()),
+        ])
+    finally:
+        hub_logger.removeHandler(handler)
+        hub_logger.disabled = was_disabled
+
+    assert results[0] == "fine"
+    assert isinstance(results[1], RuntimeError)
+    text = "\n".join(records)
+    assert "instructions" in text, f"section not named in log: {text!r}"
+    assert "prime_static" in text, f"phase not named in log: {text!r}"
+
+
+@pytest.mark.asyncio
+async def test_lock_is_released_when_a_builder_raises():
+    """A failure must not strand the session lock and deadlock the next refresh."""
+    async def boom():
+        raise RuntimeError("first refresh failed")
+
+    async def ok():
+        return "second refresh ran"
+
+    hub = _bare_hub()
+    await hub._run_builders("refresh_warm", [("messages", boom())])
+    assert not hub._db_lock.locked()
+
+    results = await asyncio.wait_for(
+        hub._run_builders("refresh_warm", [("messages", ok())]), timeout=1.0
+    )
+    assert results == ["second refresh ran"]

--- a/backend/tests/unit/test_db_pool_config.py
+++ b/backend/tests/unit/test_db_pool_config.py
@@ -1,0 +1,65 @@
+"""The database pool geometry is operator-tunable, and must fail safe.
+
+These knobs exist because the pool was hardcoded at `pool_size=20,
+max_overflow=20`. The ceiling against the server is
+`(pool_size + max_overflow) * workers * replicas`, and `start.sh` runs up to 4
+workers — so a default deployment can ask for 160 connections against a stock
+PostgreSQL's 97 usable ones. The server then refuses the connect outright
+("remaining connection slots are reserved for roles with the SUPERUSER
+attribute") rather than queueing, which reaches the user as a failed agent run.
+An operator hitting that had no lever short of editing the image.
+
+A malformed value must never take the process down at import: these are read
+while the engine is being built, before anything can report a config error
+usefully.
+"""
+import pytest
+
+from app.settings import database as db
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in (
+        "BOW_DB_POOL_SIZE",
+        "BOW_DB_MAX_OVERFLOW",
+        "BOW_DB_IDLE_SESSION_TIMEOUT_MS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def test_defaults_when_unset(env):
+    assert db._pool_size() == db.DEFAULT_DB_POOL_SIZE
+    assert db._max_overflow() == db.DEFAULT_DB_MAX_OVERFLOW
+    # Idle reaping stays off unless asked for: the GUC behind it is PG 14+, and
+    # an unrecognised startup parameter fails every connection.
+    assert db._idle_session_timeout_ms() == 0
+
+
+def test_overrides_are_honoured(env):
+    env.setenv("BOW_DB_POOL_SIZE", "5")
+    env.setenv("BOW_DB_MAX_OVERFLOW", "3")
+    env.setenv("BOW_DB_IDLE_SESSION_TIMEOUT_MS", "600000")
+    assert db._pool_size() == 5
+    assert db._max_overflow() == 3
+    assert db._idle_session_timeout_ms() == 600000
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "twenty", "20.5", "-1"])
+def test_unusable_values_fall_back_to_the_default(env, raw):
+    """Empty, non-numeric and negative all fall back rather than raise."""
+    env.setenv("BOW_DB_POOL_SIZE", raw)
+    assert db._pool_size() == db.DEFAULT_DB_POOL_SIZE
+
+
+def test_zero_pool_size_is_allowed(env):
+    """0 is a legitimate SQLAlchemy pool_size (unbounded), so keep it."""
+    env.setenv("BOW_DB_POOL_SIZE", "0")
+    assert db._pool_size() == 0
+
+
+def test_zero_disables_idle_reaping(env):
+    """0 is the documented 'off' switch, not a value to pass to the server."""
+    env.setenv("BOW_DB_IDLE_SESSION_TIMEOUT_MS", "0")
+    assert db._idle_session_timeout_ms() == 0

--- a/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
+++ b/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
@@ -77,6 +77,33 @@ made it deterministic:
 | `entities` section `None` | **20/20** | **0/20** |
 | `refresh_warm` wall-clock | 14 ms | 13 ms |
 
+### Guarding the builder list alone was not enough
+
+The first fix put the lock inside `_run_builders`, which left the same race one
+layer up. Both public methods touch the session *outside* their builder list —
+`_instruction_query()` in `prime_static`, the org-settings read and the
+scheduled-tasks read in `refresh_warm` — and `agent_v2` gathers the two methods
+concurrently on one hub at startup (`agent_v2.py:4119-4122`):
+
+```python
+await asyncio.gather(
+    self.context_hub.prime_static(query=prompt_text),
+    self.context_hub.refresh_warm(),
+)
+```
+
+Caught in review. Measured over five runs each, queries visible to the planner:
+
+| lifecycle | lock in `_run_builders` | lock at the entry points |
+|---|---|---|
+| **concurrent prime + warm, cold session** | **0, 0, 0, 0, 0** | **2, 2, 2, 2, 2** |
+| concurrent prime + warm, connected session | 2, 2, 2, 2, 2 | 2, 2, 2, 2, 2 |
+| sequential prime + warm, cold session | 2, 2, 2, 2, 2 | 2, 2, 2, 2, 2 |
+| standalone warm refresh, cold session | 2, 2, 2, 2, 2 | 2, 2, 2, 2, 2 |
+
+The lock now spans the whole of both public methods, and `_run_builders` raises
+if a caller has not taken it.
+
 ### The damage was invisible
 
 Each builder catches its own failure and returns an empty section, so nothing
@@ -175,8 +202,21 @@ reclaim, by concentrating traffic so the tail goes genuinely idle.
 **`idle_session_timeout` is PostgreSQL 14+, and an unrecognised GUC passed as a
 startup parameter makes every connection fail** (verified —
 `UndefinedObjectError`). It is therefore off by default and opt-in via
-`BOW_DB_IDLE_SESSION_TIMEOUT_MS`; the Helm chart, which bundles PostgreSQL 17,
-sets it.
+`BOW_DB_IDLE_SESSION_TIMEOUT_MS`.
+
+The chart defaults it on, but **only for the bundled subchart** (PostgreSQL 17,
+a version we control). An earlier revision defaulted it in `values.yaml`, which
+review caught: the ConfigMap emitted it for external databases too, so an
+existing deployment pointed at an external PostgreSQL 13 would have had every
+connection fail on upgrade — reintroducing through Helm exactly the hard break
+the backend default was written to avoid. It is now conditioned on
+`postgresql.enabled` and an empty `database.host`, and an operator on an
+external 14+ server opts in explicitly.
+
+Also caught in review: the ConfigMap tested these values by truthiness, so a
+deliberate `maxOverflow: 0` was dropped and the backend fell back to its own
+default of 20 — 25 connections per worker where five were asked for. The
+template now tests for unset explicitly, with render coverage for numeric zero.
 
 ## Finding 3 — single-writer mode on Postgres is harmful (do not enable it)
 

--- a/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
+++ b/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
@@ -95,9 +95,37 @@ aren't dependent on each other" complaint, and it is not a prompting problem.
 ### There was never any parallelism to lose
 
 Four builders sharing one session share one DBAPI connection, so their queries
-could not overlap on the wire even in principle. The `gather` bought nothing and
-cost correctness; wall-clock is unchanged (14 ms → 13 ms isolated, p50 149 ms →
-170 ms under 10-way concurrency, within run-to-run noise).
+could not overlap on the wire even in principle.
+
+Measured directly, interleaving the two versions over three repetitions of 40
+refreshes each, on a warm session where neither version races (so both produce
+the same two populated sections):
+
+| `refresh_warm` p50 | rep 1 | rep 2 | rep 3 |
+|---|---|---|---|
+| `gather` | 14.39 ms | 14.26 ms | 14.38 ms |
+| serialized | 14.55 ms | 13.94 ms | 14.09 ms |
+
+No measurable cost — the serialized version is marginally *ahead* on two of
+three reps, well inside run-to-run noise.
+
+On the cold path (a session that has just committed, i.e. the real loop path)
+the raw numbers do differ, and the comparison is not like-for-like:
+
+| cold session | p50 | sections populated |
+|---|---|---|
+| `gather` | 11.21 ms | **1 of 4** |
+| serialized | 14.30 ms | **2 of 4** |
+
+The racing version is ~3 ms faster *because it is failing*: a builder that loses
+the race returns an empty section immediately instead of running its query. The
+extra 3 ms is the cost of actually doing the work that used to be silently
+dropped, not overhead introduced by the lock.
+
+A caveat on end-to-end numbers: agent wall-clock across sandbox runs ranged
+29–88 s for the *same* context code, tracking LLM call volume (58 vs 107 calls
+between two 10-agent runs). End-to-end timings here cannot resolve a few ms per
+refresh, which is why the isolated benchmark above is the one to trust.
 
 Under load it got worse, as the window widens: a 10-agent concurrent run logged
 **26 swallowed concurrency errors across 98 refreshes**, versus 2 across 15 on a

--- a/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
+++ b/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
@@ -1,0 +1,216 @@
+# Sandbox Feedback Loop — silent context loss in the agent loop, and what actually drains the connection pool
+
+Investigated from a customer report on self-hosted Kubernetes with PostgreSQL:
+runs failing with
+
+```
+Agent failed: remaining connection slots are reserved for roles with the SUPERUSER attribute
+```
+
+and, on a later turn, the same failure wearing a different mask:
+
+```
+Agent failed: This Session's transaction has been rolled back due to a previous
+exception during flush. ... Original exception was: remaining connection slots
+are reserved ...
+```
+
+The customer's other complaint, on the same report, was that the agent kept
+losing the thread — "the parameters aren't dependent on each other, and the
+period doesn't update". That turned out to be the same investigation.
+
+## Environment
+
+Real PostgreSQL, because SQLite models neither pools nor the session semantics
+at issue. Sized to the customer's exact shape (stock server defaults).
+
+```bash
+PGBIN=/usr/lib/postgresql/16/bin; PGDATA=/var/lib/postgresql/bowpg
+runuser -u postgres -- $PGBIN/initdb -D $PGDATA --auth=trust -U postgres
+runuser -u postgres -- $PGBIN/pg_ctl -D $PGDATA \
+  -o "-p 55432 -c max_connections=100 -c listen_addresses='127.0.0.1'" -l $PGDATA/pg.log start
+runuser -u postgres -- psql -h 127.0.0.1 -p 55432 -U postgres -c "create database bow;"
+
+cd backend
+export BOW_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:55432/bow"
+export BOW_ENCRYPTION_KEY=<fernet> ENVIRONMENT=production
+uv run alembic upgrade head && uv run python main.py
+```
+
+`max_connections=100`, `superuser_reserved_connections=3` → **97 usable**.
+Seeded via the API: user + org, an Anthropic provider with *only* Claude 4.5
+Haiku enabled (so it is both default and small-default), and a `postgresql` data
+source pointing at a second database with a 4 000-row `services` table. Agent
+turns were driven through `POST /api/reports/{id}/completions` with
+`stream: true`, i.e. the real SSE path.
+
+## Finding 1 — `refresh_warm` raced on the agent's session, and lost context silently
+
+`ContextHub.refresh_warm` ran its four warm builders under
+`asyncio.gather(..., return_exceptions=True)`. All four are constructed with the
+**same** `AsyncSession` (`context_hub.py:352-356`, fed `self.db` from
+`agent_v2.py:754`). An `AsyncSession` is not safe for concurrent use, so the
+overlapping calls raised:
+
+```
+ERROR app.ai.context.builders.query_context_builder:
+Failed to load queries for report ...: This session is provisioning a new
+connection; concurrent operations are not permitted
+```
+
+This fired on the **first live turn**. `prime_static` had the identical shape,
+with higher stakes — a lost section there is the schema or the instructions.
+
+### The trigger is the pool-release optimisation
+
+An isolated probe showed **0 errors**, which was the clue. The builders only
+collide while the session is *provisioning* a connection — and the widest such
+window is when the session holds no connection at all. That is exactly the state
+`agent_v2._release_db_between_steps()` leaves it in: it commits before each loop
+iteration, which returns the connection to the pool. Modelling that in the probe
+made it deterministic:
+
+| probe (20 rounds) | racing `gather` | serialized |
+|---|---|---|
+| swallowed concurrency errors | **40** | **0** |
+| `queries` section empty | **20/20** | **0/20** |
+| `entities` section `None` | **20/20** | **0/20** |
+| `refresh_warm` wall-clock | 14 ms | 13 ms |
+
+### The damage was invisible
+
+Each builder catches its own failure and returns an empty section, so nothing
+propagated. On a report with two saved queries:
+
+| | before | after |
+|---|---|---|
+| queries in the database | 2 | 2 |
+| **queries the planner actually sees** | **0**, in 10/10 refreshes | **2**, in 10/10 |
+
+The `<queries>` section is the agent's record of what it has already run. A user
+refining a previous answer — "now break that down by month" — was talking to an
+agent that had forgotten the thing it was refining. That is the "parameters
+aren't dependent on each other" complaint, and it is not a prompting problem.
+
+### There was never any parallelism to lose
+
+Four builders sharing one session share one DBAPI connection, so their queries
+could not overlap on the wire even in principle. The `gather` bought nothing and
+cost correctness; wall-clock is unchanged (14 ms → 13 ms isolated, p50 149 ms →
+170 ms under 10-way concurrency, within run-to-run noise).
+
+Under load it got worse, as the window widens: a 10-agent concurrent run logged
+**26 swallowed concurrency errors across 98 refreshes**, versus 2 across 15 on a
+single-agent run. (Errors, not refreshes — a single refresh can lose more than
+one section, so this bounds the rate rather than stating it.)
+
+## Finding 2 — nothing was draining the connection pool
+
+The headline error is *not* a `QueuePool` timeout. It is the server refusing the
+connect, which reaches the user as a failed run. The arithmetic:
+`(pool_size + max_overflow) × workers × replicas`, where `pool_size` and
+`max_overflow` were hardcoded at 20 each and `start.sh` runs up to 4 workers —
+160 against 97 usable.
+
+Worker count is itself accidental: the Helm chart sets `resources.requests.cpu`
+but no `limits.cpu`, so `start.sh`'s cgroup detection finds no quota and falls
+through to `nproc`, which reports the **node's** cores, not the request.
+
+### `pool_use_lifo` alone does nothing — that hypothesis was wrong
+
+The initial theory was that FIFO checkout keeps every slot recently-used so
+`pool_recycle` never retires any. Measured, both settle at the pool size and
+stay there:
+
+| 20-conn pool, after a 40-way burst, light traffic | open backends over 24 s |
+|---|---|
+| FIFO | 20, 20, 20, … 20 |
+| LIFO | 20, 20, 20, … 20 |
+
+`pool_recycle` is applied lazily at checkout and *replaces* a stale connection
+rather than closing it, and SQLAlchemy has no idle-pool reaper. **A QueuePool
+never shrinks.**
+
+### What actually drains it
+
+Letting the *server* close idle sessions. With `idle_session_timeout` set and
+`pool_pre_ping` (already enabled) reconnecting transparently:
+
+| 20-conn pool, `idle_session_timeout=5s`, 1 query/sec | settles at |
+|---|---|
+| FIFO | **4** open backends |
+| LIFO | **1** open backend |
+
+So `pool_use_lifo` is real but secondary: it multiplies what the timeout can
+reclaim, by concentrating traffic so the tail goes genuinely idle.
+
+**`idle_session_timeout` is PostgreSQL 14+, and an unrecognised GUC passed as a
+startup parameter makes every connection fail** (verified —
+`UndefinedObjectError`). It is therefore off by default and opt-in via
+`BOW_DB_IDLE_SESSION_TIMEOUT_MS`; the Helm chart, which bundles PostgreSQL 17,
+sets it.
+
+## Finding 3 — single-writer mode on Postgres is harmful (do not enable it)
+
+`_use_single_write_session()` is always on for SQLite and opt-in elsewhere. The
+plausible theory was that enabling it on Postgres would cut connection demand,
+since every background write otherwise opens its own pooled session. Measured
+across two 10-agent runs, it does the opposite:
+
+| 10 concurrent agents | legacy | single-writer |
+|---|---|---|
+| `got result for unknown protocol state` | **0** | **2**, then **4** |
+| `Exception terminating connection` | **0** | **2**, then **4** |
+| peak connections | 24 | 25 — *no gain* |
+| slowest agent | 61.6 s | 72.7 s |
+
+Funnelling every write through one `AsyncSession` while tool coroutines run
+concurrently corrupts the asyncpg connection. `_tool_db_lock` does not cover all
+of it. **`BOW_AGENT_SINGLE_WRITE_SESSION` must stay off on Postgres** until that
+is addressed; the win it was supposed to deliver is not there.
+
+(The code comment points at `docs/design/single-writer-agent-refactor.md`, which
+does not exist — the rollout rationale is lost.)
+
+## Finding 4 — `_mlog` was an out-of-scope name, inverting two error messages
+
+Found while benchmarking. `_mlog` was a closure inside `main_execution`, but two
+call sites outside that frame referenced it. Both sit inside `except Exception`
+blocks, so the `NameError` was caught and relabelled as the failure of whatever
+the block guarded — **on the success path**:
+
+- `_persist_focus_on_use` logged `focus-on-use: commit failed` *after the commit
+  had succeeded* (8 times in one 10-agent run), then ran a no-op rollback;
+- `_ensure_clients_for_attached` logged `mid-run client construction failed` for
+  a client that was built and registered fine.
+
+Both point an operator at the opposite of what happened, and both masked genuine
+failures of the same paths.
+
+## Result
+
+All four addressed; final 8-agent concurrent run on the same sandbox:
+
+```
+refresh_warm calls:        110      concurrency errors:       0
+prime_static calls:          8      sections lost:            0
+focus-on-use commit ERR:     0      NameError _mlog:          0
+protocol-state errors:       0      pool timeouts:            0
+TOTAL ERRORs:                0
+
+connections: max 25, idle after run 2   (was: max 30, idle after run 22)
+```
+
+## Still open
+
+1. **`limits.cpu` is unset in the chart**, so worker count follows the node's
+   core count rather than the CPU request. Not changed here — it alters the
+   resource contract of every existing deployment.
+2. **Single-writer on Postgres** (Finding 3) needs the concurrent-session hazard
+   fixed before the mode is usable there.
+3. **Background writes are unbounded per agent.** `_schedule_bg_write` has no
+   concurrency cap and `_pending_writes` is an unbounded list, so
+   "connections per agent" is emergent. `BOW_MAX_CONCURRENT_AGENTS` caps agents,
+   not connections.
+4. **`idle_session_timeout` is opt-in.** Auto-detecting server version at engine
+   build would let it default on, at the cost of a startup round-trip.

--- a/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
+++ b/docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md
@@ -204,14 +204,25 @@ startup parameter makes every connection fail** (verified —
 `UndefinedObjectError`). It is therefore off by default and opt-in via
 `BOW_DB_IDLE_SESSION_TIMEOUT_MS`.
 
-The chart defaults it on, but **only for the bundled subchart** (PostgreSQL 17,
-a version we control). An earlier revision defaulted it in `values.yaml`, which
-review caught: the ConfigMap emitted it for external databases too, so an
-existing deployment pointed at an external PostgreSQL 13 would have had every
-connection fail on upgrade — reintroducing through Helm exactly the hard break
-the backend default was written to avoid. It is now conditioned on
-`postgresql.enabled` and an empty `database.host`, and an operator on an
-external 14+ server opts in explicitly.
+The chart defaults it on, but **only where it can be certain the app is talking
+to the bundled subchart** (PostgreSQL 17, a version we control). Getting that
+condition right took two rounds of review, both times on the same asymmetry:
+missing the default costs a quiet worker some idle connections, while applying
+it to a server older than 14 fails every connection on upgrade.
+
+- The first revision defaulted it in `values.yaml`, so the ConfigMap emitted it
+  for external databases too — reintroducing through Helm exactly the hard break
+  the backend's opt-in default was written to avoid.
+- The second conditioned it on `postgresql.enabled` and an empty
+  `database.host`, which still missed the *documented* Secret install: with
+  `postgresql.auth.existingSecret` / `config.secretRef` set, the chart emits no
+  URL of its own and the Secret supplies `BOW_DATABASE_URL` — pointing anywhere
+  — while both of those values sit at their bundled defaults.
+
+The condition now mirrors the URL-generating branch exactly: password auth, the
+subchart enabled, no external `database.host`, and neither Secret path in play.
+An explicit setting always wins, which is how an operator on a known 14+ server
+opts in regardless of how the URL is supplied.
 
 Also caught in review: the ConfigMap tested these values by truthiness, so a
 deliberate `maxOverflow: 0` was dropped and the backend fell back to its own

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -209,6 +209,19 @@ The `Secret` is loaded after the ConfigMap via `envFrom`, so its values
 override any plaintext defaults from the ConfigMap. You only need to include
 the keys you want to set/override.
 
+Because the `Secret` can point `BOW_DATABASE_URL` at any server, the chart stops
+assuming the bundled PostgreSQL once `postgresql.auth.existingSecret` or
+`config.secretRef` is set, and leaves `config.database.idleSessionTimeoutMs`
+unset. That timeout lets the server close pooled connections a quiet worker is
+holding but not using, so they stop occupying `max_connections` slots. It needs
+**PostgreSQL 14+** — on older servers the parameter is rejected at connect time
+and every connection fails — so set it explicitly once you know your server's
+version:
+
+```bash
+--set config.database.idleSessionTimeoutMs=600000   # 10 minutes; PostgreSQL 14+
+```
+
 ### Microsoft Entra (Azure AD) with group sync
 
 ```yaml

--- a/k8s/chart/templates/config.yaml
+++ b/k8s/chart/templates/config.yaml
@@ -80,6 +80,16 @@ data:
   UVICORN_WORKERS: {{ .Values.config.uvicornWorkers | quote }}
   {{- end }}
 
+  {{- if .Values.config.database.poolSize }}
+  BOW_DB_POOL_SIZE: {{ .Values.config.database.poolSize | quote }}
+  {{- end }}
+  {{- if .Values.config.database.maxOverflow }}
+  BOW_DB_MAX_OVERFLOW: {{ .Values.config.database.maxOverflow | quote }}
+  {{- end }}
+  {{- if .Values.config.database.idleSessionTimeoutMs }}
+  BOW_DB_IDLE_SESSION_TIMEOUT_MS: {{ .Values.config.database.idleSessionTimeoutMs | quote }}
+  {{- end }}
+
   bowConfig: |
     # Deployment Configuration
     base_url: ${BOW_BASE_URL}

--- a/k8s/chart/templates/config.yaml
+++ b/k8s/chart/templates/config.yaml
@@ -97,15 +97,30 @@ data:
   {{- /*
     idle_session_timeout is PostgreSQL 14+, and an unrecognised startup parameter
     fails EVERY connection — so this may only default on for a server whose
-    version we control. That is the bundled subchart (PostgreSQL 17), i.e.
-    postgresql.enabled is not false and no external database.host is set.
-    Pointing the chart at an external server leaves it unset, and an operator on
-    14+ opts in by setting it; setting it explicitly always wins.
+    version we control: the bundled subchart (PostgreSQL 17).
+
+    "Bundled" means this ConfigMap itself emits a BOW_DATABASE_URL pointing at
+    `<release>-postgresql` AND nothing can replace it — mirror the conditions on
+    that URL above, and exclude both Secret paths. A Secret is the documented way
+    to supply BOW_DATABASE_URL (see k8s/README.md), and `config.secretRef` is
+    loaded after this ConfigMap via envFrom, so either one can point the app at
+    an external server of unknown version while every value tested here is still
+    at its default. Missing the default costs a quiet worker nothing but some
+    idle connections; getting it wrong fails every connection on upgrade.
+
+    An explicit setting always wins, which is how an operator on a known 14+
+    server opts in regardless of how the URL is supplied.
   */}}
   {{- $idle := .Values.config.database.idleSessionTimeoutMs }}
+  {{- $urlFromSecret := or (not (empty .Values.postgresql.auth.existingSecret)) (not (empty .Values.config.secretRef)) }}
+  {{- $bundledDb := and
+        (eq (default "password" .Values.database.auth.provider) "password")
+        (not (eq .Values.postgresql.enabled false))
+        (empty .Values.database.host)
+        (not $urlFromSecret) }}
   {{- if not (or (kindIs "invalid" $idle) (eq (toString $idle) "")) }}
   BOW_DB_IDLE_SESSION_TIMEOUT_MS: {{ $idle | quote }}
-  {{- else if and (not (eq .Values.postgresql.enabled false)) (empty .Values.database.host) }}
+  {{- else if $bundledDb }}
   BOW_DB_IDLE_SESSION_TIMEOUT_MS: "600000"
   {{- end }}
 

--- a/k8s/chart/templates/config.yaml
+++ b/k8s/chart/templates/config.yaml
@@ -80,14 +80,33 @@ data:
   UVICORN_WORKERS: {{ .Values.config.uvicornWorkers | quote }}
   {{- end }}
 
-  {{- if .Values.config.database.poolSize }}
-  BOW_DB_POOL_SIZE: {{ .Values.config.database.poolSize | quote }}
+  {{- /*
+    Test these for "unset" explicitly, not by truthiness: a numeric 0 is falsey
+    to Helm, so `if .poolSize` would drop an intentional `maxOverflow: 0` and
+    silently hand the backend its own default of 20 instead — 25 connections per
+    worker where the operator asked for 5.
+  */}}
+  {{- $pool := .Values.config.database.poolSize }}
+  {{- if not (or (kindIs "invalid" $pool) (eq (toString $pool) "")) }}
+  BOW_DB_POOL_SIZE: {{ $pool | quote }}
   {{- end }}
-  {{- if .Values.config.database.maxOverflow }}
-  BOW_DB_MAX_OVERFLOW: {{ .Values.config.database.maxOverflow | quote }}
+  {{- $overflow := .Values.config.database.maxOverflow }}
+  {{- if not (or (kindIs "invalid" $overflow) (eq (toString $overflow) "")) }}
+  BOW_DB_MAX_OVERFLOW: {{ $overflow | quote }}
   {{- end }}
-  {{- if .Values.config.database.idleSessionTimeoutMs }}
-  BOW_DB_IDLE_SESSION_TIMEOUT_MS: {{ .Values.config.database.idleSessionTimeoutMs | quote }}
+  {{- /*
+    idle_session_timeout is PostgreSQL 14+, and an unrecognised startup parameter
+    fails EVERY connection — so this may only default on for a server whose
+    version we control. That is the bundled subchart (PostgreSQL 17), i.e.
+    postgresql.enabled is not false and no external database.host is set.
+    Pointing the chart at an external server leaves it unset, and an operator on
+    14+ opts in by setting it; setting it explicitly always wins.
+  */}}
+  {{- $idle := .Values.config.database.idleSessionTimeoutMs }}
+  {{- if not (or (kindIs "invalid" $idle) (eq (toString $idle) "")) }}
+  BOW_DB_IDLE_SESSION_TIMEOUT_MS: {{ $idle | quote }}
+  {{- else if and (not (eq .Values.postgresql.enabled false)) (empty .Values.database.host) }}
+  BOW_DB_IDLE_SESSION_TIMEOUT_MS: "600000"
   {{- end }}
 
   bowConfig: |

--- a/k8s/chart/tests/config_test.yaml
+++ b/k8s/chart/tests/config_test.yaml
@@ -32,3 +32,32 @@ tests:
       - equal:
           path: data.BOW_TELEMETRY_ENABLED
           value: "true"
+
+  - it: sets the database pool env only for values that are set
+    asserts:
+      # idleSessionTimeoutMs ships with a default, so it is always rendered.
+      - equal:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+          value: "600000"
+      # poolSize / maxOverflow default to empty: the app's own defaults win and
+      # no env var is emitted at all.
+      - notExists:
+          path: data.BOW_DB_POOL_SIZE
+      - notExists:
+          path: data.BOW_DB_MAX_OVERFLOW
+
+  - it: renders the database pool env when the operator sizes it
+    set:
+      config.database.poolSize: 10
+      config.database.maxOverflow: 5
+      config.database.idleSessionTimeoutMs: 0
+    asserts:
+      - equal:
+          path: data.BOW_DB_POOL_SIZE
+          value: "10"
+      - equal:
+          path: data.BOW_DB_MAX_OVERFLOW
+          value: "5"
+      # 0 disables idle reaping — and must not be rendered as a stale default.
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS

--- a/k8s/chart/tests/config_test.yaml
+++ b/k8s/chart/tests/config_test.yaml
@@ -33,24 +33,67 @@ tests:
           path: data.BOW_TELEMETRY_ENABLED
           value: "true"
 
-  - it: sets the database pool env only for values that are set
+  - it: defaults the idle-session timeout on only for the bundled server
     asserts:
-      # idleSessionTimeoutMs ships with a default, so it is always rendered.
+      # The bundled subchart is PostgreSQL 17, so the GUC is known-supported.
       - equal:
           path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
           value: "600000"
-      # poolSize / maxOverflow default to empty: the app's own defaults win and
-      # no env var is emitted at all.
+      # Pool geometry stays unset so the app's own defaults apply.
       - notExists:
           path: data.BOW_DB_POOL_SIZE
       - notExists:
           path: data.BOW_DB_MAX_OVERFLOW
 
+  - it: leaves the idle-session timeout unset for an external database
+    set:
+      database.host: rds.example.com
+    asserts:
+      # idle_session_timeout is PostgreSQL 14+ and an unrecognised startup
+      # parameter fails EVERY connection, so an external server of unknown
+      # version must not inherit this default.
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+
+  - it: leaves the idle-session timeout unset when the bundled server is disabled
+    set:
+      postgresql.enabled: false
+    asserts:
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+
+  - it: honours an explicit idle-session timeout on an external database
+    set:
+      database.host: rds.example.com
+      config.database.idleSessionTimeoutMs: 600000
+    asserts:
+      - equal:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+          value: "600000"
+
+  - it: renders numeric zero rather than dropping it
+    set:
+      config.database.poolSize: 5
+      config.database.maxOverflow: 0
+      config.database.idleSessionTimeoutMs: 0
+    asserts:
+      - equal:
+          path: data.BOW_DB_POOL_SIZE
+          value: "5"
+      # 0 is falsey to Helm. Dropping it would hand the backend its own default
+      # of 20, allowing 25 connections per worker where 5 were asked for.
+      - equal:
+          path: data.BOW_DB_MAX_OVERFLOW
+          value: "0"
+      # Likewise 0 here means "disable reaping", not "use the default".
+      - equal:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+          value: "0"
+
   - it: renders the database pool env when the operator sizes it
     set:
       config.database.poolSize: 10
       config.database.maxOverflow: 5
-      config.database.idleSessionTimeoutMs: 0
     asserts:
       - equal:
           path: data.BOW_DB_POOL_SIZE
@@ -58,6 +101,3 @@ tests:
       - equal:
           path: data.BOW_DB_MAX_OVERFLOW
           value: "5"
-      # 0 disables idle reaping — and must not be rendered as a stale default.
-      - notExists:
-          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS

--- a/k8s/chart/tests/config_test.yaml
+++ b/k8s/chart/tests/config_test.yaml
@@ -62,6 +62,58 @@ tests:
       - notExists:
           path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
 
+  - it: leaves the idle-session timeout unset when the URL comes from a Secret
+    set:
+      postgresql.auth.existingSecret: bowapp-secrets
+      config.secretRef: bowapp-secrets
+    asserts:
+      # The documented Secret install (k8s/README.md) supplies BOW_DATABASE_URL
+      # itself and is loaded after this ConfigMap via envFrom, so it can point
+      # at an external server of unknown version while postgresql.enabled and
+      # database.host are both still at their bundled defaults.
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+      # Guard the premise: with a Secret in play the chart emits no URL of its
+      # own, which is exactly why it cannot know the server version.
+      - notExists:
+          path: data.BOW_DATABASE_URL
+
+  - it: leaves the idle-session timeout unset for an existingSecret alone
+    set:
+      postgresql.auth.existingSecret: bowapp-secrets
+    asserts:
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+
+  - it: leaves the idle-session timeout unset for a config.secretRef alone
+    set:
+      config.secretRef: bowapp-secrets
+    asserts:
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+
+  - it: leaves the idle-session timeout unset for an IAM-authenticated database
+    set:
+      database.auth.provider: aws_iam
+      database.host: rds.example.com
+      database.username: bow
+      database.name: bow
+    asserts:
+      - notExists:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+
+  - it: honours an explicit idle-session timeout under a Secret install
+    set:
+      postgresql.auth.existingSecret: bowapp-secrets
+      config.secretRef: bowapp-secrets
+      config.database.idleSessionTimeoutMs: 600000
+    asserts:
+      # However the URL is supplied, an operator who knows their server is 14+
+      # can still opt in.
+      - equal:
+          path: data.BOW_DB_IDLE_SESSION_TIMEOUT_MS
+          value: "600000"
+
   - it: honours an explicit idle-session timeout on an external database
     set:
       database.host: rds.example.com

--- a/k8s/chart/values.schema.json
+++ b/k8s/chart/values.schema.json
@@ -88,6 +88,15 @@
         "allowMultipleOrganizations": { "type": "boolean" },
         "verifyEmails": { "type": "boolean" },
         "uvicornWorkers": { "type": ["string", "integer"] },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "poolSize": { "type": ["string", "integer"] },
+            "maxOverflow": { "type": ["string", "integer"] },
+            "idleSessionTimeoutMs": { "type": ["string", "integer"] }
+          }
+        },
         "otel": {
           "type": "object",
           "additionalProperties": false,

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -138,11 +138,16 @@ config:
     # quiet worker's backends drain instead of holding slots for the life of the
     # process. A connection pool never shrinks on its own. `0` disables.
     # REQUIRES PostgreSQL 14+: on older servers the parameter is rejected at
-    # connect time and *every* connection fails. Left empty here, which means
-    # `600000` (10 min) when the bundled PostgreSQL 17 subchart is in use, and
-    # unset when the chart points at an external `database.host` — whose version
-    # this chart cannot know. On an external server 14 or newer, set it
-    # explicitly to get the same draining behaviour.
+    # connect time and *every* connection fails. Left empty here, which applies
+    # `600000` (10 min) only when this chart can be certain the app is talking to
+    # the bundled PostgreSQL 17 subchart — that is, it generates the database URL
+    # itself and nothing can override it. It stays unset when the URL is
+    # delegated elsewhere and the version is therefore unknown: an external
+    # `database.host`, an IAM-authenticated `database.auth.provider`,
+    # `postgresql.enabled: false`, or a Secret supplying `BOW_DATABASE_URL` via
+    # `postgresql.auth.existingSecret` / `config.secretRef`.
+    # Set it explicitly on any server you know is 14 or newer to get the same
+    # draining behaviour — an explicit value always wins.
     idleSessionTimeoutMs: ""
   otel:
     # -- Enable OpenTelemetry tracing export.

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -22,6 +22,17 @@ postgresql:
     persistence:
       size: 20Gi
     nodeSelector: {}
+    # Stock PostgreSQL allows 100 connections, 3 of them reserved for
+    # superusers. One app worker's pool alone can reach
+    # `config.database.poolSize + maxOverflow` (40 by default), and `start.sh`
+    # runs up to 4 workers when the node is big enough — so the default app
+    # deployment can ask for more than the default server allows, and the
+    # server then refuses the connect outright ("remaining connection slots are
+    # reserved for roles with the SUPERUSER attribute") rather than queueing.
+    # Raise this together with `config.database.*` and `replicaCount`; each
+    # connection costs the server memory, so size it, don't max it.
+    extendedConfiguration: |
+      max_connections = 300
 
 # -- Managed database with IAM auth (alternative to the bundled postgresql subchart).
 # When `database.auth.provider` is not `password`, the postgresql subchart values
@@ -109,6 +120,27 @@ config:
   verifyEmails: false
   # -- Number of Uvicorn worker processes. Leave empty to use Uvicorn's default.
   uvicornWorkers: ""
+  # -- App-side database connection pool, per Uvicorn worker.
+  # The ceiling against the server is
+  # `(poolSize + maxOverflow) * uvicornWorkers * replicaCount`. Keep that under
+  # the server's `max_connections` minus `superuser_reserved_connections`
+  # (stock PostgreSQL: 100 - 3 = 97), or connects are refused outright with
+  # "remaining connection slots are reserved for roles with the SUPERUSER
+  # attribute" — which surfaces to users as a failed agent run, not as a
+  # pool timeout. The bundled postgresql subchart below is sized to match.
+  database:
+    # -- Pooled connections held per worker. Empty uses the app default (20).
+    poolSize: ""
+    # -- Extra connections a worker may open under load. Empty uses the app
+    # default (20).
+    maxOverflow: ""
+    # -- Let the server close pooled connections left idle this long (ms), so a
+    # quiet worker's backends drain instead of holding slots for the life of the
+    # process. A connection pool never shrinks on its own. `0` disables.
+    # REQUIRES PostgreSQL 14+ — on older servers this parameter is rejected at
+    # connect time and every connection fails, so clear it if your database is
+    # older than 14. The bundled subchart is PostgreSQL 17.
+    idleSessionTimeoutMs: "600000"
   otel:
     # -- Enable OpenTelemetry tracing export.
     enabled: false

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -137,10 +137,13 @@ config:
     # -- Let the server close pooled connections left idle this long (ms), so a
     # quiet worker's backends drain instead of holding slots for the life of the
     # process. A connection pool never shrinks on its own. `0` disables.
-    # REQUIRES PostgreSQL 14+ — on older servers this parameter is rejected at
-    # connect time and every connection fails, so clear it if your database is
-    # older than 14. The bundled subchart is PostgreSQL 17.
-    idleSessionTimeoutMs: "600000"
+    # REQUIRES PostgreSQL 14+: on older servers the parameter is rejected at
+    # connect time and *every* connection fails. Left empty here, which means
+    # `600000` (10 min) when the bundled PostgreSQL 17 subchart is in use, and
+    # unset when the chart points at an external `database.host` — whose version
+    # this chart cannot know. On an external server 14 or newer, set it
+    # explicitly to get the same draining behaviour.
+    idleSessionTimeoutMs: ""
   otel:
     # -- Enable OpenTelemetry tracing export.
     enabled: false


### PR DESCRIPTION
Investigated from a self-hosted Kubernetes + PostgreSQL report failing with
"remaining connection slots are reserved for roles with the SUPERUSER
attribute", alongside a complaint that the agent kept losing the thread of a
conversation. Both reproduced in a Postgres sandbox sized to the customer's
defaults (max_connections=100, 3 reserved); see
docs/feedback-loops/agent-context-loss-and-pool-drain-2026-09-12.md.

Context builders no longer race on the agent's session
------------------------------------------------------
ContextHub.refresh_warm and prime_static gathered their builders under
asyncio.gather(..., return_exceptions=True), but every builder is constructed
with the same AsyncSession. That is not safe for concurrent use, so the losers
raised "This session is provisioning a new connection; concurrent operations are
not permitted" — and each builder catches its own failure and returns an empty
section, so the planner was handed <queries> with no items as though the report
had none. A user refining a previous answer was talking to an agent that had
forgotten what it was refining.

The trigger is _release_db_between_steps(): it commits before each loop
iteration, leaving the session with no connection, which is exactly when the
provisioning window is widest. On a report with two saved queries the planner
saw zero of them in 10 of 10 refreshes following a commit; it now sees both in
10 of 10.

Serializing costs nothing — four builders on one session share one DBAPI
connection, so the gather was never parallel. Wall-clock is unchanged (14ms ->
13ms isolated; p50 149ms -> 170ms under 10-way concurrency, within noise), and a
builder that does fail is now logged with its section named.

The pool can now drain
----------------------
A QueuePool never shrinks: pool_recycle is applied lazily at checkout and
replaces a connection rather than closing it, and SQLAlchemy has no idle reaper.
Measured, a 20-connection pool stayed at 20 open backends indefinitely under
light traffic. Letting the server close idle sessions is what actually drains
it, with pool_pre_ping reconnecting transparently; pool_use_lifo then multiplies
the effect by concentrating traffic so the tail goes genuinely idle (settles at
4 open backends under FIFO, 1 under LIFO).

idle_session_timeout is PostgreSQL 14+ and an unrecognised GUC fails every
connect, so it is opt-in via BOW_DB_IDLE_SESSION_TIMEOUT_MS; the chart, which
bundles PostgreSQL 17, sets it. pool_size and max_overflow were hardcoded,
leaving an operator hitting slot exhaustion no lever short of editing the image
— they are now BOW_DB_POOL_SIZE / BOW_DB_MAX_OVERFLOW, and the chart sizes the
bundled server's max_connections to match what the app can actually ask for.

Two error messages stop saying the opposite of what happened
-----------------------------------------------------------
_mlog was a closure inside main_execution, referenced from two methods outside
that frame. Both sit in except blocks, so the NameError was caught and
relabelled as the failure of whatever the block guarded, on the success path:
focus-on-use logged "commit failed" after the commit had succeeded, and a
mid-run client that was built fine logged "construction failed".

Verified: an 8-agent concurrent run on the sandbox now completes with zero
errors of any class (was 26 context-section losses and 8 focus-on-use errors),
and idle connections after the run drop from 22 to 2.

Not done here, and deliberately: BOW_AGENT_SINGLE_WRITE_SESSION was benchmarked
for Postgres and is harmful — it corrupts the asyncpg connection ("got result
for unknown protocol state") across repeated runs, gives no connection saving
(peak 25 vs 24) and is slower. It stays opt-in. The chart also still sets no
limits.cpu, so worker count follows the node's core count rather than the CPU
request; changing that alters the resource contract of every deployment.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0121EQukxDsuZ6gAB3SGj4Q5