### PR TITLE
Resolve agent icons once, ship the token on every payload

### DIFF
--- a/backend/app/schemas/agent_icon.py
+++ b/backend/app/schemas/agent_icon.py
@@ -1,0 +1,143 @@
+"""The single answer to "what icon does this agent have".
+
+An agent's icon used to be recomputed independently by every surface that drew
+one — the agents explorer, the report agent panel, the data tools, two separate
+tool-execution serializers — and they disagreed. The worst case was an agent
+with more than one connection: ``type`` was taken from ``connections[0]`` while
+``connector_key`` scanned for the *first connection resolving a brand*, so an
+agent wired to ``[postgresql, notion-mcp]`` rendered notion's logo in the
+explorer and postgres' in the tool ticker.
+
+So resolution happens here, once, and every payload that names an agent carries
+the result as ``icon_token``. The client renders the token and decides nothing.
+
+Token vocabulary (a subset of the override format already parsed by the
+frontend's ``utils/agentIcon.ts``, so an older client understands it):
+
+``emoji:<grapheme>``
+    Render the emoji.
+``type:<key>``
+    Render ``<key>``'s icon, where the key is either a connector brand
+    (``notion``) or a connection type (``postgresql``). One kind for both
+    because the client resolves a key against the brand map first and the
+    type-asset map second — the same fallthrough it already applies to a
+    ``type:`` override.
+``None``
+    Nothing to render (an agent with no connections); the client falls back to
+    its own generic glyph.
+
+Precedence: the admin's explicit override wins, then a connector brand, then the
+first connection's type. Brand-over-type is a deliberate choice and not
+self-evident — for a mostly-postgres agent that also has a notion connection it
+shows notion — but it is what the explorer has always shown, which is the icon
+users already recognize the agent by.
+"""
+
+from typing import Any, Optional, Sequence
+
+EMOJI_PREFIX = "emoji:"
+TYPE_PREFIX = "type:"
+
+
+def _connector_key_from_config(cfg: Any) -> Optional[str]:
+    """Preset key ('gmail', 'notion', …) for a tool-provider connection so the UI
+    renders the provider's brand icon even though the connection type is 'mcp'.
+
+    Prefer an explicit ``config.catalog_key``; otherwise match ``config.server_url``
+    against the MCP presets. Mirrors ``data_source_service._conn_connector_key`` so
+    report-embedded connections resolve the same key as the connections route.
+    Returns None when the config isn't a known preset connector.
+    """
+    if isinstance(cfg, str):
+        import json as _json
+        try:
+            cfg = _json.loads(cfg)
+        except Exception:
+            cfg = None
+    if not isinstance(cfg, dict):
+        return None
+    if cfg.get("catalog_key"):
+        return cfg["catalog_key"]
+    server_url = cfg.get("server_url")
+    if server_url:
+        try:
+            from app.schemas.data_source_registry import mcp_presets
+            for p in mcp_presets():
+                if p.get("server_url") == server_url:
+                    return p["key"]
+        except Exception:
+            pass
+    return None
+
+
+def _get(obj: Any, field: str) -> Any:
+    """Read a field off a connection, whether it's an ORM row, a Pydantic model
+    or a plain dict — the three shapes the call sites actually pass."""
+    if isinstance(obj, dict):
+        return obj.get(field)
+    return getattr(obj, field, None)
+
+
+def connection_connector_key(conn: Any) -> Optional[str]:
+    """The brand key for one connection, or None if it isn't a known connector.
+
+    ``ConnectionEmbedded``/``ConnectionReportEmbedded`` have already derived
+    ``connector_key``; ORM ``Connection`` rows have not, so fall back to reading
+    their config.
+    """
+    key = _get(conn, "connector_key")
+    if key:
+        return key
+    return _connector_key_from_config(_get(conn, "config"))
+
+
+def _parse_override(icon: Optional[str]) -> Optional[str]:
+    """The token an admin's explicit override contributes, or None when it
+    contributes nothing.
+
+    Mirrors ``parseAgentIcon``: ``emoji:`` and ``type:`` are rendered, anything
+    else (``preset:``, a future kind, a garbage value) is ignored so the derived
+    icon shows instead of a broken one.
+    """
+    if not isinstance(icon, str):
+        return None
+    raw = icon.strip()
+    sep = raw.find(":")
+    if sep == -1:
+        return None
+    kind, value = raw[:sep], raw[sep + 1:].strip()
+    if not value:
+        return None
+    if kind == "emoji":
+        return f"{EMOJI_PREFIX}{value}"
+    if kind == "type":
+        return f"{TYPE_PREFIX}{value}"
+    return None
+
+
+def resolve_agent_icon_token(
+    icon: Optional[str],
+    connections: Optional[Sequence[Any]],
+) -> Optional[str]:
+    """Resolve an agent's icon to a single token. See the module docstring.
+
+    ``connections`` must be in the order the agent's relationship yields them
+    (``Connection.created_at, Connection.id``) — "the first connection" is only
+    a stable answer because of that ordering.
+    """
+    override = _parse_override(icon)
+    if override:
+        return override
+
+    conns = list(connections or [])
+    for conn in conns:
+        key = connection_connector_key(conn)
+        if key:
+            return f"{TYPE_PREFIX}{key}"
+
+    for conn in conns:
+        conn_type = _get(conn, "type")
+        if conn_type:
+            return f"{TYPE_PREFIX}{conn_type}"
+
+    return None

--- a/backend/app/schemas/completion_v2_schema.py
+++ b/backend/app/schemas/completion_v2_schema.py
@@ -12,10 +12,20 @@ from .file_schema import FileSchema
 
 
 class ToolExecutionDataSourceSchema(BaseModel):
-    """Lightweight data source info for display in tool execution UI."""
+    """Lightweight data source info for display in tool execution UI.
+
+    Rides along with every tool execution in every view — the report page, the
+    shared ``/c/{token}`` page and the report summary — which is why the data
+    tools read their icon from here rather than from a page-level prop the
+    shared views never passed.
+    """
     id: str
     name: Optional[str] = None
     type: Optional[str] = None  # connection type e.g. 'postgres', 'bigquery'
+    # Resolved display icon ("emoji:<grapheme>" | "type:<key>" | None), from
+    # app.schemas.agent_icon — the same token the agents list and report payload
+    # carry, so one agent draws one icon everywhere.
+    icon_token: Optional[str] = None
 
 
 class ToolExecutionUISchema(ToolExecutionSchema):

--- a/backend/app/schemas/data_source_schema.py
+++ b/backend/app/schemas/data_source_schema.py
@@ -2,35 +2,35 @@ from pydantic import BaseModel
 from typing import Any, Dict, List, Optional, Union
 
 
-def _connector_key_from_config(cfg: Any) -> Optional[str]:
-    """Preset key ('gmail', 'notion', …) for a tool-provider connection so the UI
-    renders the provider's brand icon even though the connection type is 'mcp'.
+from app.schemas.agent_icon import (
+    _connector_key_from_config,
+    resolve_agent_icon_token,
+)
+from pydantic import Field, model_validator
 
-    Prefer an explicit ``config.catalog_key``; otherwise match ``config.server_url``
-    against the MCP presets. Mirrors ``data_source_service._conn_connector_key`` so
-    report-embedded connections resolve the same key as the connections route.
-    Returns None when the config isn't a known preset connector.
+
+class AgentIconTokenMixin(BaseModel):
+    """Carries the agent's resolved icon as ``icon_token``.
+
+    Any agent-facing schema with ``icon`` and ``connections`` fields gets the
+    token for free by mixing this in — which is the point: the resolution lives
+    in one place (``app.schemas.agent_icon``) and no construction site can
+    forget it or disagree with it. ``icon``/``type``/``connector_key`` stay on
+    the payload for the connection-level UI that legitimately needs them.
     """
-    if isinstance(cfg, str):
-        import json as _json
-        try:
-            cfg = _json.loads(cfg)
-        except Exception:
-            cfg = None
-    if not isinstance(cfg, dict):
-        return None
-    if cfg.get("catalog_key"):
-        return cfg["catalog_key"]
-    server_url = cfg.get("server_url")
-    if server_url:
-        try:
-            from app.schemas.data_source_registry import mcp_presets
-            for p in mcp_presets():
-                if p.get("server_url") == server_url:
-                    return p["key"]
-        except Exception:
-            pass
-    return None
+
+    # Resolved display icon: "emoji:<grapheme>" | "type:<key>" | None.
+    # Clients render this verbatim instead of re-deriving from type/connector_key.
+    icon_token: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _resolve_icon_token(self):
+        if self.icon_token is None:
+            self.icon_token = resolve_agent_icon_token(
+                getattr(self, 'icon', None),
+                getattr(self, 'connections', None),
+            )
+        return self
 
 
 class DataSourceSummarySchema(BaseModel):
@@ -52,14 +52,22 @@ class DataSourceSummarySchema(BaseModel):
     class Config:
         from_attributes = True
 
-class DataSourceMinimalSchema(BaseModel):
-    """Minimal DataSource schema."""
+class DataSourceMinimalSchema(AgentIconTokenMixin):
+    """Minimal DataSource schema — the agent chip shape used by instructions,
+    entities and prompts."""
     id: str
     name: str
     type: Optional[str] = None  # Computed from connection
     description: Optional[str] = None
     # Optional per-agent custom icon override ("emoji:<grapheme>" | "preset:<key>").
     icon: Optional[str] = None
+
+    # Input-only (never serialized): the mixin needs the agent's connections to
+    # resolve icon_token, and this shape doesn't otherwise expose them. Same
+    # trick ConnectionReportEmbedded uses for `config`. Populated automatically
+    # when validating off an ORM DataSource; pass it explicitly when building
+    # this schema field-by-field, or icon_token resolves to the override only.
+    connections: Optional[Any] = Field(default=None, exclude=True)
 
     class Config:
         from_attributes = True
@@ -224,7 +232,7 @@ class ConnectionReportEmbedded(BaseModel):
         from_attributes = True
 
 
-class DataSourceReportSchema(BaseModel):
+class DataSourceReportSchema(AgentIconTokenMixin):
     """DataSource schema used in Report responses.
 
     Serialized to anyone who can view the report — so no agent-management
@@ -268,7 +276,7 @@ class DataSourceBase(BaseModel):
     name: str = None
 
 
-class DataSourceSchema(DataSourceBase):
+class DataSourceSchema(DataSourceBase, AgentIconTokenMixin):
     """Full DataSource (Domain) schema with nested connection info."""
     class Config:
         from_attributes = True
@@ -327,7 +335,7 @@ class DataSourceSchema(DataSourceBase):
         from_attributes = True
 
 
-class DataSourceListItemSchema(BaseModel):
+class DataSourceListItemSchema(AgentIconTokenMixin):
     """List item schema for DataSource with nested connection info."""
     id: str
     name: str

--- a/backend/app/schemas/instruction_reference_schema.py
+++ b/backend/app/schemas/instruction_reference_schema.py
@@ -39,6 +39,10 @@ class InstructionReferenceSchema(InstructionReferenceBase):
     # Optional per-agent custom icon override ("emoji:<grapheme>" | "preset:<key>").
     # None = use the default type/connector icon.
     data_source_icon: Optional[str] = None
+    # Resolved display icon for the referenced agent ("emoji:<grapheme>" |
+    # "type:<key>" | None) from app.schemas.agent_icon — render this rather than
+    # re-deriving from data_source_type/data_source_icon.
+    data_source_icon_token: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/mention_schema.py
+++ b/backend/app/schemas/mention_schema.py
@@ -14,6 +14,9 @@ class DataSourceMention(BaseModel):
     data_source_type: str  # From DataSource.type (postgres, snowflake, etc.)
     # Optional per-agent custom icon override ("emoji:<grapheme>" | "preset:<key>").
     icon: Optional[str] = None
+    # Resolved display icon ("emoji:<grapheme>" | "type:<key>" | None), see
+    # app.schemas.agent_icon — render this rather than data_source_type/icon.
+    icon_token: Optional[str] = None
 
     # Real fields from DataSource model
     description: Optional[str] = None  # DataSource.description

--- a/backend/app/serializers/completion_v2.py
+++ b/backend/app/serializers/completion_v2.py
@@ -18,6 +18,7 @@ from app.schemas.completion_v2_schema import (
     ToolExecutionUISchema,
     ToolExecutionDataSourceSchema,
 )
+from app.schemas.agent_icon import resolve_agent_icon_token
 from app.schemas.widget_schema import WidgetSchema
 from app.schemas.step_schema import StepSchema
 from app.schemas.visualization_schema import VisualizationSchema
@@ -85,7 +86,15 @@ def _extract_data_source_ids(tool_execution: ToolExecution) -> List[str]:
 async def _resolve_data_sources(
     db: AsyncSession, ds_ids: List[str]
 ) -> List[ToolExecutionDataSourceSchema]:
-    """Look up DataSource name + first Connection type for a list of DS IDs."""
+    """Look up display info for a list of DS IDs: name, first connection type,
+    and the agent's resolved ``icon_token``.
+
+    Every connection is selected, ordered the same way ``DataSource.connections``
+    is, because the icon of a multi-connection agent depends on all of them (a
+    notion connection gives the agent notion's logo even when it isn't first).
+    The previous version selected one unordered join row, which made both the
+    type and the icon depend on whichever row the database happened to return.
+    """
     if not ds_ids:
         return []
 
@@ -97,22 +106,67 @@ async def _resolve_data_sources(
         select(
             DataSource.id,
             DataSource.name,
+            DataSource.icon,
             Connection.type,
+            Connection.config,
         )
         .join(domain_connection, domain_connection.c.data_source_id == DataSource.id)
         .join(Connection, Connection.id == domain_connection.c.connection_id)
         .where(DataSource.id.in_(ds_ids))
+        .order_by(Connection.created_at, Connection.id)
     )
-    # Take first connection type per DS
-    seen: Dict[str, ToolExecutionDataSourceSchema] = {}
-    for row in rows:
-        ds_id = str(row[0])
-        if ds_id not in seen:
-            seen[ds_id] = ToolExecutionDataSourceSchema(
-                id=ds_id, name=row[1], type=row[2]
-            )
+
+    names: Dict[str, Optional[str]] = {}
+    icons: Dict[str, Optional[str]] = {}
+    conns: Dict[str, List[Dict[str, Any]]] = {}
+    for ds_id_raw, name, icon, conn_type, conn_config in rows:
+        ds_id = str(ds_id_raw)
+        names.setdefault(ds_id, name)
+        icons.setdefault(ds_id, icon)
+        conns.setdefault(ds_id, []).append({"type": conn_type, "config": conn_config})
+
     # Return in original order
-    return [seen[did] for did in ds_ids if did in seen]
+    return [
+        ToolExecutionDataSourceSchema(
+            id=did,
+            name=names[did],
+            type=(conns[did][0]["type"] if conns.get(did) else None),
+            icon_token=resolve_agent_icon_token(icons[did], conns.get(did)),
+        )
+        for did in ds_ids
+        if did in names
+    ]
+
+
+async def resolve_data_sources_for_tool_executions(
+    db: AsyncSession, tool_executions: List[Any]
+) -> Dict[str, List[ToolExecutionDataSourceSchema]]:
+    """Map tool-execution id -> the agents it references, in ONE query for the
+    whole page.
+
+    The per-block async serializer resolves one tool execution at a time, which a
+    list endpoint can't afford; without this the list paths shipped no agents at
+    all and the client was left to guess an icon from whatever else it had. Use
+    this wherever blocks are serialized in bulk.
+    """
+    by_te: Dict[str, List[str]] = {}
+    all_ids: List[str] = []
+    for te in tool_executions or []:
+        if te is None:
+            continue
+        ds_ids = _extract_data_source_ids(te)
+        if ds_ids:
+            by_te[str(te.id)] = ds_ids
+            all_ids.extend(ds_ids)
+    if not all_ids:
+        return {}
+
+    resolved = await _resolve_data_sources(db, list(dict.fromkeys(all_ids)))
+    index = {ds.id: ds for ds in resolved}
+    return {
+        te_id: [index[did] for did in ds_ids if did in index]
+        for te_id, ds_ids in by_te.items()
+    }
 
 
 # How many result rows to embed inline in the completions list as a preview.

--- a/backend/app/services/completion_service.py
+++ b/backend/app/services/completion_service.py
@@ -33,7 +33,12 @@ from app.schemas.completion_v2_schema import (
     CompletionsV2Response,
 )
 from app.services.llm_service import LLMService
-from app.serializers.completion_v2 import PREVIEW_ROWS, serialize_block_v2, serialize_block_v2_sync
+from app.serializers.completion_v2 import (
+    PREVIEW_ROWS,
+    resolve_data_sources_for_tool_executions,
+    serialize_block_v2,
+    serialize_block_v2_sync,
+)
 from app.models.visualization import Visualization
 from app.schemas.agent_execution_schema import PlanDecisionSchema
 from app.schemas.sse_schema import SSEEvent, format_sse_event
@@ -1231,6 +1236,12 @@ class CompletionService:
 
         span.add_event("batch_queries_done")
 
+        # The agents each tool execution references, resolved once for the page.
+        # The sync serializer can't query, and without this the completions list
+        # shipped no agents — leaving the data tools to infer an icon from a
+        # page-level prop that only the report page passes.
+        ds_by_te = await resolve_data_sources_for_tool_executions(db, list(te_map.values()))
+
         # 5) Build per-completion block lists and compute aggregates using pre-loaded data
         completion_id_to_blocks: dict[str, list[CompletionBlockV2Schema]] = {cid: [] for cid in completion_ids}
         total_blocks = 0
@@ -1291,6 +1302,7 @@ class CompletionService:
                 widget_last_step=widget_last_step,
                 created_step=created_step,
                 created_visualizations=created_visualizations,
+                data_sources=ds_by_te.get(str(te.id)) if te else None,
             )
 
             completion_id_to_blocks[b.completion_id].append(block_schema)
@@ -1706,6 +1718,12 @@ class CompletionService:
             for v in vis_res.scalars().all():
                 visualization_map[v.id] = v
 
+        # The agents each tool execution references, resolved once for the page.
+        # The sync serializer can't query, and without this the completions list
+        # shipped no agents — leaving the data tools to infer an icon from a
+        # page-level prop that only the report page passes.
+        ds_by_te = await resolve_data_sources_for_tool_executions(db, list(te_map.values()))
+
         # Build per-completion block lists using pre-loaded data
         completion_id_to_blocks: dict[str, list[CompletionBlockV2Schema]] = {cid: [] for cid in ids}
         latest_block_for_step = _latest_block_per_step(blocks, te_map, all_completions)
@@ -1746,6 +1764,7 @@ class CompletionService:
                 widget_last_step=widget_last_step,
                 created_step=created_step,
                 created_visualizations=created_visualizations,
+                data_sources=ds_by_te.get(str(te.id)) if te else None,
             )
             completion_id_to_blocks[b.completion_id].append(block_schema)
 

--- a/backend/app/services/instruction_service.py
+++ b/backend/app/services/instruction_service.py
@@ -75,6 +75,42 @@ SETTLED_HUNK_KEY = "__settled__"
 VOIDED_HUNK_KEY = "__voided__"
 
 
+async def _resolve_reference_data_source(db, data_source_id):
+    """Display fields for the agent an instruction reference points at.
+
+    Returns None when the agent is gone. Loads every connection in the
+    relationship's order so ``data_source_icon_token`` matches the icon the same
+    agent shows in the agents explorer and the data tools — the two call sites
+    this replaces each took one unordered join row, so a multi-connection agent
+    could get a different icon here than anywhere else.
+    """
+    from app.models.connection import Connection
+    from app.models.domain_connection import domain_connection
+    from app.schemas.agent_icon import resolve_agent_icon_token
+
+    rows = await db.execute(
+        select(DataSource.name, DataSource.icon, Connection.type, Connection.config)
+        .select_from(DataSource)
+        .outerjoin(domain_connection, domain_connection.c.data_source_id == DataSource.id)
+        .outerjoin(Connection, domain_connection.c.connection_id == Connection.id)
+        .where(DataSource.id == data_source_id)
+        .order_by(Connection.created_at, Connection.id)
+    )
+    found = rows.all()
+    if not found:
+        return None
+
+    name, icon = found[0][0], found[0][1]
+    # outerjoin yields one all-NULL connection row for an agent with none.
+    conns = [{"type": r[2], "config": r[3]} for r in found if r[2] is not None]
+    return {
+        "data_source_name": name,
+        "data_source_type": conns[0]["type"] if conns else None,
+        "data_source_icon": icon,
+        "data_source_icon_token": resolve_agent_icon_token(icon, conns),
+    }
+
+
 class InstructionService:
     def __init__(self):
         self.reference_service = InstructionReferenceService()
@@ -5225,7 +5261,14 @@ class InstructionService:
             )
             primary_ds = primary_result.scalars().all()
             instruction_dict["primary_for"] = [
-                DataSourceMinimalSchema(id=str(ds.id), name=ds.name, icon=getattr(ds, "icon", None)).model_dump()
+                DataSourceMinimalSchema(
+                    id=str(ds.id),
+                    name=ds.name,
+                    icon=getattr(ds, "icon", None),
+                    # Input-only; lets the schema resolve icon_token (excluded
+                    # from the dump, see DataSourceMinimalSchema).
+                    connections=getattr(ds, "connections", None),
+                ).model_dump()
                 for ds in primary_ds
             ]
         except Exception as e:
@@ -5248,20 +5291,9 @@ class InstructionService:
                         ref_data["object"] = MetadataResourceSchema.from_orm(referenced_obj).model_dump()
                         
                         # Add data source info for metadata resources
-                        from app.models.connection import Connection
-                        from app.models.domain_connection import domain_connection
-                        ds_result = await db.execute(
-                            select(DataSource.name, Connection.type, DataSource.icon)
-                            .select_from(DataSource)
-                            .outerjoin(domain_connection, domain_connection.c.data_source_id == DataSource.id)
-                            .outerjoin(Connection, domain_connection.c.connection_id == Connection.id)
-                            .where(DataSource.id == referenced_obj.data_source_id)
-                        )
-                        ds_info = ds_result.first()
+                        ds_info = await _resolve_reference_data_source(db, referenced_obj.data_source_id)
                         if ds_info:
-                            ref_data["data_source_name"] = ds_info.name
-                            ref_data["data_source_type"] = ds_info.type
-                            ref_data["data_source_icon"] = ds_info.icon
+                            ref_data.update(ds_info)
                             ref_data["data_source_id"] = referenced_obj.data_source_id
                             
                     elif ref.object_type == "datasource_table":
@@ -5269,20 +5301,9 @@ class InstructionService:
                         ref_data["object"] = DataSourceTableSchema.from_orm(referenced_obj).model_dump()
                         
                         # Add data source info for datasource tables
-                        from app.models.connection import Connection
-                        from app.models.domain_connection import domain_connection
-                        ds_result = await db.execute(
-                            select(DataSource.name, Connection.type, DataSource.icon)
-                            .select_from(DataSource)
-                            .outerjoin(domain_connection, domain_connection.c.data_source_id == DataSource.id)
-                            .outerjoin(Connection, domain_connection.c.connection_id == Connection.id)
-                            .where(DataSource.id == referenced_obj.datasource_id)
-                        )
-                        ds_info = ds_result.first()
+                        ds_info = await _resolve_reference_data_source(db, referenced_obj.datasource_id)
                         if ds_info:
-                            ref_data["data_source_name"] = ds_info.name
-                            ref_data["data_source_type"] = ds_info.type
-                            ref_data["data_source_icon"] = ds_info.icon
+                            ref_data.update(ds_info)
                             ref_data["data_source_id"] = referenced_obj.datasource_id
                 else:
                     logger.warning(f"Referenced object not found: type={ref.object_type}, id={ref.object_id}")

--- a/backend/app/services/mention_service.py
+++ b/backend/app/services/mention_service.py
@@ -180,6 +180,7 @@ class MentionService:
                 'name': getattr(ds, 'name', ''),
                 'data_source_type': getattr(ds, 'type', ''),
                 'icon': getattr(ds, 'icon', None),
+                'icon_token': getattr(ds, 'icon_token', None),
                 'description': getattr(ds, 'description', None),
                 'is_active': True,
                 'is_public': None,

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -3521,6 +3521,13 @@ class ReportService:
         
         
         # Build per-completion block lists (sanitized)
+        # Agents referenced by these tool executions, resolved once. The data
+        # tools render their source icon from this; a shared conversation used to
+        # ship no agents at all, so the same tool card that showed a snowflake
+        # icon to the report's owner showed a generic one to everyone else.
+        from app.serializers.completion_v2 import resolve_data_sources_for_tool_executions
+        ds_by_te = await resolve_data_sources_for_tool_executions(db, list(te_map.values()))
+
         completion_id_to_blocks: dict = {cid: [] for cid in completion_ids}
         for b in blocks:
             pd = pd_map.get(b.plan_decision_id) if b.plan_decision_id else None
@@ -3573,6 +3580,12 @@ class ReportService:
                     "arguments_json": te.arguments_json,
                     "result_json": result_json,
                     "duration_ms": te.duration_ms,
+                    # Id + resolved icon only: enough for the tool card's source
+                    # icon, without naming the org's agents to a public viewer.
+                    "data_sources": [
+                        {"id": ds.id, "icon_token": ds.icon_token}
+                        for ds in ds_by_te.get(str(te.id), [])
+                    ] or None,
                 })
             
             completion_id_to_blocks[b.completion_id].append(block_data)
@@ -3681,16 +3694,33 @@ class ReportService:
             from app.models.domain_connection import domain_connection
             from app.schemas.completion_v2_schema import ToolExecutionDataSourceSchema
 
+            from app.schemas.agent_icon import resolve_agent_icon_token
+
+            # Every connection, in the relationship's order — a multi-connection
+            # agent's icon depends on all of them, not on whichever join row
+            # came back first (see app.schemas.agent_icon).
             ds_rows = await db.execute(
-                select(DS.id, DS.name, Connection.type)
+                select(DS.id, DS.name, DS.icon, Connection.type, Connection.config)
                 .join(domain_connection, domain_connection.c.data_source_id == DS.id)
                 .join(Connection, Connection.id == domain_connection.c.connection_id)
                 .where(DS.id.in_(list(set(all_ds_ids))))
+                .order_by(Connection.created_at, Connection.id)
             )
+            ds_conns: dict[str, list[dict]] = {}
+            ds_names: dict[str, object] = {}
+            ds_icons: dict[str, object] = {}
             for r in ds_rows:
                 ds_id = str(r[0])
-                if ds_id not in ds_schema_map:
-                    ds_schema_map[ds_id] = ToolExecutionDataSourceSchema(id=ds_id, name=r[1], type=r[2])
+                ds_names.setdefault(ds_id, r[1])
+                ds_icons.setdefault(ds_id, r[2])
+                ds_conns.setdefault(ds_id, []).append({"type": r[3], "config": r[4]})
+            for ds_id, conns in ds_conns.items():
+                ds_schema_map[ds_id] = ToolExecutionDataSourceSchema(
+                    id=ds_id,
+                    name=ds_names[ds_id],
+                    type=conns[0]["type"] if conns else None,
+                    icon_token=resolve_agent_icon_token(ds_icons[ds_id], conns),
+                )
 
         # 4) Build query schemas
         queries: list[SummaryToolExecutionSchema] = []

--- a/backend/tests/unit/test_agent_icon_token.py
+++ b/backend/tests/unit/test_agent_icon_token.py
@@ -1,0 +1,138 @@
+"""One agent, one icon — on every payload that names it.
+
+The bug these cover: an agent's icon used to be recomputed by each surface that
+drew one, from a different pair of fields. ``type`` came from ``connections[0]``
+while ``connector_key`` scanned for the first connection resolving a brand, so an
+agent wired to ``[postgresql, notion-mcp]`` showed notion's logo in the agents
+explorer and postgres' in the data-tool ticker.
+"""
+
+import datetime as dt
+
+import pytest
+
+from app.schemas.agent_icon import resolve_agent_icon_token
+from app.schemas.completion_v2_schema import ToolExecutionDataSourceSchema
+from app.schemas.data_source_schema import (
+    DataSourceListItemSchema,
+    DataSourceMinimalSchema,
+    DataSourceReportSchema,
+)
+
+NOW = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+PG = {"id": "c1", "name": "warehouse", "type": "postgresql"}
+NOTION = {"id": "c2", "name": "notion", "type": "mcp", "config": {"catalog_key": "notion"}}
+
+
+@pytest.mark.parametrize(
+    "icon, connections, expected",
+    [
+        # A single ordinary connection: the connection's type.
+        (None, [PG], "type:postgresql"),
+        # The reported bug. A brand anywhere in the list wins, whichever position
+        # it is in — so both orderings agree, and so does every surface.
+        (None, [PG, NOTION], "type:notion"),
+        (None, [NOTION, PG], "type:notion"),
+        # An explicit override outranks anything derived.
+        ("emoji:\U0001f4ca", [PG, NOTION], "emoji:\U0001f4ca"),
+        ("type:snowflake", [PG, NOTION], "type:snowflake"),
+        # 'preset:' is reserved but not yet renderable, and a malformed token is
+        # not a reason to show a broken image: both fall through to the derived
+        # icon (mirrors the frontend's parseAgentIcon).
+        ("preset:pretty", [PG], "type:postgresql"),
+        ("nonsense", [PG], "type:postgresql"),
+        ("emoji:", [PG], "type:postgresql"),
+        # Nothing to draw.
+        (None, [], None),
+        (None, None, None),
+    ],
+)
+def test_resolve_agent_icon_token(icon, connections, expected):
+    assert resolve_agent_icon_token(icon, connections) == expected
+
+
+def test_connector_key_derived_from_server_url_not_only_catalog_key():
+    """A catalog connection records its server_url and not always a catalog_key."""
+    conn = {"type": "mcp", "config": {"server_url": "https://mcp.notion.com/mcp"}}
+    assert resolve_agent_icon_token(None, [conn]) == "type:notion"
+
+
+def test_already_derived_connector_key_is_preferred_over_config():
+    """Embedded connection schemas have derived connector_key themselves; the
+    resolver must use it rather than re-parsing a config it may not carry."""
+    conn = {"type": "mcp", "connector_key": "linear", "config": None}
+    assert resolve_agent_icon_token(None, [conn]) == "type:linear"
+
+
+def _list_item(**kw):
+    return DataSourceListItemSchema(
+        id=kw.pop("id", "a1"),
+        name=kw.pop("name", "FKA"),
+        description=None,
+        status="active",
+        created_at=NOW,
+        **kw,
+    )
+
+
+def _report_item(**kw):
+    return DataSourceReportSchema(
+        id=kw.pop("id", "a1"),
+        name=kw.pop("name", "FKA"),
+        organization_id="o1",
+        created_at=NOW,
+        updated_at=NOW,
+        description=None,
+        summary=None,
+        is_active=True,
+        **kw,
+    )
+
+
+@pytest.mark.parametrize("connections, expected", [
+    ([PG], "type:postgresql"),
+    ([PG, NOTION], "type:notion"),
+    ([], None),
+])
+def test_every_agent_facing_schema_agrees(connections, expected):
+    """The agents list (explorer, pickers), the report payload (agent panel) and
+    the instruction/entity chip shape must not disagree about one agent."""
+    tokens = {
+        "list": _list_item(connections=connections).icon_token,
+        "report": _report_item(connections=connections).icon_token,
+        "minimal": DataSourceMinimalSchema(
+            id="a1", name="FKA", connections=connections
+        ).icon_token,
+        # What the data tools receive, resolved from the same helper.
+        "tool_execution": ToolExecutionDataSourceSchema(
+            id="a1",
+            name="FKA",
+            type=(connections[0]["type"] if connections else None),
+            icon_token=resolve_agent_icon_token(None, connections),
+        ).icon_token,
+    }
+    assert set(tokens.values()) == {expected}, tokens
+
+
+def test_legacy_type_field_does_not_change_the_token():
+    """``type`` is the first connection's; the token may legitimately differ from
+    it (a brand later in the list). Both stay on the payload, and the client must
+    render the token — so the token must not be contaminated by ``type``."""
+    item = _list_item(connections=[PG, NOTION], type="postgresql", connector_key="notion")
+    assert item.type == "postgresql"
+    assert item.icon_token == "type:notion"
+
+
+def test_minimal_schema_does_not_serialize_its_input_only_connections():
+    """``connections`` exists on the chip shape only so the token can be resolved;
+    leaking it would widen a deliberately slim payload."""
+    dumped = DataSourceMinimalSchema(id="a1", name="FKA", connections=[PG, NOTION]).model_dump()
+    assert dumped["icon_token"] == "type:notion"
+    assert "connections" not in dumped
+
+
+def test_explicit_icon_token_is_not_overwritten():
+    """Call sites that resolved the token themselves (raw SQL paths) pass it in."""
+    item = _list_item(connections=[PG], icon_token="type:already_set")
+    assert item.icon_token == "type:already_set"

--- a/frontend/components/AgentFlyout.vue
+++ b/frontend/components/AgentFlyout.vue
@@ -32,7 +32,7 @@
                 <DataSourceIcon
                   :type="primaryConnection?.type"
                   :connector-key="primaryConnection?.connector_key"
-                  :icon="agentDetails?.icon"
+                  :icon-token="agentDetails?.icon_token" :icon="agentDetails?.icon"
                   class="h-4 w-4 flex-shrink-0"
                 />
                 <div class="text-sm font-semibold text-gray-900 dark:text-white truncate">

--- a/frontend/components/AgentSelector.vue
+++ b/frontend/components/AgentSelector.vue
@@ -56,17 +56,17 @@
         <template v-if="nav">
           <UTooltip v-if="collapsed" :text="navLabel" :popper="{ placement: 'right' }">
             <span class="relative flex items-center justify-center w-5 h-5">
-              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" :icon="navSelected.icon" class="w-[18px] h-[18px] rounded" />
-              <DataSourceIcon v-else-if="navIconAgents.length" :type="navIconAgents[0].type" :connector-key="navIconAgents[0].connector_key" :icon="navIconAgents[0].icon" class="w-[18px] h-[18px] rounded" />
+              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" :icon-token="navSelected.icon_token" :icon="navSelected.icon" class="w-[18px] h-[18px] rounded" />
+              <DataSourceIcon v-else-if="navIconAgents.length" :type="navIconAgents[0].type" :connector-key="navIconAgents[0].connector_key" :icon-token="navIconAgents[0].icon_token" :icon="navIconAgents[0].icon" class="w-[18px] h-[18px] rounded" />
               <UIcon v-else name="heroicons-cube" class="w-[18px] h-[18px]" />
               <span v-if="!navSelected && agents.length > 1" class="absolute -top-1.5 -right-1.5 min-w-[14px] h-3.5 px-1 rounded-full bg-gray-900 text-white text-[8px] font-semibold leading-none flex items-center justify-center">{{ agents.length > 9 ? '9+' : agents.length }}</span>
             </span>
           </UTooltip>
           <template v-else>
             <span class="flex items-center justify-center">
-              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" :icon="navSelected.icon" class="w-[18px] h-[18px] rounded" />
+              <DataSourceIcon v-if="navSelected" :type="navSelected.connections?.[0]?.type" :connector-key="navSelected.connections?.[0]?.connector_key" :icon-token="navSelected.icon_token" :icon="navSelected.icon" class="w-[18px] h-[18px] rounded" />
               <span v-else-if="navIconAgents.length" class="flex -space-x-1.5 items-center">
-                <DataSourceIcon v-for="(it, i) in navIconAgents" :key="i" :type="it.type" :connector-key="it.connector_key" :icon="it.icon" class="w-[18px] h-[18px] ring-2 ring-white rounded-full bg-white" />
+                <DataSourceIcon v-for="(it, i) in navIconAgents" :key="i" :type="it.type" :connector-key="it.connector_key" :icon-token="it.icon_token" :icon="it.icon" class="w-[18px] h-[18px] ring-2 ring-white rounded-full bg-white" />
               </span>
               <UIcon v-else name="heroicons-cube" class="w-[18px] h-[18px]" />
             </span>
@@ -134,10 +134,10 @@
                     ]"
                   >
                     <DataSourceIcon
-                      v-if="a.connections?.[0]?.type || a.icon"
+                      v-if="a.connections?.[0]?.type || a.icon || a.icon_token"
                       :type="a.connections?.[0]?.type"
                       :connector-key="a.connections?.[0]?.connector_key"
-                      :icon="a.icon"
+                      :icon-token="a.icon_token" :icon="a.icon"
                       class="h-4 w-4 flex-shrink-0"
                     />
                     <UIcon v-else name="heroicons-circle-stack" class="w-4 h-4 text-gray-400 flex-shrink-0" />

--- a/frontend/components/CommandPalette.vue
+++ b/frontend/components/CommandPalette.vue
@@ -24,7 +24,7 @@
     >
       <!-- Agents use the real data-source logo for their type -->
       <template #agents-icon="{ command }">
-        <DataSourceIcon :type="command.dsType" :icon="command.dsIcon" class="h-4 w-4 flex-shrink-0" />
+        <DataSourceIcon :icon-token="command.dsIconToken" class="h-4 w-4 flex-shrink-0" />
       </template>
     </UCommandPalette>
 
@@ -204,8 +204,7 @@ const agentsGroup = computed(() => {
     commands: filtered.map((a: any) => ({
       id: `agent-${a.id}`,
       label: a.name,
-      dsType: a.type,
-      dsIcon: a.icon,
+      dsIconToken: a.icon_token,
       suffix: a.status === 'active' ? 'active' : 'inactive',
       to: `/agents/${a.id}`,
     })),

--- a/frontend/components/DataSourceIcon.vue
+++ b/frontend/components/DataSourceIcon.vue
@@ -17,7 +17,9 @@ import { computed, ref, watch } from 'vue';
 
 // Props to accept the type of data source and class
 const props = defineProps<{
-    type: string | null | undefined;
+    // Connection-level inputs: use these to draw ONE CONNECTION (a catalog tile,
+    // a connection row, a table's source) where there is no agent to resolve.
+    type?: string | null;
     // Optional catalog key for a known connector (e.g. "notion", "monday"). When
     // set, the provider's brand icon is preferred over the generic type icon.
     connectorKey?: string | null;
@@ -25,14 +27,23 @@ const props = defineProps<{
     // "preset:<key>"). When it resolves to an emoji it wins over everything
     // else; otherwise the default type/connector logic below applies.
     icon?: string | null;
+    // AGENT-LEVEL input, and the one to prefer wherever the payload carries it:
+    // the backend's already-resolved `icon_token`. It supersedes
+    // type/connectorKey/icon, so every surface showing a given agent shows the
+    // same icon instead of each deriving one from a different pair of fields
+    // (see backend/app/schemas/agent_icon.py).
+    iconToken?: string | null;
     class?: string;
 }>();
 
 const FALLBACK_ICON = '/data_sources_icons/document.png'
 
-// Parse the custom icon override. Unrecognised/future tokens resolve to 'none'
-// and fall through to the default type icon, so nothing ever renders broken.
-const parsedIcon = computed(() => parseAgentIcon(props.icon))
+// The resolved agent token when the call site has one, else the raw override.
+// Both use the same vocabulary, so one parser covers them. Unrecognised/future
+// tokens resolve to 'none' and fall through to the default type icon, so nothing
+// ever renders broken.
+const activeToken = computed(() => props.iconToken || props.icon)
+const parsedIcon = computed(() => parseAgentIcon(activeToken.value))
 
 // A "type:<key>" override pins one of the agent's connection type/connector
 // icons. We feed the key into BOTH the connector-brand and the type-asset

--- a/frontend/components/EvalRunDetail.vue
+++ b/frontend/components/EvalRunDetail.vue
@@ -134,7 +134,7 @@
                   {{ modelDisplayName(row.case?.prompt_json?.model_id, row.case) }}
                 </span>
                 <span v-for="dsId in (row.case?.data_source_ids_json || [])" :key="dsId" class="inline-flex items-center gap-1" v-show="dataSourceById[dsId]">
-                  <DataSourceIcon v-if="dataSourceById[dsId]" :type="dataSourceById[dsId].type" :icon="dataSourceById[dsId].icon" class="h-3" />
+                  <DataSourceIcon v-if="dataSourceById[dsId]" :type="dataSourceById[dsId].type" :icon-token="dataSourceById[dsId].icon_token" :icon="dataSourceById[dsId].icon" class="h-3" />
                   {{ dataSourceById[dsId]?.name }}
                 </span>
                 <NuxtLink v-if="row.result.report_id" :to="`/reports/${row.result.report_id}`" target="_blank" class="ms-auto inline-flex items-center gap-1 text-blue-500 hover:underline">

--- a/frontend/components/InstructionDetailsModal.vue
+++ b/frontend/components/InstructionDetailsModal.vue
@@ -27,7 +27,7 @@
                         <div v-for="dataSource in instruction.data_sources"
                              :key="dataSource.id"
                              class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
-                            <DataSourceIcon :type="dataSource.type" :icon="dataSource.icon" class="h-3" />
+                            <DataSourceIcon :type="dataSource.type" :icon-token="dataSource.icon_token" :icon="dataSource.icon" class="h-3" />
                             <span>{{ dataSource.name }}</span>
                         </div>
                     </div>
@@ -40,7 +40,7 @@
                         <div v-for="ref in (instruction as any).references"
                              :key="ref.id"
                              class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 p-1 rounded-md">
-                             <DataSourceIcon :type="ref.data_source_type" :icon="ref.data_source_icon" class="h-3" />
+                             <DataSourceIcon :type="ref.data_source_type" :icon-token="ref.data_source_icon_token" :icon="ref.data_source_icon" class="h-3" />
                              <span>{{ ref.data_source_name }}</span>
                             <UIcon :name="getRefIcon(ref.object_type)" class="w-3 h-3" />
                             <span>{{ getRefDisplayName(ref) }}</span>

--- a/frontend/components/InstructionGlobalCreateComponent.vue
+++ b/frontend/components/InstructionGlobalCreateComponent.vue
@@ -283,7 +283,7 @@
                                 :key="ds.id"
                                 class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-gray-50 border border-gray-200 rounded text-[11px] text-gray-700"
                             >
-                                <DataSourceIcon :type="ds.type" :icon="ds.icon" class="h-3" />
+                                <DataSourceIcon :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="h-3" />
                                 {{ ds.name }}
                             </div>
                         </div>
@@ -302,7 +302,7 @@
                             >
                                 <!-- DS icon for tables/tools (shows which agent) -->
                                 <template v-if="ref.data_source_type && (ref.type === 'datasource_table' || ref.type === 'connection_tool')">
-                                    <DataSourceIcon :type="ref.data_source_type" :icon="ref.data_source_icon" class="h-3 shrink-0" />
+                                    <DataSourceIcon :type="ref.data_source_type" :icon-token="ref.data_source_icon_token" :icon="ref.data_source_icon" class="h-3 shrink-0" />
                                     <!-- Wrench pip only when we have DS icon, to distinguish tools from tables -->
                                     <Icon v-if="ref.type === 'connection_tool'" name="heroicons:wrench-screwdriver" class="w-2.5 h-2.5 shrink-0 text-gray-400" />
                                 </template>
@@ -653,7 +653,7 @@
                             <span v-if="isAllDataSourcesSelected" class="text-xs text-gray-700">{{ $t('instructionGlobalCreate.allSources') }}</span>
                             <span v-else-if="selectedDataSources.length === 0" class="text-gray-400 text-xs">{{ $t('instructionGlobalCreate.fields.sources') }}</span>
                             <div v-else class="flex items-center gap-1 text-xs text-gray-700">
-                                <DataSourceIcon :type="getSelectedDataSourceObjects[0]?.type" :icon="getSelectedDataSourceObjects[0]?.icon" class="h-3" />
+                                <DataSourceIcon :type="getSelectedDataSourceObjects[0]?.type" :icon-token="getSelectedDataSourceObjects[0]?.icon_token" :icon="getSelectedDataSourceObjects[0]?.icon" class="h-3" />
                                 <span class="truncate max-w-[100px]">{{ getSelectedDataSourceObjects[0]?.name }}</span>
                                 <span v-if="getSelectedDataSourceObjects.length > 1" class="text-gray-500">{{ $t('instructionGlobalCreate.plusN', { n: getSelectedDataSourceObjects.length - 1 }) }}</span>
                             </div>
@@ -661,9 +661,9 @@
                         <template #option="{ option }">
                             <div class="flex items-center w-full py-0.5">
                                 <div v-if="option.id === 'all'" class="flex -space-x-1 me-1.5">
-                                    <DataSourceIcon v-for="ds in availableDataSources.slice(0, 3)" :key="ds.id" :type="ds.type" :icon="ds.icon" class="h-3 border border-white rounded" />
+                                    <DataSourceIcon v-for="ds in availableDataSources.slice(0, 3)" :key="ds.id" :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="h-3 border border-white rounded" />
                                 </div>
-                                <DataSourceIcon v-else :type="option.type" :icon="option.icon" class="h-3 me-1.5" />
+                                <DataSourceIcon v-else :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-3 me-1.5" />
                                 <span class="text-xs">{{ option.name }}</span>
                             </div>
                         </template>
@@ -701,7 +701,7 @@
                                     <span class="text-[11px] font-medium text-gray-900 break-all">{{ option.name || option.text_preview?.slice(0, 40) + '...' }}</span>
                                 </div>
                                 <div v-if="option.data_source_name" class="flex items-center gap-1">
-                                    <DataSourceIcon :type="option.data_source_type" :icon="option.data_source_icon" class="h-2.5 flex-shrink-0" />
+                                    <DataSourceIcon :type="option.data_source_type" :icon-token="option.data_source_icon_token" :icon="option.data_source_icon" class="h-2.5 flex-shrink-0" />
                                     <span class="text-[10px] text-gray-500 truncate">{{ option.data_source_name }}</span>
                                 </div>
                                 <div v-else-if="option.type === 'instruction'" class="flex items-center gap-1">

--- a/frontend/components/InstructionPrivateCreateComponent.vue
+++ b/frontend/components/InstructionPrivateCreateComponent.vue
@@ -89,7 +89,7 @@
                                     v-for="ds in getSelectedDataSourceObjects.slice(0, 3)"
                                     :key="ds.id"
                                     :type="ds.type"
-                                    :icon="ds.icon"
+                                    :icon-token="ds.icon_token" :icon="ds.icon"
                                     class="h-4 border border-white rounded"
                                 />
                             </div>
@@ -376,9 +376,9 @@ Examples:
                             <div class="flex items-center justify-between w-full py-0.5 pe-1">
                                 <div class="flex items-center">
                                     <div v-if="option.id === 'all'" class="flex -space-x-1 me-1.5">
-                                        <DataSourceIcon v-for="ds in availableDataSources.slice(0, 3)" :key="ds.id" :type="ds.type" :icon="ds.icon" class="h-3 border border-white rounded" />
+                                        <DataSourceIcon v-for="ds in availableDataSources.slice(0, 3)" :key="ds.id" :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="h-3 border border-white rounded" />
                                     </div>
-                                    <DataSourceIcon v-else :type="option.type" :icon="option.icon" class="h-3 me-1.5" />
+                                    <DataSourceIcon v-else :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-3 me-1.5" />
                                     <span class="text-xs">{{ option.name }}</span>
                                 </div>
                                 <UCheckbox :model-value="option.id === 'all' ? isAllDataSourcesSelected : selectedDataSources.includes(String(option.id))" @update:model-value="handleDataSourceToggle(String(option.id))" @click.stop class="flex-shrink-0 ms-1" />
@@ -411,7 +411,7 @@ Examples:
                                     <span class="text-xs font-medium text-gray-900 dark:text-white truncate">{{ option.name }}</span>
                                 </div>
                                 <div class="flex items-center gap-1.5 ms-6">
-                                    <DataSourceIcon :type="option.data_source_type" :icon="option.data_source_icon" class="h-2.5 flex-shrink-0" />
+                                    <DataSourceIcon :type="option.data_source_type" :icon-token="option.data_source_icon_token" :icon="option.data_source_icon" class="h-2.5 flex-shrink-0" />
                                     <span class="text-[10px] text-gray-500 dark:text-gray-400 truncate">{{ option.data_source_name }}</span>
                                 </div>
                             </div>

--- a/frontend/components/KnowledgeExplorer.vue
+++ b/frontend/components/KnowledgeExplorer.vue
@@ -91,7 +91,7 @@
           <template v-else>
             <div v-for="grp in pendingGroups" :key="grp.id">
               <div class="px-2 py-1 flex items-center gap-1.5 text-[11px] font-semibold text-gray-500 dark:text-gray-400">
-                <DataSourceIcon v-if="grp.type || grp.icon" :type="grp.type" :connector-key="grp.connector_key" :icon="grp.icon" class="w-3.5 h-3.5 shrink-0" />
+                <DataSourceIcon v-if="grp.type || grp.icon || grp.icon_token" :type="grp.type" :connector-key="grp.connector_key" :icon-token="grp.icon_token" :icon="grp.icon" class="w-3.5 h-3.5 shrink-0" />
                 <UIcon v-else name="i-heroicons-globe-alt" class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0" />
                 <span class="flex-1 truncate">{{ grp.name }}</span>
                 <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ grp.rows.length }}</span>
@@ -118,7 +118,7 @@
             <div v-if="searchResults.agents.length">
               <div class="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Agents</div>
               <button v-for="a in searchResults.agents" :key="a.id" type="button" class="w-full flex items-center gap-2 h-8 rounded-md text-[13px] text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/70 px-2" @click="onAgentClick(a)">
-                <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon="a.icon" class="w-4 h-4 shrink-0" />
+                <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon-token="a.icon_token" :icon="a.icon" class="w-4 h-4 shrink-0" />
                 <span class="flex-1 text-start truncate">{{ a.name }}</span>
               </button>
             </div>
@@ -207,7 +207,7 @@
 
           <template v-for="agent in agents" :key="agent.id">
             <TreeGroup :label="agent.name" :count="agentCount(agent.id) || undefined" :pending="agentPending(agent.id)" :status-dot="agentStatusDot(agent)" :lock="agent.is_public === false" :badge="needsSignIn(agent) ? $t('agentsPage.signInBadge') : (agent.publish_status === 'disabled' ? $t('agentsPage.disabledBadge') : (agent.is_connector ? $t('agentsPage.connectorBadge') : ''))" :badge-interactive="needsSignIn(agent)" :disabled="needsSignIn(agent) && !canManageAgent(agent.id)" :active="agentView?.agentId === agent.id" :open="isOpen('agent:' + agent.id)" @toggle="onAgentClick(agent)" @badge="openAgentTab(agent.id)">
-              <template #icon><DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon="agent.icon" class="w-4 h-4 shrink-0" /></template>
+              <template #icon><DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon-token="agent.icon_token" :icon="agent.icon" class="w-4 h-4 shrink-0" /></template>
 
               <!-- Content sections need a queryable agent, so they stay hidden while
                    the viewer hasn't signed in with their own credentials. Settings
@@ -413,7 +413,7 @@
                     class="shrink-0"
                     @change="setAgentIcon"
                   />
-                  <DataSourceIcon v-else-if="agentDetail" :type="agentDetail.type" :connector-key="agentDetail.connector_key" :icon="agentDetail.icon" class="w-4 h-4 shrink-0" />
+                  <DataSourceIcon v-else-if="agentDetail" :type="agentDetail.type" :connector-key="agentDetail.connector_key" :icon-token="agentDetail.icon_token" :icon="agentDetail.icon" class="w-4 h-4 shrink-0" />
                   <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="(agentDetail?.status || 'active') === 'active' ? 'bg-green-500' : 'bg-gray-300'" :title="(agentDetail?.status || 'active') === 'active' ? $t('agentsPage.active') : $t('agentsPage.inactive')"></span>
                   <h2 class="text-base font-semibold text-gray-900 dark:text-white truncate">{{ agentDetail?.name || agentViewName }}</h2>
                   <UPopover v-if="agentCanUpdate" :popper="{ placement: 'bottom-start' }" :ui="{ ring: '', shadow: 'shadow-md' }">
@@ -624,7 +624,7 @@
               </template>
               <template v-else>
                 <button type="button" class="flex items-center gap-1.5 min-w-0 rounded px-1 -mx-1 hover:bg-gray-100 dark:hover:bg-gray-800/70" :title="$t('agentsPage.tipOpenAgent')" @click="openAgent(panelView.agentId)">
-                  <DataSourceIcon :type="panelAgent?.type" :connector-key="panelAgent?.connector_key" :icon="panelAgent?.icon" class="w-[18px] h-[18px] shrink-0" />
+                  <DataSourceIcon :type="panelAgent?.type" :connector-key="panelAgent?.connector_key" :icon-token="panelAgent?.icon_token" :icon="panelAgent?.icon" class="w-[18px] h-[18px] shrink-0" />
                   <span class="text-[13px] font-medium text-gray-700 dark:text-gray-300 truncate hover:text-gray-900 dark:hover:text-white">{{ panelAgent?.name || $t('agentsPage.agent') }}</span>
                 </button>
                 <UIcon name="i-heroicons-chevron-right" class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0 rtl:rotate-180" />
@@ -935,7 +935,7 @@
                 <KSelect v-if="metaEditable" v-model="draft.data_source_ids" :options="agentOptsForDraft" multiple :placeholder="$t('agentsPage.allAgentsPlaceholder')" icon="i-heroicons-cube" @update:modelValue="onMetaChange" />
                 <template v-else>
                   <span v-if="(detail.data_sources || []).length === 0" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><UIcon name="i-heroicons-globe-alt" class="w-3 h-3 text-gray-400 dark:text-gray-500" />{{ $t('agentsPage.allAgentsPlaceholder') }}</span>
-                  <span v-for="ds in detail.data_sources" :key="ds.id" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon="ds.icon" class="w-3 h-3" />{{ ds.name }}</span>
+                  <span v-for="ds in detail.data_sources" :key="ds.id" class="inline-flex items-center gap-1 px-2 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 text-[11px]"><DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon-token="ds.icon_token" :icon="ds.icon" class="w-3 h-3" />{{ ds.name }}</span>
                 </template>
                 <!-- Folder (cosmetic placement), one per scope. Picking a
                      folder here files the instruction without a drag; "Top
@@ -2493,7 +2493,7 @@ const loadPendingChanges = async () => {
 // collapse into one synthetic "Global" group. Each group keeps a stable label
 // and icon so the flat list reads like the tree's agent sections.
 const pendingGroups = computed(() => {
-  const map = new Map<string, { id: string; name: string; type?: string; connector_key?: string; rows: Instruction[] }>()
+  const map = new Map<string, { id: string; name: string; type?: string; connector_key?: string; icon?: string | null; icon_token?: string | null; rows: Instruction[] }>()
   // The pending_only list is served by the same optimistic sweep as the dots —
   // hide rows the authoritative pass has since proven resolved.
   for (const ins of pendingRows.value.filter(r => canEditInstruction(r) && !verifiedNotPending.value.has(r.id))) {
@@ -2506,7 +2506,7 @@ const pendingGroups = computed(() => {
       for (const ds of dss) {
         if (!map.has(ds.id)) {
           const agent = agents.value.find(a => a.id === ds.id)
-          map.set(ds.id, { id: ds.id, name: ds.name, type: agent?.type || (ds as any).type, icon: agent?.icon ?? (ds as any).icon, connector_key: agent?.connector_key, rows: [] })
+          map.set(ds.id, { id: ds.id, name: ds.name, type: agent?.type || (ds as any).type, icon: agent?.icon ?? (ds as any).icon, icon_token: agent?.icon_token ?? (ds as any).icon_token, connector_key: agent?.connector_key, rows: [] })
         }
         map.get(ds.id)!.rows.push(ins)
       }

--- a/frontend/components/ReviewFeed.vue
+++ b/frontend/components/ReviewFeed.vue
@@ -26,7 +26,7 @@
         <!-- Agent filter -->
         <UPopover :popper="{ placement: 'bottom-start' }" :ui="{ ring: '', shadow: 'shadow-md' }">
           <button type="button" class="inline-flex items-center gap-1 h-7 px-2 rounded-md border border-gray-200 dark:border-gray-800 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-            <DataSourceIcon v-if="agentFilter" :type="agentTypeOf(agentFilter)" :icon="agentIconOf(agentFilter)" class="w-3 h-3" />
+            <DataSourceIcon v-if="agentFilter" :icon-token="agentIconTokenOf(agentFilter)" class="w-3 h-3" />
             <UIcon v-else name="i-heroicons-cube" class="w-3 h-3 text-gray-400 dark:text-gray-500" />
             {{ agentFilter ? agentNameOf(agentFilter) : 'All agents' }}
             <UIcon name="i-heroicons-chevron-down" class="w-2.5 h-2.5 opacity-60" />
@@ -34,7 +34,7 @@
           <template #panel="{ close }">
             <div class="p-1 w-56 max-h-72 overflow-auto">
               <button class="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800/50 text-left text-[13px]" @click="agentFilter = null; close()"><UIcon name="i-heroicons-cube" class="w-4 h-4 text-gray-400 dark:text-gray-500" />All agents<UIcon v-if="!agentFilter" name="i-heroicons-check" class="w-3.5 h-3.5 ml-auto text-gray-900 dark:text-white" /></button>
-              <button v-for="a in agents" :key="a.id" class="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800/50 text-left text-[13px]" @click="agentFilter = a.id; close()"><DataSourceIcon :type="a.type" :icon="a.icon" class="w-4 h-4" /><span class="truncate">{{ a.name }}</span><UIcon v-if="agentFilter === a.id" name="i-heroicons-check" class="w-3.5 h-3.5 ml-auto text-gray-900 dark:text-white shrink-0" /></button>
+              <button v-for="a in agents" :key="a.id" class="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800/50 text-left text-[13px]" @click="agentFilter = a.id; close()"><DataSourceIcon :type="a.type" :icon-token="a.icon_token" :icon="a.icon" class="w-4 h-4" /><span class="truncate">{{ a.name }}</span><UIcon v-if="agentFilter === a.id" name="i-heroicons-check" class="w-3.5 h-3.5 ml-auto text-gray-900 dark:text-white shrink-0" /></button>
             </div>
           </template>
         </UPopover>
@@ -85,7 +85,7 @@
               <p v-if="row.why" class="mt-0.5 text-[12px] text-gray-500 dark:text-gray-400 line-clamp-2">{{ row.why }}</p>
               <div class="mt-1.5 flex items-center gap-2 text-[11px] text-gray-400 dark:text-gray-500">
                 <span class="inline-flex items-center gap-1">
-                  <DataSourceIcon v-if="row.singleAgentId" :type="agentTypeOf(row.singleAgentId)" :icon="agentIconOf(row.singleAgentId)" class="w-3 h-3" />
+                  <DataSourceIcon v-if="row.singleAgentId" :icon-token="agentIconTokenOf(row.singleAgentId)" class="w-3 h-3" />
                   <UIcon v-else name="i-heroicons-globe-alt" class="w-3 h-3" />
                   {{ row.agentLabel }}
                 </span>
@@ -131,7 +131,7 @@
         <div class="mb-4">
           <label class="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Agent</label>
           <div class="relative mt-1">
-            <DataSourceIcon v-if="settingsAgentId" :type="agentTypeOf(settingsAgentId)" :icon="agentIconOf(settingsAgentId)" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4" />
+            <DataSourceIcon v-if="settingsAgentId" :icon-token="agentIconTokenOf(settingsAgentId)" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4" />
             <select v-model="settingsAgentId" class="w-full h-9 pl-9 pr-2 text-[13px] bg-gray-50 border border-gray-200 rounded-md outline-none focus:border-gray-400 focus:bg-white appearance-none dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-500">
               <option v-for="a in agents" :key="a.id" :value="a.id">{{ a.name }}</option>
             </select>
@@ -184,8 +184,7 @@ const TYPE_META: Record<string, { label: string; icon: string; tint: string }> =
 const typeMeta = (t: string) => TYPE_META[t] || { label: t, icon: 'i-heroicons-bell', tint: 'gray' }
 
 const agentNameOf = (id: string) => props.agents.find(a => a.id === id)?.name || 'Agent'
-const agentTypeOf = (id: string) => props.agents.find(a => a.id === id)?.type
-const agentIconOf = (id: string) => props.agents.find(a => a.id === id)?.icon
+const agentIconTokenOf = (id: string) => props.agents.find(a => a.id === id)?.icon_token
 
 const accentClass = (it: any) => it.severity === 'error' ? 'bg-red-400' : it.severity === 'warning' ? 'bg-amber-400' : 'bg-transparent'
 const iconWrapClass = (it: any) => {

--- a/frontend/components/console/RecentInstructions.vue
+++ b/frontend/components/console/RecentInstructions.vue
@@ -35,7 +35,7 @@
                                         v-for="dataSource in instruction.data_sources.slice(0, 3)"
                                         :key="dataSource.id"
                                         :type="dataSource.type"
-                                        :icon="dataSource.icon"
+                                        :icon-token="dataSource.icon_token" :icon="dataSource.icon"
                                         class="w-4 h-4"
                                         :title="dataSource.name"
                                     />

--- a/frontend/components/console/TraceModal.vue
+++ b/frontend/components/console/TraceModal.vue
@@ -206,7 +206,7 @@
                                     <h4 class="text-sm font-medium text-gray-900 dark:text-white">{{ getSelectedItemTitle() }}</h4>
                                     <span v-if="selectedItemDataSources.length" class="flex items-center gap-1.5 ms-2">
                                         <span v-for="ds in selectedItemDataSources" :key="ds.id" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-[11px] text-gray-600 dark:text-gray-400">
-                                            <DataSourceIcon :type="ds.type" :icon="ds.icon" class="w-3.5 h-3.5" />
+                                            <DataSourceIcon :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="w-3.5 h-3.5" />
                                             <span>{{ ds.name || ds.type }}</span>
                                         </span>
                                     </span>

--- a/frontend/components/diagnosis/RunsTable.vue
+++ b/frontend/components/diagnosis/RunsTable.vue
@@ -67,7 +67,7 @@
                                         data-testid="agent-chip"
                                         @click.stop="$emit('pivot', `agent:${quote(a.name)}`)"
                                     >
-                                        <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon="a.icon" class="h-3.5 w-3.5 flex-shrink-0" />
+                                        <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon-token="a.icon_token" :icon="a.icon" class="h-3.5 w-3.5 flex-shrink-0" />
                                         <span class="truncate">{{ a.name }}</span>
                                     </button>
                                 </div>

--- a/frontend/components/entity/EntityEditModal.vue
+++ b/frontend/components/entity/EntityEditModal.vue
@@ -32,7 +32,7 @@
             class="inline-flex items-center gap-1 bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-[11px] font-medium px-1.5 py-0.5 rounded"
             data-testid="entity-edit-agent-chip"
           >
-            <DataSourceIcon :type="ds.type" :icon="ds.icon" class="h-3" />
+            <DataSourceIcon :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="h-3" />
             {{ ds.name }}
           </span>
         </template>

--- a/frontend/components/entity/EntityForm.vue
+++ b/frontend/components/entity/EntityForm.vue
@@ -45,7 +45,7 @@
             <span v-if="selectedDataSourceIds.length === 0" class="text-gray-500 dark:text-gray-400">{{ $t('entityForm.selectAgents') }}</span>
             <div v-else class="flex items-center flex-wrap gap-1">
               <span v-for="ds in selectedDataSourceObjects" :key="ds.id" class="flex items-center bg-blue-100 dark:bg-blue-900/50 text-blue-800 text-[10px] px-1.5 py-0.5 rounded">
-                <DataSourceIcon :type="ds.type" :icon="ds.icon" class="h-3 me-1" />
+                <DataSourceIcon :type="ds.type" :icon-token="ds.icon_token" :icon="ds.icon" class="h-3 me-1" />
                 {{ ds.name }}
               </span>
             </div>
@@ -54,7 +54,7 @@
         <template #option="{ option }">
           <div class="flex items-center justify-between w-full py-1 pe-2">
             <div class="flex items-center">
-              <DataSourceIcon :type="option.type" :icon="option.icon" class="h-3 me-2" />
+              <DataSourceIcon :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-3 me-2" />
               <span class="text-xs">{{ option.name }}</span>
             </div>
             <UCheckbox
@@ -108,6 +108,7 @@ interface DataSource {
   name: string
   type: string
   icon?: string | null
+  icon_token?: string | null
 }
 
 interface EntityFormData {

--- a/frontend/components/instructions/BuildExplorerModal.vue
+++ b/frontend/components/instructions/BuildExplorerModal.vue
@@ -29,7 +29,7 @@
                             <DataSourceIcon
                                 v-if="selectedDsFilter"
                                 :type="(selectedDsFilter as any).type || (selectedDsFilter as any).connections?.[0]?.type"
-                                :icon="(selectedDsFilter as any).icon"
+                                :icon-token="(selectedDsFilter as any).icon_token" :icon="(selectedDsFilter as any).icon"
                                 class="h-4 flex-shrink-0"
                             />
                             <Icon v-else name="heroicons:funnel" class="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" />
@@ -64,7 +64,7 @@
                                     @click="dsFilterId = d.id; dsFilterDropdownOpen = false"
                                     class="w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors text-start border-t border-gray-100 dark:border-gray-800"
                                 >
-                                    <DataSourceIcon :type="(d as any).type || (d as any).connections?.[0]?.type" :icon="(d as any).icon" class="h-4 flex-shrink-0" />
+                                    <DataSourceIcon :type="(d as any).type || (d as any).connections?.[0]?.type" :icon-token="(d as any).icon_token" :icon="(d as any).icon" class="h-4 flex-shrink-0" />
                                     <span class="truncate flex-1 font-medium">{{ (d as any).name }}</span>
                                     <Icon v-if="dsFilterId === d.id" name="heroicons:check" class="w-3 h-3 text-blue-500" />
                                 </button>

--- a/frontend/components/instructions/BulkScopeModal.vue
+++ b/frontend/components/instructions/BulkScopeModal.vue
@@ -40,7 +40,7 @@
                 <template #option="{ option }">
                     <div class="flex items-center gap-2">
                         <UIcon v-if="option.value === 'global'" name="i-heroicons-globe-alt" class="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                        <DataSourceIcon v-else :type="option.type" :icon="option.icon" class="h-4" />
+                        <DataSourceIcon v-else :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-4" />
                         <span>{{ option.label }}</span>
                     </div>
                 </template>
@@ -71,6 +71,7 @@ interface DataSource {
     name: string
     type?: string
     icon?: string | null
+    icon_token?: string | null
 }
 
 interface Option {
@@ -78,6 +79,7 @@ interface Option {
     label: string
     type?: string
     icon?: string | null
+    icon_token?: string | null
 }
 
 const props = defineProps<{
@@ -104,7 +106,8 @@ const options = computed<Option[]>(() => [
         value: ds.id,
         label: ds.name,
         type: ds.type,
-        icon: ds.icon ?? null
+        icon: ds.icon ?? null,
+        icon_token: ds.icon_token ?? null
     }))
 ])
 

--- a/frontend/components/instructions/InstructionEditor.vue
+++ b/frontend/components/instructions/InstructionEditor.vue
@@ -79,7 +79,7 @@
             <template v-else>
               <span class="font-mono font-medium text-gray-900 dark:text-white block">{{ item.name }}</span>
               <div class="flex items-center gap-1 mt-0.5">
-                <DataSourceIcon v-if="item.dataSourceType || item.dataSourceIcon" :type="item.dataSourceType" :icon="item.dataSourceIcon" class="h-2.5" />
+                <DataSourceIcon v-if="item.dataSourceType || item.dataSourceIcon || item.dataSourceIconToken" :type="item.dataSourceType" :icon-token="item.dataSourceIconToken" :icon="item.dataSourceIcon" class="h-2.5" />
                 <span class="text-[10px] text-gray-500 dark:text-gray-400">{{ item.dataSourceName }}</span>
               </div>
             </template>
@@ -136,6 +136,7 @@ interface MentionItem {
   dataSourceName: string | null
   dataSourceType: string | null
   dataSourceIcon: string | null
+  dataSourceIconToken: string | null
 }
 
 const props = defineProps<{
@@ -440,6 +441,7 @@ async function fetchMentionSuggestions(query: string): Promise<MentionItem[]> {
       dataSourceName: item.data_source_name || null,
       dataSourceType: item.data_source_type || null,
       dataSourceIcon: item.data_source_icon ?? item.icon ?? null,
+      dataSourceIconToken: item.data_source_icon_token ?? item.icon_token ?? null,
     }))
   } catch {
     return []

--- a/frontend/components/instructions/InstructionText.vue
+++ b/frontend/components/instructions/InstructionText.vue
@@ -7,9 +7,9 @@
       >
         <template v-if="segment.ref">
           <DataSourceIcon
-            v-if="segment.ref.data_source_type || segment.ref.data_source_icon"
+            v-if="segment.ref.data_source_type || segment.ref.data_source_icon || segment.ref.data_source_icon_token"
             :type="segment.ref.data_source_type"
-            :icon="segment.ref.data_source_icon"
+            :icon-token="segment.ref.data_source_icon_token" :icon="segment.ref.data_source_icon"
             class="h-3 flex-shrink-0"
           />
           <Icon
@@ -70,6 +70,9 @@ interface Reference {
   type: string
   name: string | null
   data_source_type: string | null
+  // Resolved agent icon, when the chip refers to an agent.
+  data_source_icon?: string | null
+  data_source_icon_token?: string | null
 }
 
 const props = defineProps<{
@@ -85,6 +88,8 @@ const normalizedRefs = computed((): Reference[] =>
     type: r.type || r.object_type || '',
     name: r.name || r.display_text || null,
     data_source_type: r.data_source_type || null,
+    data_source_icon: (r as any).data_source_icon ?? null,
+    data_source_icon_token: (r as any).data_source_icon_token ?? null,
   }))
 )
 

--- a/frontend/components/instructions/InstructionsFilterBar.vue
+++ b/frontend/components/instructions/InstructionsFilterBar.vue
@@ -208,13 +208,13 @@
                         >
                             <template #label>
                                 <span class="flex items-center gap-2 text-xs">
-                                    <DataSourceIcon v-if="selectedDataSource?.type || selectedDataSource?.icon" :type="selectedDataSource.type" :icon="selectedDataSource?.icon" class="h-4" />
+                                    <DataSourceIcon v-if="selectedDataSource?.type || selectedDataSource?.icon || selectedDataSource?.icon_token" :type="selectedDataSource.type" :icon-token="selectedDataSource?.icon_token" :icon="selectedDataSource?.icon" class="h-4" />
                                     {{ selectedDataSource?.label || 'All Data Sources' }}
                                 </span>
                             </template>
                             <template #option="{ option }">
                                 <span class="flex items-center gap-2 text-xs">
-                                    <DataSourceIcon v-if="option.type || option.icon" :type="option.type" :icon="option.icon" class="h-4" />
+                                    <DataSourceIcon v-if="option.type || option.icon || option.icon_token" :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-4" />
                                     {{ option.label }}
                                 </span>
                             </template>
@@ -272,6 +272,7 @@ interface DataSource {
     name: string
     type: string
     icon?: string | null
+    icon_token?: string | null
 }
 
 interface SourceTypeOption {
@@ -400,7 +401,8 @@ const dataSourceOptions = computed(() => {
             value: ds.id,
             label: ds.name,
             type: ds.type,
-            icon: ds.icon ?? null
+            icon: ds.icon ?? null,
+            icon_token: ds.icon_token ?? null
         }))
     ]
 })

--- a/frontend/components/instructions/InstructionsTable.vue
+++ b/frontend/components/instructions/InstructionsTable.vue
@@ -152,8 +152,7 @@
                                         <UTooltip :text="instruction.data_sources.map((ds: any) => ds.name).join(', ')">
                                             <div class="flex items-center gap-1">
                                                 <DataSourceIcon
-                                                    :type="getDataSourceType(instruction) as any"
-                                                    :icon="getDataSourceIcon(instruction)"
+                                                    :icon-token="getDataSourceIconToken(instruction)"
                                                     :class="compact ? 'h-3 w-3' : 'h-3.5 w-3.5'"
                                                     class="flex-shrink-0"
                                                 />
@@ -273,8 +272,9 @@ const props = withDefaults(defineProps<{
     instructions: Instruction[]
     loading?: boolean
     compact?: boolean
-    // Optional: provide full data sources list so we can resolve missing ds.type from list endpoints
-    dataSources?: Array<{ id: string; type?: string | null }>
+    // Optional: the full agents list, so a slim embedded agent (which may carry
+    // no resolved icon) can be looked up by id.
+    dataSources?: Array<{ id: string; type?: string | null; icon_token?: string | null }>
 
     // Selection
     selectable?: boolean
@@ -333,23 +333,21 @@ const emit = defineEmits<{
 const helpers = useInstructionHelpers()
 const expandedRows = ref<Set<string>>(new Set())
 
-const dataSourceTypeById = computed<Record<string, string | null | undefined>>(() => {
+const iconTokenById = computed<Record<string, string | null | undefined>>(() => {
     const out: Record<string, string | null | undefined> = {}
     for (const ds of props.dataSources || []) {
-        out[ds.id] = ds.type
+        out[ds.id] = ds.icon_token
     }
     return out
 })
 
-const getDataSourceType = (instruction: Instruction) => {
-    const first = instruction.data_sources?.[0]
-    if (!first) return null
-    return first.type ?? dataSourceTypeById.value[first.id] ?? null
-}
-
-const getDataSourceIcon = (instruction: Instruction) => {
+// The agent's resolved icon, from the embedded row or (when that shape predates
+// the token) the agents list. Nothing is derived from type/icon here — that is
+// what made this table disagree with the agents explorer.
+const getDataSourceIconToken = (instruction: Instruction) => {
     const first: any = instruction.data_sources?.[0]
-    return first?.icon ?? null
+    if (!first) return null
+    return first.icon_token ?? iconTokenById.value[first.id] ?? null
 }
 
 const toggleExpand = (id: string) => {

--- a/frontend/components/prompt/DataSourceSelector.vue
+++ b/frontend/components/prompt/DataSourceSelector.vue
@@ -20,7 +20,7 @@
                     <span v-else-if="internalSelectedDataSources.length > 0" class="flex items-center">
                         <template v-if="isCompactFinal">
                             <!-- Compact: show only first icon -->
-                            <DataSourceIcon :type="internalSelectedDataSources[0].type" :connector-key="internalSelectedDataSources[0].connector_key" :icon="internalSelectedDataSources[0].icon" class="h-4" />
+                            <DataSourceIcon :type="internalSelectedDataSources[0].type" :connector-key="internalSelectedDataSources[0].connector_key" :icon-token="internalSelectedDataSources[0].icon_token" :icon="internalSelectedDataSources[0].icon" class="h-4" />
                         </template>
                         <template v-else>
                             <!-- Non-compact: show stacked icons -->
@@ -30,7 +30,7 @@
                                     :key="ds.id"
                                     :type="ds.type"
                                     :connector-key="ds.connector_key"
-                                    :icon="ds.icon"
+                                    :icon-token="ds.icon_token" :icon="ds.icon"
                                     class="h-4 ring-1 ring-white rounded flex-shrink-0"
                                 />
                             </div>
@@ -97,7 +97,7 @@
                                     :data-selected="(!isAutoMode && isSelected(ds)) ? 'true' : 'false'"
                                 >
                                     <div class="flex items-center min-w-0">
-                                        <DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon="ds.icon" class="h-4 flex-shrink-0" />
+                                        <DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon-token="ds.icon_token" :icon="ds.icon" class="h-4 flex-shrink-0" />
                                         <span class="ms-2 text-[13px] truncate">{{ ds.name }}</span>
                                         <!-- Non-production agents only reach here for managers; flag
                                              the lifecycle stage so it's clear they aren't live for
@@ -130,7 +130,7 @@
                                     @click="openCredentialsModal(ds)"
                                 >
                                     <div class="flex items-center min-w-0 opacity-50">
-                                        <DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon="ds.icon" class="h-4 flex-shrink-0" />
+                                        <DataSourceIcon :type="ds.type" :connector-key="ds.connector_key" :icon-token="ds.icon_token" :icon="ds.icon" class="h-4 flex-shrink-0" />
                                         <span class="ms-2 text-[13px] truncate">{{ ds.name }}</span>
                                     </div>
                                     <button

--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -82,6 +82,12 @@
             <div :class="['flex items-center space-x-2 flex-1 min-w-0', { 'opacity-50': item.needs_connect }]">
               <DataSourceIcon v-if="category.name === 'tables'" :type="item.icon_type" class="h-3.5 flex-shrink-0" />
               <Icon v-if="category.name === 'tables'" name="heroicons-table-cells" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />
+              <!-- Agents are identified by their own icon here, as they are in the
+                   explorer, the selector and the expanded panel below — a generic
+                   cube for every agent made this the one agent list that didn't
+                   show which agent you were picking. Cube stays as the fallback
+                   for an agent with no resolvable icon. -->
+              <DataSourceIcon v-else-if="category.name === 'data_sources' && item.icon_token" :icon-token="item.icon_token" class="h-3.5 w-3.5 flex-shrink-0" />
               <Icon v-else-if="category.name === 'data_sources'" name="heroicons-cube" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />
               <Icon v-else-if="category.name === 'files'" name="heroicons-document" class="w-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />
               <Icon v-else-if="category.name === 'entities'" :name="item.entity_type === 'metric' ? 'heroicons-chart-bar' : 'heroicons-cube'" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />

--- a/frontend/components/prompt/MentionInput.vue
+++ b/frontend/components/prompt/MentionInput.vue
@@ -128,7 +128,7 @@
             <button @click="closeItemCard" class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded p-1">
               <Icon name="heroicons-chevron-left" class="w-4 h-4" />
             </button>
-            <DataSourceIcon v-if="expandedCategory === 'data_sources' || expandedCategory === 'tables'" :type="expandedItem?.icon_type" :icon="expandedItem?.icon" class="h-3.5 flex-shrink-0" />
+            <DataSourceIcon v-if="expandedCategory === 'data_sources' || expandedCategory === 'tables'" :type="expandedItem?.icon_type" :icon-token="expandedItem?.icon_token" :icon="expandedItem?.icon" class="h-3.5 flex-shrink-0" />
             <Icon v-else-if="expandedCategory === 'files'" name="heroicons-document" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />
             <Icon v-else-if="expandedCategory === 'entities'" :name="expandedItem?.entity_type === 'metric' ? 'heroicons-chart-bar' : 'heroicons-cube'" class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 dark:text-gray-400" />
             <div class="text-[13px] font-medium truncate">{{ expandedItem?.name }}</div>
@@ -246,6 +246,8 @@ interface MentionItem {
   subtitle?: string
   icon_type?: string
   icon?: string | null
+  // Backend-resolved agent icon; preferred over icon_type/icon.
+  icon_token?: string | null
   entity_type?: string
   description?: string
   columns?: string[]
@@ -1444,6 +1446,7 @@ async function fetchAvailableMentions() {
             subtitle: ds.description || ds.type,
             icon_type: ds.type,
             icon: ds.icon,
+            icon_token: ds.icon_token,
             // Per-agent connect state — mirrors DataSourceSelector's needs-connect logic.
             needs_connect: needsUserConnection(ds),
             raw: ds,

--- a/frontend/components/prompt/PromptCard.vue
+++ b/frontend/components/prompt/PromptCard.vue
@@ -12,7 +12,7 @@
           :key="a.id"
           class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border text-violet-700 border-violet-200 bg-violet-50 dark:text-violet-300 dark:border-violet-900 dark:bg-violet-900/20"
         >
-          <DataSourceIcon :type="a.type" :icon="a.icon" class="h-3 w-auto" />
+          <DataSourceIcon :type="a.type" :icon-token="a.icon_token" :icon="a.icon" class="h-3 w-auto" />
           {{ a.name }}
         </span>
       </div>

--- a/frontend/components/prompt/PromptEditModal.vue
+++ b/frontend/components/prompt/PromptEditModal.vue
@@ -94,7 +94,7 @@
                   <span v-else class="text-xs truncate">{{ $t('prompts.nAgentsSelected', { n: agentIds.length }) }}</span>
                 </template>
                 <template #option="{ option }">
-                  <DataSourceIcon v-if="option.type || option.icon" :type="option.type" :icon="option.icon" class="h-3.5 w-auto flex-shrink-0" />
+                  <DataSourceIcon v-if="option.type || option.icon || option.icon_token" :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-3.5 w-auto flex-shrink-0" />
                   <span class="text-xs truncate">{{ option.name }}</span>
                 </template>
               </USelectMenu>
@@ -106,7 +106,7 @@
                   :key="a.id"
                   class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded border border-violet-200 dark:border-violet-900 text-violet-700 dark:text-violet-300 bg-violet-50 dark:bg-violet-900/20"
                 >
-                  <DataSourceIcon :type="a.type" :icon="a.icon" class="h-3 w-auto" />
+                  <DataSourceIcon :type="a.type" :icon-token="a.icon_token" :icon="a.icon" class="h-3 w-auto" />
                   {{ a.name }}
                   <button type="button" class="hover:text-red-500" @click="removeAgent(a.id)">
                     <UIcon name="heroicons-x-mark" class="w-2.5 h-2.5" />

--- a/frontend/components/prompt/PromptViewModal.vue
+++ b/frontend/components/prompt/PromptViewModal.vue
@@ -57,7 +57,7 @@
               :key="a.id"
               class="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded border border-violet-200 dark:border-violet-900 text-violet-700 dark:text-violet-300 bg-violet-50 dark:bg-violet-900/20"
             >
-              <DataSourceIcon :type="a.type" :icon="a.icon" class="h-3 w-auto" />
+              <DataSourceIcon :type="a.type" :icon-token="a.icon_token" :icon="a.icon" class="h-3 w-auto" />
               {{ a.name }}
             </span>
           </div>

--- a/frontend/components/report/ReportAgentPanel.vue
+++ b/frontend/components/report/ReportAgentPanel.vue
@@ -10,7 +10,7 @@
           <Icon name="heroicons:x-mark" class="w-4 h-4 text-gray-500 dark:text-gray-400" />
         </button>
         <Icon v-if="(visibleAgents[0] as any).isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-        <DataSourceIcon v-else :type="visibleAgents[0].type || visibleAgents[0].connections?.[0]?.type" :connector-key="(visibleAgents[0] as any).connector_key || visibleAgents[0].connections?.[0]?.connector_key" :icon="visibleAgents[0].icon" class="h-5 flex-shrink-0" />
+        <DataSourceIcon v-else :type="visibleAgents[0].type" :connector-key="(visibleAgents[0] as any).connector_key" :icon-token="visibleAgents[0].icon_token" :icon="visibleAgents[0].icon" class="h-5 flex-shrink-0" />
         <span class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ visibleAgents[0].name }}</span>
         <span
           v-if="stageBadge(visibleAgents[0])"
@@ -27,7 +27,7 @@
           class="w-full flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-gray-800 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors bg-white/80 dark:bg-gray-900/80"
         >
           <Icon v-if="(selectedAgent as any)?.isGlobal" name="heroicons:globe-alt" class="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-          <DataSourceIcon v-else-if="selectedAgent" :type="selectedAgent.type || selectedAgent.connections?.[0]?.type" :connector-key="(selectedAgent as any).connector_key || selectedAgent.connections?.[0]?.connector_key" :icon="selectedAgent.icon" class="h-5 flex-shrink-0" />
+          <DataSourceIcon v-else-if="selectedAgent" :type="selectedAgent.type" :connector-key="(selectedAgent as any).connector_key" :icon-token="selectedAgent.icon_token" :icon="selectedAgent.icon" class="h-5 flex-shrink-0" />
           <span class="truncate flex-1 text-start font-medium text-gray-900 dark:text-white">
             {{ selectedAgent?.name || $t('reportAgent.selectAgent') }}
           </span>
@@ -50,7 +50,7 @@
               :class="selectedAgentId === agent.id ? 'bg-indigo-50 text-indigo-700' : 'text-gray-700 dark:text-gray-300'"
             >
               <Icon v-if="(agent as any).isGlobal" name="heroicons:globe-alt" class="w-4 h-4 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-              <DataSourceIcon v-else :type="agent.type || agent.connections?.[0]?.type" :connector-key="(agent as any).connector_key || agent.connections?.[0]?.connector_key" :icon="agent.icon" class="h-4 flex-shrink-0" />
+              <DataSourceIcon v-else :type="agent.type" :connector-key="(agent as any).connector_key" :icon-token="agent.icon_token" :icon="agent.icon" class="h-4 flex-shrink-0" />
               <span class="truncate flex-1 text-start font-medium">{{ agent.name }}</span>
               <span
                 v-if="stageBadge(agent)"
@@ -351,7 +351,7 @@
                       <!-- Data source indicator -->
                       <template v-if="inst.data_sources?.length">
                         <span v-for="ds in inst.data_sources" :key="ds.id" class="inline-flex items-center gap-0.5 px-1 py-0.5 rounded bg-gray-50 dark:bg-gray-800 text-[9px] text-gray-600 dark:text-gray-400 font-medium border border-gray-100 dark:border-gray-800">
-                          <DataSourceIcon :type="getInstructionDsType(ds)" :icon="getInstructionDsIcon(ds)" class="h-2.5 flex-shrink-0" />
+                          <DataSourceIcon :icon-token="instructionDsIconToken(ds)" class="h-2.5 flex-shrink-0" />
                           <span class="truncate max-w-[80px]">{{ ds.name }}</span>
                         </span>
                       </template>
@@ -850,20 +850,13 @@ const instructions = computed(() => selectedAgentId.value ? (instructionsCache.v
 const queries = computed(() => selectedAgentId.value ? (queriesCache.value[selectedAgentId.value] || []) : [])
 const evals = computed(() => selectedAgentId.value ? (evalsCache.value[selectedAgentId.value] || []) : [])
 
-// Resolve DS type for instruction's embedded data_source (may lack connections)
-function getInstructionDsType(ds: any): string | undefined {
-  // Try the DS object itself
-  if (ds.type) return ds.type
-  if (ds.connections?.[0]?.type) return ds.connections[0].type
-  // Look up from agents prop (which has full connection info)
-  const match = props.agents.find(a => a.id === ds.id)
-  return match?.type || match?.connections?.[0]?.type || undefined
-}
-
-function getInstructionDsIcon(ds: any): string | null | undefined {
-  if (ds.icon) return ds.icon
-  const match = props.agents.find(a => a.id === ds.id)
-  return match?.icon
+// The resolved icon for an instruction's embedded agent. The embedded shape is
+// slim and can predate the token, so fall back to the full agent from the
+// `agents` prop — but never re-derive one from type/connections here: that is
+// what made this panel disagree with the agents explorer and the data tools.
+function instructionDsIconToken(ds: any): string | null | undefined {
+  if (ds?.icon_token) return ds.icon_token
+  return props.agents.find(a => a.id === ds?.id)?.icon_token
 }
 
 function selectAgent(agentId: string) {

--- a/frontend/components/report/ReportEmptyState.vue
+++ b/frontend/components/report/ReportEmptyState.vue
@@ -84,7 +84,7 @@
 							<DataSourceIcon
 								:type="a.type || a.connections?.[0]?.type"
 								:connector-key="a.connector_key || a.connections?.[0]?.connector_key"
-								:icon="a.icon"
+								:icon-token="a.icon_token" :icon="a.icon"
 								class="h-3.5 flex-shrink-0"
 							/>
 							<span class="max-w-[11rem] truncate">{{ a.name }}</span>

--- a/frontend/components/tools/CreateDataTool.vue
+++ b/frontend/components/tools/CreateDataTool.vue
@@ -16,8 +16,8 @@
         <span v-if="groupedTables.length" class="inline-flex items-center flex-wrap">
           <template v-for="(group, gidx) in groupedTables" :key="gidx">
             <span v-if="gidx > 0" class="ms-1 text-gray-300 dark:text-gray-600">|</span>
-            <DataSourceIcon :type="group.type" class="h-2.5 ms-1" :title="group.title" />
-            <span v-if="group.type === 'bow'" class="ms-1 text-gray-500 dark:text-gray-400">{{ $t('tools.createData.bowSource') }} ·</span>
+            <DataSourceIcon :icon-token="group.iconToken" class="h-2.5 ms-1" :title="group.title" />
+            <span v-if="group.isBow" class="ms-1 text-gray-500 dark:text-gray-400">{{ $t('tools.createData.bowSource') }} ·</span>
             <span class="ms-1 text-gray-500 dark:text-gray-400 inline-flex items-center flex-wrap" :title="group.title">
               <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                 <UIcon
@@ -170,11 +170,13 @@ import QueryCodeEditorModal from '~/components/tools/QueryCodeEditorModal.vue'
 import Spinner from '~/components/Spinner.vue'
 import DataSourceIcon from '~/components/DataSourceIcon.vue'
 
+// The agent shape the ticker needs: an id to match tables_by_source against and
+// the backend's pre-resolved icon. Deliberately not `type`/`connections` — an
+// icon derived from those here disagreed with every other view (see
+// composables/useToolTables.ts).
 interface DataSource {
   id: string
-  type?: string
-  data_source_type?: string
-  connections?: Array<{ id: string; type: string }>
+  icon_token?: string | null
 }
 
 interface Props {
@@ -391,8 +393,16 @@ const executedOnCache = computed(() => {
 })
 const isCached = (n: string) => isCachedTable(n) || executedOnCache.value
 
+// Prefer the agents the backend attached to THIS tool execution: that list rides
+// along in every view (report page, shared /c/{token}, trace modal), whereas the
+// `dataSources` prop is only passed on the report page — which is why the shared
+// views used to fall back to a generic icon. The prop stays as a fallback.
+const iconAgents = computed<DataSource[]>(
+  () => (props.toolExecution as any)?.data_sources || props.dataSources || [],
+)
+
 const groupedTables = computed<ToolTableGroup[]>(() =>
-  groupToolTables((props.toolExecution as any)?.arguments_json, props.dataSources)
+  groupToolTables((props.toolExecution as any)?.arguments_json, iconAgents.value)
 )
 
 // Hide the data preview by default for small table results (< 10 rows).

--- a/frontend/components/tools/InspectDataTool.vue
+++ b/frontend/components/tools/InspectDataTool.vue
@@ -13,7 +13,7 @@
             <span v-if="groupedTables.length" class="inline-flex items-center flex-wrap gap-1">
               <template v-for="(group, gidx) in groupedTables" :key="gidx">
                 <span v-if="gidx > 0" class="text-gray-300 dark:text-gray-600">|</span>
-                <DataSourceIcon :type="group.type" class="h-2" />
+                <DataSourceIcon :icon-token="group.iconToken" class="h-2" />
                 <span class="inline-flex items-center flex-wrap" :title="group.title">
                   <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                     <UIcon
@@ -38,7 +38,7 @@
             <span v-if="groupedTables.length" class="inline-flex items-center flex-wrap gap-1">
               <template v-for="(group, gidx) in groupedTables" :key="gidx">
                 <span v-if="gidx > 0" class="text-gray-300 dark:text-gray-600">|</span>
-                <DataSourceIcon :type="group.type" class="h-2.5" />
+                <DataSourceIcon :icon-token="group.iconToken" class="h-2.5" />
                 <span class="inline-flex items-center flex-wrap" :title="group.title">
                   <span v-for="(nm, nidx) in group.visible" :key="nidx" class="inline-flex items-center">
                     <UIcon
@@ -150,11 +150,11 @@ interface ToolExecution {
   duration_ms?: number
 }
 
+// See CreateDataTool: id to match tables_by_source, plus the backend's
+// pre-resolved icon. Nothing icon-shaped is derived on the client.
 interface DataSource {
   id: string
-  type?: string
-  data_source_type?: string
-  connections?: Array<{ id: string; type: string }>
+  icon_token?: string | null
 }
 
 interface Props {
@@ -234,8 +234,15 @@ const executedOnCache = computed(() => {
 })
 const isCached = (n: string) => isCachedTable(n) || executedOnCache.value
 
+// The agents the backend attached to this tool execution — present in every
+// view, unlike the `dataSources` prop (report page only), which stays as a
+// fallback.
+const iconAgents = computed<DataSource[]>(
+  () => (props.toolExecution as any)?.data_sources || props.dataSources || [],
+)
+
 const groupedTables = computed<ToolTableGroup[]>(() =>
-  groupToolTables(props.toolExecution?.arguments_json, props.dataSources)
+  groupToolTables(props.toolExecution?.arguments_json, iconAgents.value)
 )
 
 function toggleExpanded() {

--- a/frontend/components/tools/SearchAgentsTool.vue
+++ b/frontend/components/tools/SearchAgentsTool.vue
@@ -27,7 +27,7 @@
               :key="a.id"
               :type="a.type"
               :connector-key="a.connector_key"
-              :icon="a.icon"
+              :icon-token="a.icon_token" :icon="a.icon"
               class="w-3.5 h-3.5 flex-shrink-0"
             />
             <span v-if="agents.length > 8" class="ms-0.5 text-[10px] text-gray-400 flex-shrink-0">+{{ agents.length - 8 }}</span>
@@ -48,7 +48,7 @@
             <DataSourceIcon
               :type="a.type"
               :connector-key="a.connector_key"
-              :icon="a.icon"
+              :icon-token="a.icon_token" :icon="a.icon"
               class="w-3.5 h-3.5 me-1.5 flex-shrink-0"
             />
             <span class="font-medium text-gray-700 dark:text-gray-300 truncate">{{ a.name }}</span>

--- a/frontend/components/tools/SetReportAgentsTool.vue
+++ b/frontend/components/tools/SetReportAgentsTool.vue
@@ -31,7 +31,7 @@
         <span class="text-xs text-gray-800 dark:text-gray-200 min-w-0 truncate flex items-center gap-1">
           <span>Add</span>
           <template v-for="a in confAgents" :key="a.id">
-            <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon="a.icon" class="w-3.5 h-3.5 flex-shrink-0" />
+            <DataSourceIcon :type="a.type" :connector-key="a.connector_key" :icon-token="a.icon_token" :icon="a.icon" class="w-3.5 h-3.5 flex-shrink-0" />
             <span class="font-medium">{{ a.name }}</span>
           </template>
           <span v-if="!confAgents.length" class="font-medium">{{ confAgentNames.join(', ') }}</span>

--- a/frontend/composables/useToolTables.ts
+++ b/frontend/composables/useToolTables.ts
@@ -1,11 +1,23 @@
 // Shared table-list display logic for data tools (InspectDataTool,
-// CreateDataTool). Groups the planner's `tables_by_source` argument by
-// connection type and truncates long lists for the one-line ticker —
+// CreateDataTool). Groups the planner's `tables_by_source` argument by the
+// agent's icon and truncates long lists for the one-line ticker —
 // "applications, tiers +6" instead of ten wrapping names. The full list
 // stays reachable via the group's `title` tooltip.
+//
+// The icon is NOT derived here. It arrives pre-resolved as `icon_token` on the
+// agent payload (backend/app/schemas/agent_icon.py) and is passed straight to
+// DataSourceIcon, so the ticker shows the same icon the agents explorer shows.
+// This file used to reduce an agent to `connections[0].type`, which is why a
+// multi-connection agent got one icon here and a different one everywhere else.
 
 export interface ToolTableGroup {
-  type: string
+  // Pre-resolved agent icon ("emoji:<grapheme>" | "type:<key>"), for
+  // <DataSourceIcon :icon-token="…">. Null when the agent is unknown to this
+  // payload — the caller renders its own generic glyph.
+  iconToken: string | null
+  // Bag of Words' own training data rather than one of the org's agents — the
+  // ticker labels that group differently.
+  isBow: boolean
   names: string[]      // full list (tooltip / expanded views)
   visible: string[]    // first MAX_VISIBLE_TABLES names for the ticker line
   more: number         // how many names were truncated (0 = none)
@@ -15,16 +27,22 @@ export interface ToolTableGroup {
 
 export const MAX_VISIBLE_TABLES = 3
 
-interface DataSourceLike {
+// Bag of Words' own training data is a synthetic source with no agent row.
+const BOW_SOURCE_ID = 'builtin:bow'
+const BOW_ICON_TOKEN = 'type:bow'
+// An agent the payload doesn't describe (dropped from the report, or a view
+// that resolved no agents at all).
+const UNKNOWN_ICON_TOKEN = 'type:resource'
+
+/** Any payload shape that names an agent and carries its resolved icon. */
+export interface AgentIconSource {
   id: string
-  type?: string
-  data_source_type?: string
-  connections?: Array<{ id: string; type: string }>
+  icon_token?: string | null
 }
 
 export function groupToolTables(
   argumentsJson: any,
-  dataSources?: DataSourceLike[],
+  dataSources?: AgentIconSource[] | null,
   maxVisible: number = MAX_VISIBLE_TABLES,
 ): ToolTableGroup[] {
   const aj = argumentsJson || {}
@@ -32,26 +50,27 @@ export function groupToolTables(
 
   const groups: Record<string, string[]> = {}
   for (const group of aj.tables_by_source) {
-    let connType = group.data_source_id === 'builtin:bow' ? 'bow' : 'resource'
+    let token = group.data_source_id === BOW_SOURCE_ID ? BOW_ICON_TOKEN : UNKNOWN_ICON_TOKEN
     if (group.data_source_id && dataSources?.length) {
       const ds = dataSources.find((d) => d.id === group.data_source_id)
-      if (ds) {
-        connType = ds.connections?.[0]?.type || ds.type || ds.data_source_type || 'resource'
+      if (ds?.icon_token) {
+        token = ds.icon_token
       }
     }
-    if (!groups[connType]) groups[connType] = []
+    if (!groups[token]) groups[token] = []
     if (Array.isArray(group.tables)) {
-      groups[connType].push(...group.tables)
+      groups[token].push(...group.tables)
     }
   }
 
-  return Object.entries(groups).map(([type, names]) => {
+  return Object.entries(groups).map(([iconToken, names]) => {
     // Truncate per source group. When exactly one name would be hidden,
     // just show it — "+1" costs the same width as the name it hides.
     const truncate = names.length > maxVisible + 1
     const visible = truncate ? names.slice(0, maxVisible) : names
     return {
-      type,
+      iconToken,
+      isBow: iconToken === BOW_ICON_TOKEN,
       names,
       visible,
       more: truncate ? names.length - maxVisible : 0,

--- a/frontend/pages/c/[token]/index.vue
+++ b/frontend/pages/c/[token]/index.vue
@@ -101,7 +101,7 @@
                                             <div v-if="m.prompt?.content" class="pt-1 markdown-wrapper">
                                                 <InstructionText
                                                     :text="m.prompt.content"
-                                                    :references="promptMentionsToRefs(m.prompt.mentions)"
+                                                    :references="promptMentionsToRefs(m.prompt.mentions, agentIconTokens)"
                                                     :prose="true"
                                                 />
                                             </div>
@@ -333,6 +333,22 @@ import GetConnectionTool from '~/components/tools/GetConnectionTool.vue'
 import ToolWidgetPreview from '~/components/tools/ToolWidgetPreview.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
 import { promptMentionsToRefs } from '~/utils/mentions'
+
+// A shared conversation never names the org's agents, but the tool cards do
+// carry each referenced agent's resolved icon. Reuse it so an @agent chip draws
+// the same icon as the tool card beneath it, rather than the one snapshotted
+// into the prompt when the message was sent.
+const agentIconTokens = computed<Record<string, string | null | undefined>>(() => {
+    const out: Record<string, string | null | undefined> = {}
+    for (const c of (conversation.value?.completions || []) as any[]) {
+        for (const b of c.completion_blocks || []) {
+            for (const ds of b.tool_execution?.data_sources || []) {
+                if (ds?.id && ds.icon_token) out[ds.id] = ds.icon_token
+            }
+        }
+    }
+    return out
+})
 // Same markdown pipeline as the report view. MDC (stock, no `mdc` config in
 // nuxt.config) renders a ```mermaid / ```d2 / ```infographic fence as a plain
 // code block and leaves $…$ math as literal text, so a shared answer degraded

--- a/frontend/pages/projects/[id]/index.vue
+++ b/frontend/pages/projects/[id]/index.vue
@@ -244,7 +244,7 @@
                                                     :disabled="savingAgents"
                                                     @click="addAgent(agent.id)"
                                                 >
-                                                    <DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon="agent.icon" class="h-3.5 shrink-0" />
+                                                    <DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon-token="agent.icon_token" :icon="agent.icon" class="h-3.5 shrink-0" />
                                                     <span class="flex-1 truncate text-start">{{ agent.name }}</span>
                                                 </button>
                                                 <div v-if="!agentCandidates.length" class="px-2 py-1.5 text-gray-400">{{ $t('projects.settings.noAgents') }}</div>
@@ -255,7 +255,7 @@
                             </div>
                             <div v-if="project.data_sources?.length" class="space-y-1">
                                 <div v-for="agent in project.data_sources" :key="agent.id" class="group/agent flex items-center gap-1.5 text-[12px] text-gray-600 dark:text-gray-300">
-                                    <DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon="agent.icon" class="h-3.5 shrink-0" />
+                                    <DataSourceIcon :type="agent.type" :connector-key="agent.connector_key" :icon-token="agent.icon_token" :icon="agent.icon" class="h-3.5 shrink-0" />
                                     <span class="flex-1 truncate">{{ agent.name }}</span>
                                     <button
                                         v-if="project.can_manage"

--- a/frontend/pages/prompts/index.vue
+++ b/frontend/pages/prompts/index.vue
@@ -48,11 +48,11 @@
             :ui="{ option: { base: 'text-xs py-1.5' } }"
           >
             <template #label>
-              <DataSourceIcon v-if="selectedAgentOption?.type || selectedAgentOption?.icon" :type="selectedAgentOption.type" :icon="selectedAgentOption.icon" class="h-3.5 w-auto flex-shrink-0" />
+              <DataSourceIcon v-if="selectedAgentOption?.type || selectedAgentOption?.icon || selectedAgentOption?.icon_token" :type="selectedAgentOption.type" :icon-token="selectedAgentOption.icon_token" :icon="selectedAgentOption.icon" class="h-3.5 w-auto flex-shrink-0" />
               <span class="text-xs truncate">{{ selectedAgentOption?.label || $t('prompts.allAgents') }}</span>
             </template>
             <template #option="{ option }">
-              <DataSourceIcon v-if="option.type || option.icon" :type="option.type" :icon="option.icon" class="h-3.5 w-auto flex-shrink-0" />
+              <DataSourceIcon v-if="option.type || option.icon || option.icon_token" :type="option.type" :icon-token="option.icon_token" :icon="option.icon" class="h-3.5 w-auto flex-shrink-0" />
               <span class="text-xs truncate">{{ option.label }}</span>
             </template>
           </USelectMenu>
@@ -181,13 +181,13 @@ const agentNames = computed<Record<string, string>>(() =>
   Object.fromEntries(agents.value.map(a => [a.id, a.name])),
 )
 // id → { name, type } for the card chips' DataSourceIcon.
-const agentMap = computed<Record<string, { name: string; type?: string; icon?: string | null }>>(() =>
-  Object.fromEntries(agents.value.map(a => [a.id, { name: a.name, type: a.type, icon: a.icon }])),
+const agentMap = computed<Record<string, { name: string; type?: string; icon?: string | null; icon_token?: string | null }>>(() =>
+  Object.fromEntries(agents.value.map(a => [a.id, { name: a.name, type: a.type, icon: a.icon, icon_token: a.icon_token }])),
 )
 
 const agentFilterOptions = computed(() => [
   { value: '', label: t('prompts.allAgents'), type: undefined as string | undefined, icon: null as string | null },
-  ...agents.value.map(a => ({ value: a.id, label: a.name, type: a.type, icon: a.icon })),
+  ...agents.value.map(a => ({ value: a.id, label: a.name, type: a.type, icon: a.icon, icon_token: a.icon_token })),
 ])
 const selectedAgentOption = computed(() => agentFilterOptions.value.find(o => o.value === agentFilter.value))
 
@@ -213,8 +213,9 @@ async function loadAgents() {
     agents.value = (data.value || []).map((d: any) => ({
       id: d.id,
       name: d.name,
-      type: d.type || d.connections?.[0]?.type,
+      type: d.type,
       icon: d.icon,
+      icon_token: d.icon_token,
     }))
   } catch {}
 }

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -147,7 +147,7 @@
 											<div v-if="m.prompt?.content" class="pt-1">
 												<InstructionText
 													:text="m.prompt.content"
-													:references="promptMentionsToRefs(m.prompt.mentions)"
+													:references="promptMentionsToRefs(m.prompt.mentions, agentIconTokens)"
 													:prose="true"
 												/>
 											</div>
@@ -245,7 +245,7 @@
 												<div v-if="m.prompt?.content" class="pt-1">
 													<InstructionText
 														:text="m.prompt.content"
-														:references="promptMentionsToRefs(m.prompt.mentions)"
+														:references="promptMentionsToRefs(m.prompt.mentions, agentIconTokens)"
 														:prose="true"
 													/>
 												</div>
@@ -315,7 +315,7 @@
 														<div v-if="s.prompt?.content" class="pt-1">
 															<InstructionText
 																:text="s.prompt.content"
-																:references="promptMentionsToRefs(s.prompt.mentions)"
+																:references="promptMentionsToRefs(s.prompt.mentions, agentIconTokens)"
 																:prose="true"
 															/>
 														</div>
@@ -443,7 +443,7 @@
 													<div v-if="s.prompt?.content" class="pt-1">
 														<InstructionText
 															:text="s.prompt.content"
-															:references="promptMentionsToRefs(s.prompt.mentions)"
+															:references="promptMentionsToRefs(s.prompt.mentions, agentIconTokens)"
 															:prose="true"
 														/>
 													</div>
@@ -1069,6 +1069,15 @@ import Spinner from '~/components/Spinner.vue'
 import InstructionText from '~/components/instructions/InstructionText.vue'
 import { useCan } from '~/composables/usePermissions'
 import { promptMentionsToRefs } from '~/utils/mentions'
+
+// An @agent chip in an already-sent prompt names a LIVE agent, so it should draw
+// the icon that agent has now — not the one snapshotted into the prompt's
+// mentions when the message was sent. Same agent, same icon, on one screen.
+const agentIconTokens = computed<Record<string, string | null | undefined>>(() => {
+	const out: Record<string, string | null | undefined> = {}
+	for (const a of (currentAgents.value || []) as any[]) out[a.id] = a.icon_token
+	return out
+})
 import { MarkdownRender } from 'markstream-vue'
 import 'markstream-vue/index.css'
 // Render load_mode via the shared label map — the UI calls 'intelligent' mode "Smart".

--- a/frontend/pages/reports/[id]/index.vue
+++ b/frontend/pages/reports/[id]/index.vue
@@ -512,7 +512,7 @@
 																class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer text-xs text-gray-700 dark:text-gray-300"
 																@click="close(); openInstructionById(ins.id)"
 															>
-																<DataSourceIcon v-if="ins.data_source_type || ins.data_source_icon" :type="ins.data_source_type" :icon="ins.data_source_icon" class="h-3.5 w-3.5 flex-shrink-0" />
+																<DataSourceIcon v-if="ins.data_source_type || ins.data_source_icon" :type="ins.data_source_type" :icon-token="ins.data_source_icon_token" :icon="ins.data_source_icon" class="h-3.5 w-3.5 flex-shrink-0" />
 																<Icon v-else name="heroicons-cube" class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
 																<span class="flex-1 truncate">{{ ins.title || $t('reportView.untitled') }}</span>
 																<span class="text-[10px] text-gray-400 flex-shrink-0">{{ ins.category || 'general' }}</span>
@@ -787,7 +787,7 @@
 					<DataSourceIcon
 						v-if="currentAgents.length === 1"
 						:type="currentAgents[0].type || currentAgents[0].connections?.[0]?.type"
-						:icon="currentAgents[0].icon"
+						:icon-token="currentAgents[0].icon_token" :icon="currentAgents[0].icon"
 						class="h-3.5 flex-shrink-0"
 					/>
 					<Icon v-else name="heroicons:cog-6-tooth" class="w-3.5 h-3.5" />
@@ -3723,7 +3723,10 @@ async function loadCompletions({ skipEstimate = false } = {}) {
 					created_widget_id: b.tool_execution.created_widget_id,
 					created_step_id: b.tool_execution.created_step_id,
 					created_widget: b.tool_execution.created_widget,
-					created_step: b.tool_execution.created_step
+					created_step: b.tool_execution.created_step,
+					// Agents this call referenced, with their resolved icon_token —
+					// the data tools' source icon comes from here.
+					data_sources: b.tool_execution.data_sources
 				} : undefined
 			})) || []
 
@@ -3949,7 +3952,10 @@ async function loadPreviousCompletions() {
                     created_widget_id: b.tool_execution.created_widget_id,
                     created_step_id: b.tool_execution.created_step_id,
                     created_widget: b.tool_execution.created_widget,
-                    created_step: b.tool_execution.created_step
+                    created_step: b.tool_execution.created_step,
+                    // Agents this call referenced, with their resolved icon_token —
+                    // the data tools' source icon comes from here.
+                    data_sources: b.tool_execution.data_sources
                 } : undefined
             })) || []
 

--- a/frontend/pages/reports/[id]/legacy.vue
+++ b/frontend/pages/reports/[id]/legacy.vue
@@ -53,7 +53,7 @@
                                     <button
                                     class="text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 border border-gray-200 dark:border-gray-700 text-xs rounded-md p-1.5"
                                     @click="handleExampleClick(data_source.conversation_starters?.[0])">  
-                                        <DataSourceIcon :type="data_source.type" :icon="data_source.icon" class="h-3 inline me-2" />
+                                        <DataSourceIcon :type="data_source.type" :icon-token="data_source.icon_token" :icon="data_source.icon" class="h-3 inline me-2" />
                                         {{ data_source.conversation_starters?.[0].split('\n')[0]  }}
                                     </button>
                                 </li>

--- a/frontend/pages/reports/index.vue
+++ b/frontend/pages/reports/index.vue
@@ -361,7 +361,7 @@
                                             :key="data_source.id || data_source.name"
                                             :text="data_source.name"
                                         >
-                                            <DataSourceIcon :type="data_source.type" :icon="data_source.icon" class="h-3 inline" />
+                                            <DataSourceIcon :type="data_source.type" :icon-token="data_source.icon_token" :icon="data_source.icon" class="h-3 inline" />
                                         </UTooltip>
                                         <UTooltip
                                             v-if="report.data_sources.length > 2"

--- a/frontend/utils/mentions.ts
+++ b/frontend/utils/mentions.ts
@@ -269,7 +269,17 @@ export interface PromptMentionRef {
  */
 export function promptMentionsToRefs(
   mentions?: Array<{ name: string; items: any[] }>,
+  /** Current agent id -> icon_token. A prompt's mentions are a snapshot taken
+   *  when the message was sent, so a chip would keep showing the icon the agent
+   *  had then; the chip names a live agent, so prefer the agent's icon now. */
+  agentIconTokens?: Map<string, string | null | undefined> | Record<string, string | null | undefined>,
 ): PromptMentionRef[] {
+  const currentToken = (id: string) => {
+    if (!agentIconTokens) return undefined
+    return agentIconTokens instanceof Map
+      ? agentIconTokens.get(id)
+      : agentIconTokens[id]
+  }
   if (!mentions?.length) return []
   const refs: PromptMentionRef[] = []
   for (const group of mentions) {
@@ -292,7 +302,10 @@ export function promptMentionsToRefs(
         data_source_type: item.connection_type || item.data_source_type || item.icon_type || undefined,
         // An agent mention resolves to the same icon the agents explorer and the
         // data tools draw for it; DataSourceIcon prefers this over the type above.
-        data_source_icon_token: type === 'data_source' ? (item.icon_token ?? undefined) : undefined,
+        data_source_icon_token:
+          type === 'data_source'
+            ? (currentToken(item.id) ?? item.icon_token ?? undefined)
+            : undefined,
         name,
       })
     }

--- a/frontend/utils/mentions.ts
+++ b/frontend/utils/mentions.ts
@@ -256,6 +256,9 @@ export interface PromptMentionRef {
   type: string
   name: string
   data_source_type?: string
+  // An AGENT mention's resolved icon. Tables carry no agent-level token and
+  // keep rendering from data_source_type, which is their connection's.
+  data_source_icon_token?: string | null
 }
 
 /**
@@ -287,6 +290,9 @@ export function promptMentionsToRefs(
         // data source's type); include it so the chip renders the correct
         // data-source icon instead of the generic fallback glyph.
         data_source_type: item.connection_type || item.data_source_type || item.icon_type || undefined,
+        // An agent mention resolves to the same icon the agents explorer and the
+        // data tools draw for it; DataSourceIcon prefers this over the type above.
+        data_source_icon_token: type === 'data_source' ? (item.icon_token ?? undefined) : undefined,
         name,
       })
     }


### PR DESCRIPTION
## Summary

Centralizes agent icon resolution into a single source of truth (`app.schemas.agent_icon`) and ships the resolved icon token (`icon_token`) on every payload that names an agent. This fixes a bug where multi-connection agents showed different icons in different surfaces (e.g., notion logo in the explorer but postgres in the data tools).

## Key Changes

**Backend:**
- Added `app/schemas/agent_icon.py` with `resolve_agent_icon_token()` that implements icon resolution logic once:
  - Explicit admin override wins (emoji or type tokens)
  - Connector brand (e.g., notion) takes precedence over connection type
  - Falls back to first connection's type
  - Returns `None` for agents with no connections
- Created `AgentIconTokenMixin` in `data_source_schema.py` that auto-resolves `icon_token` for any schema with `icon` and `connections` fields
- Updated all agent-facing schemas (`DataSourceListItemSchema`, `DataSourceReportSchema`, `DataSourceMinimalSchema`, `ToolExecutionDataSourceSchema`) to include and resolve `icon_token`
- Fixed `completion_v2.py` serializer to load all connections in order (not just one unordered row) so icon resolution matches across surfaces
- Added `resolve_data_sources_for_tool_executions()` to batch-resolve agents for tool execution lists (fixing shared conversation views that previously shipped no agents)
- Updated `instruction_service.py` to use the centralized resolver for instruction references
- Updated `report_service.py` to resolve agents for public conversation views

**Frontend:**
- Updated `DataSourceIcon.vue` to accept `icon-token` prop and render it directly instead of deriving from `type`/`connector_key`
- Updated `useToolTables.ts` to use pre-resolved `icon_token` from agent payloads instead of deriving from `connections[0].type`
- Updated all components that render agent icons to pass `icon-token` to `DataSourceIcon`
- Updated `promptMentionsToRefs()` to accept and use current agent icon tokens for live agent references
- Updated report pages to pass agent icon tokens to prompt mention rendering

## Notable Implementation Details

- Icon token vocabulary: `emoji:<grapheme>`, `type:<key>`, or `None`
- Connections must be ordered by `created_at, id` for stable "first connection" semantics
- Schemas with `connections` as input-only field (never serialized) use the mixin to resolve the token
- Batch resolution for tool executions prevents N+1 queries on list endpoints
- Backward compatible: `type` and `connector_key` fields remain on payloads for connection-level UI

https://claude.ai/code/session_01DcB1WRtsNAtvuLSdWbqnr8