### PR TITLE
Fix agent trace permissions to use manage_data_source instead of view_console

### DIFF
--- a/backend/tests/e2e/rbac/test_rbac_registry.py
+++ b/backend/tests/e2e/rbac/test_rbac_registry.py
@@ -430,7 +430,6 @@ KNOWN_STALE_FRONTEND_PERMISSIONS = frozenset({
     "update_organization_members",
     "view_builds",
     "view_completion_plan",
-    "view_console",
     "view_schema",
 })
 

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -857,7 +857,7 @@
                           <span class="flex items-center gap-1.5 mb-1.5">
                             <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="activeSuggestion?.source === 'ai' ? 'bg-violet-500' : 'bg-blue-500'"></span>
                             <span class="text-[10px] text-gray-500 dark:text-gray-400 truncate">{{ activeSuggestion?.source === 'ai' ? $t('agentsPage.aiSuggestion') : $t('agentsPage.proposed') }}<template v-if="activeSuggestion?.created_at"> · {{ fmtDate(activeSuggestion.created_at) }}</template></span>
-                            <button v-if="activeSuggestion?.completion_id || activeSuggestion?.report_id" type="button" class="ms-1 text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 transition-colors" :title="$t('agentsPage.tipViewTrace')" @click.stop="openTrace(activeSuggestion)"><UIcon name="i-heroicons-arrows-pointing-out" class="w-3 h-3" /></button>
+                            <button v-if="canViewConsole && (activeSuggestion?.completion_id || activeSuggestion?.report_id)" type="button" class="ms-1 text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 transition-colors" :title="$t('agentsPage.tipViewTrace')" @click.stop="openTrace(activeSuggestion)"><UIcon name="i-heroicons-arrows-pointing-out" class="w-3 h-3" /></button>
                           </span>
                           <!-- Brief evidence stamped by the AI when it proposed this change -->
                           <span v-if="activeSuggestion?.evidence" class="block mb-1.5 text-[10px] leading-snug text-gray-400 dark:text-gray-500 italic line-clamp-3">{{ activeSuggestion.evidence }}</span>
@@ -1229,7 +1229,7 @@ import TraceModal from '~/components/console/TraceModal.vue'
 import ReviewFeed from '~/components/ReviewFeed.vue'
 import AgentAutomationSettings from '~/components/AgentAutomationSettings.vue'
 import DiffMatchPatch from 'diff-match-patch'
-import { useCan, useCanAny, useCanAll } from '~/composables/usePermissions'
+import { useCan, useCanAny, useCanAll, useCanAccessMonitoring } from '~/composables/usePermissions'
 import { useConnectionSignIn } from '~/composables/useConnectionSignIn'
 import { getEffectiveStatus, statusDotClass } from '~/composables/useConnectionStatus'
 import { useInstructionHelpers, type Instruction } from '~/composables/useInstructionHelpers'
@@ -3119,7 +3119,12 @@ const toggleHistory = () => { if (canEditDetail.value) showHistory.value = !show
 const sourceLabel = (pb: any) => pb?.source === 'ai' ? 'AI' : 'Proposed'
 
 // Agent trace: open the report/completion that produced this suggestion.
-const canViewConsole = computed(() => useCan('view_console'))
+// A suggestion carries only trace coordinates (report_id/completion_id), not
+// the agents behind that report, so gate on console access — org-wide or an
+// agent manager — and let ConsoleScope.assert_report_visible scope the
+// per-report drill-down server-side. (`view_console`, used here before, was
+// never a registry permission and hid this from everyone but a full admin.)
+const canViewConsole = computed(() => useCanAccessMonitoring())
 const showTraceModal = ref(false)
 const traceReportId = ref<string | null>(null)
 const traceCompletionId = ref<string | null>(null)

--- a/frontend/components/instructions/BuildExplorerModal.vue
+++ b/frontend/components/instructions/BuildExplorerModal.vue
@@ -714,7 +714,7 @@ import GitBranchIcon from '~/components/icons/GitBranchIcon.vue'
 import InstructionGlobalCreateComponent from '~/components/InstructionGlobalCreateComponent.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 import type { Instruction } from '~/composables/useInstructionHelpers'
-import { useCan, useCanAny } from '~/composables/usePermissions'
+import { useCanAny, useCanAccessMonitoring } from '~/composables/usePermissions'
 import { useAgent } from '~/composables/useAgent'
 import { onClickOutside } from '@vueuse/core'
 
@@ -939,7 +939,11 @@ const toast = useToast()
 // on every build operation via _enforce_build_ds_access.
 const canCreateBuilds = computed(() => useCanAny('manage_instructions', 'data_source'))
 const canManageTests = computed(() => useCanAny('manage_evals', 'data_source'))
-const canViewConsole = computed(() => useCan('view_console'))
+// Builds carry trace coordinates but not the agents behind the report, so gate
+// on console access (org-wide or agent manager) and let the backend's
+// ConsoleScope scope the per-report drill-down. `view_console` was never a
+// registry permission — it hid this from everyone but a full org admin.
+const canViewConsole = computed(() => useCanAccessMonitoring())
 
 // TraceModal state (opened from the "View trace" button on builds that were
 // produced by an agent execution).

--- a/frontend/composables/usePermissions.ts
+++ b/frontend/composables/usePermissions.ts
@@ -101,6 +101,32 @@ export const useHasOrgWideConsole = () =>
 export const useCanAccessMonitoring = () =>
   useHasOrgWideConsole() || useCanAny('manage', 'data_source')
 
+// Who can open the agent trace ("debugger") for ONE report — the bug icon on an
+// assistant message, and the same drill-down reached from a build or an
+// instruction suggestion.
+//
+// Mirrors ConsoleScope.assert_report_visible in app/core/console_access.py:
+// org admins see every report; an agent manager sees a report only when EVERY
+// agent it draws on is one they manage, because a trace replays the whole
+// conversation (generated SQL, tool arguments, results) and nothing below the
+// report carries agent attribution. A report with no agent at all is org-admin
+// only, matching the backend's `not rows` branch — so an empty/unknown list
+// fails closed here rather than reading as "nothing to check".
+//
+// Accepts the hydrated `report.data_sources` objects or plain ids.
+// Usage: useCanViewReportTrace(report.value?.data_sources)
+export const useCanViewReportTrace = (
+  dataSources?: Array<string | { id?: string | null }> | null,
+) => {
+  if (useHasOrgWideConsole()) return true
+  if (!Array.isArray(dataSources)) return false
+  const ids = [...new Set(dataSources
+    .map((item) => typeof item === 'string' ? item : item?.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0))]
+  if (ids.length === 0) return false
+  return ids.every((id) => useCan('manage', { type: 'data_source', id }))
+}
+
 // ALL-of check: does the user hold `permission` on EVERY resource id in the
 // list? Mirrors the backend's ALL-attached-agents rule for editing a shared
 // instruction (check_resource_permissions fails on the first miss). Ported

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -528,7 +528,7 @@
 
 											<!-- Debug button -->
 											<button
-												v-if="canViewConsole"
+												v-if="canViewTrace"
 												@click="openTraceModal(m.system_completion_id || m.id)"
 												class="flex items-center justify-center w-6 h-6 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md transition-colors group"
 												:title="$t('reportView.viewAgentTrace')"
@@ -1201,7 +1201,7 @@ import QueryCodeEditorModal from '~/components/tools/QueryCodeEditorModal.vue'
 import ImagePreviewModal from '~/components/ImagePreviewModal.vue'
 import Spinner from '~/components/Spinner.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
-import { useCan } from '~/composables/usePermissions'
+import { useCanViewReportTrace } from '~/composables/usePermissions'
 import { promptMentionsToRefs } from '~/utils/mentions'
 import { MarkdownRender } from 'markstream-vue'
 import 'markstream-vue/index.css'
@@ -1340,7 +1340,12 @@ function modelBrandFor(model?: string | null) {
 }
 
 // Permissions
-const canViewConsole = computed(() => useCan('view_console'))
+// Agent trace ("debugger") on an assistant message. `view_console` never
+// existed in the permission registry, so this was silently false for everyone
+// but a full org admin — including the agent's own owner, whom the backend
+// (ConsoleScope) does authorize. Gate on the real rule instead: org-wide
+// console, or `manage` on every agent this report draws on.
+const canViewTrace = computed(() => useCanViewReportTrace(report.value?.data_sources))
 
 // Org settings (follow-up suggestions toggle)
 const { isFollowUpsEnabled } = useOrgSettings()


### PR DESCRIPTION
## Summary
This PR fixes the permission checks for viewing agent traces (the "debugger" feature) across the frontend. The previous implementation used a non-existent `view_console` permission that was never registered in the backend, effectively hiding this feature from all users except full org admins. This change aligns the frontend with the backend's actual authorization logic.

## Key Changes

- **New permission composable**: Added `useCanViewReportTrace()` in `usePermissions.ts` that mirrors the backend's `ConsoleScope.assert_report_visible` logic:
  - Org admins can view all report traces
  - Agent managers can view traces only when they manage ALL agents in the report
  - Reports with no agents are org-admin only (fails closed)
  - Accepts both hydrated data source objects and plain IDs

- **Updated trace access gates**:
  - `KnowledgeExplorer.vue`: Changed suggestion trace button from `useCan('view_console')` to `useCanAccessMonitoring()` (org-wide console or agent manager)
  - `reports/[id]/index.vue`: Changed assistant message trace button from `useCan('view_console')` to `useCanViewReportTrace(report.value?.data_sources)` for per-report agent validation
  - `BuildExplorerModal.vue`: Changed build trace button from `useCan('view_console')` to `useCanAccessMonitoring()`

- **Removed invalid permission**: Deleted `view_console` from the frontend permission registry test, as it was never a valid backend permission

## Implementation Details

The solution uses two different permission checks depending on context:
- **`useCanAccessMonitoring()`**: Used for suggestions and builds where agent attribution isn't available in the UI, delegating per-report validation to the backend
- **`useCanViewReportTrace()`**: Used for reports where agent data is available, validating upfront that the user manages all agents in the report

This maintains security by ensuring users can only view traces for reports they're authorized to see, while properly supporting agent managers (not just org admins).

https://claude.ai/code/session_01Coqep3yvasFQho6zN4LuCT