### PR TITLE
Extract empty report state to reusable component

### DIFF
--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -2217,28 +2217,19 @@ const onAgentClick = (agent: any) => {
   if (!isOpen('agent:' + agent.id)) expand('agent:' + agent.id)
   openAgent(agent.id)
 }
-const createReportForAgent = async (id: string) => {
-  try {
-    const { data, error } = await useMyFetch<any>('/reports', { method: 'POST', body: { title: 'New report', data_sources: [id] } })
-    const rid = (data.value as any)?.id
-    if (error.value || !rid) throw new Error('Failed to create report')
-    navigateTo(`/reports/${rid}`)
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) }
-}
+// Opens a draft scoped to this agent. Nothing is written until the user sends
+// a prompt; ?agents= is an explicit scope, so it lands on the created report
+// as its data_sources (and overrides project defaults) exactly as this POST did.
+const createReportForAgent = (id: string) => navigateTo({ path: '/reports/new', query: { agents: id } })
 // Start a training session for an agent: a new report scoped to ONLY this
 // agent/data source, switched to training mode, with a pre-filled (non-submitting)
 // prompt — mirrors the legacy agents page.
-const startTrainingSessionForAgent = async (agentId: string) => {
+const startTrainingSessionForAgent = (agentId: string) => {
   if (!agentId) return
   const prompt = 'I need to update the instruction for this agent with '
-  try {
-    const { data, error } = await useMyFetch<any>('/reports', { method: 'POST', body: { title: 'Training session', data_sources: [agentId] } })
-    const rid = (data.value as any)?.id
-    if (error.value || !rid) throw new Error('Failed to create report')
-    const { error: modeErr } = await useMyFetch(`/reports/${rid}`, { method: 'PUT', body: { mode: 'training' } })
-    if (modeErr.value) throw new Error(String(modeErr.value))
-    await navigateTo({ path: `/reports/${rid}`, query: { prompt } })
-  } catch (e: any) { toast.add({ title: t('agentsPage.toastError'), description: e?.message, color: 'red' }) }
+  // The draft carries the mode instead of the old create-then-PUT: the create
+  // endpoint takes `mode` and runs the same training-mode permission gate on it.
+  return navigateTo({ path: '/reports/new', query: { agents: agentId, mode: 'training', prompt } })
 }
 // description inline edit
 const startEditDesc = () => { descForm.value = agentDetail.value?.description || ''; editingDesc.value = true; nextTick(() => descInputRef.value?.focus()) }

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -693,9 +693,17 @@ const emit = defineEmits(['submitCompletion','queueCompletion','removeQueuedProm
 // The chip mirrors the report's project and doubles as the move control:
 // picking a project moves the report (owner-only route enforces the rest).
 const { projects: availableProjects, fetchProjects, moveReport: moveReportToProject } = useProjects()
+const { newReportPayload } = useNewReportProjectContext()
 const currentProject = ref<any>(props.project || null)
 watch(() => props.project, (p) => { currentProject.value = p || null })
 const isMovingProject = ref(false)
+// Whether the user picked a project by hand in this box. Without a report to
+// move, the pick can't be read back off the server, and the route context
+// (see useNewReportProjectContext) is the default — so createReport only lets
+// the picker override that default once it has actually been used. Otherwise
+// a draft submitted before `projects` finishes loading (the chip renders from
+// that list) would silently drop the project it was opened from.
+const projectExplicitlyPicked = ref(false)
 // Default agents of the containing project — feeds the agent picker so
 // "Auto" inside a project means the project's agents, not the whole org.
 const projectDefaultAgents = ref<any[]>([])
@@ -713,6 +721,7 @@ const pickProject = async (proj: any | null, close: () => void) => {
     // Standalone: nothing to move yet — just hold the choice for the caller.
     if (!props.report_id) {
         currentProject.value = proj ? { id: proj.id, name: proj.name, color: proj.color } : null
+        projectExplicitlyPicked.value = true
         emit('projectChanged', currentProject.value)
         close()
         return
@@ -1726,18 +1735,27 @@ async function createReport() {
             isSubmitting.value = false
             return
         }
+        // Project context comes from the route (a project page, or the draft
+        // page's ?project=), and the picker overrides it once the user has
+        // touched it — including a deliberate "No project", which has to clear
+        // the inherited id rather than fall back to it.
+        const body: Record<string, any> = {
+            title: 'untitled report',
+            files: successfullyUploadedFiles.value?.map((file: any) => file.id) || [],
+            new_message: text.value,
+            // Persist the picker's mode on the report itself. The query
+            // param below only shapes the FIRST completion; without this
+            // the report loads as chat and the picker snaps back.
+            mode: mode.value,
+            ...newReportPayload(selectedDataSources.value?.map((ds: any) => String(ds.id)) || [])
+        }
+        if (projectExplicitlyPicked.value) {
+            if (currentProject.value?.id) body.project_id = currentProject.value.id
+            else delete body.project_id
+        }
         const response = await useMyFetch('/reports', {
             method: 'POST',
-            body: JSON.stringify({
-                title: 'untitled report',
-                files: successfullyUploadedFiles.value?.map((file: any) => file.id) || [],
-                new_message: text.value,
-                data_sources: selectedDataSources.value?.map((ds: any) => ds.id) || [],
-                // Persist the picker's mode on the report itself. The query
-                // param below only shapes the FIRST completion; without this
-                // the report loads as chat and the picker snaps back.
-                mode: mode.value
-            })
+            body: JSON.stringify(body)
         })
         if ((response as any)?.error?.value) {
             throw new Error('Report creation failed')

--- a/frontend/components/prompt/PromptBoxV2.vue
+++ b/frontend/components/prompt/PromptBoxV2.vue
@@ -596,7 +596,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch, getCurrentInstance } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick, getCurrentInstance } from 'vue'
 import { useRouter } from 'vue-router'
 
 import DataSourceSelector from '@/components/prompt/DataSourceSelector.vue'
@@ -1697,6 +1697,13 @@ defineExpose({
     // the same auto-mode handling and report persistence as the dropdown rows.
     toggleDataSource: (ds: any) => dataSourceSelectorRef.value?.toggleDataSource?.(ds),
     getProject: () => currentProject.value?.id || null,
+    // Send a prompt on behalf of a control outside the box (the empty state's
+    // starter questions), through the same gating as the send button.
+    submitPrompt: async (value: string) => {
+        text.value = value
+        await nextTick()
+        submit()
+    },
 })
 
 // Keep local text in sync with parent-provided content (landing page)

--- a/frontend/components/report/ReportEmptyState.vue
+++ b/frontend/components/report/ReportEmptyState.vue
@@ -1,0 +1,270 @@
+<!-- What a report with no conversation shows: the training-mode tip sheet, or
+     the agent picker and that selection's starter questions. Shared by the
+     report view and the draft page (/reports/new) so an empty report and a
+     report that doesn't exist yet are the same screen — the draft just has no
+     row behind it. The selection itself lives in the prompt box; this emits
+     clicks and renders what it is told. -->
+<template>
+	<div class="mt-32 fade-in">
+	<!-- Training mode empty state -->
+	<template v-if="mode === 'training'">
+		<h1 class="text-4xl mb-4">🎓</h1>
+		<h1 class="text-lg font-semibold">{{ $t('reports.trainingEmptyTitle') }}</h1>
+		<hr class="my-4">
+		<p class="text-gray-500 dark:text-gray-400 text-sm"><span class="font-semibold">{{ $t('reports.trainingEmptyTipLabel') }}</span> <br />
+			{{ $t('reports.trainingEmptyBody') }}
+		</p>
+		<div class="mt-4 flex flex-wrap gap-2">
+			<button
+				v-for="s in ($tm('reports.trainingStarters') as any[])"
+				:key="s.title"
+				class="px-3 py-1.5 text-xs rounded-full border border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100 transition-colors"
+				@click="$emit('starter', `${s.title}\n\n${s.prompt}`)"
+			>
+				{{ s.title }}
+			</button>
+		</div>
+	</template>
+	<!-- Chat / deep mode empty state -->
+	<template v-else>
+		<div class="flex flex-col items-center text-center">
+			<img
+				src="/assets/empty-states/empty-integrations.png"
+				alt=""
+				class="w-56 max-w-full mb-2 select-none pointer-events-none dark:hidden"
+			/>
+			<div class="hidden dark:flex items-center justify-center w-24 h-24 rounded-2xl bg-gray-800 mb-2">
+				<UIcon name="i-heroicons-chat-bubble-left-right" class="w-10 h-10 text-gray-500" />
+			</div>
+			<h1 class="text-lg font-semibold">{{ $t('reports.emptyTitle') }}</h1>
+			<!-- Agent picker + starter questions: one start-aligned column the
+			     width of the composer below, so the search rule and the question
+			     dividers land on its edges. Both live in a max-w-2xl column, but
+			     the message column pads ps-4/pe-2 while the composer card sits a
+			     further 16px in on both sides — hence the extra start/end inset
+			     here. Below sm the two already line up (px-3 vs p-3). -->
+			<div class="w-full text-start sm:ps-4 sm:pe-6">
+				<!-- Agents: only worth showing when there's a choice to make.
+				     Multi-select — it drives the prompt box's selector, which
+				     owns auto-mode and persistence. Most-recently-used first, so
+				     the agents you actually work with lead the row. -->
+				<div v-if="availableAgents.length > 1" class="mt-7">
+					<!-- The search field is the section header: no separate title,
+					     it names the row and filters it as you type. -->
+					<div class="flex items-center gap-2 px-1 pb-1.5 border-b border-gray-100 dark:border-gray-800">
+						<Icon name="heroicons:magnifying-glass" class="w-3.5 h-3.5 flex-shrink-0 text-gray-300 dark:text-gray-600" />
+						<input
+							v-model="agentChipQuery"
+							type="text"
+							data-testid="empty-agent-search"
+							:placeholder="$t('projects.overview.searchAgents')"
+							class="w-full bg-transparent text-[13px] text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
+						/>
+					</div>
+					<div
+						:class="[
+							'mt-2 flex flex-wrap gap-1',
+							showAllAgentChips ? 'max-h-36 overflow-y-auto' : ''
+						]"
+					>
+						<button
+							v-for="a in visibleAgentChips"
+							:key="a.id"
+							type="button"
+							data-testid="empty-agent-chip"
+							:aria-pressed="isAgentSelected(a)"
+							:class="[
+								'inline-flex items-center gap-1.5 px-1.5 py-1 rounded-md text-[13px] transition-colors',
+								isAgentSelected(a)
+									? 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100'
+									: 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/60'
+							]"
+							@click="$emit('toggle-agent', a)"
+						>
+							<DataSourceIcon
+								:type="a.type || a.connections?.[0]?.type"
+								:connector-key="a.connector_key || a.connections?.[0]?.connector_key"
+								:icon="a.icon"
+								class="h-3.5 flex-shrink-0"
+							/>
+							<span class="max-w-[11rem] truncate">{{ a.name }}</span>
+							<Icon
+								v-if="isAgentSelected(a)"
+								name="heroicons:check"
+								class="w-3 h-3 flex-shrink-0 text-gray-400"
+							/>
+						</button>
+						<!-- Long agent lists would otherwise bury the questions
+						     under a wall of chips — reveal the tail on demand. -->
+						<button
+							v-if="hiddenAgentChipCount > 0"
+							type="button"
+							data-testid="empty-agent-chip-more"
+							class="inline-flex items-center px-1.5 py-1 rounded-md text-[13px] text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+							@click="showAllAgentChips = true"
+						>
+							+{{ hiddenAgentChipCount }}
+						</button>
+						<span v-if="visibleAgentChips.length === 0" class="px-1.5 py-1 text-[13px] text-gray-400">
+							{{ $t('mentionInput.noResults') }}
+						</span>
+					</div>
+					<!-- Outside the scroll area — inside it, collapsing would mean
+					     scrolling past every chip to find the way back. -->
+					<button
+						v-if="showAllAgentChips"
+						type="button"
+						data-testid="empty-agent-chip-less"
+						class="mt-1 px-1.5 text-[12px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+						@click="showAllAgentChips = false"
+					>
+						{{ $t('tools.common.showLess') }}
+					</button>
+				</div>
+				<!-- Starter questions for the selected agents, one per line.
+				     Nothing selected ⇒ nothing to suggest. -->
+				<div
+					v-if="currentAgents.length > 0 && conversationStarters.length > 0"
+					:class="availableAgents.length > 1 ? 'mt-5' : 'mt-7'"
+				>
+					<ul class="divide-y divide-gray-100 dark:divide-gray-800/70">
+						<li v-for="s in conversationStarters" :key="s.title" class="group">
+							<button
+								type="button"
+								dir="auto"
+								data-testid="empty-starter"
+								class="w-full flex items-center justify-between gap-3 py-2.5 px-1 text-start text-[13px] leading-snug text-gray-500 dark:text-gray-400 transition-colors duration-150 hover:text-gray-900 dark:hover:text-gray-100"
+								@click="$emit('starter', `${s.title}\n\n${s.prompt}`)"
+							>
+								<span class="truncate">{{ s.title }}</span>
+								<Icon
+									name="heroicons-arrow-up-right"
+									class="w-3.5 h-3.5 flex-shrink-0 text-gray-300 dark:text-gray-600 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-150"
+								/>
+							</button>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import DataSourceIcon from '@/components/DataSourceIcon.vue'
+
+const props = withDefaults(defineProps<{
+	// Mode of the composer below, which decides which empty state applies.
+	mode?: 'chat' | 'training'
+	// Every agent the user could pick, published by the prompt box's selector.
+	availableAgents?: any[]
+	// The agents currently scoping the conversation.
+	currentAgents?: any[]
+	// The selection is "Auto" — scoped to everything because the user hasn't
+	// chosen. That is the absence of a choice, so no chip reads as selected;
+	// the first click is what turns it into a real selection.
+	agentsAreAuto?: boolean
+}>(), {
+	mode: 'chat',
+	availableAgents: () => [],
+	currentAgents: () => [],
+	agentsAreAuto: false,
+})
+
+defineEmits<{
+	(e: 'toggle-agent', agent: any): void
+	(e: 'starter', text: string): void
+}>()
+
+// Orgs can have dozens of agents; show a handful and keep the rest one click
+// away so the starter questions stay above the fold. Beyond this the row wraps
+// past two lines and stops reading as a shortcut — the search field is the way
+// through a long roster.
+const AGENT_CHIP_LIMIT = 6
+const showAllAgentChips = ref(false)
+const agentChipQuery = ref('')
+
+// Most-recently-used first (`last_used_at` from /data_sources/active — the last
+// conversation this user actually had with the agent), never-used ones after,
+// alphabetical within each group so the order is stable and predictable.
+const sortedAgents = computed(() => {
+	return [...(props.availableAgents || [])].sort((a: any, b: any) => {
+		const ta = a?.last_used_at ? Date.parse(a.last_used_at) : 0
+		const tb = b?.last_used_at ? Date.parse(b.last_used_at) : 0
+		if (ta !== tb) return tb - ta
+		return String(a?.name || '').localeCompare(String(b?.name || ''))
+	})
+})
+
+const matchingAgents = computed(() => {
+	const q = agentChipQuery.value.trim().toLowerCase()
+	if (!q) return sortedAgents.value
+	return sortedAgents.value.filter((a: any) => String(a?.name || '').toLowerCase().includes(q))
+})
+
+const visibleAgentChips = computed(() => {
+	const all = matchingAgents.value
+	if (showAllAgentChips.value || all.length <= AGENT_CHIP_LIMIT) return all
+	// Selected agents win the slots, but the row keeps its recency order so
+	// chips don't reshuffle under the cursor as the selection changes.
+	const kept = new Set<string>()
+	let budget = AGENT_CHIP_LIMIT
+	for (const a of all) if (budget > 0 && isAgentSelected(a)) { kept.add(String(a.id)); budget-- }
+	for (const a of all) if (budget > 0 && !kept.has(String(a.id))) { kept.add(String(a.id)); budget-- }
+	return all.filter((a: any) => kept.has(String(a.id)))
+})
+const hiddenAgentChipCount = computed(() => matchingAgents.value.length - visibleAgentChips.value.length)
+
+function isAgentSelected(agent: any) {
+	if (props.agentsAreAuto) return false
+	return (props.currentAgents || []).some((a: any) => String(a?.id) === String(agent?.id))
+}
+
+// Conversation starters from the selected agents, sourced from agent-scoped
+// starter Prompts (not the legacy data_source.conversation_starters JSON).
+// Each prompt's `text` is "Title\nDetailed prompt" — split into { title, prompt }.
+const conversationStarters = ref<{ title: string; prompt: string }[]>([])
+async function loadAgentStarters() {
+	const ids = [...new Set((props.currentAgents || []).map((a: any) => a?.id).filter(Boolean))]
+	if (!ids.length) { conversationStarters.value = []; return }
+	const texts: string[] = []
+	try {
+		// Fetch starters for all selected agents in ONE batched request (union)
+		// instead of one /prompts call per agent — a report with many attached
+		// agents otherwise fired a request per agent just to fill 3 suggestions.
+		const { data } = await useMyFetch(`/prompts?data_source_ids=${ids.join(',')}`)
+		for (const p of ((data.value as any)?.prompts || [])) if (p?.text) texts.push(p.text)
+	} catch { /* ignore */ }
+	conversationStarters.value = [...new Set<string>(texts)].slice(0, 3).map((s: string) => {
+		const nl = s.indexOf('\n')
+		return nl === -1
+			? { title: s, prompt: s }
+			: { title: s.slice(0, nl).trim(), prompt: s.slice(nl + 1).trim() }
+	})
+}
+// Key the watch on the actual set of agent ids (not a deep watch) so starters
+// are refetched only when agents are added/removed, not on every nested change.
+watch(
+	() => [...new Set((props.currentAgents || []).map((a: any) => a?.id).filter(Boolean))].sort().join(','),
+	loadAgentStarters,
+	{ immediate: true },
+)
+</script>
+
+<style scoped>
+.fade-in {
+    animation: fadeIn 0.6s ease-in;
+}
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+</style>

--- a/frontend/composables/useProjects.ts
+++ b/frontend/composables/useProjects.ts
@@ -30,7 +30,15 @@ const loading = ref(false)
 // the project rail promises. Callers use this to build the right payload.
 export function useNewReportProjectContext() {
     const route = useRoute()
-    const activeProjectId = computed(() => projectIdFromPath(route.path))
+    // A report can be started from inside a project's own page, or from the
+    // draft page (/reports/new), which is not under /projects/:id and so
+    // carries the project it was opened from as a query param instead.
+    const activeProjectId = computed(() => {
+        const fromPath = projectIdFromPath(route.path)
+        if (fromPath) return fromPath
+        const q = route.query.project
+        return typeof q === 'string' && q ? q : null
+    })
 
     // `explicit` are agents the user genuinely picked for this report (e.g. a
     // prompt's data-source mentions). Inside a project, an empty pick means

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -46,9 +46,8 @@
     <button @click="router.push('/')" class="flex items-center gap-2 min-w-0">
       <img :src="workspaceIconUrl || '/assets/logo-128.png'" alt="Bag of words" class="max-h-6 max-w-[84px] object-contain" />
     </button>
-    <button @click="createNewReport" :disabled="creatingReport" class="flex items-center justify-center w-9 h-9 -me-1 rounded-md text-blue-500 hover:bg-gray-100 dark:hover:bg-gray-800/70 disabled:opacity-50" aria-label="New report">
-      <Spinner v-if="creatingReport" class="animate-spin w-5 h-5" />
-      <UIcon v-else name="heroicons-plus-circle" class="w-6 h-6" />
+    <button @click="createNewReport" class="flex items-center justify-center w-9 h-9 -me-1 rounded-md text-blue-500 hover:bg-gray-100 dark:hover:bg-gray-800/70" aria-label="New report">
+      <UIcon name="heroicons-plus-circle" class="w-6 h-6" />
     </button>
   </div>
 
@@ -129,23 +128,20 @@
              <button
                name="create-report"
                @click="createNewReport"
-               :disabled="creatingReport"
                :class="[
-                 'flex items-center px-2.5 py-1.5 w-full rounded-md text-blue-500 hover:bg-gray-100 dark:hover:bg-gray-800/70 disabled:opacity-50 disabled:cursor-not-allowed',
+                 'flex items-center px-2.5 py-1.5 w-full rounded-md text-blue-500 hover:bg-gray-100 dark:hover:bg-gray-800/70',
                  isCollapsed ? 'justify-center' : 'gap-2.5'
                ]">
-              <UTooltip v-if="isCollapsed" :text="creatingReport ? $t('common.loading') : $t('nav.newReport')" :popper="{ placement: tooltipPlacement }">
+              <UTooltip v-if="isCollapsed" :text="$t('nav.newReport')" :popper="{ placement: tooltipPlacement }">
                 <span :class="['flex items-center justify-center', isCollapsed ? 'w-5 h-5 text-[16px]' : 'w-5 h-5 text-[18px]']">
-                  <Spinner v-if="creatingReport" class="animate-spin" />
-                  <UIcon v-else name="heroicons-plus-circle" />
+                  <UIcon name="heroicons-plus-circle" />
                 </span>
               </UTooltip>
               <template v-else>
                 <span :class="['flex items-center justify-center', isCollapsed ? 'w-5 h-5 text-[16px]' : 'w-5 h-5 text-[18px]']">
-                  <Spinner v-if="creatingReport" class="animate-spin" />
-                  <UIcon v-else name="heroicons-plus-circle" />
+                  <UIcon name="heroicons-plus-circle" />
                 </span>
-                <span v-if="showText" class="font-medium">{{ creatingReport ? $t('common.loading') : $t('nav.newReport') }}</span>
+                <span v-if="showText" class="font-medium">{{ $t('nav.newReport') }}</span>
               </template>
             </button>
         </li>
@@ -302,6 +298,18 @@
         </div>
         <div v-show="reportsOpen" class="-me-1 pe-1" :class="isShortSidebar ? '' : 'flex-1 min-h-0 overflow-y-auto'">
           <ul class="font-normal text-[13px] !ps-0 space-y-0.5">
+            <!-- The draft being composed at /reports/new. There is no report
+                 yet, so this row is a placeholder that keeps the rail from
+                 looking like the user is nowhere; it disappears the moment the
+                 first prompt creates the real report and we navigate to it. -->
+            <li v-if="isDraftReportRoute" data-testid="draft-report-row" class="relative rounded-md">
+              <div class="flex items-center gap-2 px-2.5 py-1.5 pe-8 w-full rounded-md text-gray-900 dark:text-white bg-gray-200/70 dark:bg-gray-800 font-medium">
+                <span class="inline-flex items-center shrink-0">
+                  <span class="w-1.5 h-1.5 rounded-full border border-gray-400 dark:border-gray-500"></span>
+                </span>
+                <span class="flex-1 truncate italic text-gray-500 dark:text-gray-400">{{ $t('reports.newReport') }}</span>
+              </div>
+            </li>
             <!-- Draggable onto a project row above. The row keeps its place in
                  this list after the move — a project is a label on the report,
                  not a folder it disappears into — and gains the accent strip. -->
@@ -771,12 +779,12 @@
     return items
   })
   
-  // Agent management - use selectedAgentObjects for new report creation
-  const { initAgent, initAgentPreference, selectedAgentObjects, agents, hasAgents } = useAgent()
+  // Agent management
+  const { initAgent, initAgentPreference, agents, hasAgents } = useAgent()
 
   // Projects (shared folders) shown above the recent reports list.
   const { projects, fetchProjects, createProject, updateProject, deleteProject, moveReport } = useProjects()
-  const { activeProjectId, newReportPayload } = useNewReportProjectContext()
+  const { activeProjectId } = useNewReportProjectContext()
   const { fetchActivity, sortByActivity, openStream } = useReportActivity()
 
 
@@ -879,12 +887,13 @@
   const { isCollapsed: rawCollapsed, showText: rawShowText, toggle: toggleSidebar, mobileOpen, openMobile, closeMobile } = useSidebar()
   const isCollapsed = computed(() => mobileOpen.value ? false : rawCollapsed.value)
   const showText = computed(() => mobileOpen.value ? true : rawShowText.value)
-  const creatingReport = ref(false)
 
   // Mobile chrome. The report-detail page is full-height (h-dvh) and ships its
   // own ReportHeader, so we suppress the global mobile bar there to avoid a
   // double header and the extra top padding that would make it overflow.
   const isReportDetail = computed(() => /^\/reports\/[^/]+$/.test(route.path))
+  // The draft page shares the report layout but has no report behind it.
+  const isDraftReportRoute = computed(() => route.path === '/reports/new')
   const showMobileBar = computed(() => !isReportDetail.value)
   // Top padding for the content wrapper. Desktop only needs to clear the
   // banner; mobile also needs to clear the 48px mobile bar when it is shown.
@@ -1457,41 +1466,16 @@
     })
   }
 
-const createNewReport = async () => {
-  if (creatingReport.value) return
-  creatingReport.value = true
-  
-  try {
-    // Inside a project, hand the choice of agents to the project's defaults
-    // (see useNewReportProjectContext). Outside one, use the agents pinned in
-    // AgentSelector — empty when the selection is Auto, which is exactly how
-    // the backend encodes Auto (it resolves the scope per run instead of
-    // freezing today's roster onto the report).
-    const dataSourceIds = activeProjectId.value
-      ? []
-      : selectedAgentObjects.value.map((a: any) => a.id)
-
-    const response = await useMyFetch('/reports', {
-        method: 'POST',
-        body: JSON.stringify({
-          title: 'untitled report',
-          files: [],
-          ...newReportPayload(dataSourceIds),
-        })
-    });
-
-    if ((response as any).error?.value) {
-        throw new Error('Report creation failed');
-    }
-
-    const data = ((response as any).data?.value) as any;
-    fetchRecentReports()
-    await router.push({
-        path: `/reports/${data.id}`
-    })
-  } finally {
-    creatingReport.value = false
-  }
+// "New report" opens a draft page — no row is written until the user actually
+// sends a prompt, at which point PromptBoxV2 creates the report and navigates
+// to it. Inside a project the folder rides along in the query string, since a
+// draft has no report to carry a project_id on (see useNewReportProjectContext,
+// which reads both). Agents are resolved by the draft page the same way this
+// used to build its payload: the project's defaults inside one, the pinned
+// AgentSelector scope outside.
+const createNewReport = () => {
+  const query = activeProjectId.value ? { project: activeProjectId.value } : undefined
+  return router.push({ path: '/reports/new', query })
 }
 
   async function signOff() {

--- a/frontend/pages/projects/[id]/index.vue
+++ b/frontend/pages/projects/[id]/index.vue
@@ -25,11 +25,9 @@
                         <button
                             name="new-report-in-project"
                             @click="createReportInProject"
-                            :disabled="creating"
-                            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700"
                         >
-                            <Spinner v-if="creating" class="animate-spin w-4 h-4" />
-                            <UIcon v-else name="i-heroicons-plus" class="w-4 h-4" />
+                            <UIcon name="i-heroicons-plus" class="w-4 h-4" />
                             {{ $t('nav.newReport') }}
                         </button>
                         <UTooltip :text="$t('projects.tabs.settings')">
@@ -123,8 +121,7 @@
                                     <p class="mt-3 text-[13px] text-gray-500 dark:text-gray-400">{{ $t('projects.emptyProject') }}</p>
                                     <button
                                         @click="createReportInProject"
-                                        :disabled="creating"
-                                        class="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] rounded-md border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+                                        class="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] rounded-md border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
                                     >
                                         <UIcon name="i-heroicons-plus" class="w-4 h-4" />{{ $t('nav.newReport') }}
                                     </button>
@@ -435,14 +432,12 @@ const { getCronLabel } = useCronLabel()
 const toast = useToast()
 const { data: currentUser } = useAuth()
 const { fetchProjects, updateProject, deleteProject } = useProjects()
-const { newReportPayload } = useNewReportProjectContext()
 const { organization } = useOrganization()
 
 const projectId = computed(() => String(route.params.id))
 
 const project = ref<any>(null)
 const loadingProject = ref(true)
-const creating = ref(false)
 const savingSettings = ref(false)
 const confirmDeleteOpen = ref(false)
 const deleting = ref(false)
@@ -752,31 +747,11 @@ const formatDate = (value: string | null) => {
     } catch { return '' }
 }
 
-const createReportInProject = async () => {
-    if (creating.value) return
-    creating.value = true
-    try {
-        // Empty data_sources + project_id: the backend copies the project's
-        // default agents onto the report, and only when the caller didn't pick
-        // agents explicitly. See useNewReportProjectContext — every "New
-        // report" entry point builds the payload the same way.
-        const resp: any = await useMyFetch('/reports', {
-            method: 'POST',
-            body: JSON.stringify({
-                title: 'untitled report',
-                files: [],
-                ...newReportPayload([]),
-            }),
-        })
-        if (resp?.error?.value) throw resp.error.value
-        const data = resp.data?.value as any
-        await router.push(`/reports/${data.id}`)
-    } catch (e: any) {
-        toast.add({ title: t('common.error'), description: String(e?.data?.detail || e?.message || ''), color: 'red' })
-    } finally {
-        creating.value = false
-    }
-}
+// Opens a draft scoped to this project; the report row is written only when
+// the user sends the first prompt, carrying ?project= through to the create
+// call (see useNewReportProjectContext). Agents stay empty so the backend
+// copies the project's defaults, exactly as this POST used to.
+const createReportInProject = () => router.push({ path: '/reports/new', query: { project: projectId.value } })
 
 const saveSettings = async () => {
     if (savingSettings.value) return

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -592,150 +592,15 @@
 				<Spinner class="w-4 h-4 me-2" />
 				<span class="text-sm">{{ $t('reportView.loadingReport') }}</span>
 			</div>
-			<div v-else class="mt-32 fade-in">
-				<!-- Training mode empty state -->
-				<template v-if="currentPromptMode === 'training'">
-					<h1 class="text-4xl mb-4">🎓</h1>
-					<h1 class="text-lg font-semibold">{{ $t('reports.trainingEmptyTitle') }}</h1>
-					<hr class="my-4">
-					<p class="text-gray-500 dark:text-gray-400 text-sm"><span class="font-semibold">{{ $t('reports.trainingEmptyTipLabel') }}</span> <br />
-						{{ $t('reports.trainingEmptyBody') }}
-					</p>
-					<div class="mt-4 flex flex-wrap gap-2">
-						<button
-							v-for="s in ($tm('reports.trainingStarters') as any[])"
-							:key="s.title"
-							class="px-3 py-1.5 text-xs rounded-full border border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100 transition-colors"
-							@click="handleExampleClick(`${s.title}\n\n${s.prompt}`)"
-						>
-							{{ s.title }}
-						</button>
-					</div>
-				</template>
-				<!-- Chat / deep mode empty state -->
-				<template v-else>
-					<div class="flex flex-col items-center text-center">
-						<img
-							src="/assets/empty-states/empty-integrations.png"
-							alt=""
-							class="w-56 max-w-full mb-2 select-none pointer-events-none dark:hidden"
-						/>
-						<div class="hidden dark:flex items-center justify-center w-24 h-24 rounded-2xl bg-gray-800 mb-2">
-							<UIcon name="i-heroicons-chat-bubble-left-right" class="w-10 h-10 text-gray-500" />
-						</div>
-						<h1 class="text-lg font-semibold">{{ $t('reports.emptyTitle') }}</h1>
-						<!-- Agent picker + starter questions: one start-aligned column the
-						     width of the composer below, so the search rule and the question
-						     dividers land on its edges. Both live in a max-w-2xl column, but
-						     the message column pads ps-4/pe-2 while the composer card sits a
-						     further 16px in on both sides — hence the extra start/end inset
-						     here. Below sm the two already line up (px-3 vs p-3). -->
-						<div class="w-full text-start sm:ps-4 sm:pe-6">
-							<!-- Agents: only worth showing when there's a choice to make.
-							     Multi-select — it drives the prompt box's selector, which
-							     owns auto-mode and persistence. Most-recently-used first, so
-							     the agents you actually work with lead the row. -->
-							<div v-if="availableAgents.length > 1" class="mt-7">
-								<!-- The search field is the section header: no separate title,
-								     it names the row and filters it as you type. -->
-								<div class="flex items-center gap-2 px-1 pb-1.5 border-b border-gray-100 dark:border-gray-800">
-									<Icon name="heroicons:magnifying-glass" class="w-3.5 h-3.5 flex-shrink-0 text-gray-300 dark:text-gray-600" />
-									<input
-										v-model="agentChipQuery"
-										type="text"
-										data-testid="empty-agent-search"
-										:placeholder="$t('projects.overview.searchAgents')"
-										class="w-full bg-transparent text-[13px] text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
-									/>
-								</div>
-								<div
-									:class="[
-										'mt-2 flex flex-wrap gap-1',
-										showAllAgentChips ? 'max-h-36 overflow-y-auto' : ''
-									]"
-								>
-									<button
-										v-for="a in visibleAgentChips"
-										:key="a.id"
-										type="button"
-										data-testid="empty-agent-chip"
-										:aria-pressed="isAgentSelected(a)"
-										:class="[
-											'inline-flex items-center gap-1.5 px-1.5 py-1 rounded-md text-[13px] transition-colors',
-											isAgentSelected(a)
-												? 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100'
-												: 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/60'
-										]"
-										@click="toggleAgentSelection(a)"
-									>
-										<DataSourceIcon
-											:type="a.type || a.connections?.[0]?.type"
-											:connector-key="a.connector_key || a.connections?.[0]?.connector_key"
-											:icon="a.icon"
-											class="h-3.5 flex-shrink-0"
-										/>
-										<span class="max-w-[11rem] truncate">{{ a.name }}</span>
-										<Icon
-											v-if="isAgentSelected(a)"
-											name="heroicons:check"
-											class="w-3 h-3 flex-shrink-0 text-gray-400"
-										/>
-									</button>
-									<!-- Long agent lists would otherwise bury the questions
-									     under a wall of chips — reveal the tail on demand. -->
-									<button
-										v-if="hiddenAgentChipCount > 0"
-										type="button"
-										data-testid="empty-agent-chip-more"
-										class="inline-flex items-center px-1.5 py-1 rounded-md text-[13px] text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-										@click="showAllAgentChips = true"
-									>
-										+{{ hiddenAgentChipCount }}
-									</button>
-									<span v-if="visibleAgentChips.length === 0" class="px-1.5 py-1 text-[13px] text-gray-400">
-										{{ $t('mentionInput.noResults') }}
-									</span>
-								</div>
-								<!-- Outside the scroll area — inside it, collapsing would mean
-								     scrolling past every chip to find the way back. -->
-								<button
-									v-if="showAllAgentChips"
-									type="button"
-									data-testid="empty-agent-chip-less"
-									class="mt-1 px-1.5 text-[12px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-									@click="showAllAgentChips = false"
-								>
-									{{ $t('tools.common.showLess') }}
-								</button>
-							</div>
-							<!-- Starter questions for the selected agents, one per line.
-							     Nothing selected ⇒ nothing to suggest. -->
-							<div
-								v-if="currentAgents.length > 0 && agentConversationStarters.length > 0"
-								:class="availableAgents.length > 1 ? 'mt-5' : 'mt-7'"
-							>
-								<ul class="divide-y divide-gray-100 dark:divide-gray-800/70">
-									<li v-for="s in agentConversationStarters" :key="s.title" class="group">
-										<button
-											type="button"
-											dir="auto"
-											data-testid="empty-starter"
-											class="w-full flex items-center justify-between gap-3 py-2.5 px-1 text-start text-[13px] leading-snug text-gray-500 dark:text-gray-400 transition-colors duration-150 hover:text-gray-900 dark:hover:text-gray-100"
-											@click="handleExampleClick(`${s.title}\n\n${s.prompt}`)"
-										>
-											<span class="truncate">{{ s.title }}</span>
-											<Icon
-												name="heroicons-arrow-up-right"
-												class="w-3.5 h-3.5 flex-shrink-0 text-gray-300 dark:text-gray-600 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-150"
-											/>
-										</button>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-				</template>
-			</div>
+			<ReportEmptyState
+				v-else
+				:mode="currentPromptMode"
+				:available-agents="availableAgents"
+				:current-agents="currentAgents"
+				:agents-are-auto="agentsAreAuto"
+				@toggle-agent="toggleAgentSelection"
+				@starter="handleExampleClick"
+			/>
 			</div>
 		</div>
 
@@ -1189,6 +1054,7 @@ import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 import SplitScreenLayout from '~/components/report/SplitScreenLayout.vue'
 import ReportHeader from '~/components/report/ReportHeader.vue'
 import ReportAgentPanel from '~/components/report/ReportAgentPanel.vue'
+import ReportEmptyState from '~/components/report/ReportEmptyState.vue'
 import ChatSummary from '~/components/report/ChatSummary.vue'
 import ForkBanner from '~/components/ForkBanner.vue'
 import ForkedQueriesPanel from '~/components/ForkedQueriesPanel.vue'
@@ -1897,14 +1763,6 @@ async function handleAgentConnected() {
 // Drives the blank-report agent picker (shown only when there's more than one).
 const availableAgents = ref<any[]>([])
 
-// Orgs can have dozens of agents; show a handful and keep the rest one click
-// away so the starter questions stay above the fold. Beyond this the row wraps
-// past two lines and stops reading as a shortcut — the search field is the way
-// through a long roster.
-const AGENT_CHIP_LIMIT = 6
-const showAllAgentChips = ref(false)
-const agentChipQuery = ref('')
-
 // The prompt box is in "Auto" — the report is scoped to every agent because
 // the user hasn't chosen. That's the absence of a choice, so the picker shows
 // nothing selected; the first click is what turns it into a real selection.
@@ -1913,78 +1771,12 @@ const agentChipQuery = ref('')
 // picker highlights them.
 const agentsAreAuto = ref(false)
 
-// Most-recently-used first (`last_used_at` from /data_sources/active — the last
-// conversation this user actually had with the agent), never-used ones after,
-// alphabetical within each group so the order is stable and predictable.
-const sortedAgents = computed(() => {
-    return [...(availableAgents.value || [])].sort((a: any, b: any) => {
-        const ta = a?.last_used_at ? Date.parse(a.last_used_at) : 0
-        const tb = b?.last_used_at ? Date.parse(b.last_used_at) : 0
-        if (ta !== tb) return tb - ta
-        return String(a?.name || '').localeCompare(String(b?.name || ''))
-    })
-})
-
-const matchingAgents = computed(() => {
-    const q = agentChipQuery.value.trim().toLowerCase()
-    if (!q) return sortedAgents.value
-    return sortedAgents.value.filter((a: any) => String(a?.name || '').toLowerCase().includes(q))
-})
-
-const visibleAgentChips = computed(() => {
-    const all = matchingAgents.value
-    if (showAllAgentChips.value || all.length <= AGENT_CHIP_LIMIT) return all
-    // Selected agents win the slots, but the row keeps its recency order so
-    // chips don't reshuffle under the cursor as the selection changes.
-    const kept = new Set<string>()
-    let budget = AGENT_CHIP_LIMIT
-    for (const a of all) if (budget > 0 && isAgentSelected(a)) { kept.add(String(a.id)); budget-- }
-    for (const a of all) if (budget > 0 && !kept.has(String(a.id))) { kept.add(String(a.id)); budget-- }
-    return all.filter((a: any) => kept.has(String(a.id)))
-})
-const hiddenAgentChipCount = computed(() => matchingAgents.value.length - visibleAgentChips.value.length)
-
-function isAgentSelected(agent: any) {
-    if (agentsAreAuto.value) return false
-    return (currentAgents.value || []).some((a: any) => String(a?.id) === String(agent?.id))
-}
-
 // Route the click back through the prompt box's selector so the blank-report
 // picker and the dropdown stay one selection: same auto-mode behaviour, same
 // persistence to the report.
 function toggleAgentSelection(agent: any) {
     promptBoxRef.value?.toggleDataSource?.(agent)
 }
-
-// Conversation starters from the selected agents, sourced from agent-scoped
-// starter Prompts (not the legacy data_source.conversation_starters JSON).
-// Each prompt's `text` is "Title\nDetailed prompt" — split into { title, prompt }.
-const agentConversationStarters = ref<{ title: string; prompt: string }[]>([])
-async function loadAgentStarters() {
-    const ids = [...new Set((currentAgents.value || []).map((a: any) => a?.id).filter(Boolean))]
-    if (!ids.length) { agentConversationStarters.value = []; return }
-    const texts: string[] = []
-    try {
-        // Fetch starters for all selected agents in ONE batched request (union)
-        // instead of one /prompts call per agent — a report with many attached
-        // agents otherwise fired a request per agent just to fill 3 suggestions.
-        const { data } = await useMyFetch(`/prompts?data_source_ids=${ids.join(',')}`)
-        for (const p of ((data.value as any)?.prompts || [])) if (p?.text) texts.push(p.text)
-    } catch { /* ignore */ }
-    agentConversationStarters.value = [...new Set<string>(texts)].slice(0, 3).map((s: string) => {
-        const nl = s.indexOf('\n')
-        return nl === -1
-            ? { title: s, prompt: s }
-            : { title: s.slice(0, nl).trim(), prompt: s.slice(nl + 1).trim() }
-    })
-}
-// Key the watch on the actual set of agent ids (not a deep watch) so starters
-// are refetched only when agents are added/removed, not on every nested change.
-watch(
-    () => [...new Set((currentAgents.value || []).map((a: any) => a?.id).filter(Boolean))].sort().join(','),
-    loadAgentStarters,
-    { immediate: true },
-)
 
 async function openInstructionById(instructionId: string, opts?: { initialVersionNumber?: number | null }) {
 	// Immediately switch to agent panel with loading state
@@ -5720,20 +5512,6 @@ onMounted(async () => {
 	opacity: 0;
 }
 
-.fade-in {
-    animation: fadeIn 0.6s ease-in;
-}
-
-@keyframes fadeIn {
-    0% {
-        opacity: 0;
-        transform: translateY(10px);
-    }
-    100% {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
 
 /* Minimal shimmer for reconnect banner */
 .poll-shimmer {

--- a/frontend/pages/reports/new.vue
+++ b/frontend/pages/reports/new.vue
@@ -2,8 +2,9 @@
 	<!-- Draft report: the chrome of a report with nothing behind it. No row is
 	     written until the first prompt — PromptBoxV2 creates the report and
 	     navigates to it (see its createReport), the same path the home page
-	     has always used. The composer sits in the same place as on a real
-	     report so the hand-off doesn't move it. -->
+	     has always used. The body is the report view's own empty state and the
+	     composer sits in the same place, so the hand-off changes nothing on
+	     screen except the conversation appearing. -->
 	<div class="flex flex-col h-dvh overflow-y-hidden bg-white dark:bg-gray-900 relative">
 		<header class="sticky top-0 bg-white dark:bg-gray-900 z-10 flex flex-col border-gray-200 dark:border-gray-700">
 			<div class="flex flex-row pt-1 h-[40px] pb-1 pe-2 items-center">
@@ -14,19 +15,26 @@
 			</div>
 		</header>
 
-		<!-- Where the conversation will go. Empty by definition. -->
-		<div class="flex-1 overflow-y-auto flex items-center justify-center">
-			<div class="px-4 text-center">
-				<img :src="orgIconUrl || '/assets/logo-128.png'" alt="" class="h-10 max-w-[100px] object-contain mx-auto opacity-90" />
-				<p class="mt-4 text-lg font-normal text-gray-500 dark:text-gray-400">{{ $t('home.whatCanIHelpWith') }}</p>
+		<!-- Where the conversation will go. Same scroll container and column as
+		     the report view, so the empty state lands in the same spot. -->
+		<div class="flex-1 overflow-y-auto mt-4 pb-4">
+			<div class="ps-3 pe-3 sm:ps-4 sm:pe-2 pb-[3px] max-w-2xl w-full mx-auto">
+				<ReportEmptyState
+					:mode="currentMode"
+					:available-agents="availableAgents"
+					:current-agents="currentAgents"
+					:agents-are-auto="agentsAreAuto"
+					@toggle-agent="toggleAgentSelection"
+					@starter="handleExampleClick"
+				/>
 			</div>
 		</div>
 
-		<!-- Composer: same container as the report view, so creating the report
-		     doesn't shift it. -->
+		<!-- Composer: same container as the report view. -->
 		<div class="shrink-0 bg-white dark:bg-gray-900">
 			<div :class="['mx-auto w-full', isExcel ? 'px-0' : 'px-0 max-w-none sm:px-4 sm:max-w-2xl']">
 				<PromptBoxV2
+					ref="promptBoxRef"
 					:project="draftProject"
 					:projectSelectable="true"
 					:initialSelectedDataSources="initialAgents"
@@ -34,19 +42,23 @@
 					:textareaContent="prefill"
 					:compact="isExcel"
 					@update:modelValue="(v: string) => prefill = v"
+					@update:selectedDataSources="(val: any[]) => currentAgents = val"
+					@update:availableDataSources="(val: any[]) => availableAgents = val"
+					@update:autoMode="(val: boolean) => agentsAreAuto = val"
+					@update:mode="(m: any) => currentMode = m"
 					@openInstructions="showInstructionsModal = true"
 				/>
 			</div>
 		</div>
 
-		<!-- Instructions panel, same affordance as the home page. -->
+		<!-- Instructions panel, same affordance as the report view's agent tab. -->
 		<UModal v-model="showInstructionsModal" :ui="{ width: 'sm:max-w-3xl' }">
 			<div class="h-[78vh] flex flex-col">
 				<ReportAgentPanel
 					:agents="instructionPanelAgents"
 					:show-close="true"
 					@close="showInstructionsModal = false"
-					@starter-click="onInstructionStarter"
+					@starter-click="handleExampleClick"
 				/>
 			</div>
 		</UModal>
@@ -57,6 +69,7 @@
 import PromptBoxV2 from '~/components/prompt/PromptBoxV2.vue'
 import GoBackChevron from '@/components/excel/GoBackChevron.vue'
 import ReportAgentPanel from '~/components/report/ReportAgentPanel.vue'
+import ReportEmptyState from '~/components/report/ReportEmptyState.vue'
 import { useExcel } from '~/composables/useExcel'
 
 definePageMeta({
@@ -69,8 +82,6 @@ const route = useRoute()
 const { isExcel } = useExcel()
 const { agents, selectedAgentObjects, effectiveAgentObjects } = useAgent()
 const { projects, fetchProjects } = useProjects()
-const { organization } = useOrganization()
-const { data: currentUser } = useAuth()
 
 // ── Draft context, all carried in the query string ──────────────────────
 // A draft has no row to hang context on, so the entry point that opened it
@@ -115,23 +126,33 @@ const initialAgents = computed(() => {
 	return selectedAgentObjects.value
 })
 
-const showInstructionsModal = ref(false)
-const instructionPanelAgents = computed(() => [
-	...(initialAgents.value.length ? initialAgents.value : (effectiveAgentObjects.value || [])),
-	{ id: '__global__', name: 'Global', isGlobal: true },
-])
-const onInstructionStarter = (starter: string) => {
-	const nl = (starter || '').indexOf('\n')
-	prefill.value = nl === -1 ? starter : starter.slice(nl + 1).trim()
-	showInstructionsModal.value = false
+// Live state published by the prompt box, exactly as the report view consumes
+// it — the empty state renders the selection, the box owns it.
+const promptBoxRef = ref<any>(null)
+const currentAgents = ref<any[]>([])
+const availableAgents = ref<any[]>([])
+const agentsAreAuto = ref(false)
+const currentMode = ref<'chat' | 'training'>(initialMode.value)
+
+// Route the click back through the prompt box's selector so the empty-state
+// picker and the dropdown stay one selection.
+function toggleAgentSelection(agent: any) {
+	promptBoxRef.value?.toggleDataSource?.(agent)
 }
 
-const orgIconUrl = computed(() => {
-	const orgId = organization.value?.id
-	const orgs = (currentUser.value as any)?.organizations || []
-	const org = orgs.find((o: any) => o.id === orgId) || orgs[0]
-	return org?.icon_url || null
-})
+// A starter is a prompt, so it sends — which on a draft is what creates the
+// report. Same behaviour as clicking a starter on an empty report.
+function handleExampleClick(starter: string) {
+	if (!starter) return
+	showInstructionsModal.value = false
+	promptBoxRef.value?.submitPrompt?.(starter)
+}
+
+const showInstructionsModal = ref(false)
+const instructionPanelAgents = computed(() => [
+	...(currentAgents.value.length ? currentAgents.value : (effectiveAgentObjects.value || [])),
+	{ id: '__global__', name: 'Global', isGlobal: true },
+])
 
 onMounted(() => { if (projectId.value) fetchProjects() })
 </script>

--- a/frontend/pages/reports/new.vue
+++ b/frontend/pages/reports/new.vue
@@ -1,0 +1,137 @@
+<template>
+	<!-- Draft report: the chrome of a report with nothing behind it. No row is
+	     written until the first prompt — PromptBoxV2 creates the report and
+	     navigates to it (see its createReport), the same path the home page
+	     has always used. The composer sits in the same place as on a real
+	     report so the hand-off doesn't move it. -->
+	<div class="flex flex-col h-dvh overflow-y-hidden bg-white dark:bg-gray-900 relative">
+		<header class="sticky top-0 bg-white dark:bg-gray-900 z-10 flex flex-col border-gray-200 dark:border-gray-700">
+			<div class="flex flex-row pt-1 h-[40px] pb-1 pe-2 items-center">
+				<GoBackChevron />
+				<h1 class="text-sm md:text-start text-center w-[500px]">
+					<span class="font-semibold text-sm p-1 text-gray-400 dark:text-gray-500">{{ $t('reports.newReport') }}</span>
+				</h1>
+			</div>
+		</header>
+
+		<!-- Where the conversation will go. Empty by definition. -->
+		<div class="flex-1 overflow-y-auto flex items-center justify-center">
+			<div class="px-4 text-center">
+				<img :src="orgIconUrl || '/assets/logo-128.png'" alt="" class="h-10 max-w-[100px] object-contain mx-auto opacity-90" />
+				<p class="mt-4 text-lg font-normal text-gray-500 dark:text-gray-400">{{ $t('home.whatCanIHelpWith') }}</p>
+			</div>
+		</div>
+
+		<!-- Composer: same container as the report view, so creating the report
+		     doesn't shift it. -->
+		<div class="shrink-0 bg-white dark:bg-gray-900">
+			<div :class="['mx-auto w-full', isExcel ? 'px-0' : 'px-0 max-w-none sm:px-4 sm:max-w-2xl']">
+				<PromptBoxV2
+					:project="draftProject"
+					:projectSelectable="true"
+					:initialSelectedDataSources="initialAgents"
+					:initialMode="initialMode"
+					:textareaContent="prefill"
+					:compact="isExcel"
+					@update:modelValue="(v: string) => prefill = v"
+					@openInstructions="showInstructionsModal = true"
+				/>
+			</div>
+		</div>
+
+		<!-- Instructions panel, same affordance as the home page. -->
+		<UModal v-model="showInstructionsModal" :ui="{ width: 'sm:max-w-3xl' }">
+			<div class="h-[78vh] flex flex-col">
+				<ReportAgentPanel
+					:agents="instructionPanelAgents"
+					:show-close="true"
+					@close="showInstructionsModal = false"
+					@starter-click="onInstructionStarter"
+				/>
+			</div>
+		</UModal>
+	</div>
+</template>
+
+<script setup lang="ts">
+import PromptBoxV2 from '~/components/prompt/PromptBoxV2.vue'
+import GoBackChevron from '@/components/excel/GoBackChevron.vue'
+import ReportAgentPanel from '~/components/report/ReportAgentPanel.vue'
+import { useExcel } from '~/composables/useExcel'
+
+definePageMeta({
+	layout: 'default',
+	auth: true,
+	permissions: ['create_reports']
+})
+
+const route = useRoute()
+const { isExcel } = useExcel()
+const { agents, selectedAgentObjects, effectiveAgentObjects } = useAgent()
+const { projects, fetchProjects } = useProjects()
+const { organization } = useOrganization()
+const { data: currentUser } = useAuth()
+
+// ── Draft context, all carried in the query string ──────────────────────
+// A draft has no row to hang context on, so the entry point that opened it
+// passes what it knows: ?project= (the folder it was started in), ?agents=
+// (a comma-separated scope, e.g. "New report" on an agent), ?mode=training,
+// and ?prompt= (prefilled, never auto-submitted).
+const projectId = computed(() => {
+	const q = route.query.project
+	return typeof q === 'string' && q ? q : null
+})
+const agentIds = computed(() => {
+	const q = route.query.agents
+	return (typeof q === 'string' ? q : '').split(',').map(s => s.trim()).filter(Boolean)
+})
+const initialMode = computed(() => (route.query.mode === 'training' ? 'training' : 'chat') as 'chat' | 'training')
+const prefill = ref(typeof route.query.prompt === 'string' ? route.query.prompt : '')
+
+// The project chip. Resolved from the loaded list for display only — the id
+// that actually lands on the report comes from the route, so submitting
+// before this resolves still files the report correctly.
+const draftProject = computed(() => {
+	if (!projectId.value) return null
+	const p = (projects.value || []).find((x: any) => String(x.id) === String(projectId.value))
+	return p ? { id: p.id, name: p.name, color: p.color } : null
+})
+
+// Which agents the composer opens with:
+// - ?agents= — an entry point that named a scope (the agent page). Explicit,
+//   so it overrides project defaults server-side.
+// - inside a project — nothing, which is Auto, which the backend fills with
+//   the project's default agents. Same payload the project page used to POST.
+// - otherwise — the agents the user pinned workspace-wide, empty under Auto.
+// Picks made here ride on the created report only; unlike the home page this
+// never writes back to the user's saved selection, since a draft opened for
+// one agent shouldn't repin their whole workspace.
+const initialAgents = computed(() => {
+	if (agentIds.value.length) {
+		const byId = new Map((agents.value || []).map((a: any) => [String(a.id), a]))
+		return agentIds.value.map(id => byId.get(String(id))).filter(Boolean)
+	}
+	if (projectId.value) return []
+	return selectedAgentObjects.value
+})
+
+const showInstructionsModal = ref(false)
+const instructionPanelAgents = computed(() => [
+	...(initialAgents.value.length ? initialAgents.value : (effectiveAgentObjects.value || [])),
+	{ id: '__global__', name: 'Global', isGlobal: true },
+])
+const onInstructionStarter = (starter: string) => {
+	const nl = (starter || '').indexOf('\n')
+	prefill.value = nl === -1 ? starter : starter.slice(nl + 1).trim()
+	showInstructionsModal.value = false
+}
+
+const orgIconUrl = computed(() => {
+	const orgId = organization.value?.id
+	const orgs = (currentUser.value as any)?.organizations || []
+	const org = orgs.find((o: any) => o.id === orgId) || orgs[0]
+	return org?.icon_url || null
+})
+
+onMounted(() => { if (projectId.value) fetchProjects() })
+</script>


### PR DESCRIPTION
## Summary
Refactored the empty report state UI into a standalone `ReportEmptyState` component and created a new `/reports/new` draft page that allows users to compose reports before they're persisted to the database.

## Key Changes

- **New Component**: Created `ReportEmptyState.vue` that encapsulates the empty state UI previously inline in the report view, including:
  - Training mode tip sheet with starter prompts
  - Agent picker with search and "show more" functionality
  - Conversation starters for selected agents
  - Proper sorting (most-recently-used agents first)

- **New Draft Page**: Added `/reports/new` page that:
  - Displays the same empty state and composer as a report view
  - Accepts query parameters for context: `?project=`, `?agents=`, `?mode=training`, `?prompt=`
  - Creates the actual report only when the user submits their first prompt
  - Maintains the same agent selection and mode state as the report view

- **Prompt Box Enhancement**: 
  - Added `submitPrompt()` method to allow external controls (like starter questions) to trigger submission
  - Added `projectExplicitlyPicked` tracking to distinguish user selections from defaults
  - Improved project context handling for draft reports

- **Navigation Updates**:
  - Modified "New Report" buttons across the app to navigate to `/reports/new` instead of creating reports immediately
  - Removed loading states from "New Report" buttons since creation is now deferred
  - Added draft report row to the sidebar that disappears when the report is created

- **Agent Management**:
  - Updated `KnowledgeExplorer` to open drafts scoped to specific agents via query params
  - Simplified training session creation to use the draft page with `?mode=training`

## Implementation Details

- The empty state component is fully self-contained with its own agent sorting, filtering, and starter prompt loading logic
- Draft reports use query parameters to preserve context (project, agents, mode) without requiring a database row
- The draft page shares the same layout and styling as the report view for visual consistency
- Agent selection in drafts is not persisted to user preferences (unlike the home page), keeping draft-specific choices isolated

https://claude.ai/code/session_01Kzt1rDtj4g4E7GFEfD5kFe